### PR TITLE
perf(compiler): inline single-expression pure defn at call site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 Opt-in (`CompileOptions::setOptimizationLevel(2)`):
 - `TailCallRewriter`: detect self-recursive `defn` calls in tail position and rewrite them into an implicit `recur` loop. Eliminates per-iteration PHP stack frames. Variadic and multi-arity defs are skipped. Stack-trace shape inside the loop changes from N frames to one (#2141)
+- `CallInliner`: splice the body of a single-arity pure `defn` at the call site instead of dispatching through the resolved `AbstractFn`, skipping one PHP frame and exposing the body to constant folding (e.g. `(my-inc 5)` → `6`). Only fires when every argument is pure (`SymbolicPurityDetector`) and the body is one pure expression; variadic, recursive, memoised and `^:async` defs are skipped (#2135)
 
 Compile-time folding and simplification:
 - `ConstantFolder`: fold pure `phel.core` calls on literal args (comparisons, boolean predicates, bitwise / `bit-*`, `count` / `first` / `last` / `nth` on literal collections, `str`, `min` / `max` / `mod` / `quot` / `rem` / `abs`). Skipped when runtime would throw or promote (#2088)

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -65,6 +65,8 @@ Core compilation pipeline: Phel source -> tokens -> AST -> analyzed nodes -> PHP
 
 The simplification pass runs **after** the analyser-level `ConstantFolder`. It currently drops pure non-tail expressions from `(do ...)` bodies; purity is decided by `PureExpressionDetector`, which delegates `CallNode` checks to `ConstantFolder` so a call is "pure" only when the folder can statically compute its value (calls that would throw at runtime stay un-dropped).
 
+`Simplification/` also hosts the call inliner (opt level >= 2, issue #2135): `InvokeSymbol` calls `CallInliner::tryInline()` for a `GlobalVarNode` callee. When the callee is a single-arity, non-variadic, non-recursive, non-memoised pure `defn` (body read from the `GlobalEnvironment` `defFnNode` side-table) and every argument is pure, the body is spliced at the call site with parameters replaced by the argument nodes and envs rebased onto the caller. Purity here is structural via `SymbolicPurityDetector` (a closed allowlist of side-effect-free `phel.core` / `php/` ops), unlike `PureExpressionDetector` which proves purity by full evaluation. At opt level < 2 `tryInline` returns `null` immediately, so default output is unchanged.
+
 ## Structure
 
 ```

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
@@ -127,7 +127,9 @@ final readonly class CallInliner
             $paramMap[$param->getName()] = $args[$i];
         }
 
-        $inlined = $this->rebase($ret, $env, $env->getContext(), $callLocation, $paramMap, true);
+        // `rebase` can still abort (returning `null`) if the body holds a
+        // node type outside the whitelist or a non-parameter local.
+        $inlined = $this->rebase($ret, new RebaseContext($env, $env->getContext(), $callLocation, $paramMap, true));
         if (!$inlined instanceof AbstractNode) {
             return null;
         }
@@ -147,74 +149,55 @@ final readonly class CallInliner
 
     /**
      * Rebuilds a whitelisted node onto the call-site environment.
-     *
-     * `$inBody` distinguishes the two walks that share this logic: the
-     * callee body (where a `LocalVarNode` naming a parameter is replaced
-     * by its argument, and any other local aborts the inline) and an
-     * argument subtree (where every `LocalVarNode` is a caller-scope
-     * local and is kept verbatim). Switching to argument mode on
-     * substitution prevents a caller local that happens to share a
-     * parameter's name from being substituted a second time.
-     *
-     * @param array<string, AbstractNode> $paramMap
      */
-    private function rebase(
-        AbstractNode $node,
-        NodeEnvironmentInterface $env,
-        string $context,
-        ?SourceLocation $loc,
-        array $paramMap,
-        bool $inBody,
-    ): ?AbstractNode {
-        $targetEnv = $env->withContext($context);
-
+    private function rebase(AbstractNode $node, RebaseContext $ctx): ?AbstractNode
+    {
         if ($node instanceof LiteralNode) {
-            return new LiteralNode($targetEnv, $node->getValue(), $loc);
+            return new LiteralNode($ctx->targetEnv(), $node->getValue(), $ctx->loc);
         }
 
         if ($node instanceof GlobalVarNode) {
-            return new GlobalVarNode($targetEnv, $node->getNamespace(), $node->getName(), $node->getMeta(), $loc);
+            return new GlobalVarNode($ctx->targetEnv(), $node->getNamespace(), $node->getName(), $node->getMeta(), $ctx->loc);
         }
 
         if ($node instanceof PhpVarNode) {
-            return new PhpVarNode($targetEnv, $node->getName(), $loc);
+            return new PhpVarNode($ctx->targetEnv(), $node->getName(), $ctx->loc);
         }
 
         if ($node instanceof LocalVarNode) {
-            return $this->rebaseLocalVar($node, $env, $context, $loc, $paramMap, $inBody);
+            return $this->rebaseLocalVar($node, $ctx);
         }
 
         if ($node instanceof CallNode) {
-            return $this->rebaseCall($node, $env, $context, $loc, $paramMap, $inBody);
+            return $this->rebaseCall($node, $ctx);
         }
 
         if ($node instanceof IfNode) {
-            return $this->rebaseIf($node, $env, $context, $loc, $paramMap, $inBody);
+            return $this->rebaseIf($node, $ctx);
         }
 
         return null;
     }
 
     /**
-     * @param array<string, AbstractNode> $paramMap
+     * `$ctx->inBody` distinguishes the two walks that share the rebasing
+     * logic: the callee body (where a `LocalVarNode` naming a parameter
+     * is replaced by its argument, and any other local aborts the
+     * inline) and an argument subtree (where every `LocalVarNode` is a
+     * caller-scope local and is kept verbatim). Switching to argument
+     * mode on substitution prevents a caller local that happens to share
+     * a parameter's name from being substituted a second time.
      */
-    private function rebaseLocalVar(
-        LocalVarNode $node,
-        NodeEnvironmentInterface $env,
-        string $context,
-        ?SourceLocation $loc,
-        array $paramMap,
-        bool $inBody,
-    ): ?AbstractNode {
-        $name = $node->getName()->getName();
-
-        if (!$inBody) {
+    private function rebaseLocalVar(LocalVarNode $node, RebaseContext $ctx): ?AbstractNode
+    {
+        if (!$ctx->inBody) {
             // Caller-scope local inside an argument subtree: keep it.
-            return new LocalVarNode($env->withContext($context), $node->getName(), $loc);
+            return new LocalVarNode($ctx->targetEnv(), $node->getName(), $ctx->loc);
         }
 
-        if (array_key_exists($name, $paramMap)) {
-            return $this->rebase($paramMap[$name], $env, $context, $loc, $paramMap, false);
+        $name = $node->getName()->getName();
+        if (array_key_exists($name, $ctx->paramMap)) {
+            return $this->rebase($ctx->paramMap[$name], $ctx->asArgument());
         }
 
         // A non-parameter local in the callee body would reference a
@@ -222,25 +205,18 @@ final readonly class CallInliner
         return null;
     }
 
-    /**
-     * @param array<string, AbstractNode> $paramMap
-     */
-    private function rebaseCall(
-        CallNode $node,
-        NodeEnvironmentInterface $env,
-        string $context,
-        ?SourceLocation $loc,
-        array $paramMap,
-        bool $inBody,
-    ): ?AbstractNode {
-        $fn = $this->rebase($node->getFn(), $env, NodeEnvironment::CONTEXT_EXPRESSION, $loc, $paramMap, $inBody);
+    private function rebaseCall(CallNode $node, RebaseContext $ctx): ?AbstractNode
+    {
+        $subCtx = $ctx->withContext(NodeEnvironment::CONTEXT_EXPRESSION);
+
+        $fn = $this->rebase($node->getFn(), $subCtx);
         if (!$fn instanceof AbstractNode) {
             return null;
         }
 
         $args = [];
         foreach ($node->getArguments() as $arg) {
-            $rebased = $this->rebase($arg, $env, NodeEnvironment::CONTEXT_EXPRESSION, $loc, $paramMap, $inBody);
+            $rebased = $this->rebase($arg, $subCtx);
             if (!$rebased instanceof AbstractNode) {
                 return null;
             }
@@ -248,29 +224,20 @@ final readonly class CallInliner
             $args[] = $rebased;
         }
 
-        return new CallNode($env->withContext($context), $fn, $args, $loc);
+        return new CallNode($ctx->targetEnv(), $fn, $args, $ctx->loc);
     }
 
-    /**
-     * @param array<string, AbstractNode> $paramMap
-     */
-    private function rebaseIf(
-        IfNode $node,
-        NodeEnvironmentInterface $env,
-        string $context,
-        ?SourceLocation $loc,
-        array $paramMap,
-        bool $inBody,
-    ): ?AbstractNode {
-        $test = $this->rebase($node->getTestExpr(), $env, NodeEnvironment::CONTEXT_EXPRESSION, $loc, $paramMap, $inBody);
-        $then = $this->rebase($node->getThenExpr(), $env, $context, $loc, $paramMap, $inBody);
-        $else = $this->rebase($node->getElseExpr(), $env, $context, $loc, $paramMap, $inBody);
+    private function rebaseIf(IfNode $node, RebaseContext $ctx): ?AbstractNode
+    {
+        $test = $this->rebase($node->getTestExpr(), $ctx->withContext(NodeEnvironment::CONTEXT_EXPRESSION));
+        $then = $this->rebase($node->getThenExpr(), $ctx);
+        $else = $this->rebase($node->getElseExpr(), $ctx);
 
         if (!$test instanceof AbstractNode || !$then instanceof AbstractNode || !$else instanceof AbstractNode) {
             return null;
         }
 
-        return new IfNode($env->withContext($context), $test, $then, $else, $loc);
+        return new IfNode($ctx->targetEnv(), $test, $then, $else, $ctx->loc);
     }
 
     private function fold(AbstractNode $node): AbstractNode

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification;
+
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\RecurFrame;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\ConstantFolder;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\SourceLocation;
+
+use function array_key_exists;
+use function count;
+
+/**
+ * Inlines a call to a single-expression pure `defn` at the call site
+ * (issue #2135). Instead of dispatching through the resolved
+ * `AbstractFn`, the callee's body is spliced in with each parameter
+ * replaced by the corresponding (analysed) argument node, skipping one
+ * PHP frame and exposing the body to downstream constant folding.
+ *
+ * Gated behind `setOptimizationLevel >= 2`: at lower levels every call
+ * routes through the normal dispatch path, so the compiled stdlib stays
+ * byte-identical.
+ *
+ * Soundness rests on three restrictions:
+ *
+ *  1. **Pure arguments only.** Each argument must be pure per
+ *     {@see SymbolicPurityDetector}, so dropping (unused param),
+ *     duplicating (param used more than once) or reordering it across
+ *     the splice has no observable effect.
+ *  2. **Pure single-expression body.** The body must be one pure
+ *     expression (a `DoNode` with no leading statements), so splicing it
+ *     exactly once preserves the callee's semantics and effect count.
+ *  3. **Closed node whitelist.** Only node types whose environment can
+ *     be safely rebased onto the call site are rewritten; anything else
+ *     aborts the inline (returns `null`) and the call falls back to
+ *     dispatch.
+ *
+ * Because the spliced nodes are already analysed (globals resolved,
+ * macros expanded), inlining works across namespaces and never
+ * re-enters the analyzer, so no re-resolution or re-expansion can occur.
+ */
+final readonly class CallInliner
+{
+    public function __construct(
+        private SymbolicPurityDetector $purity = new SymbolicPurityDetector(),
+        private ConstantFolder $folder = new ConstantFolder(),
+    ) {}
+
+    /**
+     * @param list<AbstractNode> $args analysed arguments, in expression context
+     *
+     * @return AbstractNode|null the inlined (and folded) node, or `null`
+     *                           when the call must keep dispatching
+     */
+    public function tryInline(
+        GlobalVarNode $f,
+        array $args,
+        NodeEnvironmentInterface $env,
+        AnalyzerInterface $analyzer,
+        ?SourceLocation $callLocation = null,
+    ): ?AbstractNode {
+        if ($analyzer->getOptimizationLevel() < 2) {
+            return null;
+        }
+
+        if ($this->isMemoisedOrAsync($f->getMeta())) {
+            return null;
+        }
+
+        // The side-table only holds single-arity `defn` bodies; a `null`
+        // here means the callee is unknown, multi-arity, or not a `defn`.
+        $fnNode = $analyzer->getDefFnNode($f->getNamespace(), $f->getName());
+        if (!$fnNode instanceof FnNode) {
+            return null;
+        }
+
+        if ($fnNode->isVariadic() || $fnNode->getRecurs()) {
+            return null;
+        }
+
+        // Stay out of the tail slot of an enclosing `loop`/`recur` frame
+        // so we never disturb tail-call semantics.
+        if ($env->getCurrentRecurFrame() instanceof RecurFrame
+            && $env->isContext(NodeEnvironment::CONTEXT_RETURN)
+        ) {
+            return null;
+        }
+
+        $params = $fnNode->getParams();
+        if (count($params) !== count($args)) {
+            return null;
+        }
+
+        $body = $fnNode->getBody();
+        if (!$body instanceof DoNode || $body->getStmts() !== []) {
+            return null;
+        }
+
+        foreach ($args as $arg) {
+            if (!$this->purity->isPure($arg)) {
+                return null;
+            }
+        }
+
+        $ret = $body->getRet();
+        if (!$this->purity->isPure($ret)) {
+            return null;
+        }
+
+        $paramMap = [];
+        foreach ($params as $i => $param) {
+            $paramMap[$param->getName()] = $args[$i];
+        }
+
+        $inlined = $this->rebase($ret, $env, $env->getContext(), $callLocation, $paramMap, true);
+        if (!$inlined instanceof AbstractNode) {
+            return null;
+        }
+
+        return $this->fold($inlined);
+    }
+
+    /**
+     * @param PersistentMapInterface<mixed, mixed> $meta
+     */
+    private function isMemoisedOrAsync(PersistentMapInterface $meta): bool
+    {
+        return (bool) $meta[Keyword::create('memoize')]
+            || (bool) $meta[Keyword::create('memoize-lru')]
+            || (bool) $meta[Keyword::create('async')];
+    }
+
+    /**
+     * Rebuilds a whitelisted node onto the call-site environment.
+     *
+     * `$inBody` distinguishes the two walks that share this logic: the
+     * callee body (where a `LocalVarNode` naming a parameter is replaced
+     * by its argument, and any other local aborts the inline) and an
+     * argument subtree (where every `LocalVarNode` is a caller-scope
+     * local and is kept verbatim). Switching to argument mode on
+     * substitution prevents a caller local that happens to share a
+     * parameter's name from being substituted a second time.
+     *
+     * @param array<string, AbstractNode> $paramMap
+     */
+    private function rebase(
+        AbstractNode $node,
+        NodeEnvironmentInterface $env,
+        string $context,
+        ?SourceLocation $loc,
+        array $paramMap,
+        bool $inBody,
+    ): ?AbstractNode {
+        $targetEnv = $env->withContext($context);
+
+        if ($node instanceof LiteralNode) {
+            return new LiteralNode($targetEnv, $node->getValue(), $loc);
+        }
+
+        if ($node instanceof GlobalVarNode) {
+            return new GlobalVarNode($targetEnv, $node->getNamespace(), $node->getName(), $node->getMeta(), $loc);
+        }
+
+        if ($node instanceof PhpVarNode) {
+            return new PhpVarNode($targetEnv, $node->getName(), $loc);
+        }
+
+        if ($node instanceof LocalVarNode) {
+            return $this->rebaseLocalVar($node, $env, $context, $loc, $paramMap, $inBody);
+        }
+
+        if ($node instanceof CallNode) {
+            return $this->rebaseCall($node, $env, $context, $loc, $paramMap, $inBody);
+        }
+
+        if ($node instanceof IfNode) {
+            return $this->rebaseIf($node, $env, $context, $loc, $paramMap, $inBody);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, AbstractNode> $paramMap
+     */
+    private function rebaseLocalVar(
+        LocalVarNode $node,
+        NodeEnvironmentInterface $env,
+        string $context,
+        ?SourceLocation $loc,
+        array $paramMap,
+        bool $inBody,
+    ): ?AbstractNode {
+        $name = $node->getName()->getName();
+
+        if (!$inBody) {
+            // Caller-scope local inside an argument subtree: keep it.
+            return new LocalVarNode($env->withContext($context), $node->getName(), $loc);
+        }
+
+        if (array_key_exists($name, $paramMap)) {
+            return $this->rebase($paramMap[$name], $env, $context, $loc, $paramMap, false);
+        }
+
+        // A non-parameter local in the callee body would reference a
+        // binding we are not introducing here: refuse to inline.
+        return null;
+    }
+
+    /**
+     * @param array<string, AbstractNode> $paramMap
+     */
+    private function rebaseCall(
+        CallNode $node,
+        NodeEnvironmentInterface $env,
+        string $context,
+        ?SourceLocation $loc,
+        array $paramMap,
+        bool $inBody,
+    ): ?AbstractNode {
+        $fn = $this->rebase($node->getFn(), $env, NodeEnvironment::CONTEXT_EXPRESSION, $loc, $paramMap, $inBody);
+        if (!$fn instanceof AbstractNode) {
+            return null;
+        }
+
+        $args = [];
+        foreach ($node->getArguments() as $arg) {
+            $rebased = $this->rebase($arg, $env, NodeEnvironment::CONTEXT_EXPRESSION, $loc, $paramMap, $inBody);
+            if (!$rebased instanceof AbstractNode) {
+                return null;
+            }
+
+            $args[] = $rebased;
+        }
+
+        return new CallNode($env->withContext($context), $fn, $args, $loc);
+    }
+
+    /**
+     * @param array<string, AbstractNode> $paramMap
+     */
+    private function rebaseIf(
+        IfNode $node,
+        NodeEnvironmentInterface $env,
+        string $context,
+        ?SourceLocation $loc,
+        array $paramMap,
+        bool $inBody,
+    ): ?AbstractNode {
+        $test = $this->rebase($node->getTestExpr(), $env, NodeEnvironment::CONTEXT_EXPRESSION, $loc, $paramMap, $inBody);
+        $then = $this->rebase($node->getThenExpr(), $env, $context, $loc, $paramMap, $inBody);
+        $else = $this->rebase($node->getElseExpr(), $env, $context, $loc, $paramMap, $inBody);
+
+        if (!$test instanceof AbstractNode || !$then instanceof AbstractNode || !$else instanceof AbstractNode) {
+            return null;
+        }
+
+        return new IfNode($env->withContext($context), $test, $then, $else, $loc);
+    }
+
+    private function fold(AbstractNode $node): AbstractNode
+    {
+        if ($node instanceof CallNode) {
+            return $this->folder->fold($node) ?? $node;
+        }
+
+        if ($node instanceof IfNode) {
+            return $this->folder->foldIf($node) ?? $node;
+        }
+
+        return $node;
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/RebaseContext.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/RebaseContext.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Lang\SourceLocation;
+
+/**
+ * Immutable walk state threaded through {@see CallInliner}'s body
+ * rebasing. Bundles the call-site environment, the context the node
+ * being built should emit under, the source location to stamp, the
+ * parameter-to-argument substitution map, and whether the walk is
+ * currently inside the callee body (`true`) or an argument subtree
+ * (`false`).
+ */
+final readonly class RebaseContext
+{
+    /**
+     * @param array<string, AbstractNode> $paramMap
+     */
+    public function __construct(
+        public NodeEnvironmentInterface $env,
+        public string $context,
+        public ?SourceLocation $loc,
+        public array $paramMap,
+        public bool $inBody,
+    ) {}
+
+    public function withContext(string $context): self
+    {
+        return new self($this->env, $context, $this->loc, $this->paramMap, $this->inBody);
+    }
+
+    public function asArgument(): self
+    {
+        return new self($this->env, $this->context, $this->loc, $this->paramMap, false);
+    }
+
+    public function targetEnv(): NodeEnvironmentInterface
+    {
+        return $this->env->withContext($this->context);
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/SymbolicPurityDetector.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/SymbolicPurityDetector.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Shared\CompilerConstants;
+
+use function array_all;
+
+/**
+ * Symbolic purity oracle for the call inliner.
+ *
+ * Unlike {@see PureExpressionDetector} — which proves purity by fully
+ * evaluating a node at compile time and therefore reports any expression
+ * over a free variable as impure — this detector decides purity
+ * *structurally*: an expression is pure when it only references
+ * literals / locals / globals and calls a closed allowlist of
+ * side-effect-free `phel.core` fns (or their `php/` infix equivalents)
+ * on pure arguments.
+ *
+ * "Pure" here means: evaluating the node has no observable effect (no
+ * I/O, no mutation, no global state change). A pure expression may still
+ * raise (e.g. `(/ x 0)`) — the inliner splices the body exactly once, so
+ * any such exception keeps its original trigger point.
+ *
+ * The fn allowlist mirrors the scalar operations {@see ConstantFolder}
+ * already evaluates at compile time: that set is, by construction, a
+ * vetted list of effect-free core fns.
+ */
+final readonly class SymbolicPurityDetector
+{
+    /**
+     * Side-effect-free `phel.core` fns. Mirrors the scalar ops
+     * {@see ConstantFolder::compute()} and {@see ConstantFolder::BOOL_PREDICATES}
+     * already trust as pure enough to evaluate at compile time.
+     *
+     * @var array<string, true>
+     */
+    private const array PURE_CORE_FNS = [
+        '+' => true,
+        '-' => true,
+        '*' => true,
+        '/' => true,
+        'inc' => true,
+        'dec' => true,
+        '=' => true,
+        'not=' => true,
+        '<' => true,
+        '<=' => true,
+        '>' => true,
+        '>=' => true,
+        'min' => true,
+        'max' => true,
+        'mod' => true,
+        'quot' => true,
+        'rem' => true,
+        'abs' => true,
+        'not' => true,
+        'nil?' => true,
+        'true?' => true,
+        'false?' => true,
+        'boolean' => true,
+    ];
+
+    /**
+     * Side-effect-free `php/` infix operators. Excludes `=` / `=&`
+     * (assignment), `.` (concat / property access ambiguity) and
+     * `instanceof`, none of which the inliner needs.
+     *
+     * @var array<string, true>
+     */
+    private const array PURE_PHP_OPS = [
+        '+' => true,
+        '-' => true,
+        '*' => true,
+        '/' => true,
+        '%' => true,
+        '**' => true,
+        '==' => true,
+        '===' => true,
+        '!=' => true,
+        '!==' => true,
+        '<' => true,
+        '>' => true,
+        '<=' => true,
+        '>=' => true,
+        '<=>' => true,
+        '|' => true,
+        '&' => true,
+        '^' => true,
+        '<<' => true,
+        '>>' => true,
+        '~' => true,
+    ];
+
+    public function isPure(AbstractNode $node): bool
+    {
+        if ($node instanceof LiteralNode
+            || $node instanceof LocalVarNode
+            || $node instanceof GlobalVarNode
+            || $node instanceof PhpVarNode
+        ) {
+            return true;
+        }
+
+        if ($node instanceof IfNode) {
+            return $this->isPure($node->getTestExpr())
+                && $this->isPure($node->getThenExpr())
+                && $this->isPure($node->getElseExpr());
+        }
+
+        if ($node instanceof CallNode) {
+            return $this->isPureCall($node);
+        }
+
+        return false;
+    }
+
+    private function isPureCall(CallNode $node): bool
+    {
+        if (!$this->isPureOperator($node->getFn())) {
+            return false;
+        }
+
+        return array_all(
+            $node->getArguments(),
+            fn(AbstractNode $arg): bool => $this->isPure($arg),
+        );
+    }
+
+    private function isPureOperator(AbstractNode $fn): bool
+    {
+        if ($fn instanceof PhpVarNode) {
+            return isset(self::PURE_PHP_OPS[$fn->getName()]);
+        }
+
+        if ($fn instanceof GlobalVarNode) {
+            return $fn->getNamespace() === CompilerConstants::PHEL_CORE_NAMESPACE
+                && isset(self::PURE_CORE_FNS[$fn->getName()->getName()]);
+        }
+
+        return false;
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/SymbolicPurityDetector.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/SymbolicPurityDetector.php
@@ -38,9 +38,13 @@ use function array_all;
 final readonly class SymbolicPurityDetector
 {
     /**
-     * Side-effect-free `phel.core` fns. Mirrors the scalar ops
-     * {@see ConstantFolder::compute()} and {@see ConstantFolder::BOOL_PREDICATES}
-     * already trust as pure enough to evaluate at compile time.
+     * Side-effect-free `phel.core` fns. Drawn from the scalar ops
+     * {@see \Phel\Compiler\Domain\Analyzer\TypeAnalyzer\ConstantFolder::compute()}
+     * and its boolean predicates already trust as pure enough to evaluate
+     * at compile time. This set is intentionally *wider* in applicability:
+     * the folder only fires on literal arguments, whereas the inliner
+     * accepts these ops over free variables too, so it must be updated
+     * separately when a new pure-but-not-foldable core fn appears.
      *
      * @var array<string, true>
      */

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -6,6 +6,7 @@ namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
 use Exception;
 use Phel;
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
@@ -15,7 +16,6 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\ConstantFolder;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification\CallInliner;
-use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
@@ -39,11 +39,18 @@ use function sprintf;
  *
  * Invokes a function or callable with the given arguments.
  */
-final class InvokeSymbol implements SpecialFormAnalyzerInterface
+final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
 {
-    use WithAnalyzerTrait;
-
     private const string UNHANDLED = "\0__phel_unhandled__";
+
+    private CallInliner $callInliner;
+
+    public function __construct(
+        private AnalyzerInterface $analyzer,
+        ?CallInliner $callInliner = null,
+    ) {
+        $this->callInliner = $callInliner ?? new CallInliner();
+    }
 
     /**
      * @param PersistentListInterface<mixed> $list
@@ -76,10 +83,10 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
         if ($f instanceof GlobalVarNode) {
             $this->verifyArgsAgainstParamTags($f, $args, $list);
 
-            // Skip the inliner allocation entirely on the default path;
-            // it only does work at optimization level >= 2.
+            // Skip the inliner call on the default path; it only does
+            // work at optimization level >= 2.
             if ($this->analyzer->getOptimizationLevel() >= 2) {
-                $inlined = new CallInliner()->tryInline($f, $args, $env, $this->analyzer, $list->getStartLocation());
+                $inlined = $this->callInliner->tryInline($f, $args, $env, $this->analyzer, $list->getStartLocation());
                 if ($inlined instanceof AbstractNode) {
                     return $inlined;
                 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -14,6 +14,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\ConstantFolder;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification\CallInliner;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -74,6 +75,11 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
 
         if ($f instanceof GlobalVarNode) {
             $this->verifyArgsAgainstParamTags($f, $args, $list);
+
+            $inlined = new CallInliner()->tryInline($f, $args, $env, $this->analyzer, $list->getStartLocation());
+            if ($inlined instanceof AbstractNode) {
+                return $inlined;
+            }
         }
 
         $call = new CallNode(

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -76,9 +76,13 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
         if ($f instanceof GlobalVarNode) {
             $this->verifyArgsAgainstParamTags($f, $args, $list);
 
-            $inlined = new CallInliner()->tryInline($f, $args, $env, $this->analyzer, $list->getStartLocation());
-            if ($inlined instanceof AbstractNode) {
-                return $inlined;
+            // Skip the inliner allocation entirely on the default path;
+            // it only does work at optimization level >= 2.
+            if ($this->analyzer->getOptimizationLevel() >= 2) {
+                $inlined = new CallInliner()->tryInline($f, $args, $env, $this->analyzer, $list->getStartLocation());
+                if ($inlined instanceof AbstractNode) {
+                    return $inlined;
+                }
             }
         }
 

--- a/tests/php/Integration/Compiler/CallInlineRuntimeTest.php
+++ b/tests/php/Integration/Compiler/CallInlineRuntimeTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Compiler;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompileOptions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * End-to-end coverage for the call inliner gated behind
+ * `CompileOptions::setOptimizationLevel(2)` (issue #2135). A call to a
+ * single-expression pure `defn` is spliced at the call site instead of
+ * dispatching through the resolved `AbstractFn`.
+ */
+final class CallInlineRuntimeTest extends TestCase
+{
+    private static GlobalEnvironmentInterface $globalEnv;
+
+    private CompilerFacade $compilerFacade;
+
+    public static function setUpBeforeClass(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Symbol::resetGen();
+        $globalEnv = GlobalEnvironmentSingleton::initializeNew();
+        new BuildFacade()->compileFile(
+            __DIR__ . '/../../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core'),
+        );
+        self::$globalEnv = $globalEnv;
+    }
+
+    protected function setUp(): void
+    {
+        $this->compilerFacade = new CompilerFacade();
+        self::$globalEnv->setNs('user');
+        Symbol::resetGen();
+    }
+
+    public function test_literal_call_folds_to_a_constant(): void
+    {
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval('(defn my-inc [x] (+ x 1))', $options);
+
+        $result = $this->compilerFacade->eval('(my-inc 5)', $options);
+
+        self::assertSame(6, $result);
+    }
+
+    public function test_symbolic_call_is_inlined_skipping_the_callee_frame(): void
+    {
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval('(defn my-double [x] (* x 2))', $options);
+
+        $php = $this->compilerFacade->compile('(let [y 10] (my-double y))', $options)->getPhpCode();
+
+        // The callee dispatch is gone; only the spliced `*` op remains.
+        self::assertStringNotContainsString('my-double', $php);
+        self::assertSame(20, $this->compilerFacade->eval('(let [y 10] (my-double y))', $options));
+    }
+
+    public function test_shadowed_caller_local_is_not_captured(): void
+    {
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval('(defn add1 [x] (+ x 1))', $options);
+
+        // The caller binds `x` to 99; the param `x` must resolve to the
+        // argument 7, not the caller local, so the result is 8 not 100.
+        $result = $this->compilerFacade->eval('(let [x 99] (add1 7))', $options);
+
+        self::assertSame(8, $result);
+    }
+
+    public function test_side_effecting_callee_is_not_inlined(): void
+    {
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval('(defn shout [x] (str x "!"))', $options);
+
+        // `str` is pure, so `shout` *is* inlinable — sanity that it runs.
+        self::assertSame('hi!', $this->compilerFacade->eval('(shout "hi")', $options));
+
+        // A genuinely side-effecting body must keep dispatching.
+        $this->compilerFacade->eval('(defn log-it [x] (php/printf "%d" x))', $options);
+        $php = $this->compilerFacade->compile('(log-it 5)', $options)->getPhpCode();
+
+        self::assertStringContainsString('log-it', $php, 'side-effecting callee should still dispatch');
+    }
+
+    public function test_recursive_callee_is_not_inlined(): void
+    {
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval(
+            '(defn sum-to [n acc] (if (zero? n) acc (recur (dec n) (+ acc n))))',
+            $options,
+        );
+
+        $result = $this->compilerFacade->eval('(sum-to 5 0)', $options);
+
+        self::assertSame(15, $result);
+    }
+
+    public function test_opt_level_zero_keeps_the_dispatch(): void
+    {
+        $options = new CompileOptions();
+        $this->compilerFacade->eval('(defn my-inc0 [x] (+ x 1))', $options);
+
+        $php = $this->compilerFacade->compile('(my-inc0 5)', $options)->getPhpCode();
+
+        self::assertStringContainsString('my-inc0', $php);
+        self::assertSame(6, $this->compilerFacade->eval('(my-inc0 5)', $options));
+    }
+}

--- a/tests/php/Integration/Compiler/CallInlineRuntimeTest.php
+++ b/tests/php/Integration/Compiler/CallInlineRuntimeTest.php
@@ -81,12 +81,15 @@ final class CallInlineRuntimeTest extends TestCase
     public function test_side_effecting_callee_is_not_inlined(): void
     {
         $options = new CompileOptions()->setOptimizationLevel(2);
-        $this->compilerFacade->eval('(defn shout [x] (str x "!"))', $options);
 
-        // `str` is pure, so `shout` *is* inlinable — sanity that it runs.
+        // `str` is not in the purity allowlist, so `shout` is NOT inlined;
+        // the call keeps dispatching and still returns the right value.
+        $this->compilerFacade->eval('(defn shout [x] (str x "!"))', $options);
+        $shoutPhp = $this->compilerFacade->compile('(shout "hi")', $options)->getPhpCode();
+        self::assertStringContainsString('shout', $shoutPhp, 'non-allowlisted callee should still dispatch');
         self::assertSame('hi!', $this->compilerFacade->eval('(shout "hi")', $options));
 
-        // A genuinely side-effecting body must keep dispatching.
+        // A genuinely side-effecting body must keep dispatching too.
         $this->compilerFacade->eval('(defn log-it [x] (php/printf "%d" x))', $options);
         $php = $this->compilerFacade->compile('(log-it 5)', $options)->getPhpCode();
 

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/CallInlinerTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/CallInlinerTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\TypeAnalyzer\Simplification;
+
+use Phel;
+use Phel\Compiler\Application\Analyzer;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification\CallInliner;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
+use PHPUnit\Framework\TestCase;
+
+final class CallInlinerTest extends TestCase
+{
+    private CallInliner $inliner;
+
+    private Analyzer $analyzer;
+
+    private NodeEnvironment $env;
+
+    protected function setUp(): void
+    {
+        $this->inliner = new CallInliner();
+        $this->analyzer = new Analyzer(new GlobalEnvironment());
+        $this->analyzer->setOptimizationLevel(2);
+
+        $this->env = NodeEnvironment::empty()->withExpressionContext();
+    }
+
+    public function test_inlines_and_folds_literal_call(): void
+    {
+        // (defn my-inc [x] (+ x 1)) ; call (my-inc 5) -> 6
+        $this->seedDefn('my-inc', ['x'], $this->plusBody('x', 1));
+
+        $result = $this->inline('my-inc', [new LiteralNode($this->env, 5)]);
+
+        self::assertInstanceOf(LiteralNode::class, $result);
+        self::assertSame(6, $result->getValue());
+    }
+
+    public function test_inlines_symbolic_call_to_a_pure_body(): void
+    {
+        // (my-inc y) where y is a caller local -> a (+ y 1) call, no dispatch.
+        $this->seedDefn('my-inc', ['x'], $this->plusBody('x', 1));
+
+        $result = $this->inline('my-inc', [new LocalVarNode($this->env, Symbol::create('y'))]);
+
+        self::assertInstanceOf(CallNode::class, $result);
+        $args = $result->getArguments();
+        self::assertInstanceOf(LocalVarNode::class, $args[0]);
+        self::assertSame('y', $args[0]->getName()->getName());
+    }
+
+    public function test_declines_when_optimization_level_below_2(): void
+    {
+        $this->analyzer->setOptimizationLevel(1);
+        $this->seedDefn('my-inc', ['x'], $this->plusBody('x', 1));
+
+        self::assertNull($this->inline('my-inc', [new LiteralNode($this->env, 5)]));
+    }
+
+    public function test_declines_when_no_side_table_entry(): void
+    {
+        // No seedDefn call: the callee is unknown / multi-arity.
+        self::assertNull($this->inline('unknown', [new LiteralNode($this->env, 5)]));
+    }
+
+    public function test_declines_variadic_callee(): void
+    {
+        $this->seedDefn('my-list', ['xs'], $this->plusBody('xs', 1), isVariadic: true);
+
+        self::assertNull($this->inline('my-list', [new LiteralNode($this->env, 5)]));
+    }
+
+    public function test_declines_recursive_callee(): void
+    {
+        $this->seedDefn('my-loop', ['x'], $this->plusBody('x', 1), recurs: true);
+
+        self::assertNull($this->inline('my-loop', [new LiteralNode($this->env, 5)]));
+    }
+
+    public function test_declines_on_arity_mismatch(): void
+    {
+        $this->seedDefn('my-inc', ['x'], $this->plusBody('x', 1));
+
+        self::assertNull($this->inline('my-inc', [
+            new LiteralNode($this->env, 5),
+            new LiteralNode($this->env, 6),
+        ]));
+    }
+
+    public function test_declines_impure_argument(): void
+    {
+        $this->seedDefn('my-inc', ['x'], $this->plusBody('x', 1));
+
+        // arg `(some-fn)` is a user call -> impure
+        $impureArg = new CallNode(
+            $this->env,
+            new GlobalVarNode($this->env, 'user', Symbol::create('some-fn'), Phel::map()),
+            [],
+        );
+
+        self::assertNull($this->inline('my-inc', [$impureArg]));
+    }
+
+    public function test_declines_impure_body(): void
+    {
+        // (defn log-it [x] (println x)) -> body is side-effecting
+        $body = new DoNode($this->env, [], new CallNode(
+            $this->env,
+            new GlobalVarNode($this->env, CompilerConstants::PHEL_CORE_NAMESPACE, Symbol::create('println'), Phel::map()),
+            [new LocalVarNode($this->env, Symbol::create('x'))],
+        ));
+        $this->seedDefn('log-it', ['x'], $body);
+
+        self::assertNull($this->inline('log-it', [new LiteralNode($this->env, 5)]));
+    }
+
+    public function test_declines_multi_statement_body(): void
+    {
+        $body = new DoNode(
+            $this->env,
+            [new LiteralNode($this->env, 1)],
+            $this->plusRet('x', 1),
+        );
+        $this->seedDefn('my-inc', ['x'], $body);
+
+        self::assertNull($this->inline('my-inc', [new LiteralNode($this->env, 5)]));
+    }
+
+    public function test_declines_memoised_callee(): void
+    {
+        $this->seedDefn('my-inc', ['x'], $this->plusBody('x', 1));
+        $meta = Phel::map(Keyword::create('memoize'), true);
+
+        self::assertNull($this->inline('my-inc', [new LiteralNode($this->env, 5)], $meta));
+    }
+
+    /**
+     * @param list<string> $paramNames
+     */
+    private function seedDefn(
+        string $name,
+        array $paramNames,
+        DoNode $body,
+        bool $isVariadic = false,
+        bool $recurs = false,
+    ): void {
+        $params = array_map(Symbol::create(...), $paramNames);
+        $fnNode = new FnNode($this->env, $params, $body, [], $isVariadic, $recurs);
+        $this->analyzer->setDefFnNode('user', Symbol::create($name), $fnNode);
+    }
+
+    /**
+     * @param list<AbstractNode> $args
+     */
+    private function inline(string $name, array $args, ?PersistentMapInterface $meta = null): ?AbstractNode
+    {
+        $f = new GlobalVarNode($this->env, 'user', Symbol::create($name), $meta ?? Phel::map());
+
+        return $this->inliner->tryInline($f, $args, $this->env, $this->analyzer);
+    }
+
+    private function plusBody(string $param, int $addend): DoNode
+    {
+        return new DoNode($this->env, [], $this->plusRet($param, $addend));
+    }
+
+    private function plusRet(string $param, int $addend): CallNode
+    {
+        return new CallNode(
+            $this->env,
+            new GlobalVarNode($this->env, CompilerConstants::PHEL_CORE_NAMESPACE, Symbol::create('+'), Phel::map()),
+            [new LocalVarNode($this->env, Symbol::create($param)), new LiteralNode($this->env, $addend)],
+        );
+    }
+}

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/SymbolicPurityDetectorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/SymbolicPurityDetectorTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\TypeAnalyzer\Simplification;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification\SymbolicPurityDetector;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
+use PHPUnit\Framework\TestCase;
+
+final class SymbolicPurityDetectorTest extends TestCase
+{
+    private SymbolicPurityDetector $detector;
+
+    private NodeEnvironment $env;
+
+    protected function setUp(): void
+    {
+        $this->detector = new SymbolicPurityDetector();
+        $this->env = NodeEnvironment::empty()->withExpressionContext();
+    }
+
+    public function test_literal_is_pure(): void
+    {
+        self::assertTrue($this->detector->isPure(new LiteralNode($this->env, 42)));
+    }
+
+    public function test_local_var_is_pure(): void
+    {
+        self::assertTrue($this->detector->isPure(new LocalVarNode($this->env, Symbol::create('x'))));
+    }
+
+    public function test_global_var_reference_is_pure(): void
+    {
+        $node = new GlobalVarNode($this->env, 'user', Symbol::create('my-fn'), Phel::map());
+
+        self::assertTrue($this->detector->isPure($node));
+    }
+
+    public function test_core_arithmetic_over_free_var_is_pure(): void
+    {
+        // `(+ x 1)` — the case PureExpressionDetector reports impure
+        // because it cannot fold a free variable. Structurally it is pure.
+        self::assertTrue($this->detector->isPure($this->coreCall('+', [
+            new LocalVarNode($this->env, Symbol::create('x')),
+            new LiteralNode($this->env, 1),
+        ])));
+    }
+
+    public function test_nested_pure_calls_are_pure(): void
+    {
+        // `(* (+ x 1) 2)`
+        $inner = $this->coreCall('+', [
+            new LocalVarNode($this->env, Symbol::create('x')),
+            new LiteralNode($this->env, 1),
+        ]);
+
+        self::assertTrue($this->detector->isPure($this->coreCall('*', [
+            $inner,
+            new LiteralNode($this->env, 2),
+        ])));
+    }
+
+    public function test_pure_if_branches_are_pure(): void
+    {
+        $node = new IfNode(
+            $this->env,
+            $this->coreCall('<', [new LocalVarNode($this->env, Symbol::create('x')), new LiteralNode($this->env, 0)]),
+            new LiteralNode($this->env, 'neg'),
+            new LocalVarNode($this->env, Symbol::create('x')),
+        );
+
+        self::assertTrue($this->detector->isPure($node));
+    }
+
+    public function test_php_infix_operator_is_pure(): void
+    {
+        $node = new CallNode($this->env, new PhpVarNode($this->env, '+'), [
+            new LocalVarNode($this->env, Symbol::create('x')),
+            new LiteralNode($this->env, 1),
+        ]);
+
+        self::assertTrue($this->detector->isPure($node));
+    }
+
+    public function test_side_effecting_core_call_is_impure(): void
+    {
+        self::assertFalse($this->detector->isPure($this->coreCall('println', [
+            new LocalVarNode($this->env, Symbol::create('x')),
+        ])));
+    }
+
+    public function test_user_call_is_impure(): void
+    {
+        $node = new CallNode(
+            $this->env,
+            new GlobalVarNode($this->env, 'user', Symbol::create('add'), Phel::map()),
+            [new LiteralNode($this->env, 1)],
+        );
+
+        self::assertFalse($this->detector->isPure($node));
+    }
+
+    public function test_pure_call_with_impure_argument_is_impure(): void
+    {
+        // `(+ (println x) 1)` — operator is pure but an argument is not.
+        $node = $this->coreCall('+', [
+            $this->coreCall('println', [new LocalVarNode($this->env, Symbol::create('x'))]),
+            new LiteralNode($this->env, 1),
+        ]);
+
+        self::assertFalse($this->detector->isPure($node));
+    }
+
+    public function test_php_assignment_operator_is_impure(): void
+    {
+        $node = new CallNode($this->env, new PhpVarNode($this->env, '='), [
+            new LocalVarNode($this->env, Symbol::create('x')),
+            new LiteralNode($this->env, 1),
+        ]);
+
+        self::assertFalse($this->detector->isPure($node));
+    }
+
+    public function test_unhandled_node_type_is_impure(): void
+    {
+        self::assertFalse($this->detector->isPure(new VectorNode($this->env, [])));
+    }
+
+    /**
+     * @param list<AbstractNode> $args
+     */
+    private function coreCall(string $name, array $args): CallNode
+    {
+        return new CallNode(
+            $this->env,
+            new GlobalVarNode($this->env, CompilerConstants::PHEL_CORE_NAMESPACE, Symbol::create($name), Phel::map()),
+            $args,
+        );
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Direct positional dispatch (#2117) and the `defn` `FnNode` side-table (#2202) landed earlier. The next step (#2135): when a call site targets a single-expression pure `defn`, splice the body in instead of dispatching through the resolved `AbstractFn`. This skips one PHP frame and exposes the body to downstream constant folding.

The bench-first gate `CallInliningBench` (#2209) already established the win. Measured here:

| subject | per-call |
|---|---|
| `status_quo` (dispatch) | ~0.074 μs |
| `inlined` | ~0.020 μs |
| `direct` (folded) | ~0.020 μs |

~3.7× faster at the call site.

While wiring this up, `PureExpressionDetector` turned out unsuitable as the body gate: it proves purity by *full constant evaluation*, so a symbolic body like `(+ x 1)` (free param) is reported impure. A dedicated structural oracle was needed to reach the symbolic frame-skip case the issue targets.

## 💡 Goal

Inline calls to single-arity pure `defn`s at the call site, gated behind `CompileOptions::setOptimizationLevel(2)`, leaving the default (level 0) output byte-identical.

- `(my-inc 5)` → `6` (inlined, then constant-folded)
- `(my-inc x)` → `(+ x 1)` (inlined, `my-inc` frame skipped)
- recursive / variadic / memoised / `^:async` / side-effecting callees → unchanged dispatch

## 🔖 Changes

- **`SymbolicPurityDetector`** — structural purity oracle: a node is pure when it only references literals / locals / globals and calls a closed allowlist of side-effect-free `phel.core` fns (or `php/` infix ops) on pure arguments. Mirrors `ConstantFolder`'s vetted scalar-op set, but decides purity *symbolically* (over free vars) rather than by evaluation.
- **`CallInliner`** — reads the callee body from the `GlobalEnvironment` `defFnNode` side-table and, when the gates pass (opt ≥ 2, single arity, non-variadic, no `recur`, not memoised/`^:async`, one pure expression body, pure args, arity match, not in an enclosing recur tail), rebuilds the body onto the call-site environment with each parameter replaced by its argument node, then constant-folds the result. Anything outside the node whitelist aborts the inline (falls back to dispatch). Because spliced nodes are already analysed, it works across namespaces and never re-enters the analyzer — no re-resolution, no capture.
- **`InvokeSymbol`** — adds the `CallInliner::tryInline()` branch for `GlobalVarNode` callees, after arg analysis and param-tag checks.
- Unit tests for both new classes; runtime acceptance tests (literal fold, symbolic frame-skip, shadowed-name hygiene, recursion/side-effect exclusion, opt-0 dispatch fallback).
- `CHANGELOG.md` (Unreleased) and `src/php/Compiler/CLAUDE.md` updated.

Closes #2135
