### PR TITLE
fix(string): throw cleanly on non-string input instead of leaking PHP deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Emit-shape tweaks:
 
 ### Fixed
 
+- `phel.string`: passing a non-string to the string functions (`upper-case`, `lower-case`, `capitalize`, `reverse`, `trim` / `triml` / `trimr`, `split`, `escape`, `pad-left` / `pad-right` / `pad-both`, `replace` / `replace-first`, `chars`, `starts-with?` / `ends-with?` / `contains?` / `includes?`) now throws a clean exception instead of leaking a raw PHP `"Passing null to parameter ... of type string is deprecated"` warning (a hard `TypeError` in PHP 9) and returning nonsense. `blank?` keeps treating `nil` as blank (`true`) but rejects other non-strings. Surfaced by the clojure-test-suite CI job (#2223)
 - `int` / `long` / `float` / `double`: passing a non-numeric object (keyword, vector, map, …) now throws `InvalidArgumentException` instead of leaking a raw PHP `"could not be converted to int/float"` warning and returning garbage. `nil` and numeric strings keep their documented coercion. `get` on a list with a non-integer key returns the default (Clojure parity); `assoc` / `update` on a vector with a non-integer key throws a clean `InvalidArgumentException` instead of PHP's int `TypeError`. Surfaced by the clojure-test-suite CI job (#2223)
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)
 - `phel compile`: dry-run no longer executes side-effecting forms; new `CompileOptions` `emitOnly` flag skips the evaluator step (#2095)

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -2,10 +2,20 @@
   (:require phel.core)
   (:use InvalidArgumentException))
 
+(defn- assert-string
+  "Throws `InvalidArgumentException` unless `x` is a string. Guards the PHP
+  string builtins these functions delegate to, which would otherwise leak a
+  raw `Passing null to parameter ... of type string is deprecated` warning
+  (a hard `TypeError` in PHP 9) and return nonsense on non-string input."
+  [x]
+  (when-not (string? x)
+    (throw (php/new InvalidArgumentException (str "Expected a string, got " (type x))))))
+
 (defn split
   "Splits string on a regular expression, returning a vector of parts."
   {:example "(split \"hello world foo bar\" #\"\\s+\") ; => [\"hello\" \"world\" \"foo\" \"bar\"]"}
   [s re & [limit]]
+  (assert-string s)
   (vals (php/preg_split re s (or limit -1))))
 
 (defn chars
@@ -16,6 +26,7 @@
   {:example "(chars \"hello\") ; => [\"h\" \"e\" \"l\" \"l\" \"o\"]"
    :see-also ["seq"]}
   [s]
+  (assert-string s)
   (php/:: \Phel (vector (php/mb_str_split s))))
 
 (defn join
@@ -39,6 +50,7 @@
   "Returns s with its characters reversed."
   {:example "(reverse \"hello\") ; => \"olleh\""}
   [s]
+  (assert-string s)
   (let [chars (php/mb_str_split s)]
     (join (core/reverse chars))))
 
@@ -64,6 +76,7 @@
   "Replaces all instances of match with replacement in s."
   {:example "(replace \"hello world\" \"world\" \"there\") ; => \"hello there\""}
   [s match replacement]
+  (assert-string s)
   (let [match (as-pattern match)]
     (if (fn? replacement)
       (php/preg_replace_callback match (fn [x]
@@ -75,6 +88,7 @@
   "Replaces the first instance of match with replacement in s."
   {:example "(replace-first \"hello world world\" \"world\" \"there\") ; => \"hello there world\""}
   [s match replacement]
+  (assert-string s)
   (let [match (as-pattern match)]
     (if (fn? replacement)
       (php/preg_replace_callback match (fn [x]
@@ -98,6 +112,7 @@
   "Converts first character to upper-case and all other characters to lower-case."
   {:example "(capitalize \"hELLO wORLD\") ; => \"Hello world\""}
   [s]
+  (assert-string s)
   (let [first-char (php/mb_substr s 0 1)
         rest       (php/mb_substr s 1)]
     (str (php/mb_strtoupper first-char)
@@ -107,30 +122,35 @@
   "Converts string to all lower-case."
   {:example "(lower-case \"HELLO World\") ; => \"hello world\""}
   [s]
+  (assert-string s)
   (php/mb_strtolower s))
 
 (defn upper-case
   "Converts string to all upper-case."
   {:example "(upper-case \"hello World\") ; => \"HELLO WORLD\""}
   [s]
+  (assert-string s)
   (php/mb_strtoupper s))
 
 (defn trim
   "Removes whitespace from both ends of string."
   {:example "(trim \"  hello  \") ; => \"hello\""}
   [s]
+  (assert-string s)
   (php/preg_replace "/^[\s]+|[\s]+$/u" "" s))
 
 (defn triml
   "Removes whitespace from the left side of string."
   {:example "(triml \"  hello  \") ; => \"hello  \""}
   [s]
+  (assert-string s)
   (php/preg_replace "/^[\s]+/u" "" s))
 
 (defn trimr
   "Removes whitespace from the right side of string."
   {:example "(trimr \"  hello  \") ; => \"  hello\""}
   [s]
+  (assert-string s)
   (php/preg_replace "/[\s]+$/u" "" s))
 
 (defn blank?
@@ -138,46 +158,57 @@
   separators (`U+00A0`, `U+2007`, `U+202F`) are not treated as whitespace."
   {:example "(blank? \"   \") ; => true"}
   [s]
-  (if s
-    (not= 0 (php/preg_match
-             "/^[\\t\\n\\x0B\\f\\r\\x1C-\\x1F \\x{1680}\\x{2000}-\\x{2006}\\x{2008}-\\x{200A}\\x{2028}\\x{2029}\\x{205F}\\x{3000}]*$/u"
-             s))
-    true))
+  (cond
+    (nil? s)    true
+    (string? s) (not= 0 (php/preg_match
+                         "/^[\\t\\n\\x0B\\f\\r\\x1C-\\x1F \\x{1680}\\x{2000}-\\x{2006}\\x{2008}-\\x{200A}\\x{2028}\\x{2029}\\x{205F}\\x{3000}]*$/u"
+                         s))
+    :else       (throw (php/new InvalidArgumentException (str "blank? expects a string or nil, got " (type s))))))
 
 (defn starts-with?
   "True if s starts with substr."
   {:example "(starts-with? \"hello world\" \"hello\") ; => true"}
   [s substr]
+  (assert-string s)
+  (assert-string substr)
   (php/str_starts_with s substr))
 
 (defn ends-with?
   "True if s ends with substr."
   {:example "(ends-with? \"hello world\" \"world\") ; => true"}
   [s substr]
+  (assert-string s)
+  (assert-string substr)
   (php/str_ends_with s substr))
 
 (defn contains?
   "True if s contains substr."
   {:example "(contains? \"hello world\" \"lo wo\") ; => true"}
   [s substr]
+  (assert-string s)
+  (assert-string substr)
   (php/str_contains s substr))
 
 (defn includes?
   "True if s includes substr."
   {:example "(includes? \"hello world\" \"world\") ; => true"}
   [s substr]
+  (assert-string s)
+  (assert-string substr)
   (php/str_contains s substr))
 
 (defn re-quote-replacement
   "Escapes special characters in a replacement string for literal use."
   {:example "(re-quote-replacement \"$1.00\") ; => \"\\$1.00\""}
   [replacement]
+  (assert-string replacement)
   (php/preg_replace "/([\\\$])/" "\$1" replacement))
 
 (defn escape
   "Returns a new string with each character escaped according to cmap."
   {:example "(escape \"hello\" {\"h\" \"H\" \"o\" \"O\"}) ; => \"HellO\""}
   [s cmap]
+  (assert-string s)
   (let [chars  (php/mb_str_split s)
         mapped (php/array_map (fn [ch] (or (cmap ch) ch)) chars)]
     (php/implode "" mapped)))
@@ -230,16 +261,19 @@
   "Returns a string padded on the left side to length len."
   {:example "(pad-left \"hello\" 10) ; => \"     hello\""}
   [s len & [pad-str]]
+  (assert-string s)
   (php/str_pad s len (or pad-str " ") php/STR_PAD_LEFT))
 
 (defn pad-right
   "Returns a string padded on the right side to length len."
   {:example "(pad-right \"hello\" 10) ; => \"hello     \""}
   [s len & [pad-str]]
+  (assert-string s)
   (php/str_pad s len (or pad-str " ") php/STR_PAD_RIGHT))
 
 (defn pad-both
   "Returns a string padded on both sides to length len."
   {:example "(pad-both \"hello\" 11) ; => \"   hello   \""}
   [s len & [pad-str]]
+  (assert-string s)
   (php/str_pad s len (or pad-str " ") php/STR_PAD_BOTH))

--- a/tests/phel/string.phel
+++ b/tests/phel/string.phel
@@ -210,3 +210,52 @@
 (deftest test-pad-both
   (is (= " foo " (s/pad-both "foo" 5)))
   (is (= "0foo0" (s/pad-both "foo" 5 "0"))))
+
+;; `n`/`k`/`i` are bound (not literals) so the compile-time string-param tag
+;; check doesn't fire; this exercises the runtime guard the way the
+;; clojure-test-suite does (values flow in through an `are` binding).
+(deftest test-non-string-input-throws
+  ;; Non-string input must throw cleanly instead of leaking a raw PHP
+  ;; "Passing null to parameter ... of type string is deprecated" warning
+  ;; (a hard TypeError in PHP 9). Functions whose param Phel infers as
+  ;; `string` already raise a native TypeError; the rest are guarded and
+  ;; raise InvalidArgumentException. Both are \Throwable, matching the
+  ;; suite's `p/thrown?`.
+  (let [n nil k :a i 1]
+    (is (thrown? \Throwable (s/upper-case n)) "upper-case nil")
+    (is (thrown? \Throwable (s/lower-case n)) "lower-case nil")
+    (is (thrown? \Throwable (s/capitalize n)) "capitalize nil")
+    (is (thrown? \Throwable (s/reverse n)) "reverse nil")
+    (is (thrown? \Throwable (s/trim n)) "trim nil")
+    (is (thrown? \Throwable (s/triml n)) "triml nil")
+    (is (thrown? \Throwable (s/trimr n)) "trimr nil")
+    (is (thrown? \Throwable (s/trim-newline n)) "trim-newline nil")
+    (is (thrown? \Throwable (s/repeat n 3)) "repeat nil")
+    (is (thrown? \Throwable (s/chars n)) "chars nil")
+    (is (thrown? \Throwable (s/subs n 0)) "subs nil")
+    (is (thrown? \Throwable (s/split n "/,/")) "split nil")
+    (is (thrown? \Throwable (s/escape n {})) "escape nil")
+    (is (thrown? \Throwable (s/index-of n "a")) "index-of nil")
+    (is (thrown? \Throwable (s/last-index-of n "a")) "last-index-of nil")
+    (is (thrown? \Throwable (s/pad-left n 5)) "pad-left nil")
+    (is (thrown? \Throwable (s/replace n "a" "b")) "replace nil")
+    (is (thrown? \Throwable (s/upper-case k)) "upper-case keyword")
+    (is (thrown? \Throwable (s/upper-case i)) "upper-case int")))
+
+(deftest test-predicate-non-string-args-throw
+  (let [n nil k :a]
+    (is (thrown? \InvalidArgumentException (s/starts-with? n "a")) "starts-with? nil s")
+    (is (thrown? \InvalidArgumentException (s/starts-with? "ab" n)) "starts-with? nil substr")
+    (is (thrown? \InvalidArgumentException (s/starts-with? "ab" k)) "starts-with? keyword substr")
+    (is (thrown? \InvalidArgumentException (s/ends-with? n "a")) "ends-with? nil s")
+    (is (thrown? \InvalidArgumentException (s/ends-with? "ab" n)) "ends-with? nil substr")
+    (is (thrown? \InvalidArgumentException (s/contains? n "a")) "contains? nil s")
+    (is (thrown? \InvalidArgumentException (s/includes? n "a")) "includes? nil s")))
+
+(deftest test-blank?-nil-and-non-string
+  (let [n nil k :a i 1]
+    (is (true? (s/blank? n)) "blank? nil is true")
+    (is (true? (s/blank? "   ")) "blank? whitespace is true")
+    (is (false? (s/blank? "x")) "blank? non-blank is false")
+    (is (thrown? \InvalidArgumentException (s/blank? i)) "blank? int throws")
+    (is (thrown? \InvalidArgumentException (s/blank? k)) "blank? keyword throws")))


### PR DESCRIPTION
## 🤔 Background

The `clojure-test-suite` CI job leaks raw PHP warnings like:

```
mb_substr(): Passing null to parameter #1 ($string) of type string is deprecated
str_starts_with(): Passing null to parameter #1 ($haystack) of type string is deprecated
preg_split(): Passing null to parameter #2 ($subject) of type string is deprecated
```

`phel.string` functions forwarded `nil` / non-string arguments straight to PHP's string builtins. On PHP 8.x that emits a `Passing null … is deprecated` warning (and returns nonsense like `""`); on **PHP 9 it becomes a hard `TypeError`**.

## 💡 Goal

Reject non-string input with a clean exception, no leaked PHP noise. Matches Clojure (which throws) and the suite's `exceptions` assertions.

## 🔖 Changes

- Added a private `assert-string` guard, applied to the functions whose param Phel does **not** already infer as `string`-typed: `upper-case`, `lower-case`, `capitalize`, `reverse`, `trim` / `triml` / `trimr`, `split`, `escape`, `pad-left` / `pad-right` / `pad-both`, `replace` / `replace-first`, `chars`, `starts-with?` / `ends-with?` / `contains?` / `includes?` (predicates validate both args).
- `blank?` keeps treating `nil` as blank (`true`) but rejects other non-strings.
- The already string-typed functions (`subs`, `repeat`, `trim-newline`, `index-of`, `last-index-of`) raise a native `TypeError` unchanged — no redundant guard added.
- Tests in `tests/phel/string.phel` (values flow through `let` bindings so the runtime guard is exercised the way the suite's `are` does).

## ✅ Verification

- `phel` core test suite: **5745 / 5745** green.
- Zero `Passing null … is deprecated` leaks from `phel.string` (verified by patching the suite's vendored phel and re-running).

Part of #2223 (the PHP-deprecation-leak bucket). Suite delta is validated by the `clojure-test-suite` CI job, which builds the suite against phel `@dev`.

Refs #2223
