### PR TITLE
docs(api): expose phel.edn/transit/reflect in API tooling

### DIFF
--- a/src/phel/transit.phel
+++ b/src/phel/transit.phel
@@ -283,7 +283,7 @@
 
 (defn write-string
   "Serialises `value` to a Transit+JSON-Verbose string."
-  {:example "(write-string {:a 1}) ; => \"{\\\"~:a\\\":1}\""
+  {:example "(write-string {:a 1}) ; => \"[\\\"~#cmap\\\",[\\\"~:a\\\",1]]\""
    :see-also ["read-string"]}
   [value]
   (php/json_encode (encode value) json-flags))

--- a/src/php/Api/ApiConfig.php
+++ b/src/php/Api/ApiConfig.php
@@ -19,6 +19,7 @@ final class ApiConfig extends AbstractConfig
             'phel.base64',
             'phel.cli',
             'phel.core',
+            'phel.edn',
             'phel.html',
             'phel.http',
             'phel.json',
@@ -26,6 +27,7 @@ final class ApiConfig extends AbstractConfig
             'phel.mock',
             'phel.pprint',
             'phel.reader',
+            'phel.reflect',
             'phel.repl',
             'phel.router',
             'phel.schema',
@@ -35,6 +37,7 @@ final class ApiConfig extends AbstractConfig
             'phel.test.rose',
             'phel.test.selector',
             'phel.test.shrink',
+            'phel.transit',
             'phel.walk',
             'phel.watch',
         ];


### PR DESCRIPTION
## Summary

`phel.edn`, `phel.reflect`, and `phel.transit` are public, shipped modules, but they are missing from `ApiConfig::allNamespaces()`. That list is the single source of truth for the API tooling, so today these three modules are invisible to:

- the generated API reference (no pages on phel-lang.org)
- REPL autocompletion (`replComplete` / `replCompleteWithTypes`)
- `phel doc` / symbol metadata lookup
- the `api.json` / API search index

This PR adds the three namespaces to the list (alphabetical slots) so they are documented and discoverable on par with every other built-in module.

It also corrects the `phel.transit/write-string` docstring example, which claimed a JSON-object output that the function never produces.

## Changes

- `src/php/Api/ApiConfig.php`: add `'phel.edn'`, `'phel.reflect'`, `'phel.transit'` to `allNamespaces()`.
- `src/phel/transit.phel`: fix the `write-string` `:example`. Maps serialise to the Transit `"~#cmap"` array form, not a JSON object.

```clojure
;; before (wrong)
(write-string {:a 1}) ; => "{\"~:a\":1}"

;; after (actual runtime output)
(write-string {:a 1}) ; => "[\"~#cmap\",[\"~:a\",1]]"
```

## Verification

Runtime output confirming the modules work and the corrected example (Phel v0.40.0):

```clojure
(edn/read-string "{:a 1 :b [2 3]}")    ; => {:a 1, :b [2 3]}
(edn/write-string {:a 1 :b [2 3]})     ; => "{:a 1, :b [2 3]}"
(transit/write-string {:a 1})          ; => "[\"~#cmap\",[\"~:a\",1]]"
(transit/read-string "[\"~:foo\",1]")  ; => [:foo 1]
(reflect/class-info \DateTime)         ; => {:name ... :methods ... :properties ... :parents ... :interfaces ...}
(reflect/supers \RuntimeException)     ; => #{Exception Throwable Stringable}
```

After the change, `composer build` on the website regenerates the three reference pages and the API search index includes them.

## Notes

- No behaviour change: this only registers existing public modules with the doc/tooling layer.
- If `allNamespaces()` is covered by a snapshot/fixture test, the snapshot needs regenerating in the same PR.

## Discovered via

Auditing the phel-lang.org docs against the runtime: the three modules were documented in the website's cheat-sheet/guides but had no generated API reference because of this missing registration.
