### PR TITLE
fix(build): never evict a (load ...) secondary the current build still needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Emit-shape tweaks:
 - `get` / `nth` on a vector with a non-int key return the default / throw `OutOfBoundsException` instead of leaking a PHP warning (#2211)
 - Reader meta on vector / map / set literals survives compile/emit, fixing `group-by` element-meta loss (#2189)
 - `BigInt` / `BigDecimal::fromFloat` render `NaN` / `Infinity` in rejection messages instead of coercing to string (PHP 8.5 warning)
+- `phel build`: LRU eviction in the compiled-code cache no longer drops a `(load ...)` secondary the current build still needs, which could ship a `phel/core.php` whose `(load "core/meta")` had no compiled sibling and failed at runtime away from the source tree; a build never evicts entries it produced this run
 
 ## [0.40.0](https://github.com/phel-lang/phel-lang/compare/v0.39.0...v0.40.0) - 2026-05-25
 

--- a/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
+++ b/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
@@ -41,6 +41,17 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
      */
     private array $tombstones = [];
 
+    /**
+     * Source paths put or read in this process. A build `(load ...)`s its
+     * secondaries into the cache and the `SecondaryFileHarvester` reads them
+     * back at the end of the same run; LRU eviction triggered by a later
+     * `put` must never delete a file this run still needs, or the build
+     * would ship a `(load ...)` with no compiled sibling.
+     *
+     * @var array<string, true>
+     */
+    private array $touchedThisProcess = [];
+
     private bool $loaded = false;
 
     /**
@@ -95,6 +106,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
         }
 
         $this->entries[$sourcePath]['last_accessed'] = time();
+        $this->touchedThisProcess[$sourcePath] = true;
 
         return $compiledPath;
     }
@@ -136,6 +148,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
             'compiled_path' => $compiledPath,
             'last_accessed' => time(),
         ];
+        $this->touchedThisProcess[$sourcePath] = true;
         unset($this->tombstones[$sourcePath]);
 
         $this->evictLRU();
@@ -218,7 +231,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
             @unlink($compiledPath);
         }
 
-        unset($this->entries[$sourcePath]);
+        unset($this->entries[$sourcePath], $this->touchedThisProcess[$sourcePath]);
         $this->tombstones[$sourcePath] = true;
         $this->saveEntries();
     }
@@ -240,6 +253,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
 
         $this->entries = [];
         $this->tombstones = [];
+        $this->touchedThisProcess = [];
         $this->saveEntries();
         $this->envMemo = [];
     }
@@ -455,6 +469,13 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
     /**
      * Evicts least-recently-used entries when the entry count exceeds
      * `$maxEntries`. Removes ~10% of the oldest entries.
+     *
+     * Entries touched in this process are never evicted: a build loads its
+     * secondaries into the cache and the `SecondaryFileHarvester` reads them
+     * back at the end of the same run, so dropping one mid-build would ship
+     * a `(load ...)` with no compiled sibling. This makes `maxEntries` a soft
+     * cap for the current run; stale entries from earlier runs reclaim space
+     * on the next process.
      */
     private function evictLRU(): void
     {
@@ -470,6 +491,10 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
         foreach (array_keys($this->entries) as $sourcePath) {
             if ($evicted >= $evictCount) {
                 break;
+            }
+
+            if (isset($this->touchedThisProcess[$sourcePath])) {
+                continue;
             }
 
             $entry = $this->entries[$sourcePath];

--- a/tests/php/Unit/Build/Infrastructure/Cache/CompiledCodeCacheTest.php
+++ b/tests/php/Unit/Build/Infrastructure/Cache/CompiledCodeCacheTest.php
@@ -259,16 +259,21 @@ final class CompiledCodeCacheTest extends TestCase
 
     public function test_lru_eviction_removes_oldest_entries(): void
     {
-        $cache = new CompiledCodeCache($this->cacheDir, '', 5);
-
+        // Seed entries in one process, then let a fresh instance evict.
+        // Entries are only evictable once a *later* process inherits them
+        // from disk without touching them; the producing process protects
+        // its own working set (see test_entries_touched_this_process_are_not_evicted).
+        $seed = new CompiledCodeCache($this->cacheDir, '', 5);
         for ($i = 1; $i <= 5; ++$i) {
-            $cache->put($this->cacheDir . sprintf('/ns%d.phel', $i), 'ns' . $i, 'hash' . $i, '// code ' . $i);
+            $seed->put($this->cacheDir . sprintf('/ns%d.phel', $i), 'ns' . $i, 'hash' . $i, '// code ' . $i);
         }
 
-        // Access ns3 to mark it recently used
+        $cache = new CompiledCodeCache($this->cacheDir, '', 5);
+
+        // Access ns3 to mark it recently used in this process
         $cache->get($this->cacheDir . '/ns3.phel', 'hash3');
 
-        // Add a 6th entry — should evict the oldest (ns1)
+        // Add a 6th entry — should evict the oldest untouched entry (ns1)
         $cache->put($this->cacheDir . '/ns6.phel', 'ns6', 'hash6', '// code 6');
 
         self::assertNull($cache->get($this->cacheDir . '/ns1.phel', 'hash1'));
@@ -278,18 +283,38 @@ final class CompiledCodeCacheTest extends TestCase
 
     public function test_lru_eviction_deletes_files(): void
     {
-        $cache = new CompiledCodeCache($this->cacheDir, '', 3);
+        $seed = new CompiledCodeCache($this->cacheDir, '', 3);
+        $seed->put($this->cacheDir . '/ns1.phel', 'ns1', 'hash1', '// code 1');
+        $seed->put($this->cacheDir . '/ns2.phel', 'ns2', 'hash2', '// code 2');
+        $seed->put($this->cacheDir . '/ns3.phel', 'ns3', 'hash3', '// code 3');
 
-        $cache->put($this->cacheDir . '/ns1.phel', 'ns1', 'hash1', '// code 1');
-        $cache->put($this->cacheDir . '/ns2.phel', 'ns2', 'hash2', '// code 2');
-        $cache->put($this->cacheDir . '/ns3.phel', 'ns3', 'hash3', '// code 3');
-
-        $path1 = $cache->getCompiledPath($this->cacheDir . '/ns1.phel', 'ns1');
+        $path1 = $seed->getCompiledPath($this->cacheDir . '/ns1.phel', 'ns1');
         self::assertFileExists($path1);
 
+        $cache = new CompiledCodeCache($this->cacheDir, '', 3);
         $cache->put($this->cacheDir . '/ns4.phel', 'ns4', 'hash4', '// code 4');
 
         self::assertFileDoesNotExist($path1);
+    }
+
+    public function test_entries_touched_this_process_are_not_evicted(): void
+    {
+        // A build `(load ...)`s its secondaries into the cache and the
+        // SecondaryFileHarvester reads them back at the end of the same run.
+        // Even when the run exceeds maxEntries, none of its own entries may
+        // be dropped, or the build would ship a `(load ...)` with no sibling.
+        $cache = new CompiledCodeCache($this->cacheDir, '', 3);
+
+        for ($i = 1; $i <= 6; ++$i) {
+            $cache->put($this->cacheDir . sprintf('/ns%d.phel', $i), 'ns' . $i, 'hash' . $i, '// code ' . $i);
+        }
+
+        for ($i = 1; $i <= 6; ++$i) {
+            self::assertNotNull(
+                $cache->get($this->cacheDir . sprintf('/ns%d.phel', $i), 'hash' . $i),
+                sprintf('Entry ns%d produced this process must survive eviction', $i),
+            );
+        }
     }
 
     public function test_no_eviction_when_under_max_entries(): void


### PR DESCRIPTION
## 🤔 Background

`phel build` compiles a namespace split across `(load ...)` sub-files: the primary compiles directly, while each secondary is pulled in by the primary's `(load ...)` at build-time eval, which leaves its compiled `.php` in the compiled-code cache. `SecondaryFileHarvester` then copies those cached files into the build output so the artifact ships a sibling `.php` for every `(load ...)`.

The cache enforces an LRU cap (`maxEntries`, default 500), evicting the oldest entries on every `put`. When a build crossed that cap, eviction deleted a secondary the build still needed (`core/meta` is loaded first, so it is the oldest and first victim). The harvester then found nothing, silently skipped it, and shipped a `phel/core.php` whose `(load "core/meta")` had no compiled sibling — fatal at runtime away from the source tree. Surfaced as a flaky `BuildCommandLoadE2ETest` failure.

## 💡 Goal

A build must never evict cache entries it produced in the same run before the harvester reads them back.

## 🔖 Changes

- `CompiledCodeCache` tracks source paths `put`/`get` in the current process and skips them during LRU eviction. `maxEntries` becomes a soft cap for the active run; stale entries from earlier runs still reclaim space on the next process.
- Updated the eviction unit tests to exercise the real cross-process scenario and added a regression test pinning the build-protection contract.
- CHANGELOG updated.