### PR TITLE
ref(compiler): consolidate emitter test tree + read opt-level live in FnSymbol

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -49,8 +49,8 @@ return RectorConfig::configure()
             __DIR__ . '/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php',
             __DIR__ . '/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/SetVarEmitter.php',
             __DIR__ . '/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VectorEmitter.php',
-            __DIR__ . '/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php',
-            __DIR__ . '/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php',
+            __DIR__ . '/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php',
+            __DIR__ . '/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php',
         ],
         PrivatizeFinalClassPropertyRector::class => [
             __DIR__ . '/tests/php/Unit/Printer/TypePrinter/StubStruct.php',

--- a/src/php/Compiler/Application/Analyzer.php
+++ b/src/php/Compiler/Application/Analyzer.php
@@ -56,9 +56,10 @@ final class Analyzer implements AnalyzerInterface
 
     public function setOptimizationLevel(int $level): void
     {
-        // Resetting the cached list analyzer ensures the next analyze
-        // call reads the new level when wiring up special-form handlers
-        // (e.g. FnSymbol picks up the level at construction time).
+        // Special-form handlers read the level live via
+        // $this->analyzer->getOptimizationLevel(), so no cached handler holds a
+        // stale level. The list-analyzer reset is kept as a cheap defensive
+        // guard in case a future handler ever captures the level at construction.
         $this->optimizationLevel = max(0, $level);
         $this->listAnalyzer = null;
     }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -312,7 +312,6 @@ final class AnalyzePersistentList
             Symbol::NAME_FN => new FnSymbol(
                 $this->analyzer,
                 $this->assertsEnabled,
-                optimizationLevel: $this->analyzer->getOptimizationLevel(),
             ),
             Symbol::NAME_QUOTE => new QuoteSymbol(),
             Symbol::NAME_VAR => new VarSymbol($this->analyzer),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -40,7 +40,6 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
         private AnalyzerInterface $analyzer,
         private bool $assertsEnabled = true,
         private ReturnTypeInferrer $returnTypeInferrer = new ReturnTypeInferrer(),
-        private int $optimizationLevel = 0,
         private TailCallRewriter $tailCallRewriter = new TailCallRewriter(),
     ) {}
 
@@ -170,7 +169,7 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
 
         [$selfNs, $selfNameStr] = $this->splitBoundTo($env->getBoundTo());
 
-        if ($this->optimizationLevel >= 2
+        if ($this->analyzer->getOptimizationLevel() >= 2
             && $selfNs !== null
             && $selfNameStr !== null
             && !$fnSymbolTuple->isVariadic()

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitterTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhelTest\Unit\Compiler\Emitter\OutputEmitter;
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\CompilerFactory;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\LiteralEmitter;

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhelTest\Unit\Compiler\Emitter\OutputEmitter\NodeEmitter;
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\CompilerFactory;
 use Phel\Compiler\Domain\Analyzer\Ast\ApplyNode;

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitterTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhelTest\Unit\Compiler\Emitter\OutputEmitter\NodeEmitter;
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\CompilerFactory;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhelTest\Unit\Compiler\Emitter\OutputEmitter\NodeEmitter;
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\CompilerFactory;
 use Phel\Compiler\Domain\Analyzer\Ast\FnNode;

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/InNsEmitterTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/InNsEmitterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhelTest\Unit\Compiler\Emitter\OutputEmitter\NodeEmitter;
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\CompilerFactory;
 use Phel\Compiler\Domain\Analyzer\Ast\InNsNode;

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitterTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhelTest\Unit\Compiler\Emitter\OutputEmitter\NodeEmitter;
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\CompilerFactory;
 use Phel\Compiler\Domain\Analyzer\Ast\NsNode;

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/OutputEmitterOptionsTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/OutputEmitterOptionsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhelTest\Unit\Compiler\Emitter\OutputEmitter;
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\Domain\Emitter\OutputEmitter\EmitMode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\OutputEmitterOptions;

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/SourceMap/VLQTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/SourceMap/VLQTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhelTest\Unit\Compiler\Emitter\OutputEmitter\SourceMap;
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\SourceMap;
 
 use Phel\Compiler\Domain\Emitter\OutputEmitter\SourceMap\VLQ;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
## 🤔 Background

Two internal-quality issues surfaced while auditing the `Compiler` module:

1. A half-finished test-directory migration left a stale `tests/php/Unit/Compiler/Emitter/` tree living alongside the current `tests/php/Unit/Compiler/Domain/Emitter/` tree — confusing about where emitter tests belong.
2. `FnSymbol` captured the optimization level at **construction time**, while its sibling `InvokeSymbol` reads it **live** from the analyzer. `Analyzer::setOptimizationLevel()` only worked by accident (nulling `listAnalyzer` forced a fresh `symbolAnalyzerCache`), an implicit, undocumented coupling that would silently break opt-level switching if the cache strategy ever changed.

## 💡 Goal

Remove the duplicate test tree and the fragile opt-level coupling — pure internal cleanup, no behavior or public-API change.

## 🔖 Changes

- Move 8 stale emitter unit tests (`LiteralEmitter`, `OutputEmitterOptions`, `VLQ`, `Apply`, `Call`, `FnAsClass`, `Ns`, `InNs`) from `Unit/Compiler/Emitter/` into the `Unit/Compiler/Domain/Emitter/` tree to mirror `src/` layout; update namespaces and the two `rector.php` skip paths accordingly.
- `FnSymbol` now reads the optimization level live via `$this->analyzer->getOptimizationLevel()` (consistent with `InvokeSymbol`) instead of capturing it in the constructor; drop the now-dead `optimizationLevel` ctor param and its pass-through in `AnalyzePersistentList`.
- Clarify the `Analyzer::setOptimizationLevel()` comment: handlers read the level live, and the `listAnalyzer` reset is now a cheap defensive measure rather than the correctness mechanism.

No user-facing change, so no CHANGELOG entry. All 3806 compiler tests pass; psalm/phpstan/cs-fixer/rector clean.