### PR TITLE
ref(compiler): inject Munge into AnalyzePersistentList + richer NotSupportedAstException

### DIFF
--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -53,6 +53,7 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
 use Phel\Shared\Exceptions\AbstractLocatedException;
 use Phel\Shared\Munge;
+use Phel\Shared\MungeInterface;
 
 use function count;
 use function in_array;
@@ -70,6 +71,7 @@ final class AnalyzePersistentList
     public function __construct(
         private readonly AnalyzerInterface $analyzer,
         private readonly bool $assertsEnabled,
+        private readonly MungeInterface $munge = new Munge(),
     ) {}
 
     /**
@@ -335,7 +337,7 @@ final class AnalyzePersistentList
             Symbol::NAME_THROW => new ThrowSymbol($this->analyzer),
             Symbol::NAME_LOOP => new LoopSymbol($this->analyzer, new BindingValidator()),
             Symbol::NAME_FOREACH => new ForeachSymbol($this->analyzer),
-            Symbol::NAME_DEF_STRUCT => new DefStructSymbol($this->analyzer, new Munge(), new MethodBodyAnalyzer($this->analyzer)),
+            Symbol::NAME_DEF_STRUCT => new DefStructSymbol($this->analyzer, $this->munge, new MethodBodyAnalyzer($this->analyzer)),
             Symbol::NAME_DEF_EXCEPTION => new DefExceptionSymbol($this->analyzer),
             Symbol::NAME_PHP_OBJECT_SET => new PhpOSetSymbol($this->analyzer),
             Symbol::NAME_SET_VAR => new SetVarSymbol($this->analyzer),

--- a/src/php/Compiler/Domain/Emitter/Exceptions/NotSupportedAstException.php
+++ b/src/php/Compiler/Domain/Emitter/Exceptions/NotSupportedAstException.php
@@ -12,6 +12,11 @@ final class NotSupportedAstException extends RuntimeException
 {
     public static function withClassName(string $astNodeClassName): self
     {
-        return new self(sprintf("Not supported AstClassName: '%s'", $astNodeClassName));
+        return new self(sprintf(
+            "No node emitter is registered for AST node '%s'. "
+            . 'The analyzer produced a node the emitter cannot handle; '
+            . 'register an emitter for it in NodeEmitterFactory::instantiateEmitter().',
+            $astNodeClassName,
+        ));
     }
 }

--- a/tests/php/Unit/Compiler/Domain/Emitter/Exceptions/NotSupportedAstExceptionTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/Exceptions/NotSupportedAstExceptionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\Exceptions;
+
+use Phel\Compiler\Domain\Emitter\Exceptions\NotSupportedAstException;
+use PHPUnit\Framework\TestCase;
+
+final class NotSupportedAstExceptionTest extends TestCase
+{
+    public function test_message_names_the_unsupported_node(): void
+    {
+        $exception = NotSupportedAstException::withClassName('SomeNode');
+
+        self::assertStringContainsString('SomeNode', $exception->getMessage());
+    }
+
+    public function test_message_points_to_the_factory_for_remediation(): void
+    {
+        $exception = NotSupportedAstException::withClassName('SomeNode');
+
+        self::assertStringContainsString('NodeEmitterFactory::instantiateEmitter', $exception->getMessage());
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Two small internal-quality items from the `Compiler` module audit:

1. `AnalyzePersistentList` allocated `new Munge()` inline inside the `defstruct` branch of the special-form dispatch — inconsistent with the rest of the codebase, which obtains `Munge` via `CompilerFactory::createMunge()` or a ctor default (e.g. `LoadPathResolver`).
2. `NotSupportedAstException::withClassName()` produced `"Not supported AstClassName: 'X'"` — an internal invariant breach (the analyzer produced a node the emitter has no handler for) with no hint about what to do.

## 💡 Goal

Tidy both without any behavior change for valid programs.

## 🔖 Changes

- `AnalyzePersistentList` now takes `Munge` as a constructor dependency (default `new Munge()`, mirroring `LoadPathResolver`), and the `defstruct` branch reuses `$this->munge` instead of allocating per cache-miss.
- `NotSupportedAstException` message now states it is a missing-emitter invariant breach and points to `NodeEmitterFactory::instantiateEmitter()` for remediation.
- Add `NotSupportedAstExceptionTest` covering both the node name and the remediation hint in the message.

No user-facing change, so no CHANGELOG entry. All compiler tests pass; psalm/phpstan/cs-fixer/rector clean.