### PR TITLE
test(compiler): add control-flow emitter unit tests for If/Let/Try

### DIFF
--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitterTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitterTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel;
+use Phel\Compiler\Application\Analyzer;
+use Phel\Compiler\CompilerFactory;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\IfSymbol;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\IfEmitter;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class IfEmitterTest extends TestCase
+{
+    private IfEmitter $ifEmitter;
+
+    private Analyzer $analyzer;
+
+    protected function setUp(): void
+    {
+        $this->ifEmitter = new IfEmitter(new CompilerFactory()->createOutputEmitter());
+        $this->analyzer = new Analyzer(new GlobalEnvironment());
+    }
+
+    public function test_statement_context_emits_if_else_block(): void
+    {
+        $output = $this->emit(NodeEnvironment::empty());
+
+        // A bare string literal is a pure value, so in statement context both
+        // branch bodies are dropped — only the if/else structure is emitted.
+        self::assertStringContainsString('if (', $output);
+        self::assertStringContainsString('} else {', $output);
+    }
+
+    public function test_expression_context_emits_ternary(): void
+    {
+        $output = $this->emit(NodeEnvironment::empty()->withExpressionContext());
+
+        self::assertStringStartsWith('(', $output);
+        self::assertStringContainsString(' ? ', $output);
+        self::assertStringContainsString(' : ', $output);
+        self::assertStringNotContainsString('} else {', $output);
+        // As ternary operands both branch values are emitted.
+        self::assertStringContainsString('then-branch', $output);
+        self::assertStringContainsString('else-branch', $output);
+    }
+
+    public function test_return_context_collapses_to_return_ternary(): void
+    {
+        $output = $this->emit(NodeEnvironment::empty()->withReturnContext());
+
+        self::assertStringContainsString('return (', $output);
+        self::assertStringContainsString(' ? ', $output);
+        self::assertStringNotContainsString('} else {', $output);
+        self::assertStringContainsString('then-branch', $output);
+        self::assertStringContainsString('else-branch', $output);
+    }
+
+    public function test_statement_context_with_nil_else_drops_else_branch(): void
+    {
+        $output = $this->emit(NodeEnvironment::empty(), withElse: false);
+
+        self::assertStringContainsString('if (', $output);
+        self::assertStringNotContainsString('else', $output);
+    }
+
+    private function emit(NodeEnvironmentInterface $env, bool $withElse = true): string
+    {
+        // Wrap the test in `(do true)` so IfSymbol does not constant-fold the
+        // literal test away and we keep a real IfNode to emit.
+        $form = [
+            Symbol::create(Symbol::NAME_IF),
+            Phel::list([Symbol::create(Symbol::NAME_DO), true]),
+            'then-branch',
+        ];
+        if ($withElse) {
+            $form[] = 'else-branch';
+        }
+
+        $node = new IfSymbol($this->analyzer)->analyze(Phel::list($form), $env);
+        self::assertInstanceOf(IfNode::class, $node);
+
+        ob_start();
+        $this->ifEmitter->emit($node);
+
+        return (string) ob_get_clean();
+    }
+}

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LetEmitterTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LetEmitterTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel;
+use Phel\Compiler\Application\Analyzer;
+use Phel\Compiler\CompilerFactory;
+use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\BindingValidator;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\LetSymbol;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\LetEmitter;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class LetEmitterTest extends TestCase
+{
+    private LetEmitter $letEmitter;
+
+    private LetSymbol $letSymbol;
+
+    protected function setUp(): void
+    {
+        $this->letEmitter = new LetEmitter(new CompilerFactory()->createOutputEmitter());
+        $this->letSymbol = new LetSymbol(
+            new Analyzer(new GlobalEnvironment()),
+            new Deconstructor(new BindingValidator()),
+        );
+    }
+
+    public function test_statement_context_emits_plain_binding_assignments(): void
+    {
+        $output = $this->emit(NodeEnvironment::empty());
+
+        self::assertStringContainsString(' = ', $output);
+        self::assertStringContainsString(';', $output);
+        self::assertStringNotContainsString('(function()', $output);
+    }
+
+    public function test_expression_context_wraps_in_an_iife(): void
+    {
+        $output = $this->emit(NodeEnvironment::empty()->withExpressionContext());
+
+        self::assertStringContainsString('(function()', $output);
+        self::assertStringContainsString('})()', $output);
+        self::assertStringContainsString(' = ', $output);
+    }
+
+    public function test_return_context_emits_bindings_without_iife_and_returns_body(): void
+    {
+        $output = $this->emit(NodeEnvironment::empty()->withReturnContext());
+
+        self::assertStringNotContainsString('(function()', $output);
+        self::assertStringContainsString(' = ', $output);
+        self::assertStringContainsString('return ', $output);
+    }
+
+    private function emit(NodeEnvironmentInterface $env): string
+    {
+        // `x` is referenced twice in the body, so LetSimplifier neither drops
+        // the binding (it stays referenced) nor inlines it (the body tail is a
+        // call, not a bare `x` local) — we keep a real LetNode to emit.
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_LET),
+            Phel::vector([
+                Symbol::create('x'),
+                Phel::list([Symbol::create('php/+'), 1, 1]),
+            ]),
+            Phel::list([Symbol::create('php/+'), Symbol::create('x'), Symbol::create('x')]),
+        ]);
+
+        $node = $this->letSymbol->analyze($list, $env);
+        self::assertInstanceOf(LetNode::class, $node);
+
+        ob_start();
+        $this->letEmitter->emit($node);
+
+        return (string) ob_get_clean();
+    }
+}

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/TryEmitterTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/TryEmitterTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel;
+use Phel\Compiler\Application\Analyzer;
+use Phel\Compiler\CompilerFactory;
+use Phel\Compiler\Domain\Analyzer\Ast\TryNode;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\TrySymbol;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\TryEmitter;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class TryEmitterTest extends TestCase
+{
+    private TryEmitter $tryEmitter;
+
+    private TrySymbol $trySymbol;
+
+    protected function setUp(): void
+    {
+        $this->tryEmitter = new TryEmitter(new CompilerFactory()->createOutputEmitter());
+        $this->trySymbol = new TrySymbol(new Analyzer(new GlobalEnvironment()));
+    }
+
+    public function test_statement_context_emits_try_catch(): void
+    {
+        $output = $this->emit(NodeEnvironment::empty(), withCatch: true);
+
+        self::assertStringContainsString('try {', $output);
+        self::assertStringContainsString('} catch (', $output);
+        self::assertStringNotContainsString('(function()', $output);
+    }
+
+    public function test_return_context_emits_try_catch_without_iife(): void
+    {
+        $output = $this->emit(NodeEnvironment::empty()->withReturnContext(), withCatch: true);
+
+        self::assertStringNotContainsString('(function()', $output);
+        self::assertStringContainsString('try {', $output);
+        self::assertStringContainsString('} catch (', $output);
+    }
+
+    public function test_expression_context_wraps_try_catch_in_an_iife(): void
+    {
+        $output = $this->emit(NodeEnvironment::empty()->withExpressionContext(), withCatch: true);
+
+        self::assertStringContainsString('(function()', $output);
+        self::assertStringContainsString('})()', $output);
+        self::assertStringContainsString('try {', $output);
+    }
+
+    public function test_body_only_try_emits_body_without_try_block(): void
+    {
+        $output = $this->emit(NodeEnvironment::empty(), withCatch: false);
+
+        self::assertStringNotContainsString('try {', $output);
+        self::assertStringContainsString('1 + 1', $output);
+    }
+
+    private function emit(NodeEnvironmentInterface $env, bool $withCatch): string
+    {
+        $form = [
+            Symbol::create(Symbol::NAME_TRY),
+            Phel::list([Symbol::create('php/+'), 1, 1]),
+        ];
+        if ($withCatch) {
+            $form[] = Phel::list([
+                Symbol::create(Symbol::NAME_CATCH),
+                Symbol::create('\\Exception'),
+                Symbol::create('e'),
+                Phel::list([Symbol::create('php/+'), 2, 2]),
+            ]);
+        }
+
+        $node = $this->trySymbol->analyze(Phel::list($form), $env);
+        self::assertInstanceOf(TryNode::class, $node);
+
+        ob_start();
+        $this->tryEmitter->emit($node);
+
+        return (string) ob_get_clean();
+    }
+}


### PR DESCRIPTION
## 🤔 Background

The `Compiler` module audit flagged that only 8 of 42 node emitters had direct unit tests. Control-flow emitters (`IfEmitter`, `LetEmitter`, `TryEmitter`) were covered only end-to-end by integration `.test` fixtures, leaving their per-context branches (statement / expression / return) without isolated coverage. The repo rule is "when touching the compiler add focused unit tests plus an integration scenario" — the unit half was missing here.

## 💡 Goal

Add focused, non-brittle unit tests that pin the distinguishing output shape of each control-flow emitter in each `NodeEnvironment` context. No production code changes.

## 🔖 Changes

- `IfEmitterTest`: statement `if/else` block, expression ternary, return-context ternary collapse, and the `when`-shaped statement branch that drops a `nil` else.
- `LetEmitterTest`: plain binding assignments in statement context vs IIFE (`(function() { … })()`) wrap in expression context.
- `TryEmitterTest`: `try/catch` in statement context, expression-context IIFE wrap, and body-only passthrough (no `try {` when there is no catch/finally).

Nodes are produced through the special-form analyzers (`IfSymbol`/`LetSymbol`/`TrySymbol`) rather than the full pipeline, so constant folding / let-simplification do not collapse the node under test. Assertions match stable PHP tokens, not exact strings.

No user-facing change, so no CHANGELOG entry. All 3817 compiler tests pass; psalm/phpstan/cs-fixer/rector clean.