### PR TITLE
ref(compiler): centralize bare-expression capture in OutputEmitter

### DIFF
--- a/src/php/Compiler/Domain/Emitter/OutputEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter.php
@@ -117,6 +117,29 @@ final class OutputEmitter implements OutputEmitterInterface
         $nodeEmitter->emit($node);
     }
 
+    public function captureNodeAsExpression(AbstractNode $node): string
+    {
+        ob_start();
+        try {
+            $this->emitNode($node);
+        } finally {
+            $buf = (string) ob_get_clean();
+        }
+
+        // The node's baked-in env may be RETURN (so it emits `return …;`), but
+        // the caller splices the chunk into a surrounding expression position
+        // (ternary arm, `if (…)` test, native-op fragment), where a `return`
+        // prefix or trailing `;` would be invalid PHP. Strip both so the
+        // chunk renders as a bare expression.
+        $buf = preg_replace('/^return\s+/', '', $buf) ?? '';
+        $buf = rtrim($buf);
+        if ($buf !== '' && str_ends_with($buf, ';')) {
+            return substr($buf, 0, -1);
+        }
+
+        return $buf;
+    }
+
     public function emitLine(string $str = '', ?SourceLocation $sl = null): void
     {
         if ($str !== '') {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -638,18 +638,7 @@ final class CallEmitter implements NodeEmitterInterface
 
         $loc = $node->getStartSourceLocation();
 
-        ob_start();
-        try {
-            $this->outputEmitter->emitNode($node->getArguments()[0]);
-        } finally {
-            $argEmit = (string) ob_get_clean();
-        }
-
-        $argEmit = preg_replace('/^return\s+/', '', $argEmit) ?? '';
-        $argEmit = rtrim($argEmit);
-        if (str_ends_with($argEmit, ';')) {
-            $argEmit = substr($argEmit, 0, -1);
-        }
+        $argEmit = $this->outputEmitter->captureNodeAsExpression($node->getArguments()[0]);
 
         $this->outputEmitter->emitStr(sprintf($fragment, $argEmit), $loc);
         return true;

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
@@ -194,32 +194,17 @@ final class IfEmitter implements NodeEmitterInterface
     }
 
     /**
-     * Emit a node and strip the analyser's `return ` prefix / trailing
-     * `;` from the captured output — the same node may sit deep inside
+     * Emit a node as a bare expression — the same node may sit deep inside
      * a chain whose original env is RETURN, but our chunk is consumed
      * as a bare expression in the surrounding `if (…)` test position,
      * so the context decoration would produce invalid PHP.
      */
     private function emitNodeAsExpression(AbstractNode $node): void
     {
-        ob_start();
-        try {
-            $this->outputEmitter->emitNode($node);
-        } finally {
-            $buf = (string) ob_get_clean();
-        }
-
-        $buf = preg_replace('/^return\s+/', '', $buf);
-        if ($buf === null) {
-            $buf = '';
-        }
-
-        $buf = rtrim($buf);
-        if ($buf !== '' && str_ends_with($buf, ';')) {
-            $buf = substr($buf, 0, -1);
-        }
-
-        $this->outputEmitter->emitStr($buf, $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr(
+            $this->outputEmitter->captureNodeAsExpression($node),
+            $node->getStartSourceLocation(),
+        );
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LetEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LetEmitter.php
@@ -180,31 +180,16 @@ final class LetEmitter implements NodeEmitterInterface
     }
 
     /**
-     * Capture the emit output of a chain operand and strip the
-     * analyser's `return ` prefix / trailing `;` so the result fits
-     * inside the ternary expression. Same trick `IfEmitter` uses for
+     * Emit a chain operand as a bare expression so the result fits inside
+     * the ternary expression. Same trick `IfEmitter` uses for
      * test-position chains.
      */
     private function emitOperandAsExpression(AbstractNode $operand): void
     {
-        ob_start();
-        try {
-            $this->outputEmitter->emitNode($operand);
-        } finally {
-            $buf = (string) ob_get_clean();
-        }
-
-        $stripped = preg_replace('/^return\s+/', '', $buf);
-        if ($stripped === null) {
-            $stripped = '';
-        }
-
-        $stripped = rtrim($stripped);
-        if ($stripped !== '' && str_ends_with($stripped, ';')) {
-            $stripped = substr($stripped, 0, -1);
-        }
-
-        $this->outputEmitter->emitStr($stripped, $operand->getStartSourceLocation());
+        $this->outputEmitter->emitStr(
+            $this->outputEmitter->captureNodeAsExpression($operand),
+            $operand->getStartSourceLocation(),
+        );
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
@@ -36,6 +36,14 @@ interface OutputEmitterInterface
 
     public function emitNode(AbstractNode $node): void;
 
+    /**
+     * Emit a node into a temporary buffer and return it as a bare PHP
+     * expression string, stripping a leading `return` (with its following
+     * whitespace) and a single trailing `;` so the chunk can be spliced
+     * into a surrounding expression position.
+     */
+    public function captureNodeAsExpression(AbstractNode $node): string;
+
     public function emitLine(string $str = '', ?SourceLocation $sl = null): void;
 
     public function emitStr(string $str, ?SourceLocation $sl = null): void;

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitterTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitterTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter;
+
+use Phel\Compiler\CompilerFactory;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
+use PHPUnit\Framework\TestCase;
+
+final class OutputEmitterTest extends TestCase
+{
+    private OutputEmitterInterface $outputEmitter;
+
+    protected function setUp(): void
+    {
+        $this->outputEmitter = new CompilerFactory()->createOutputEmitter();
+    }
+
+    public function test_capture_strips_return_prefix_from_return_context_node(): void
+    {
+        // A literal in RETURN context emits `return 42;`.
+        $node = new LiteralNode(NodeEnvironment::empty()->withReturnContext(), 42);
+
+        self::assertSame('42', $this->outputEmitter->captureNodeAsExpression($node));
+    }
+
+    public function test_capture_returns_empty_for_dropped_statement_literal(): void
+    {
+        // A bare literal is a pure value, so in STATEMENT context it is
+        // dropped entirely and nothing is emitted.
+        $node = new LiteralNode(NodeEnvironment::empty(), 42);
+
+        self::assertSame('', $this->outputEmitter->captureNodeAsExpression($node));
+    }
+
+    public function test_capture_leaves_expression_context_node_untouched(): void
+    {
+        // A literal in EXPRESSION context already emits a bare `42`.
+        $node = new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 42);
+
+        self::assertSame('42', $this->outputEmitter->captureNodeAsExpression($node));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`IfEmitter`, `LetEmitter` and `CallEmitter` each carried a byte-for-byte copy of the same workaround: emit a node into a temporary output buffer, then strip the analyser's `return ` prefix and trailing `;` so the captured chunk can be spliced into a surrounding **expression** position (a ternary arm, an `if (…)` test, or a native-operator `sprintf` fragment). The node's baked-in `NodeEnvironment` may be `RETURN`, so without the strip the chunk would be invalid PHP.

Three identical copies of nested `ob_start()` + `preg_replace('/^return\s+/', …)` is a duplication / single-responsibility smell flagged by the compiler-module audit.

## 💡 Goal

Collapse the three copies into one shared method without changing any generated output.

## 🔖 Changes

- Add `OutputEmitter::captureNodeAsExpression(AbstractNode): string` (declared on `OutputEmitterInterface`) that owns the buffer capture + `return`/`;` stripping.
- `IfEmitter::emitNodeAsExpression`, `LetEmitter::emitOperandAsExpression` and `CallEmitter`'s native-op fragment path now delegate to it.

## ✅ Verification

- All integration `.test` fixtures pass unchanged → generated PHP is **byte-identical** (this is a pure refactor of the workaround, not a behavior change).
- Full compiler suite (3819) + core tests (5772) green; psalm/phpstan/cs-fixer/rector clean.

No user-facing change, so no CHANGELOG entry.

## 📝 Follow-up (out of scope)

The fully clean fix would emit the inner node directly in expression context so no `return ` prefix is produced and no stripping is needed. That requires a per-node env override (`withEnv`-style clone) which `AbstractNode` does not support today. This PR centralizes the existing workaround as a stepping stone toward that.