### PR TITLE
ref(compiler): extract NilAndBooleanCheckSpecialization from CallSpecialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- Compiler internals: extracted the `nil?` / `some?` / `true?` / `false?` / `truthy?` call-site eligibility checks out of `CallSpecialization` into a focused `NilAndBooleanCheckSpecialization` collaborator (no change to generated code)
+
 ## [0.41.0](https://github.com/phel-lang/phel-lang/compare/v0.40.0...v0.41.0) - 2026-06-01
 
 ### Added

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -89,11 +89,11 @@ final readonly class CallSpecialization
      */
     public static function isBoolReturningSpecialisation(CallNode $node): bool
     {
-        if (self::isNilCheck($node)
-            || self::isSomeCheck($node)
-            || self::isTrueCheck($node)
-            || self::isFalseCheck($node)
-            || self::isTruthyCheck($node)
+        if (NilAndBooleanCheckSpecialization::isNilCheck($node)
+            || NilAndBooleanCheckSpecialization::isSomeCheck($node)
+            || NilAndBooleanCheckSpecialization::isTrueCheck($node)
+            || NilAndBooleanCheckSpecialization::isFalseCheck($node)
+            || NilAndBooleanCheckSpecialization::isTruthyCheck($node)
             || self::isTypePredicate($node)
             || self::isEmptyCheck($node)
             || self::isContainsCheck($node)
@@ -126,23 +126,23 @@ final readonly class CallSpecialization
             return true;
         }
 
-        if (self::isNilCheck($node)) {
+        if (NilAndBooleanCheckSpecialization::isNilCheck($node)) {
             return true;
         }
 
-        if (self::isSomeCheck($node)) {
+        if (NilAndBooleanCheckSpecialization::isSomeCheck($node)) {
             return true;
         }
 
-        if (self::isTrueCheck($node)) {
+        if (NilAndBooleanCheckSpecialization::isTrueCheck($node)) {
             return true;
         }
 
-        if (self::isFalseCheck($node)) {
+        if (NilAndBooleanCheckSpecialization::isFalseCheck($node)) {
             return true;
         }
 
-        if (self::isTruthyCheck($node)) {
+        if (NilAndBooleanCheckSpecialization::isTruthyCheck($node)) {
             return true;
         }
 
@@ -726,53 +726,6 @@ final readonly class CallSpecialization
     }
 
     /**
-     * `(nil? x)` — single-arg identity check against `nil`. The runtime
-     * body is `(id x nil)` which routes through the registry; the
-     * specialised emit is the literal `($x === null)`.
-     */
-    public static function isNilCheck(CallNode $node): bool
-    {
-        return self::isUnaryCoreCall($node, 'nil?');
-    }
-
-    /**
-     * `(some? x)` (1-arg) — `(not (nil? x))`. Maps to `($x !== null)`.
-     * Skips the 2-arg overload (`(some? pred coll)`); that variant has
-     * a different shape and the specialised emit would not be a single
-     * native expression.
-     */
-    public static function isSomeCheck(CallNode $node): bool
-    {
-        return self::isUnaryCoreCall($node, 'some?');
-    }
-
-    /**
-     * `(true? x)` — Phel `true?` is identity-strict (`(id x true)`),
-     * so the call collapses to `($x === true)` for any argument.
-     */
-    public static function isTrueCheck(CallNode $node): bool
-    {
-        return self::isUnaryCoreCall($node, 'true?');
-    }
-
-    /**
-     * `(false? x)` — `(id x false)`, collapses to `($x === false)`.
-     */
-    public static function isFalseCheck(CallNode $node): bool
-    {
-        return self::isUnaryCoreCall($node, 'false?');
-    }
-
-    /**
-     * `(truthy? x)` — Phel-truthy probe. The runtime body wraps
-     * `Truthy::isTruthy($x)`; the inline check is equivalent.
-     */
-    public static function isTruthyCheck(CallNode $node): bool
-    {
-        return self::isUnaryCoreCall($node, 'truthy?');
-    }
-
-    /**
      * `(deref x)` 1-arg / `(reset! v val)` 2-arg — runtime bodies are
      * single `php/->` method calls. Direct emission saves the registry
      * lookup + adapter frame. The 3-arg deref overload (timeout) keeps
@@ -1093,22 +1046,6 @@ final readonly class CallSpecialization
         $arg = $args[0];
         return $arg instanceof LocalVarNode
             && self::isPersistentMapTag($arg->getInferredType());
-    }
-
-    private static function isUnaryCoreCall(CallNode $node, string $name): bool
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return false;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== $name
-        ) {
-            return false;
-        }
-
-        return count($node->getArguments()) === 1;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NilAndBooleanCheckSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NilAndBooleanCheckSpecialization.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Shared\CompilerConstants;
+
+use function count;
+
+/**
+ * Call-site eligibility checks for the single-argument `phel.core`
+ * nil / boolean predicates (`nil?`, `some?`, `true?`, `false?`,
+ * `truthy?`) that {@see NodeEmitter\CallEmitter}
+ * lowers to a native PHP comparison instead of a registry dispatch.
+ */
+final readonly class NilAndBooleanCheckSpecialization
+{
+    private function __construct() {}
+
+    /**
+     * `(nil? x)` — single-arg identity check against `nil`. The runtime
+     * body is `(id x nil)` which routes through the registry; the
+     * specialised emit is the literal `($x === null)`.
+     */
+    public static function isNilCheck(CallNode $node): bool
+    {
+        return self::isUnaryCoreCall($node, 'nil?');
+    }
+
+    /**
+     * `(some? x)` (1-arg) — `(not (nil? x))`. Maps to `($x !== null)`.
+     * Skips the 2-arg overload (`(some? pred coll)`); that variant has
+     * a different shape and the specialised emit would not be a single
+     * native expression.
+     */
+    public static function isSomeCheck(CallNode $node): bool
+    {
+        return self::isUnaryCoreCall($node, 'some?');
+    }
+
+    /**
+     * `(true? x)` — Phel `true?` is identity-strict (`(id x true)`),
+     * so the call collapses to `($x === true)` for any argument.
+     */
+    public static function isTrueCheck(CallNode $node): bool
+    {
+        return self::isUnaryCoreCall($node, 'true?');
+    }
+
+    /**
+     * `(false? x)` — `(id x false)`, collapses to `($x === false)`.
+     */
+    public static function isFalseCheck(CallNode $node): bool
+    {
+        return self::isUnaryCoreCall($node, 'false?');
+    }
+
+    /**
+     * `(truthy? x)` — Phel-truthy probe. The runtime body wraps
+     * `Truthy::isTruthy($x)`; the inline check is equivalent.
+     */
+    public static function isTruthyCheck(CallNode $node): bool
+    {
+        return self::isUnaryCoreCall($node, 'truthy?');
+    }
+
+    private static function isUnaryCoreCall(CallNode $node, string $name): bool
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return false;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || $fn->getName()->getName() !== $name
+        ) {
+            return false;
+        }
+
+        return count($node->getArguments()) === 1;
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -13,6 +13,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\CallSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\GlobalCallTarget;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NilAndBooleanCheckSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape;
 use Phel\Lang\Symbol;
@@ -448,7 +449,7 @@ final class CallEmitter implements NodeEmitterInterface
      */
     private function tryEmitNilCheck(CallNode $node): bool
     {
-        if (!CallSpecialization::isNilCheck($node)) {
+        if (!NilAndBooleanCheckSpecialization::isNilCheck($node)) {
             return false;
         }
 
@@ -465,7 +466,7 @@ final class CallEmitter implements NodeEmitterInterface
      */
     private function tryEmitSomeCheck(CallNode $node): bool
     {
-        if (!CallSpecialization::isSomeCheck($node)) {
+        if (!NilAndBooleanCheckSpecialization::isSomeCheck($node)) {
             return false;
         }
 
@@ -478,7 +479,7 @@ final class CallEmitter implements NodeEmitterInterface
 
     private function tryEmitTrueCheck(CallNode $node): bool
     {
-        if (!CallSpecialization::isTrueCheck($node)) {
+        if (!NilAndBooleanCheckSpecialization::isTrueCheck($node)) {
             return false;
         }
 
@@ -491,7 +492,7 @@ final class CallEmitter implements NodeEmitterInterface
 
     private function tryEmitFalseCheck(CallNode $node): bool
     {
-        if (!CallSpecialization::isFalseCheck($node)) {
+        if (!NilAndBooleanCheckSpecialization::isFalseCheck($node)) {
             return false;
         }
 
@@ -509,7 +510,7 @@ final class CallEmitter implements NodeEmitterInterface
      */
     private function tryEmitTruthyCheck(CallNode $node): bool
     {
-        if (!CallSpecialization::isTruthyCheck($node)) {
+        if (!NilAndBooleanCheckSpecialization::isTruthyCheck($node)) {
             return false;
         }
 

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NilAndBooleanCheckSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NilAndBooleanCheckSpecializationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NilAndBooleanCheckSpecialization;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
+use PHPUnit\Framework\TestCase;
+
+final class NilAndBooleanCheckSpecializationTest extends TestCase
+{
+    public function test_unary_nil_check_is_recognised(): void
+    {
+        self::assertTrue(NilAndBooleanCheckSpecialization::isNilCheck($this->coreCall('nil?', [$this->local('x')])));
+    }
+
+    public function test_each_predicate_recognises_only_its_own_name(): void
+    {
+        $arg = [$this->local('x')];
+
+        self::assertTrue(NilAndBooleanCheckSpecialization::isSomeCheck($this->coreCall('some?', $arg)));
+        self::assertTrue(NilAndBooleanCheckSpecialization::isTrueCheck($this->coreCall('true?', $arg)));
+        self::assertTrue(NilAndBooleanCheckSpecialization::isFalseCheck($this->coreCall('false?', $arg)));
+        self::assertTrue(NilAndBooleanCheckSpecialization::isTruthyCheck($this->coreCall('truthy?', $arg)));
+
+        self::assertFalse(NilAndBooleanCheckSpecialization::isNilCheck($this->coreCall('some?', $arg)));
+    }
+
+    public function test_two_arg_call_is_not_specialised(): void
+    {
+        // `(some? pred coll)` overload — different shape, must not specialise.
+        $node = $this->coreCall('some?', [$this->local('pred'), $this->local('coll')]);
+
+        self::assertFalse(NilAndBooleanCheckSpecialization::isSomeCheck($node));
+    }
+
+    public function test_zero_arg_call_is_not_specialised(): void
+    {
+        $node = $this->coreCall('nil?', []);
+
+        self::assertFalse(NilAndBooleanCheckSpecialization::isNilCheck($node));
+    }
+
+    public function test_non_core_namespace_is_not_specialised(): void
+    {
+        $node = new CallNode(
+            $this->env(),
+            new GlobalVarNode($this->env(), 'my\\app', Symbol::create('nil?'), Phel::map()),
+            [$this->local('x')],
+        );
+
+        self::assertFalse(NilAndBooleanCheckSpecialization::isNilCheck($node));
+    }
+
+    public function test_local_var_callee_is_not_specialised(): void
+    {
+        $node = new CallNode($this->env(), $this->local('nil?'), [$this->local('x')]);
+
+        self::assertFalse(NilAndBooleanCheckSpecialization::isNilCheck($node));
+    }
+
+    /**
+     * @param list<AbstractNode> $args
+     */
+    private function coreCall(string $name, array $args): CallNode
+    {
+        return new CallNode(
+            $this->env(),
+            new GlobalVarNode($this->env(), CompilerConstants::PHEL_CORE_NAMESPACE, Symbol::create($name), Phel::map()),
+            $args,
+        );
+    }
+
+    private function local(string $name): LocalVarNode
+    {
+        return new LocalVarNode($this->env(), Symbol::create($name));
+    }
+
+    private function env(): NodeEnvironment
+    {
+        return NodeEnvironment::empty()->withExpressionContext();
+    }
+}


### PR DESCRIPTION
## 🤔 Background

The Compiler-module audit flagged `CallSpecialization` (1325 LOC) as a god-class concentrating ~30 call-site lowering families. This is the first step of splitting it into focused collaborators.

## 💡 Goal

Move one cohesive, self-contained family out without changing any generated code, establishing the extraction pattern for follow-up PRs.

## 🔖 Changes

- New `NilAndBooleanCheckSpecialization` holding the single-argument `phel.core` nil/boolean predicate eligibility checks — `nil?`, `some?`, `true?`, `false?`, `truthy?` — plus their shared private `isUnaryCoreCall` helper (used only by these five).
- `CallSpecialization`'s internal `isSpecialized` / `isBoolReturningSpecialisation` dispatch and `CallEmitter`'s five call sites now delegate to the new class.
- Adds `NilAndBooleanCheckSpecializationTest` (recognition per name, arity guard, non-core namespace, local-var callee).

## ✅ Verification

- Pure logic move — all integration `.test` fixtures pass unchanged → generated PHP is **byte-identical**.
- Full compiler suite (3827) green; psalm/phpstan/cs-fixer/rector clean.

## 📝 Follow-up

Subsequent PRs will peel further cohesive families (typed collection methods, assoc/conj chains, type/numeric predicates, tag inference helpers) off `CallSpecialization` the same way.