### PR TITLE
ref(compiler): extract AtomMethodSpecialization from CallSpecialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Compiler internals: extracted the `nil?` / `some?` / `true?` / `false?` / `truthy?` call-site eligibility checks out of `CallSpecialization` into a focused `NilAndBooleanCheckSpecialization` collaborator (no change to generated code)
+- Compiler internals: extracted the atom accessor (`deref` / `reset!`) call-site eligibility out of `CallSpecialization` into a focused `AtomMethodSpecialization` collaborator (no change to generated code)
 
 ## [0.41.0](https://github.com/phel-lang/phel-lang/compare/v0.40.0...v0.41.0) - 2026-06-01
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/AtomMethodSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/AtomMethodSpecialization.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Shared\CompilerConstants;
+
+use function count;
+
+/**
+ * Call-site eligibility for the `phel.core` atom accessors (`deref`,
+ * `reset!`) that {@see NodeEmitter\CallEmitter}
+ * lowers to a direct `php/->` method call instead of a registry dispatch.
+ */
+final readonly class AtomMethodSpecialization
+{
+    private function __construct() {}
+
+    /**
+     * `(deref x)` 1-arg / `(reset! v val)` 2-arg — runtime bodies are
+     * single `php/->` method calls. Direct emission saves the registry
+     * lookup + adapter frame. The 3-arg deref overload (timeout) keeps
+     * the runtime dispatch because its body is a cond chain. Returns
+     * the (method, arg-indices-after-target) tuple, or `null`.
+     *
+     * @return array{0: string, 1: list<int>}|null
+     */
+    public static function atomMethodCall(CallNode $node): ?array
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+        ) {
+            return null;
+        }
+
+        $name = $fn->getName()->getName();
+        $argc = count($node->getArguments());
+
+        if ($name === 'deref' && $argc === 1) {
+            return ['deref', []];
+        }
+
+        if ($name === 'reset!' && $argc === 2) {
+            return ['set', [1]];
+        }
+
+        return null;
+    }
+
+    public static function isAtomMethodCall(CallNode $node): bool
+    {
+        return self::atomMethodCall($node) !== null;
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -166,7 +166,7 @@ final readonly class CallSpecialization
             return true;
         }
 
-        if (self::isAtomMethodCall($node)) {
+        if (AtomMethodSpecialization::isAtomMethodCall($node)) {
             return true;
         }
 
@@ -723,43 +723,6 @@ final readonly class CallSpecialization
         }
 
         return self::normalisedTag($target->getInferredType()) === 'array';
-    }
-
-    /**
-     * `(deref x)` 1-arg / `(reset! v val)` 2-arg — runtime bodies are
-     * single `php/->` method calls. Direct emission saves the registry
-     * lookup + adapter frame. The 3-arg deref overload (timeout) keeps
-     * the runtime dispatch because its body is a cond chain. Returns
-     * the (method, arg-indices-after-target) tuple, or `null`.
-     *
-     * @return array{0: string, 1: list<int>}|null
-     */
-    public static function atomMethodCall(CallNode $node): ?array
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-        ) {
-            return null;
-        }
-
-        $name = $fn->getName()->getName();
-        $argc = count($node->getArguments());
-
-        if ($name === 'deref' && $argc === 1) {
-            return ['deref', []];
-        }
-
-        if ($name === 'reset!' && $argc === 2) {
-            return ['set', [1]];
-        }
-
-        return null;
-    }
-
-    public static function isAtomMethodCall(CallNode $node): bool
-    {
-        return self::atomMethodCall($node) !== null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -11,6 +11,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\AtomMethodSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\CallSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\GlobalCallTarget;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NilAndBooleanCheckSpecialization;
@@ -529,7 +530,7 @@ final class CallEmitter implements NodeEmitterInterface
      */
     private function tryEmitAtomMethodCall(CallNode $node): bool
     {
-        $shape = CallSpecialization::atomMethodCall($node);
+        $shape = AtomMethodSpecialization::atomMethodCall($node);
         if ($shape === null) {
             return false;
         }

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/AtomMethodSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/AtomMethodSpecializationTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\AtomMethodSpecialization;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
+use PHPUnit\Framework\TestCase;
+
+final class AtomMethodSpecializationTest extends TestCase
+{
+    public function test_unary_deref_maps_to_deref_method(): void
+    {
+        $node = $this->coreCall('deref', [$this->local('a')]);
+
+        self::assertSame(['deref', []], AtomMethodSpecialization::atomMethodCall($node));
+        self::assertTrue(AtomMethodSpecialization::isAtomMethodCall($node));
+    }
+
+    public function test_binary_reset_maps_to_set_method_with_value_arg(): void
+    {
+        $node = $this->coreCall('reset!', [$this->local('a'), $this->local('v')]);
+
+        self::assertSame(['set', [1]], AtomMethodSpecialization::atomMethodCall($node));
+        self::assertTrue(AtomMethodSpecialization::isAtomMethodCall($node));
+    }
+
+    public function test_three_arg_deref_timeout_overload_is_not_specialised(): void
+    {
+        $node = $this->coreCall('deref', [$this->local('a'), $this->local('t'), $this->local('d')]);
+
+        self::assertNull(AtomMethodSpecialization::atomMethodCall($node));
+    }
+
+    public function test_unary_reset_is_not_specialised(): void
+    {
+        $node = $this->coreCall('reset!', [$this->local('a')]);
+
+        self::assertNull(AtomMethodSpecialization::atomMethodCall($node));
+    }
+
+    public function test_other_core_fn_is_not_specialised(): void
+    {
+        $node = $this->coreCall('inc', [$this->local('a')]);
+
+        self::assertNull(AtomMethodSpecialization::atomMethodCall($node));
+    }
+
+    public function test_non_core_namespace_is_not_specialised(): void
+    {
+        $node = new CallNode(
+            $this->env(),
+            new GlobalVarNode($this->env(), 'my\\app', Symbol::create('deref'), Phel::map()),
+            [$this->local('a')],
+        );
+
+        self::assertNull(AtomMethodSpecialization::atomMethodCall($node));
+    }
+
+    public function test_local_var_callee_is_not_specialised(): void
+    {
+        $node = new CallNode($this->env(), $this->local('deref'), [$this->local('a')]);
+
+        self::assertNull(AtomMethodSpecialization::atomMethodCall($node));
+    }
+
+    /**
+     * @param list<AbstractNode> $args
+     */
+    private function coreCall(string $name, array $args): CallNode
+    {
+        return new CallNode(
+            $this->env(),
+            new GlobalVarNode($this->env(), CompilerConstants::PHEL_CORE_NAMESPACE, Symbol::create($name), Phel::map()),
+            $args,
+        );
+    }
+
+    private function local(string $name): LocalVarNode
+    {
+        return new LocalVarNode($this->env(), Symbol::create($name));
+    }
+
+    private function env(): NodeEnvironment
+    {
+        return NodeEnvironment::empty()->withExpressionContext();
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Second step of splitting the `CallSpecialization` god-class (follow-up to #2236). Continues peeling cohesive, self-contained families off into focused collaborators.

## 💡 Goal

Move the atom-accessor family out without changing any generated code.

## 🔖 Changes

- New `AtomMethodSpecialization` holding the `phel.core` atom accessor eligibility — `(deref x)` → `deref` method, `(reset! v val)` → `set` method — which `CallEmitter` lowers to a direct `php/->` method call instead of a registry dispatch. The 3-arg `deref` timeout overload and 1-arg `reset!` correctly stay on dispatch.
- `CallSpecialization`'s `isSpecialized` dispatch and `CallEmitter`'s call site now delegate to the new class.
- Adds `AtomMethodSpecializationTest` (deref/reset! mapping, arity overloads, non-core namespace).

## ✅ Verification

- Pure logic move — all integration `.test` fixtures pass unchanged → generated PHP is **byte-identical**.
- Full compiler suite (3834) green; psalm/phpstan/cs-fixer/rector clean.

## 📝 Follow-up

More cohesive families (typed collection methods, assoc/conj chains, type/numeric predicates) remain to be peeled off `CallSpecialization`; the tag-inference private helpers are shared and will need a dedicated home before the tag-dependent families can move cleanly.