### PR TITLE
ref(compiler): extract TagNormalizer from CallSpecialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Compiler internals: extracted the `nil?` / `some?` / `true?` / `false?` / `truthy?` call-site eligibility checks out of `CallSpecialization` into a focused `NilAndBooleanCheckSpecialization` collaborator (no change to generated code)
 - Compiler internals: extracted the atom accessor (`deref` / `reset!`) call-site eligibility out of `CallSpecialization` into a focused `AtomMethodSpecialization` collaborator (no change to generated code)
+- Compiler internals: extracted the inferred-type-tag normalisation helpers out of `CallSpecialization` into a shared `TagNormalizer` (no change to generated code)
 
 ## [0.41.0](https://github.com/phel-lang/phel-lang/compare/v0.40.0...v0.41.0) - 2026-06-01
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -29,7 +29,6 @@ use function is_bool;
 use function is_float;
 use function is_int;
 use function is_string;
-use function ltrim;
 
 /**
  * Syntactic predicates for `CallNode` instances the `CallEmitter`
@@ -225,7 +224,7 @@ final readonly class CallSpecialization
             return null;
         }
 
-        if (self::normalisedTag($target->getInferredType()) !== PersistentVectorInterface::class) {
+        if (TagNormalizer::normalise($target->getInferredType()) !== PersistentVectorInterface::class) {
             return null;
         }
 
@@ -281,7 +280,7 @@ final readonly class CallSpecialization
             return null;
         }
 
-        $tag = self::normalisedTag($target->getInferredType());
+        $tag = TagNormalizer::normalise($target->getInferredType());
         if ($tag === null || !isset(self::SEQ_TAGS[$tag])) {
             return null;
         }
@@ -322,7 +321,7 @@ final readonly class CallSpecialization
             return null;
         }
 
-        $tag = self::normalisedTag($target->getInferredType());
+        $tag = TagNormalizer::normalise($target->getInferredType());
         if ($tag === null) {
             return null;
         }
@@ -417,7 +416,7 @@ final readonly class CallSpecialization
                 return null;
             }
 
-            if (self::normalisedTag($target->getInferredType()) !== $expectedTag) {
+            if (TagNormalizer::normalise($target->getInferredType()) !== $expectedTag) {
                 return null;
             }
 
@@ -620,7 +619,7 @@ final readonly class CallSpecialization
             return null;
         }
 
-        $tag = self::normalisedTag($target->getInferredType());
+        $tag = TagNormalizer::normalise($target->getInferredType());
         return match ($tag) {
             PersistentVectorInterface::class => 'get',
             PersistentMapInterface::class => 'find',
@@ -649,7 +648,7 @@ final readonly class CallSpecialization
             return false;
         }
 
-        $tag = self::normalisedTag($fn->getInferredType());
+        $tag = TagNormalizer::normalise($fn->getInferredType());
         if ($tag === null) {
             return false;
         }
@@ -689,7 +688,7 @@ final readonly class CallSpecialization
             return false;
         }
 
-        return self::normalisedTag($target->getInferredType()) === 'array';
+        return TagNormalizer::normalise($target->getInferredType()) === 'array';
     }
 
     /**
@@ -722,7 +721,7 @@ final readonly class CallSpecialization
             return false;
         }
 
-        return self::normalisedTag($target->getInferredType()) === 'array';
+        return TagNormalizer::normalise($target->getInferredType()) === 'array';
     }
 
     /**
@@ -758,7 +757,7 @@ final readonly class CallSpecialization
             return null;
         }
 
-        $tag = self::normalisedTag($target->getInferredType());
+        $tag = TagNormalizer::normalise($target->getInferredType());
         if ($tag === null) {
             return null;
         }
@@ -813,7 +812,7 @@ final readonly class CallSpecialization
             return null;
         }
 
-        $tag = self::normalisedTag($target->getInferredType());
+        $tag = TagNormalizer::normalise($target->getInferredType());
         if ($tag === null) {
             return null;
         }
@@ -860,7 +859,7 @@ final readonly class CallSpecialization
             return null;
         }
 
-        $tag = self::normalisedTag($target->getInferredType());
+        $tag = TagNormalizer::normalise($target->getInferredType());
         if ($tag !== Keyword::class && $tag !== Symbol::class) {
             return null;
         }
@@ -957,7 +956,7 @@ final readonly class CallSpecialization
             return null;
         }
 
-        $tag = self::normalisedTag($target->getInferredType());
+        $tag = TagNormalizer::normalise($target->getInferredType());
         if ($tag !== 'int' && $tag !== 'float') {
             return null;
         }
@@ -1008,7 +1007,7 @@ final readonly class CallSpecialization
 
         $arg = $args[0];
         return $arg instanceof LocalVarNode
-            && self::isPersistentMapTag($arg->getInferredType());
+            && TagNormalizer::isPersistentMap($arg->getInferredType());
     }
 
     /**
@@ -1036,18 +1035,8 @@ final readonly class CallSpecialization
             return true;
         }
 
-        $tag = self::normalisedTag(self::inferredTypeOfNode($arg));
+        $tag = TagNormalizer::normalise(self::inferredTypeOfNode($arg));
         return $tag !== null && $tag === 'string';
-    }
-
-    private static function isPersistentMapTag(?string $tag): bool
-    {
-        return self::normalisedTag($tag) === PersistentMapInterface::class;
-    }
-
-    private static function normalisedTag(?string $tag): ?string
-    {
-        return $tag === null ? null : ltrim($tag, '\\');
     }
 
     /**
@@ -1076,7 +1065,7 @@ final readonly class CallSpecialization
         return array_all(
             $args,
             static function (AbstractNode $arg): bool {
-                $tag = self::normalisedTag(self::inferredTypeOfNode($arg));
+                $tag = TagNormalizer::normalise(self::inferredTypeOfNode($arg));
                 return $tag !== null && in_array($tag, self::NUMERIC_PRIMITIVE_TAGS, true);
             },
         );
@@ -1091,7 +1080,7 @@ final readonly class CallSpecialization
             return self::matchesLiteralPrimitive($arg->getValue(), $acceptedTags);
         }
 
-        $tag = self::normalisedTag(self::inferredTypeOfNode($arg));
+        $tag = TagNormalizer::normalise(self::inferredTypeOfNode($arg));
         return $tag !== null && in_array($tag, $acceptedTags, true);
     }
 
@@ -1195,7 +1184,7 @@ final readonly class CallSpecialization
             return is_int($value) ? 'int' : null;
         }
 
-        $tag = self::normalisedTag(self::inferredTypeOfNode($arg));
+        $tag = TagNormalizer::normalise(self::inferredTypeOfNode($arg));
         return in_array($tag, self::NUMERIC_PRIMITIVE_TAGS, true) ? $tag : null;
     }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/TagNormalizer.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/TagNormalizer.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+
+use function ltrim;
+
+/**
+ * Normalisation helpers for the analyser's inferred type tags consumed by
+ * the call-site specialisations. A tag is the FQN string the analyser
+ * grafts onto a binding's `:tag` meta; it may carry a leading backslash,
+ * so consumers compare against the normalised form.
+ */
+final readonly class TagNormalizer
+{
+    private function __construct() {}
+
+    /**
+     * Strip a leading backslash from an inferred type tag so it compares
+     * equal to a PHP `::class` constant. Returns `null` for an untagged
+     * binding.
+     */
+    public static function normalise(?string $tag): ?string
+    {
+        return $tag === null ? null : ltrim($tag, '\\');
+    }
+
+    public static function isPersistentMap(?string $tag): bool
+    {
+        return self::normalise($tag) === PersistentMapInterface::class;
+    }
+}

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/TagNormalizerTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/TagNormalizerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Emitter\OutputEmitter\TagNormalizer;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class TagNormalizerTest extends TestCase
+{
+    public function test_null_tag_stays_null(): void
+    {
+        self::assertNull(TagNormalizer::normalise(null));
+    }
+
+    public function test_leading_backslash_is_stripped(): void
+    {
+        self::assertSame(Symbol::class, TagNormalizer::normalise('\\' . Symbol::class));
+    }
+
+    public function test_tag_without_leading_backslash_is_unchanged(): void
+    {
+        self::assertSame('int', TagNormalizer::normalise('int'));
+    }
+
+    public function test_is_persistent_map_matches_with_or_without_leading_backslash(): void
+    {
+        self::assertTrue(TagNormalizer::isPersistentMap(PersistentMapInterface::class));
+        self::assertTrue(TagNormalizer::isPersistentMap('\\' . PersistentMapInterface::class));
+    }
+
+    public function test_is_persistent_map_rejects_other_tags(): void
+    {
+        self::assertFalse(TagNormalizer::isPersistentMap('int'));
+        self::assertFalse(TagNormalizer::isPersistentMap(null));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Third step of splitting the `CallSpecialization` god-class (after #2236, #2237). The remaining specialisation families (`contains?`, `empty?`, named accessors, typed collection methods, …) all share one private helper — `normalisedTag` — so it must get its own home before any of them can move cleanly.

## 💡 Goal

Extract the shared inferred-type-tag normalisation helpers without changing any generated code, unblocking the tag-driven family extractions that follow.

## 🔖 Changes

- New `TagNormalizer` holding `normalise(?string): ?string` (strips a leading backslash so a tag compares equal to a `::class` constant) and `isPersistentMap(?string): bool`.
- `CallSpecialization`'s 16 `normalisedTag` + 1 `isPersistentMapTag` call sites now delegate to `TagNormalizer`; the two private helpers are removed.
- Adds `TagNormalizerTest` (null passthrough, backslash strip, no-op, persistent-map match with/without backslash, negatives).

## ✅ Verification

- Pure logic move — all integration `.test` fixtures pass unchanged → generated PHP is **byte-identical**.
- Full compiler suite (3840) green; psalm/phpstan/cs-fixer/rector clean.

## 📝 Follow-up

With `TagNormalizer` in place, the next PRs can peel the tag-driven families (`contains?` / `empty?` / named-accessor, typed vector/seq methods, assoc/conj chains) off `CallSpecialization`.