### PR TITLE
ref(compiler): extract TypedCollectionMethodSpecialization from CallSpecialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Compiler internals: extracted the `nil?` / `some?` / `true?` / `false?` / `truthy?` call-site eligibility checks out of `CallSpecialization` into a focused `NilAndBooleanCheckSpecialization` collaborator (no change to generated code)
 - Compiler internals: extracted the atom accessor (`deref` / `reset!`) call-site eligibility out of `CallSpecialization` into a focused `AtomMethodSpecialization` collaborator (no change to generated code)
 - Compiler internals: extracted the inferred-type-tag normalisation helpers out of `CallSpecialization` into a shared `TagNormalizer` (no change to generated code)
+- Compiler internals: extracted the typed persistent-collection accessor lowering (`count` / `nth` on vectors, `first` / `rest` on seqs) out of `CallSpecialization` into a focused `TypedCollectionMethodSpecialization` collaborator (no change to generated code)
 
 ## [0.41.0](https://github.com/phel-lang/phel-lang/compare/v0.40.0...v0.41.0) - 2026-06-01
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -12,13 +12,11 @@ use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Lang\AbstractFn;
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
-use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\ContainsInterface;
 use Phel\Lang\FnInterface;
 use Phel\Lang\Keyword;
-use Phel\Lang\SeqInterface;
 use Phel\Lang\Symbol;
 use Phel\Shared\CompilerConstants;
 
@@ -64,19 +62,6 @@ final readonly class CallSpecialization
 
     /** @var list<string> */
     private const array EQUALITY_PRIMITIVE_TAGS = ['int', 'float', 'bool', 'string'];
-
-    /** @var array<string, string> Phel core seq accessor → PHP method */
-    private const array SEQ_METHODS = [
-        'first' => 'first',
-        'rest' => 'rest',
-    ];
-
-    /** @var array<string, true> Tags whose runtime types implement SeqInterface */
-    private const array SEQ_TAGS = [
-        SeqInterface::class => true,
-        PersistentVectorInterface::class => true,
-        PersistentListInterface::class => true,
-    ];
 
     private function __construct() {}
 
@@ -169,11 +154,11 @@ final readonly class CallSpecialization
             return true;
         }
 
-        if (self::isTypedVectorAccessor($node)) {
+        if (TypedCollectionMethodSpecialization::isTypedVectorAccessor($node)) {
             return true;
         }
 
-        if (self::isTypedSeqAccessor($node)) {
+        if (TypedCollectionMethodSpecialization::isTypedSeqAccessor($node)) {
             return true;
         }
 
@@ -194,103 +179,6 @@ final readonly class CallSpecialization
         }
 
         return self::isTypedBinaryOp($node);
-    }
-
-    /**
-     * `(nth v i)` / `(count v)` where the analyser has tagged the
-     * target as `PersistentVectorInterface`. The runtime `nth` body
-     * walks a `cond` over set / seq / vector / map / php-array; for a
-     * typed vector every branch collapses to a single method call.
-     *
-     * @return array{method: string, args: list<int>}|null list of arg
-     *                                                     indices to
-     *                                                     pass as
-     *                                                     method args
-     */
-    public static function typedVectorMethodCall(CallNode $node): ?array
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return null;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
-            return null;
-        }
-
-        $args = $node->getArguments();
-        $target = $args[0] ?? null;
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        if (TagNormalizer::normalise($target->getInferredType()) !== PersistentVectorInterface::class) {
-            return null;
-        }
-
-        $name = $fn->getName()->getName();
-
-        if ($name === 'count' && count($args) === 1) {
-            return ['method' => 'count', 'args' => []];
-        }
-
-        if ($name === 'nth' && count($args) === 2) {
-            return ['method' => 'get', 'args' => [1]];
-        }
-
-        return null;
-    }
-
-    public static function isTypedVectorAccessor(CallNode $node): bool
-    {
-        return self::typedVectorMethodCall($node) !== null;
-    }
-
-    /**
-     * `(first s)` / `(rest s)` where the analyser has tagged the
-     * target as a `SeqInterface` / `PersistentVectorInterface` /
-     * `PersistentListInterface`. The runtime body of each fn walks a
-     * cond chain that handles nil, strings, php-arrays, sets, etc.;
-     * for a tagged seq every branch collapses to `$s->first()` /
-     * `$s->rest()`.
-     */
-    public static function typedSeqMethodName(CallNode $node): ?string
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return null;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
-            return null;
-        }
-
-        $name = $fn->getName()->getName();
-        if (!isset(self::SEQ_METHODS[$name])) {
-            return null;
-        }
-
-        $args = $node->getArguments();
-        if (count($args) !== 1) {
-            return null;
-        }
-
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        $tag = TagNormalizer::normalise($target->getInferredType());
-        if ($tag === null || !isset(self::SEQ_TAGS[$tag])) {
-            return null;
-        }
-
-        return self::SEQ_METHODS[$name];
-    }
-
-    public static function isTypedSeqAccessor(CallNode $node): bool
-    {
-        return self::typedSeqMethodName($node) !== null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -17,6 +17,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\GlobalCallTarget;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NilAndBooleanCheckSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\TypedCollectionMethodSpecialization;
 use Phel\Lang\Symbol;
 
 use function array_slice;
@@ -799,7 +800,7 @@ final class CallEmitter implements NodeEmitterInterface
      */
     private function tryEmitTypedSeqAccessor(CallNode $node): bool
     {
-        $method = CallSpecialization::typedSeqMethodName($node);
+        $method = TypedCollectionMethodSpecialization::typedSeqMethodName($node);
         if ($method === null) {
             return false;
         }
@@ -821,7 +822,7 @@ final class CallEmitter implements NodeEmitterInterface
      */
     private function tryEmitTypedVectorAccessor(CallNode $node): bool
     {
-        $spec = CallSpecialization::typedVectorMethodCall($node);
+        $spec = TypedCollectionMethodSpecialization::typedVectorMethodCall($node);
         if ($spec === null) {
             return false;
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecialization.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\SeqInterface;
+use Phel\Shared\CompilerConstants;
+
+use function count;
+
+/**
+ * Call-site eligibility for `phel.core` accessors on a `LocalVarNode`
+ * whose inferred tag is a persistent collection type, which
+ * {@see NodeEmitter\CallEmitter}
+ * lowers to a direct method call instead of the runtime `cond`-chain body.
+ */
+final readonly class TypedCollectionMethodSpecialization
+{
+    /** @var array<string, string> Phel core seq accessor → PHP method */
+    private const array SEQ_METHODS = [
+        'first' => 'first',
+        'rest' => 'rest',
+    ];
+
+    /** @var array<string, true> Tags whose runtime types implement SeqInterface */
+    private const array SEQ_TAGS = [
+        SeqInterface::class => true,
+        PersistentVectorInterface::class => true,
+        PersistentListInterface::class => true,
+    ];
+
+    private function __construct() {}
+
+    /**
+     * `(nth v i)` / `(count v)` where the analyser has tagged the
+     * target as `PersistentVectorInterface`. The runtime `nth` body
+     * walks a `cond` over set / seq / vector / map / php-array; for a
+     * typed vector every branch collapses to a single method call.
+     *
+     * @return array{method: string, args: list<int>}|null list of arg
+     *                                                     indices to
+     *                                                     pass as
+     *                                                     method args
+     */
+    public static function typedVectorMethodCall(CallNode $node): ?array
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return null;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        $target = $args[0] ?? null;
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        if (TagNormalizer::normalise($target->getInferredType()) !== PersistentVectorInterface::class) {
+            return null;
+        }
+
+        $name = $fn->getName()->getName();
+
+        if ($name === 'count' && count($args) === 1) {
+            return ['method' => 'count', 'args' => []];
+        }
+
+        if ($name === 'nth' && count($args) === 2) {
+            return ['method' => 'get', 'args' => [1]];
+        }
+
+        return null;
+    }
+
+    public static function isTypedVectorAccessor(CallNode $node): bool
+    {
+        return self::typedVectorMethodCall($node) !== null;
+    }
+
+    /**
+     * `(first s)` / `(rest s)` where the analyser has tagged the
+     * target as a `SeqInterface` / `PersistentVectorInterface` /
+     * `PersistentListInterface`. The runtime body of each fn walks a
+     * cond chain that handles nil, strings, php-arrays, sets, etc.;
+     * for a tagged seq every branch collapses to `$s->first()` /
+     * `$s->rest()`.
+     */
+    public static function typedSeqMethodName(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return null;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return null;
+        }
+
+        $name = $fn->getName()->getName();
+        if (!isset(self::SEQ_METHODS[$name])) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        $tag = TagNormalizer::normalise($target->getInferredType());
+        if ($tag === null || !isset(self::SEQ_TAGS[$tag])) {
+            return null;
+        }
+
+        return self::SEQ_METHODS[$name];
+    }
+
+    public static function isTypedSeqAccessor(CallNode $node): bool
+    {
+        return self::typedSeqMethodName($node) !== null;
+    }
+}

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
@@ -15,88 +15,12 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\CallSpecialization;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
-use Phel\Lang\SeqInterface;
 use Phel\Lang\Symbol;
 use Phel\Shared\CompilerConstants;
 use PHPUnit\Framework\TestCase;
 
 final class CallSpecializationTest extends TestCase
 {
-    public function test_count_on_typed_vector_specialises_to_method_call(): void
-    {
-        $node = $this->coreCall('count', [$this->vectorLocal('v')]);
-
-        $spec = CallSpecialization::typedVectorMethodCall($node);
-
-        self::assertSame(['method' => 'count', 'args' => []], $spec);
-    }
-
-    public function test_nth_on_typed_vector_specialises_to_get(): void
-    {
-        $node = $this->coreCall('nth', [$this->vectorLocal('v'), new LiteralNode($this->env(), 0)]);
-
-        $spec = CallSpecialization::typedVectorMethodCall($node);
-
-        self::assertSame(['method' => 'get', 'args' => [1]], $spec);
-    }
-
-    public function test_nth_on_untyped_local_falls_back(): void
-    {
-        $env = $this->env();
-        $node = $this->coreCall('nth', [
-            new LocalVarNode($env, Symbol::create('v')),
-            new LiteralNode($env, 0),
-        ]);
-
-        self::assertNull(CallSpecialization::typedVectorMethodCall($node));
-    }
-
-    public function test_count_with_wrong_arity_skips(): void
-    {
-        $node = $this->coreCall('count', [$this->vectorLocal('v'), new LiteralNode($this->env(), 0)]);
-
-        self::assertNull(CallSpecialization::typedVectorMethodCall($node));
-    }
-
-    public function test_other_core_fn_on_typed_vector_skips(): void
-    {
-        $node = $this->coreCall('inc', [$this->vectorLocal('v')]);
-
-        self::assertNull(CallSpecialization::typedVectorMethodCall($node));
-    }
-
-    public function test_first_on_typed_seq_specialises_to_first_method(): void
-    {
-        $node = $this->coreCall('first', [$this->localWithTag('s', SeqInterface::class)]);
-
-        self::assertSame('first', CallSpecialization::typedSeqMethodName($node));
-    }
-
-    public function test_rest_on_typed_vector_specialises_to_rest_method(): void
-    {
-        $node = $this->coreCall('rest', [$this->localWithTag('v', PersistentVectorInterface::class)]);
-
-        self::assertSame('rest', CallSpecialization::typedSeqMethodName($node));
-    }
-
-    public function test_first_on_untyped_local_falls_back(): void
-    {
-        $env = $this->env();
-        $node = $this->coreCall('first', [new LocalVarNode($env, Symbol::create('s'))]);
-
-        self::assertNull(CallSpecialization::typedSeqMethodName($node));
-    }
-
-    public function test_next_is_not_specialised(): void
-    {
-        // `next` returns nil on empty rest; a bare method call cannot
-        // reproduce that without a runtime probe, so the specialiser
-        // stays out of it.
-        $node = $this->coreCall('next', [$this->localWithTag('s', SeqInterface::class)]);
-
-        self::assertNull(CallSpecialization::typedSeqMethodName($node));
-    }
-
     public function test_assoc_on_typed_map_specialises_to_put(): void
     {
         $env = $this->env();

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecializationTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\TypedCollectionMethodSpecialization;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\SeqInterface;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
+use PHPUnit\Framework\TestCase;
+
+final class TypedCollectionMethodSpecializationTest extends TestCase
+{
+    public function test_count_on_typed_vector_specialises_to_method_call(): void
+    {
+        $node = $this->coreCall('count', [$this->vectorLocal('v')]);
+
+        $spec = TypedCollectionMethodSpecialization::typedVectorMethodCall($node);
+
+        self::assertSame(['method' => 'count', 'args' => []], $spec);
+    }
+
+    public function test_nth_on_typed_vector_specialises_to_get(): void
+    {
+        $node = $this->coreCall('nth', [$this->vectorLocal('v'), new LiteralNode($this->env(), 0)]);
+
+        $spec = TypedCollectionMethodSpecialization::typedVectorMethodCall($node);
+
+        self::assertSame(['method' => 'get', 'args' => [1]], $spec);
+    }
+
+    public function test_nth_on_untyped_local_falls_back(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('nth', [
+            new LocalVarNode($env, Symbol::create('v')),
+            new LiteralNode($env, 0),
+        ]);
+
+        self::assertNull(TypedCollectionMethodSpecialization::typedVectorMethodCall($node));
+    }
+
+    public function test_count_with_wrong_arity_skips(): void
+    {
+        $node = $this->coreCall('count', [$this->vectorLocal('v'), new LiteralNode($this->env(), 0)]);
+
+        self::assertNull(TypedCollectionMethodSpecialization::typedVectorMethodCall($node));
+    }
+
+    public function test_other_core_fn_on_typed_vector_skips(): void
+    {
+        $node = $this->coreCall('inc', [$this->vectorLocal('v')]);
+
+        self::assertNull(TypedCollectionMethodSpecialization::typedVectorMethodCall($node));
+    }
+
+    public function test_first_on_typed_seq_specialises_to_first_method(): void
+    {
+        $node = $this->coreCall('first', [$this->localWithTag('s', SeqInterface::class)]);
+
+        self::assertSame('first', TypedCollectionMethodSpecialization::typedSeqMethodName($node));
+    }
+
+    public function test_rest_on_typed_vector_specialises_to_rest_method(): void
+    {
+        $node = $this->coreCall('rest', [$this->localWithTag('v', PersistentVectorInterface::class)]);
+
+        self::assertSame('rest', TypedCollectionMethodSpecialization::typedSeqMethodName($node));
+    }
+
+    public function test_first_on_untyped_local_falls_back(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('first', [new LocalVarNode($env, Symbol::create('s'))]);
+
+        self::assertNull(TypedCollectionMethodSpecialization::typedSeqMethodName($node));
+    }
+
+    public function test_next_is_not_specialised(): void
+    {
+        // `next` returns nil on empty rest; a bare method call cannot
+        // reproduce that without a runtime probe, so the specialiser
+        // stays out of it.
+        $node = $this->coreCall('next', [$this->localWithTag('s', SeqInterface::class)]);
+
+        self::assertNull(TypedCollectionMethodSpecialization::typedSeqMethodName($node));
+    }
+
+    /**
+     * @param list<AbstractNode> $args
+     */
+    private function coreCall(string $name, array $args): CallNode
+    {
+        return new CallNode(
+            $this->env(),
+            new GlobalVarNode($this->env(), CompilerConstants::PHEL_CORE_NAMESPACE, Symbol::create($name), Phel::map()),
+            $args,
+        );
+    }
+
+    private function vectorLocal(string $name): LocalVarNode
+    {
+        return $this->localWithTag($name, PersistentVectorInterface::class);
+    }
+
+    private function localWithTag(string $name, string $tag): LocalVarNode
+    {
+        $sym = Symbol::create($name);
+        $meta = Phel::map(Keyword::create('tag'), $tag);
+        $locals = [$sym->withMeta($meta)];
+
+        $env = NodeEnvironment::empty()
+            ->withExpressionContext()
+            ->withMergedLocals($locals);
+
+        return new LocalVarNode($env, $sym);
+    }
+
+    private function env(): NodeEnvironment
+    {
+        return NodeEnvironment::empty()->withExpressionContext();
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Fourth step of splitting the `CallSpecialization` god-class (after #2236, #2237, #2238). The shared `TagNormalizer` from #2238 unblocks moving the tag-driven families; this PR moves the first of them.

## 💡 Goal

Move the typed persistent-collection accessor family out without changing any generated code.

## 🔖 Changes

- New `TypedCollectionMethodSpecialization` holding `typedVectorMethodCall` / `isTypedVectorAccessor` (`count` / `nth` on a `PersistentVectorInterface`-tagged local) and `typedSeqMethodName` / `isTypedSeqAccessor` (`first` / `rest` on a `SeqInterface` / `PersistentVectorInterface` / `PersistentListInterface`-tagged local), together with the `SEQ_METHODS` / `SEQ_TAGS` lookup tables that only this family used.
- `CallSpecialization`'s `isSpecialized` dispatch and `CallEmitter`'s two call sites now delegate to the new class.
- The existing typed-vector/seq unit tests move from `CallSpecializationTest` into the new `TypedCollectionMethodSpecializationTest` (co-located with the code under test).

## ✅ Verification

- Pure logic move — all integration `.test` fixtures pass unchanged → generated PHP is **byte-identical**.
- Full compiler suite (3840) green; psalm/phpstan/cs-fixer/rector clean.

## 📝 Follow-up

Remaining tag-driven families on `CallSpecialization` (assoc/conj chains, `contains?` / `empty?` / named accessors, type & numeric predicates) can move next using `TagNormalizer`.