### PR TITLE
ref(compiler): extract AssocConjSpecialization from CallSpecialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Compiler internals: extracted the atom accessor (`deref` / `reset!`) call-site eligibility out of `CallSpecialization` into a focused `AtomMethodSpecialization` collaborator (no change to generated code)
 - Compiler internals: extracted the inferred-type-tag normalisation helpers out of `CallSpecialization` into a shared `TagNormalizer` (no change to generated code)
 - Compiler internals: extracted the typed persistent-collection accessor lowering (`count` / `nth` on vectors, `first` / `rest` on seqs) out of `CallSpecialization` into a focused `TypedCollectionMethodSpecialization` collaborator (no change to generated code)
+- Compiler internals: extracted the `assoc` / `conj` / `dissoc` method lowering and the transient `(-> coll (assoc …) …)` chain detection out of `CallSpecialization` into a focused `AssocConjSpecialization` collaborator (no change to generated code)
 
 ## [0.41.0](https://github.com/phel-lang/phel-lang/compare/v0.40.0...v0.41.0) - 2026-06-01
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/AssocConjSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/AssocConjSpecialization.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Shared\CompilerConstants;
+
+use function array_slice;
+use function array_unshift;
+use function count;
+
+/**
+ * Call-site eligibility for `assoc` / `conj` / `dissoc` on a
+ * `LocalVarNode` tagged with a persistent-collection type, which
+ * {@see NodeEmitter\CallEmitter}
+ * lowers to a direct method call (single call) or a batched transient
+ * chain (`(-> coll (assoc …) (assoc …) …)`).
+ */
+final readonly class AssocConjSpecialization
+{
+    private function __construct() {}
+
+    /**
+     * `(assoc coll k v)` 3-arg / `(conj coll x)` 2-arg / `(dissoc coll k)` 2-arg
+     * specialise to a direct method call when the target carries an
+     * inferred persistent-collection tag:
+     *
+     *  - `PersistentMapInterface`  → `put` / `cons` (n/a) / `remove`
+     *  - `PersistentVectorInterface` → `update` / `append` / (n/a)
+     *
+     * Skips variadic / extra-arg arities — those need a loop the runtime
+     * dispatch handles separately.
+     */
+    public static function typedAssocConjDissocMethod(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return null;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        $target = $args[0] ?? null;
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        $tag = TagNormalizer::normalise($target->getInferredType());
+        if ($tag === null) {
+            return null;
+        }
+
+        $name = $fn->getName()->getName();
+        $argCount = count($args);
+
+        if ($name === 'assoc' && $argCount === 3) {
+            return match ($tag) {
+                PersistentMapInterface::class => 'put',
+                PersistentVectorInterface::class => 'update',
+                default => null,
+            };
+        }
+
+        if ($name === 'conj' && $argCount === 2) {
+            return match ($tag) {
+                PersistentVectorInterface::class => 'append',
+                default => null,
+            };
+        }
+
+        if ($name === 'dissoc' && $argCount === 2 && $tag === PersistentMapInterface::class) {
+            return 'remove';
+        }
+
+        return null;
+    }
+
+    public static function isTypedAssocConjDissoc(CallNode $node): bool
+    {
+        return self::typedAssocConjDissocMethod($node) !== null;
+    }
+
+    /**
+     * Detects an `(-> m (assoc k v) (assoc k v) ...)` or
+     * `(-> v (conj x) (conj y) ...)` chain — after thread-macro
+     * expansion these are nested `CallNode`s of the same op terminating
+     * at a `LocalVarNode` whose tag matches `PersistentMapInterface` or
+     * `PersistentVectorInterface`. A chain of length 1 is **not**
+     * batched: the existing single-call specialiser already lowers it
+     * to a direct method call, and a transient round-trip would just
+     * add work.
+     *
+     * Returns the leaf target, the transient method to spam, and the
+     * argument groups (`[k, v]` pairs for `assoc`, single-element
+     * `[x]` lists for `conj`) — `null` when the call is not a chain.
+     *
+     * @return array{
+     *     target: LocalVarNode,
+     *     method: 'append'|'put',
+     *     groups: list<list<AbstractNode>>
+     * }|null
+     */
+    public static function assocConjChain(CallNode $node): ?array
+    {
+        $shape = self::classifyChainHead($node);
+        if ($shape === null) {
+            return null;
+        }
+
+        [$opName, $expectedArgCount, $method, $expectedTag] = $shape;
+
+        $groups = [];
+        $current = $node;
+        while (true) {
+            $cFn = $current->getFn();
+            if (!$cFn instanceof GlobalVarNode) {
+                return null;
+            }
+
+            if ($cFn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+                || $cFn->getName()->getName() !== $opName
+            ) {
+                return null;
+            }
+
+            $cArgs = $current->getArguments();
+            if (count($cArgs) !== $expectedArgCount) {
+                return null;
+            }
+
+            array_unshift($groups, array_slice($cArgs, 1));
+
+            $target = $cArgs[0];
+            if ($target instanceof CallNode) {
+                $current = $target;
+                continue;
+            }
+
+            if (!$target instanceof LocalVarNode) {
+                return null;
+            }
+
+            if (TagNormalizer::normalise($target->getInferredType()) !== $expectedTag) {
+                return null;
+            }
+
+            if (count($groups) < 2) {
+                return null;
+            }
+
+            return [
+                'target' => $target,
+                'method' => $method,
+                'groups' => $groups,
+            ];
+        }
+    }
+
+    public static function isAssocConjChain(CallNode $node): bool
+    {
+        return self::assocConjChain($node) !== null;
+    }
+
+    /**
+     * @return array{0: string, 1: int, 2: 'append'|'put', 3: class-string}|null
+     */
+    private static function classifyChainHead(CallNode $node): ?array
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+        ) {
+            return null;
+        }
+
+        return match ($fn->getName()->getName()) {
+            'assoc' => ['assoc', 3, 'put', PersistentMapInterface::class],
+            'conj' => ['conj', 2, 'append', PersistentVectorInterface::class],
+            default => null,
+        };
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -20,7 +20,6 @@ use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use Phel\Shared\CompilerConstants;
 
-use function array_slice;
 use function count;
 use function in_array;
 use function is_bool;
@@ -162,11 +161,11 @@ final readonly class CallSpecialization
             return true;
         }
 
-        if (self::isTypedAssocConjDissoc($node)) {
+        if (AssocConjSpecialization::isTypedAssocConjDissoc($node)) {
             return true;
         }
 
-        if (self::isAssocConjChain($node)) {
+        if (AssocConjSpecialization::isAssocConjChain($node)) {
             return true;
         }
 
@@ -179,150 +178,6 @@ final readonly class CallSpecialization
         }
 
         return self::isTypedBinaryOp($node);
-    }
-
-    /**
-     * `(assoc coll k v)` 3-arg / `(conj coll x)` 2-arg / `(dissoc coll k)` 2-arg
-     * specialise to a direct method call when the target carries an
-     * inferred persistent-collection tag:
-     *
-     *  - `PersistentMapInterface`  → `put` / `cons` (n/a) / `remove`
-     *  - `PersistentVectorInterface` → `update` / `append` / (n/a)
-     *
-     * Skips variadic / extra-arg arities — those need a loop the runtime
-     * dispatch handles separately.
-     */
-    public static function typedAssocConjDissocMethod(CallNode $node): ?string
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return null;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
-            return null;
-        }
-
-        $args = $node->getArguments();
-        $target = $args[0] ?? null;
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        $tag = TagNormalizer::normalise($target->getInferredType());
-        if ($tag === null) {
-            return null;
-        }
-
-        $name = $fn->getName()->getName();
-        $argCount = count($args);
-
-        if ($name === 'assoc' && $argCount === 3) {
-            return match ($tag) {
-                PersistentMapInterface::class => 'put',
-                PersistentVectorInterface::class => 'update',
-                default => null,
-            };
-        }
-
-        if ($name === 'conj' && $argCount === 2) {
-            return match ($tag) {
-                PersistentVectorInterface::class => 'append',
-                default => null,
-            };
-        }
-
-        if ($name === 'dissoc' && $argCount === 2 && $tag === PersistentMapInterface::class) {
-            return 'remove';
-        }
-
-        return null;
-    }
-
-    public static function isTypedAssocConjDissoc(CallNode $node): bool
-    {
-        return self::typedAssocConjDissocMethod($node) !== null;
-    }
-
-    /**
-     * Detects an `(-> m (assoc k v) (assoc k v) ...)` or
-     * `(-> v (conj x) (conj y) ...)` chain — after thread-macro
-     * expansion these are nested `CallNode`s of the same op terminating
-     * at a `LocalVarNode` whose tag matches `PersistentMapInterface` or
-     * `PersistentVectorInterface`. A chain of length 1 is **not**
-     * batched: the existing single-call specialiser already lowers it
-     * to a direct method call, and a transient round-trip would just
-     * add work.
-     *
-     * Returns the leaf target, the transient method to spam, and the
-     * argument groups (`[k, v]` pairs for `assoc`, single-element
-     * `[x]` lists for `conj`) — `null` when the call is not a chain.
-     *
-     * @return array{
-     *     target: LocalVarNode,
-     *     method: 'append'|'put',
-     *     groups: list<list<AbstractNode>>
-     * }|null
-     */
-    public static function assocConjChain(CallNode $node): ?array
-    {
-        $shape = self::classifyChainHead($node);
-        if ($shape === null) {
-            return null;
-        }
-
-        [$opName, $expectedArgCount, $method, $expectedTag] = $shape;
-
-        $groups = [];
-        $current = $node;
-        while (true) {
-            $cFn = $current->getFn();
-            if (!$cFn instanceof GlobalVarNode) {
-                return null;
-            }
-
-            if ($cFn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-                || $cFn->getName()->getName() !== $opName
-            ) {
-                return null;
-            }
-
-            $cArgs = $current->getArguments();
-            if (count($cArgs) !== $expectedArgCount) {
-                return null;
-            }
-
-            array_unshift($groups, array_slice($cArgs, 1));
-
-            $target = $cArgs[0];
-            if ($target instanceof CallNode) {
-                $current = $target;
-                continue;
-            }
-
-            if (!$target instanceof LocalVarNode) {
-                return null;
-            }
-
-            if (TagNormalizer::normalise($target->getInferredType()) !== $expectedTag) {
-                return null;
-            }
-
-            if (count($groups) < 2) {
-                return null;
-            }
-
-            return [
-                'target' => $target,
-                'method' => $method,
-                'groups' => $groups,
-            ];
-        }
-    }
-
-    public static function isAssocConjChain(CallNode $node): bool
-    {
-        return self::assocConjChain($node) !== null;
     }
 
     /**
@@ -896,25 +751,6 @@ final readonly class CallSpecialization
         $arg = $args[0];
         return $arg instanceof LocalVarNode
             && TagNormalizer::isPersistentMap($arg->getInferredType());
-    }
-
-    /**
-     * @return array{0: string, 1: int, 2: 'append'|'put', 3: class-string}|null
-     */
-    private static function classifyChainHead(CallNode $node): ?array
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-        ) {
-            return null;
-        }
-
-        return match ($fn->getName()->getName()) {
-            'assoc' => ['assoc', 3, 'put', PersistentMapInterface::class],
-            'conj' => ['conj', 2, 'append', PersistentVectorInterface::class],
-            default => null,
-        };
     }
 
     private static function isStringConcatable(AbstractNode $arg): bool

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -11,6 +11,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\AssocConjSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\AtomMethodSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\CallSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\GlobalCallTarget;
@@ -733,7 +734,7 @@ final class CallEmitter implements NodeEmitterInterface
      */
     private function tryEmitAssocConjChain(CallNode $node): bool
     {
-        $chain = CallSpecialization::assocConjChain($node);
+        $chain = AssocConjSpecialization::assocConjChain($node);
         if ($chain === null) {
             return false;
         }
@@ -767,7 +768,7 @@ final class CallEmitter implements NodeEmitterInterface
      */
     private function tryEmitTypedAssocConjDissoc(CallNode $node): bool
     {
-        $method = CallSpecialization::typedAssocConjDissocMethod($node);
+        $method = AssocConjSpecialization::typedAssocConjDissocMethod($node);
         if ($method === null) {
             return false;
         }

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/AssocConjSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/AssocConjSpecializationTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\AssocConjSpecialization;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
+use PHPUnit\Framework\TestCase;
+
+final class AssocConjSpecializationTest extends TestCase
+{
+    public function test_assoc_on_typed_map_specialises_to_put(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('assoc', [
+            $this->localWithTag('m', PersistentMapInterface::class),
+            new LiteralNode($env, 'k'),
+            new LiteralNode($env, 1),
+        ]);
+
+        self::assertSame('put', AssocConjSpecialization::typedAssocConjDissocMethod($node));
+    }
+
+    public function test_assoc_on_typed_vector_specialises_to_update(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('assoc', [
+            $this->vectorLocal('v'),
+            new LiteralNode($env, 0),
+            new LiteralNode($env, 42),
+        ]);
+
+        self::assertSame('update', AssocConjSpecialization::typedAssocConjDissocMethod($node));
+    }
+
+    public function test_conj_on_typed_vector_specialises_to_append(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('conj', [
+            $this->vectorLocal('v'),
+            new LiteralNode($env, 99),
+        ]);
+
+        self::assertSame('append', AssocConjSpecialization::typedAssocConjDissocMethod($node));
+    }
+
+    public function test_dissoc_on_typed_map_specialises_to_remove(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('dissoc', [
+            $this->localWithTag('m', PersistentMapInterface::class),
+            new LiteralNode($env, 'k'),
+        ]);
+
+        self::assertSame('remove', AssocConjSpecialization::typedAssocConjDissocMethod($node));
+    }
+
+    public function test_variadic_assoc_is_not_specialised(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('assoc', [
+            $this->localWithTag('m', PersistentMapInterface::class),
+            new LiteralNode($env, 'k1'),
+            new LiteralNode($env, 1),
+            new LiteralNode($env, 'k2'),
+            new LiteralNode($env, 2),
+        ]);
+
+        self::assertNull(AssocConjSpecialization::typedAssocConjDissocMethod($node));
+    }
+
+    public function test_conj_on_untyped_local_falls_back(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('conj', [
+            new LocalVarNode($env, Symbol::create('v')),
+            new LiteralNode($env, 99),
+        ]);
+
+        self::assertNull(AssocConjSpecialization::typedAssocConjDissocMethod($node));
+    }
+
+    public function test_assoc_chain_of_two_batches_into_groups(): void
+    {
+        $env = $this->env();
+        $map = $this->localWithTag('m', PersistentMapInterface::class);
+        $inner = $this->coreCall('assoc', [$map, new LiteralNode($env, 'a'), new LiteralNode($env, 1)]);
+        $outer = $this->coreCall('assoc', [$inner, new LiteralNode($env, 'b'), new LiteralNode($env, 2)]);
+
+        $chain = AssocConjSpecialization::assocConjChain($outer);
+
+        self::assertNotNull($chain);
+        self::assertSame($map, $chain['target']);
+        self::assertSame('put', $chain['method']);
+        self::assertCount(2, $chain['groups']);
+    }
+
+    public function test_single_assoc_is_not_treated_as_a_chain(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('assoc', [
+            $this->localWithTag('m', PersistentMapInterface::class),
+            new LiteralNode($env, 'k'),
+            new LiteralNode($env, 1),
+        ]);
+
+        self::assertNull(AssocConjSpecialization::assocConjChain($node));
+    }
+
+    /**
+     * @param list<AbstractNode> $args
+     */
+    private function coreCall(string $name, array $args): CallNode
+    {
+        return new CallNode(
+            $this->env(),
+            new GlobalVarNode($this->env(), CompilerConstants::PHEL_CORE_NAMESPACE, Symbol::create($name), Phel::map()),
+            $args,
+        );
+    }
+
+    private function vectorLocal(string $name): LocalVarNode
+    {
+        return $this->localWithTag($name, PersistentVectorInterface::class);
+    }
+
+    private function localWithTag(string $name, string $tag): LocalVarNode
+    {
+        $sym = Symbol::create($name);
+        $meta = Phel::map(Keyword::create('tag'), $tag);
+        $locals = [$sym->withMeta($meta)];
+
+        $env = NodeEnvironment::empty()
+            ->withExpressionContext()
+            ->withMergedLocals($locals);
+
+        return new LocalVarNode($env, $sym);
+    }
+
+    private function env(): NodeEnvironment
+    {
+        return NodeEnvironment::empty()->withExpressionContext();
+    }
+}

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
@@ -12,8 +12,6 @@ use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\CallSpecialization;
-use Phel\Lang\Collections\Map\PersistentMapInterface;
-use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use Phel\Shared\CompilerConstants;
@@ -21,77 +19,6 @@ use PHPUnit\Framework\TestCase;
 
 final class CallSpecializationTest extends TestCase
 {
-    public function test_assoc_on_typed_map_specialises_to_put(): void
-    {
-        $env = $this->env();
-        $node = $this->coreCall('assoc', [
-            $this->localWithTag('m', PersistentMapInterface::class),
-            new LiteralNode($env, 'k'),
-            new LiteralNode($env, 1),
-        ]);
-
-        self::assertSame('put', CallSpecialization::typedAssocConjDissocMethod($node));
-    }
-
-    public function test_assoc_on_typed_vector_specialises_to_update(): void
-    {
-        $env = $this->env();
-        $node = $this->coreCall('assoc', [
-            $this->vectorLocal('v'),
-            new LiteralNode($env, 0),
-            new LiteralNode($env, 42),
-        ]);
-
-        self::assertSame('update', CallSpecialization::typedAssocConjDissocMethod($node));
-    }
-
-    public function test_conj_on_typed_vector_specialises_to_append(): void
-    {
-        $env = $this->env();
-        $node = $this->coreCall('conj', [
-            $this->vectorLocal('v'),
-            new LiteralNode($env, 99),
-        ]);
-
-        self::assertSame('append', CallSpecialization::typedAssocConjDissocMethod($node));
-    }
-
-    public function test_dissoc_on_typed_map_specialises_to_remove(): void
-    {
-        $env = $this->env();
-        $node = $this->coreCall('dissoc', [
-            $this->localWithTag('m', PersistentMapInterface::class),
-            new LiteralNode($env, 'k'),
-        ]);
-
-        self::assertSame('remove', CallSpecialization::typedAssocConjDissocMethod($node));
-    }
-
-    public function test_variadic_assoc_is_not_specialised(): void
-    {
-        $env = $this->env();
-        $node = $this->coreCall('assoc', [
-            $this->localWithTag('m', PersistentMapInterface::class),
-            new LiteralNode($env, 'k1'),
-            new LiteralNode($env, 1),
-            new LiteralNode($env, 'k2'),
-            new LiteralNode($env, 2),
-        ]);
-
-        self::assertNull(CallSpecialization::typedAssocConjDissocMethod($node));
-    }
-
-    public function test_conj_on_untyped_local_falls_back(): void
-    {
-        $env = $this->env();
-        $node = $this->coreCall('conj', [
-            new LocalVarNode($env, Symbol::create('v')),
-            new LiteralNode($env, 99),
-        ]);
-
-        self::assertNull(CallSpecialization::typedAssocConjDissocMethod($node));
-    }
-
     public function test_not_eq_peephole_fires_when_inner_eq_is_typed(): void
     {
         $this->env();
@@ -226,11 +153,6 @@ final class CallSpecializationTest extends TestCase
             ),
             $args,
         );
-    }
-
-    private function vectorLocal(string $name): LocalVarNode
-    {
-        return $this->localWithTag($name, PersistentVectorInterface::class);
     }
 
     private function localWithTag(string $name, string $tag): LocalVarNode


### PR DESCRIPTION
## 🤔 Background

Fifth step of splitting the `CallSpecialization` god-class (after #2236, #2237, #2238, #2239). Continues peeling tag-driven families off using the shared `TagNormalizer`.

## 💡 Goal

Move the `assoc` / `conj` / `dissoc` lowering family out without changing any generated code.

## 🔖 Changes

- New `AssocConjSpecialization` holding `typedAssocConjDissocMethod` / `isTypedAssocConjDissoc` (single-call `assoc`→`put`/`update`, `conj`→`append`, `dissoc`→`remove` on tagged map/vector locals) and `assocConjChain` / `isAssocConjChain` (the transient `(-> coll (assoc …) (assoc …) …)` batch detection), plus their exclusive private `classifyChainHead` helper.
- `CallSpecialization`'s `isSpecialized` dispatch and `CallEmitter`'s two call sites now delegate to the new class.
- The existing assoc/conj unit tests move from `CallSpecializationTest` into the new `AssocConjSpecializationTest`, with an added test covering the chain-batching path (`assocConjChain`) and its single-call exclusion.

## ✅ Verification

- Pure logic move — all integration `.test` fixtures pass unchanged → generated PHP is **byte-identical**.
- Full compiler suite (3842) green; psalm/phpstan/cs-fixer/rector clean.

## 📝 Follow-up

Remaining families on `CallSpecialization`: `contains?` / `empty?` / named accessors, type & numeric predicates, typed binary/variadic numeric ops, `get`/php-array access, string-concat / keyword-find.