### PR TITLE
ref(compiler): extract TypePredicateSpecialization from CallSpecialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Compiler internals: extracted the inferred-type-tag normalisation helpers out of `CallSpecialization` into a shared `TagNormalizer` (no change to generated code)
 - Compiler internals: extracted the typed persistent-collection accessor lowering (`count` / `nth` on vectors, `first` / `rest` on seqs) out of `CallSpecialization` into a focused `TypedCollectionMethodSpecialization` collaborator (no change to generated code)
 - Compiler internals: extracted the `assoc` / `conj` / `dissoc` method lowering and the transient `(-> coll (assoc …) …)` chain detection out of `CallSpecialization` into a focused `AssocConjSpecialization` collaborator (no change to generated code)
+- Compiler internals: extracted the single-arg type predicates (`int?` / `keyword?` / `map?` / … ) and numeric predicates (`zero?` / `pos?` / `neg?`) out of `CallSpecialization` into a focused `TypePredicateSpecialization` collaborator (no change to generated code)
 
 ## [0.41.0](https://github.com/phel-lang/phel-lang/compare/v0.40.0...v0.41.0) - 2026-06-01
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -77,14 +77,14 @@ final readonly class CallSpecialization
             || NilAndBooleanCheckSpecialization::isTrueCheck($node)
             || NilAndBooleanCheckSpecialization::isFalseCheck($node)
             || NilAndBooleanCheckSpecialization::isTruthyCheck($node)
-            || self::isTypePredicate($node)
+            || TypePredicateSpecialization::isTypePredicate($node)
             || self::isEmptyCheck($node)
             || self::isContainsCheck($node)
         ) {
             return true;
         }
 
-        return self::isNumericPredicate($node) !== null;
+        return TypePredicateSpecialization::isNumericPredicate($node) !== null;
     }
 
     public static function isSpecialized(CallNode $node): bool
@@ -129,11 +129,11 @@ final readonly class CallSpecialization
             return true;
         }
 
-        if (self::isNumericPredicate($node) !== null) {
+        if (TypePredicateSpecialization::isNumericPredicate($node) !== null) {
             return true;
         }
 
-        if (self::isTypePredicate($node)) {
+        if (TypePredicateSpecialization::isTypePredicate($node)) {
             return true;
         }
 
@@ -617,94 +617,6 @@ final readonly class CallSpecialization
     public static function isNamedAccessor(CallNode $node): bool
     {
         return self::namedAccessorMethod($node) !== null;
-    }
-
-    /**
-     * `(int? x)` / `(float? x)` / `(double? x)` / `(string? x)` /
-     * `(keyword? x)` / `(symbol? x)` / `(ratio? x)` — single-arg
-     * type predicates whose runtime body is a one-liner native
-     * check. Returns the PHP expression fragment to splice between
-     * the surrounding parens, or `null` when the call is not one of
-     * these predicates.
-     *
-     * The fragment expects `%s` substitution for the (already-emitted)
-     * argument expression.
-     */
-    public static function typePredicateFragment(CallNode $node): ?string
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-        ) {
-            return null;
-        }
-
-        $args = $node->getArguments();
-        if (count($args) !== 1) {
-            return null;
-        }
-
-        return match ($fn->getName()->getName()) {
-            'int?' => 'is_int(%s)',
-            'float?', 'double?' => 'is_float(%s)',
-            'string?' => 'is_string(%s)',
-            'keyword?' => '(%s instanceof \\Phel\\Lang\\Keyword)',
-            'symbol?' => '(%s instanceof \\Phel\\Lang\\Symbol)',
-            'ratio?' => '(%s instanceof \\Phel\\Lang\\Ratio)',
-            'struct?' => '(%s instanceof \\Phel\\Lang\\Collections\\Struct\\AbstractPersistentStruct)',
-            'set?' => '(%s instanceof \\Phel\\Lang\\Collections\\HashSet\\PersistentHashSetInterface)',
-            'lazy-seq?' => '(%s instanceof \\Phel\\Lang\\Collections\\LazySeq\\LazySeqInterface)',
-            'queue?' => '(%s instanceof \\Phel\\Lang\\Collections\\Queue\\PersistentQueue)',
-            'map?' => '((%1$s instanceof \\Phel\\Lang\\Collections\\Map\\PersistentMapInterface) && !(%1$s instanceof \\Phel\\Lang\\Collections\\Struct\\AbstractPersistentStruct))',
-            'vector?' => '((%1$s instanceof \\Phel\\Lang\\Collections\\Vector\\PersistentVectorInterface) || (%1$s instanceof \\Phel\\Lang\\Collections\\Map\\MapEntry))',
-            'seq?' => '((%1$s instanceof \\Phel\\Lang\\Collections\\LazySeq\\LazySeqInterface) || (%1$s instanceof \\Phel\\Lang\\Collections\\LazySeq\\Cons) || (%1$s instanceof \\Phel\\Lang\\Collections\\LinkedList\\PersistentListInterface))',
-            default => null,
-        };
-    }
-
-    public static function isTypePredicate(CallNode $node): bool
-    {
-        return self::typePredicateFragment($node) !== null;
-    }
-
-    /**
-     * `(zero? x)` / `(pos? x)` / `(neg? x)` on an `int` / `float`
-     * tagged local. Other numeric shapes (`BigInt`, `Ratio`,
-     * `BigDecimal`) need the runtime `NumericOperations` dispatch
-     * because the native operators do not honour their equality
-     * semantics. Returns the predicate name when eligible, `null`
-     * otherwise.
-     */
-    public static function isNumericPredicate(CallNode $node): ?string
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-        ) {
-            return null;
-        }
-
-        $name = $fn->getName()->getName();
-        if (!in_array($name, ['zero?', 'pos?', 'neg?'], true)) {
-            return null;
-        }
-
-        $args = $node->getArguments();
-        if (count($args) !== 1) {
-            return null;
-        }
-
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        $tag = TagNormalizer::normalise($target->getInferredType());
-        if ($tag !== 'int' && $tag !== 'float') {
-            return null;
-        }
-
-        return $name;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -19,6 +19,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\NilAndBooleanCheckSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\TypedCollectionMethodSpecialization;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\TypePredicateSpecialization;
 use Phel\Lang\Symbol;
 
 use function array_slice;
@@ -629,13 +630,13 @@ final class CallEmitter implements NodeEmitterInterface
 
     /**
      * Splice the argument into the native predicate fragment from
-     * `CallSpecialization::typePredicateFragment`. The fragment uses
+     * `TypePredicateSpecialization::typePredicateFragment`. The fragment uses
      * `sprintf` placeholders so multi-instanceof predicates (`map?`,
      * `vector?`, `seq?`) can reference the argument multiple times.
      */
     private function tryEmitTypePredicate(CallNode $node): bool
     {
-        $fragment = CallSpecialization::typePredicateFragment($node);
+        $fragment = TypePredicateSpecialization::typePredicateFragment($node);
         if ($fragment === null) {
             return false;
         }
@@ -654,7 +655,7 @@ final class CallEmitter implements NodeEmitterInterface
      */
     private function tryEmitNumericPredicate(CallNode $node): bool
     {
-        $name = CallSpecialization::isNumericPredicate($node);
+        $name = TypePredicateSpecialization::isNumericPredicate($node);
         if ($name === null) {
             return false;
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/TypePredicateSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/TypePredicateSpecialization.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Shared\CompilerConstants;
+
+use function count;
+use function in_array;
+
+/**
+ * Call-site eligibility for the single-argument `phel.core` type and
+ * numeric predicates that
+ * {@see NodeEmitter\CallEmitter}
+ * lowers to a native `instanceof` / `is_*` expression instead of a
+ * registry dispatch.
+ */
+final readonly class TypePredicateSpecialization
+{
+    private function __construct() {}
+
+    /**
+     * `(int? x)` / `(float? x)` / `(double? x)` / `(string? x)` /
+     * `(keyword? x)` / `(symbol? x)` / `(ratio? x)` — single-arg
+     * type predicates whose runtime body is a one-liner native
+     * check. Returns the PHP expression fragment to splice between
+     * the surrounding parens, or `null` when the call is not one of
+     * these predicates.
+     *
+     * The fragment expects `%s` substitution for the (already-emitted)
+     * argument expression.
+     */
+    public static function typePredicateFragment(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+        ) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        return match ($fn->getName()->getName()) {
+            'int?' => 'is_int(%s)',
+            'float?', 'double?' => 'is_float(%s)',
+            'string?' => 'is_string(%s)',
+            'keyword?' => '(%s instanceof \\Phel\\Lang\\Keyword)',
+            'symbol?' => '(%s instanceof \\Phel\\Lang\\Symbol)',
+            'ratio?' => '(%s instanceof \\Phel\\Lang\\Ratio)',
+            'struct?' => '(%s instanceof \\Phel\\Lang\\Collections\\Struct\\AbstractPersistentStruct)',
+            'set?' => '(%s instanceof \\Phel\\Lang\\Collections\\HashSet\\PersistentHashSetInterface)',
+            'lazy-seq?' => '(%s instanceof \\Phel\\Lang\\Collections\\LazySeq\\LazySeqInterface)',
+            'queue?' => '(%s instanceof \\Phel\\Lang\\Collections\\Queue\\PersistentQueue)',
+            'map?' => '((%1$s instanceof \\Phel\\Lang\\Collections\\Map\\PersistentMapInterface) && !(%1$s instanceof \\Phel\\Lang\\Collections\\Struct\\AbstractPersistentStruct))',
+            'vector?' => '((%1$s instanceof \\Phel\\Lang\\Collections\\Vector\\PersistentVectorInterface) || (%1$s instanceof \\Phel\\Lang\\Collections\\Map\\MapEntry))',
+            'seq?' => '((%1$s instanceof \\Phel\\Lang\\Collections\\LazySeq\\LazySeqInterface) || (%1$s instanceof \\Phel\\Lang\\Collections\\LazySeq\\Cons) || (%1$s instanceof \\Phel\\Lang\\Collections\\LinkedList\\PersistentListInterface))',
+            default => null,
+        };
+    }
+
+    public static function isTypePredicate(CallNode $node): bool
+    {
+        return self::typePredicateFragment($node) !== null;
+    }
+
+    /**
+     * `(zero? x)` / `(pos? x)` / `(neg? x)` on an `int` / `float`
+     * tagged local. Other numeric shapes (`BigInt`, `Ratio`,
+     * `BigDecimal`) need the runtime `NumericOperations` dispatch
+     * because the native operators do not honour their equality
+     * semantics. Returns the predicate name when eligible, `null`
+     * otherwise.
+     */
+    public static function isNumericPredicate(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+        ) {
+            return null;
+        }
+
+        $name = $fn->getName()->getName();
+        if (!in_array($name, ['zero?', 'pos?', 'neg?'], true)) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        $tag = TagNormalizer::normalise($target->getInferredType());
+        if ($tag !== 'int' && $tag !== 'float') {
+            return null;
+        }
+
+        return $name;
+    }
+}

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/TypePredicateSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/TypePredicateSpecializationTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\TypePredicateSpecialization;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
+use PHPUnit\Framework\TestCase;
+
+final class TypePredicateSpecializationTest extends TestCase
+{
+    public function test_int_predicate_lowers_to_is_int(): void
+    {
+        $node = $this->coreCall('int?', [$this->local('x')]);
+
+        self::assertSame('is_int(%s)', TypePredicateSpecialization::typePredicateFragment($node));
+        self::assertTrue(TypePredicateSpecialization::isTypePredicate($node));
+    }
+
+    public function test_keyword_predicate_lowers_to_instanceof(): void
+    {
+        $node = $this->coreCall('keyword?', [$this->local('x')]);
+
+        self::assertSame('(%s instanceof \\Phel\\Lang\\Keyword)', TypePredicateSpecialization::typePredicateFragment($node));
+    }
+
+    public function test_non_predicate_core_fn_is_not_a_type_predicate(): void
+    {
+        $node = $this->coreCall('inc', [$this->local('x')]);
+
+        self::assertNull(TypePredicateSpecialization::typePredicateFragment($node));
+        self::assertFalse(TypePredicateSpecialization::isTypePredicate($node));
+    }
+
+    public function test_two_arg_predicate_is_not_specialised(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('int?', [$this->local('x'), new LiteralNode($env, 1)]);
+
+        self::assertNull(TypePredicateSpecialization::typePredicateFragment($node));
+    }
+
+    public function test_numeric_predicate_on_int_tagged_local(): void
+    {
+        $node = $this->coreCall('zero?', [$this->localWithTag('n', 'int')]);
+
+        self::assertSame('zero?', TypePredicateSpecialization::isNumericPredicate($node));
+    }
+
+    public function test_numeric_predicate_on_float_tagged_local(): void
+    {
+        $node = $this->coreCall('pos?', [$this->localWithTag('n', 'float')]);
+
+        self::assertSame('pos?', TypePredicateSpecialization::isNumericPredicate($node));
+    }
+
+    public function test_numeric_predicate_on_untyped_local_falls_back(): void
+    {
+        $node = $this->coreCall('neg?', [$this->local('n')]);
+
+        self::assertNull(TypePredicateSpecialization::isNumericPredicate($node));
+    }
+
+    public function test_numeric_predicate_on_non_numeric_tag_falls_back(): void
+    {
+        $node = $this->coreCall('zero?', [$this->localWithTag('n', 'string')]);
+
+        self::assertNull(TypePredicateSpecialization::isNumericPredicate($node));
+    }
+
+    public function test_non_core_namespace_predicate_is_not_specialised(): void
+    {
+        $node = new CallNode(
+            $this->env(),
+            new GlobalVarNode($this->env(), 'my\\app', Symbol::create('int?'), Phel::map()),
+            [$this->local('x')],
+        );
+
+        self::assertNull(TypePredicateSpecialization::typePredicateFragment($node));
+    }
+
+    /**
+     * @param list<AbstractNode> $args
+     */
+    private function coreCall(string $name, array $args): CallNode
+    {
+        return new CallNode(
+            $this->env(),
+            new GlobalVarNode($this->env(), CompilerConstants::PHEL_CORE_NAMESPACE, Symbol::create($name), Phel::map()),
+            $args,
+        );
+    }
+
+    private function local(string $name): LocalVarNode
+    {
+        return new LocalVarNode($this->env(), Symbol::create($name));
+    }
+
+    private function localWithTag(string $name, string $tag): LocalVarNode
+    {
+        $sym = Symbol::create($name);
+        $meta = Phel::map(Keyword::create('tag'), $tag);
+        $locals = [$sym->withMeta($meta)];
+
+        $env = NodeEnvironment::empty()
+            ->withExpressionContext()
+            ->withMergedLocals($locals);
+
+        return new LocalVarNode($env, $sym);
+    }
+
+    private function env(): NodeEnvironment
+    {
+        return NodeEnvironment::empty()->withExpressionContext();
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Sixth step of splitting the `CallSpecialization` god-class (after #2236–#2240).

## 💡 Goal

Move the type/numeric predicate family out without changing any generated code.

## 🔖 Changes

- New `TypePredicateSpecialization` holding `typePredicateFragment` / `isTypePredicate` (single-arg `int?` / `float?` / `string?` / `keyword?` / `symbol?` / `ratio?` / `struct?` / `set?` / `map?` / `vector?` / `seq?` / … → native `is_*` / `instanceof` fragment) and `isNumericPredicate` (`zero?` / `pos?` / `neg?` on an `int` / `float`-tagged local).
- `CallSpecialization`'s `isSpecialized` and `isBoolReturningSpecialisation` dispatch and `CallEmitter`'s two call sites now delegate to the new class.
- Adds `TypePredicateSpecializationTest` (fragment mapping, arity guard, non-predicate fallback, numeric predicate tag gating).

## ✅ Verification

- Pure logic move — all integration `.test` fixtures pass unchanged → generated PHP is **byte-identical**.
- Full compiler suite (3850) green; psalm/phpstan/cs-fixer/rector clean.

## 📝 Follow-up

Remaining families on `CallSpecialization`: `contains?` / `empty?` / named accessors, typed binary/variadic numeric ops (+ their shared `NUMERIC_*` tables), `get` / php-array access, string-concat / keyword-find, not-eq peephole.