### PR TITLE
ref(compiler): extract TypedValueSpecialization from CallSpecialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Compiler internals: extracted the typed persistent-collection accessor lowering (`count` / `nth` on vectors, `first` / `rest` on seqs) out of `CallSpecialization` into a focused `TypedCollectionMethodSpecialization` collaborator (no change to generated code)
 - Compiler internals: extracted the `assoc` / `conj` / `dissoc` method lowering and the transient `(-> coll (assoc …) …)` chain detection out of `CallSpecialization` into a focused `AssocConjSpecialization` collaborator (no change to generated code)
 - Compiler internals: extracted the single-arg type predicates (`int?` / `keyword?` / `map?` / … ) and numeric predicates (`zero?` / `pos?` / `neg?`) out of `CallSpecialization` into a focused `TypePredicateSpecialization` collaborator (no change to generated code)
+- Compiler internals: extracted the tagged-target value ops (`contains?` / `empty?` / `name` / `namespace` / keyword-find) out of `CallSpecialization` into a focused `TypedValueSpecialization` collaborator (no change to generated code)
 
 ## [0.41.0](https://github.com/phel-lang/phel-lang/compare/v0.40.0...v0.41.0) - 2026-06-01
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -11,13 +11,9 @@ use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Lang\AbstractFn;
-use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
-use Phel\Lang\ContainsInterface;
 use Phel\Lang\FnInterface;
-use Phel\Lang\Keyword;
-use Phel\Lang\Symbol;
 use Phel\Shared\CompilerConstants;
 
 use function count;
@@ -78,8 +74,8 @@ final readonly class CallSpecialization
             || NilAndBooleanCheckSpecialization::isFalseCheck($node)
             || NilAndBooleanCheckSpecialization::isTruthyCheck($node)
             || TypePredicateSpecialization::isTypePredicate($node)
-            || self::isEmptyCheck($node)
-            || self::isContainsCheck($node)
+            || TypedValueSpecialization::isEmptyCheck($node)
+            || TypedValueSpecialization::isContainsCheck($node)
         ) {
             return true;
         }
@@ -93,7 +89,7 @@ final readonly class CallSpecialization
             return true;
         }
 
-        if (self::isKeywordFind($node)) {
+        if (TypedValueSpecialization::isKeywordFind($node)) {
             return true;
         }
 
@@ -137,15 +133,15 @@ final readonly class CallSpecialization
             return true;
         }
 
-        if (self::isNamedAccessor($node)) {
+        if (TypedValueSpecialization::isNamedAccessor($node)) {
             return true;
         }
 
-        if (self::isEmptyCheck($node)) {
+        if (TypedValueSpecialization::isEmptyCheck($node)) {
             return true;
         }
 
-        if (self::isContainsCheck($node)) {
+        if (TypedValueSpecialization::isContainsCheck($node)) {
             return true;
         }
 
@@ -468,158 +464,6 @@ final readonly class CallSpecialization
     }
 
     /**
-     * `(contains? coll k)` on a target tagged as a
-     * `\Phel\Lang\ContainsInterface`-implementing collection
-     * (PersistentMap / PersistentVector / PersistentHashSet) or as a
-     * PHP `array`. The runtime body walks
-     * `nil? → ContainsInterface → is_array → is_string → throw`; the
-     * tagged target collapses to one of the first two branches.
-     *
-     * Returns:
-     *  - `'method'` for ContainsInterface targets — emit `$coll->contains($k)`
-     *  - `'array'` for array tags                 — emit `array_key_exists($k, $coll)`
-     *  - `null` otherwise.
-     */
-    public static function containsCheckKind(CallNode $node): ?string
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== 'contains?'
-        ) {
-            return null;
-        }
-
-        $args = $node->getArguments();
-        if (count($args) !== 2) {
-            return null;
-        }
-
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        $tag = TagNormalizer::normalise($target->getInferredType());
-        if ($tag === null) {
-            return null;
-        }
-
-        if ($tag === 'array') {
-            return 'array';
-        }
-
-        $containsInterfaces = [
-            PersistentMapInterface::class,
-            PersistentVectorInterface::class,
-            PersistentHashSetInterface::class,
-            ContainsInterface::class,
-        ];
-
-        return in_array($tag, $containsInterfaces, true) ? 'method' : null;
-    }
-
-    public static function isContainsCheck(CallNode $node): bool
-    {
-        return self::containsCheckKind($node) !== null;
-    }
-
-    /**
-     * `(empty? x)` on a tagged local. Returns the PHP expression
-     * fragment with `%s` substitution for the (already-emitted)
-     * argument, or `null` when the call is not eligible.
-     *
-     *  - `^array x`                       → `(%s === [])`
-     *  - `^string x`                      → `(%s === '')`
-     *  - `^int x`                         → `(%s === 0)`
-     *  - `^PersistentMapInterface x`      → `(%s->count() === 0)`
-     *  - `^PersistentVectorInterface x`   → `(%s->count() === 0)`
-     */
-    public static function emptyCheckFragment(CallNode $node): ?string
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== 'empty?'
-        ) {
-            return null;
-        }
-
-        $args = $node->getArguments();
-        if (count($args) !== 1) {
-            return null;
-        }
-
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        $tag = TagNormalizer::normalise($target->getInferredType());
-        if ($tag === null) {
-            return null;
-        }
-
-        return match ($tag) {
-            'array' => '(%s === [])',
-            'string' => "(%s === '')",
-            'int' => '(%s === 0)',
-            PersistentMapInterface::class,
-            PersistentVectorInterface::class => '(%s->count() === 0)',
-            default => null,
-        };
-    }
-
-    public static function isEmptyCheck(CallNode $node): bool
-    {
-        return self::emptyCheckFragment($node) !== null;
-    }
-
-    /**
-     * `(name x)` / `(namespace x)` on a target tagged
-     * `\Phel\Lang\Keyword` or `\Phel\Lang\Symbol`. The runtime body
-     * for `name` is `(if (string? x) x (php/-> x (getName)))`; the
-     * tagged target always hits the second branch. Returns the
-     * method name (`getName` / `getNamespace`) when eligible, `null`
-     * otherwise.
-     */
-    public static function namedAccessorMethod(CallNode $node): ?string
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-        ) {
-            return null;
-        }
-
-        $args = $node->getArguments();
-        if (count($args) !== 1) {
-            return null;
-        }
-
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        $tag = TagNormalizer::normalise($target->getInferredType());
-        if ($tag !== Keyword::class && $tag !== Symbol::class) {
-            return null;
-        }
-
-        return match ($fn->getName()->getName()) {
-            'name' => 'getName',
-            'namespace' => 'getNamespace',
-            default => null,
-        };
-    }
-
-    public static function isNamedAccessor(CallNode $node): bool
-    {
-        return self::namedAccessorMethod($node) !== null;
-    }
-
-    /**
      * `(str ...)` whose every argument compiles to a string-typed
      * expression: string literals or `LocalVarNode`s tagged `string`.
      */
@@ -642,27 +486,6 @@ final readonly class CallSpecialization
         }
 
         return array_all($args, static fn(AbstractNode $arg): bool => self::isStringConcatable($arg));
-    }
-
-    /**
-     * `(:k m)` where the analyser has tagged `m` as `PersistentMapInterface`,
-     * so `Keyword::__invoke` reduces to a single `$m->find($k)` call.
-     */
-    public static function isKeywordFind(CallNode $node): bool
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof LiteralNode || !$fn->getValue() instanceof Keyword) {
-            return false;
-        }
-
-        $args = $node->getArguments();
-        if (count($args) !== 1) {
-            return false;
-        }
-
-        $arg = $args[0];
-        return $arg instanceof LocalVarNode
-            && TagNormalizer::isPersistentMap($arg->getInferredType());
     }
 
     private static function isStringConcatable(AbstractNode $arg): bool

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -19,6 +19,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\NilAndBooleanCheckSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\TypedCollectionMethodSpecialization;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\TypedValueSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\TypePredicateSpecialization;
 use Phel\Lang\Symbol;
 
@@ -308,7 +309,7 @@ final class CallEmitter implements NodeEmitterInterface
      */
     private function tryEmitKeywordFind(CallNode $node): bool
     {
-        if (!CallSpecialization::isKeywordFind($node)) {
+        if (!TypedValueSpecialization::isKeywordFind($node)) {
             return false;
         }
 
@@ -563,7 +564,7 @@ final class CallEmitter implements NodeEmitterInterface
      */
     private function tryEmitContainsCheck(CallNode $node): bool
     {
-        $kind = CallSpecialization::containsCheckKind($node);
+        $kind = TypedValueSpecialization::containsCheckKind($node);
         if ($kind === null) {
             return false;
         }
@@ -594,7 +595,7 @@ final class CallEmitter implements NodeEmitterInterface
      */
     private function tryEmitEmptyCheck(CallNode $node): bool
     {
-        $fragment = CallSpecialization::emptyCheckFragment($node);
+        $fragment = TypedValueSpecialization::emptyCheckFragment($node);
         if ($fragment === null) {
             return false;
         }
@@ -616,7 +617,7 @@ final class CallEmitter implements NodeEmitterInterface
      */
     private function tryEmitNamedAccessor(CallNode $node): bool
     {
-        $method = CallSpecialization::namedAccessorMethod($node);
+        $method = TypedValueSpecialization::namedAccessorMethod($node);
         if ($method === null) {
             return false;
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedValueSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedValueSpecialization.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\ContainsInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
+
+use function count;
+use function in_array;
+
+/**
+ * Call-site eligibility for `phel.core` operations on a single
+ * tagged-value target — `contains?`, `empty?`, `name` / `namespace`,
+ * and keyword-find (`(:k m)`) — which
+ * {@see NodeEmitter\CallEmitter}
+ * lowers to a native check / accessor instead of a registry dispatch.
+ */
+final readonly class TypedValueSpecialization
+{
+    private function __construct() {}
+
+    /**
+     * `(contains? coll k)` on a target tagged as a
+     * `\Phel\Lang\ContainsInterface`-implementing collection
+     * (PersistentMap / PersistentVector / PersistentHashSet) or as a
+     * PHP `array`. The runtime body walks
+     * `nil? → ContainsInterface → is_array → is_string → throw`; the
+     * tagged target collapses to one of the first two branches.
+     *
+     * Returns:
+     *  - `'method'` for ContainsInterface targets — emit `$coll->contains($k)`
+     *  - `'array'` for array tags                 — emit `array_key_exists($k, $coll)`
+     *  - `null` otherwise.
+     */
+    public static function containsCheckKind(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || $fn->getName()->getName() !== 'contains?'
+        ) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 2) {
+            return null;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        $tag = TagNormalizer::normalise($target->getInferredType());
+        if ($tag === null) {
+            return null;
+        }
+
+        if ($tag === 'array') {
+            return 'array';
+        }
+
+        $containsInterfaces = [
+            PersistentMapInterface::class,
+            PersistentVectorInterface::class,
+            PersistentHashSetInterface::class,
+            ContainsInterface::class,
+        ];
+
+        return in_array($tag, $containsInterfaces, true) ? 'method' : null;
+    }
+
+    public static function isContainsCheck(CallNode $node): bool
+    {
+        return self::containsCheckKind($node) !== null;
+    }
+
+    /**
+     * `(empty? x)` on a tagged local. Returns the PHP expression
+     * fragment with `%s` substitution for the (already-emitted)
+     * argument, or `null` when the call is not eligible.
+     *
+     *  - `^array x`                       → `(%s === [])`
+     *  - `^string x`                      → `(%s === '')`
+     *  - `^int x`                         → `(%s === 0)`
+     *  - `^PersistentMapInterface x`      → `(%s->count() === 0)`
+     *  - `^PersistentVectorInterface x`   → `(%s->count() === 0)`
+     */
+    public static function emptyCheckFragment(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || $fn->getName()->getName() !== 'empty?'
+        ) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        $tag = TagNormalizer::normalise($target->getInferredType());
+        if ($tag === null) {
+            return null;
+        }
+
+        return match ($tag) {
+            'array' => '(%s === [])',
+            'string' => "(%s === '')",
+            'int' => '(%s === 0)',
+            PersistentMapInterface::class,
+            PersistentVectorInterface::class => '(%s->count() === 0)',
+            default => null,
+        };
+    }
+
+    public static function isEmptyCheck(CallNode $node): bool
+    {
+        return self::emptyCheckFragment($node) !== null;
+    }
+
+    /**
+     * `(name x)` / `(namespace x)` on a target tagged
+     * `\Phel\Lang\Keyword` or `\Phel\Lang\Symbol`. The runtime body
+     * for `name` is `(if (string? x) x (php/-> x (getName)))`; the
+     * tagged target always hits the second branch. Returns the
+     * method name (`getName` / `getNamespace`) when eligible, `null`
+     * otherwise.
+     */
+    public static function namedAccessorMethod(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+        ) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        $tag = TagNormalizer::normalise($target->getInferredType());
+        if ($tag !== Keyword::class && $tag !== Symbol::class) {
+            return null;
+        }
+
+        return match ($fn->getName()->getName()) {
+            'name' => 'getName',
+            'namespace' => 'getNamespace',
+            default => null,
+        };
+    }
+
+    public static function isNamedAccessor(CallNode $node): bool
+    {
+        return self::namedAccessorMethod($node) !== null;
+    }
+
+    /**
+     * `(:k m)` where the analyser has tagged `m` as `PersistentMapInterface`,
+     * so `Keyword::__invoke` reduces to a single `$m->find($k)` call.
+     */
+    public static function isKeywordFind(CallNode $node): bool
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof LiteralNode || !$fn->getValue() instanceof Keyword) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return false;
+        }
+
+        $arg = $args[0];
+        return $arg instanceof LocalVarNode
+            && TagNormalizer::isPersistentMap($arg->getInferredType());
+    }
+}

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/TypedValueSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/TypedValueSpecializationTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\TypedValueSpecialization;
+use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
+use PHPUnit\Framework\TestCase;
+
+final class TypedValueSpecializationTest extends TestCase
+{
+    public function test_contains_on_array_tagged_target_is_array_kind(): void
+    {
+        $node = $this->coreCall('contains?', [$this->localWithTag('a', 'array'), new LiteralNode($this->env(), 'k')]);
+
+        self::assertSame('array', TypedValueSpecialization::containsCheckKind($node));
+    }
+
+    public function test_contains_on_map_tagged_target_is_method_kind(): void
+    {
+        $node = $this->coreCall('contains?', [$this->localWithTag('m', PersistentMapInterface::class), new LiteralNode($this->env(), 'k')]);
+
+        self::assertSame('method', TypedValueSpecialization::containsCheckKind($node));
+        self::assertTrue(TypedValueSpecialization::isContainsCheck($node));
+    }
+
+    public function test_contains_on_hash_set_tagged_target_is_method_kind(): void
+    {
+        $node = $this->coreCall('contains?', [$this->localWithTag('s', PersistentHashSetInterface::class), new LiteralNode($this->env(), 'k')]);
+
+        self::assertSame('method', TypedValueSpecialization::containsCheckKind($node));
+    }
+
+    public function test_contains_on_untyped_target_falls_back(): void
+    {
+        $node = $this->coreCall('contains?', [$this->local('m'), new LiteralNode($this->env(), 'k')]);
+
+        self::assertNull(TypedValueSpecialization::containsCheckKind($node));
+    }
+
+    public function test_empty_fragment_per_tag(): void
+    {
+        self::assertSame('(%s === [])', TypedValueSpecialization::emptyCheckFragment($this->coreCall('empty?', [$this->localWithTag('a', 'array')])));
+        self::assertSame("(%s === '')", TypedValueSpecialization::emptyCheckFragment($this->coreCall('empty?', [$this->localWithTag('s', 'string')])));
+        self::assertSame('(%s === 0)', TypedValueSpecialization::emptyCheckFragment($this->coreCall('empty?', [$this->localWithTag('i', 'int')])));
+        self::assertSame('(%s->count() === 0)', TypedValueSpecialization::emptyCheckFragment($this->coreCall('empty?', [$this->localWithTag('m', PersistentMapInterface::class)])));
+    }
+
+    public function test_empty_on_untyped_target_falls_back(): void
+    {
+        self::assertNull(TypedValueSpecialization::emptyCheckFragment($this->coreCall('empty?', [$this->local('x')])));
+    }
+
+    public function test_name_and_namespace_accessor_methods(): void
+    {
+        self::assertSame('getName', TypedValueSpecialization::namedAccessorMethod($this->coreCall('name', [$this->localWithTag('k', Keyword::class)])));
+        self::assertSame('getNamespace', TypedValueSpecialization::namedAccessorMethod($this->coreCall('namespace', [$this->localWithTag('s', Symbol::class)])));
+    }
+
+    public function test_named_accessor_on_untagged_target_falls_back(): void
+    {
+        self::assertNull(TypedValueSpecialization::namedAccessorMethod($this->coreCall('name', [$this->local('x')])));
+    }
+
+    public function test_keyword_find_on_map_tagged_arg(): void
+    {
+        $node = new CallNode(
+            $this->env(),
+            new LiteralNode($this->env(), Keyword::create('k')),
+            [$this->localWithTag('m', PersistentMapInterface::class)],
+        );
+
+        self::assertTrue(TypedValueSpecialization::isKeywordFind($node));
+    }
+
+    public function test_keyword_find_on_untyped_arg_falls_back(): void
+    {
+        $node = new CallNode(
+            $this->env(),
+            new LiteralNode($this->env(), Keyword::create('k')),
+            [$this->local('m')],
+        );
+
+        self::assertFalse(TypedValueSpecialization::isKeywordFind($node));
+    }
+
+    /**
+     * @param list<AbstractNode> $args
+     */
+    private function coreCall(string $name, array $args): CallNode
+    {
+        return new CallNode(
+            $this->env(),
+            new GlobalVarNode($this->env(), CompilerConstants::PHEL_CORE_NAMESPACE, Symbol::create($name), Phel::map()),
+            $args,
+        );
+    }
+
+    private function local(string $name): LocalVarNode
+    {
+        return new LocalVarNode($this->env(), Symbol::create($name));
+    }
+
+    private function localWithTag(string $name, string $tag): LocalVarNode
+    {
+        $sym = Symbol::create($name);
+        $meta = Phel::map(Keyword::create('tag'), $tag);
+        $locals = [$sym->withMeta($meta)];
+
+        $env = NodeEnvironment::empty()
+            ->withExpressionContext()
+            ->withMergedLocals($locals);
+
+        return new LocalVarNode($env, $sym);
+    }
+
+    private function env(): NodeEnvironment
+    {
+        return NodeEnvironment::empty()->withExpressionContext();
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Final small-bits step of splitting the `CallSpecialization` god-class (after #2236–#2241). Moves the remaining cleanly self-contained families.

## 💡 Goal

Move the tagged-target value ops out without changing any generated code.

## 🔖 Changes

- New `TypedValueSpecialization` holding `containsCheckKind` / `isContainsCheck` (`contains?` → `->contains()` / `array_key_exists`), `emptyCheckFragment` / `isEmptyCheck` (`empty?` → native fragment per tag), `namedAccessorMethod` / `isNamedAccessor` (`name` / `namespace` on Keyword/Symbol → `getName` / `getNamespace`), and `isKeywordFind` (`(:k m)` on a map-tagged arg).
- `CallSpecialization`'s `isSpecialized` / `isBoolReturningSpecialisation` dispatch and `CallEmitter`'s four call sites now delegate to the new class.
- Adds `TypedValueSpecializationTest`.

## ✅ Verification

- Pure logic move — all integration `.test` fixtures pass unchanged → generated PHP is **byte-identical**.
- Full compiler suite (3860) green; psalm/phpstan/cs-fixer/rector clean.

## 📝 Follow-up

`CallSpecialization` now holds the entangled numeric cluster (`typedBinaryOpName`, `typedVariadicChain`, not-eq peephole, `get`/php-array access, `str` concat) which shares the `inferredTypeOfNode` helper; that group is intentionally left for a later, separate extraction (it needs a shared-helper move first, like `TagNormalizer` was). Net so far: `CallSpecialization` 1325 → ~660 LOC across 7 focused collaborators, all byte-identical.