### PR TITLE
test(compiler): pin AST source-location propagation across phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Compiler internals: end-to-end regression test pinning that AST source locations survive every phase (lexer → parser → reader → analyzer)
+
 ### Changed
 
+- Compiler internals: documented `AbstractNode::getStartSourceLocation()`'s nullable contract
 - Compiler internals: extracted the `nil?` / `some?` / `true?` / `false?` / `truthy?` call-site eligibility checks out of `CallSpecialization` into a focused `NilAndBooleanCheckSpecialization` collaborator (no change to generated code)
 - Compiler internals: extracted the atom accessor (`deref` / `reset!`) call-site eligibility out of `CallSpecialization` into a focused `AtomMethodSpecialization` collaborator (no change to generated code)
 - Compiler internals: extracted the inferred-type-tag normalisation helpers out of `CallSpecialization` into a shared `TagNormalizer` (no change to generated code)

--- a/src/php/Compiler/Domain/Analyzer/Ast/AbstractNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/AbstractNode.php
@@ -19,6 +19,15 @@ abstract class AbstractNode
         return $this->env;
     }
 
+    /**
+     * The source location of the form this node was analysed from, used
+     * by error reporting and source maps to point back at the original
+     * Phel. `null` for nodes the compiler synthesises without original
+     * source (macro expansion, simplification, inlining) and for a few
+     * resolver-built literals (e.g. `__DIR__` / `__FILE__`); analysers
+     * should propagate the location from the source form wherever one
+     * exists.
+     */
     public function getStartSourceLocation(): ?SourceLocation
     {
         return $this->startSourceLocation;

--- a/tests/php/Unit/Compiler/SourceLocationPropagationTest.php
+++ b/tests/php/Unit/Compiler/SourceLocationPropagationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler;
+
+use Gacela\Framework\Attribute\CacheableConfig;
+use Gacela\Framework\Gacela;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
+use Phel\Lang\SourceLocation;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Source locations must survive every compiler phase
+ * (lexer -> parser -> reader -> analyzer) so error reporting and source
+ * maps can point back at the original Phel. This pins that contract
+ * end-to-end for a representative form.
+ */
+final class SourceLocationPropagationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        CacheableConfig::reset();
+        Gacela::bootstrap(__DIR__);
+    }
+
+    protected function tearDown(): void
+    {
+        CacheableConfig::reset();
+    }
+
+    public function test_top_level_form_keeps_its_start_location(): void
+    {
+        $node = $this->analyzeFirstForm('(php/+ 1 2)', 'top.phel');
+
+        $loc = $node->getStartSourceLocation();
+        self::assertInstanceOf(SourceLocation::class, $loc);
+        self::assertSame('top.phel', $loc->getFile());
+        self::assertSame(1, $loc->getLine());
+        self::assertSame(0, $loc->getColumn());
+    }
+
+    public function test_line_is_propagated_for_a_form_below_blank_lines(): void
+    {
+        // Two leading newlines push the form to line 3.
+        $node = $this->analyzeFirstForm("\n\n(php/+ 1 2)", 'below.phel');
+
+        $loc = $node->getStartSourceLocation();
+        self::assertInstanceOf(SourceLocation::class, $loc);
+        self::assertSame(3, $loc->getLine());
+    }
+
+    private function analyzeFirstForm(string $code, string $file): AbstractNode
+    {
+        $facade = new CompilerFacade();
+        $tokenStream = $facade->lexString($code, $file);
+
+        while (($parseNode = $facade->parseNext($tokenStream)) instanceof NodeInterface) {
+            if ($parseNode instanceof TriviaNodeInterface) {
+                continue;
+            }
+
+            $ast = $facade->read($parseNode)->getAst();
+
+            return $facade->analyze($ast, NodeEnvironment::empty());
+        }
+
+        self::fail('No analyzable form parsed from source');
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Compiler-module audit item #7: the repo constraint says "source locations must propagate through all phases for error reporting," but `AbstractNode`'s `?SourceLocation` is nullable with no test enforcing that real-source nodes actually keep their location. A regression here would silently degrade error messages and source maps.

Hard enforcement (non-null) is unsafe — compiler-synthesised nodes (macro expansion, simplification, inlining) legitimately have no source. So this pins the contract with a test instead.

## 💡 Goal

Lock in that a form analysed through the real pipeline keeps its file/line/column, and document the nullable contract.

## 🔖 Changes

- `SourceLocationPropagationTest`: drives a representative form through the real `CompilerFacade` (lexer → parser → reader → analyzer) and asserts the resulting AST node carries the correct `file` / `line` / `column`, including line propagation for a form below blank lines.
- Documented `AbstractNode::getStartSourceLocation()`'s nullable contract (`null` only for compiler-synthesised nodes).

## ✅ Verification

- New test green; full compiler suite (3863) green; psalm/phpstan/cs-fixer/rector clean. No production behavior change (doc + test only).