### PR TITLE
fix(lexer): count source columns in code points, not bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Lexer: error/source-map columns are now counted in code points instead of bytes, so locations are accurate for source containing multibyte (UTF-8) characters (ASCII-only code is unaffected)
+
 ### Added
 
 - Compiler internals: end-to-end regression test pinning that AST source locations survive every phase (lexer → parser → reader → analyzer)

--- a/src/php/Compiler/Application/Lexer.php
+++ b/src/php/Compiler/Application/Lexer.php
@@ -12,6 +12,7 @@ use Phel\Compiler\Domain\Lexer\TokenStream;
 use Phel\Lang\SourceLocation;
 
 use function count;
+use function mb_strlen;
 use function sprintf;
 use function strlen;
 
@@ -158,15 +159,19 @@ final class Lexer implements LexerInterface
 
     private function moveCursor(string $str): void
     {
-        $len = strlen($str);
-        $this->cursor += $len;
+        // The cursor indexes into the raw byte string (it feeds preg_match's
+        // offset and substr), so it must advance by the byte length. Columns,
+        // however, are reported in code points so error locations line up with
+        // what a user sees in multibyte (UTF-8) source. For ASCII the two are
+        // identical, so column numbers are unchanged for ASCII-only code.
+        $this->cursor += strlen($str);
         $lastNewLinePos = strrpos($str, "\n");
 
         if ($lastNewLinePos !== false) {
             $this->line += substr_count($str, "\n");
-            $this->column = $len - $lastNewLinePos - 1;
+            $this->column = mb_strlen(substr($str, $lastNewLinePos + 1), 'UTF-8');
         } else {
-            $this->column += $len;
+            $this->column += mb_strlen($str, 'UTF-8');
         }
     }
 

--- a/tests/php/Unit/Compiler/Lexer/LexerTest.php
+++ b/tests/php/Unit/Compiler/Lexer/LexerTest.php
@@ -34,6 +34,36 @@ final class LexerTest extends TestCase
         );
     }
 
+    public function test_multibyte_atom_columns_are_counted_in_code_points(): void
+    {
+        // `café` is 4 code points but 5 bytes (é = 2 bytes). Columns must
+        // advance by code points so the following tokens line up with what a
+        // user sees, not with the byte offset.
+        self::assertEquals(
+            [
+                new Token(Token::T_ATOM, 'café', new SourceLocation('string', 1, 0), new SourceLocation('string', 1, 4)),
+                new Token(Token::T_WHITESPACE, ' ', new SourceLocation('string', 1, 4), new SourceLocation('string', 1, 5)),
+                new Token(Token::T_ATOM, 'x', new SourceLocation('string', 1, 5), new SourceLocation('string', 1, 6)),
+                new Token(Token::T_EOF, '', new SourceLocation('string', 1, 6), new SourceLocation('string', 1, 6)),
+            ],
+            $this->lex('café x'),
+        );
+    }
+
+    public function test_multibyte_after_newline_in_token_is_counted_in_code_points(): void
+    {
+        // A string literal spanning a newline whose trailing segment contains
+        // a multibyte char: the end column counts the trailing code points
+        // (`é"` = 2), not its 3 bytes.
+        self::assertEquals(
+            [
+                new Token(Token::T_STRING, "\"a\né\"", new SourceLocation('string', 1, 0), new SourceLocation('string', 2, 2)),
+                new Token(Token::T_EOF, '', new SourceLocation('string', 2, 2), new SourceLocation('string', 2, 2)),
+            ],
+            $this->lex("\"a\né\""),
+        );
+    }
+
     public function test_read_comment_without_text(): void
     {
         self::assertEquals(


### PR DESCRIPTION
## 🤔 Background

Compiler-module audit item #6. `Lexer::moveCursor` computed columns with byte arithmetic (`strlen`, `strrpos`/`substr_count` offsets). For source containing multibyte UTF-8 characters (string literals, comments, identifiers like `café`), the reported error and source-map **columns drifted** by the number of extra bytes on the line. Line numbers were already correct (newline is single-byte).

## 💡 Goal

Report columns in code points so locations match what a user sees, without changing the byte-based cursor the lexer needs internally.

## 🔖 Changes

- `Lexer::moveCursor`: the cursor still advances by `strlen` (it indexes the raw byte string for `preg_match` offset / `substr`), but the column now advances by `mb_strlen` of the consumed text — and, after a newline, by the code-point length of the trailing segment.
- Added focused `LexerTest` cases: a multibyte atom (`café x`) and a multibyte segment after a newline inside a string literal.

## ✅ Verification

- For ASCII, `mb_strlen == strlen`, so columns are unchanged — **all integration fixtures pass byte-identical** (full compiler suite 3865 green).
- New lexer tests assert correct code-point columns for multibyte input.
- psalm/phpstan/cs-fixer/rector clean.