### PR TITLE
ref(compiler): extract NumericOperationSpecialization from CallSpecialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Compiler internals: extracted the `assoc` / `conj` / `dissoc` method lowering and the transient `(-> coll (assoc …) …)` chain detection out of `CallSpecialization` into a focused `AssocConjSpecialization` collaborator (no change to generated code)
 - Compiler internals: extracted the single-arg type predicates (`int?` / `keyword?` / `map?` / … ) and numeric predicates (`zero?` / `pos?` / `neg?`) out of `CallSpecialization` into a focused `TypePredicateSpecialization` collaborator (no change to generated code)
 - Compiler internals: extracted the tagged-target value ops (`contains?` / `empty?` / `name` / `namespace` / keyword-find) out of `CallSpecialization` into a focused `TypedValueSpecialization` collaborator (no change to generated code)
+- Compiler internals: extracted the typed numeric / comparison / equality operator lowering (incl. the variadic chain, not-eq peephole, and node type inference) out of `CallSpecialization` into a focused `NumericOperationSpecialization` collaborator, completing the god-class split (no change to generated code)
 
 ## [0.41.0](https://github.com/phel-lang/phel-lang/compare/v0.40.0...v0.41.0) - 2026-06-01
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -9,7 +9,6 @@ use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
-use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Lang\AbstractFn;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
@@ -17,10 +16,6 @@ use Phel\Lang\FnInterface;
 use Phel\Shared\CompilerConstants;
 
 use function count;
-use function in_array;
-use function is_bool;
-use function is_float;
-use function is_int;
 use function is_string;
 
 /**
@@ -32,32 +27,6 @@ use function is_string;
  */
 final readonly class CallSpecialization
 {
-    /**
-     * Two-arg `phel.core` arithmetic / ordering ops whose dispatch
-     * reduces to a single PHP native op when both args are statically
-     * proven `int` / `float`. Maps the Phel name to the PHP operator
-     * the emitter splices between the args. `=` is handled separately
-     * because it accepts a wider set of primitive tags than the
-     * numeric ops.
-     *
-     * @var array<string, string>
-     */
-    private const array NUMERIC_BINARY_OPS = [
-        '+' => '+',
-        '-' => '-',
-        '*' => '*',
-        '<' => '<',
-        '<=' => '<=',
-        '>' => '>',
-        '>=' => '>=',
-    ];
-
-    /** @var list<string> */
-    private const array NUMERIC_PRIMITIVE_TAGS = ['int', 'float'];
-
-    /** @var list<string> */
-    private const array EQUALITY_PRIMITIVE_TAGS = ['int', 'float', 'bool', 'string'];
-
     private function __construct() {}
 
     /**
@@ -165,156 +134,15 @@ final readonly class CallSpecialization
             return true;
         }
 
-        if (self::isNotEqPeephole($node)) {
+        if (NumericOperationSpecialization::isNotEqPeephole($node)) {
             return true;
         }
 
-        if (self::isTypedVariadicChain($node)) {
+        if (NumericOperationSpecialization::isTypedVariadicChain($node)) {
             return true;
         }
 
-        return self::isTypedBinaryOp($node);
-    }
-
-    /**
-     * `(not (= a b))` where the inner `=` is already typed-binary-op
-     * specialisable (`===` between two typed primitives). The
-     * peephole emits `($a !== $b)` directly, sparing the runtime
-     * `phel.core/not` dispatch and the `!` wrapper.
-     *
-     * Returns the inner `=` `CallNode` so the emitter can splice the
-     * args between `!==`.
-     */
-    public static function notEqPeepholeInner(CallNode $node): ?CallNode
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return null;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== 'not'
-        ) {
-            return null;
-        }
-
-        $args = $node->getArguments();
-        if (count($args) !== 1) {
-            return null;
-        }
-
-        $inner = $args[0];
-        if (!$inner instanceof CallNode) {
-            return null;
-        }
-
-        if (self::typedBinaryOpName($inner) !== '===') {
-            return null;
-        }
-
-        return $inner;
-    }
-
-    public static function isNotEqPeephole(CallNode $node): bool
-    {
-        return self::notEqPeepholeInner($node) instanceof CallNode;
-    }
-
-    /**
-     * `(<op> a b)` against `phel.core` arithmetic / comparison ops
-     * where both args are statically proven primitive. Returns the PHP
-     * operator to emit between the args, or `null` when the call is
-     * not specialisable.
-     */
-    public static function typedBinaryOpName(CallNode $node): ?string
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return null;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
-            return null;
-        }
-
-        $args = $node->getArguments();
-        if (count($args) !== 2) {
-            return null;
-        }
-
-        $name = $fn->getName()->getName();
-
-        if (isset(self::NUMERIC_BINARY_OPS[$name])) {
-            return self::bothArgsHavePrimitiveTag($args, self::NUMERIC_PRIMITIVE_TAGS)
-                ? self::NUMERIC_BINARY_OPS[$name]
-                : null;
-        }
-
-        if ($name === '=') {
-            return self::bothArgsHavePrimitiveTag($args, self::EQUALITY_PRIMITIVE_TAGS)
-                ? '==='
-                : null;
-        }
-
-        return null;
-    }
-
-    public static function isTypedBinaryOp(CallNode $node): bool
-    {
-        return self::typedBinaryOpName($node) !== null;
-    }
-
-    /**
-     * Variadic (N>=3 args) `phel.core` numeric / ordering ops where the
-     * analyser has tagged **every** operand as a primitive
-     * `LocalVarNode` (`^int` / `^float`). Returns the PHP operator to
-     * splice between consecutive operands together with a `kind`
-     * discriminating chained arithmetic from chained comparison emission.
-     *
-     * Literals are deliberately excluded for N>=3: a pure-literal int
-     * chain that the constant folder refused (because the product would
-     * exceed `PHP_INT_MAX`) must keep its runtime dispatch so
-     * `BigInt` / `Ratio` promotion still triggers. The user opts into the
-     * primitive-only trade-off by tagging the binding.
-     *
-     * @return array{op: string, kind: 'arith'|'compare'}|null
-     */
-    public static function typedVariadicChain(CallNode $node): ?array
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return null;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
-            return null;
-        }
-
-        $args = $node->getArguments();
-        if (count($args) < 3) {
-            return null;
-        }
-
-        if (!self::allArgsAreTaggedNumericLocals($args)) {
-            return null;
-        }
-
-        $name = $fn->getName()->getName();
-
-        if (in_array($name, ['+', '*'], true)) {
-            return ['op' => self::NUMERIC_BINARY_OPS[$name], 'kind' => 'arith'];
-        }
-
-        if (in_array($name, ['<', '<=', '>', '>='], true)) {
-            return ['op' => self::NUMERIC_BINARY_OPS[$name], 'kind' => 'compare'];
-        }
-
-        return null;
-    }
-
-    public static function isTypedVariadicChain(CallNode $node): bool
-    {
-        return self::typedVariadicChain($node) !== null;
+        return NumericOperationSpecialization::isTypedBinaryOp($node);
     }
 
     /**
@@ -494,180 +322,8 @@ final readonly class CallSpecialization
             return true;
         }
 
-        $tag = TagNormalizer::normalise(self::inferredTypeOfNode($arg));
+        $tag = TagNormalizer::normalise(NumericOperationSpecialization::inferredTypeOfNode($arg));
         return $tag !== null && $tag === 'string';
     }
 
-    /**
-     * `true` when every argument compiles to a PHP value the emitter
-     * can splice into a native binary op: a primitive literal of the
-     * accepted shape, or a `LocalVarNode` whose analyser tag is one of
-     * `$acceptedTags` (`int` / `float` for numeric ops, plus `bool` /
-     * `string` for equality).
-     *
-     * @param list<AbstractNode> $args
-     * @param list<string>       $acceptedTags
-     */
-    private static function bothArgsHavePrimitiveTag(array $args, array $acceptedTags): bool
-    {
-        return array_all(
-            $args,
-            static fn(AbstractNode $arg): bool => self::isPrimitiveOperand($arg, $acceptedTags),
-        );
-    }
-
-    /**
-     * @param list<AbstractNode> $args
-     */
-    private static function allArgsAreTaggedNumericLocals(array $args): bool
-    {
-        return array_all(
-            $args,
-            static function (AbstractNode $arg): bool {
-                $tag = TagNormalizer::normalise(self::inferredTypeOfNode($arg));
-                return $tag !== null && in_array($tag, self::NUMERIC_PRIMITIVE_TAGS, true);
-            },
-        );
-    }
-
-    /**
-     * @param list<string> $acceptedTags
-     */
-    private static function isPrimitiveOperand(AbstractNode $arg, array $acceptedTags): bool
-    {
-        if ($arg instanceof LiteralNode) {
-            return self::matchesLiteralPrimitive($arg->getValue(), $acceptedTags);
-        }
-
-        $tag = TagNormalizer::normalise(self::inferredTypeOfNode($arg));
-        return $tag !== null && in_array($tag, $acceptedTags, true);
-    }
-
-    /**
-     * Static type the emitter can attribute to `$arg`'s emitted PHP
-     * expression. Handles two shapes:
-     *
-     *  - `LocalVarNode` — analyser-resolved binding tag (`^int` / `^float`
-     *    / a class FQN). The numeric / equality specialiser was built
-     *    around this case in PR #2148.
-     *  - `CallNode` whose `fn` is a `PhpVarNode` listed in
-     *    {@see KnownPhpFunctionReturnTypes}. The fn name resolves to a
-     *    PHP scalar function whose return shape is fixed (`php/cos` →
-     *    `float`, `php/count` → `int`, etc.), so the call site can be
-     *    spliced into a native binary op the same way a tagged local
-     *    can. This is the path closing #2175 — real game / raycaster
-     *    code reads `(+ ^float angle (php/cos a))`, not
-     *    `(+ ^float a ^float b)`.
-     *
-     * Returns `null` when the node carries no usable type, which leaves
-     * the call site on the generic runtime dispatch.
-     */
-    private static function inferredTypeOfNode(AbstractNode $arg): ?string
-    {
-        if ($arg instanceof LocalVarNode) {
-            return $arg->getInferredType();
-        }
-
-        if (!$arg instanceof CallNode) {
-            return null;
-        }
-
-        $fn = $arg->getFn();
-        if ($fn instanceof PhpVarNode) {
-            return KnownPhpFunctionReturnTypes::returnTypeOf($fn->getName());
-        }
-
-        // Nested typed-arith / typed-equality calls keep their numeric tag so
-        // an outer specialiser fires on the chained shape. `(+ a (* b c))`
-        // with all-numeric operands lowers `(* b c)` to a native PHP product;
-        // the outer `+` must see that product as `float` (when any operand is
-        // float) or `int` so it can emit `($a + ($b * $c))` instead of a
-        // runtime dispatch around the inner native expression.
-        return self::numericTypeOfTypedBinaryCall($arg);
-    }
-
-    /**
-     * Result tag of a numeric typed-arith call (`+`, `-`, `*`) when every
-     * operand carries a known numeric tag. The promotion rule mirrors
-     * PHP's arithmetic operators: any `float` operand yields `float`,
-     * otherwise `int`. Comparison ops return `bool` and aren't covered
-     * here because the caller wants a numeric tag to splice into another
-     * arithmetic op; equality / comparison feed the boolean-expression
-     * detector instead.
-     *
-     * Recursion is bounded by AST depth — each call inspects strictly
-     * smaller subexpressions.
-     */
-    private static function numericTypeOfTypedBinaryCall(CallNode $node): ?string
-    {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-        ) {
-            return null;
-        }
-
-        $name = $fn->getName()->getName();
-        if (!in_array($name, ['+', '-', '*'], true)) {
-            return null;
-        }
-
-        $args = $node->getArguments();
-        if (count($args) < 2) {
-            return null;
-        }
-
-        $anyFloat = false;
-        foreach ($args as $arg) {
-            $tag = self::operandNumericTag($arg);
-            if ($tag === null) {
-                return null;
-            }
-
-            if ($tag === 'float') {
-                $anyFloat = true;
-            }
-        }
-
-        return $anyFloat ? 'float' : 'int';
-    }
-
-    private static function operandNumericTag(AbstractNode $arg): ?string
-    {
-        if ($arg instanceof LiteralNode) {
-            $value = $arg->getValue();
-            if (is_float($value)) {
-                return 'float';
-            }
-
-            return is_int($value) ? 'int' : null;
-        }
-
-        $tag = TagNormalizer::normalise(self::inferredTypeOfNode($arg));
-        return in_array($tag, self::NUMERIC_PRIMITIVE_TAGS, true) ? $tag : null;
-    }
-
-    /**
-     * @param list<string> $acceptedTags
-     */
-    private static function matchesLiteralPrimitive(mixed $value, array $acceptedTags): bool
-    {
-        if (is_int($value)) {
-            return in_array('int', $acceptedTags, true);
-        }
-
-        if (is_float($value)) {
-            return in_array('float', $acceptedTags, true);
-        }
-
-        if (is_bool($value)) {
-            return in_array('bool', $acceptedTags, true);
-        }
-
-        if (is_string($value)) {
-            return in_array('string', $acceptedTags, true);
-        }
-
-        return false;
-    }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -17,6 +17,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\CallSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\GlobalCallTarget;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NilAndBooleanCheckSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NumericOperationSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\TypedCollectionMethodSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\TypedValueSpecialization;
@@ -330,11 +331,11 @@ final class CallEmitter implements NodeEmitterInterface
      * call sites that dispatch is wasted work and collapses to a
      * single PHP operator.
      *
-     * Eligibility lives on {@see CallSpecialization::typedBinaryOpName()}.
+     * Eligibility lives on {@see NumericOperationSpecialization::typedBinaryOpName()}.
      */
     private function tryEmitTypedBinaryOp(CallNode $node): bool
     {
-        $op = CallSpecialization::typedBinaryOpName($node);
+        $op = NumericOperationSpecialization::typedBinaryOpName($node);
         if ($op === null) {
             return false;
         }
@@ -356,11 +357,11 @@ final class CallEmitter implements NodeEmitterInterface
      * `&&` chain `(($a < $b) && ($b < $c))` because PHP `<` does not
      * thread its result through the next comparison the way Phel does.
      *
-     * Eligibility lives on {@see CallSpecialization::typedVariadicChain()}.
+     * Eligibility lives on {@see NumericOperationSpecialization::typedVariadicChain()}.
      */
     private function tryEmitTypedVariadicChain(CallNode $node): bool
     {
-        $spec = CallSpecialization::typedVariadicChain($node);
+        $spec = NumericOperationSpecialization::typedVariadicChain($node);
         if ($spec === null) {
             return false;
         }
@@ -704,11 +705,11 @@ final class CallEmitter implements NodeEmitterInterface
      * emits `($a !== $b)` directly, skipping both `phel.core/not`
      * and the explicit `!(($a === $b))` wrapper.
      *
-     * Eligibility lives on {@see CallSpecialization::notEqPeepholeInner()}.
+     * Eligibility lives on {@see NumericOperationSpecialization::notEqPeepholeInner()}.
      */
     private function tryEmitNotEqPeephole(CallNode $node): bool
     {
-        $inner = CallSpecialization::notEqPeepholeInner($node);
+        $inner = NumericOperationSpecialization::notEqPeepholeInner($node);
         if (!$inner instanceof CallNode) {
             return false;
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecialization.php
@@ -1,0 +1,377 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Shared\CompilerConstants;
+
+use function array_all;
+use function count;
+use function in_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_string;
+
+/**
+ * Call-site eligibility for `phel.core` arithmetic / comparison /
+ * equality operators on statically-typed operands, which
+ * {@see NodeEmitter\CallEmitter}
+ * lowers to native PHP binary operators (`+`, `<`, `===`, …) instead of
+ * the runtime numeric dispatch.
+ *
+ * Also owns {@see self::inferredTypeOfNode()} — the node→type-tag
+ * inference used here for operand typing and reused by the string-concat
+ * specialiser.
+ */
+final readonly class NumericOperationSpecialization
+{
+    /**
+     * Two-arg `phel.core` arithmetic / ordering ops whose dispatch
+     * reduces to a single PHP native op when both args are statically
+     * proven `int` / `float`. Maps the Phel name to the PHP operator
+     * the emitter splices between the args. `=` is handled separately
+     * because it accepts a wider set of primitive tags than the
+     * numeric ops.
+     *
+     * @var array<string, string>
+     */
+    private const array NUMERIC_BINARY_OPS = [
+        '+' => '+',
+        '-' => '-',
+        '*' => '*',
+        '<' => '<',
+        '<=' => '<=',
+        '>' => '>',
+        '>=' => '>=',
+    ];
+
+    /** @var list<string> */
+    private const array NUMERIC_PRIMITIVE_TAGS = ['int', 'float'];
+
+    /** @var list<string> */
+    private const array EQUALITY_PRIMITIVE_TAGS = ['int', 'float', 'bool', 'string'];
+
+    private function __construct() {}
+
+    /**
+     * `(not (= a b))` where the inner `=` is already typed-binary-op
+     * specialisable (`===` between two typed primitives). The
+     * peephole emits `($a !== $b)` directly, sparing the runtime
+     * `phel.core/not` dispatch and the `!` wrapper.
+     *
+     * Returns the inner `=` `CallNode` so the emitter can splice the
+     * args between `!==`.
+     */
+    public static function notEqPeepholeInner(CallNode $node): ?CallNode
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return null;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || $fn->getName()->getName() !== 'not'
+        ) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $inner = $args[0];
+        if (!$inner instanceof CallNode) {
+            return null;
+        }
+
+        if (self::typedBinaryOpName($inner) !== '===') {
+            return null;
+        }
+
+        return $inner;
+    }
+
+    public static function isNotEqPeephole(CallNode $node): bool
+    {
+        return self::notEqPeepholeInner($node) instanceof CallNode;
+    }
+
+    /**
+     * `(<op> a b)` against `phel.core` arithmetic / comparison ops
+     * where both args are statically proven primitive. Returns the PHP
+     * operator to emit between the args, or `null` when the call is
+     * not specialisable.
+     */
+    public static function typedBinaryOpName(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return null;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 2) {
+            return null;
+        }
+
+        $name = $fn->getName()->getName();
+
+        if (isset(self::NUMERIC_BINARY_OPS[$name])) {
+            return self::bothArgsHavePrimitiveTag($args, self::NUMERIC_PRIMITIVE_TAGS)
+                ? self::NUMERIC_BINARY_OPS[$name]
+                : null;
+        }
+
+        if ($name === '=') {
+            return self::bothArgsHavePrimitiveTag($args, self::EQUALITY_PRIMITIVE_TAGS)
+                ? '==='
+                : null;
+        }
+
+        return null;
+    }
+
+    public static function isTypedBinaryOp(CallNode $node): bool
+    {
+        return self::typedBinaryOpName($node) !== null;
+    }
+
+    /**
+     * Variadic (N>=3 args) `phel.core` numeric / ordering ops where the
+     * analyser has tagged **every** operand as a primitive
+     * `LocalVarNode` (`^int` / `^float`). Returns the PHP operator to
+     * splice between consecutive operands together with a `kind`
+     * discriminating chained arithmetic from chained comparison emission.
+     *
+     * Literals are deliberately excluded for N>=3: a pure-literal int
+     * chain that the constant folder refused (because the product would
+     * exceed `PHP_INT_MAX`) must keep its runtime dispatch so
+     * `BigInt` / `Ratio` promotion still triggers. The user opts into the
+     * primitive-only trade-off by tagging the binding.
+     *
+     * @return array{op: string, kind: 'arith'|'compare'}|null
+     */
+    public static function typedVariadicChain(CallNode $node): ?array
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return null;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) < 3) {
+            return null;
+        }
+
+        if (!self::allArgsAreTaggedNumericLocals($args)) {
+            return null;
+        }
+
+        $name = $fn->getName()->getName();
+
+        if (in_array($name, ['+', '*'], true)) {
+            return ['op' => self::NUMERIC_BINARY_OPS[$name], 'kind' => 'arith'];
+        }
+
+        if (in_array($name, ['<', '<=', '>', '>='], true)) {
+            return ['op' => self::NUMERIC_BINARY_OPS[$name], 'kind' => 'compare'];
+        }
+
+        return null;
+    }
+
+    public static function isTypedVariadicChain(CallNode $node): bool
+    {
+        return self::typedVariadicChain($node) !== null;
+    }
+
+    /**
+     * Static type the emitter can attribute to `$arg`'s emitted PHP
+     * expression. Handles two shapes:
+     *
+     *  - `LocalVarNode` — analyser-resolved binding tag (`^int` / `^float`
+     *    / a class FQN). The numeric / equality specialiser was built
+     *    around this case in PR #2148.
+     *  - `CallNode` whose `fn` is a `PhpVarNode` listed in
+     *    {@see KnownPhpFunctionReturnTypes}. The fn name resolves to a
+     *    PHP scalar function whose return shape is fixed (`php/cos` →
+     *    `float`, `php/count` → `int`, etc.), so the call site can be
+     *    spliced into a native binary op the same way a tagged local
+     *    can. This is the path closing #2175 — real game / raycaster
+     *    code reads `(+ ^float angle (php/cos a))`, not
+     *    `(+ ^float a ^float b)`.
+     *
+     * Returns `null` when the node carries no usable type, which leaves
+     * the call site on the generic runtime dispatch.
+     */
+    public static function inferredTypeOfNode(AbstractNode $arg): ?string
+    {
+        if ($arg instanceof LocalVarNode) {
+            return $arg->getInferredType();
+        }
+
+        if (!$arg instanceof CallNode) {
+            return null;
+        }
+
+        $fn = $arg->getFn();
+        if ($fn instanceof PhpVarNode) {
+            return KnownPhpFunctionReturnTypes::returnTypeOf($fn->getName());
+        }
+
+        // Nested typed-arith / typed-equality calls keep their numeric tag so
+        // an outer specialiser fires on the chained shape. `(+ a (* b c))`
+        // with all-numeric operands lowers `(* b c)` to a native PHP product;
+        // the outer `+` must see that product as `float` (when any operand is
+        // float) or `int` so it can emit `($a + ($b * $c))` instead of a
+        // runtime dispatch around the inner native expression.
+        return self::numericTypeOfTypedBinaryCall($arg);
+    }
+
+    /**
+     * `true` when every argument compiles to a PHP value the emitter
+     * can splice into a native binary op: a primitive literal of the
+     * accepted shape, or a `LocalVarNode` whose analyser tag is one of
+     * `$acceptedTags` (`int` / `float` for numeric ops, plus `bool` /
+     * `string` for equality).
+     *
+     * @param list<AbstractNode> $args
+     * @param list<string>       $acceptedTags
+     */
+    private static function bothArgsHavePrimitiveTag(array $args, array $acceptedTags): bool
+    {
+        return array_all(
+            $args,
+            static fn(AbstractNode $arg): bool => self::isPrimitiveOperand($arg, $acceptedTags),
+        );
+    }
+
+    /**
+     * @param list<AbstractNode> $args
+     */
+    private static function allArgsAreTaggedNumericLocals(array $args): bool
+    {
+        return array_all(
+            $args,
+            static function (AbstractNode $arg): bool {
+                $tag = TagNormalizer::normalise(self::inferredTypeOfNode($arg));
+                return $tag !== null && in_array($tag, self::NUMERIC_PRIMITIVE_TAGS, true);
+            },
+        );
+    }
+
+    /**
+     * @param list<string> $acceptedTags
+     */
+    private static function isPrimitiveOperand(AbstractNode $arg, array $acceptedTags): bool
+    {
+        if ($arg instanceof LiteralNode) {
+            return self::matchesLiteralPrimitive($arg->getValue(), $acceptedTags);
+        }
+
+        $tag = TagNormalizer::normalise(self::inferredTypeOfNode($arg));
+        return $tag !== null && in_array($tag, $acceptedTags, true);
+    }
+
+    /**
+     * Result tag of a numeric typed-arith call (`+`, `-`, `*`) when every
+     * operand carries a known numeric tag. The promotion rule mirrors
+     * PHP's arithmetic operators: any `float` operand yields `float`,
+     * otherwise `int`. Comparison ops return `bool` and aren't covered
+     * here because the caller wants a numeric tag to splice into another
+     * arithmetic op; equality / comparison feed the boolean-expression
+     * detector instead.
+     *
+     * Recursion is bounded by AST depth — each call inspects strictly
+     * smaller subexpressions.
+     */
+    private static function numericTypeOfTypedBinaryCall(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+        ) {
+            return null;
+        }
+
+        $name = $fn->getName()->getName();
+        if (!in_array($name, ['+', '-', '*'], true)) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) < 2) {
+            return null;
+        }
+
+        $anyFloat = false;
+        foreach ($args as $arg) {
+            $tag = self::operandNumericTag($arg);
+            if ($tag === null) {
+                return null;
+            }
+
+            if ($tag === 'float') {
+                $anyFloat = true;
+            }
+        }
+
+        return $anyFloat ? 'float' : 'int';
+    }
+
+    private static function operandNumericTag(AbstractNode $arg): ?string
+    {
+        if ($arg instanceof LiteralNode) {
+            $value = $arg->getValue();
+            if (is_float($value)) {
+                return 'float';
+            }
+
+            return is_int($value) ? 'int' : null;
+        }
+
+        $tag = TagNormalizer::normalise(self::inferredTypeOfNode($arg));
+        return in_array($tag, self::NUMERIC_PRIMITIVE_TAGS, true) ? $tag : null;
+    }
+
+    /**
+     * @param list<string> $acceptedTags
+     */
+    private static function matchesLiteralPrimitive(mixed $value, array $acceptedTags): bool
+    {
+        if (is_int($value)) {
+            return in_array('int', $acceptedTags, true);
+        }
+
+        if (is_float($value)) {
+            return in_array('float', $acceptedTags, true);
+        }
+
+        if (is_bool($value)) {
+            return in_array('bool', $acceptedTags, true);
+        }
+
+        if (is_string($value)) {
+            return in_array('string', $acceptedTags, true);
+        }
+
+        return false;
+    }
+}

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecializationTest.php
@@ -11,13 +11,13 @@ use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
-use Phel\Compiler\Domain\Emitter\OutputEmitter\CallSpecialization;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NumericOperationSpecialization;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use Phel\Shared\CompilerConstants;
 use PHPUnit\Framework\TestCase;
 
-final class CallSpecializationTest extends TestCase
+final class NumericOperationSpecializationTest extends TestCase
 {
     public function test_not_eq_peephole_fires_when_inner_eq_is_typed(): void
     {
@@ -28,7 +28,7 @@ final class CallSpecializationTest extends TestCase
         ]);
         $outer = $this->coreCall('not', [$inner]);
 
-        self::assertSame($inner, CallSpecialization::notEqPeepholeInner($outer));
+        self::assertSame($inner, NumericOperationSpecialization::notEqPeepholeInner($outer));
     }
 
     public function test_not_eq_peephole_skips_when_inner_eq_is_untyped(): void
@@ -40,7 +40,7 @@ final class CallSpecializationTest extends TestCase
         ]);
         $outer = $this->coreCall('not', [$inner]);
 
-        self::assertNull(CallSpecialization::notEqPeepholeInner($outer));
+        self::assertNull(NumericOperationSpecialization::notEqPeepholeInner($outer));
     }
 
     public function test_not_eq_peephole_skips_when_outer_is_not_not(): void
@@ -52,7 +52,7 @@ final class CallSpecializationTest extends TestCase
         ]);
         $outer = $this->coreCall('inc', [$inner]);
 
-        self::assertNull(CallSpecialization::notEqPeepholeInner($outer));
+        self::assertNull(NumericOperationSpecialization::notEqPeepholeInner($outer));
     }
 
     public function test_variadic_mul_three_int_locals_chains_arith(): void
@@ -65,7 +65,7 @@ final class CallSpecializationTest extends TestCase
 
         self::assertSame(
             ['op' => '*', 'kind' => 'arith'],
-            CallSpecialization::typedVariadicChain($node),
+            NumericOperationSpecialization::typedVariadicChain($node),
         );
     }
 
@@ -79,7 +79,7 @@ final class CallSpecializationTest extends TestCase
 
         self::assertSame(
             ['op' => '<', 'kind' => 'compare'],
-            CallSpecialization::typedVariadicChain($node),
+            NumericOperationSpecialization::typedVariadicChain($node),
         );
     }
 
@@ -94,7 +94,7 @@ final class CallSpecializationTest extends TestCase
             new LiteralNode($env, 100000000),
         ]);
 
-        self::assertNull(CallSpecialization::typedVariadicChain($node));
+        self::assertNull(NumericOperationSpecialization::typedVariadicChain($node));
     }
 
     public function test_variadic_chain_rejects_two_args(): void
@@ -104,7 +104,7 @@ final class CallSpecializationTest extends TestCase
             $this->localWithTag('b', 'int'),
         ]);
 
-        self::assertNull(CallSpecialization::typedVariadicChain($node));
+        self::assertNull(NumericOperationSpecialization::typedVariadicChain($node));
     }
 
     public function test_variadic_chain_rejects_eq_op(): void
@@ -118,7 +118,7 @@ final class CallSpecializationTest extends TestCase
             $this->localWithTag('c', 'int'),
         ]);
 
-        self::assertNull(CallSpecialization::typedVariadicChain($node));
+        self::assertNull(NumericOperationSpecialization::typedVariadicChain($node));
     }
 
     public function test_variadic_chain_rejects_untyped_local(): void
@@ -130,7 +130,7 @@ final class CallSpecializationTest extends TestCase
             $this->localWithTag('c', 'int'),
         ]);
 
-        self::assertNull(CallSpecialization::typedVariadicChain($node));
+        self::assertNull(NumericOperationSpecialization::typedVariadicChain($node));
     }
 
     private function env(): NodeEnvironment


### PR DESCRIPTION
## 🤔 Background

Final step of the `CallSpecialization` god-class split (after #2236–#2242). The numeric operator family was left for last because it shares the `inferredTypeOfNode` node→type-tag inference with the str-concat specialiser — the entanglement noted as follow-up in #2242.

## 💡 Goal

Move the numeric/comparison/equality operator family out without changing any generated code, finishing the split.

## 🔖 Changes

- New `NumericOperationSpecialization` holding `typedBinaryOpName` / `isTypedBinaryOp` (two-arg `+ - * < <= > >=` / `=` on typed primitives → native op / `===`), `typedVariadicChain` / `isTypedVariadicChain` (N≥3 tagged-numeric-local chains), `notEqPeepholeInner` / `isNotEqPeephole` (`(not (= a b))` → `!==`), the `NUMERIC_BINARY_OPS` / `NUMERIC_PRIMITIVE_TAGS` / `EQUALITY_PRIMITIVE_TAGS` tables, and the operand-typing helpers.
- `inferredTypeOfNode` is made **public** on the new class so `CallSpecialization::isStringConcatable` (str-concat stays) can reuse it — this shared helper was the blocker for the extraction.
- `CallSpecialization`'s `isSpecialized` dispatch and `CallEmitter`'s three call sites delegate to the new class.
- The numeric unit tests move from `CallSpecializationTest` → `NumericOperationSpecializationTest` (git rename preserves history).

## ✅ Verification

- Pure logic move — all integration `.test` fixtures pass unchanged → generated PHP is **byte-identical** (full compiler suite 3865 green).
- psalm/phpstan/cs-fixer/rector clean.

## 📊 Result

`CallSpecialization` is now **329 LOC, down from 1325** (−75%), split across 8 focused collaborators (`NilAndBooleanCheck`, `AtomMethod`, `TagNormalizer`, `TypedCollectionMethod`, `AssocConj`, `TypePredicate`, `TypedValue`, `NumericOperation`). What remains is the `isSpecialized` / `isBoolReturningSpecialisation` dispatch plus the `get` / php-array / str-concat families.