### PR TITLE
docs(compiler): note the *Specialization collaborators in module CLAUDE.md

### DIFF
--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -104,6 +104,8 @@ The analyser already tracks param types (`ParamTypeInferrer`), return types (`Re
 
 Add new consumers by extending those predicates (or adding a sibling under `Compiler/Domain/Emitter/OutputEmitter/`). The contract is: never fabricate a type — propagate only what the analyser already published.
 
+Call-site specialization eligibility lives in focused `*Specialization` collaborators under `OutputEmitter/` (`NumericOperation`, `TypePredicate`, `TypedValue`, `TypedCollectionMethod`, `AssocConj`, `AtomMethod`, `NilAndBooleanCheck`), with shared tag helpers in `TagNormalizer`; `CallSpecialization` only aggregates them via `isSpecialized()` / `isBoolReturningSpecialisation()`. Add a new family as its own `*Specialization` class and register it in that dispatch.
+
 ## Global Environment
 
 State lives in `Domain/Analyzer/Environment/GlobalEnvironmentRegistry` (process-wide static). The Application's `GlobalEnvironmentManager` and the infrastructure's `GlobalEnvironmentSingleton` both read/write the same slot.


### PR DESCRIPTION
## 🤔 Background

The `CallSpecialization` god-class was split into 8 focused `*Specialization` collaborators (#2236–#2242, #2245). The Compiler module `CLAUDE.md` describes the inferred-type plumbing but predates the split.

## 💡 Goal

Leave a scannable pointer so future agents know where call-site specialization eligibility lives and how to add a new family.

## 🔖 Changes

- One note in `src/php/Compiler/CLAUDE.md` (Inferred-type plumbing section): specialization eligibility lives in focused `*Specialization` collaborators under `OutputEmitter/` with shared tag helpers in `TagNormalizer`; `CallSpecialization` only aggregates them via `isSpecialized()` / `isBoolReturningSpecialisation()`. New families go in their own `*Specialization` class registered in that dispatch.

Docs-only; no code or behavior change.