### PR TITLE
docs: condense and verify all guides against the runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 - Compiler internals: split the `CallSpecialization` call-site lowering god-class (1325 → ~330 LOC) into eight focused, independently tested collaborators — `NilAndBooleanCheckSpecialization`, `AtomMethodSpecialization`, `TagNormalizer` (shared tag helpers), `TypedCollectionMethodSpecialization`, `AssocConjSpecialization`, `TypePredicateSpecialization`, `TypedValueSpecialization`, and `NumericOperationSpecialization`; `CallSpecialization` now only aggregates them via `isSpecialized()` / `isBoolReturningSpecialisation()`. Pure refactor — generated PHP is unchanged.
 - Compiler internals: centralized the bare-expression capture used by the `If` / `Let` / `Call` emitters into `OutputEmitter::captureNodeAsExpression()`, and documented `AbstractNode::getStartSourceLocation()`'s nullable contract
+- Docs: condensed every guide under `docs/` (~17% smaller) and re-verified each against the live runtime; fixed broken examples (`transducers` custom-transducer form that emitted invalid PHP and a private `xf-step` call), corrected wrong claims (`bigint` prints without an `N` suffix, schema closed-map `:maybe` validation, `match` guard ordering with coercing predicates, transit `cmap` keyword-key encoding), and added the missing `numeric-tower` and `project-layout` entries to the docs index
 
 ## [0.41.0](https://github.com/phel-lang/phel-lang/compare/v0.40.0...v0.41.0) - 2026-06-01
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 1. [Quick Start](quickstart.md): install, REPL, first script
 2. [Common Patterns](patterns.md): everyday idioms
 3. [PHP/Phel Interop](php-interop.md): call PHP from Phel and back
+4. [Project Layout](project-layout.md): the `.phel/` directory and runtime state
 
 Coming from Clojure? Read [Clojure Migration](clojure-migration.md).
 
@@ -15,6 +16,7 @@ Coming from Clojure? Read [Clojure Migration](clojure-migration.md).
 - [Reader Shortcuts](reader-shortcuts.md): `#inst`, `#regex`, `#php`, anonymous fn `#(...)`
 - [Reader Conditionals](reader-conditionals.md): `.cljc` portability
 - [Data Structures](data-structures-guide.md): vectors, maps, sets, transients
+- [Numeric Tower](numeric-tower.md): `int`, `float`, `BigInt`, `BigDecimal`, `Ratio`
 - [Lazy Sequences](lazy-sequences.md): `lazy-seq`, infinite seqs, realization
 - [Transducers](transducers.md): composable transformations
 - [Pattern Matching](match-guide.md): `match` with guards and destructuring

--- a/docs/agent-docs.md
+++ b/docs/agent-docs.md
@@ -13,15 +13,11 @@ composer require phel-lang/phel-lang
 ./vendor/bin/phel agent-install --all --with-examples  # also copy runnable example apps
 ```
 
-`.agents/` (rules, task recipes, quick-syntax) is copied by default; pass `--no-docs` to skip it. Example apps are
-**excluded** by default to keep installs slim — add `--with-examples` to include `.agents/examples/`.
+Platforms: `claude`, `cursor`, `codex`, `gemini`, `copilot`, `aider`. Omit the platform with `--auto` to install only for agents already present (`.claude/`, `.cursor/`, `AGENTS.md`, ...).
 
-Platforms: `claude`, `cursor`, `codex`, `gemini`, `copilot`, `aider`. Omit the platform and use `--auto` to install
-only for agents already present in the project (`.claude/`, `.cursor/`, `AGENTS.md`, ...).
+`.agents/` docs (rules, task recipes, quick-syntax) are copied by default; `--no-docs` skips them. Example apps are excluded by default; `--with-examples` includes `.agents/examples/`.
 
-Existing targets back up to `<path>.pre-phel.bak`. `--force` skips backup, `--dry-run` previews,
-`--uninstall` removes a skill (restoring any backup). Inspect state with `--list`; `--check` reports version drift
-and exits non-zero if any.
+Existing targets back up to `<path>.pre-phel.bak`. `--force` skips backup, `--dry-run` previews, `--uninstall` removes a skill (restoring any backup). `--list` shows source/target/state per platform; `--check` reports version drift and exits 1 on any.
 
 ## Destinations
 
@@ -46,7 +42,7 @@ Each installed file routes the agent to `.agents/index.md` for task recipes: sca
 
 ## Sync
 
-`resources/agents/VERSION` tracks the targeted phel-lang release. `composer test-agents` runs every example's tests against the current source; breaking a public API surfaces as a red build on PR.
+`resources/agents/VERSION` tracks the targeted phel-lang release. `composer test-agents` runs every example's tests against current source; breaking a public API surfaces as a red build on PR.
 
 ## Repository maintenance adapters
 

--- a/docs/agent-metrics.md
+++ b/docs/agent-metrics.md
@@ -4,7 +4,7 @@ Template for tracking how long each agent takes to build a representative app fr
 
 ## Scenario
 
-Fresh project, fresh chat session. Prompt: **"Build a todo HTTP API in Phel with tests."**
+Fresh project, fresh chat. Prompt: **"Build a todo HTTP API in Phel with tests."**
 
 Target:
 - HTTP endpoint for create/list/show/delete
@@ -34,7 +34,7 @@ Target:
 2. Run `composer require phel-lang/phel-lang`.
 3. For "yes" rows only: `./vendor/bin/phel agent-install <platform>`.
 4. Feed the prompt above. Time from send to green `phel test`.
-5. Open a PR updating this table with your result. Attach the transcript as a gist or comment link.
+5. Open a PR updating this table; attach the transcript as a gist or comment link.
 
 ## Why this matters
 

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -1,8 +1,6 @@
 # AI Module Guide
 
-`phel.ai` is a small, provider-agnostic client for LLM chat, structured extraction, tool use, embeddings, and semantic search.
-
-Supported providers:
+`phel.ai` is a provider-agnostic client for LLM chat, structured extraction, tool use, embeddings, and semantic search.
 
 | Provider | Chat | Tools | Embeddings |
 |----------|------|-------|------------|
@@ -20,13 +18,12 @@ Supported providers:
 ;; or configure explicitly:
 (ai/configure {:api-key "sk-ant-..."})
 
-(ai/complete "Say hi in one word")
-; => "Hi"
+(ai/complete "Say hi in one word")   ; => "Hi"
 ```
 
 ## Configuration
 
-`configure` merges options into a shared atom `ai/config`.
+`configure` merges options into the shared atom `ai/config`.
 
 | Key | Default | Purpose |
 |-----|---------|---------|
@@ -35,12 +32,12 @@ Supported providers:
 | `:max-tokens` | `1024` | Output token cap |
 | `:api-key` | `nil` | Falls back to env var |
 | `:base-url` | `nil` | Override endpoint (proxies, self-hosted) |
-| `:timeout` | `120` | HTTP timeout in seconds |
+| `:timeout` | `120` | HTTP timeout (seconds) |
 | `:max-retries` | `2` | Retry 429/5xx with exponential backoff |
 
 Default model evolves with `src/phel/ai.phel`; check there for the current value.
 
-Every per-call `opts` map on `chat`, `complete`, `chat-with-tools`, `extract`, and `extract-many` accepts the same keys (including `:max-retries`) for per-request overrides.
+Every per-call `opts` map (on `chat`, `complete`, `chat-with-tools`, `extract`, `extract-many`) accepts the same keys for per-request overrides:
 
 ```phel
 (ai/complete "Summarize the news" {:provider :openai :model "gpt-4o-mini"})
@@ -73,7 +70,7 @@ Multi-turn via `chat-with-history`:
 
 ## Structured extraction
 
-Populate a schema:
+Populate a schema; `extract-many` returns a vector when the input has multiple items:
 
 ```phel
 (ai/extract
@@ -82,11 +79,9 @@ Populate a schema:
 ; => {:name "Alice" :age 30 :email "alice@example.com"}
 ```
 
-`extract-many` returns a vector when the input contains multiple items.
-
 ## Tool use
 
-Define tools with provider-agnostic `tool`, then drive the loop manually with `chat-with-tools` + `tool-result`, or hand off to `run-tools`.
+Define tools with provider-agnostic `tool`, then either hand off to `run-tools` or drive the loop manually with `chat-with-tools` + `tool-result`.
 
 ```phel
 (def tools
@@ -98,13 +93,11 @@ Define tools with provider-agnostic `tool`, then drive the loop manually with `c
   {"get-weather" (fn [args] (str "72F sunny in " (get args :city)))})
 
 (ai/run-tools [{:role "user" :content "weather in Paris?"}]
-              tools
-              handlers
-              {:max-turns 5})
+              tools handlers {:max-turns 5})
 ;; => "It's 72F and sunny in Paris."
 ```
 
-`run-tools` sends the conversation, resolves tool calls via `handlers` (map of tool name to fn), feeds results back, and stops when the model returns plain text or `:max-turns` is reached. Anthropic-only.
+`run-tools` sends the conversation, resolves tool calls via `handlers` (tool name to fn), feeds results back, and stops when the model returns plain text or `:max-turns` is reached. Anthropic-only.
 
 For finer control, use `chat-with-tools` directly:
 
@@ -117,7 +110,7 @@ For finer control, use `chat-with-tools` directly:
 `chat-with-tools` returns:
 
 ```phel
-{:text       "..."    ; assistant text (may be nil if only tool calls)
+{:text       "..."    ; assistant text (nil if only tool calls)
  :tool-calls [{:name "..." :id "..." :input {...}}]
  :stop-reason "..."
  :raw        {...}}   ; full provider body
@@ -133,11 +126,11 @@ For finer control, use `chat-with-tools` directly:
 ; => [{:text "cats purr" :embedding [...] :similarity 0.87}]
 ```
 
-Vector math primitives for custom pipelines: `dot-product`, `magnitude`, `cosine-similarity`, `nearest`.
+Vector-math primitives for custom pipelines: `dot-product`, `magnitude`, `cosine-similarity`, `nearest`.
 
 ## Retry & timeouts
 
-`:max-retries` (default `2`) retries on HTTP 429 and 5xx with exponential backoff (500ms, 1s, 2s, ...). Network errors bubble up. Tune per call.
+`:max-retries` (default `2`) retries HTTP 429 and 5xx with exponential backoff (500ms, 1s, 2s, ...). Network errors bubble up. Tune per call:
 
 ```phel
 (ai/complete "long task" {:timeout 300 :max-retries 4})

--- a/docs/async-guide.md
+++ b/docs/async-guide.md
@@ -2,9 +2,7 @@
 
 Two concurrency layers over PHP fibers. Most primitives live in `phel.core` (no require). `delay` lives in `phel.async` because Phel's `delay` sleeps, unlike `clojure.core/delay` (a lazy-thunk wrapper).
 
-## Overview
-
-**AMPHP-backed layer.** Built on `amphp/amp`. An event loop drives fiber-based IO, timers, and combinators. `async`, `await`, `await-all`, `await-any`, `pmap`, `future`, `future-cancel`, `future-cancelled?` in `phel.core`; `delay` in `phel.async`. Use inside an event loop, or for timers, IO multiplexing, or fan-out across many Futures.
+**AMPHP-backed layer.** Built on `amphp/amp`; an event loop drives fiber-based IO, timers, and combinators. `async`, `await`, `await-all`, `await-any`, `pmap`, `future`, `future-cancel`, `future-cancelled?` in `phel.core`; `delay` in `phel.async`. Use inside an event loop, for timers, IO multiplexing, or fan-out across many Futures.
 
 **Fiber-backed layer.** Cooperative single-threaded scheduler in `\Phel\Fiber\FiberFacade`, no event loop. `promise`, `deliver`, `future-call`, `future-fiber`, `future?` in `phel.core`. Safe at the top level of a script or REPL. Good for CPU coordination, producer/consumer handoffs, lightweight deref-with-timeout.
 
@@ -24,11 +22,7 @@ Rule of thumb: fiber layer for plain scripts; AMPHP layer when IO, timers, or AM
 
 ### `async`
 
-```phel
-(async body...)
-```
-
-Schedules `body` on the AMPHP event loop in a fresh fiber. Returns `Amp\Future`. Amp v3 manages the event loop automatically; no explicit `Loop::run` call needed. Exceptions in the body surface when awaited.
+`(async body...)` schedules `body` on the AMPHP event loop in a fresh fiber and returns `Amp\Future`. Amp v3 manages the loop automatically; no explicit `Loop::run` needed. Exceptions surface when awaited.
 
 ```phel
 (await (async (+ 1 2))) ;; => 3
@@ -36,15 +30,11 @@ Schedules `body` on the AMPHP event loop in a fresh fiber. Returns `Amp\Future`.
 
 ### `await`
 
-```phel
-(await future)
-```
-
-Blocks the current fiber until the Future resolves, then returns its value. Accepts a raw `Amp\Future` or a `Future` wrapper. Must be called from inside a fiber.
+`(await future)` blocks the current fiber until the Future resolves, then returns its value. Accepts a raw `Amp\Future` or a `Future` wrapper. Must be called from inside a fiber.
 
 ### `^:async` on `defn`
 
-`^:async` wraps the body in `(async ...)`. The function returns `Amp\Future` for callers to `await`.
+`^:async` wraps each arity's body in `(async ...)`, so the function returns `Amp\Future` for callers to `await`. `^{:async false}` opts out without removing the metadata key.
 
 ```phel
 (defn ^:async fetch [url]
@@ -53,15 +43,9 @@ Blocks the current fiber until the Future resolves, then returns its value. Acce
 (await (fetch "https://example.com"))
 ```
 
-Multi-arity bodies are wrapped per arity. `^{:async false}` opts out without removing the metadata key.
-
 ### `delay` (in `phel.async`)
 
-```phel
-(delay seconds)
-```
-
-Suspends for `seconds` (float). At top level behaves like `php/sleep`. Inside `async`/`future` body suspends the *fiber* only and becomes cancellable via `future-cancel`. Uses `Amp\delay`.
+`(delay seconds)` suspends for `seconds` (float) via `Amp\delay`. At top level it behaves like `php/sleep`; inside an `async`/`future` body it suspends the *fiber* only and becomes cancellable via `future-cancel`.
 
 > **Not Clojure's `delay`.** `clojure.core/delay` is a lazy-thunk wrapper, not a sleep. Phel's `delay` lives in `phel.async` (not `phel.core`) to keep the difference visible to `.cljc` portable code.
 
@@ -73,11 +57,7 @@ Suspends for `seconds` (float). At top level behaves like `php/sleep`. Inside `a
 
 ### `await-all`
 
-```phel
-(await-all futures)
-```
-
-Awaits every Future and returns resolved values in order. If any Future fails, the exception propagates; others keep running to their next checkpoint.
+`(await-all futures)` awaits every Future and returns resolved values in order. If any fails, the exception propagates; others keep running to their next checkpoint.
 
 ```phel
 (await-all [(async (fetch :a)) (async (fetch :b))])
@@ -85,27 +65,15 @@ Awaits every Future and returns resolved values in order. If any Future fails, t
 
 ### `await-any`
 
-```phel
-(await-any futures)
-```
-
-Returns the value of the first Future to resolve. Losing Futures are not auto-cancelled; pair with `future-cancel` when needed.
+`(await-any futures)` returns the value of the first Future to resolve. Losing Futures are not auto-cancelled; pair with `future-cancel` when needed.
 
 ### `pmap`
 
-```phel
-(pmap f coll) (pmap f coll1 coll2 ...)
-```
-
-Concurrent `map` via fibers; results in input order. PHP fibers are cooperative on a single thread: `pmap` overlaps IO-bound work (HTTP, DB, file IO) but does **not** parallelize CPU work across cores. ClojureScript and Basilisp follow the same single-threaded model; `clojure.core/pmap` uses a thread pool.
+`(pmap f coll)` / `(pmap f coll1 coll2 ...)` is concurrent `map` via fibers; results in input order. PHP fibers are cooperative on a single thread: `pmap` overlaps IO-bound work (HTTP, DB, file IO) but does **not** parallelize CPU work across cores. ClojureScript and Basilisp follow the same single-threaded model; `clojure.core/pmap` uses a thread pool.
 
 ### `future`
 
-```phel
-(future body...)
-```
-
-Wraps `body` in `Amp\Future`, returns a `Future` supporting `deref`, `realized?`, 3-arg `deref` timeouts, `future-cancel`, `future-cancelled?`, `future-done?`. Requires a fiber context (call inside `async` or an AMPHP loop).
+`(future body...)` wraps `body` in `Amp\Future` and returns a `Future` supporting `deref`, `realized?`, 3-arg `deref` timeouts, `future-cancel`, `future-cancelled?`, `future-done?`. Requires a fiber context (call inside `async` or an AMPHP loop).
 
 ```phel
 (async
@@ -115,37 +83,21 @@ Wraps `body` in `Amp\Future`, returns a `Future` supporting `deref`, `realized?`
 
 ### `future-cancel`
 
-```phel
-(future-cancel f)
-```
-
-Signals the Future's `DeferredCancellation` token. Pending and subsequent `deref` calls throw `Amp\CancelledException` (or return the fallback for the 3-arg form). Cooperative: the body runs until it hits a cancellation-aware checkpoint.
+`(future-cancel f)` signals the Future's `DeferredCancellation` token. Pending and subsequent `deref` calls throw `Amp\CancelledException` (or return the fallback for the 3-arg form). Cooperative: the body runs until it hits a cancellation-aware checkpoint.
 
 ### `future-cancelled?`
 
-```phel
-(future-cancelled? f)
-```
-
-Returns `true` once `future-cancel` was called. Does not imply the body stopped; use `future-done?` for terminal state.
+`(future-cancelled? f)` returns `true` once `future-cancel` was called. Does not imply the body stopped; use `future-done?` for terminal state.
 
 ## Fiber layer reference
 
 ### `promise`
 
-```phel
-(promise)
-```
-
-Returns a new unrealized promise. Single delivery: once set, the value is frozen. `deref` suspends cooperatively from inside a fiber, or drains the scheduler from top level. Single-process; not cross-process safe.
+`(promise)` returns a new unrealized promise. Single delivery: once set, the value is frozen. `deref` suspends cooperatively from inside a fiber, or drains the scheduler from top level. Single-process; not cross-process safe.
 
 ### `deliver`
 
-```phel
-(deliver p value)
-```
-
-Delivers `value` to promise `p`. Returns `p` on first delivery, `nil` if already realized. Idempotent: subsequent calls are no-ops; stored value never changes.
+`(deliver p value)` delivers `value` to promise `p`. Returns `p` on first delivery, `nil` if already realized. Idempotent: subsequent calls are no-ops; stored value never changes.
 
 ```phel
 (let [p (promise)]
@@ -156,27 +108,15 @@ Delivers `value` to promise `p`. Returns `p` on first delivery, `nil` if already
 
 ### `future-call`
 
-```phel
-(future-call f)
-```
-
-Runs zero-arg `f` in a new fiber via the cooperative scheduler. Returns a `Future` supporting `deref`, `realized?`, `future-done?`, `future-cancel`. `f` must be zero-arg; use a closure to capture state.
+`(future-call f)` runs zero-arg `f` in a new fiber via the cooperative scheduler. Returns a `Future` supporting `deref`, `realized?`, `future-done?`, `future-cancel`. `f` must be zero-arg; use a closure to capture state.
 
 ### `future-fiber`
 
-```phel
-(future-fiber body...)
-```
-
-Macro over `future-call`. Write `@(future-fiber (expensive))` without an outer `async` block. No event loop, so blocking PHP calls freeze the scheduler until they return.
+`(future-fiber body...)` is a macro over `future-call`. Write `@(future-fiber (expensive))` without an outer `async` block. No event loop, so blocking PHP calls freeze the scheduler until they return.
 
 ### `future?`
 
-```phel
-(future? x)
-```
-
-Returns `true` if `x` is a fiber-future or `Future`. Useful when receiving Futures from code that may use either layer.
+`(future? x)` returns `true` if `x` is a fiber-future or `Future`. Useful when receiving Futures from code that may use either layer.
 
 ## Shared primitives
 
@@ -185,13 +125,13 @@ Returns `true` if `x` is a fiber-future or `Future`. Useful when receiving Futur
 | Form | Behavior |
 |------|----------|
 | `(deref x)` / `@x` | Block until realized. Fiber path suspends cooperatively; AMPHP path awaits via the event loop |
-| `(deref x timeout-ms timeout-val)` | Return `timeout-val` if not realized within `timeout-ms`. Fiber path uses a deadline poll; AMPHP path uses `Future::await` with `TimeoutCancellation` |
+| `(deref x timeout-ms timeout-val)` | Return `timeout-val` if not realized within `timeout-ms`. Fiber path polls a deadline; AMPHP path uses `Future::await` with `TimeoutCancellation` |
 | `(realized? x)` | `true` once a value is available. Works for promises, fiber futures, `Future` |
-| `(future-done? x)` | For fiber futures, checks `isDone`; otherwise falls back to `realized?`. Use for "terminal state including cancellation", not just "value present" |
+| `(future-done? x)` | For fiber futures checks `isDone`; otherwise falls back to `realized?`. Use for "terminal state including cancellation", not just "value present" |
 
 ## Error and cancellation model
 
-- **AMPHP path**: exceptions in a `future`/`async` body surface from `await`/`deref`. Cancellation via `Amp\DeferredCancellation`; after `future-cancel`, `deref` raises `Amp\CancelledException`, and the 3-arg form returns its fallback.
+- **AMPHP path**: exceptions in a `future`/`async` body surface from `await`/`deref`. Cancellation via `Amp\DeferredCancellation`; after `future-cancel`, `deref` raises `Amp\CancelledException` and the 3-arg form returns its fallback.
 - **Fiber path**: exceptions in `future-call` bodies re-raise on `deref`. `future-cancel` flips a flag checked at cooperative checkpoints; the 3-arg `deref` returns its fallback without waiting.
 - **`deliver` is idempotent**: first call wins; the return value tells you whether you set it. Use for "first writer wins" handoffs without locks.
 
@@ -203,10 +143,10 @@ Returns `true` if `x` is a fiber-future or `Future`. Useful when receiving Futur
 
 ## Pitfalls
 
-- **`future` outside an event loop**. AMPHP `future` needs a fiber context; use `future-fiber` for top-level scripts.
-- **Mixing future types**. `future?` is the safe predicate; `deref`, `realized?`, `future-done?` dispatch by type.
-- **CPU-bound `pmap`**. PHP fibers share one thread. CPU-heavy `f` won't speed up and may add overhead. Shell out to workers for parallelism.
-- **Blocking PHP calls inside fiber futures**. `sleep`, `usleep`, synchronous `curl`, blocking socket reads freeze the scheduler. Use `delay` (AMPHP) or non-blocking IO.
+- **`future` outside an event loop** needs a fiber context; use `future-fiber` for top-level scripts.
+- **Mixing future types**: `future?` is the safe predicate; `deref`, `realized?`, `future-done?` dispatch by type.
+- **CPU-bound `pmap`**: PHP fibers share one thread, so CPU-heavy `f` won't speed up and may add overhead. Shell out to workers for parallelism.
+- **Blocking PHP calls inside fiber futures** (`sleep`, `usleep`, synchronous `curl`, blocking socket reads) freeze the scheduler. Use `delay` (AMPHP) or non-blocking IO.
 
 ## Recipes
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1,6 +1,6 @@
 # Building CLIs with `phel.cli`
 
-`phel.cli` is a data-driven wrapper over [`symfony/console`](https://symfony.com/doc/current/components/console.html). Subcommands, arguments, options, prompts, tables, progress bars, shell completion, and signal handling all defined as plain Phel maps. No extra dependency; `symfony/console` ships with phel-lang.
+`phel.cli` is a data-driven wrapper over [`symfony/console`](https://symfony.com/doc/current/components/console.html) (which ships with phel-lang, no extra dependency). Subcommands, arguments, options, prompts, tables, progress bars, shell completion, and signal handling are all plain Phel maps.
 
 ## Quickstart
 
@@ -97,9 +97,7 @@ Your `:run` handler receives a **context map**:
  :style     <SymfonyStyle>}
 ```
 
-Return `nil` or `0` for success, any other `int` for an exit code.
-
-Uncaught `Throwable` becomes a red `<error>` line plus exit code `1`. With `-v`, the stack trace is written.
+Return `nil` or `0` for success, any other `int` for an exit code. An uncaught `Throwable` becomes a red `<error>` line plus exit code `1`; `-v` adds the stack trace.
 
 ## Writing to output
 
@@ -175,7 +173,7 @@ Available `:style` values: `:default`, `:borderless`, `:compact`, `:symfony`, `:
          :complete (fn [_input] ["dev" "staging" "prod"])}]}
 ```
 
-Symfony calls your completion function when the user presses `<TAB>` after installing the shell completion script:
+Symfony calls your completion function on `<TAB>` once the shell completion script is installed:
 
 ```bash
 my-tool _complete --generate-hook=bash > ~/.bash_completion.d/my-tool
@@ -201,7 +199,7 @@ my-tool _complete --generate-hook=bash > ~/.bash_completion.d/my-tool
 
 ## Testing your CLI
 
-Test helpers run handlers without spawning a process:
+Test helpers run handlers without spawning a process. `(cli/application "name" [specs])` is a two-arity shortcut for the map form:
 
 ```phel
 (ns my-tool-test.test.main
@@ -231,7 +229,7 @@ For prompt testing, pipe canned STDIN:
 
 ## Running under `phel run`
 
-When invoked via `./bin/phel run path/to/script.phel arg1 arg2`, Phel's own Symfony console occupies `$_SERVER['argv']`. User-facing arguments come through the Phel core var `argv`. Pass them to `cli/run` explicitly:
+Under `./bin/phel run path/to/script.phel arg1 arg2`, Phel's own console occupies `$_SERVER['argv']`; user args arrive through the core var `argv`. Pass them explicitly:
 
 ```phel
 ;; Bad: reads the wrapper's argv, so "run" looks like your first command.
@@ -241,7 +239,7 @@ When invoked via `./bin/phel run path/to/script.phel arg1 arg2`, Phel's own Symf
 (cli/run app (cli/argv argv))
 ```
 
-Only needed under `phel run`. A standalone binary built with `phel build` uses `$_SERVER['argv']` directly, so `(cli/run app)` is fine there.
+Only needed under `phel run`. A standalone binary built with `phel build` reads `$_SERVER['argv']` directly, so `(cli/run app)` is fine there.
 
 ## Best practices
 

--- a/docs/clojure-migration.md
+++ b/docs/clojure-migration.md
@@ -1,6 +1,6 @@
 # Clojure to Phel Migration Guide
 
-Phel is a Lisp compiling to PHP. If you know Clojure, you know most of Phel. This guide covers the differences. Jump to [Quick reference](#quick-reference) for the at-a-glance view.
+Phel is a Lisp compiling to PHP. If you know Clojure, you know most of Phel; this guide covers the differences.
 
 ## Quick reference
 
@@ -9,11 +9,11 @@ Phel is a Lisp compiling to PHP. If you know Clojure, you know most of Phel. Thi
 | `(ns my.app (:require [clojure.string :as str]))` | `(ns my.app (:require phel.string :as str))` | `.` separator (matches Clojure); `\` accepted for back-compat but deprecated |
 | `(.method obj arg)` | `(php/-> obj (method arg))` | Instance method |
 | `(Class/staticMethod arg)` | `(php/:: Class (method arg))` | Static method |
-| `(ClassName. arg)` | `(ClassName. arg)`, `(new ClassName arg)`, or `(php/new ClassName arg)` | `ClassName.` and `new` both read as `(php/new ClassName ...)` |
+| `(ClassName. arg)` | `(ClassName. arg)`, `(new ClassName arg)`, `(php/new ClassName arg)` | All read as `(php/new ClassName ...)` |
 | `(.-field obj)` | `(php/-> obj -field)` | Property access |
-| `(:import [java.util Date])` | `(:use DateTime)` in the `ns` form | Imports a PHP class by short name; also works with FQNs: `(:use Phel\Lang\Symbol)` |
-| `(instance? Type x)` | `(instance? Type x)` or `(php/instanceof x Type)` | Phel ships an `instance?` macro that wraps `php/instanceof` with Clojure's argument order |
-| `(class x)` | `(type x)` | Returns a keyword like `:string`, `:int`, `:hash-map` |
+| `(:import [java.util Date])` | `(:use DateTime)` in `ns` | Imports a PHP class by short name; FQNs too: `(:use Phel\Lang\Symbol)` |
+| `(instance? Type x)` | `(instance? Type x)` or `(php/instanceof x Type)` | `instance?` macro wraps `php/instanceof` with Clojure's arg order |
+| `(class x)` | `(type x)` | Returns a keyword: `:string`, `:int`, `:hash-map` |
 | `(subs s start end)` | `(phel.string/subs s start end)` | Substring |
 | `(clojure.string/upper-case s)` | `(phel.string/upper-case s)` | String utils in `phel.string` |
 
@@ -22,23 +22,23 @@ Phel is a Lisp compiling to PHP. If you know Clojure, you know most of Phel. Thi
 Most of Clojure's core library works identically:
 
 - **Data structures**: persistent vectors `[]`, maps `{}`, sets, lists `'()`, lazy-seqs, sorted collections (`sorted-map`, `sorted-map-by`, `sorted-set`, `sorted-set-by`)
-- **Collection API**: `conj`, `conj!`, `disj`, `into`, `assoc`, `dissoc`, `get`, `get-in`, `update`, `update-in`, `merge`, `select-keys`, `keys`, `vals`, `update-keys`, `update-vals`, `rename-keys`, `zipmap`, `frequencies`, `group-by`
-- **Sequence API**: `map`, `filter`, `remove`, `reduce`, `first`, `rest`, `next`, `cons`, `nth`, `last`, `butlast`, `take`, `drop`, `drop-last`, `partition`, `sort-by`, `min-key`, `max-key`, `run!`
+- **Collections**: `conj`, `conj!`, `disj`, `into`, `assoc`, `dissoc`, `get`, `get-in`, `update`, `update-in`, `merge`, `select-keys`, `keys`, `vals`, `update-keys`, `update-vals`, `rename-keys`, `zipmap`, `frequencies`, `group-by`
+- **Sequences**: `map`, `filter`, `remove`, `reduce`, `first`, `rest`, `next`, `cons`, `nth`, `last`, `butlast`, `take`, `drop`, `drop-last`, `partition`, `sort-by`, `min-key`, `max-key`, `run!`
 - **Higher-order**: `comp`, `partial`, `juxt`, `apply`, `fnil`, `some-fn`
 - **Predicates**: `some?`, `seq?`, `map?`, `set?`, `vector?`, `list?`, `coll?`, `counted?`, `sorted?`, `char?`, `integer?`, `boolean`, `nan?` / `NaN?`
 - **Coercions**: `str`, `keyword`, `symbol`, `name`, `namespace`, `vec`, `float`, `double`, `byte`, `char`, `array-map`, `to-array`, `object-array`, `aclone`
 - **Macros**: `defn`, `def`, `defmacro`, `let`, `letfn`, `if`, `when`, `cond`, `case`, `condp`, `->`, `->>`, `as->`, `some->`, `some->>`, `cond->`, `cond->>`, `and`, `or`, `not`, `loop`/`recur`, `doseq`, `dotimes`, `for`, `if-some`, `when-some`, `when-first`, `assert`
-- **Protocols and types**: `defprotocol`, `extend-type`, `extend-protocol`, `satisfies?`, `extends?`, `reify`, `defrecord`, `deftype`
+- **Protocols/types**: `defprotocol`, `extend-type`, `extend-protocol`, `satisfies?`, `extends?`, `reify`, `defrecord`, `deftype`
 - **Multimethods**: `defmulti`, `defmethod`, `isa?`, `derive`, `parents`, `ancestors`, `make-hierarchy`
 - **Destructuring**: vectors, maps, `:keys`, `:strs`, `:syms`, `:or`, `& rest`
 - **Metadata**: `meta`, `with-meta`, `vary-meta`, `^:keyword` reader syntax
 - **Atoms**: `atom`, `deref` / `@`, `swap!`, `reset!`, `add-watch`, `remove-watch`, `set-validator!`
 - **Taps**: `tap>`, `add-tap`, `remove-tap` (synchronous dispatch; no background queue)
-- **Futures**: Futures via `future`/`future-fiber` (in `phel.core`). Note: `delay` in Phel lives in `phel.async` and is a sleep, not a Clojure-style lazy thunk; `force`/`delay?` do not exist.
+- **Futures**: `future` / `future-fiber` (in `phel.core`). Note: `delay` lives in `phel.async` and is a sleep, not a lazy thunk; `force`/`delay?` do not exist.
 - **Exceptions**: `ex-info`, `ex-data`, `ex-message`, `ex-cause`, `throw`, `try` / `catch` / `finally`
 - **Transducers**: `transduce`, `into` (3-arg), `sequence`, `completing`, `cat`, plus transducer arities for `map`, `filter`, `take`, `drop`, `keep`, `distinct`, `dedupe`, `mapcat`, `interpose`, and more
 - **Testing**: `deftest`, `is`, `testing`, `are`, `do-report`, extensible `assert-expr` (in `phel.test`)
-- **String utils**: `phel.string` with `upper-case`, `lower-case`, `split`, `join`, `trim`, `replace`, `starts-with?`, `ends-with?`, and more
+- **Strings**: `phel.string` with `upper-case`, `lower-case`, `split`, `join`, `trim`, `replace`, `starts-with?`, `ends-with?`, and more
 - **Regex**: `re-find`, `re-matches`, `re-pattern`, `#"..."` literals
 
 ## Reader syntax
@@ -48,14 +48,14 @@ Clojure reader syntax is accepted wholesale. Older Phel-specific forms still wor
 | Syntax | Meaning | Old Phel form (deprecated) |
 |--------|---------|----------------------------|
 | `#(inc %)` | Anonymous fn shorthand | `\|(inc $)` |
-| `~x`, `~@xs` | Unquote and unquote-splicing | `,x`, `,@xs` |
+| `~x`, `~@xs` | Unquote / unquote-splicing | `,x`, `,@xs` |
 | `name#` | Auto-gensym suffix in syntax-quote | `name$` |
-| `#'foo` | Var-quote (read as bare symbol `foo`) | |
+| `#'foo` | Var-quote (first-class `Phel\Lang\Var`) | |
 | `\a`, `\space`, `\uNNNN`, `\oNNN` | Character literal (compiles to single-char PHP string) | |
 | `##Inf`, `##-Inf`, `##NaN` | Symbolic numeric literal | |
 | `2r1111`, `16rFF` | Radix literal (bases 2 to 36) | |
-| `1N`, `1.5M` | BigInt / BigDecimal suffix (read as `Phel\Lang\BigInt` / `Phel\Lang\BigDecimal`) | |
-| `1/2`, `-3/4` | Ratio literal (read as `Phel\Lang\Ratio`; integer-valued ratios collapse to `int`/`BigInt`) | |
+| `1N`, `1.5M` | BigInt / BigDecimal suffix (`Phel\Lang\BigInt` / `Phel\Lang\BigDecimal`) | |
+| `1/2`, `-3/4` | Ratio literal (`Phel\Lang\Ratio`; integer-valued ratios collapse to `int`/`BigInt`) | |
 | `#"regex"` | Regex literal | |
 | `#?(...)`, `#?@(...)` | Reader conditionals (for `.cljc`) | |
 | `#<tag> form` | Tagged literal dispatch | |
@@ -63,13 +63,13 @@ Clojure reader syntax is accepted wholesale. Older Phel-specific forms still wor
 Notes:
 
 - Named `fn` for self-recursion: `(fn fact [n] (if (zero? n) 1 (* n (fact (dec n)))))`. Multi-arity named fns resolve the name across arities.
-- `defmacro` bodies have `&form` (original macro call) and `&env` (locals at the call site), enabling dialect detection via `(:ns &env)` in `.cljc` sources.
-- `#'foo` reads as a first-class `Phel\Lang\Var` (see `var?`, `var-get`, `find-var`, `bound?`, `with-redefs`). No `Char` type: `\A` compiles to the single-character string `"A"`.
-- Unknown `#<tag>` literals inside unselected `#?` branches parse without error, so `.cljc` files with foreign tags like `#cpp` in non-`:phel` branches work.
+- `defmacro` bodies have `&form` (original call) and `&env` (locals at call site), enabling dialect detection via `(:ns &env)` in `.cljc`.
+- `#'foo` reads as a `Phel\Lang\Var` (see `var?`, `var-get`, `find-var`, `bound?`, `with-redefs`). No `Char` type: `\A` compiles to `"A"`.
+- Unknown `#<tag>` literals inside unselected `#?` branches parse without error, so `.cljc` files with foreign tags (e.g. `#cpp` in non-`:phel` branches) work.
 
 ## Namespace syntax
 
-Phel uses `.` as the namespace separator, matching Clojure. The legacy `\` separator is still accepted for back-compat but deprecated; new code should use `.`.
+Phel uses `.` as the separator, matching Clojure. The legacy `\` separator still parses but is deprecated.
 
 ```phel
 ;; Preferred (Clojure-style):
@@ -82,11 +82,11 @@ Phel uses `.` as the namespace separator, matching Clojure. The legacy `\` separ
 (ns my\app (:require phel\string :as str))
 ```
 
-See [backslash-to-dot migration](migration/backslash-to-dot.md) for details.
+See [backslash-to-dot migration](migration/backslash-to-dot.md).
 
 **Automatic aliasing**: `clojure.*` namespaces in `:require` resolve to `phel.*` when the target exists. `.cljc` files using `(:require [clojure.string :as str])` work unchanged.
 
-**Importing PHP classes**: use `(:use ...)` in the `ns` form (Phel's equivalent of `(:import ...)`). PHP class names keep `\` as their native separator:
+**Importing PHP classes**: use `(:use ...)` (Phel's equivalent of `(:import ...)`). PHP class names keep `\` as their native separator:
 
 ```phel
 (ns my.app
@@ -98,7 +98,7 @@ See [backslash-to-dot migration](migration/backslash-to-dot.md) for details.
 (php/:: Symbol (create "foo"))  ; FQN Phel\Lang\Symbol is aliased
 ```
 
-`:use` is optional. Classes can always be referenced by FQN: `(php/new \DateTime)`.
+`:use` is optional; classes can always be referenced by FQN: `(php/new \DateTime)`.
 
 ## PHP interop (vs Java interop)
 
@@ -115,14 +115,7 @@ See [backslash-to-dot migration](migration/backslash-to-dot.md) for details.
 | PHP function | N/A | `(php/strlen "hello")` |
 | String concat | `(str a b)` | `(str a b)` or `(php/. a b)` |
 
-Any PHP function works with the `php/` prefix:
-
-```phel
-(php/array_map f arr)
-(php/strtolower "HELLO")
-(php/json_encode {:a 1})
-(php/date "Y-m-d")
-```
+Any PHP function works with the `php/` prefix: `(php/array_map f arr)`, `(php/strtolower "HELLO")`, `(php/json_encode {:a 1})`, `(php/date "Y-m-d")`.
 
 ## .cljc cross-compilation
 
@@ -138,18 +131,15 @@ Any PHP function works with the `php/` prefix:
      :clj  (str "Hello, " name "!")))
 ```
 
-Platform tags: `:phel`, `:clj`, `:cljs`, `:default`. Phel selects `:phel` first, then `:default`.
-
-Splice variant for embedding multiple forms:
+Platform tags: `:phel`, `:clj`, `:cljs`, `:default`. Phel selects `:phel` first, then `:default`. Splice variant embeds multiple forms:
 
 ```clojure
-[1 2 #?@(:phel [3 4] :clj [5 6])]
-;; In Phel: [1 2 3 4]
+[1 2 #?@(:phel [3 4] :clj [5 6])]   ; In Phel: [1 2 3 4]
 ```
 
 ## Clojure-compatible renames
 
-Old Phel-specific names still work but are deprecated:
+Old Phel-specific names still work but are deprecated (removed in a future major):
 
 | Clojure name | Old Phel name |
 |--------------|---------------|
@@ -163,69 +153,59 @@ Old Phel-specific names still work but are deprecated:
 | `NaN?` | `nan?` |
 | `integer?` | `int?` (alias, not deprecated) |
 
-Deprecated names are removed in a future major version.
-
 ## What's not available (and why)
 
-Some Clojure features don't translate to PHP:
-
-| Clojure feature | Why it's absent | Alternative |
-|-----------------|----------------|-------------|
+| Clojure feature | Why absent | Alternative |
+|-----------------|------------|-------------|
 | **Refs / STM** | No concurrent transactions in PHP | Use `atom` for mutable state |
 | **Agents** | No background threads | PHP job queues via interop |
-| **core.async** | No goroutines/CSP, but fiber primitives (`promise`, `deliver`, `future-fiber`) cover CSP-lite handoffs, all in `phel.core` except `delay` (requires `phel.async`). | See [docs/async-guide.md](async-guide.md) |
-| **BigInt / BigDecimal / Ratio** | First-class `Phel\Lang\BigInt`, `Phel\Lang\BigDecimal`, `Phel\Lang\Ratio` ship in core | Use literals `1N`, `1.5M`, `1/2` or constructors `bigint`, `bigdec`, `rationalize`. See [numeric-tower.md](numeric-tower.md) |
-| **Character type** | PHP has no char type | Character literals (`\a`) and `char` / `char?` are supported but compile to single-character strings |
-| **Spec** | Not ported | Use runtime assertions or PHP validation |
-| **`alter-var-root`** | Available: `(alter-var-root #'sym f)` re-roots the global binding | Use `with-redefs` for scoped overrides; `add-watch`/`remove-watch` on vars for change tracking |
+| **core.async** | No goroutines/CSP; fiber primitives (`promise`, `deliver`, `future-fiber`) cover CSP-lite handoffs, all in `phel.core` except `delay` (needs `phel.async`) | See [async-guide.md](async-guide.md) |
+| **BigInt / BigDecimal / Ratio** | First-class `Phel\Lang\BigInt`, `Phel\Lang\BigDecimal`, `Phel\Lang\Ratio` ship in core | Literals `1N`, `1.5M`, `1/2` or constructors `bigint`, `bigdec`, `rationalize`. See [numeric-tower.md](numeric-tower.md) |
+| **Character type** | PHP has no char type | `\a` literals and `char` / `char?` compile to single-char strings |
+| **Spec** | Not ported | Runtime assertions or PHP validation (also `phel.schema`) |
+| **`alter-var-root`** | Available: `(alter-var-root #'sym f)` re-roots the global binding | `with-redefs` for scoped overrides; `add-watch`/`remove-watch` on vars for tracking |
 
-The async surface lives in `phel.core`, no require needed: `future`, `future-cancel`, `future-cancelled?`, `future-done?`, `future?`, `pmap`, `promise`, `deliver`, plus fiber combinators `async`, `await`, `await-all`, `await-any`, `future-call`, `future-fiber`, and `->closure`. Built on AMPHP fibers. Semantics match `future` where possible (including timeout-bounded `deref`), but cancellation is cooperative, and `pmap` is single-threaded (overlaps IO, does not parallelize CPU). Only `delay` needs `(:require phel.async)`, since Phel's `delay` is a sleep primitive while `clojure.core/delay` is a lazy thunk. See [docs/async-guide.md](async-guide.md).
+The async surface lives in `phel.core` (no require): `future`, `future-cancel`, `future-cancelled?`, `future-done?`, `future?`, `pmap`, `promise`, `deliver`, plus fiber combinators `async`, `await`, `await-all`, `await-any`, `future-call`, `future-fiber`, `->closure`. Built on AMPHP fibers. Semantics match `future` where possible (including timeout-bounded `deref`), but cancellation is cooperative and `pmap` is single-threaded (overlaps IO, does not parallelize CPU). Only `delay` needs `(:require phel.async)`, since Phel's `delay` is a sleep primitive. See [async-guide.md](async-guide.md).
 
 ## Structural differences
 
-### defstruct, defrecord, and deftype
+### defstruct, defrecord, deftype
 
-Phel's native type form is `defstruct`. `defrecord` and `deftype` are thin macros over `defstruct` and produce the `->Name` / `map->Name` factories:
+`defstruct` is Phel's native type form. `defrecord` and `deftype` are thin macros over it, producing `->Name` / `map->Name` factories:
 
 ```phel
 ;; defstruct (native)
 (defstruct Point [x y])
-(let [p (Point 1 2)]
-  (get p :x)) ;; => 1
+(let [p (Point 1 2)] (get p :x))   ;; => 1
 
 ;; defrecord (Clojure-compatible)
 (defrecord Point [x y])
-(->Point 1 2)            ;; positional factory
-(map->Point {:x 1 :y 2}) ;; map factory
+(->Point 1 2)             ;; positional factory
+(map->Point {:x 1 :y 2})  ;; map factory
 
-;; deftype
+;; deftype (no map-> counterpart)
 (deftype PointT [x y])
-(->PointT 1 2)           ;; positional factory (no map-> counterpart)
+(->PointT 1 2)
 ```
 
-Inline protocol methods work in both macro bodies (spliced into `extend-type`):
+Inline protocol methods work in both (spliced into `extend-type`); `reify` gives anonymous implementations:
 
 ```phel
-(defprotocol Drawable
-  (draw [this canvas]))
+(defprotocol Drawable (draw [this canvas]))
 
 (defrecord Shape [label]
   Drawable
   (draw [this canvas] (str canvas ":" (get this :label))))
-```
 
-`reify` supports anonymous protocol implementation:
-
-```phel
 (reify Drawable
   (draw [this canvas] (str canvas ":anon")))
 ```
 
-Phel's `deftype` shares the map-backed `defstruct` infrastructure: instances stay map-like (keys accessible via `get`). For Clojure's non-map `deftype`, fall back to native PHP interop.
+`deftype` shares `defstruct`'s map-backed infrastructure: instances stay map-like (keys via `get`). For Clojure's non-map `deftype`, fall back to native PHP interop.
 
 ### No lazy-seq by default
 
-Phel sequences are eager. Use `lazy-seq` when needed:
+Phel sequences are eager; use `lazy-seq` when needed. `(range)` with 0 args returns an infinite lazy sequence.
 
 ```phel
 (defn lazy-fib
@@ -233,11 +213,9 @@ Phel sequences are eager. Use `lazy-seq` when needed:
   ([a b] (lazy-seq (cons a (lazy-fib b (+ a b))))))
 ```
 
-`(range)` with 0 arguments returns an infinite lazy sequence.
-
 ### Test framework
 
-`phel.test` mirrors `clojure.test`:
+`phel.test` mirrors `clojure.test`. Run with `./bin/phel test`.
 
 ```phel
 (ns my-app.test
@@ -252,19 +230,13 @@ Phel sequences are eager. Use `lazy-seq` when needed:
       3 3 6)))
 ```
 
-Extend `is` with custom assertions via `phel.test/assert-expr`:
-
-```phel
-(defmethod phel.test/assert-expr 'my-form [msg form] ...)
-```
-
-Run tests with `./bin/phel test`.
+Extend `is` with custom assertions: `(defmethod phel.test/assert-expr 'my-form [msg form] ...)`.
 
 ## Migration checklist
 
 1. Rename `.clj` files to `.phel` (or `.cljc` for shared code)
-2. Keep namespace separators as `.` (e.g. `my.app.core`); the legacy `\` form still parses but is deprecated
+2. Use `.` namespace separators (e.g. `my.app.core`); legacy `\` still parses but is deprecated
 3. Replace Java interop with PHP interop (`(.method obj)` → `(php/-> obj (method))`)
-4. Rewrite `(:import [java.util Date])` clauses as `(:use DateTime)` in the `ns` form
-5. Replace concurrency primitives (refs, agents, core.async) with `atom` or the AMPHP-backed primitives in `phel.core` (`future`, `pmap`, `promise`, `deliver`, ...); add `(:require phel.async :refer [delay])` only for the sleep primitive
+4. Rewrite `(:import [java.util Date])` as `(:use DateTime)` in the `ns` form
+5. Replace concurrency primitives (refs, agents, core.async) with `atom` or the AMPHP-backed `phel.core` primitives (`future`, `pmap`, `promise`, `deliver`, ...); add `(:require phel.async :refer [delay])` only for the sleep primitive
 6. Run `./bin/phel test` to verify

--- a/docs/data-formats.md
+++ b/docs/data-formats.md
@@ -5,7 +5,7 @@ Phel ships two eval-free interchange modules for talking to other Clojure-aligne
 - [`phel.edn`](#phel-edn): [Extensible Data Notation](https://github.com/edn-format/edn), the Clojure-native subset of reader syntax.
 - [`phel.transit`](#phel-transit): [Transit](https://github.com/cognitect/transit-format) layered on top of JSON.
 
-Neither module goes through `eval`, so they are safe to point at untrusted input.
+Neither goes through `eval`, so both are safe to point at untrusted input.
 
 ## `phel.edn`
 
@@ -14,7 +14,7 @@ Neither module goes through `eval`, so they are safe to point at untrusted input
 | Function | Purpose |
 |---|---|
 | `(read-string s)` / `(read-string s opts)` | Read the first EDN form from `s`. |
-| `(read-string-all s)` / `(read-string-all s opts)` | Read every form, returns a vector. |
+| `(read-string-all s)` / `(read-string-all s opts)` | Read every form; returns a vector. |
 | `(write-string v)` | Serialise `v` to EDN. |
 | `(write-string-all xs)` | Serialise a sequence; values joined by a single space. |
 
@@ -22,12 +22,14 @@ Neither module goes through `eval`, so they are safe to point at untrusted input
 
 | Key | Value | Behaviour |
 |---|---|---|
-| `:readers` | `{tag fn}` | Per-call tag handlers. Tags may be symbols, keywords, or strings. The handler receives the already-parsed form. The global `TagRegistry` is snapshotted before the call and restored in a `finally`. |
-| `:eof` | any | Returned by `read-string` when input is empty / whitespace-only / comment-only (default `nil`). |
+| `:readers` | `{tag fn}` | Per-call tag handlers. Tags may be symbols, keywords, or strings; the handler receives the already-parsed form. The global `TagRegistry` is snapshotted before the call and restored in a `finally`. |
+| `:eof` | any | Returned by `read-string` when input is empty, whitespace-only, or comment-only (default `nil`). |
 
 ### Type mapping
 
-`phel.edn` delegates reading to Phel's own reader and writing to `Printer::readable()`, so every value Phel can print readably round-trips. That includes nil, booleans, integers, floats, strings, characters, keywords, symbols, lists, vectors, maps, sets, the `#_` discard form, `;` comments, and built-in tagged literals (`#uuid`, `#inst`, `#regex`).
+`phel.edn` delegates reading to Phel's own reader and writing to `Printer::readable()`, so every value Phel can print readably round-trips: nil, booleans, integers, floats, strings, characters, keywords, symbols, lists, vectors, maps, sets, the `#_` discard form, `;` comments, and built-in tagged literals (`#uuid`, `#inst`, `#regex`).
+
+The lexer accepts EDN's full tag grammar, so namespaced tags (`#my.app/Person`, `#myapp/double`, `#my.app.module`) lex as a single tag. Unqualified tags (`#uuid`, `#inst`) work unchanged.
 
 ### Examples
 
@@ -54,10 +56,6 @@ Neither module goes through `eval`, so they are safe to point at untrusted input
 ;; => :no-data
 ```
 
-### Namespaced tags
-
-The lexer accepts EDN's full tag grammar, so `#my.app/Person`, `#myapp/double`, and `#my.app.module` lex as a single tag. Unqualified tags (`#uuid`, `#inst`) continue to work unchanged.
-
 ## `phel.transit`
 
 ### Public API
@@ -67,7 +65,7 @@ The lexer accepts EDN's full tag grammar, so `#my.app/Person`, `#myapp/double`, 
 | `(read-string s)` / `(read-string s opts)` | Decode one Transit+JSON-Verbose value. |
 | `(write-string v)` | Encode `v` to a Transit+JSON-Verbose string. |
 
-This first iteration implements **JSON-Verbose** only: maps with string keys serialise to ordinary JSON objects (no key caching), composite-key maps to `~#cmap`.
+This first iteration implements **JSON-Verbose** only: maps with string keys serialise to ordinary JSON objects (no key caching); any other map serialises as a `~#cmap`.
 
 ### Options map
 
@@ -102,9 +100,15 @@ Plain Phel strings whose first character is `~`, `^`, or `` ` `` are escaped on 
 (ns my-app.api
   (:require phel.transit :as transit))
 
-(transit/write-string {:users [{:name "Alice" :tags #{:admin}}]})
-;; => "{\"~:users\":[{\"~:name\":\"Alice\",\"~:tags\":[\"~#set\",[\"~:admin\"]]}]}"
+;; String-keyed map -> plain JSON object
+(transit/write-string {"name" "Alice"})
+;; => "{\"name\":\"Alice\"}"
 
+;; Keyword keys are composite keys, so the map becomes a ~#cmap
+(transit/write-string {:status :ok :count 42})
+;; => "[\"~#cmap\",[\"~:status\",\"~:ok\",\"~:count\",42]]"
+
+;; Reading a string-keyed object yields keyword keys back
 (transit/read-string "{\"~:status\":\"~:ok\",\"~:count\":42}")
 ;; => {:status :ok :count 42}
 
@@ -119,7 +123,7 @@ Plain Phel strings whose first character is `~`, `^`, or `` ` `` are escaped on 
 ;; => [:unknown "myapp/Foo" [1 2]]
 ```
 
-### What is intentionally out of scope (for now)
+### Intentionally out of scope (for now)
 
 - **Cached keys** (the non-verbose Transit+JSON encoding with `^` cache markers).
 - **Transit+MessagePack**.

--- a/docs/data-structures-guide.md
+++ b/docs/data-structures-guide.md
@@ -1,570 +1,244 @@
 # Data Structures Manipulation Guide
 
-Functions for manipulating Phel's immutable, persistent data structures: vectors, maps, sets, lists. Operations return new versions while sharing structure with the original. Reads stay O(1) amortized; updates cost log32(n). Function names follow Clojure conventions (`conj`, `assoc`, `dissoc`, `merge`, `update`, `get`, `keys`, `vals`, `into`, `group-by`, `frequencies`, …). See the [quick reference](#quick-reference).
+Functions for Phel's immutable, persistent data structures (vectors, maps, sets, lists). Operations return new versions while sharing structure with the original: reads stay O(1) amortized, updates cost log32(n). Names follow Clojure conventions. See the [quick reference](#quick-reference).
 
-## String Iteration
+## Strings as Sequences
 
-Strings work with all sequence functions:
-
-```phel
-;; Iterate with for
-(for [c :in "hello"] c)
-;; => ["h" "e" "l" "l" "o"]
-
-;; Map over characters directly
-(map php/strtoupper "hello")
-;; => ["H" "E" "L" "L" "O"]
-
-;; Filter characters
-(filter #(not= % "l") "hello")
-;; => ["h" "e" "o"]
-
-;; Take and drop work directly
-(take 3 "hello")
-;; => ["h" "e" "l"]
-
-(drop 2 "hello")
-;; => ["l" "l" "o"]
-
-;; Count frequency of characters
-(frequencies "hello")
-;; => {"h" 1 "e" 1 "l" 2 "o" 1}
-```
-
-### Sequence Operations on Strings
+Strings work with every sequence function and iterate by UTF-8 character:
 
 ```phel
-;; first, next, rest
-(first "hello")   ; => "h"
-(next "hello")    ; => ["e" "l" "l" "o"]
-(rest "hello")    ; => ["e" "l" "l" "o"]
-
-;; Lazy operations
+(for [c :in "hello"] c)             ; => ["h" "e" "l" "l" "o"]
+(map php/strtoupper "hello")        ; => ["H" "E" "L" "L" "O"]
+(filter #(not= % "l") "hello")      ; => ["h" "e" "o"]
+(take 3 "hello")                    ; => ["h" "e" "l"]
+(drop 2 "hello")                    ; => ["l" "l" "o"]
+(first "hello")                     ; => "h"
+(next "hello")                      ; => ["e" "l" "l" "o"]   (rest behaves the same)
 (take-while #(not= % "l") "hello")  ; => ["h" "e"]
 (drop-while #(not= % "l") "hello")  ; => ["l" "l" "o"]
-
-;; Reduce over characters
-(reduce str "" "hello")  ; => "hello"
-
-;; Distinct characters
-(distinct "hheelloo")    ; => ["h" "e" "l" "o"]
-
-;; Reverse characters
-(reverse "hello")        ; => ["o" "l" "l" "e" "h"]
+(reduce str "" "hello")             ; => "hello"
+(distinct "hheelloo")               ; => ["h" "e" "l" "o"]
+(reverse "hello")                   ; => ["o" "l" "l" "e" "h"]
+(frequencies "hello")               ; => {"h" 1 "e" 1 "l" 2 "o" 1}
 ```
 
-### String Conversion Functions
+Convert a string to a character vector with `seq`, or `phel.string/chars`:
 
-**`seq`** - Convert string to vector of characters:
 ```phel
-(seq "hello")
-;; => ["h" "e" "l" "l" "o"]
+(seq "hello")                       ; => ["h" "e" "l" "l" "o"]
 ```
 
-**`phel.string/chars`** - String to character vector:
 ```phel
 (ns app.example (:require phel.string :as str))
-(str/chars "hello")
-;; => ["h" "e" "l" "l" "o"]
+(str/chars "hello")                 ; => ["h" "e" "l" "l" "o"]
 ```
 
-### Unicode Support
-
-String operations handle multibyte UTF-8:
+Multibyte UTF-8 is handled correctly:
 
 ```phel
-(count "café")      ; => 4
+(count "café")          ; => 4
+(first "日本語")         ; => "日"
 (frequencies "🎉🎉🎊")  ; => {"🎉" 2 "🎊" 1}
-(first "日本語")     ; => "日"
-(map identity "🎉🎊🎈")  ; => ["🎉" "🎊" "🎈"]
+(map identity "🎉🎊🎈") ; => ["🎉" "🎊" "🎈"]
 ```
 
----
+## Adding & Building
 
-## Adding & Building Collections
+### `conj` : conjoin (universal add)
 
-### `conj` - Conjoin (Universal Add)
-
-Adds elements to any collection. Behavior varies by type:
+Adds elements; position depends on type. **Signature:** `([] [coll] [coll value] [coll value & more])`
 
 ```phel
-;; Vectors - appends to end
-(conj [1 2 3] 4)
-;; => [1 2 3 4]
-
-;; Lists - prepends to beginning
-(conj '(1 2 3) 4)
-;; => (4 1 2 3)
-
-;; Sets - adds element
-(conj #{1 2 3} 4)
-;; => #{1 2 3 4}
-
-;; Maps - accepts [key value] vectors
-(conj {:a 1} [:b 2])
-;; => {:a 1 :b 2}
-
-;; Maps - merges another map
-(conj {:a 1} {:b 2 :c 3})
-;; => {:a 1 :b 2 :c 3}
-
-;; Nil - creates a list
-(conj nil 1)
-;; => (1)
-
-;; Variadic - add multiple elements
-(conj [1 2] 3 4 5)
-;; => [1 2 3 4 5]
+(conj [1 2 3] 4)        ; => [1 2 3 4]      ; vectors append
+(conj '(1 2 3) 4)       ; => (4 1 2 3)      ; lists prepend
+(conj #{1 2 3} 4)       ; => #{1 2 3 4}     ; sets add
+(conj {:a 1} [:b 2])    ; => {:a 1 :b 2}    ; maps take [k v]
+(conj {:a 1} {:b 2 :c 3}) ; => {:a 1 :b 2 :c 3}  ; or merge a map
+(conj nil 1)            ; => (1)            ; nil creates a list
+(conj [1 2] 3 4 5)      ; => [1 2 3 4 5]    ; variadic
 ```
 
-**Signature:** `([] [coll] [coll value] [coll value & more])`
+### `assoc` : associate key/value
 
----
-
-### `assoc` - Associate Key-Value Pairs
-
-Associates a value with a key. Maps: add or update entries. Vectors: update by index.
+Maps: add or update an entry. Vectors: update by index. **Signature:** `[ds key value]`
 
 ```phel
-;; Maps - add or update key
-(assoc {:a 1} :b 2)
-;; => {:a 1 :b 2}
-
-(assoc {:a 1 :b 2} :a 3)
-;; => {:a 3 :b 2}
-
-;; Vectors - update by index
-(assoc [10 20 30] 1 99)
-;; => [10 99 30]
+(assoc {:a 1} :b 2)       ; => {:a 1 :b 2}
+(assoc {:a 1 :b 2} :a 3)  ; => {:a 3 :b 2}
+(assoc [10 20 30] 1 99)   ; => [10 99 30]
 ```
 
-**Signature:** `[ds key value]`
+See also `conj` for structured data, `assoc-in` for nested updates.
 
-**See also:** `conj` for structured data, `assoc-in` for nested updates.
+### `into` : bulk addition
 
----
-
-### `into` - Bulk Addition
-
-Returns a collection with all elements from the source(s) added.
+Adds all elements from the source(s). **Signatures:** `[to from]`, `[to xform from]`
 
 ```phel
-(into [1 2] [3 4 5])
-;; => [1 2 3 4 5]
-
-(into [] '(1 2 3 4))
-;; => [1 2 3 4]
-
-(into {} [[:a 1] [:b 2]])
-;; => {:a 1 :b 2}
-
-(into #{1 2} [2 3 4])
-;; => #{1 2 3 4}
-
-;; With a transducer (middle argument)
-(into [] (map inc) [1 2 3])
-;; => [2 3 4]
+(into [1 2] [3 4 5])        ; => [1 2 3 4 5]
+(into {} [[:a 1] [:b 2]])   ; => {:a 1 :b 2}
+(into #{1 2} [2 3 4])       ; => #{1 2 3 4}
+(into [] (map inc) [1 2 3]) ; => [2 3 4]   ; with a transducer
 ```
-
-**Signatures:** `[to from]`, `[to xform from]`
 
 See [Transducers](transducers.md).
 
----
+## Accessing
 
-## Accessing Elements
+### `get` / `get-in`
 
-### `get` - Safe Access
-
-Gets the value at a key. Returns `nil` or an optional default if not found.
+`get` reads one key (maps) or index (vectors), returning `nil` or an optional default. `get-in` walks a path of keys/indices. **Signatures:** `[ds k & [opt]]`, `[ds ks & [opt]]`
 
 ```phel
-(get {:a 1 :b 2} :a)
-;; => 1
+(get {:a 1 :b 2} :a)              ; => 1
+(get {:a 1 :b 2} :c "default")    ; => "default"
+(get [10 20 30] 1)                ; => 20
 
-(get {:a 1 :b 2} :c)
-;; => nil
-
-(get {:a 1 :b 2} :c "default")
-;; => "default"
-
-;; Works with vectors (by index)
-(get [10 20 30] 1)
-;; => 20
+(get-in {:a {:b {:c 1}}} [:a :b :c])         ; => 1
+(get-in {:a [["b" "a"]]} [:a 0 1])           ; => "a"
+(get-in {:a {:b 1}} [:a :x :y] "not-found")  ; => "not-found"
 ```
 
-**Signature:** `[ds k & [opt]]`
+### `keys` / `vals`
 
----
-
-### `get-in` - Nested Access
-
-Accesses a value in nested data via a sequence of keys.
+Return a map's keys or values. **Signature:** `[coll]`
 
 ```phel
-(get-in {:a {:b {:c 1}}} [:a :b :c])
-;; => 1
-
-(get-in {:a [["b" "a"]]} [:a 0 1])
-;; => "a"
-
-;; With default value
-(get-in {:a {:b 1}} [:a :x :y] "not-found")
-;; => "not-found"
+(keys {:a 1 :b 2 :c 3})  ; => (:a :b :c)
+(vals {:a 1 :b 2 :c 3})  ; => (1 2 3)
 ```
 
-**Signature:** `[ds ks & [opt]]`
+`values` is a deprecated alias of `vals` (since v0.32.0) that still works.
 
----
+### `contains?` : check for key
 
-### `keys` - Extract Keys
-
-Returns a sequence of all keys in a map.
+Returns `true` if the key/index exists. Checks **keys/indices, not values**. **Signature:** `[coll key]`
 
 ```phel
-(keys {:a 1 :b 2 :c 3})
-;; => (:a :b :c)
+(contains? {:a 1 :b 2} :a)  ; => true
+(contains? [10 20 30] 1)    ; => true  ; index 1 exists
+(contains? [10 20 30] 3)    ; => false ; index 3 doesn't
 ```
 
-**Signature:** `[coll]`
+### `find` : find first match
 
----
-
-### `vals` - Extract Values
-
-Returns a sequence of all values in a map.
+Returns the first item where the predicate is true, else `nil`. **Signature:** `[pred coll]`
 
 ```phel
-(vals {:a 1 :b 2 :c 3})
-;; => (1 2 3)
+(find #(> % 5) [1 3 7 2 9])  ; => 7
+(find even? [1 3 5 7])       ; => nil
 ```
 
-**Signature:** `[coll]`
+**Clojure note:** Clojure's `find` returns a `[key value]` entry on associative structures; Phel's `find` is a general search function.
 
-> `values` is a deprecated alias that still works.
+## Modifying
 
----
+### `update` / `update-in` : transform a value
 
-### `contains?` - Check for Key
-
-Returns `true` if a key exists. **Important:** Checks keys/indices, not values.
+Apply a function (plus extra args) to the value at a key/path. **Signatures:** `[ds k f & args]`, `[ds [k & ks] f & args]`
 
 ```phel
-(contains? {:a 1 :b 2} :a)
-;; => true
-
-(contains? [10 20 30] 1)
-;; => true (index 1 exists)
-
-(contains? [10 20 30] 3)
-;; => false (index 3 doesn't exist)
+(update {:a 1} :a inc)                    ; => {:a 2}
+(update {:a 1} :a + 10)                   ; => {:a 11}
+(update [10 20 30] 1 * 2)                 ; => [10 40 30]
+(update-in {:a {:b 1}} [:a :b] inc)       ; => {:a {:b 2}}
+(update-in {:a {:b [1 2 3]}} [:a :b 0] * 10) ; => {:a {:b [10 2 3]}}
 ```
 
-**Signature:** `[coll key]`
+### `assoc-in` : nested association
 
----
-
-### `find` - Find First Match
-
-Returns the first item where the predicate returns true.
+Sets a nested value, creating intermediate maps as needed. **Signature:** `[ds [k & ks] v]`
 
 ```phel
-(find #(> % 5) [1 3 7 2 9])
-;; => 7
-
-(find even? [1 3 5 7])
-;; => nil
+(assoc-in {:a {}} [:a :b :c] 1)            ; => {:a {:b {:c 1}}}
+(assoc-in {:a {:b [1 2 3]}} [:a :b 0] 99)  ; => {:a {:b [99 2 3]}}
 ```
 
-**Signature:** `[pred coll]`
+### `dissoc` / `dissoc-in` : remove keys
 
-**Clojure note:** Clojure's `find` returns a `[key value]` entry on associative structures. Phel's `find` is a general search function.
-
----
-
-## Modifying Collections
-
-### `update` - Transform a Value
-
-Applies a function to the value at a key.
+Remove a key (`dissoc`) or a nested key (`dissoc-in` ⭐). **Signatures:** `[ds key]`, `[ds [k & ks]]`
 
 ```phel
-(update {:a 1} :a inc)
-;; => {:a 2}
-
-(update {:a 1} :a + 10)
-;; => {:a 11}
-
-(update [10 20 30] 1 * 2)
-;; => [10 40 30]
+(dissoc {:a 1 :b 2 :c 3} :b)               ; => {:a 1 :c 3}
+(dissoc #{:a :b :c} :b)                    ; => #{:a :c}
+(dissoc-in {:a {:b {:c 1 :d 2}}} [:a :b :c]) ; => {:a {:b {:d 2}}}
 ```
 
-**Signature:** `[ds k f & args]`
-
----
-
-### `update-in` - Nested Transform
-
-Applies a function to a nested value.
-
-```phel
-(update-in {:a {:b 1}} [:a :b] inc)
-;; => {:a {:b 2}}
-
-(update-in {:a {:b [1 2 3]}} [:a :b 0] * 10)
-;; => {:a {:b [10 2 3]}}
-```
-
-**Signature:** `[ds [k & ks] f & args]`
-
----
-
-### `assoc-in` - Nested Association
-
-Associates a nested value, creating intermediate structures as needed.
-
-```phel
-(assoc-in {:a {}} [:a :b :c] 1)
-;; => {:a {:b {:c 1}}}
-
-(assoc-in {:a {:b [1 2 3]}} [:a :b 0] 99)
-;; => {:a {:b [99 2 3]}}
-```
-
-**Signature:** `[ds [k & ks] v]`
-
----
-
-### `dissoc` - Dissociate Keys
-
-Removes a key.
-
-```phel
-(dissoc {:a 1 :b 2 :c 3} :b)
-;; => {:a 1 :c 3}
-
-(dissoc #{:a :b :c} :b)
-;; => #{:a :c}
-```
-
-**Signature:** `[ds key]`
-
----
-
-### `dissoc-in` - Nested Dissociation ⭐
-
-Removes a nested key.
-
-```phel
-(dissoc-in {:a {:b {:c 1 :d 2}}} [:a :b :c])
-;; => {:a {:b {:d 2}}}
-```
-
-**Signature:** `[ds [k & ks]]`
-
-**⭐ Phel-specific:** Not in Clojure core.
-
----
+⭐ `dissoc-in` is Phel-specific (not in Clojure core).
 
 ## Combining Maps
 
-### `merge` - Merge Maps
+### `merge` / `merge-with` / `deep-merge`
 
-Merges multiple maps into one. Later values override earlier ones for duplicate keys.
+`merge` combines maps, later values win. `merge-with` resolves duplicates with a function. `deep-merge` (⭐) recurses into nested maps, sets, and vectors. **Signatures:** `[& maps]`, `[f & maps]`, `[& args]`
 
 ```phel
-(merge {:a 1 :b 2} {:b 3 :c 4})
-;; => {:a 1 :b 3 :c 4}
+(merge {:a 1 :b 2} {:b 3 :c 4})            ; => {:a 1 :b 3 :c 4}
+(merge {:a 1} {:b 2} {:c 3})               ; => {:a 1 :b 2 :c 3}
 
-(merge {:a 1} {:b 2} {:c 3})
-;; => {:a 1 :b 2 :c 3}
+(merge-with + {:a 1 :b 2} {:b 3 :c 4})     ; => {:a 1 :b 5 :c 4}
+(merge-with concat {:a [1]} {:a [2] :b [3]}) ; => {:a [1 2] :b [3]}
+
+(deep-merge {:a {:b 1 :c 2}} {:a {:c 3 :d 4}}) ; => {:a {:b 1 :c 3 :d 4}}
+(deep-merge {:a #{:b :c}} {:a #{:c :d}})       ; => {:a #{:b :c :d}}
+(deep-merge {:a [1 2]} {:a [3]})               ; => {:a [1 2 3]}
 ```
 
-**Signature:** `[& maps]`
+⭐ `deep-merge` is Phel-specific; handy for config merging.
 
----
-
-### `merge-with` - Merge with Function
-
-Merges maps, resolving duplicate keys with a function.
+### `select-keys` / `zipmap` / `invert`
 
 ```phel
-(merge-with + {:a 1 :b 2} {:b 3 :c 4})
-;; => {:a 1 :b 5 :c 4}
+(select-keys {:a 1 :b 2 :c 3} [:a :c])  ; => {:a 1 :c 3}
+(select-keys {:a 1 :b 2} [:a :x])       ; => {:a 1}     ; missing keys ignored
 
-(merge-with concat {:a [1]} {:a [2] :b [3]})
-;; => {:a [1 2] :b [3]}
+(zipmap [:a :b :c] [1 2 3])             ; => {:a 1 :b 2 :c 3}
+(zipmap [:a :b :c] [1 2])               ; => {:a 1 :b 2} ; extras dropped
+
+(invert {:a 1 :b 2})                    ; => {1 :a 2 :b} ; swap keys/values
 ```
 
-**Signature:** `[f & maps]`
+**Signatures:** `[m ks]`, `[keys vals]`, `[map]`
 
----
+## Analysis
 
-### `deep-merge` - Recursive Merge ⭐
+### `frequencies` / `group-by`
 
-Recursively merges nested data structures (maps, sets, vectors).
+`frequencies` counts occurrences (also accepts strings). `group-by` buckets elements by a function's result. **Signatures:** `[coll]`, `[f coll]`
 
 ```phel
-(deep-merge {:a {:b 1 :c 2}} {:a {:c 3 :d 4}})
-;; => {:a {:b 1 :c 3 :d 4}}
+(frequencies [:a :b :a :c :b :a])           ; => {:a 3 :b 2 :c 1}
+(frequencies "hello")                       ; => {"h" 1 "e" 1 "l" 2 "o" 1}
 
-(deep-merge {:a #{:b :c}} {:a #{:c :d}})
-;; => {:a #{:b :c :d}}
-
-(deep-merge {:a [1 2]} {:a [3]})
-;; => {:a [1 2 3]}
+(group-by count ["a" "bb" "ccc" "dd" "e"])  ; => {1 ["a" "e"] 2 ["bb" "dd"] 3 ["ccc"]}
+(group-by even? [1 2 3 4 5 6])              ; => {false [1 3 5] true [2 4 6]}
 ```
 
-**Signature:** `[& args]`
+## Nested Structures
 
-**⭐ Phel-specific:** Not in Clojure core. Useful for configuration merging.
-
----
-
-### `select-keys` - Filter by Keys
-
-Returns a new map with only the specified keys.
+`*-in` functions take a path (sequence of keys/indices) to navigate. Paths mix map keys and vector indices freely.
 
 ```phel
-(select-keys {:a 1 :b 2 :c 3} [:a :c])
-;; => {:a 1 :c 3}
+(get-in data [:user :profile :email])         ; read
+(update-in data [:user :age] inc)              ; update
+(assoc-in {} [:a :b :c] 42)                    ; => {:a {:b {:c 42}}}  (creates maps)
+(dissoc-in data [:user :profile :temp-data])   ; remove
+(get-in {:users [{:name "Alice"} {:name "Bob"}]} [:users 1 :name]) ; => "Bob"
 
-(select-keys {:a 1 :b 2} [:a :x])
-;; => {:a 1}
-```
-
-**Signature:** `[m ks]`
-
----
-
-### `zipmap` - Create Map from Sequences
-
-Pairs keys and values from two sequences into a map.
-
-```phel
-(zipmap [:a :b :c] [1 2 3])
-;; => {:a 1 :b 2 :c 3}
-
-;; Drops extra keys or values
-(zipmap [:a :b :c] [1 2])
-;; => {:a 1 :b 2}
-```
-
-**Signature:** `[keys vals]`
-
----
-
-### `invert` - Swap Keys and Values
-
-Returns a map with keys and values swapped.
-
-```phel
-(invert {:a 1 :b 2})
-;; => {1 :a 2 :b}
-```
-
-**Signature:** `[map]`
-
----
-
-## Analysis Functions
-
-### `frequencies` - Count Occurrences
-
-Returns a map of items to occurrence counts.
-
-```phel
-(frequencies [:a :b :a :c :b :a])
-;; => {:a 3 :b 2 :c 1}
-
-(frequencies "hello")
-;; => {"h" 1 "e" 1 "l" 2 "o" 1}
-```
-
-**Signature:** `[coll]`
-
-Phel additionally accepts strings as iterable sequences.
-
----
-
-### `group-by` - Organize by Function
-
-Groups elements by the result of applying a function.
-
-```phel
-(group-by count ["a" "bb" "ccc" "dd" "e"])
-;; => {1 ["a" "e"] 2 ["bb" "dd"] 3 ["ccc"]}
-
-(group-by even? [1 2 3 4 5 6])
-;; => {false [1 3 5] true [2 4 6]}
-```
-
-**Signature:** `[f coll]`
-
----
-
-## Working with Nested Structures
-
-`*-in` functions take a path (sequence of keys) to navigate the structure.
-
-### Common Patterns
-
-```phel
-;; Read nested value
-(get-in data [:user :profile :email])
-
-;; Update nested value
-(update-in data [:user :age] inc)
-
-;; Set nested value (creates intermediate maps)
-(assoc-in {} [:a :b :c] 42)
-;; => {:a {:b {:c 42}}}
-
-;; Remove nested key
-(dissoc-in data [:user :profile :temp-data])
-
-;; Mixed indices and keys
-(get-in {:users [{:name "Alice"} {:name "Bob"}]} [:users 1 :name])
-;; => "Bob"
-```
-
-### Path Navigation
-
-Paths work with any combination of map keys and vector indices:
-
-```phel
-(def data {:items [{:id 1 :tags #{:a :b}}
-                   {:id 2 :tags #{:c}}]})
-
+(def data {:items [{:id 1 :tags #{:a :b}} {:id 2 :tags #{:c}}]})
 (update-in data [:items 0 :tags] conj :c)
 ;; => {:items [{:id 1 :tags #{:a :b :c}} {:id 2 :tags #{:c}}]}
 ```
 
----
-
 ## Transient Collections
 
-For hot paths with many sequential updates, use **transient collections**. They allow efficient mutable operations, then convert back to persistent.
-
-### Workflow
+For hot paths with many sequential updates, use transients: efficient in-place mutation, then convert back to persistent. Mutate with the bang variants `conj!`, `assoc!`, `dissoc!`; finish with `persistent` (or its alias `persistent!`). Do not use a transient after converting it.
 
 ```phel
-;; 1. Create transient version
 (def t (transient []))
+(conj! t 1) (conj! t 2) (conj! t 3)
+(persistent t)  ; => [1 2 3]
 
-;; 2. Perform mutations (use bang variants: conj!, assoc!, dissoc!)
-(conj! t 1)
-(conj! t 2)
-(conj! t 3)
-
-;; 3. Convert back to persistent
-(def result (persistent! t))
-;; => [1 2 3]
-```
-
-### Example: Building a large map
-
-```phel
 (defn build-map [^int n]
   (let [t (transient {})]
     (loop [i 0]
@@ -574,53 +248,18 @@ For hot paths with many sequential updates, use **transient collections**. They 
     (persistent! t)))
 ```
 
-Phel ships both `persistent` and `persistent!` (alias). Don't use the transient after calling either.
-
----
-
 ## Phel-Specific Extensions ⭐
 
-Functions not in Clojure core.
-
-### `pairs` - Get Key-Value Pairs
-
-Returns key-value pairs from an associative structure.
+Not in Clojure core.
 
 ```phel
-(pairs {:a 1 :b 2})
-;; => ([:a 1] [:b 2])
+(pairs {:a 1 :b 2})         ; => ([:a 1] [:b 2])  ; key/value pairs
+(kvs {:a 1 :b 2 :c 3})      ; => [:a 1 :b 2 :c 3] ; flat alternating k/v
+(find-index #(> % 5) [1 3 7 2 9]) ; => 2  ; index of first match (pred gets the item)
+(find-index even? [1 3 4 6])      ; => 2
 ```
 
----
-
-### `kvs` - Flatten Key-Value Pairs
-
-Returns a flat vector of alternating keys and values.
-
-```phel
-(kvs {:a 1 :b 2 :c 3})
-;; => [:a 1 :b 2 :c 3]
-```
-
-Useful for APIs that expect key-value arguments.
-
----
-
-### `find-index` - Find with Index
-
-Returns the index of the first item where the predicate (called with the item) is true.
-
-```phel
-(find-index #(> % 5) [1 3 7 2 9])
-;; => 2  (index of 7)
-
-(find-index even? [1 3 4 6])
-;; => 2  (index of first even item)
-```
-
-The predicate receives one argument: the item.
-
----
+`kvs` is useful for APIs expecting key/value arguments.
 
 ## Quick Reference
 
@@ -655,8 +294,6 @@ The predicate receives one argument: the item.
 
 ⭐ = Phel-specific extension
 
----
-
 ## Deprecated Functions
 
 | Deprecated (v0.25.0) | Use Instead |
@@ -667,18 +304,6 @@ The predicate receives one argument: the item.
 | `put-in` | `assoc-in` |
 | `unset-in` | `dissoc-in` |
 
-Signatures and behavior are identical; replace the name.
-
-```phel
-;; Old (deprecated)
-(push [1 2] 3)
-(put {:a 1} :b 2)
-
-;; New (recommended)
-(conj [1 2] 3)
-(assoc {:a 1} :b 2)
-```
-
----
+Signatures and behavior are identical; just replace the name.
 
 See `docs/examples/05_data-structures.phel` for runnable code.

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -10,6 +10,8 @@ Add Phel to a PHP project without touching `app/` or `src/`.
 4. Export PHP wrappers under your framework's `App\` PSR-4 root via `phel export`.
 5. Prod: `phel build` at deploy, `require 'build/app/main.php'` at boot. Dev: `\Phel::run($root, 'app.main')` compiles on first call.
 
+Namespaces need at least two segments (`shop.pricing`, not `pricing`); a single-segment ns exports invalid PHP.
+
 Two ways to call Phel from PHP:
 
 | Flavor | How | When |
@@ -23,8 +25,6 @@ Two load modes, same provider/kernel hook:
 |------|------|------------------|
 | Prod (AOT) | `require 'build/app/main.php'`, precompiled | Zero compile, one `require` |
 | Dev (JIT) | `\Phel::run($root, 'app.main')` | Gacela bootstrap + compile on first call |
-
-Namespaces need at least two segments (`shop.pricing`, not `pricing`).
 
 Install: `composer require phel-lang/phel-lang`
 
@@ -58,7 +58,7 @@ phel/
   (:require auth.tokens))
 ```
 
-Loading `app.main` (via `require` or `\Phel::run()`) registers every exported function across all three namespaces. Any controller can call any wrapper:
+Loading `app.main` (via `require` or `\Phel::run()`) registers every exported function across all three namespaces. The build walks requires transitively, so `build/app/main.php` `require_once`s every dependency. Any controller can then call any wrapper:
 
 ```php
 App\PhelGenerated\Shop\Pricing::applyDiscount(...)
@@ -66,7 +66,7 @@ App\PhelGenerated\Reports\Daily::summary(...)
 App\PhelGenerated\Auth\Tokens::makeToken(...)
 ```
 
-New feature: add the file, add one `:require` in `app/main.phel`, run `phel export` + `phel build`.
+New feature: add the `.phel` file, add one `:require` in `app/main.phel`, rerun `phel export` + `phel build`.
 
 ---
 
@@ -145,7 +145,7 @@ final class CheckoutController
 
 ## Symfony
 
-`phel-config.php`:
+`phel-config.php` (only the export target differs from Laravel):
 
 ```php
 <?php
@@ -161,7 +161,7 @@ return PhelConfig::forProject()
     ->withExportTargetDirectory(__DIR__ . '/src/PhelGenerated');
 ```
 
-Default `App\ → src/` PSR-4 covers `App\PhelGenerated\`.
+The default `App\ → src/` PSR-4 mapping covers `App\PhelGenerated\`.
 
 `src/Kernel.php`:
 
@@ -188,7 +188,7 @@ public function boot(): void
 }
 ```
 
-Controllers use any wrapper: `App\PhelGenerated\Reports\Daily`, `App\PhelGenerated\Shop\Pricing`, etc. All registered by the main load.
+Controllers use any wrapper (`App\PhelGenerated\Reports\Daily`, etc.), all registered by the main load.
 
 ---
 
@@ -231,11 +231,10 @@ echo $greet('World') . "\n";
 
 ## Notes
 
-- **Main namespace**: `phel/app/main.phel` lists one `(:require other.ns)` per feature namespace. The build walks requires transitively, so `build/app/main.php` `require_once`s every dependency. Loading it from the provider/kernel registers every `{:export true}` function. Controllers call any wrapper without knowing which Phel files exist. New feature: create the `.phel` file, add one `:require` in `app/main.phel`, rerun `phel export` + `phel build`.
-- Namespace path matches directory: `phel/shop/pricing.phel` to `(ns shop.pricing)`. Single-segment ns exports invalid PHP; use at least two segments.
+- Namespace path matches directory: `phel/shop/pricing.phel` to `(ns shop.pricing)`.
 - Hyphens become camelCase: `(ns my-lib.core)` to `App\PhelGenerated\MyLib\Core`; `apply-discount` to `applyDiscount`.
 - Prod path (`require build/app/main.php`): self-contained, no Gacela bootstrap, no compiler. Just `\Phel::addDefinition()` calls.
-- Dev path (`\Phel::run()`) boots Gacela and compiles to temp files on first call. Guard with a static flag; never call from Laravel `register()` or per-request hot paths.
+- Dev path (`\Phel::run()`) boots Gacela and compiles to temp files on first call. Guard with a static flag; never call from Laravel `register()` or a per-request hot path.
 - `withBuildDestDir()` is relative to the project root.
 - Commit `build/` in the deploy artifact, or run `phel build` in CI. Skip committing in dev so `is_file()` is false and `\Phel::run()` kicks in.
 - Add `vendor/bin/phel test` to CI alongside `phpunit`.

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -3,7 +3,7 @@
 ## Pages
 
 1. [Architecture](architecture.md): module layout, Gacela pattern, dependency map.
-2. [Compiler](compiler.md): six-stage pipeline with worked example.
+2. [Compiler](compiler.md): seven-stage pipeline with worked example.
 3. [Special forms](special-forms.md): list, dispatch, how to add one.
 4. [Macros](macros.md): `macroexpand`, quasiquote, auto-gensym.
 5. [Runtime](runtime.md): `Lang/`, persistent collections, `Registry`, `\Phel` facade.

--- a/docs/lazy-sequences.md
+++ b/docs/lazy-sequences.md
@@ -2,30 +2,25 @@
 
 Defer computation until values are needed. Two constructs: `lazy-seq` wraps an expression; `lazy-cat` concatenates collections.
 
-## The `lazy-seq` Macro
+## `lazy-seq`
 
-`lazy-seq` takes a body returning a sequence or nil. It yields a LazySeq that runs the body on first access and caches the result.
-
-### Basic Usage
+Takes a body returning a sequence or nil. Yields a LazySeq that runs the body on first access (`first`, `rest`, `take`, ...) and caches the result. Mechanically: it builds a zero-arg thunk over the body, returns a LazySeq holding it, and evaluates+caches on first access.
 
 ```phel
-;; Create a lazy sequence that computes on demand
 (def my-lazy-seq
   (lazy-seq
     (println "Computing...")
     [1 2 3 4 5]))
 
-;; Nothing printed yet
-(first my-lazy-seq)  ; Prints "Computing..." and returns 1
-(first my-lazy-seq)  ; Returns 1 (cached, no printing)
+(first my-lazy-seq)  ; prints "Computing..." then returns 1
+(first my-lazy-seq)  ; returns 1 (cached, no printing)
 ```
 
-### Infinite Sequences with `lazy-seq`
+### Infinite sequences
 
-Combine `lazy-seq` with recursion to build infinite sequences:
+Combine `lazy-seq` with recursion. Use `cons` to defer the recursive call:
 
 ```phel
-;; Generate infinite sequence of integers starting from n
 (defn ints-from [^int n]
   (lazy-seq
     (cons n (ints-from (inc n)))))
@@ -34,72 +29,42 @@ Combine `lazy-seq` with recursion to build infinite sequences:
 (take 3 (ints-from 10)) ; => [10 11 12]
 ```
 
-### How It Works
+## `lazy-cat`
 
-`lazy-seq`:
-1. Creates a thunk (zero-arg function) that evaluates the body
-2. Returns a LazySeq holding the thunk
-3. On first access (`first`, `rest`, `take`, etc.), evaluates the thunk
-4. Caches the result
-
-## The `lazy-cat` Macro
-
-Concatenates collections. Expands to `concat` and evaluates arguments eagerly. Fine for finite or already-realized sequences, **not** for recursive infinite ones.
-
-### Basic Concatenation
+Concatenates collections; expands to `concat` and evaluates its arguments eagerly. Fine for finite or already-realized sequences, **not** for recursive infinite ones.
 
 ```phel
-(lazy-cat [1 2] [3 4] [5 6])
-;; => (1 2 3 4 5 6)
-
-(lazy-cat (range 3) (range 3 6))
-;; => (0 1 2 3 4 5)
+(lazy-cat [1 2] [3 4] [5 6])               ; => (1 2 3 4 5 6)
+(lazy-cat (range 3) (range 3 6))           ; => (0 1 2 3 4 5)
+(lazy-cat (take 3 (range 100)) (take 3 (range 10 20))) ; => (0 1 2 10 11 12)
 ```
 
-### With Finite Lazy Sequences
-
-Works with lazy sequences that terminate:
+For recursive infinite sequences use `cons`, never `lazy-cat`:
 
 ```phel
-(lazy-cat (take 3 (range 100)) (take 3 (range 10 20)))
-;; => (0 1 2 10 11 12)
-```
-
-### For Recursive Sequences: Use `cons`
-
-When building recursive infinite sequences, use `cons` instead:
-
-```phel
-;; ✅ Correct pattern for recursive sequences
+;; ✅ cons defers the recursive call
 (defn ints [n]
   (lazy-seq (cons n (ints (inc n)))))
 
 (take 5 (ints 0))  ; => [0 1 2 3 4]
 
-;; ❌ This will cause stack overflow
+;; ❌ lazy-cat evaluates all args first -> the recursive call never returns
 (defn ints [n]
-  (lazy-seq (lazy-cat [n] (ints (inc n)))))  ; Don't do this!
+  (lazy-seq (lazy-cat [n] (ints (inc n)))))  ; stack overflow
 ```
 
-`lazy-cat` evaluates all arguments before concatenating, so the recursive call runs immediately and never returns. `cons` defers evaluation.
-
-## Common Patterns
-
-### Building Infinite Sequences
+## Common patterns
 
 ```phel
-;; Fibonacci sequence
+;; Fibonacci
 (defn fib-seq
   ([] (fib-seq 0 1))
   ([a b] (lazy-seq (cons a (fib-seq b (+ a b))))))
 
 (take 10 (fib-seq))
 ;; => [0 1 1 2 3 5 8 13 21 34]
-```
 
-### Filtering Infinite Sequences
-
-```phel
+;; Sieve of primes (filtering an infinite sequence)
 (defn primes []
   (let [sieve (fn sieve [s]
                 (lazy-seq
@@ -110,159 +75,115 @@ When building recursive infinite sequences, use `cons` instead:
 
 (take 10 (primes))
 ;; => [2 3 5 7 11 13 17 19 23 29]
-```
 
-### Chunked Processing
-
-```phel
-; assumes (:require phel.string :as str)
-;; Process a large dataset lazily
+;; Chunked processing - only touches records as consumed
+;; assumes (:require phel.string :as str)
 (defn process-records [records]
   (->> records
        (filter (fn [x] (not (empty? x))))
        (map (fn [x] (str/trim x)))
        (map parse-record)))
 
-;; Only processes records as needed
 (take 100 (process-records lazy-data-source))
 ```
 
-## Built-in Lazy Functions
+## Built-in lazy functions
 
-Many core functions return lazy sequences:
+These return lazy sequences:
 
-- **`range`** - Lazy sequence of numbers
-- **`iterate`** - Infinite sequence by repeatedly applying a function
-- **`repeat`** - Infinite sequence of a repeated value
-- **`cycle`** - Infinite sequence by cycling through a collection
-- **`map`** - Lazy transformation
-- **`filter`** - Lazy filtering
-- **`take`** - Takes first n elements (realizes them)
-- **`drop`** - Skips first n elements (lazy)
-
-### Examples
+- `range` - lazy sequence of numbers
+- `iterate` - infinite sequence by repeatedly applying a function
+- `repeat` - infinite sequence of a repeated value
+- `cycle` - infinite sequence by cycling through a collection
+- `map` - lazy transformation
+- `filter` - lazy filtering
+- `take` - first n elements (realizes them)
+- `drop` - skips first n elements (lazy)
 
 ```phel
-;; Infinite sequence of powers of 2
 (take 10 (iterate (fn [x] (* 2 x)) 1))
 ;; => [1 2 4 8 16 32 64 128 256 512]
 
-;; Infinite cycling
 (take 7 (cycle [:a :b :c]))
 ;; => [:a :b :c :a :b :c :a]
 
-;; Lazy composition
 (->> (range 100)
      (filter even?)
      (map (fn [x] (* x x)))
      (take 5))
 ;; => [0 4 16 36 64]
 
-;; Lazy string processing
 (take 3 (map php/strtoupper "hello world"))
 ;; => ["H" "E" "L"]
 ```
 
-## Performance Considerations
+## Performance
 
-### When to Use Lazy Sequences
+**Use lazy sequences for:** large or infinite collections, partial consumption, composing transformations, memory efficiency.
 
-**Use:**
-- Large or infinite collections
-- Not all elements will be consumed
-- Composing transformations
-- Memory efficiency matters
-
-**Avoid:**
-- All elements accessed immediately
-- Multiple iterations over the same sequence
-- Holding the head causes memory leaks
+**Avoid when:** all elements are accessed immediately, you iterate the same sequence multiple times, or holding the head leaks memory.
 
 ### Chunking
 
-Lazy sequences realize elements in chunks. Lower overhead, but:
+Lazy sequences realize elements in chunks (lower overhead), so side effects may run for more elements than you consume:
 
 ```phel
-;; Side effects may happen in chunks
 (take 5 (map (fn [x] (do (println x) x)) (range 100)))
-;; May print more than 5 numbers due to chunking
+;; may print more than 5 numbers due to chunking
 ```
 
-### Realizing Sequences
-
-Force realization when needed:
+### Realizing
 
 ```phel
-(doall lazy-seq)  ; Realizes entire sequence, returns it
-(dorun lazy-seq)  ; Realizes entire sequence, returns nil
+(doall lazy-seq)  ; realizes entire sequence, returns it
+(dorun lazy-seq)  ; realizes entire sequence, returns nil
 ```
 
-## Common Gotchas
+## Gotchas
 
-### 1. Holding the Head
+**1. Holding the head** keeps the whole sequence in memory:
 
 ```phel
-;; ❌ Bad - holds reference to the head
+;; ❌ binds `nums`, so first + last hold the entire sequence
 (let [nums (range 1000000)]
   (println (first nums))
-  (println (last nums)))  ; Entire sequence held in memory!
+  (println (last nums)))
 
-;; ✅ Good - don't hold the head
+;; ✅ don't bind the head
 (println (first (range 1000000)))
 (println (last (range 1000000)))
 ```
 
-### 2. Lazy Sequences in Tests
-
-Realize lazy sequences before asserting:
+**2. Lazy sequences in tests** - realize before asserting:
 
 ```phel
-;; ❌ May not fail even if lazy-seq has issues
-(is (= expected lazy-result))
-
-;; ✅ Better - force realization
-(is (= expected (doall lazy-result)))
+(is (= expected (doall lazy-result)))  ; ✅ force realization
 ```
 
-### 3. Side Effects in Lazy Sequences
-
-Side effects run on realization, not creation:
+**3. Side effects run on realization, not creation:**
 
 ```phel
 (def log-and-inc
   (map (fn [x] (do (println "Processing" x) (inc x)))
        (range 5)))
-
-;; Nothing printed yet!
-(first log-and-inc)  ; Now prints "Processing 0" and returns 1
+;; nothing printed yet
+(first log-and-inc)  ; now prints "Processing 0" and returns 1
 ```
 
-## Debugging Lazy Sequences
-
-### Check if Realized
+## Debugging
 
 ```phel
 (realized? my-lazy-seq)  ; true if already computed
-```
 
-### Inspect without Realizing
-
-```phel
-;; Take a small sample for debugging
+;; Inspect without fully realizing
 (take 10 potentially-infinite-seq)
-
-;; Or use take-while with a condition
 (take-while (fn [x] (< x 100)) (iterate inc 0))
-```
 
-### Print Safely
-
-```phel
 ;; Limit printing to avoid infinite loops
 (println (take 20 my-lazy-seq))
 ```
 
-## Further Reading
+## Further reading
 
 - [Lazy sequences examples](examples/README.md)
 - [Transducers](transducers.md)

--- a/docs/match-guide.md
+++ b/docs/match-guide.md
@@ -10,11 +10,11 @@
 
 (defn describe [x]
   (match [x]
-    [0]            "zero"
-    [(_ :guard pos?)] "positive"
-    [[a b]]        (str "pair " a " / " b)
+    [0]                   "zero"
+    [[a b]]               (str "pair " a " / " b)
     [{:type :err :msg m}] (str "error: " m)
-    :else          "other"))
+    [(n :guard pos?)]     "positive"
+    :else                 "other"))
 ```
 
 ## Pattern kinds
@@ -28,7 +28,7 @@
 | `{:k sym}` | map with key `:k`, bind value to `sym` |
 | `(:or a b c)` | any of the alternatives |
 | `(sym :as name)` | bind whole subject to `name` |
-| `(sym :guard pred)` | literal plus runtime predicate |
+| `(sym :guard pred)` | bind plus runtime predicate |
 
 ## Guards
 
@@ -50,7 +50,8 @@
 
 - Each pattern vector length must equal the target count
 - `:else` must be the final clause
-- Nested patterns bind in left-to-right order; a later binding shadows an earlier one with the same name
+- Nested patterns bind left-to-right; a later binding shadows an earlier one with the same name
+- A `:guard` predicate runs against the raw value. Numeric predicates like `pos?` coerce non-numbers in Phel (so `(pos? [1 2])` is truthy), so put literal/structural patterns before an open numeric guard.
 
 ## See also
 

--- a/docs/migration/backslash-to-dot.md
+++ b/docs/migration/backslash-to-dot.md
@@ -1,4 +1,4 @@
-# Migration: backslash namespace separator to dot
+# Migration: Backslash Namespace Separator to Dot
 
 Phel historically used the PHP-style backslash (`\`) as the namespace separator in every position: `ns` forms, `:require`/`:use` clauses, fully-qualified call sites, and class FQNs. The dot (`.`) is the target form going forward. The backslash form is **deprecated** and will be removed in a future release.
 

--- a/docs/mocking-guide.md
+++ b/docs/mocking-guide.md
@@ -1,6 +1,6 @@
 # Mocking in Phel
 
-`phel.mock` ships with phel-lang — no separate install. Require it only in test namespaces.
+`phel.mock` ships with phel-lang, no separate install. Require it only in test namespaces.
 
 Replace dependencies with controlled stand-ins for testing.
 

--- a/docs/numeric-tower.md
+++ b/docs/numeric-tower.md
@@ -1,4 +1,4 @@
-# Numeric tower
+# Numeric Tower
 
 Phel has a numeric tower built around five scalar shapes:
 
@@ -16,7 +16,7 @@ Phel has a numeric tower built around five scalar shapes:
 
 ### Exact decimal literals: `1.5M`
 
-`M`-suffixed numerals read as `BigDecimal`. Use for monetary values and any computation where binary float drift is unacceptable.
+`M`-suffixed numerals read as `BigDecimal` and print with the `M` suffix. Use for monetary values and any computation where binary float drift is unacceptable.
 
 ```phel
 1.5M                ; => 1.5M (a BigDecimal)
@@ -27,10 +27,10 @@ Phel has a numeric tower built around five scalar shapes:
 
 ### Promoting integers: `bigint` and `+'`
 
-Promote with the explicit constructors:
+Promote with the explicit constructors. A `BigInt` prints as a plain integer (no `N` suffix):
 
 ```phel
-(bigint 42)         ; => 42N (a BigInt)
+(bigint 42)         ; => 42 (a BigInt)
 (bigint "1000000000000000000000")
 (rationalize 0.1)   ; => 1/10
 ```
@@ -38,8 +38,8 @@ Promote with the explicit constructors:
 The promoting arithmetic ops (`+'`, `-'`, `*'`, `inc'`, `dec'`) auto-promote to `BigInt` on overflow, so use them whenever overflow is possible:
 
 ```phel
-(*' 1000000000 1000000000 1000000000)  ; => big enough to overflow PHP int
-(inc' 9223372036854775807)             ; => 9223372036854775808N
+(*' 1000000000 1000000000 1000000000)  ; => 1000000000000000000000000000 (BigInt)
+(inc' 9223372036854775807)             ; => 9223372036854775808 (BigInt)
 ```
 
 ### Large integer literals lex as `float`

--- a/docs/parallel-tests.md
+++ b/docs/parallel-tests.md
@@ -1,21 +1,12 @@
 # Parallel Test Runner
 
-`phel test --parallel=<N|auto|max>` fans out test namespaces across a
-pool of subprocess workers, mirroring Clojure's
-[eftest](https://github.com/eftest/eftest) `:multithread? :namespaces`
-mode: opt-in, default workers ≈ CPU count, deterministic output,
-no impact on existing serial runs.
+`phel test --parallel=<N|auto|max>` fans out test namespaces across a pool of subprocess workers, mirroring Clojure's [eftest](https://github.com/eftest/eftest) `:multithread? :namespaces` mode: opt-in, default workers ≈ CPU count, deterministic output, no impact on serial runs.
 
 ## When to use it
 
-- A suite with non-trivial per-namespace work (DB-spinup, AST
-  benchmarks, heavy property tests).
-- CI where the wall clock dominates the queue cost of spawning more
-  workers.
+Use it for suites with non-trivial per-namespace work (DB spin-up, AST benchmarks, heavy property tests), or CI where wall clock dominates worker spawn cost.
 
-Skip it for very small suites or when a per-namespace fixture spins
-up a shared resource (DB, port, fixture file) that doesn't tolerate
-N concurrent loaders.
+Skip it for tiny suites, or when a per-namespace fixture spins up a shared resource (DB, port, fixture file) that can't tolerate N concurrent loaders.
 
 ## Usage
 
@@ -26,20 +17,17 @@ phel test --parallel=max       # every core the kernel reports, uncapped
 phel test --parallel=1         # collapses back to the serial path
 ```
 
-You can also set the worker count via env var:
+Set the worker count via env var instead; it overrides the cap on both `auto` and `max`:
 
 ```bash
 PHEL_TEST_WORKERS=12 phel test --parallel=auto
 ```
 
-The env var overrides the cap on both `auto` and `max`, so power
-users can dial in their own ceiling without touching the CLI.
-
 ## Output
 
 ```text
 Running 33 namespace(s) across 4 parallel worker(s)...
- 33/33 [============================] 100%   1 s — phel-test.are
+ 33/33 [============================] 100%   1 s  phel-test.are
 
 Passed:  55
 Failed:  0
@@ -49,27 +37,19 @@ Total:   55
 Ran 33 namespace(s) across 4 worker(s) in 1.49s.
 ```
 
-- A live `Symfony\ProgressBar` shows progress while workers run.
-- Passing namespaces just bump the bar.
-- Failing or erroring namespaces print their full captured block under
-  a `--- ns ---` header, so failure context is preserved.
-- A single aggregate `Passed / Failed / Error / [Skipped] / Total`
-  block is printed at the end, computed from per-worker counts.
+A live `Symfony\ProgressBar` advances as namespaces finish; passing namespaces just bump the bar. Failing/erroring namespaces print their full captured block under a `--- ns ---` header. A single aggregate `Passed / Failed / Error / [Skipped] / Total` block prints at the end, computed from per-worker counts.
 
-Output is **deterministic in input order**: workers complete in
-arbitrary order, but the parent buffers results per slot and only
-flushes a slot when every preceding namespace has finished. The same
-input always produces the same on-screen sequence.
+Output is **deterministic in input order**: workers complete in arbitrary order, but the parent buffers results per slot and flushes a slot only once every preceding namespace has finished. Same input, same on-screen sequence.
 
 ## Auto-disable rules
 
-`--parallel` is silently downgraded to serial when:
+`--parallel` silently downgrades to serial when:
 
-- `--reporter=tap` is selected — TAP needs a monotonic test counter.
-- `--list` is selected — discovery only, nothing to fan out.
-- A profiler hook is installed — counts only accrue in the parent.
+- `--reporter=tap`: TAP needs a monotonic test counter.
+- `--list`: discovery only, nothing to fan out.
+- A profiler hook is installed: counts only accrue in the parent.
 
-Run with `-v` to see why parallelism was skipped:
+Run with `-v` to see why:
 
 ```
 Ignoring --parallel: TAP reporter requires a monotonic test counter.
@@ -77,42 +57,31 @@ Ignoring --parallel: TAP reporter requires a monotonic test counter.
 
 ## CPU detection
 
-`--parallel=auto` and `--parallel=max` share a small fallback chain:
+`auto` and `max` share a fallback chain:
 
-1. `PHEL_TEST_WORKERS` env var (if set to a positive integer)
+1. `PHEL_TEST_WORKERS` (if a positive integer)
 2. `nproc` on PATH
 3. `sysctl -n hw.ncpu` (macOS/BSD)
 4. `/proc/cpuinfo` line count (Linux without `nproc`)
-5. Hardcoded fallback of `4`
+5. Hardcoded `4`
 
-`auto` clamps the result to a cap of 8 so a default run stays kind
-to laptops and shared CI runners. `max` skips the cap.
+`auto` clamps to a cap of 8 to stay kind to laptops and shared CI runners; `max` skips the cap.
 
-## Architecture (one-paragraph cheat sheet)
+## Architecture
 
-The parent process runs `phel test` as usual, but instead of
-generating one big Phel expression for every namespace, it spawns N
-subprocesses (`phel _test-worker`, hidden), each holding open over
-stdin / stdout. The parent sends one work frame per namespace
-(length-prefixed JSON: `{index, ns, file, options}`); each worker
-loads the namespace, runs `(phel.test/run-tests ...)` in a captured
-output buffer, and writes back a result frame (`{index, ns, ok,
-output, failed-tests, counts, error}`). The parent keeps results
-indexed by their input position and flushes them to the terminal in
-order; the live progress bar advances whenever a slot resolves.
+The parent runs `phel test` as usual but, instead of one big Phel expression per namespace, spawns N hidden `phel _test-worker` subprocesses held open over stdin/stdout. It sends one length-prefixed JSON work frame per namespace (`{index, ns, file, options}`); each worker loads the namespace, runs `(phel.test/run-tests ...)` in a captured buffer, and writes back a result frame (`{index, ns, ok, output, failed-tests, counts, error}`). The parent keeps results indexed by input position and flushes them in order; the progress bar advances as slots resolve.
 
-No `pcntl_fork`, no shared memory, no threads — just `proc_open`
-and `stream_select`. Works on Linux and macOS. Windows is untested.
+No `pcntl_fork`, no shared memory, no threads; just `proc_open` and `stream_select`. Works on Linux and macOS. Windows untested.
 
 ## Caveats
 
-- **Each worker pays one-time bootstrap cost** to `(phel.test/run-tests ...)` so very small suites may run slower in parallel mode than serial.
-- **Stateful per-namespace fixtures** (DB seeding, port binding, shared file) need to be made worker-safe or you have to keep `--parallel=1` for that suite.
+- **One-time bootstrap cost per worker**, so very small suites may run slower than serial.
+- **Stateful per-namespace fixtures** (DB seeding, port binding, shared file) must be worker-safe, else keep `--parallel=1` for that suite.
 - **TAP / profiler combos auto-disable**; junit-xml works fine.
-- **Cross-worker `--fail-fast` not yet wired** — fail-fast within a worker still works, but the parent does not cancel sibling workers on first failure.
+- **Cross-worker `--fail-fast` not yet wired**: fail-fast within a worker works, but the parent does not cancel siblings on first failure.
 
 ## See also
 
-- `phel test --help` — full flag reference
+- `phel test --help`: full flag reference
 - [Quickstart: Tests](quickstart.md#tests)
-- `src/php/Run/CLAUDE.md` — module-level architecture notes
+- `src/php/Run/CLAUDE.md`: module architecture notes

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -2,158 +2,81 @@
 
 ## Working with Nil
 
-### Safe Navigation
-
 ```phel
-;; Nested ifs
-(if user
-  (if (get user :profile)
-    (if (get (get user :profile) :address)
-      (get (get (get user :profile) :address) :city)
-      nil)
-    nil)
-  nil)
-
-;; Threading with get
-(-> user
-    (get :profile)
-    (get :address)
-    (get :city))
-
-;; Or get-in
+;; Safe navigation: thread get, or get-in
+(-> user (get :profile) (get :address) (get :city))
 (get-in user [:profile :address :city])
-```
 
-### Default Values
-
-```phel
-(get config :port 8080)                    ; Default 8080
-(or (get config :host) "localhost")        ; Fallback
-
-;; Multiple fallbacks
+;; Defaults and fallbacks
+(get config :port 8080)                       ; default 8080
 (or (get-in user [:settings :theme])
     (get-in defaults [:theme])
     "light")
-```
 
-### Nil-Safe Operations
-
-```phel
-;; when: body runs only on truthy
-(when user
-  (println "User:" (get user :name))
-  (send-email user))
-
-;; when-let: bind + check
-(when-let [email (get user :email)]
-  (send-notification email))
-
-;; if-let: with else
-(if-let [role (get user :role)]
-  (str "User is a " role)
-  "User has no role")
+;; Nil-safe binding/control
+(when user (println "User:" (get user :name)))
+(when-let [email (get user :email)] (send-notification email))
+(if-let [role (get user :role)] (str "User is a " role) "User has no role")
 
 ;; some?: not nil
-(some? user)                              ; => true if not nil
-(filter some? [1 nil 2 nil 3])            ; => [1 2 3]
+(filter some? [1 nil 2 nil 3])                ; => [1 2 3]
 
-;; boolean: coerce
-(boolean nil)                             ; => false
-(boolean 0)                               ; => true   (only nil/false falsy)
-(boolean "")                              ; => true
+;; boolean: only nil/false are falsy
+(boolean nil)                                 ; => false
+(boolean 0)                                   ; => true
+(boolean "")                                  ; => true
 ```
 
 ## Collection Transformations
 
-### Map Operations
-
 ```phel
-(map inc [1 2 3])                          ; => [2 3 4]
-(map str/upper-case ["hello" "world"])     ; => ["HELLO" "WORLD"]
-(map #(* % 2) [1 2 3 4])                   ; => [2 4 6 8]
+;; map
+(map inc [1 2 3])                             ; => [2 3 4]
+(map #(* % 2) [1 2 3 4])                      ; => [2 4 6 8]
+(map-indexed (fn [i x] [i x]) ["a" "b"])      ; => [[0 "a"] [1 "b"]]
+(map + [1 2 3] [10 20 30])                    ; => [11 22 33] (multiple colls)
 
-;; With index
-(map-indexed (fn [i x] [i x]) ["a" "b" "c"])
-;; => [[0 "a"] [1 "b"] [2 "c"]]
-
-;; Multiple collections
-(map + [1 2 3] [10 20 30])                 ; => [11 22 33]
-(map str ["a" "b"] [1 2])                  ; => ["a1" "b2"]
-```
-
-### Filter Operations
-
-```phel
-;; Keep matching
-(filter even? [1 2 3 4 5 6])               ; => [2 4 6]
-(filter #(> % 10) [5 15 8 20 3])           ; => [15 20]
-
-;; Remove matching
-(remove nil? [1 nil 2 nil 3])              ; => [1 2 3]
-(remove empty? ["a" "" "b" "" "c"])        ; => ["a" "b" "c"]
-
-;; Keep non-nil results
+;; filter / remove / keep
+(filter even? [1 2 3 4 5 6])                  ; => [2 4 6]
+(remove nil? [1 nil 2 nil 3])                 ; => [1 2 3]
 (keep (fn [x] (when (even? x) (* x 2)))
-      [1 2 3 4 5])                         ; => [4 8]
+      [1 2 3 4 5])                            ; => [4 8] (drops nil results)
+
+;; partition / group-by
+(partition 2 [1 2 3 4 5 6])                   ; => [[1 2] [3 4] [5 6]]
+(partition-all 3 [1 2 3 4 5])                 ; => [[1 2 3] [4 5]]
+(group-by even? [1 2 3 4 5 6])                ; => {true [2 4 6] false [1 3 5]}
+(group-by :type [{:type :fruit :name "apple"}
+                 {:type :veg :name "carrot"}])
+;; => {:fruit [...] :veg [...]}
 ```
 
-### Reduce Operations
+### Reduce
 
 ```phel
-;; Sum
-(reduce + 0 [1 2 3 4 5])                   ; => 15
+(reduce + 0 [1 2 3 4 5])                      ; => 15
 
 ;; Build a map
 (reduce (fn [acc [k v]] (assoc acc k v))
-        {}
-        [[:a 1] [:b 2] [:c 3]])            ; => {:a 1 :b 2 :c 3}
+        {} [[:a 1] [:b 2] [:c 3]])            ; => {:a 1 :b 2 :c 3}
 
-;; Group by
+;; Group into buckets
 (reduce (fn [acc x]
-          (let [key (if (even? x) :even :odd)]
-            (update acc key #(conj (or % []) x))))
-        {:even [] :odd []}
-        [1 2 3 4 5 6])
+          (update acc (if (even? x) :even :odd) #(conj (or % []) x)))
+        {:even [] :odd []} [1 2 3 4 5 6])
 ;; => {:even [2 4 6] :odd [1 3 5]}
 
-;; Maximum
+;; Max
 (let [coll [3 1 4 1 5 9 2 6]]
-  (reduce (fn [max x] (if (> x max) x max))
-          (first coll)
-          (rest coll)))
-;; => 9
-```
-
-### Partition and Group
-
-```phel
-;; Chunks
-(partition 2 [1 2 3 4 5 6])                ; => [[1 2] [3 4] [5 6]]
-(partition-all 3 [1 2 3 4 5])              ; => [[1 2 3] [4 5]]
-
-;; Group by predicate
-(group-by even? [1 2 3 4 5 6])
-;; => {true [2 4 6] false [1 3 5]}
-
-(group-by :type [{:type :fruit :name "apple"}
-                 {:type :veg :name "carrot"}
-                 {:type :fruit :name "banana"}])
-;; => {:fruit [{:type :fruit :name "apple"}
-;;             {:type :fruit :name "banana"}]
-;;     :veg [{:type :veg :name "carrot"}]}
+  (reduce (fn [m x] (if (> x m) x m)) (first coll) (rest coll)))  ; => 9
 ```
 
 ## Threading Macros
 
-### Thread-First `->`
-
-Threads value as **first** argument:
+`->` threads the value as the **first** argument; `->>` as the **last**.
 
 ```phel
-;; Without
-(get (assoc (dissoc user :password) :active true) :name)
-
-;; With
+;; -> for map/object ops (first arg)
 (-> user
     (dissoc :password)
     (assoc :active true)
@@ -162,57 +85,30 @@ Threads value as **first** argument:
 (-> "  Hello World  "
     (str/trim)
     (str/lower-case)
-    (str/replace " " "-"))
-;; => "hello-world"
-```
+    (str/replace " " "-"))                    ; => "hello-world"
 
-### Thread-Last `->>`
-
-Threads value as **last** argument:
-
-```phel
+;; ->> for collection ops (last arg)
 (->> [1 2 3 4 5 6 7 8 9 10]
      (filter even?)
      (map #(* % 2))
-     (reduce +))
-;; => 60
-
-(->> users
-     (filter #(get % :active))
-     (map #(get % :email))
-     (filter some?)
-     (take 10))
-```
-
-### When to Use Which
-
-```phel
-;; -> for object/map ops (first arg)
-(-> user
-    (get :profile)
-    (assoc :verified true))
-
-;; ->> for collection ops (last arg)
-(->> numbers
-     (filter pos?)
-     (map square)
-     (reduce +))
+     (reduce +))                              ; => 60
 ```
 
 ## Pattern Matching
 
-`phel.match` destructures by shape and binds symbols in one step. Use when `cond`/`case` would re-query the same value from multiple angles.
+`phel.match` destructures by shape and binds symbols in one step. Use it when `cond`/`case` would re-query the same value from multiple angles.
+
 ```phel
 (ns app.commands
   (:require phel.match :refer [match]))
 
 (defn handle [event]
   (match [event]
-    [{:type :add :value v}]            (str "add " v)
+    [{:type :add :value v}]               (str "add " v)
     [{:type :remove :id (_ :guard pos?)}] "remove-valid"
-    [[:cmd (:or :up :down) n]]         (str "move " n)
-    [[head & rest]]                    (str "list of " (count rest) " after " head)
-    :else                              :unknown))
+    [[:cmd (:or :up :down) n]]            (str "move " n)
+    [[head & rest]]                       (str "list of " (count rest) " after " head)
+    :else                                 :unknown))
 ```
 
 Pattern elements:
@@ -229,67 +125,49 @@ Pattern elements:
 | `(pat :as x)` | Match `pat` and also bind whole value to `x` |
 | `(:or a b c)` | Any of the alternatives |
 
-The outer `[event]` vector matches several values at once:
+The outer `[...]` vector matches several values at once:
 
 ```phel
 (match [http-status role]
-  [200 :admin]       :dashboard
-  [200 _]            :ok
-  [401 _]            :login
+  [200 :admin]              :dashboard
+  [200 _]                   :ok
+  [401 _]                   :login
   [(_ :guard #(>= % 500)) _] :error
-  :else              :unknown)
+  :else                     :unknown)
 ```
 
 Without `:else`, `match` throws `RuntimeException` when nothing fits. Add `:else` when "none of these" is valid.
 
 ## Error Handling
 
-### Try-Catch
-
 ```phel
+;; try/catch
 (defn safe-divide [a b]
   (try
     (/ a b)
-    (catch \DivisionByZeroError e
-      (println "Cannot divide by zero")
-      nil)))
+    (catch \DivisionByZeroError e nil)))
 
-(defn parse-json [str]
+(defn parse-json [s]
   (try
-    (php/json_decode str true)
+    (php/json_decode s true)
     (catch \JsonException e
       {:error (php/-> e (getMessage))})))
-```
 
-### Result Types (Either Pattern)
-
-```phel
-;; Maps with :ok or :error
+;; Result maps ({:ok ...} / {:error ...})
 (defn validate-email [email]
   (if (str/contains? email "@")
     {:ok email}
     {:error "Invalid email format"}))
 
-(defn process-user [data]
-  (let [result (validate-email (get data :email))]
-    (if (get result :ok)
-      (create-user data)
-      result)))
-
 ;; Or nil for errors
 (defn safe-parse-int [s]
   (when (php/is_numeric s)
     (php/intval s)))
-```
 
-### Validation Chains
-
-```phel
+;; Validation chain: stop at first nil
 (defn validate [validations value]
-  (reduce (fn [val validator]
-            (when val (validator val)))
-          value
-          validations))
+  (reduce (fn [val validator] (when val (validator val)))
+          value validations))
 
 (def email-validations
   [#(when-not (str/contains? % "@") nil)
@@ -302,31 +180,24 @@ Without `:else`, `match` throws `RuntimeException` when nothing fits. Add `:else
 
 ## State Management
 
-### Atoms (Mutable References)
+### Atoms (mutable references)
 
 ```phel
 (def counter (atom 0))
 
-;; Read
-(deref counter)                            ; => 0
-@counter                                   ; shorthand
+(deref counter)            ; => 0
+@counter                   ; shorthand for (deref counter)
 
-;; Update
-(swap! counter inc)                        ; => 1
-(swap! counter #(+ % 10))                  ; => 11
-(swap! counter + 5)                        ; => 16
-
-;; Set
-(reset! counter 0)                         ; => 0
+(swap! counter inc)        ; => 1
+(swap! counter + 5)        ; => 6  (extra args passed to fn)
+(reset! counter 0)         ; => 0
 ```
 
-### Managing Application State
+### Application state in one atom
 
 ```phel
 (def app-state
-  (atom {:users []
-         :current-user nil
-         :loading false}))
+  (atom {:users [] :current-user nil :loading false}))
 
 (defn add-user [user]
   (swap! app-state update :users #(conj % user)))
@@ -336,69 +207,37 @@ Without `:else`, `match` throws `RuntimeException` when nothing fits. Add `:else
 
 (defn toggle-loading []
   (swap! app-state update :loading not))
-
-;; Usage
-(add-user {:id 1 :name "Alice"})
-(set-current-user {:id 1 :name "Alice"})
-(toggle-loading)
 ```
 
-### Vars (Dynamic Bindings)
+### Vars (dynamic bindings)
 
 ```phel
 (def ^:dynamic *debug* false)
 
 (defn log [msg]
-  (when *debug*
-    (println "[DEBUG]" msg)))
+  (when *debug* (println "[DEBUG]" msg)))
 
 ;; Override temporarily
 (binding [*debug* true]
-  (log "This will print")
-  (do-something))
+  (log "This will print"))
 
 (log "This won't print")
 ```
 
 ## Recursion and Looping
 
-### Simple Recursion
-
 ```phel
-;; Note: `*'` always returns BigInt for integer results.
+;; Simple recursion. Note: `*'` always returns BigInt for integer results.
 (defn factorial [^int n]
-  (if (<= n 1)
-    1
-    (*' n (factorial (dec n)))))
+  (if (<= n 1) 1 (*' n (factorial (dec n)))))
 
-(defn sum-list [coll]
-  (if (empty? coll)
-    0
-    (+ (first coll) (sum-list (rest coll)))))
-```
-
-### Tail Recursion with `recur`
-
-```phel
+;; Tail recursion with recur (no stack growth)
 (defn factorial [^int n]
   (loop [n n acc 1]
-    (if (<= n 1)
-      acc
-      (recur (dec n) (*' acc n)))))
+    (if (<= n 1) acc (recur (dec n) (*' acc n)))))
 
-(defn sum-list [coll]
-  (loop [items coll total 0]
-    (if (empty? items)
-      total
-      (recur (rest items) (+ total (first items))))))
-```
-
-### Iterating with `loop`
-
-```phel
-(loop [items [1 2 3 4 5]
-       evens []
-       odds []]
+;; loop accumulating multiple values
+(loop [items [1 2 3 4 5] evens [] odds []]
   (if (empty? items)
     {:evens evens :odds odds}
     (let [x (first items)]
@@ -406,139 +245,93 @@ Without `:else`, `match` throws `RuntimeException` when nothing fits. Add `:else
         (recur (rest items) (conj evens x) odds)
         (recur (rest items) evens (conj odds x))))))
 ;; => {:evens [2 4] :odds [1 3 5]}
-```
 
-### Early Exit from Loop
-
-```phel
+;; Early exit
 (defn find-first [pred coll]
   (loop [items coll]
     (cond
-      (empty? items) nil
+      (empty? items)       nil
       (pred (first items)) (first items)
       (recur (rest items)))))
 
-(find-first #(> % 10) [2 5 8 12 15])      ; => 12
+(find-first #(> % 10) [2 5 8 12 15])          ; => 12
 ```
 
 ## Destructuring
 
-### Vector Destructuring
-
 ```phel
-(let [[a b c] [1 2 3]]
-  (+ a b c))                               ; => 6
+;; Vector
+(let [[a b c] [1 2 3]] (+ a b c))             ; => 6
+(let [[first & rest] [1 2 3 4 5]] [first rest]) ; => [1 [2 3 4 5]]
+(let [[a [b c]] [1 [2 3]]] (+ a b c))         ; => 6 (nested)
 
-;; Rest
-(let [[first & rest] [1 2 3 4 5]]
-  [first rest])                            ; => [1 [2 3 4 5]]
+(defn process-coords [[x y]] (+ x y))
+(process-coords [10 20])                       ; => 30
 
-;; Nested
-(let [[a [b c]] [1 [2 3]]]
-  (+ a b c))                               ; => 6
-
-;; Function params
-(defn process-coords [[x y]]
-  (+ x y))
-
-(process-coords [10 20])                   ; => 30
-```
-
-### Map Destructuring
-
-```phel
+;; Map (long form: {:key binding-symbol})
 (let [{:name name :age age} {:name "Alice" :age 30}]
-  (str name " is " age))
-;; => "Alice is 30"
+  (str name " is " age))                       ; => "Alice is 30"
 
-;; :keys shorthand
+;; :keys shorthand for same-named bindings
 (let [{:keys [name age]} {:name "Alice" :age 30}]
-  (str name " is " age))
+  (str name " is " age))                       ; => "Alice is 30"
 
 ;; :or defaults
-(let [{:keys [name age] :or {age 18}} {:name "Bob"}]
-  age)                                     ; => 18
+(let [{:keys [name age] :or {age 18}} {:name "Bob"}] age)  ; => 18
 
-;; Function params
 (defn greet-user [{:keys [name title] :or {title "User"}}]
   (str "Hello, " title " " name))
-
-(greet-user {:name "Alice" :title "Dr."})  ; => "Hello, Dr. Alice"
-(greet-user {:name "Bob"})                 ; => "Hello, User Bob"
+(greet-user {:name "Alice" :title "Dr."})     ; => "Hello, Dr. Alice"
+(greet-user {:name "Bob"})                     ; => "Hello, User Bob"
 ```
 
 ## Data Validation
 
-### Simple Validators
-
 ```phel
+;; Simple predicate validators
 (defn valid-email? [email]
   (and (php/is_string email)
        (str/contains? email "@")
        (> (php/strlen email) 5)))
 
 (defn valid-age? [age]
-  (and (int? age)
-       (>= age 0)
-       (<= age 150)))
+  (and (int? age) (>= age 0) (<= age 150)))
 
-(defn valid-user? [user]
-  (and (valid-email? (get user :email))
-       (valid-age? (get user :age))
-       (php/is_string (get user :name))))
-```
-
-### Validation with Errors
-
-```phel
+;; Collect errors with a transient
 (defn validate-user [user]
   (let [errors (transient [])]
-    (when-not (valid-email? (get user :email))
-      (conj! errors "Invalid email"))
-    (when-not (valid-age? (get user :age))
-      (conj! errors "Invalid age"))
-    (when-not (php/is_string (get user :name))
-      (conj! errors "Name must be a string"))
+    (when-not (valid-email? (get user :email)) (conj! errors "Invalid email"))
+    (when-not (valid-age? (get user :age))     (conj! errors "Invalid age"))
+    (when-not (php/is_string (get user :name)) (conj! errors "Name must be a string"))
     (let [err-list (persistent! errors)]
-      (if (empty? err-list)
-        {:ok user}
-        {:errors err-list}))))
-```
+      (if (empty? err-list) {:ok user} {:errors err-list}))))
 
-### Spec-like Validation
-
-```phel
+;; Spec-like: map of field -> list of predicates
 (def user-spec
   {:email [php/is_string #(str/contains? % "@")]
-   :age [int? #(>= % 0) #(<= % 150)]
-   :name [php/is_string #(> (php/strlen %) 0)]})
+   :age   [int? #(>= % 0) #(<= % 150)]
+   :name  [php/is_string #(> (php/strlen %) 0)]})
 
 (defn validate-field [validators value]
   (all? #(% value) validators))
 
 (defn validate-with-spec [spec data]
-  (let [errors
-        (reduce
-          (fn [acc key]
-            (if (validate-field (get spec key) (get data key))
-              acc
-              (assoc acc key "Validation failed")))
-          {}
-          (keys spec))]
-    (if (empty? errors)
-      {:ok data}
-      {:errors errors})))
+  (let [errors (reduce (fn [acc key]
+                         (if (validate-field (get spec key) (get data key))
+                           acc
+                           (assoc acc key "Validation failed")))
+                       {} (keys spec))]
+    (if (empty? errors) {:ok data} {:errors errors})))
 
 (validate-with-spec user-spec
-  {:email "alice@example.com" :age 30 :name "Alice"})
-;; => {:ok {...}}
+  {:email "alice@example.com" :age 30 :name "Alice"})   ; => {:ok {...}}
 ```
 
 ## Writing Macros
 
-### Auto-gensym for Hygienic Bindings
+### Auto-gensym for hygienic bindings
 
-Inside syntax-quote (`` ` ``), a symbol ending in `#` expands to a fresh unique symbol. Reuse `name#` to refer to the same generated binding:
+Inside syntax-quote (`` ` ``), a symbol ending in `#` expands to a fresh unique symbol. Reuse `name#` to refer to the same generated binding, so it can't collide with caller bindings:
 
 ```phel
 (defmacro unless
@@ -555,8 +348,6 @@ Inside syntax-quote (`` ` ``), a symbol ending in `#` expands to a fresh unique 
      ret#))
 ```
 
-`start#` and `ret#` won't collide with caller bindings.
-
 ### Implicit `&form` and `&env`
 
 Every `defmacro` body has two implicit symbols:
@@ -567,9 +358,7 @@ Every `defmacro` body has two implicit symbols:
 ```phel
 ;; Inspect lexical scope at the call site
 (defmacro has-local? [sym] (contains? &env sym))
-
-(let [a 1]
-  (has-local? a))                       ; => true (a is in scope)
+(let [a 1] (has-local? a))                    ; => true
 
 ;; Use &form to surface the original call in an exception
 (defmacro require-positive [x]
@@ -583,12 +372,12 @@ Every `defmacro` body has two implicit symbols:
 
 ```phel
 (defmacro dialect [] (if (:ns &env) "cljs" "phel"))
-(dialect) ; => "phel" when compiled by Phel
+(dialect)                                      ; => "phel" when compiled by Phel
 ```
 
-### Extending `is` with Custom Assertions
+### Extending `is` with custom assertions
 
-`phel.test/assert-expr` is an open multimethod. Teach `is` to expand new assertion forms via `defmethod`. The method takes the user-supplied `message` and original `form`, matching `clojure.test/assert-expr`, and returns the code `is` should run:
+`phel.test/assert-expr` is an open multimethod. Teach `is` to expand new assertion forms via `defmethod`. The method takes the user-supplied `message` and original `form` (matching `clojure.test/assert-expr`) and returns the code `is` should run:
 
 ```phel
 (ns my-app.test.helpers
@@ -611,9 +400,7 @@ When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the `:d
 
 ## Build-safe Entry Points
 
-`phel build` evaluates every top-level form at compile time so macros, `def`, `defn`, and `ns` register. Top-level **side effects** (game loops, `stdin` reads, sockets, sleeps) also run and can block the build indefinitely.
-
-Guard imperative entry calls with `*build-mode*`:
+`phel build` evaluates every top-level form at compile time so macros, `def`, `defn`, and `ns` register. Top-level **side effects** (game loops, `stdin` reads, sockets, sleeps) also run and can block the build indefinitely. Guard imperative entry calls with `*build-mode*`:
 
 ```phel
 (ns app.main)
@@ -628,20 +415,16 @@ Guard imperative entry calls with `*build-mode*`:
   (play))
 ```
 
-`*build-mode*` is `true` while the compiler evaluates your file during `phel build`, `false` during `phel run` or runtime artifact loading. Same applies to any top-level stdin/network/sleep call:
+`*build-mode*` is `true` while the compiler evaluates your file during `phel build`, `false` during `phel run` or runtime artifact loading. The same applies to any top-level stdin/network/sleep call:
 
 ```phel
 ;; Bad: blocks `phel build` forever on fgets.
 (def line (php/fgets (php/fopen "php://stdin" "r")))
 
-;; Good: reads at run time only.
+;; Good: open at top level, read only at run time.
 (def stdin (php/fopen "php://stdin" "r"))
-
-(defn read-line []
-  (php/fgets stdin))
-
-(when-not *build-mode*
-  (println (read-line)))
+(defn read-line [] (php/fgets stdin))
+(when-not *build-mode* (println (read-line)))
 ```
 
 `defn`, `def` of pure values, `ns`, and `(:require ...)` are always safe at top level. Only imperative work needs the guard.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -17,13 +17,13 @@ Create the directory once: `mkdir -p /tmp/php-opcache`. Restart your shell. Repe
 
 ## Why it is slow without opcache
 
-Every `./vendor/bin/phel` invocation is a fresh PHP process. Without CLI opcache, PHP re-parses every `.php` file every run: `vendor/`, Phel compiler, Symfony console, project classes. With `opcache.file_cache`, compiled bytecode persists across processes.
+Every `./vendor/bin/phel` invocation is a fresh PHP process. Without CLI opcache, PHP re-parses every `.php` file each run (`vendor/`, Phel compiler, Symfony console, project classes). `opcache.file_cache` persists compiled bytecode across processes.
 
-Phel also maintains a compiled-code cache under `.phel/cache/` memoizing Phel-to-PHP compilation per source hash. The two caches complement each other: Phel's cache skips recompilation; opcache skips re-parsing the resulting PHP.
+Phel adds a compiled-code cache under `.phel/cache/` memoizing Phel-to-PHP compilation per source hash. The two complement each other: Phel's cache skips recompilation; opcache skips re-parsing the resulting PHP.
 
-Cache invalidation is automatic. Each run hashes the `.phel` source (`md5`) against the stored entry. On mismatch, the file is recompiled and transitive dependents are invalidated. No manual clear is needed after editing a `.phel` file. Fresh compiles also call `opcache_compile_file()` on the generated PHP. Use the reset steps below only if something gets wedged.
+Invalidation is automatic: each run hashes the `.phel` source (`md5`) against the stored entry, and on mismatch recompiles the file and its transitive dependents. Fresh compiles also `opcache_compile_file()` the generated PHP. Use the reset steps below only if something gets wedged.
 
-For hot numeric / string fns, add `:tag` annotations on params and return slot (`^int`, `^float`, `^string`, `^bool`). The compiler emits the matching PHP type declarations and infers the return type from primitive ops in tail position, which lets the tracing JIT specialize the call. Tag mismatches surface as Phel diagnostics at compile time. Measure the win locally with `composer bench-jit-baseline` and `composer bench-jit-tracing` (see [`internals/benchmarks.md`](internals/benchmarks.md)).
+For hot numeric/string fns, add `:tag` annotations on params and the return slot (`^int`, `^float`, `^string`, `^bool`). The compiler emits matching PHP type declarations and infers the return type from primitive ops in tail position, letting the tracing JIT specialize the call. Tag mismatches surface as Phel diagnostics at compile time. Measure with `composer bench-jit-baseline` and `composer bench-jit-tracing` (see [`internals/benchmarks.md`](internals/benchmarks.md)).
 
 ## Memory limit
 

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -17,46 +17,28 @@ Call PHP from Phel and Phel from PHP.
 
 ### Functions
 
-Prefix PHP functions with `php/`:
+Prefix any global or namespaced PHP function with `php/`:
 
 ```phel
-(ns app.example)
-
-;; String functions
 (php/strlen "hello")              ; => 5
-(php/strtoupper "hello")          ; => "HELLO"
 (php/str_replace "o" "0" "hello") ; => "hell0"
-
-;; Array functions
 (php/array_merge [1 2] [3 4])     ; => [1 2 3 4]
-(php/count [1 2 3])               ; => 3
-
-;; Math functions
-(php/abs -5)                      ; => 5
 (php/max 1 5 3)                   ; => 5
-
-;; Namespaced functions: keep the original casing
-(php/Amp\trapSignal [php/SIGINT php/SIGTERM])
-(php/\Monolog\Logger\Utils\detectAndCleanUtf8 "input")
-
-;; Backslash-free alternatives: `.` and `/` are also accepted as namespace
-;; separators, so the same call can be written without escaping in `.cljc`
-;; files or shared snippets:
-(php/Amp.ByteStream/getStdout)
-(php/Amp.ByteStream.getStdout)
-(php/Monolog.Logger.Utils.detectAndCleanUtf8 "input")
 ```
 
-The `php/` prefix resolves any global or namespaced PHP function. The name after `php/` is the full PHP path; `\`, `.`, and `/` are interchangeable as namespace separators, so `php/Amp\trapSignal`, `php/Amp.trapSignal`, and `php/Amp/trapSignal` all compile to `\Amp\trapSignal(...)`. Case is preserved.
+The name after `php/` is the full PHP path with case preserved. `\`, `.`, and `/` are interchangeable as namespace separators, so the backslash-free forms work in `.cljc` files or shared snippets without escaping:
+
+```phel
+(php/Amp\trapSignal [php/SIGINT php/SIGTERM])   ; all three compile to
+(php/Amp.trapSignal [php/SIGINT php/SIGTERM])   ; \Amp\trapSignal(...)
+(php/Amp/trapSignal [php/SIGINT php/SIGTERM])
+```
 
 Capture references with `def` to shorten calls:
 
 ```phel
 (def trap-signal php/\Amp\trapSignal)
-(def detect-utf8 php/\Monolog\Logger\Utils\detectAndCleanUtf8)
-
 (trap-signal [php/SIGINT php/SIGTERM])
-(detect-utf8 "input")
 ```
 
 ### Classes and Objects
@@ -65,21 +47,17 @@ Capture references with `def` to shorten calls:
 (ns app.example
   (:use DateTime DateInterval))
 
-;; Create instance (all forms are equivalent)
+;; Create instance (all equivalent); PHP class names keep their PHP casing
 (def now (php/new DateTime))
 (def now (new DateTime))
 (def now (DateTime.))
-(def data (new stdClass))         ; PHP class names keep their PHP casing
 
-;; Call methods
+;; Method call: php/-> or the .method shorthand
 (php/-> now (format "Y-m-d"))     ; => "2024-01-15"
-(php/-> now (getTimestamp))       ; => 1705334400
-
-;; Method call shorthand: `.method` expands to `(php/-> ...)`
 (.format now "Y-m-d")             ; => "2024-01-15"
-(.getTimestamp now)               ; => 1705334400
 
-;; Property access shorthand: `.-field` expands to `(php/-> ...)`
+;; Property access: php/-> or the .-field shorthand
+(php/-> obj propertyName)
 (.-y (new DateInterval "P1D"))    ; => 0
 
 ;; Chain method calls
@@ -87,100 +65,79 @@ Capture references with `def` to shorten calls:
   (add (php/new DateInterval "P1D"))
   (format "Y-m-d H:i:s"))
 
-;; Static methods
+;; Static methods: php/:: or the Class/member shorthand
 (php/:: DateTime (createFromFormat "Y-m-d" "2024-01-15"))
-(DateTime/createFromFormat "Y-m-d" "2024-01-15")   ; shorthand
+(DateTime/createFromFormat "Y-m-d" "2024-01-15")
 
-;; Static constants and properties: bare `Class/MEMBER` shorthand
-(php/:: \DateTimeImmutable ATOM)                   ; => "Y-m-d\\TH:i:sP"
-\DateTimeImmutable/ATOM                            ; shorthand
-
-;; Access properties
-(php/-> obj propertyName)
+;; Static constants/properties: php/:: or the bare Class/MEMBER shorthand
+(php/:: \DateTimeImmutable ATOM)  ; => "Y-m-d\\TH:i:sP"
+\DateTimeImmutable/ATOM
 ```
 
 ### Working with PHP Arrays
 
 ```phel
-;; Create PHP array
-(def php-arr (php/array 1 2 3))
+;; Constructors
+(def php-arr (php/array 1 2 3))                  ; indexed PHP array
+(php-indexed-array 1 2 3)                         ; same
 (def assoc-arr (php-associative-array "name" "Alice" "age" 30))
 
 ;; `#php` reader literal (non-recursive): next vector/map becomes a PHP array
-(def php-arr   #php [1 2 3])                    ; => (php-indexed-array 1 2 3)
-(def assoc-arr #php {"name" "Alice" "age" 30})  ; => (php-associative-array "name" "Alice" "age" 30)
+#php [1 2 3]                                      ; => (php-indexed-array 1 2 3)
+#php {"name" "Alice" "age" 30}                    ; => (php-associative-array "name" "Alice" "age" 30)
 
-;; Access elements
-(php/aget php-arr 0)              ; => 1
+;; Access and mutate (aset mutates in place)
 (php/aget assoc-arr "name")       ; => "Alice"
-
-;; Set elements
-(php/aset php-arr 0 99)           ; Modifies array
-(php/aset assoc-arr "name" "Bob") ; Modifies array
+(php/aset php-arr 0 99)            ; modifies php-arr in place
 ```
 
 ### Namespaces and Imports
 
-Use `:use` for PHP classes:
+Use `:use` for PHP classes, then reference them without a namespace prefix:
 
 ```phel
 (ns app.services
-  (:use PDO)                      ; Single class
-  (:use DateTime DateInterval)   ; Multiple classes
+  (:use PDO)                                          ; single class
+  (:use DateTime DateInterval)                        ; multiple
   (:use Symfony\Component\HttpFoundation\Request))
 
-;; Use them without namespace prefix
 (php/new PDO "mysql:host=localhost" "user" "pass")
 (php/new Request)
 ```
 
 ### Requiring Phel Namespaces
 
-`:require` accepts list-style and vector entries (works in both `.phel` and `.cljc`):
+`:require` accepts both list-style and vector entries (works in `.phel` and `.cljc`):
 
 ```phel
-;; List entry
+;; List entries
 (ns app.services
   (:require phel.string :as str)
   (:require phel.json :as json :refer [encode decode]))
 
-;; Vector entry, same meaning
+;; Vector entries, same meaning
 (ns app.services
   (:require [phel.string :as str]
             [phel.json :as json :refer [encode decode]]))
 ```
 
-Phel uses `.` as the namespace separator, matching Clojure. The legacy `\` separator is still accepted for back-compat but deprecated; new code should use `.`.
-
-```phel
-(ns my.cljc.file
-  (:require [phel.string :as str]))
-```
+Phel uses `.` as the namespace separator, matching Clojure. The legacy `\` separator still parses but is deprecated; new code should use `.`.
 
 ## Type Conversions
 
-### Phel → PHP
+### Phel to PHP
 
 ```phel
-;; Vectors to PHP arrays
 (to-php-array [1 2 3])            ; => PHP [1, 2, 3]
-
-;; Maps to PHP associative arrays
 (to-php-array {:a 1 :b 2})        ; => PHP ["a" => 1, "b" => 2]
-
-;; Keywords to strings
-(name :keyword)                   ; => "keyword"
+(name :keyword)                   ; keyword => "keyword"
 ```
 
-### PHP → Phel
+### PHP to Phel
 
 ```phel
-;; PHP arrays to Phel collections
 (php-array-to-map php-assoc-array)   ; => {:key value}
 (vals php-indexed-array)             ; => [val1 val2 val3]
-
-;; Indexed PHP array to vector
-[1 2 3]                           ; Already works as Phel vector
 ```
 
 ## Calling Phel from PHP
@@ -191,11 +148,8 @@ Phel uses `.` as the namespace separator, matching Clojure. The legacy `\` separ
 ```phel
 (ns app.hello)
 
-(defn greet [name]
-  (str "Hello, " name "!"))
-
-(defn add [a b]
-  (+ a b))
+(defn greet [name] (str "Hello, " name "!"))
+(defn add [a b] (+ a b))
 ```
 
 **index.php:**
@@ -206,12 +160,9 @@ require 'vendor/autoload.php';
 // Bootstrap Phel and load the namespace (compiles on first call).
 \Phel::run(__DIR__, 'app.hello');
 
-// Call Phel functions by name; getDefinition returns the registered fn.
+// getDefinition returns the registered fn by name.
 $greet = \Phel::getDefinition('app.hello', 'greet');
 echo $greet('World'); // => "Hello, World!"
-
-$add = \Phel::getDefinition('app.hello', 'add');
-echo $add(5, 10); // => 15
 ```
 
 ### Web Application Example
@@ -242,12 +193,11 @@ use Symfony\Component\HttpFoundation\Response;
 \Phel::run(__DIR__, 'app.routes');
 
 $request = Request::createFromGlobals();
-$path = $request->getPathInfo();
 
 $home = \Phel::getDefinition('app.routes', 'handle-home');
 $api  = \Phel::getDefinition('app.routes', 'handle-api');
 
-$response = match ($path) {
+$response = match ($request->getPathInfo()) {
     '/'    => $home($request),
     '/api' => $api($request),
     default => new Response('Not Found', 404),
@@ -258,12 +208,11 @@ $response->send();
 
 ## Error Handling
 
-### Catching PHP Exceptions
-
 ```phel
 (ns app.db
-  (:use PDO PDOException))
+  (:use PDO PDOException InvalidArgumentException))
 
+;; Catch PHP exceptions
 (defn connect [dsn user pass]
   (try
     (php/new PDO dsn user pass)
@@ -271,20 +220,7 @@ $response->send();
       (println "Database error:" (php/-> e (getMessage)))
       nil)))
 
-(defn safe-query [pdo sql]
-  (try
-    (php/-> pdo (query sql))
-    (catch PDOException e
-      {:error (php/-> e (getMessage))
-       :code (php/-> e (getCode))})))
-```
-
-### Throwing Exceptions
-
-```phel
-(ns app.validator
-  (:use InvalidArgumentException))
-
+;; Throw PHP exceptions
 (defn validate-age [age]
   (when (< age 0)
     (throw (php/new InvalidArgumentException "Age cannot be negative")))
@@ -293,35 +229,16 @@ $response->send();
 
 ## Performance Tips
 
-### Use Transients for Batch Updates
-
 ```phel
-;; Slow: new collection each step
-(reduce (fn [acc x] (conj acc (* x 2))) [] large-list)
-
-;; Fast: mutable during build
+;; Transients: mutable during batch build, then freeze
 (persistent!
   (reduce (fn [acc x] (conj acc (* x 2))) (transient []) large-list))
-```
 
-### Prefer PHP Functions for Heavy Lifting
-
-```phel
-;; PHP's optimized functions
+;; Prefer PHP's optimized functions for heavy lifting on PHP arrays
 (php/array_map #(* % 2) php-array)
 
-;; Phel collections
-(map #(* % 2) phel-vector)
-```
-
-### Avoid Unnecessary Conversions
-
-```phel
-;; Inefficient
-(to-php-array (map inc (php-array-to-map php-data)))
-
-;; Better: stay in PHP
-(php/array_map inc php-data)
+;; Avoid unnecessary conversions: stay in PHP when the data is a PHP array
+(php/array_map inc php-data)         ; not (to-php-array (map inc (php-array-to-map php-data)))
 ```
 
 ## Common Patterns
@@ -355,12 +272,11 @@ $response->send();
     (php-array-to-map data)))
 
 (defn post-json [url data]
-  (let [json (json/encode data)
-        opts (php-associative-array
+  (let [opts (php-associative-array
                "http" (php-associative-array
                         "method" "POST"
                         "header" "Content-Type: application/json"
-                        "content" json))
+                        "content" (json/encode data)))
         context (php/stream_context_create opts)]
     (php/file_get_contents url false context)))
 ```
@@ -371,12 +287,10 @@ $response->send();
 (ns app.files)
 
 (defn read-lines [filename]
-  (let [content (php/file_get_contents filename)]
-    (php/explode "\n" content)))
+  (php/explode "\n" (php/file_get_contents filename)))
 
 (defn write-lines [filename lines]
-  (let [content (php/implode "\n" (to-php-array lines))]
-    (php/file_put_contents filename content)))
+  (php/file_put_contents filename (php/implode "\n" (to-php-array lines))))
 ```
 
 ## Tips for PHP Developers
@@ -386,21 +300,21 @@ $response->send();
 - **Keywords**: use `:keyword` for map keys.
 - **Truthiness**: only `false` and `nil` are falsy (not `0` or `""`).
 - **Parens**: `(func arg)` calls; `func` is the value.
+- **PHP arrays**: use directly or convert to Phel collections.
 
 ## Tips for Clojure Developers
 
-- **PHP interop**: use `php/` prefix (not `.` or `..`).
+- **PHP interop**: use the `php/` prefix (not `.` or `..`).
 - **Method calls**: `(php/-> obj (method))` (also `(.method obj)`).
 - **Deref**: `@my-atom` shortcuts `(deref my-atom)`.
 - **Import classes**: `:use` in `ns`, not `:import`.
 - **Require vectors**: `(:require [phel.string :as str :refer [upper-case]])` works alongside the list form.
-- **Namespace separators**: Phel uses `.` matching Clojure. The legacy `\` separator is still accepted for back-compat but deprecated.
+- **Namespace separators**: Phel uses `.` matching Clojure; legacy `\` is deprecated.
 - **Reader conditionals**: `#?(:phel ...)` and `#?@(:phel ...)` for `.cljc` files.
 - **Unquote**: `~` and `~@` inside syntax-quote (`,` / `,@` deprecated).
 - **Auto-gensym**: `name#` inside syntax-quote produces a unique symbol (`name$` deprecated).
 - **Macro env**: `&form` and `&env` are implicit in every `defmacro`. `&env` is a map of in-scope locals keyed by symbol. `(:ns &env)` is always `nil`, so the `.cljc` `(if (:ns &env) "cljs" ...)` trick lands on the non-cljs branch.
 - **Lambda syntax**: `#(+ %1 %2)` recommended; `|(+ $1 $2)` deprecated.
-- **PHP arrays**: use directly or convert to Phel collections.
 
 ## See Also
 

--- a/docs/profile-guide.md
+++ b/docs/profile-guide.md
@@ -43,7 +43,7 @@ JSON form:
 |---|---|---|
 | `--top=<N>` | `20` | Rows in the table; non-positive falls back to default |
 | `--format=table|json|both` | `table` | Stdout shape |
-| `--output=<file>` | — | Write JSON to a file (independent of `--format`) |
+| `--output=<file>` | (none) | Write JSON to a file (independent of `--format`) |
 | `--sort=self|total|calls|avg` | `self` | Table row ordering |
 | `--no-compile-phases` | off | Drop the per-source phase block |
 
@@ -55,16 +55,16 @@ Argv after the path is forwarded to the script:
 
 ## How it works
 
-The profiler is an **instrumentation** profiler, not a sampler.
+An **instrumentation** profiler, not a sampler.
 
-1. `Registry::$profilerHook` is set before the run starts. While set, `Registry::addDefinition` wraps every `AbstractFn` in a `ProfilingFn` proxy.
-2. `GlobalVarEmitter` already routes every global-fn call through `\Phel::getDefinition(...)`, so each call hits the proxy's `__invoke` without any emitter or fixture changes.
-3. Each `__invoke` notifies the session on entry / exit. The session keeps a per-call stack tracking `[name, enterNs, childInclusiveNs]`.
-4. On exit, total = `now - enterNs` and self = `total - childInclusiveNs`. The parent frame's `childInclusiveNs` is bumped so its self time stays accurate when it returns.
-5. Compile-phase timings come from the existing compiler hook (`recordPhase`), keyed by source file.
-6. The hook is cleared in a `finally` block so it never leaks across commands.
+1. `Registry::$profilerHook` is set before the run. While set, `Registry::addDefinition` wraps every `AbstractFn` in a `ProfilingFn` proxy.
+2. `GlobalVarEmitter` already routes every global-fn call through `\Phel::getDefinition(...)`, so each call hits the proxy's `__invoke`; no emitter or fixture changes.
+3. Each `__invoke` notifies the session on entry/exit; the session keeps a per-call stack of `[name, enterNs, childInclusiveNs]`.
+4. On exit, total = `now - enterNs`, self = `total - childInclusiveNs`; the parent frame's `childInclusiveNs` is bumped so its self time stays accurate.
+5. Compile-phase timings come from the compiler hook (`recordPhase`), keyed by source file.
+6. The hook is cleared in a `finally` block, so it never leaks across commands.
 
-The off-state cost is one null-check per `Registry::addDefinition`. Zero overhead at call sites when the profiler is not running.
+Off-state cost: one null-check per `Registry::addDefinition`. Zero overhead at call sites when not profiling.
 
 ## Caveats
 

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -17,17 +17,11 @@ by Git via a self-seeded `.phel/.gitignore` (`*`).
 
 ## Overrides
 
-- **Relocate everything**: `$config->withPhelDir('/var/cache/phel')` in
-  `phel-config.php` moves cache, REPL history, last-failed file and error log
-  out of the project root. Useful for WordPress plugins, shared hosting, or
-  any setup where `.phel/` would otherwise sit under a web-accessible path.
-- **`PHEL_DIR` env var** — same effect at runtime; wins over `withPhelDir()`.
-- **`PhelConfig::withCacheDir($path)`** — narrower override for just the build
-  cache.
-- **`PHEL_CACHE_DIR` env var** — final cache override; wins over `PHEL_DIR`
-  and explicit `withCacheDir()`. Useful for CI / Nix builds.
-- **`PHEL_QUIET_MIGRATION=1`** — silences the one-line stderr notice emitted
-  when the legacy `.phel-repl-history` is migrated into `.phel/repl-history`.
+- **`$config->withPhelDir('/var/cache/phel')`** in `phel-config.php`: relocates the whole `.phel/` (cache, REPL history, last-failed, error log) out of the project root. Useful for WordPress plugins, shared hosting, or any web-accessible layout.
+- **`PHEL_DIR` env var**: same effect at runtime; wins over `withPhelDir()`.
+- **`PhelConfig::withCacheDir($path)`**: narrower override for just the build cache.
+- **`PHEL_CACHE_DIR` env var**: final cache override; wins over `PHEL_DIR` and `withCacheDir()`. Useful for CI / Nix builds.
+- **`PHEL_QUIET_MIGRATION=1`**: silences the stderr notice when legacy `.phel-repl-history` migrates into `.phel/repl-history`.
 
 ## Migration
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,7 +9,7 @@ composer require phel-lang/phel-lang
 ./vendor/bin/phel init
 ```
 
-`phel init` writes `phel-config.php`, `src/main.phel`, and `tests/main_test.phel` (Flat layout, the default). Flags: `--nested` (use `src/phel/` + `tests/phel/`), `--minimal` (single-file root layout), `--dry-run` (preview), `--no-tests`, `--no-gitignore`.
+`phel init` writes `phel-config.php`, `src/main.phel`, and `tests/main_test.phel` (Flat layout, the default). Flags: `--nested` (use `src/phel/` + `tests/phel/`), `-m`/`--minimal` (single-file root layout), `--dry-run` (preview), `--no-tests`, `--no-gitignore`, `--force`.
 
 Already have a PHP project? Write `phel-config.php` by hand:
 
@@ -31,30 +31,21 @@ Create `src/hello.phel`:
 (defn greet [name]
   (str "Hello, " name "!"))
 
-;; Call the function
 (println (greet "World"))
 ```
 
-Run it:
 ```bash
-./vendor/bin/phel run src/hello.phel
-# => Hello, World!
-```
-
-Or evaluate a snippet without a file:
-```bash
-./vendor/bin/phel eval '(println "Hello, World!")'
-./vendor/bin/phel eval - < src/hello.phel    # read from stdin
+./vendor/bin/phel run src/hello.phel          # => Hello, World!
+./vendor/bin/phel eval '(println "Hello!")'   # evaluate a snippet
+./vendor/bin/phel eval - < src/hello.phel     # read from stdin
 ```
 
 ## REPL
 
-Start the REPL:
 ```bash
 ./vendor/bin/phel repl
 ```
 
-Try it out:
 ```phel
 Welcome to the Phel Repl (vX.Y.Z)
 Type "exit" or press Ctrl-D to exit.
@@ -71,7 +62,7 @@ user:5> (/ 1 0)
 user:6> *e                        ; last exception
 ```
 
-The prompt shows the current namespace; it switches on `(ns ...)` / `(in-ns ...)`. `*1`, `*2`, `*3` hold the last three REPL results; `*e` holds the last exception. Type `exit` or press Ctrl-D to quit.
+The prompt shows the current namespace; it switches on `(ns ...)` / `(in-ns ...)`. `*1`, `*2`, `*3` hold the last three results; `*e` holds the last exception. Type `exit` or Ctrl-D to quit.
 
 ## Collections
 
@@ -108,15 +99,15 @@ The prompt shows the current namespace; it switches on `(ns ...)` / `(in-ns ...)
 ## Functions
 
 ```phel
-;; Define a function (^int :tag emits a PHP int return-type)
+;; ^int :tag emits a PHP int return-type
 (defn ^int square [^int x]
   (* x x))
 
 (square 5)                        ; => 25
 
 ;; Anonymous functions
-#(* % %)                          ; Short syntax
-(fn [x] (* x x))                  ; Long syntax
+#(* % %)                          ; short syntax
+(fn [x] (* x x))                  ; long syntax
 
 ;; Map, filter, reduce
 (map square [1 2 3 4])            ; => [1 4 9 16]
@@ -133,8 +124,7 @@ The prompt shows the current namespace; it switches on `(ns ...)` / `(in-ns ...)
 (def double #(* % 2))
 (def add-ten #(+ % 10))
 (def process (comp add-ten double))
-
-(process 5)                       ; => 20 (5 * 2 + 10)
+(process 5)                       ; => 20  (5 * 2 + 10)
 ```
 
 ## Pattern Matching
@@ -154,7 +144,7 @@ The prompt shows the current namespace; it switches on `(ns ...)` / `(in-ns ...)
 (route {:method "GET" :path ["users" "42"]})    ; => [:show-user "42"]
 ```
 
-See [Pattern Matching Guide](match-guide.md) for guards, destructuring, and more patterns.
+See [Pattern Matching Guide](match-guide.md) for guards, destructuring, and more.
 
 ## Calling Phel from PHP
 
@@ -178,9 +168,7 @@ require __DIR__ . '/../vendor/autoload.php';
 echo \Phel::getDefinition('app.greet', 'hello')('World');
 ```
 
-`getDefinition` resolves any Phel function as a PHP callable. Namespace hyphens become underscores in registry keys (`my-app.lib` becomes `my_app.lib`).
-
-Full HTTP example: [Framework Integration](framework-integration.md).
+`getDefinition` resolves any Phel function as a PHP callable. Namespace hyphens become underscores in registry keys (`my-app.lib` becomes `my_app.lib`). Full HTTP example: [Framework Integration](framework-integration.md).
 
 ## Tests
 
@@ -197,8 +185,8 @@ Full HTTP example: [Framework Integration](framework-integration.md).
 
 ```bash
 ./vendor/bin/phel test                       # all tests
-./vendor/bin/phel test --filter greet        # name regex
-./vendor/bin/phel test --reporter=testdox    # also: dot, tap, junit-xml
+./vendor/bin/phel test --filter greet        # name regex/substring
+./vendor/bin/phel test --reporter=testdox    # also: default, dot, tap, junit-xml
 ./vendor/bin/phel test --parallel=auto       # fan out namespaces across CPU cores
 ```
 
@@ -219,12 +207,12 @@ app.hello:5> (resolve 'map)        ; => #'phel.core/map
 ```phel
 ;; Functions need parens
 map square [1 2 3]              ; Error: not a function
-(map square [1 2 3])            ; => [1 4 9]
+(map square [1 2 3])           ; => [1 4 9]
 
 ;; Values are immutable; conj returns a new vector
 (def nums [1 2 3])
 (conj nums 4)                   ; => [1 2 3 4]
-nums                            ; => [1 2 3]
+nums                            ; => [1 2 3]  (unchanged)
 (def nums (conj nums 4))        ; rebind to keep the new value
 ```
 

--- a/docs/reader-conditionals.md
+++ b/docs/reader-conditionals.md
@@ -1,8 +1,6 @@
 # Reader Conditionals in Phel
 
-Reader conditionals enable platform-specific code in shared source files. They resolve at parse time, before compilation. Phel selects the `:phel` branch, ignores other platforms (`:clj`, `:cljs`, ...), and falls back to `:default` when present.
-
-This enables `.cljc` files shared between Phel, Clojure, and other Lisp dialects.
+Reader conditionals enable platform-specific code in shared source files. They resolve at parse time, before compilation. Phel selects the `:phel` branch, ignores other platforms (`:clj`, `:cljs`, ...), and falls back to `:default` when present. This is what makes `.cljc` files shareable between Phel, Clojure, and other Lisp dialects.
 
 ## Basic usage: `#?()`
 
@@ -12,9 +10,7 @@ Selects one form based on platform:
 #?(:phel  (php/time)
    :clj   (System/currentTimeMillis)
    :cljs  (js/Date.now))
-; => In Phel: evaluates (php/time)
-; => In Clojure: evaluates (System/currentTimeMillis)
-; => In ClojureScript: evaluates (js/Date.now)
+; => In Phel: (php/time)
 ```
 
 ### Platform keys
@@ -29,50 +25,27 @@ Selects one form based on platform:
 
 ### Priority rules
 
-1. `:phel` is always selected if present, regardless of position
-2. `:default` is used as a fallback when no `:phel` branch exists
-3. If neither `:phel` nor `:default` is present, the entire form is dropped
+1. `:phel` is always selected if present, regardless of position.
+2. `:default` is the fallback when no `:phel` branch exists.
+3. If neither is present, the entire form is dropped (treated as whitespace).
 
 ```phel
-;; :phel takes priority over :default
-#?(:default 0 :phel 42)
-; => 42
-
-;; :default is the fallback
-#?(:clj 99 :default 0)
-; => 0
-
-;; No matching branch: form is dropped entirely
-#?(:clj 99 :cljs 88)
-; => (nothing: treated as whitespace)
+#?(:default 0 :phel 42)   ; => 42  (:phel wins)
+#?(:clj 99 :default 0)    ; => 0   (fallback)
+#?(:clj 99 :cljs 88)      ; => nothing (dropped)
 ```
 
 ## Splicing: `#?@()`
 
-Splices multiple elements from a collection into the surrounding form:
+Splices multiple elements from a collection into the surrounding form. The matched branch **must be a sequential collection** (vector or list); its elements are spliced in and the wrapper is removed.
 
 ```phel
-[1 #?@(:phel [2 3]) 4]
-; => [1 2 3 4]
+[1 #?@(:phel [2 3]) 4]              ; => [1 2 3 4]
+(php/array 0 #?@(:phel [1 2 3]) 4)  ; => array(0, 1, 2, 3, 4)
 
-(php/array 0 #?@(:phel [1 2 3]) 4)
-; => array(0, 1, 2, 3, 4)
-```
-
-The matched branch **must be a sequential collection** (vector or list). Its elements are spliced into the parent; the collection wrapper is removed.
-
-### Splicing with fallback
-
-```phel
-[1 #?@(:clj [8 9] :default [2 3]) 4]
-; => [1 2 3 4]
-```
-
-### No match splices nothing
-
-```phel
-[1 #?@(:clj [8 9]) 4]
-; => [1 4]
+;; With fallback / no match
+[1 #?@(:clj [8 9] :default [2 3]) 4] ; => [1 2 3 4]
+[1 #?@(:clj [8 9]) 4]                ; => [1 4]
 ```
 
 ### Top-level restriction
@@ -95,8 +68,8 @@ Phel discovers and compiles `.cljc` files alongside `.phel` files:
 (ns shared.utils)
 
 (defn now []
-  #?(:phel  (php/time)
-     :clj   (/ (System/currentTimeMillis) 1000)))
+  #?(:phel (php/time)
+     :clj  (/ (System/currentTimeMillis) 1000)))
 
 (defn platform []
   #?(:phel    "phel"
@@ -127,10 +100,8 @@ Phel discovers and compiles `.cljc` files alongside `.phel` files:
 (def config
   {:name "my-app"
    :version "1.0"
-   #?@(:phel [:runtime "php"
-              :min-version "8.4"]
-       :clj  [:runtime "jvm"
-              :min-version "21"])})
+   #?@(:phel [:runtime "php" :min-version "8.4"]
+       :clj  [:runtime "jvm" :min-version "21"])})
 ```
 
 ### Inside control flow
@@ -148,11 +119,11 @@ Reader conditionals resolve at parse time, so they work inside any form:
 
 Reader conditionals resolve during the **parsing phase** (Lexer -> **Parser** -> Analyzer -> Emitter). The parser:
 
-1. Reads keyword-form pairs inside `#?()` or `#?@()`
-2. Selects `:phel` if present, else `:default`
-3. `#?()`: replaces the conditional with the selected form
-4. `#?@()`: splices the selected collection into the parent
-5. No match: drops the conditional as trivia
+1. Reads keyword-form pairs inside `#?()` or `#?@()`.
+2. Selects `:phel` if present, else `:default`.
+3. `#?()`: replaces the conditional with the selected form.
+4. `#?@()`: splices the selected collection into the parent.
+5. No match: drops the conditional as trivia.
 
 The analyzer and emitter only see the selected form.
 

--- a/docs/reader-shortcuts.md
+++ b/docs/reader-shortcuts.md
@@ -4,75 +4,37 @@ Reader shortcuts are resolved by the reader during compilation.
 
 ## Collection Literals
 
-### Vectors `[]`
 ```phel
-[1 2 3]           ; Shortcut for (vector 1 2 3)
-[]                ; Empty vector
-```
-
-### Hash Maps `{}`
-```phel
-{:a 1 :b 2}       ; Shortcut for (hash-map :a 1 :b 2)
-{}                ; Empty hash map
-```
-
-### Sets `#{}`
-```phel
-#{1 2 3}          ; Shortcut for (hash-set 1 2 3)
-#{}               ; Empty set
-```
-
-### Lists `'()`
-```phel
-'(1 2 3)          ; Shortcut for (list 1 2 3)
-'()               ; Empty list (quote prevents evaluation)
+[1 2 3]       ; (vector 1 2 3)      [] empty vector
+{:a 1 :b 2}   ; (hash-map :a 1 :b 2) {} empty map
+#{1 2 3}      ; (hash-set 1 2 3)    #{} empty set
+'(1 2 3)      ; (list 1 2 3)        '() empty list
 ```
 
 ## Quote and Quasiquote
 
-### Quote `'`
-Prevents evaluation of the following form:
 ```phel
-'x                ; The symbol x (not evaluated)
-'(+ 1 2)          ; The list (+ 1 2), not the result 3
-'[1 2 3]          ; The vector [1 2 3]
+'x            ; the symbol x, not evaluated  (= (quote x))
+'(+ 1 2)      ; the list (+ 1 2), not 3
+'[1 2 3]      ; the vector [1 2 3]
 ```
 
-Equivalent to: `(quote x)`
+Quasiquote (`` ` ``) is like quote but allows selective evaluation with unquote (`~`) and unquote-splicing (`~@`):
 
-### Quasiquote `` ` ``
-Like quote, but allows selective evaluation with unquote:
 ```phel
-`(1 2 3)          ; => (1 2 3)
-`(1 ~(+ 1 1) 3)   ; => (1 2 3)
+`(1 2 3)                          ; => (1 2 3)
+(let [x 5] `(1 ~x 3))             ; => (1 5 3)     ; ~ evaluates one form
+(let [xs [2 3 4]] `(1 ~@xs 5))    ; => (1 2 3 4 5) ; ~@ splices a sequence
 ```
 
-Equivalent to: `(quasiquote ...)`
-
-### Unquote `~`
-Evaluates an expression within a quasiquote:
-```phel
-(let [x 5]
-  `(1 ~x 3))      ; => (1 5 3)
-```
-
-> **Deprecated:** `,` as an unquote reader macro. Use `~` instead.
-
-### Unquote-splicing `~@`
-Evaluates and splices a sequence into the containing form:
-```phel
-(let [xs [2 3 4]]
-  `(1 ~@xs 5))    ; => (1 2 3 4 5)
-```
-
-> **Deprecated:** `,@` as an unquote-splicing reader macro. Use `~@` instead.
+> **Deprecated:** `,` (unquote) and `,@` (unquote-splicing) reader macros. Use `~` and `~@`.
 
 ### Auto-gensym `name#`
+
 Inside a syntax-quote, a symbol ending in `#` expands to a fresh unique name. All occurrences of the same `name#` in one syntax-quote share that name, giving hygienic macros without calling `gensym`:
 
 ```phel
-(defmacro time
-  [expr]
+(defmacro time [expr]
   `(let [start# (php/microtime true)
          ret#   ~expr]
      (println "Elapsed:" (- (php/microtime true) start#) "secs")
@@ -81,34 +43,24 @@ Inside a syntax-quote, a symbol ending in `#` expands to a fresh unique name. Al
 
 Each expansion produces a fresh `start__123__auto__` / `ret__124__auto__` pair, so generated bindings can't collide with user code.
 
-> **Deprecated:** `name$` as an auto-gensym suffix. Use `name#` instead.
+> **Deprecated:** `name$` as an auto-gensym suffix. Use `name#`.
 
 ## Reader Conditionals
 
-### Platform Conditional `#?()`
-Selects a form based on the platform (resolved at parse time):
-```phel
-#?(:phel (php/time) :clj (System/currentTimeMillis))
-; => (php/time) when compiled by Phel
+Resolved at parse time. `#?()` selects one form by platform key; `#?@()` splices a collection. Phel selects `:phel`, falls back to `:default`.
 
-#?(:clj 99 :default 0)
-; => 0 (fallback when :phel is absent)
+```phel
+#?(:phel (php/time) :clj (System/currentTimeMillis))  ; => (php/time) in Phel
+#?(:clj 99 :default 0)                                 ; => 0
+[1 #?@(:phel [2 3]) 4]                                 ; => [1 2 3 4]
 ```
 
-### Platform Conditional Splicing `#?@()`
-Splices elements from a collection into the surrounding form:
-```phel
-[1 #?@(:phel [2 3]) 4]
-; => [1 2 3 4]
-```
-
-Only valid inside collections (lists, vectors, maps, sets). See [Reader Conditionals](reader-conditionals.md) for full documentation.
+`#?@()` is only valid inside a collection. See [Reader Conditionals](reader-conditionals.md) for full documentation.
 
 ## Deref `@`
 
-Shorthand for `(deref ...)`:
 ```phel
-@my-atom              ; Same as (deref my-atom)
+@my-atom              ; same as (deref my-atom)
 ```
 
 ## Tagged Literals `#<tag> form`
@@ -116,9 +68,9 @@ Shorthand for `(deref ...)`:
 Tagged literals convert a form to a value at read time. Three ship built-in:
 
 ```phel
-#inst "2026-01-01T00:00:00Z"     ; reads as \DateTimeImmutable
-#regex "\\d+"                     ; reads as a PCRE pattern string
-#uuid "550e8400-e29b-41d4-a716-446655440000"  ; reads as Phel\Lang\UUID
+#inst "2026-01-01T00:00:00Z"                   ; reads as \DateTimeImmutable
+#regex "\\d+"                                   ; reads as a PCRE pattern string
+#uuid "550e8400-e29b-41d4-a716-446655440000"   ; reads as Phel\Lang\UUID
 ```
 
 Register your own with `phel.reader/register-tag`:
@@ -129,12 +81,11 @@ Register your own with `phel.reader/register-tag`:
 
 (register-tag "money" (fn [s] {:kind :money :raw s}))
 
-;; Now the reader accepts:
 #money "10.00 EUR"
 ;; => {:kind :money :raw "10.00 EUR"}
 ```
 
-For project-wide tags, drop a `data-readers.phel` at any source root. It's auto-loaded and should register each tag explicitly:
+For project-wide tags, drop a `data-readers.phel` at any source root. It is auto-loaded and should register each tag explicitly:
 
 ```phel
 ;; src/phel/data-readers.phel
@@ -148,76 +99,52 @@ Related helpers in `phel.reader`: `tag-registered?`, `unregister-tag`, `register
 
 ## Regex Literals `#"..."`
 
-Creates a PCRE pattern string:
 ```phel
-#"\\d+"               ; Same as (re-pattern "\\d+")
-(re-find #"\\d+" "abc123")  ; => "123"
+#"\\d+"                       ; same as (re-pattern "\\d+")
+(re-find #"\\d+" "abc123")    ; => "123"
 ```
 
-## Anonymous Functions
+## Anonymous Functions `#(...)`
 
-### `#(...)` syntax
-Anonymous function with `%` parameter placeholders:
+`%` placeholders: `%` (or `%1`) is the first arg, `%2` the second, `%&` the rest:
+
 ```phel
-#(+ %1 %2)           ; Function taking 2 args
-#(* % %)             ; % is shorthand for %1
-#(apply str %&)       ; %& captures rest args
+#(* % %)             ; (fn [x] (* x x))
+#(+ %1 %2)           ; (fn [a b] (+ a b))
+#(apply str %&)      ; %& captures rest args
+
+(map #(* % 2) [1 2 3])         ; => [2 4 6]
+(filter #(> % 5) [3 6 2 8 4])  ; => [6 8]
+(reduce #(+ %1 %2) 0 [1 2 3 4]) ; => 10
 ```
 
 ### Short Function Syntax `|(...)` (Deprecated)
+
 > **Deprecated:** Use `#(...)` with `%` placeholders. `|(...)` will be removed in a future release.
 
-Anonymous function with positional parameters:
-```phel
-|(+ $1 $2)        ; Function taking 2 args
-|(* $1 $1)        ; Function squaring its argument
-|(apply f $&)     ; $& captures all arguments
-```
-
-**Parameters:**
-- `$1`, `$2`, `$3`, ...: positional arguments (1-indexed)
-- `$&`: rest args as a sequence
+Positional parameters `$1`, `$2`, ... (1-indexed), `$&` for rest args; `$` is shorthand for `$1`:
 
 ```phel
-(map |(* $ 2) [1 2 3])         ; => [2 4 6]
-(filter |(> $ 5) [3 6 2 8 4])  ; => [6 8]
-(reduce |(+ $1 $2) 0 [1 2 3 4]) ; => 10
-
-|(* $ $)        ; Same as (fn [x] (* x x))
-|(+ $1 $2)      ; Same as (fn [a b] (+ a b))
+|(* $ $)        ; (fn [x] (* x x))
+|(+ $1 $2)      ; (fn [a b] (+ a b))
+|(apply f $&)   ; $& captures all arguments
 ```
 
 ## Comments
 
-### Line Comments `;`
-Comment to end of line. Convention: `;;` for standalone lines, `;` inline after code:
 ```phel
-;; This is a standalone comment
+;; standalone comment
 (+ 1 2)           ; inline comment
-```
-
-> **Deprecated:** `#` as a line comment character. Use `;` instead.
-
-### Multiline Comments `#| |#` (Deprecated)
-> **Deprecated:** Use `(comment ...)` instead. `#| |#` will be removed in a future release.
-
-Comment blocks spanning multiple lines:
-```phel
-#|
-  This is a multiline comment.
-  Everything between #| and |# is ignored.
-|#
-```
-
-### Inline Comment `#_`
-Comments out the next form entirely:
-```phel
-(println 1 #_ 2 3)    ; => prints: 1 3
+(println 1 #_ 2 3)    ; #_ skips the next form  => prints: 1 3
 [1 #_(+ 2 3) 4]       ; => [1 4]
 ```
 
+> **Deprecated:** `#` as a line comment character (use `;`); `#| ... |#` multiline blocks (use `(comment ...)`).
+
 ## Metadata `^`
+
 Attaches metadata to the following form:
+
 ```phel
 ^{:doc "Example"} (defn foo [] ...)
 ^:private (def x 10)

--- a/docs/schema-guide.md
+++ b/docs/schema-guide.md
@@ -14,10 +14,12 @@
    [:email [:re #"^[^@]+@[^@]+$"]]
    [:age   [:maybe :int]]])
 
-(s/validate User {:id 1 :email "a@b.co"})   ; => true
-(s/explain  User {:id "x" :email "a@b"})    ; => {:schema User :value {...} :errors [...]}
-(s/coerce   User {"id" "1" "email" "a@b.co"})
+(s/validate User {:id 1 :email "a@b.co" :age nil})   ; => true
+(s/explain  User {:id "x" :email "a@b"})             ; => {:schema User :value {...} :errors [...]}
+(s/coerce   User {"id" "1" "email" "a@b.co" "age" nil})
 ```
+
+`[:maybe T]` makes the *value* nilable but the key is still required-present; omit it on a `{:closed? true}` map and validation fails with `:type :missing`.
 
 ## Schema kinds
 
@@ -47,7 +49,7 @@
 
 ```phel
 (s/register! :my/User User)
-(s/validate [:ref :my/User] {:id 1 :email "a@b.co"})
+(s/validate [:ref :my/User] {:id 1 :email "a@b.co" :age nil})
 ```
 
 ## Function instrumentation
@@ -61,6 +63,7 @@
 ## Pitfalls
 
 - `:map` is open by default; add `{:closed? true}` to reject extra keys
+- `[:maybe T]` allows a nil value but does not make the key optional
 - `[:re ...]` expects a `#"regex"` literal, not a string
 - `generate` may fail on over-constrained `[:and ...]` or `[:re ...]` schemas; pass `{:gen <gen-fn>}` in schema options to override
 

--- a/docs/transducers.md
+++ b/docs/transducers.md
@@ -1,19 +1,13 @@
 # Transducers in Phel
 
-## What are transducers?
-
 Transducers are composable pipelines that decouple the transformation (map, filter, take) from the consumer (build a vector, sum, write to a file). They turn one reducing function into another without intermediate collections.
 
-A normal pipeline allocates at every step:
+A normal pipeline allocates at every step; transducers fuse the steps into a single pass:
 
 ```phel
-;; Two intermediate lazy sequences created
+;; Two intermediate lazy sequences
 (filter even? (map inc [1 2 3 4 5]))
-```
 
-Transducers fuse the steps into a single pass:
-
-```phel
 ;; No intermediate collections
 (sequence (comp (map inc) (filter even?)) [1 2 3 4 5])
 ; => [2 4 6]
@@ -23,37 +17,18 @@ Transducers fuse the steps into a single pass:
 
 Three ways to consume a transducer:
 
-### `transduce` -- reduce with a transformation
-
-Apply a transducer, then reduce:
-
 ```phel
-;; Sum all values after incrementing
-(transduce (map inc) + [1 2 3])
-; => 9   (i.e. 2 + 3 + 4)
+;; transduce - apply a transducer, then reduce
+(transduce (map inc) + [1 2 3])             ; => 9   (2 + 3 + 4)
+(transduce (filter even?) + 0 [1 2 3 4 5 6]) ; => 12  (0 + 2 + 4 + 6, explicit init)
 
-;; With an explicit initial value
-(transduce (filter even?) + 0 [1 2 3 4 5 6])
-; => 12  (i.e. 0 + 2 + 4 + 6)
-```
-
-### `into` -- pour transformed elements into a collection
-
-```phel
-(into [] (map inc) [1 2 3])
-; => [2 3 4]
-
+;; into - pour transformed elements into a collection
+(into [] (map inc) [1 2 3])                 ; => [2 3 4]
 (into [] (map #(assoc % :active true)) [{:name "a"} {:name "b"}])
 ; => [{:name "a" :active true} {:name "b" :active true}]
-```
 
-### `sequence` -- vector of transformed results
-
-Shorthand for `(into [] xf coll)`:
-
-```phel
-(sequence (filter even?) [1 2 3 4 5 6])
-; => [2 4 6]
+;; sequence - vector of transformed results; shorthand for (into [] xf coll)
+(sequence (filter even?) [1 2 3 4 5 6])     ; => [2 4 6]
 ```
 
 ## Transducer-producing functions
@@ -80,7 +55,7 @@ Most sequence functions are dual-purpose. Called **with** a collection they retu
 
 ## Composing transducers
 
-`comp` builds a pipeline. Transducers compose left-to-right; the leftmost runs first:
+`comp` builds a pipeline. Transducers compose left-to-right (leftmost runs first), the opposite of normal function composition and matching the order of `->>`:
 
 ```phel
 (def xf (comp
@@ -90,11 +65,7 @@ Most sequence functions are dual-purpose. Called **with** a collection they retu
 
 (sequence xf (range 1 20))
 ; => [4 16 36]
-```
 
-Opposite of normal function composition, matching the order of `->>`:
-
-```phel
 ;; Equivalent lazy-sequence version (creates intermediates):
 (->> (range 1 20)
      (filter even?)
@@ -103,8 +74,6 @@ Opposite of normal function composition, matching the order of `->>`:
 ```
 
 ## Early termination
-
-### `reduced`, `reduced?`, `unreduced`
 
 A reducing function signals "stop" by wrapping its return value in `reduced`:
 
@@ -117,30 +86,26 @@ A reducing function signals "stop" by wrapping its return value in `reduced`:
 ; => 15
 ```
 
-- `(reduced x)` -- wraps `x` to signal early termination
-- `(reduced? x)` -- returns true if `x` is a wrapped Reduced value
-- `(unreduced x)` -- unwraps a Reduced value; returns `x` unchanged if not reduced
+- `(reduced x)` - wraps `x` to signal early termination
+- `(reduced? x)` - true if `x` is a wrapped Reduced value
+- `(unreduced x)` - unwraps a Reduced value; returns `x` unchanged if not reduced
 
-### How built-in transducers use early termination
-
-`take` and `take-while` use `reduced` internally. Once `take` has enough elements, it wraps the result so the outer `reduce`/`transduce` stops rather than walking the rest:
+`take` and `take-while` use `reduced` internally, so the outer `reduce`/`transduce` stops rather than walking the rest:
 
 ```phel
-;; Stops processing after 2 elements, does not touch the rest
-(transduce (take 2) conj [1 2 3 4 5])
-; => [1 2]
+(transduce (take 2) conj [1 2 3 4 5])  ; => [1 2], does not touch the rest
 ```
 
 ## Stateful transducers
 
 Some transducers need mutable state across steps (counters, seen-sets). Phel provides volatile references:
 
-- `(volatile! val)` -- create a mutable reference initialized to `val`
-- `@vol` (deref) -- read the current value
-- `(vreset! vol new-val)` -- set a new value, returns `new-val`
-- `(vswap! vol f & args)` -- apply `f` to current value + args, set and return result
+- `(volatile! val)` - create a mutable reference initialized to `val`
+- `@vol` (deref) - read the current value
+- `(vreset! vol new-val)` - set a new value, returns `new-val`
+- `(vswap! vol f & args)` - apply `f` to current value + args, set and return result
 
-`distinct` uses a volatile hash-set to track seen elements:
+`distinct`, for example, uses a volatile hash-set to track seen elements:
 
 ```phel
 ;; Simplified view of how distinct works internally:
@@ -152,35 +117,34 @@ Some transducers need mutable state across steps (counters, seen-sets). Phel pro
 
 ## Custom transducers
 
-A transducer takes a reducing function `rf` and returns a new one. The returned function handles three arities:
+A transducer takes a reducing function `rf` and returns a new one handling three arities:
 
 - **0** (init): return `(rf)`, delegate downstream init
 - **1** (completion): return `(rf result)`, optionally flush state
 - **2** (step): the transformation logic
 
-Use multi-arity `fn` to dispatch on arity, or variadic `[& args]` with `case (count args)`.
-
-### Multi-arity fn (recommended)
+Dispatch on arity with a variadic `[& args]` plus `case (count args)`. This is the shape Phel's own core transducers use internally, and it works correctly when the returned fn closes over `rf` or other state. (A multi-arity `fn` with `([] ...) ([result] ...) ([result input] ...)` clauses reads cleaner but does not currently compile for transducers, so prefer the variadic form.)
 
 ```phel
 ;; A transducer that doubles every element
 (defn map-double []
   (fn [rf]
-    (fn
-      ([] (rf))
-      ([result] (rf result))
-      ([result input] (rf result (* 2 input))))))
+    (fn [& args]
+      (case (count args)
+        0 (rf)
+        1 (rf (first args))
+        2 (rf (first args) (* 2 (second args)))))))
 
 (sequence (map-double) [1 2 3])
 ; => [2 4 6]
 ```
 
-### Full manual example with variadic dispatch
+### Custom completion logic
 
-For custom completion logic (e.g. flushing buffered state):
+Override the 1-arity branch to flush buffered state:
 
 ```phel
-;; A transducer that batches elements into groups of n
+;; Batch elements into groups of n
 (defn batch [n]
   (fn [rf]
     (let [buf (volatile! [])]
@@ -207,16 +171,21 @@ For custom completion logic (e.g. flushing buffered state):
 
 ### With early termination
 
-Wrap the result in `reduced` to stop:
+Wrap the step result in `reduced` to stop:
 
 ```phel
 ;; Take until predicate returns true (inclusive)
 (defn take-until [pred]
   (fn [rf]
-    (xf-step rf (fn [result input]
-                  (if (pred input)
-                    (reduced (rf result input))
-                    (rf result input))))))
+    (fn [& args]
+      (case (count args)
+        0 (rf)
+        1 (rf (first args))
+        2 (let [result (first args)
+                input (second args)]
+            (if (pred input)
+              (reduced (rf result input))
+              (rf result input)))))))
 
 (sequence (take-until #(> % 3)) [1 2 3 4 5])
 ; => [1 2 3 4]
@@ -242,10 +211,9 @@ Every dual-purpose function has two modes:
 - **Transducers**: avoid intermediates in multi-step pipelines, reuse one transformation across sources/destinations, or reduce into something that isn't a sequence (sums, maps, side effects).
 
 ```phel
-;; Define once, reuse everywhere
+;; Define once, reuse with different consumers
 (def xf (comp (filter even?) (map inc)))
 
-;; Use with different consumers
 (sequence xf [1 2 3 4 5 6])         ; => [3 5 7]
 (transduce xf + [1 2 3 4 5 6])      ; => 15
 (into #{} xf [1 2 3 4 5 6])         ; => #{3 5 7}


### PR DESCRIPTION
## 🤔 Background

The `docs/` guides had drifted and accumulated redundancy: duplicated examples, verbose intros, and a handful of code samples that no longer compiled or printed what they claimed. Total guide size was ~6015 lines.

## 💡 Goal

Bring every guide to 10/10: tighter, fully accurate against the live runtime, internally consistent. Every code block, function name, and CLI flag re-checked by running it.

## 🔖 Changes

- **Condensed** every guide under `docs/` (6015 → 4983 lines, -17%) while keeping all facts, tables, and unique examples. Biggest cuts: `data-structures-guide` 684→307, `patterns` 656→437, `php-interop` 409→322.
- **Verified**: all 177 fenced `phel` blocks exercised; all 32 runnable examples + snippets green; every referenced fn confirmed in `src/phel/core` / `./bin/phel doc`; every CLI flag confirmed against `--help`.
- **Accuracy fixes**:
  - `transducers`: replaced a custom-transducer example that emitted invalid PHP, and a private `xf-step` call, with the working variadic form.
  - `numeric-tower`: `bigint` prints without an `N` suffix.
  - `schema-guide`: closed-map `:maybe` key is required-present, so `validate` returns `false`.
  - `match-guide`: reordered patterns; `pos?` coerces non-numbers truthy.
  - `data-formats`: transit keyword-keyed maps encode as `["~#cmap", ...]`.
  - `internals/README`: compiler pipeline is seven-stage, not six.
  - Stripped stray `</content>` artifacts left at EOF of three files.
- **Cross-doc**: added missing `numeric-tower` and `project-layout` entries to the docs index, normalized heading case, confirmed no stale type names (`BigInteger`/`Rational`/`PhelFuture`/`ExInfoException`) and that all internal links resolve.

CHANGELOG updated under `## Unreleased`.