### PR TITLE
docs: cross-link TL;DR guides to full docs on phel-lang.org

### DIFF
--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -164,3 +164,7 @@ All failures throw `\RuntimeException`. Messages include HTTP status and provide
 
 - Source: `src/phel/ai.phel`
 - Tests: `tests/phel/ai.phel`
+
+---
+
+📖 **Full guide:** [ai API on phel-lang.org](https://phel-lang.org/documentation/reference/api/ai/)

--- a/docs/async-guide.md
+++ b/docs/async-guide.md
@@ -219,3 +219,7 @@ Wall time tracks the slowest branch, not the sum.
 
 - [Example: `docs/examples/11_async-concurrency.phel`](examples/11_async-concurrency.phel)
 - [`phel.http-client`](../src/phel/http-client.phel) for AMPHP-based HTTP calls
+
+---
+
+📖 **Full guide:** [async API on phel-lang.org](https://phel-lang.org/documentation/reference/api/async/)

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -252,3 +252,7 @@ Only needed under `phel run`. A standalone binary built with `phel build` reads 
 ## See also
 
 - [symfony/console docs](https://symfony.com/doc/current/components/console.html): underlying API
+
+---
+
+📖 **Full guide:** [cli API on phel-lang.org](https://phel-lang.org/documentation/reference/api/cli/)

--- a/docs/clojure-migration.md
+++ b/docs/clojure-migration.md
@@ -240,3 +240,7 @@ Extend `is` with custom assertions: `(defmethod phel.test/assert-expr 'my-form [
 4. Rewrite `(:import [java.util Date])` as `(:use DateTime)` in the `ns` form
 5. Replace concurrency primitives (refs, agents, core.async) with `atom` or the AMPHP-backed `phel.core` primitives (`future`, `pmap`, `promise`, `deliver`, ...); add `(:require phel.async :refer [delay])` only for the sleep primitive
 6. Run `./bin/phel test` to verify
+
+---
+
+📖 **Full guide:** [Coming from Clojure on phel-lang.org](https://phel-lang.org/documentation/guides/coming-from-clojure/)

--- a/docs/data-formats.md
+++ b/docs/data-formats.md
@@ -137,3 +137,7 @@ Plain Phel strings whose first character is `~`, `^`, or `` ` `` are escaped on 
 | Talking to Clojure/Java/JS over HTTP, MessagePack-ready wire format | Transit |
 | Human-edited input with comments and `#_` discards | EDN |
 | Round-tripping JSON-shaped data with rich types | Transit |
+
+---
+
+📖 **Full guide:** [edn / transit / json API on phel-lang.org](https://phel-lang.org/documentation/reference/api/edn/)

--- a/docs/data-structures-guide.md
+++ b/docs/data-structures-guide.md
@@ -307,3 +307,7 @@ Not in Clojure core.
 Signatures and behavior are identical; just replace the name.
 
 See `docs/examples/05_data-structures.phel` for runnable code.
+
+---
+
+📖 **Full guide:** [Data Structures on phel-lang.org](https://phel-lang.org/documentation/language/data-structures/)

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -243,3 +243,7 @@ echo $greet('World') . "\n";
 
 - [PHP/Phel Interop](php-interop.md)
 - [Quickstart](quickstart.md)
+
+---
+
+📖 **Full guide:** [Build a Web App on phel-lang.org](https://phel-lang.org/documentation/guides/build-a-web-app/)

--- a/docs/match-guide.md
+++ b/docs/match-guide.md
@@ -57,3 +57,7 @@
 
 - `phel.schema`: shapes reusable across validation and matching
 - `cond`, `case`, `condp`: simpler dispatch without destructuring
+
+---
+
+📖 **Full guide:** [match API on phel-lang.org](https://phel-lang.org/documentation/reference/api/match/)

--- a/docs/mocking-guide.md
+++ b/docs/mocking-guide.md
@@ -81,3 +81,7 @@ For long-running processes:
 ```
 
 See `tests/phel/mock.phel` for more examples.
+
+---
+
+📖 **Full guide:** [Testing on phel-lang.org](https://phel-lang.org/documentation/testing/)

--- a/docs/parallel-tests.md
+++ b/docs/parallel-tests.md
@@ -85,3 +85,7 @@ No `pcntl_fork`, no shared memory, no threads; just `proc_open` and `stream_sele
 - `phel test --help`: full flag reference
 - [Quickstart: Tests](quickstart.md#tests)
 - `src/php/Run/CLAUDE.md`: module architecture notes
+
+---
+
+📖 **Full guide:** [Testing on phel-lang.org](https://phel-lang.org/documentation/testing/)

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -437,3 +437,7 @@ When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the `:d
 - [Quick Start](quickstart.md)
 - [Reader Shortcuts](reader-shortcuts.md)
 - [Lazy Sequences](lazy-sequences.md)
+
+---
+
+📖 **Full guide:** [Cheat Sheet on phel-lang.org](https://phel-lang.org/documentation/reference/cheat-sheet/)

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -321,3 +321,7 @@ $response->send();
 - [Examples](examples/README.md)
 - [Reader Shortcuts](reader-shortcuts.md)
 - [Common Patterns](patterns.md)
+
+---
+
+📖 **Full guide:** [PHP Interop on phel-lang.org](https://phel-lang.org/documentation/php-interop/)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -227,3 +227,7 @@ Clojure devs: PHP interop uses `php/` prefix or shortcuts (`.method`, `.-field`,
 - [REPL & nREPL](nrepl-guide.md): editor integration
 - [Project Layout](project-layout.md): directory conventions
 - Full guide index: [docs/README.md](README.md)
+
+---
+
+📖 **Full guide:** [Getting Started on phel-lang.org](https://phel-lang.org/documentation/getting-started/)

--- a/docs/schema-guide.md
+++ b/docs/schema-guide.md
@@ -71,3 +71,7 @@
 
 - `phel.match` for destructuring matched shapes
 - `phel.test.gen` for property-based testing driven by schemas
+
+---
+
+📖 **Full guide:** [schema API on phel-lang.org](https://phel-lang.org/documentation/reference/api/schema/)

--- a/docs/watch-guide.md
+++ b/docs/watch-guide.md
@@ -41,3 +41,7 @@ Blocks until interrupted (Ctrl+C). Reloads changed namespaces in dependency orde
 
 - [Linter Guide](./lint-guide.md)
 - [LSP Guide](./lsp-guide.md)
+
+---
+
+📖 **Full guide:** [watch API on phel-lang.org](https://phel-lang.org/documentation/reference/api/watch/)


### PR DESCRIPTION
## 🤔 Background

The repo `docs/` guides are terse TL;DR cheatsheets for agents and contributors; phel-lang.org carries the full human-facing narrative docs. They overlapped by topic with no links between them, so readers could not jump from the short version to the full one.

## 💡 Goal

Make the two doc sets complement each other: keep the repo guides terse, and point each to its fuller counterpart instead of duplicating prose.

## 🔖 Changes

- Appended a "Full guide" footer linking to the matching phel-lang.org page on 15 repo guides: php-interop, data-structures-guide, clojure-migration, quickstart, match-guide, async-guide, schema-guide, ai-guide, cli-guide, watch-guide, mocking-guide, parallel-tests, framework-integration, patterns, data-formats.
- Every target page was verified to exist on the site before linking.

No other content changed.