### PR TITLE
fix(core): correct stale :example outputs (separator, realized?)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Lexer: error/source-map columns are now counted in code points instead of bytes, so locations are accurate for source containing multibyte (UTF-8) characters (ASCII-only code is unaffected)
 - Docs: corrected the `:example` metadata for `bigint`, `biginteger`, `+'`, `-'`, `*'`, `inc'`, and `dec'` in `phel.core` (showed a phantom `N` suffix, e.g. `(bigint 42) ; => 42N`); `BigInt` values print without a suffix, so the examples now read `=> 42`. This also fixes the auto-generated API reference on phel-lang.org and `phel doc` output
+- Docs: corrected stale `:example` outputs that no longer match the runtime: `resolve`, `require`, and `symbol-info` showed the deprecated `\` namespace separator in their results (now `phel.core` / `phel.string`), and `realized?` claimed `(take 5 (iterate inc 1))` was unrealized when that result is eager (now uses an actually-lazy `(lazy-seq (cons 1 nil))`)
 
 ### Added
 

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -1050,7 +1050,7 @@
 
 (defn resolve
   "Resolves the given symbol in the current environment and returns a resolved Symbol with the absolute namespace or nil if it cannot be resolved."
-  {:example "(resolve 'map) ; => phel\\core/map"}
+  {:example "(resolve 'map) ; => phel.core/map"}
   [sym]
   (-> (get-global-env)
       (php/-> (resolveAsSymbol sym (php/:: NodeEnvironment (empty))))))

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1105,7 +1105,7 @@
 
 (defn realized?
   "Returns true if a lazy sequence, delay, promise, or future has been realized, false otherwise."
-  {:example "(realized? (take 5 (iterate inc 1))) ; => false"
+  {:example "(realized? (lazy-seq (cons 1 nil))) ; => false"
    :see-also ["delay" "force" "lazy-seq" "future"]}
   [coll]
   (cond

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -141,7 +141,7 @@
     (require 'phel\\string :as str)
     (require '[phel\\string :as str])
     (require '[phel\\string :as str :refer [blank?]])"
-  {:example "(require '[phel\\string :as str]) ; => phel\\string"}
+  {:example "(require '[phel\\string :as str]) ; => phel.string"}
   [sym & args]
   (let [unquoted         (unquote-sym sym)
         [ns-sym opt-seq] (if (vector? unquoted)
@@ -269,7 +269,7 @@
 
   Keys: :doc, :file, :line, :column, :end-line, :end-column, :private,
         :deprecated, :min-arity, :max-arity, :is-variadic, :ns, :name"
-  {:example "(symbol-info map) ; => {:doc \"...\" :ns \"phel\\core\" :name \"map\" ...}"
+  {:example "(symbol-info map) ; => {:doc \"...\" :ns \"phel.core\" :name \"map\" ...}"
    :see-also ["doc" "dir" "apropos"]}
   [sym]
   (let [resolved-sym (resolve sym)]


### PR DESCRIPTION
## 🤔 Background

A sweep of every `; => result` annotation in `phel.core` `:example` metadata against the live runtime (the source feeding `phel doc` and the auto-generated phel-lang.org API reference) surfaced four whose stated output no longer matches reality.

## 💡 Goal

Make those examples reflect what the runtime actually returns.

## 🔖 Changes

- `resolve` example: `=> phel\core/map` → `=> phel.core/map`
- `require` example: `=> phel\string` → `=> phel.string`
- `symbol-info` example: `:ns "phel\core"` → `:ns "phel.core"`
- `realized?` example: `(take 5 (iterate inc 1))` is eager (returns `true`, not the documented `false`); switched to a genuinely-lazy `(lazy-seq (cons 1 nil))` that is actually unrealized (`=> false`).

The backslash forms reflected the deprecated `\` namespace separator; the runtime emits `.`. Each replacement verified against `./bin/phel`.

Note: the pervasive `:example` differences in print convention (idiomatic `(1 2 3)` vs printer `@[1 2 3]`, no-comma maps vs `{:a 1, :b 2}`, float `1.0` vs `1`) were left as-is. Those are a deliberate documentation convention, not bugs, and changing them is a maintainer call.

CHANGELOG updated under `## Unreleased`.