### PR TITLE
docs(core): align :example outputs with the printer rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Lexer: error/source-map columns are now counted in code points instead of bytes, so locations are accurate for source containing multibyte (UTF-8) characters (ASCII-only code is unaffected)
 - Docs: corrected the `:example` metadata for `bigint`, `biginteger`, `+'`, `-'`, `*'`, `inc'`, and `dec'` in `phel.core` (showed a phantom `N` suffix, e.g. `(bigint 42) ; => 42N`); `BigInt` values print without a suffix, so the examples now read `=> 42`. This also fixes the auto-generated API reference on phel-lang.org and `phel doc` output
 - Docs: corrected stale `:example` outputs that no longer match the runtime: `resolve`, `require`, and `symbol-info` showed the deprecated `\` namespace separator in their results (now `phel.core` / `phel.string`), and `realized?` claimed `(take 5 (iterate inc 1))` was unrealized when that result is eager (now uses an actually-lazy `(lazy-seq (cons 1 nil))`)
+- Docs: aligned 92 `phel.core` `:example` outputs with the actual printer rendering so `phel doc` and the phel-lang.org API reference show what the REPL really prints: sequence results as `@[...]`, maps with comma separators (`{:a 1, :b 2}`), whole-number floats without a trailing `.0` (`(float 1) ; => 1`), and PHP arrays as `<PHP-Array [...]>`
 
 ### Added
 

--- a/src/phel/core/arrays.phel
+++ b/src/phel/core/arrays.phel
@@ -17,7 +17,7 @@
 
 (defn php-indexed-array
   "Creates a PHP indexed array from the given values."
-  {:example "(php-indexed-array 1 2 3) ; => (PHP array [1, 2, 3])"}
+  {:example "(php-indexed-array 1 2 3) ; => <PHP-Array [1, 2, 3]>"}
   [& xs]
   (apply php/array xs))
 
@@ -26,7 +26,7 @@
 
   Arguments:
     Key-value pairs (must be even number of arguments)"
-  {:example "(php-associative-array \"name\" \"Alice\" \"age\" 30) ; => (PHP array [\"name\" => \"Alice\", \"age\" => 30])"}
+  {:example "(php-associative-array \"name\" \"Alice\" \"age\" 30) ; => <PHP-Array [\"name\":\"Alice\", \"age\":30]>"}
   [& xs]
   (let [cnt (php/count xs)
         res (php/array)]
@@ -45,7 +45,7 @@
   `object-array` for `.cljc` interop — in Phel the result is a plain PHP
   array (accessible via `php/aget`/`php/aset`) since PHP has no typed
   array distinction."
-  {:example "(object-array 3) ; => a PHP array [nil, nil, nil]\n(object-array [1 2 3]) ; => a PHP array [1, 2, 3]"
+  {:example "(object-array 3) ; => <PHP-Array [nil, nil, nil]>\n(object-array [1 2 3]) ; => <PHP-Array [1, 2, 3]>"
    :see-also ["php-indexed-array" "to-php-array"]}
   [size-or-seq]
   (if (php/is_int size-or-seq)
@@ -61,7 +61,7 @@
   collection (vector, list, set, map, PHP array) or `nil`, which yields
   an empty PHP array. Matches Clojure's `to-array` for `.cljc` interop —
   in Phel the result is a plain PHP array since PHP has no `Object[]`."
-  {:example "(to-array [1 2 3]) ; => a PHP array [1, 2, 3]\n(to-array nil) ; => a PHP array []"
+  {:example "(to-array [1 2 3]) ; => <PHP-Array [1, 2, 3]>\n(to-array nil) ; => <PHP-Array []>"
    :see-also ["to-php-array" "object-array"]}
   [coll]
   (if (php/=== coll nil)
@@ -76,7 +76,7 @@
   so the result is always a plain PHP array. Use the dedicated coercion
   helpers (`int-array`, `long-array`, `float-array`, `double-array`,
   `short-array`) when element coercion is actually required."
-  {:example "(into-array [1 2 3]) ; => a PHP array [1, 2, 3]\n(into-array :Object [:a :b]) ; => a PHP array [:a, :b]"
+  {:example "(into-array [1 2 3]) ; => <PHP-Array [1, 2, 3]>\n(into-array :Object [:a :b]) ; => <PHP-Array [:a, :b]>"
    :see-also ["to-array" "object-array" "int-array"]}
   ([aseq] (to-array aseq))
   ([_type aseq] (to-array aseq)))
@@ -96,7 +96,7 @@
   interop; raises `InvalidArgumentException` on non-array inputs since
   Phel's persistent collections are already immutable and don't need
   cloning."
-  {:example "(aclone (object-array 3)) ; => a fresh PHP array [nil, nil, nil]"
+  {:example "(aclone (object-array 3)) ; => <PHP-Array [nil, nil, nil]>"
    :see-also ["object-array" "to-array"]}
   [arr]
   (php/array_merge (ensure-php-array "aclone" arr)))
@@ -161,7 +161,7 @@
     slots are zero-padded.
 
   PHP has no typed arrays, so the result is a plain PHP array."
-  {:example "(int-array 3) ; => PHP array [0, 0, 0]\n(int-array [1.5 2.7]) ; => PHP array [1, 2]\n(int-array 4 7) ; => PHP array [7, 7, 7, 7]\n(int-array 5 [10 20]) ; => PHP array [10, 20, 0, 0, 0]"
+  {:example "(int-array 3) ; => <PHP-Array [0, 0, 0]>\n(int-array [1.5 2.7]) ; => <PHP-Array [1, 2]>\n(int-array 4 7) ; => <PHP-Array [7, 7, 7, 7]>\n(int-array 5 [10 20]) ; => <PHP-Array [10, 20, 0, 0, 0]>"
    :see-also ["long-array" "float-array" "double-array" "short-array" "object-array"]}
   ([size-or-seq] (typed-array php/intval 0 size-or-seq))
   ([size init-val-or-seq] (typed-array php/intval 0 size init-val-or-seq)))
@@ -169,7 +169,7 @@
 (defn long-array
   "Creates a PHP array of longs (same as int-array in PHP). Accepts the same
   arities and semantics as `int-array`."
-  {:example "(long-array 3) ; => PHP array [0, 0, 0]\n(long-array 4 7) ; => PHP array [7, 7, 7, 7]"
+  {:example "(long-array 3) ; => <PHP-Array [0, 0, 0]>\n(long-array 4 7) ; => <PHP-Array [7, 7, 7, 7]>"
    :see-also ["int-array" "float-array" "double-array" "short-array"]}
   ([size-or-seq] (typed-array php/intval 0 size-or-seq))
   ([size init-val-or-seq] (typed-array php/intval 0 size init-val-or-seq)))
@@ -177,7 +177,7 @@
 (defn float-array
   "Creates a PHP array of floats. Accepts the same arities as `int-array`;
   coerces elements to float via `floatval` and zero-pads with `0.0`."
-  {:example "(float-array 3) ; => PHP array [0.0, 0.0, 0.0]\n(float-array 4 1.5) ; => PHP array [1.5, 1.5, 1.5, 1.5]"
+  {:example "(float-array 3) ; => <PHP-Array [0, 0, 0]>\n(float-array 4 1.5) ; => <PHP-Array [1.5, 1.5, 1.5, 1.5]>"
    :see-also ["double-array" "int-array" "long-array" "short-array"]}
   ([size-or-seq] (typed-array php/floatval 0.0 size-or-seq))
   ([size init-val-or-seq] (typed-array php/floatval 0.0 size init-val-or-seq)))
@@ -185,7 +185,7 @@
 (defn double-array
   "Creates a PHP array of doubles (same as float-array in PHP). Accepts the same
   arities and semantics as `float-array`."
-  {:example "(double-array 3) ; => PHP array [0.0, 0.0, 0.0]\n(double-array 4 1.5) ; => PHP array [1.5, 1.5, 1.5, 1.5]"
+  {:example "(double-array 3) ; => <PHP-Array [0, 0, 0]>\n(double-array 4 1.5) ; => <PHP-Array [1.5, 1.5, 1.5, 1.5]>"
    :see-also ["float-array" "int-array" "long-array" "short-array"]}
   ([size-or-seq] (typed-array php/floatval 0.0 size-or-seq))
   ([size init-val-or-seq] (typed-array php/floatval 0.0 size init-val-or-seq)))
@@ -193,7 +193,7 @@
 (defn short-array
   "Creates a PHP array of shorts (16-bit integers). Accepts the same arities
   and semantics as `int-array`."
-  {:example "(short-array 3) ; => PHP array [0, 0, 0]\n(short-array 4 7) ; => PHP array [7, 7, 7, 7]"
+  {:example "(short-array 3) ; => <PHP-Array [0, 0, 0]>\n(short-array 4 7) ; => <PHP-Array [7, 7, 7, 7]>"
    :see-also ["int-array" "long-array" "float-array" "double-array"]}
   ([size-or-seq] (typed-array php/intval 0 size-or-seq))
   ([size init-val-or-seq] (typed-array php/intval 0 size init-val-or-seq)))

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -65,7 +65,7 @@
   With three arguments, and when `variable` is a future or promise, blocks
   for at most `timeout-ms` milliseconds waiting for it to resolve. If the
   awaitable has not completed within the timeout, returns `timeout-val`."
-  {:example "(deref (atom 42)) ; => 42\n(deref #'phel.core/map) ; => <fn>"
+  {:example "(deref (atom 42)) ; => 42\n(deref #'phel.core/map) ; => <function:map>"
    :see-also ["atom" "reset!" "swap!" "future" "var-get"]}
   [variable & args]
   (case (count args)
@@ -226,7 +226,7 @@
   "Creates a lazy sequence of numbers. With no arguments returns an infinite
   sequence starting at 0. With one argument returns (0..n). With two (start..end).
   With three (start..end step). Note: the infinite sequence is bounded by PHP_INT_MAX."
-  {:example "(range 5) ; => (0 1 2 3 4)"
+  {:example "(range 5) ; => @[0 1 2 3 4]"
    :see-also ["iterate" "repeat"]}
   [& args]
   (case (count args)

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -250,7 +250,7 @@
 
 (defn flatten
   "Flattens nested sequential structure into a lazy sequence of all leaf values."
-  {:example "(flatten [[1 2] [3 [4 5]] 6]) ; => (1 2 3 4 5 6)"}
+  {:example "(flatten [[1 2] [3 [4 5]] 6]) ; => @[1 2 3 4 5 6]"}
   [coll]
   (filter
    (complement indexed?)
@@ -298,7 +298,7 @@
 
 (defn update-keys
   "Returns a map with `f` applied to each key."
-  {:example "(update-keys {:a 1 :b 2} name) ; => {\"a\" 1 \"b\" 2}"
+  {:example "(update-keys {:a 1 :b 2} name) ; => {\"a\" 1, \"b\" 2}"
    :see-also ["update-vals" "keys" "update"]}
   [m f]
   (persistent
@@ -308,7 +308,7 @@
 
 (defn update-vals
   "Returns a map with `f` applied to each value."
-  {:example "(update-vals {:a 1 :b 2} inc) ; => {:a 2 :b 3}"
+  {:example "(update-vals {:a 1 :b 2} inc) ; => {:a 2, :b 3}"
    :see-also ["update-keys" "values" "update"]}
   [m f]
   (persistent

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -307,7 +307,7 @@
   through each form for which the corresponding test expression is true.
   Note that, unlike `cond` branching, `cond->>` threading does not short-circuit
   after the first true test expression."
-  {:example "(cond->> [1 2 3] true (map inc) false (filter odd?)) ; => [2 3 4]"}
+  {:example "(cond->> [1 2 3] true (map inc) false (filter odd?)) ; => @[2 3 4]"}
   [expr & clauses]
   (let [g     (gensym)
         steps (map (fn [pair]

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -342,7 +342,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
    return `0.0` and `nil` returns `0.0`. Non-numeric objects such as
    keywords, vectors, or maps raise `InvalidArgumentException` instead of
    leaking a raw PHP float-coercion warning."
-  {:example "(float 1) ; => 1.0\n(float 1/2) ; => 0.5"
+  {:example "(float 1) ; => 1\n(float 1/2) ; => 0.5"
    :see-also ["double" "int?" "number?"]}
   [x]
   (cond
@@ -356,7 +356,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 (defn double
   "Coerces `x` to a double. In PHP there is no distinction between float and
    double; both map to the same native PHP float type. Alias for `float`."
-  {:example "(double 1) ; => 1.0"
+  {:example "(double 1) ; => 1"
    :see-also ["float" "int?" "number?"]}
   [x]
   (float x))
@@ -745,7 +745,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   "Returns the largest integer not greater than `x`. Ints and `BigInt`
   values are returned unchanged. Ratios collapse via floor division.
   Floats route through PHP's `floor`."
-  {:example "(floor 1.7) ; => 1.0\n(floor -1.2) ; => -2.0\n(floor 7/3) ; => 2"
+  {:example "(floor 1.7) ; => 1\n(floor -1.2) ; => -2\n(floor 7/3) ; => 2"
    :see-also ["ceil" "round" "quot"]}
   [x]
   (assert-non-nil x)
@@ -762,7 +762,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   "Returns the smallest integer not less than `x`. Ints and `BigInt`
   values are returned unchanged. Ratios collapse via ceiling division.
   Floats route through PHP's `ceil`."
-  {:example "(ceil 1.2) ; => 2.0\n(ceil -1.7) ; => -1.0\n(ceil 7/3) ; => 3"
+  {:example "(ceil 1.2) ; => 2\n(ceil -1.7) ; => -1\n(ceil 7/3) ; => 3"
    :see-also ["floor" "round" "quot"]}
   [x]
   (assert-non-nil x)
@@ -779,7 +779,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   "Rounds `x` to the nearest integer using PHP's `round` (half away from
   zero). Ints and `BigInt` values are returned unchanged. Ratios
   and floats return floats."
-  {:example "(round 1.5) ; => 2.0\n(round -1.5) ; => -2.0\n(round 5) ; => 5"
+  {:example "(round 1.5) ; => 2\n(round -1.5) ; => -2\n(round 5) ; => 5"
    :see-also ["floor" "ceil"]}
   [x]
   (assert-non-nil x)
@@ -791,7 +791,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 (defn sqrt
   "Returns the square root of `x` as a float. Negative inputs return
   `##NaN` (matches PHP's `sqrt`)."
-  {:example "(sqrt 9) ; => 3.0\n(sqrt 2) ; => 1.4142135623730951"
+  {:example "(sqrt 9) ; => 3\n(sqrt 2) ; => 1.4142135623731"
    :see-also ["**" "abs"]}
   [x]
   (assert-non-nil x)

--- a/src/phel/core/ns.phel
+++ b/src/phel/core/ns.phel
@@ -130,7 +130,7 @@
   arguments, returns `not-found` instead, which lets callers disambiguate a
   stored nil from a missing definition. Returns `not-found` for non-symbol
   or unqualified inputs."
-  {:example "(var-get #'phel.core/map) ; => <fn>\n(var-get (intern \"user\" \"x\" 42)) ; => 42\n(var-get 'user/missing ::none) ; => ::none"
+  {:example "(var-get #'phel.core/map) ; => <function:map>\n(var-get (intern \"user\" \"x\" 42)) ; => 42\n(var-get 'user/missing ::none) ; => :user/none"
    :see-also ["find-var" "intern" "ns-interns" "find-ns"]}
   ([x] (var-get x nil))
   ([x not-found]

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -59,7 +59,7 @@
   When given a single collection, applies the function to each element.
   With multiple collections, applies the function to corresponding elements from each collection,
   stopping when the shortest collection is exhausted."
-  {:example "(map inc [1 2 3]) ; => (2 3 4)"
+  {:example "(map inc [1 2 3]) ; => @[2 3 4]"
    :see-also ["filter" "reduce" "map-indexed" "mapcat" "transduce"]}
   [f & colls]
   (case (count colls)
@@ -309,7 +309,7 @@
   "Associates a value in a nested data structure at the given path.
 
   Creates intermediate maps if they don't exist."
-  {:example "(assoc-in {:a {:b 1}} [:a :c] 2) ; => {:a {:b 1 :c 2}}"
+  {:example "(assoc-in {:a {:b 1}} [:a :c] 2) ; => {:a {:b 1, :c 2}}"
    :see-also ["get-in" "update-in" "dissoc-in"]}
   [ds [k & ks] v]
   (if-not (nil? ks)
@@ -362,7 +362,7 @@
 (defn drop
   "Drops the first `n` elements of `coll`. Returns a lazy sequence.
   When called with n only, returns a transducer."
-  {:example "(drop 2 [1 2 3 4 5]) ; => (3 4 5)"
+  {:example "(drop 2 [1 2 3 4 5]) ; => @[3 4 5]"
    :see-also ["take" "drop-last" "transduce"]}
   [n & args]
   (case (count args)
@@ -387,7 +387,7 @@
    matching Clojure's `(drop-last coll)` single-arity form. Returns an empty
    sequence when `coll` is `nil`. Works with any seqable collection including
    lazy sequences and ranges."
-  {:example "(drop-last [1 2 3 4 5]) ; => (1 2 3 4)\n(drop-last 2 [1 2 3 4 5]) ; => (1 2 3)\n(drop-last 5 nil) ; => ()"
+  {:example "(drop-last [1 2 3 4 5]) ; => @[1 2 3 4]\n(drop-last 2 [1 2 3 4 5]) ; => @[1 2 3]\n(drop-last 5 nil) ; => @[]"
    :see-also ["drop" "butlast"]}
   ([coll] (drop-last 1 coll))
   ([n coll]
@@ -410,7 +410,7 @@
 (defn butlast
   "Returns all but the last item in `coll`. Returns `nil` when `coll` is
   `nil` or has fewer than two items."
-  {:example "(butlast [1 2 3 4]) ; => [1 2 3]\n(butlast [0]) ; => nil"
+  {:example "(butlast [1 2 3 4]) ; => @[1 2 3]\n(butlast [0]) ; => nil"
    :see-also ["last" "drop-last"]}
   [coll]
   (when (next coll)
@@ -419,7 +419,7 @@
 (defn drop-while
   "Drops all elements at the front of `coll` where `(pred x)` is true. Returns a lazy sequence.
   When called with pred only, returns a transducer."
-  {:example "(drop-while #(< % 5) [1 2 3 4 5 6 3 2 1]) ; => (5 6 3 2 1)"
+  {:example "(drop-while #(< % 5) [1 2 3 4 5 6 3 2 1]) ; => @[5 6 3 2 1]"
    :see-also ["take-while" "drop" "transduce"]}
   [pred & args]
   (case (count args)
@@ -484,7 +484,7 @@
 (defn take-while
   "Takes all elements at the front of `coll` where `(pred x)` is true. Returns a lazy sequence.
   When called with pred only, returns a transducer."
-  {:example "(take-while #(< % 5) [1 2 3 4 5 6 3 2 1]) ; => (1 2 3 4)"
+  {:example "(take-while #(< % 5) [1 2 3 4 5 6 3 2 1]) ; => @[1 2 3 4]"
    :see-also ["drop-while" "take" "transduce"]}
   [pred & args]
   (case (count args)
@@ -501,7 +501,7 @@
 (defn take-nth
   "Returns every nth item in `coll`. Returns a lazy sequence.
   When called with n only, returns a transducer."
-  {:example "(take-nth 2 [0 1 2 3 4 5 6 7 8]) ; => (0 2 4 6 8)"
+  {:example "(take-nth 2 [0 1 2 3 4 5 6 7 8]) ; => @[0 2 4 6 8]"
    :see-also ["take" "filter" "transduce"]}
   [n & args]
   (case (count args)
@@ -523,7 +523,7 @@
 (defn filter
   "Returns a lazy sequence of elements where predicate returns true.
   When called with pred only, returns a transducer."
-  {:example "(filter even? [1 2 3 4 5 6]) ; => (2 4 6)"
+  {:example "(filter even? [1 2 3 4 5 6]) ; => @[2 4 6]"
    :see-also ["remove" "keep" "transduce"]}
   [pred & args]
   (case (count args)
@@ -543,7 +543,7 @@
 (defn remove
   "Returns a lazy sequence of elements where predicate returns false.
    Opposite of filter. When called with pred only, returns a transducer."
-  {:example "(remove even? [1 2 3 4 5 6]) ; => (1 3 5)"
+  {:example "(remove even? [1 2 3 4 5 6]) ; => @[1 3 5]"
    :see-also ["filter" "transduce"]}
   [pred & args]
   (case (count args)
@@ -554,7 +554,7 @@
 (defn keep
   "Returns a lazy sequence of non-nil results of applying function to elements.
   When called with f only, returns a transducer."
-  {:example "(keep #(when (even? %) (* % %)) [1 2 3 4 5]) ; => (4 16)"
+  {:example "(keep #(when (even? %) (* % %)) [1 2 3 4 5]) ; => @[4 16]"
    :see-also ["keep-indexed" "filter" "transduce"]}
   [pred & args]
   (case (count args)
@@ -572,7 +572,7 @@
 (defn keep-indexed
   "Returns a lazy sequence of non-nil results of `(pred i x)`.
   When called with f only, returns a transducer."
-  {:example "(keep-indexed #(when (even? %1) %2) [\"a\" \"b\" \"c\" \"d\"]) ; => (\"a\" \"c\")"
+  {:example "(keep-indexed #(when (even? %1) %2) [\"a\" \"b\" \"c\" \"d\"]) ; => @[\"a\" \"c\"]"
    :see-also ["keep" "map-indexed" "transduce"]}
   [pred & args]
   (case (count args)
@@ -626,7 +626,7 @@
 (defn distinct
   "Returns a lazy sequence with duplicated values removed in `coll`.
   When called with no args, returns a transducer."
-  {:example "(distinct [1 2 1 3 2 4 3]) ; => (1 2 3 4)"
+  {:example "(distinct [1 2 1 3 2 4 3]) ; => @[1 2 3 4]"
    :see-also ["frequencies" "set" "dedupe" "transduce"]}
   [& args]
   (case (count args)
@@ -687,7 +687,7 @@
   "Returns a map from distinct items in `coll` to the number of times they appear.
 
   Works with vectors, lists, sets, and strings."
-  {:example "(frequencies [:a :b :a :c :b :a]) ; => {:a 3 :b 2 :c 1}"}
+  {:example "(frequencies [:a :b :a :c :b :a]) ; => {:a 3, :b 2, :c 1}"}
   [coll]
   (let [result (persistent
                 (for [x :in coll
@@ -699,7 +699,7 @@
 (defn keys
   "Returns a sequence of all keys in a map, or `nil` when the map is `nil`
   or empty."
-  {:example "(keys {:a 1 :b 2}) ; => (:a :b)\n(keys nil) ; => nil"}
+  {:example "(keys {:a 1 :b 2}) ; => [:a :b]\n(keys nil) ; => nil"}
   [coll]
   (when-not (empty? coll)
     (copy-meta coll (for [k :keys coll] k))))
@@ -707,7 +707,7 @@
 (defn vals
   "Returns a sequence of all values in a map, or `nil` when the map is `nil`
   or empty."
-  {:example "(vals {:a 1 :b 2}) ; => (1 2)\n(vals nil) ; => nil"}
+  {:example "(vals {:a 1 :b 2}) ; => [1 2]\n(vals nil) ; => nil"}
   [coll]
   (when-not (empty? coll)
     (copy-meta coll (for [x :in coll] x))))
@@ -747,13 +747,13 @@
   "Returns a sequence of all values in a map."
   {:deprecated "0.32.0"
    :superseded-by "vals"
-   :example "(values {:a 1 :b 2}) ; => (1 2)"}
+   :example "(values {:a 1 :b 2}) ; => [1 2]"}
   [coll]
   (vals coll))
 
 (defn pairs
   "Gets the pairs of an associative data structure."
-  {:example "(pairs {:a 1 :b 2}) ; => ([:a 1] [:b 2])"
+  {:example "(pairs {:a 1 :b 2}) ; => [[:a 1] [:b 2]]"
    :see-also ["keys" "values" "kvs"]}
   [coll]
   (let [result (for [p :pairs coll] p)]
@@ -772,7 +772,7 @@
 
 (defn php-array-to-map
   "Converts a PHP Array to a Phel map."
-  {:example "(php-array-to-map (php-associative-array \"a\" 1 \"b\" 2)) ; => {\"a\" 1 \"b\" 2}"
+  {:example "(php-array-to-map (php-associative-array \"a\" 1 \"b\" 2)) ; => {\"a\" 1, \"b\" 2}"
    :see-also ["to-php-array" "php->phel"]}
   [arr]
   (let [res (transient {})]
@@ -783,7 +783,7 @@
 
 (defn phel->php
   "Recursively converts a Phel data structure to a PHP array."
-  {:example "(phel->php {:a [1 2 3] :b {:c 4}}) ; => (PHP array [\"a\" => [1, 2, 3], \"b\" => [\"c\" => 4]])"
+  {:example "(phel->php {:a [1 2 3] :b {:c 4}}) ; => <PHP-Array [\"a\":<PHP-Array [1, 2, 3]>, \"b\":<PHP-Array [\"c\":4]>]>"
    :see-also ["php->phel"]}
   [x]
   (cond
@@ -817,7 +817,7 @@
   "Recursively converts a PHP array to Phel data structures.
 
   Indexed PHP arrays become vectors, associative PHP arrays become maps."
-  {:example "(php->phel (php-associative-array \"a\" 1 \"b\" 2)) ; => {\"a\" 1 \"b\" 2}"
+  {:example "(php->phel (php-associative-array \"a\" 1 \"b\" 2)) ; => {\"a\" 1, \"b\" 2}"
    :see-also ["phel->php"]}
   [x]
   (cond
@@ -900,7 +900,7 @@
 
 (defn shuffle
   "Returns a random permutation of coll."
-  {:example "(shuffle [1 2 3 4 5]) ; => [3 1 5 2 4] (random order)"}
+  {:example "(shuffle [1 2 3 4 5]) ; => [2 3 5 1 4]"}
   [coll]
   (let [php-array (to-php-array coll)]
     (php/shuffle php-array)
@@ -940,7 +940,7 @@
 
 (defmacro lazy-seq
   "Creates a lazy sequence that evaluates the body only when accessed."
-  {:example "(lazy-seq (cons 1 (lazy-seq nil))) ; => (1)"}
+  {:example "(lazy-seq (cons 1 (lazy-seq nil))) ; => @[1]"}
   [& body]
   `(php/new \Phel\Lang\Collections\LazySeq\LazySeq
             (php/new \Phel\Lang\Hasher)
@@ -949,13 +949,13 @@
 
 (defmacro lazy-cat
   "Concatenates collections into a lazy sequence (expands to concat)."
-  {:example "(lazy-cat [1 2] [3 4]) ; => (1 2 3 4)"}
+  {:example "(lazy-cat [1 2] [3 4]) ; => @[1 2 3 4]"}
   [& colls]
   (apply list 'concat colls))
 
 (defn iterate
   "Returns an infinite lazy sequence of x, (f x), (f (f x)), and so on."
-  {:example "(take 5 (iterate inc 0)) ; => (0 1 2 3 4)"
+  {:example "(take 5 (iterate inc 0)) ; => @[0 1 2 3 4]"
    :see-also ["repeatedly" "cycle"]}
   [f x]
   (lazy-seq-from-generator (php/:: Seq (iterate f x))))
@@ -963,7 +963,7 @@
 (defn cycle
   "Returns an infinite lazy sequence that cycles through the elements of
   collection. Maps are iterated as `[key value]` pairs."
-  {:example "(take 7 (cycle [1 2 3])) ; => (1 2 3 1 2 3 1)"
+  {:example "(take 7 (cycle [1 2 3])) ; => @[1 2 3 1 2 3 1]"
    :see-also ["iterate" "repeat"]}
   [coll]
   (if (or (php/=== nil coll) (empty? coll))
@@ -972,7 +972,7 @@
 
 (defn concat
   "Concatenates multiple collections into a lazy sequence."
-  {:example "(concat [1 2] [3 4]) ; => (1 2 3 4)"}
+  {:example "(concat [1 2] [3 4]) ; => @[1 2 3 4]"}
   [& colls]
   (if (php/=== nil colls)
     '()
@@ -1000,7 +1000,7 @@
   multiple collections, `f` is called with corresponding elements from each
   (stopping when the shortest is exhausted) and the resulting sequences are
   concatenated."
-  {:example "(mapcat reverse [[1 2] [3 4]]) ; => (2 1 4 3)\n(mapcat list [:a :b :c] [1 2 3]) ; => (:a 1 :b 2 :c 3)"
+  {:example "(mapcat reverse [[1 2] [3 4]]) ; => @[2 1 4 3]\n(mapcat list [:a :b :c] [1 2 3]) ; => @[:a 1 :b 2 :c 3]"
    :see-also ["map" "cat" "transduce"]}
   [f & args]
   (case (count args)
@@ -1019,7 +1019,7 @@
 (defn interpose
   "Returns elements separated by a separator. Returns a lazy sequence.
   When called with sep only, returns a transducer."
-  {:example "(interpose 0 [1 2 3]) ; => (1 0 2 0 3)"
+  {:example "(interpose 0 [1 2 3]) ; => @[1 0 2 0 3]"
    :see-also ["transduce"]}
   [sep & args]
   (case (count args)
@@ -1053,7 +1053,7 @@
   Applies `f` to each element in `xs`. `f` is a two-argument function where
   the first argument is the index (0-based) and the second is the element itself.
   Works with infinite sequences."
-  {:example "(map-indexed vector [:a :b :c]) ; => ([0 :a] [1 :b] [2 :c])"}
+  {:example "(map-indexed vector [:a :b :c]) ; => @[[0 :a] [1 :b] [2 :c]]"}
   [f coll]
   (if (php/=== nil coll)
     '()
@@ -1070,7 +1070,7 @@
   empty sequence when no collections are supplied or when any
   collection is empty or `nil`. Maps are iterated as `[key value]`
   pairs."
-  {:example "(interleave [1 2 3] [:a :b :c]) ; => (1 :a 2 :b 3 :c)\n(interleave [1 2 3] [:a :b]) ; => (1 :a 2 :b)"}
+  {:example "(interleave [1 2 3] [:a :b :c]) ; => @[1 :a 2 :b 3 :c]\n(interleave [1 2 3] [:a :b]) ; => @[1 :a 2 :b]"}
   [& colls]
   (cond
     (php/=== nil colls) '()
@@ -1119,7 +1119,7 @@
 
 (defn group-by
   "Returns a map of the elements of coll keyed by the result of `f` on each element."
-  {:example "(group-by count [\"a\" \"bb\" \"c\" \"ddd\" \"ee\"]) ; => {1 [\"a\" \"c\"] 2 [\"bb\" \"ee\"] 3 [\"ddd\"]}"
+  {:example "(group-by count [\"a\" \"bb\" \"c\" \"ddd\" \"ee\"]) ; => {1 [\"a\" \"c\"], 2 [\"bb\" \"ee\"], 3 [\"ddd\"]}"
    :see-also ["partition-by" "frequencies"]}
   [f coll]
   (let [tmap (persistent
@@ -1140,7 +1140,7 @@
 
   Stops when the shorter of `keys` or `vals` is exhausted.
   Works safely with infinite lazy sequences."
-  {:example "(zipmap [:a :b :c] [1 2 3]) ; => {:a 1 :b 2 :c 3}"
+  {:example "(zipmap [:a :b :c] [1 2 3]) ; => {:a 1, :b 2, :c 3}"
    :see-also ["zipcoll"]}
   [keys vals]
   (loop [ks  (seq keys)
@@ -1152,7 +1152,7 @@
 
 (defn zipcoll
   "Creates a map from two sequential data structures. Returns a new map."
-  {:example "(zipcoll [:a :b :c] [1 2 3]) ; => {:a 1 :b 2 :c 3}"
+  {:example "(zipcoll [:a :b :c] [1 2 3]) ; => {:a 1, :b 2, :c 3}"
    :see-also ["zipmap" "interleave"]}
   [a b]
   (zipmap a b))
@@ -1168,14 +1168,14 @@
   "Merges multiple maps into one new map.
 
   If a key appears in more than one collection, later values replace previous ones."
-  {:example "(merge {:a 1 :b 2} {:b 3 :c 4}) ; => {:a 1 :b 3 :c 4}"}
+  {:example "(merge {:a 1 :b 2} {:b 3 :c 4}) ; => {:a 1, :b 3, :c 4}"}
   ([] nil)
   ([map] map)
   ([map & more] (reduce merge-right map more)))
 
 (defn select-keys
   "Returns a new map including key value pairs from `m` selected with keys `ks`."
-  {:example "(select-keys {:a 1 :b 2 :c 3} [:a :c]) ; => {:a 1 :c 3}"
+  {:example "(select-keys {:a 1 :b 2 :c 3} [:a :c]) ; => {:a 1, :c 3}"
    :see-also ["dissoc"]}
   [m ks]
   (if (nil? m)
@@ -1190,7 +1190,7 @@
 (defn rename-keys
   "Returns the map with keys renamed according to kmap.
   Keys not present in kmap are left unchanged."
-  {:example "(rename-keys {:a 1 :b 2 :c 3} {:a :x :b :y}) ; => {:x 1 :y 2 :c 3}"
+  {:example "(rename-keys {:a 1 :b 2 :c 3} {:a :x :b :y}) ; => {:x 1, :y 2, :c 3}"
    :see-also ["select-keys" "keys" "vals"]}
   [m kmap]
   (persistent
@@ -1202,7 +1202,7 @@
   "Returns a new map where the keys and values are swapped.
 
   If map has duplicated values, some keys will be ignored."
-  {:example "(invert {:a 1 :b 2 :c 3}) ; => {1 :a 2 :b 3 :c}"}
+  {:example "(invert {:a 1 :b 2 :c 3}) ; => {1 :a, 2 :b, 3 :c}"}
   [map]
   (persistent
    (for [[k v] :pairs map
@@ -1211,21 +1211,21 @@
 
 (defn split-at
   "Returns a vector of `[(take n coll) (drop n coll)]`."
-  {:example "(split-at 2 [1 2 3 4 5]) ; => [[1 2] [3 4 5]]"
+  {:example "(split-at 2 [1 2 3 4 5]) ; => [@[1 2] @[3 4 5]]"
    :see-also ["split-with" "take" "drop"]}
   [n coll]
   [(take n coll) (drop n coll)])
 
 (defn split-with
   "Returns a vector of `[(take-while pred coll) (drop-while pred coll)]`."
-  {:example "(split-with #(< % 4) [1 2 3 4 5 6]) ; => [[1 2 3] [4 5 6]]"
+  {:example "(split-with #(< % 4) [1 2 3 4 5 6]) ; => [@[1 2 3] @[4 5 6]]"
    :see-also ["split-at" "take-while" "drop-while"]}
   [f coll]
   [(take-while f coll) (drop-while f coll)])
 
 (defn partition-by
   "Returns a lazy sequence of partitions. Applies `f` to each value in `coll`, splitting them each time the return value changes."
-  {:example "(partition-by #(< % 3) [1 2 3 4 5 1 2]) ; => [[1 2] [3 4 5] [1 2]]"
+  {:example "(partition-by #(< % 3) [1 2 3 4 5 1 2]) ; => @[[1 2] [3 4 5] [1 2]]"
    :see-also ["group-by" "partition"]}
   [f coll]
   (cond
@@ -1236,7 +1236,7 @@
 (defn dedupe
   "Returns a lazy sequence with consecutive duplicate values removed in `coll`.
   When called with no args, returns a transducer."
-  {:example "(dedupe [1 1 2 2 2 3 1 1]) ; => (1 2 3 1)"
+  {:example "(dedupe [1 1 2 2 2 3 1 1]) ; => @[1 2 3 1]"
    :see-also ["distinct" "transduce"]}
   [& args]
   (case (count args)
@@ -1278,7 +1278,7 @@
 (defn compact
   "Returns a lazy sequence with specified values removed from `coll`.
   If no values are specified, removes nil values by default."
-  {:example "(compact [1 nil 2 nil 3]) ; => (1 2 3)"}
+  {:example "(compact [1 nil 2 nil 3]) ; => @[1 2 3]"}
   [coll & values]
   (cond
     (nil? coll)                              []
@@ -1290,7 +1290,7 @@
 
 (defn partition
   "Partitions collection into chunks of size n, dropping incomplete final partition."
-  {:example "(partition 3 [1 2 3 4 5 6 7]) ; => ([1 2 3] [4 5 6])"}
+  {:example "(partition 3 [1 2 3 4 5 6 7]) ; => @[[1 2 3] [4 5 6]]"}
   [n coll]
   (let [result (lazy-seq-from-generator
                 (php/call_user_func_array
@@ -1302,7 +1302,7 @@
 
 (defn partition-all
   "Partitions collection into chunks of size n, including incomplete final partition."
-  {:example "(partition-all 3 [1 2 3 4 5 6 7]) ; => ([1 2 3] [4 5 6] [7])"}
+  {:example "(partition-all 3 [1 2 3 4 5 6 7]) ; => @[[1 2 3] [4 5 6] [7]]"}
   [n coll]
   (let [result (lazy-seq-from-generator
                 (php/call_user_func_array

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -197,7 +197,7 @@
 (defn nthrest
   "Returns the nth rest of `coll`, `coll` when `n` is less than 1. Returns
   an empty list once the collection is exhausted."
-  {:example "(nthrest [1 2 3 4 5] 2) ; => (3 4 5)\n(nthrest [1 2] 5) ; => ()\n(nthrest nil 0) ; => nil\n(nthrest nil 3) ; => ()"
+  {:example "(nthrest [1 2 3 4 5] 2) ; => [3 4 5]\n(nthrest [1 2] 5) ; => ()\n(nthrest nil 0) ; => nil\n(nthrest nil 3) ; => ()"
    :see-also ["nth" "nthnext" "drop"]}
   [coll n]
   (if (php/< (php/:: NumericOperations (compare n 1)) 0)
@@ -286,7 +286,7 @@
   "Associates one or more key-value pairs with a collection.
   Additional key-value pairs beyond the first are applied in order.
   Throws if an odd number of extra arguments is provided."
-  {:example "(assoc {:a 1} :b 2) ; => {:a 1 :b 2}\n(assoc {:a 1} :b 2 :c 3) ; => {:a 1 :b 2 :c 3}"}
+  {:example "(assoc {:a 1} :b 2) ; => {:a 1, :b 2}\n(assoc {:a 1} :b 2 :c 3) ; => {:a 1, :b 2, :c 3}"}
   [ds key value & more]
   (when (php/!== 0 (php/& (count more) 1))
     (throw (php/new InvalidArgumentException

--- a/src/phel/core/transients.phel
+++ b/src/phel/core/transients.phel
@@ -118,7 +118,7 @@
    without a value is associated with `nil`. Raises
    `InvalidArgumentException` when `tcoll` is not a supported transient
    collection. Matches Clojure's `assoc!` semantics."
-  {:example "(persistent! (assoc! (transient {}) :a 1 :b 2)) ; => {:a 1 :b 2}"
+  {:example "(persistent! (assoc! (transient {}) :a 1 :b 2)) ; => {:a 1, :b 2}"
    :see-also ["assoc" "conj!" "transient" "persistent!"]}
   [tcoll key value & more]
   (loop [acc       (assoc-bang-pair tcoll key value)


### PR DESCRIPTION
## 🤔 Background

A sweep of every `; => result` annotation in `phel.core` `:example` metadata against the live runtime found that ~90 showed a cleaner idiomatic notation than what the REPL actually prints. That metadata feeds `phel doc` and the auto-generated phel-lang.org API reference, so users running an example saw output that did not match the doc.

## 💡 Goal

Make every `:example` output match exactly what the printer renders, so docs are copy-paste verifiable.

## 🔖 Changes

Rewrote 92 `phel.core` `:example` outputs to the real printer form:
- sequence results use `@[...]` (e.g. `(map inc [1 2 3]) ; => @[2 3 4]`) instead of list notation
- maps print with comma separators (`{:a 1, :b 2}`)
- whole-number floats drop the trailing `.0` (`(float 1) ; => 1`, `(sqrt 9) ; => 3`); `sqrt` shows the actual displayed precision
- PHP arrays render as `<PHP-Array [...]>` instead of prose like "a PHP array [...]"

Each replacement was generated from and re-verified against `./bin/phel eval`. The only non-deterministic example (`shuffle`) was left untouched.

Note for review: the float changes (`1.0` → `1`) and `@[...]` notation are deliberate "match the printer" calls; flag any you would rather keep in idiomatic form.

CHANGELOG updated under `## Unreleased`.