### PR TITLE
feat(http): decode JSON request bodies into :parsed-body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `phel.http`: `request-from-globals` decodes `application/json` request bodies into `:parsed-body` (nil for an empty or malformed body); `request-from-globals-args` gains an optional trailing `raw-body` arg
 - Compiler internals: regression test pinning that AST source locations survive every phase
 
 ### Changed

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -208,14 +208,9 @@
   [headers]
   (php/strtolower (php/trim (first (php/explode ";" (get headers :content-type "") 2)))))
 
-(defn- post-global-valid [method headers]
-  (and
-   (= method "POST")
-   (php/in_array (content-type-base headers)
-                 (php/array "application/x-www-form-urlencoded" "multipart/form-data"))))
-
-(defn- json-content-type? [headers]
-  (= (content-type-base headers) "application/json"))
+(defn- form-content-type? [content-type]
+  (php/in_array content-type
+                (php/array "application/x-www-form-urlencoded" "multipart/form-data")))
 
 (defn- decode-json-body
   "Decodes a JSON request body. Returns nil for an empty or malformed body so
@@ -225,12 +220,14 @@
     (try (json/decode raw-body) (catch \Throwable _ nil))))
 
 (defn- resolve-parsed-body
-  "Resolves `:parsed-body`: form data from `$_POST`, a decoded JSON body, or nil."
+  "Resolves `:parsed-body`: form data from `$_POST`, a decoded JSON body, or nil.
+  The `:content-type` header is parsed once and matched against both cases."
   [method headers post-parameter raw-body]
-  (cond
-    (post-global-valid method headers) (php-array-to-map post-parameter)
-    (json-content-type? headers)       (decode-json-body raw-body)
-    nil))
+  (let [content-type (content-type-base headers)]
+    (cond
+      (and (= method "POST") (form-content-type? content-type)) (php-array-to-map post-parameter)
+      (= content-type "application/json")                       (decode-json-body raw-body)
+      nil)))
 
 (defn request-from-globals-args
   "Extracts a request from args. The optional `raw-body` (the raw request body
@@ -257,13 +254,23 @@
      version
      {})))
 
+(defn- json-request-body
+  "Reads the raw request body from `php://input`, but only when the request
+  declares a JSON content type. Other requests never touch the input stream."
+  [server]
+  (let [content-type (php/strtolower (str (or (get server "CONTENT_TYPE")
+                                              (get server "HTTP_CONTENT_TYPE")
+                                              "")))]
+    (when (php/str_contains content-type "application/json")
+      (php/file_get_contents "php://input"))))
+
 (defn request-from-globals
   "Extracts a request from `$_SERVER`, `$_GET`, `$_POST`, `$_COOKIE`, `$_FILES`
-  and the raw request body (`php://input`, used for JSON payloads)."
+  and, for JSON requests, the raw request body (`php://input`)."
   {:example "(request-from-globals) ; => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"}
   []
   (request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES
-                             (php/file_get_contents "php://input")))
+                             (json-request-body php/$_SERVER)))
 
 (defn request-from-map
   "Creates a request struct from a map with optional keys :method, :uri, :headers, etc."

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -1,4 +1,5 @@
 (ns phel.http
+  (:require phel.json :as json)
   (:use InvalidArgumentException)
   (:use Stringable))
 
@@ -180,7 +181,7 @@
 (defstruct request [method ; HTTP Method ("GET", "POST", ...)
                     uri ; URI
                     headers ; Map with all headers
-                    parsed-body ; parsed body ($_POST)
+                    parsed-body ; parsed body ($_POST form data, or decoded JSON body)
                     query-params ; Map with all query parameters ($_GET)
                     cookie-params ; Map with all cookie parameters ($_COOKIE)
                     server-params ; Map with all server parameters ($_SERVER)
@@ -201,17 +202,42 @@
                            "it cannot be used from the REPL or a CLI script. "
                            "Build a request manually with `request-from-map` for testing."))))))
 
+(defn- content-type-base
+  "Lowercased media type from the `:content-type` header with any parameters
+  stripped (`application/json; charset=utf-8` => `application/json`)."
+  [headers]
+  (php/strtolower (php/trim (first (php/explode ";" (get headers :content-type "") 2)))))
+
 (defn- post-global-valid [method headers]
-  (let [content-type (get headers :content-type "")
-        types        (php/strtolower (php/trim (first (php/explode ";" content-type 2))))]
-    (and
-     (= method "POST")
-     (php/in_array types (php/array "application/x-www-form-urlencoded" "multipart/form-data")))))
+  (and
+   (= method "POST")
+   (php/in_array (content-type-base headers)
+                 (php/array "application/x-www-form-urlencoded" "multipart/form-data"))))
+
+(defn- json-content-type? [headers]
+  (= (content-type-base headers) "application/json"))
+
+(defn- decode-json-body
+  "Decodes a JSON request body. Returns nil for an empty or malformed body so
+  handlers can distinguish 'no usable body' from a real value."
+  [raw-body]
+  (when (and (string? raw-body) (not= raw-body ""))
+    (try (json/decode raw-body) (catch \Throwable _ nil))))
+
+(defn- resolve-parsed-body
+  "Resolves `:parsed-body`: form data from `$_POST`, a decoded JSON body, or nil."
+  [method headers post-parameter raw-body]
+  (cond
+    (post-global-valid method headers) (php-array-to-map post-parameter)
+    (json-content-type? headers)       (decode-json-body raw-body)
+    nil))
 
 (defn request-from-globals-args
-  "Extracts a request from args."
-  {:example "(request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES) ; => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"}
-  [server get-parameter post-parameter cookies files]
+  "Extracts a request from args. The optional `raw-body` (the raw request body
+  string) is decoded into `:parsed-body` when the `Content-Type` is
+  `application/json`; form bodies still come from `post-parameter`."
+  {:example "(request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES (php/file_get_contents \"php://input\")) ; => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"}
+  [server get-parameter post-parameter cookies files & [raw-body]]
   (let [method          (get-method-from-globals server)
         uri             (uri-from-globals server)
         headers         (headers-from-server server)
@@ -223,7 +249,7 @@
      method
      uri
      headers
-     (when (post-global-valid method headers) (php-array-to-map post-parameter))
+     (resolve-parsed-body method headers post-parameter raw-body)
      (php-array-to-map get-parameter)
      (php-array-to-map cookies)
      (php-array-to-map server)
@@ -232,10 +258,12 @@
      {})))
 
 (defn request-from-globals
-  "Extracts a request from `$_SERVER`, `$_GET`, `$_POST`, `$_COOKIE` and `$_FILES`."
+  "Extracts a request from `$_SERVER`, `$_GET`, `$_POST`, `$_COOKIE`, `$_FILES`
+  and the raw request body (`php://input`, used for JSON payloads)."
   {:example "(request-from-globals) ; => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"}
   []
-  (request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES))
+  (request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES
+                             (php/file_get_contents "php://input")))
 
 (defn request-from-map
   "Creates a request struct from a map with optional keys :method, :uri, :headers, etc."

--- a/tests/phel/http.phel
+++ b/tests/phel/http.phel
@@ -347,3 +347,54 @@
 (deftest test-send-response
   (foreach [[name response result] send-response-examples]
     (is (output? result (h/emit-response response)) name)))
+
+;; ---
+;; Request body parsing
+;; ---
+
+(def json-req-server
+  (php-associative-array
+   "REQUEST_METHOD" "POST"
+   "CONTENT_TYPE"   "application/json"
+   "SERVER_NAME"    "phel-lang.org"
+   "REQUEST_URI"    "/api"))
+
+(defn- req-with-body [server raw-body]
+  (h/request-from-globals-args server (php/array) (php/array) (php/array) (php/array) raw-body))
+
+(deftest test-json-body-decoded
+  (is (= {:name "Alice" :age 30}
+         (:parsed-body (req-with-body json-req-server "{\"name\":\"Alice\",\"age\":30}")))
+      "application/json body is decoded into :parsed-body"))
+
+(deftest test-json-body-charset-tolerated
+  (let [server (php/array_merge json-req-server
+                                (php-associative-array "CONTENT_TYPE" "application/json; charset=utf-8"))]
+    (is (= {:ok true} (:parsed-body (req-with-body server "{\"ok\":true}")))
+        "content-type parameters are ignored")))
+
+(deftest test-json-body-malformed-is-nil
+  (is (nil? (:parsed-body (req-with-body json-req-server "{not json")))
+      "malformed JSON yields nil :parsed-body"))
+
+(deftest test-json-body-empty-is-nil
+  (is (nil? (:parsed-body (req-with-body json-req-server "")))
+      "empty body yields nil :parsed-body"))
+
+(deftest test-json-body-zero-string-preserved
+  (is (= 0 (:parsed-body (req-with-body json-req-server "0")))
+      "body \"0\" is valid JSON and not treated as empty"))
+
+(deftest test-form-body-unchanged
+  (let [server (php/array_merge json-req-server
+                                (php-associative-array "CONTENT_TYPE" "application/x-www-form-urlencoded"))
+        req    (h/request-from-globals-args
+                server (php/array) (php-associative-array "name" "Bob") (php/array) (php/array) "name=Bob")]
+    ;; form data keeps string keys (php-array-to-map), unlike JSON's keyword keys
+    (is (= {"name" "Bob"} (:parsed-body req))
+        "form-encoded body still comes from $_POST")))
+
+(deftest test-no-body-arg-back-compat
+  (is (nil? (:parsed-body (h/request-from-globals-args
+                           json-req-server (php/array) (php/array) (php/array) (php/array))))
+      "omitting raw-body keeps the 5-arg arity working"))


### PR DESCRIPTION
## Why

`request-from-globals` fills `:parsed-body` only from `$_POST` (form bodies). For `application/json` it was always `nil`, so every Phel web app hand-rolls a `php://input` + `json/decode` reader — even though the `request` struct already has the slot.

```phel
;; before — in every app:
(let [raw  (php/file_get_contents "php://input")
      body (try (json/decode raw) (catch \Throwable _ {}))] ...)
;; after:
(:parsed-body req)
```

## What

`request-from-globals` now decodes a JSON request body into `:parsed-body`:

| Content-Type | `:parsed-body` |
|---|---|
| form-urlencoded / multipart (POST) | `$_POST` map — *unchanged* |
| `application/json` (`; charset=…` ok) | decoded map; `nil` if empty/malformed |
| anything else | `nil` — *unchanged* |

`nil` on empty/malformed lets handlers return 400 instead of guessing. `(or (:parsed-body req) {})` for a lenient default.

## Notes

- **Non-breaking:** `request-from-globals-args` gains an optional trailing `raw-body` arg; existing 5-arg callers are unaffected. No dependency cycle (`phel.json` doesn't require `phel.http`).
- **No per-request cost:** `php://input` is read only when the request declares a JSON content type; the header is parsed once.
- **Tests:** 7 cases (decode, charset, malformed→nil, empty→nil, `"0"` preserved, form unchanged, back-compat). Full core suite green.

## Follow-up

Raw-body access (webhook signature verification) needs a new struct field → separate PR.