### PR TITLE
ref(compiler): split three multi-responsibility classes into focused collaborators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 
 - Architecture: relocated the `NamespaceInformation` value object from `Build\Domain\Extractor` to `Phel\Shared`, removing the `Shared -> foreign Domain` back-reference from the Build/Run facade interfaces; sourced `CompilerFacadeInterface::lexString`'s `DEFAULT_SOURCE` default from `Shared\CompilerConstants` instead of the `Application\Lexer` concrete; sanctioned `EvalError` in `RunFacadeInterface`'s value graph (pure relocations, no behavior change) (#2261)
 - Compiler internals: split the 1325-LOC `CallSpecialization` god-class into eight focused collaborators (pure refactor, output unchanged)
+- Architecture: split three multi-responsibility classes into focused stateless collaborators (pure refactor, behavior unchanged) (#2262): `DefSymbol` delegates macro `&form`/`&env` + `^:tag` form rewriting to `MacroFormRewriter` and `:arglists` formatting to `DefArglistBuilder`; `ParamTypeInferrer` delegates PHP-/`phel.core`-call shape analysis to `CallTypeExpectationResolver`; `TestCommand` delegates option parsing/coercion + the parallelism decision to `TestCommandOptionParser`
 - Compiler internals: centralized the emitters' bare-expression capture into `OutputEmitter::captureNodeAsExpression()`
 - Tests: `RegistryTest` and `PhelVarTest` snapshot and restore the global `Registry`, fixing order-dependent `phel.core` suite failures (#2256)
 - Docs: condensed every `docs/` guide (~17% smaller), verified against the runtime, and cross-linked to phel-lang.org

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/CallTypeExpectationResolver.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/CallTypeExpectationResolver.php
@@ -1,0 +1,377 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Keyword;
+use Phel\Shared\CompilerConstants;
+
+use function count;
+use function in_array;
+use function is_float;
+use function is_int;
+use function is_object;
+use function is_string;
+use function strlen;
+
+/**
+ * Stateless shape analysis for {@see ParamTypeInferrer}. Classifies PHP-op
+ * and `phel.core` calls and reads literal/callee type hints, answering
+ * "what scalar expectation (if any) does this call shape imply, and does it
+ * guard its args?". The walker and its mutable observation state live in the
+ * inferrer; everything here is a pure function of the node graph.
+ */
+final readonly class CallTypeExpectationResolver
+{
+    /** @var list<string> */
+    private const array NUMERIC_OPS = [
+        '+', '-', '*', '/', '%', '**', '<<', '>>', '|', '&', '^',
+    ];
+
+    private const string STRING_CONCAT_OP = '.';
+
+    /** @var list<string> */
+    private const array IDENTITY_OPS = ['===', '!==', '==', '!='];
+
+    /** @var list<string> */
+    private const array ORDERING_OPS = ['<', '>', '<=', '>=', '<=>'];
+
+    /**
+     * Tags that translate directly to a single PHP scalar and therefore
+     * survive being grafted onto a param without losing valid runtime
+     * inputs. Nullable (`?int`), union (`int|null`), and FQN tags are
+     * deliberately excluded: tightening them to bare `int` rejects
+     * callers that the callee already accepts.
+     *
+     * @var list<string>
+     */
+    private const array PURE_PRIMITIVE_TAGS = ['int', 'float', 'string', 'bool', 'array'];
+
+    /**
+     * Curated allowlist of PHP stdlib fns whose arg types are stable
+     * across supported versions. Each entry's value lists the scalar tag
+     * inferred per positional arg (use `null` to skip a slot). Unions
+     * and nullable types stay out so the inferrer never tightens a slot
+     * the runtime accepts more loosely.
+     *
+     * @var array<string, list<?string>>
+     */
+    private const array PHP_FN_SIGNATURES = [
+        'random_int' => ['int', 'int'],
+        'intdiv' => ['int', 'int'],
+        'strlen' => ['string'],
+        'mb_strlen' => ['string'],
+        'str_repeat' => ['string', 'int'],
+        'count' => ['array'],
+    ];
+
+    /**
+     * `phel.core` arithmetic fns whose return is `int` when every arg
+     * is `int`. The inferrer treats them as conditional numeric ops:
+     * propagation only fires when an `int` expectation flows in from
+     * above. Without that expectation we leave the runtime contract
+     * permissive so `BigInt` / `Ratio` polymorphism keeps
+     * working at the call site.
+     *
+     * @var list<string>
+     */
+    private const array INT_STABLE_CORE_FNS = ['+', '-', '*', 'inc', 'dec'];
+
+    /**
+     * `phel.core` arithmetic wrappers whose dispatch reduces to a PHP
+     * numeric op only when a literal sibling proves the operand is
+     * `float`. An `int` literal stays ambiguous (it coerces to float
+     * inside the runtime defn when the LocalVar is float at the call
+     * site), so the wrapper observer only commits when the literal is
+     * unambiguously float. `php/+`, `php/-` keep their own int
+     * inference path because the user reached for the PHP-native op
+     * directly.
+     *
+     * @var list<string>
+     */
+    private const array NUMERIC_CORE_OBSERVERS = ['+', '-', '*', 'inc', 'dec'];
+
+    /**
+     * `phel.core` ordering wrappers. Each one reduces to the matching
+     * `php/<`, `php/<=`, ... when no `BigInt` / `Ratio` shows up at
+     * runtime, so the ordering walker can lift a numeric tag the same
+     * way it does for the PHP-native op.
+     *
+     * @var list<string>
+     */
+    private const array ORDERING_CORE_OBSERVERS = ['<', '<=', '>', '>=', '<=>'];
+
+    /**
+     * Static fallback for `phel.core` callees whose compile-time
+     * `:param-tags` channel is not available (the runtime registry is
+     * populated from a precompiled cache, so the analyzer never sees
+     * the sub-namespaces' defns and the `:param-tags` vector stays
+     * empty). The mapping mirrors the strict slot-by-slot
+     * primitive-tag contract that the runtime fn already enforces.
+     *
+     * @var array<string, list<?string>>
+     */
+    private const array CORE_FN_SIGNATURES = [
+        'rand-int' => ['int'],
+    ];
+
+    /**
+     * Globals that signal "the function defensively rejects bad inputs at
+     * runtime". A param threaded through any of these escapes inference
+     * even when later used by a primitive op, so deliberate negative tests
+     * (e.g. `(bit-and nil 1)` against an `assert-non-nil` guard) keep
+     * compiling and reach the runtime guard.
+     *
+     * @var list<string>
+     */
+    private const array GUARD_GLOBALS = [
+        'assert-non-nil',
+        'assert',
+    ];
+
+    /**
+     * PHP type predicates used as type-discriminating guards. When a
+     * param is fed to one of these, the user is admitting the value
+     * could be of multiple types, so the runtime contract must stay
+     * permissive even if a sibling branch concatenates or arithmetic's
+     * the same param.
+     *
+     * @var list<string>
+     */
+    private const array GUARD_PHP_FNS = [
+        'is_int', 'is_integer', 'is_long',
+        'is_float', 'is_double',
+        'is_string',
+        'is_bool',
+        'is_null',
+        'is_array',
+        'is_object',
+        'is_callable',
+        'is_numeric',
+        'is_iterable',
+        'is_countable',
+        'is_scalar',
+    ];
+
+    public function isGuardPhpFn(string $op): bool
+    {
+        return in_array($op, self::GUARD_PHP_FNS, true);
+    }
+
+    public function isStringConcatOp(string $op): bool
+    {
+        return $op === self::STRING_CONCAT_OP;
+    }
+
+    public function isNumericOp(string $op): bool
+    {
+        return in_array($op, self::NUMERIC_OPS, true);
+    }
+
+    public function isIdentityOp(string $op): bool
+    {
+        return in_array($op, self::IDENTITY_OPS, true);
+    }
+
+    public function isOrderingOp(string $op): bool
+    {
+        return in_array($op, self::ORDERING_OPS, true);
+    }
+
+    /**
+     * The per-slot expected tags for a curated PHP stdlib fn, or `null`
+     * when the fn is not on the allowlist.
+     *
+     * @return list<?string>|null
+     */
+    public function phpFnSignature(string $op): ?array
+    {
+        return self::PHP_FN_SIGNATURES[$op] ?? null;
+    }
+
+    public function isGuardGlobal(GlobalVarNode $fn): bool
+    {
+        $name = $fn->getName()->getName();
+        if (in_array($name, self::GUARD_GLOBALS, true)) {
+            return true;
+        }
+
+        // Phel convention: predicate names end in `?`. Calling one on a
+        // param signals "this value can be of multiple types, I'm
+        // type-discriminating" (same intent as the explicit `assert*`
+        // guards), so mark the arg guarded.
+        return $name !== '' && $name[strlen($name) - 1] === '?';
+    }
+
+    public function isIntStableCoreFn(GlobalVarNode $fn): bool
+    {
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return false;
+        }
+
+        return in_array($fn->getName()->getName(), self::INT_STABLE_CORE_FNS, true);
+    }
+
+    public function isCoreNumericObserver(GlobalVarNode $fn): bool
+    {
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return false;
+        }
+
+        return in_array($fn->getName()->getName(), self::NUMERIC_CORE_OBSERVERS, true);
+    }
+
+    public function isCoreOrderingObserver(GlobalVarNode $fn): bool
+    {
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return false;
+        }
+
+        return in_array($fn->getName()->getName(), self::ORDERING_CORE_OBSERVERS, true);
+    }
+
+    public function isCoreEqualityObserver(GlobalVarNode $fn): bool
+    {
+        return $fn->getNamespace() === CompilerConstants::PHEL_CORE_NAMESPACE
+            && $fn->getName()->getName() === '=';
+    }
+
+    /**
+     * `BigInt`, `Ratio`, `BigDecimal` literals route through
+     * `NumericOperations` at runtime; the int / float observer path
+     * must skip the call so the inferrer never narrows a param that
+     * a numeric-object literal disambiguates as polymorphic. Unlike
+     * {@see self::hasNonIntLiteralArg()}, a float literal is treated
+     * as a valid numeric signal here, not as noise.
+     */
+    public function hasNumericObjectLiteralArg(CallNode $node): bool
+    {
+        return array_any(
+            $node->getArguments(),
+            static fn(AbstractNode $arg): bool => $arg instanceof LiteralNode
+                && is_object($arg->getValue()),
+        );
+    }
+
+    /**
+     * Detects literal args that the int-stable core fns explicitly
+     * accept via runtime polymorphism (`BigInt`, `Ratio`,
+     * `BigDecimal`, floats). Their presence signals that the caller
+     * is deliberately routing through `NumericOperations`, so the
+     * sibling param's runtime contract must stay permissive even when
+     * an `int` expectation flows in from above.
+     */
+    public function hasNonIntLiteralArg(CallNode $node): bool
+    {
+        return array_any(
+            $node->getArguments(),
+            static function (AbstractNode $arg): bool {
+                if (!$arg instanceof LiteralNode) {
+                    return false;
+                }
+
+                $value = $arg->getValue();
+                if (is_int($value)) {
+                    return false;
+                }
+
+                return is_float($value) || is_object($value);
+            },
+        );
+    }
+
+    /**
+     * True when any literal arg is `nil`, `true`, or `false` — the shape
+     * of an identity comparison (`(php/=== x nil)`) the user writes to
+     * type-discriminate before treating the param as a primitive.
+     */
+    public function hasNullableLiteralArg(CallNode $node): bool
+    {
+        return array_any(
+            $node->getArguments(),
+            static fn(AbstractNode $a): bool => $a instanceof LiteralNode
+                && self::isNullableLiteral($a->getValue()),
+        );
+    }
+
+    /**
+     * Reads a numeric type hint from the literal args of a call: `float`
+     * if any literal is float, `int` if any literal is int and none are
+     * float, otherwise `null`. The numeric and ordering walkers use this
+     * so they only constrain a param when the call actually disambiguates
+     * the runtime type.
+     *
+     * @param list<AbstractNode> $args
+     */
+    public function literalNumericType(array $args): ?string
+    {
+        $hasFloat = false;
+        $hasInt = false;
+        foreach ($args as $arg) {
+            if (!$arg instanceof LiteralNode) {
+                continue;
+            }
+
+            $value = $arg->getValue();
+            if (is_float($value)) {
+                $hasFloat = true;
+            } elseif (is_int($value)) {
+                $hasInt = true;
+            }
+        }
+
+        if ($hasFloat) {
+            return 'float';
+        }
+
+        return $hasInt ? 'int' : null;
+    }
+
+    /**
+     * Builds a per-slot list of expected pure-primitive tags for the
+     * callee. Compile-time `:param-tags` win; if that channel is empty
+     * (e.g. core sub-namespaces loaded from a precompiled cache that
+     * the analyzer never sees), `phel.core` fns fall back to the
+     * `CORE_FN_SIGNATURES` allowlist so cross-namespace inference can
+     * still propagate.
+     *
+     * @return list<?string>
+     */
+    public function calleeParamExpectations(GlobalVarNode $fn): array
+    {
+        $paramTags = $fn->getMeta()->find(Keyword::create('param-tags'));
+        if ($paramTags instanceof PersistentVectorInterface && count($paramTags) > 0) {
+            $expectations = [];
+            $hasPrimitive = false;
+            foreach ($paramTags as $tag) {
+                if (is_string($tag) && in_array($tag, self::PURE_PRIMITIVE_TAGS, true)) {
+                    $expectations[] = $tag;
+                    $hasPrimitive = true;
+                } else {
+                    $expectations[] = null;
+                }
+            }
+
+            if ($hasPrimitive) {
+                return $expectations;
+            }
+        }
+
+        if ($fn->getNamespace() === CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return self::CORE_FN_SIGNATURES[$fn->getName()->getName()] ?? [];
+        }
+
+        return [];
+    }
+
+    private static function isNullableLiteral(mixed $value): bool
+    {
+        return in_array($value, [null, true, false], true);
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefArglistBuilder.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefArglistBuilder.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MultiFnNode;
+use Phel\Lang\Symbol;
+
+use function array_map;
+use function array_pop;
+use function array_slice;
+use function implode;
+
+/**
+ * Formats a def's `:arglists` metadata string from the analyzed fn node(s).
+ * Single-arity renders one `[a b & rest]` vector; multi-arity wraps every
+ * arity's vector in `( ... )`. `$skipFirst` drops leading macro implicit
+ * params (`&form`/`&env`) so the published arglist reflects the user-visible
+ * signature.
+ */
+final readonly class DefArglistBuilder
+{
+    public function buildFnNodeArglist(FnNode $fnNode, int $skipFirst = 0): string
+    {
+        return $this->formatParamsVector($fnNode->getParams(), $fnNode->isVariadic(), $skipFirst);
+    }
+
+    public function buildMultiFnNodeArglists(MultiFnNode $multiFnNode, int $skipFirst = 0): string
+    {
+        $vectors = [];
+        foreach ($multiFnNode->getFnNodes() as $fnNode) {
+            $vectors[] = $this->formatParamsVector($fnNode->getParams(), $fnNode->isVariadic(), $skipFirst);
+        }
+
+        return '(' . implode(' ', $vectors) . ')';
+    }
+
+    /**
+     * @param list<Symbol> $params
+     */
+    private function formatParamsVector(array $params, bool $isVariadic, int $skipFirst = 0): string
+    {
+        if ($skipFirst > 0) {
+            $params = array_slice($params, $skipFirst);
+        }
+
+        $names = array_map(
+            static fn(Symbol $s): string => $s->getName(),
+            $params,
+        );
+
+        if ($isVariadic && $names !== []) {
+            $restParam = array_pop($names);
+            $names[] = '&';
+            $names[] = $restParam;
+        }
+
+        return '[' . implode(' ', $names) . ']';
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -27,7 +27,6 @@ use function array_pop;
 use function array_slice;
 use function assert;
 use function count;
-use function implode;
 use function in_array;
 use function is_scalar;
 use function is_string;
@@ -76,12 +75,13 @@ final readonly class DefSymbol implements SpecialFormAnalyzerInterface
 
         [$metaMap, $init] = $this->createMetaMapAndInit($list);
 
+        $rewriter = new MacroFormRewriter();
         $isMacro = $metaMap[Keyword::create('macro')] === true;
         if ($isMacro) {
-            $init = $this->injectMacroImplicitParams($init);
+            $init = $rewriter->injectImplicitParams($init);
         }
 
-        $init = $this->injectReturnTypeFromMeta($init, $metaMap);
+        $init = $rewriter->injectReturnTypeFromMeta($init, $metaMap);
 
         $initNode = $this->analyzeInit($init, $env, $namespace, $nameSymbol, $metaMap);
         $skip = $isMacro ? self::MACRO_IMPLICIT_PARAMS : 0;
@@ -98,7 +98,7 @@ final readonly class DefSymbol implements SpecialFormAnalyzerInterface
 
             $metaMap = $metaMap->put('min-arity', max(0, $initNode->getMinArity() - $skip));
             $metaMap = $metaMap->put('is-variadic', $initNode->isVariadic());
-            $metaMap = $metaMap->put('arglists', $this->buildFnNodeArglist($initNode, $skip));
+            $metaMap = $metaMap->put('arglists', new DefArglistBuilder()->buildFnNodeArglist($initNode, $skip));
         } elseif ($initNode instanceof MultiFnNode) {
             // Stash multi-arity defs too so the inliner can select the
             // arity matching a call's argument count (#2218).
@@ -107,7 +107,7 @@ final readonly class DefSymbol implements SpecialFormAnalyzerInterface
             $metaMap = $metaMap->put('is-variadic', $initNode->isVariadic());
             $maxArity = $initNode->getMaxArity();
             $metaMap = $metaMap->put('max-arity', $maxArity === null ? null : max(0, $maxArity - $skip));
-            $metaMap = $metaMap->put('arglists', $this->buildMultiFnNodeArglists($initNode, $skip));
+            $metaMap = $metaMap->put('arglists', new DefArglistBuilder()->buildMultiFnNodeArglists($initNode, $skip));
         }
 
         $metaMap = $this->persistInferredReturnTag($metaMap, $this->inferredReturnTypeOf($initNode));
@@ -321,11 +321,6 @@ final readonly class DefSymbol implements SpecialFormAnalyzerInterface
         return (bool) $meta[Keyword::create('memoize-lru')];
     }
 
-    private function buildFnNodeArglist(FnNode $fnNode, int $skipFirst = 0): string
-    {
-        return $this->formatParamsVector($fnNode->getParams(), $fnNode->isVariadic(), $skipFirst);
-    }
-
     /**
      * Inferred return type writes back to the def's runtime meta as `:tag`
      * so cross-fn inference can see it on the next call site without
@@ -495,240 +490,5 @@ final readonly class DefSymbol implements SpecialFormAnalyzerInterface
         }
 
         return $params;
-    }
-
-    private function buildMultiFnNodeArglists(MultiFnNode $multiFnNode, int $skipFirst = 0): string
-    {
-        $vectors = [];
-        foreach ($multiFnNode->getFnNodes() as $fnNode) {
-            $vectors[] = $this->formatParamsVector($fnNode->getParams(), $fnNode->isVariadic(), $skipFirst);
-        }
-
-        return '(' . implode(' ', $vectors) . ')';
-    }
-
-    /**
-     * @param list<Symbol> $params
-     */
-    private function formatParamsVector(array $params, bool $isVariadic, int $skipFirst = 0): string
-    {
-        if ($skipFirst > 0) {
-            $params = array_slice($params, $skipFirst);
-        }
-
-        $names = array_map(
-            static fn(Symbol $s): string => $s->getName(),
-            $params,
-        );
-
-        if ($isVariadic && $names !== []) {
-            $restParam = array_pop($names);
-            $names[] = '&';
-            $names[] = $restParam;
-        }
-
-        return '[' . implode(' ', $names) . ']';
-    }
-
-    /**
-     * Rewrites a `(fn ...)` init expression to prepend `&form` and `&env` to each arity's
-     * parameter vector. Supports both single-arity and multi-arity fn forms. Returns the
-     * init unchanged if it is not a `(fn ...)` list or if the implicit params are already
-     * present (idempotent / Clojure-style shadowing).
-     */
-    private function injectMacroImplicitParams(mixed $init): mixed
-    {
-        if (!$init instanceof PersistentListInterface) {
-            return $init;
-        }
-
-        $head = $init->first();
-        if (!$head instanceof Symbol || $head->getName() !== Symbol::NAME_FN) {
-            return $init;
-        }
-
-        $second = $init->get(1);
-        if ($second instanceof PersistentVectorInterface) {
-            return $this->rewriteSingleArityFn($init);
-        }
-
-        if ($second instanceof PersistentListInterface) {
-            return $this->rewriteMultiArityFn($init);
-        }
-
-        return $init;
-    }
-
-    /**
-     * @param PersistentListInterface<mixed> $fnList
-     *
-     * @return PersistentListInterface<mixed>
-     */
-    private function rewriteSingleArityFn(PersistentListInterface $fnList): PersistentListInterface
-    {
-        $items = $fnList->toArray();
-        /** @var PersistentVectorInterface<mixed> $params */
-        $params = $items[1];
-        $items[1] = $this->prependImplicitParams($params);
-
-        return Phel::list($items)->copyLocationFrom($fnList);
-    }
-
-    /**
-     * @param PersistentListInterface<mixed> $fnList
-     *
-     * @return PersistentListInterface<mixed>
-     */
-    private function rewriteMultiArityFn(PersistentListInterface $fnList): PersistentListInterface
-    {
-        $items = $fnList->toArray();
-        for ($i = 1, $n = count($items); $i < $n; ++$i) {
-            $arity = $items[$i];
-            if (!$arity instanceof PersistentListInterface) {
-                continue;
-            }
-
-            $arityItems = $arity->toArray();
-            if ($arityItems === []) {
-                continue;
-            }
-
-            if (!$arityItems[0] instanceof PersistentVectorInterface) {
-                continue;
-            }
-
-            $arityItems[0] = $this->prependImplicitParams($arityItems[0]);
-            $items[$i] = Phel::list($arityItems)->copyLocationFrom($arity);
-        }
-
-        return Phel::list($items)->copyLocationFrom($fnList);
-    }
-
-    /**
-     * When the def's metadata carries `:tag` (typically from the name symbol,
-     * e.g. `(defn ^int add [x y] ...)`), splice that tag onto each fn arity's
-     * param vector so `FnSymbol` can pick it up as the compiled signature's
-     * return type. Skips arities that already declare their own vector `:tag`
-     * (more local declaration wins).
-     *
-     * @param PersistentMapInterface<mixed, mixed> $meta
-     */
-    private function injectReturnTypeFromMeta(mixed $init, PersistentMapInterface $meta): mixed
-    {
-        $tag = $meta->find(Keyword::create('tag'));
-        if (!($tag instanceof Symbol) && !is_string($tag)) {
-            return $init;
-        }
-
-        if (!$init instanceof PersistentListInterface) {
-            return $init;
-        }
-
-        $head = $init->first();
-        if (!$head instanceof Symbol || $head->getName() !== Symbol::NAME_FN) {
-            return $init;
-        }
-
-        $second = $init->get(1);
-        if ($second instanceof PersistentVectorInterface) {
-            return $this->rewriteSingleArityWithTag($init, $tag);
-        }
-
-        if ($second instanceof PersistentListInterface) {
-            return $this->rewriteMultiArityWithTag($init, $tag);
-        }
-
-        return $init;
-    }
-
-    /**
-     * @param PersistentListInterface<mixed> $fnList
-     *
-     * @return PersistentListInterface<mixed>
-     */
-    private function rewriteSingleArityWithTag(PersistentListInterface $fnList, mixed $tag): PersistentListInterface
-    {
-        $items = $fnList->toArray();
-        /** @var PersistentVectorInterface<mixed> $params */
-        $params = $items[1];
-        $items[1] = $this->withReturnTypeTag($params, $tag);
-
-        return Phel::list($items)->copyLocationFrom($fnList);
-    }
-
-    /**
-     * @param PersistentListInterface<mixed> $fnList
-     *
-     * @return PersistentListInterface<mixed>
-     */
-    private function rewriteMultiArityWithTag(PersistentListInterface $fnList, mixed $tag): PersistentListInterface
-    {
-        $items = $fnList->toArray();
-        for ($i = 1, $n = count($items); $i < $n; ++$i) {
-            $arity = $items[$i];
-            if (!$arity instanceof PersistentListInterface) {
-                continue;
-            }
-
-            $arityItems = $arity->toArray();
-            if ($arityItems === []) {
-                continue;
-            }
-
-            if (!$arityItems[0] instanceof PersistentVectorInterface) {
-                continue;
-            }
-
-            $arityItems[0] = $this->withReturnTypeTag($arityItems[0], $tag);
-            $items[$i] = Phel::list($arityItems)->copyLocationFrom($arity);
-        }
-
-        return Phel::list($items)->copyLocationFrom($fnList);
-    }
-
-    /**
-     * @param PersistentVectorInterface<mixed> $params
-     *
-     * @return PersistentVectorInterface<mixed>
-     */
-    private function withReturnTypeTag(PersistentVectorInterface $params, mixed $tag): PersistentVectorInterface
-    {
-        $existing = $params->getMeta();
-        if ($existing instanceof PersistentMapInterface
-            && $existing->find(Keyword::create('tag')) !== null
-        ) {
-            return $params;
-        }
-
-        $merged = ($existing ?? Phel::map())->put(Keyword::create('tag'), $tag);
-
-        return $params->withMeta($merged);
-    }
-
-    /**
-     * @param PersistentVectorInterface<mixed> $params
-     *
-     * @return PersistentVectorInterface<mixed>
-     */
-    private function prependImplicitParams(PersistentVectorInterface $params): PersistentVectorInterface
-    {
-        // Idempotency / shadowing guard: if the first two params are already `&form` and `&env`,
-        // leave the vector untouched so users can explicitly shadow.
-        if (count($params) >= 2) {
-            $first = $params->get(0);
-            $second = $params->get(1);
-            if (
-                $first instanceof Symbol && $first->getName() === '&form'
-                && $second instanceof Symbol && $second->getName() === '&env'
-            ) {
-                return $params;
-            }
-        }
-
-        $formSymbol = Symbol::create('&form')->copyLocationFrom($params);
-        $envSymbol = Symbol::create('&env')->copyLocationFrom($params);
-
-        return Phel::vector([$formSymbol, $envSymbol, ...$params->toArray()])
-            ->copyLocationFrom($params);
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/MacroFormRewriter.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/MacroFormRewriter.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+
+use function count;
+use function is_string;
+
+/**
+ * Rewrites a `def`'s `(fn ...)` init expression before analysis. Two
+ * transforms share the same single-/multi-arity dispatch:
+ *
+ *   - {@see self::injectImplicitParams()} prepends `&form`/`&env` to each
+ *     arity's param vector for macro defs.
+ *   - {@see self::injectReturnTypeFromMeta()} splices the def's `:tag`
+ *     (e.g. `(defn ^int add [x y] ...)`) onto each arity's param vector so
+ *     `FnSymbol` picks it up as the compiled signature's return type.
+ *
+ * Both are idempotent / Clojure-style: a vector that already declares the
+ * implicit params or its own `:tag` is left untouched (more local wins).
+ */
+final readonly class MacroFormRewriter
+{
+    /**
+     * Prepends `&form` and `&env` to each arity's parameter vector.
+     * Supports single-arity and multi-arity fn forms. Returns the init
+     * unchanged if it is not a `(fn ...)` list or if the implicit params
+     * are already present.
+     */
+    public function injectImplicitParams(mixed $init): mixed
+    {
+        return $this->rewriteFnParamVectors($init, $this->prependImplicitParams(...));
+    }
+
+    /**
+     * When the def's metadata carries `:tag`, splices that tag onto each
+     * fn arity's param vector. Skips arities that already declare their
+     * own vector `:tag`.
+     *
+     * @param PersistentMapInterface<mixed, mixed> $meta
+     */
+    public function injectReturnTypeFromMeta(mixed $init, PersistentMapInterface $meta): mixed
+    {
+        $tag = $meta->find(Keyword::create('tag'));
+        if (!($tag instanceof Symbol) && !is_string($tag)) {
+            return $init;
+        }
+
+        return $this->rewriteFnParamVectors(
+            $init,
+            fn(PersistentVectorInterface $params): PersistentVectorInterface => $this->withReturnTypeTag($params, $tag),
+        );
+    }
+
+    /**
+     * Dispatches a `(fn ...)` init to the single- or multi-arity rewriter,
+     * applying `$transform` to each arity's leading param vector. Returns
+     * the init unchanged when it is not a `(fn ...)` list.
+     *
+     * @param callable(PersistentVectorInterface<mixed>): PersistentVectorInterface<mixed> $transform
+     */
+    private function rewriteFnParamVectors(mixed $init, callable $transform): mixed
+    {
+        if (!$init instanceof PersistentListInterface) {
+            return $init;
+        }
+
+        $head = $init->first();
+        if (!$head instanceof Symbol || $head->getName() !== Symbol::NAME_FN) {
+            return $init;
+        }
+
+        $second = $init->get(1);
+        if ($second instanceof PersistentVectorInterface) {
+            return $this->rewriteSingleArity($init, $transform);
+        }
+
+        if ($second instanceof PersistentListInterface) {
+            return $this->rewriteMultiArity($init, $transform);
+        }
+
+        return $init;
+    }
+
+    /**
+     * @param PersistentListInterface<mixed>                                               $fnList
+     * @param callable(PersistentVectorInterface<mixed>): PersistentVectorInterface<mixed> $transform
+     *
+     * @return PersistentListInterface<mixed>
+     */
+    private function rewriteSingleArity(PersistentListInterface $fnList, callable $transform): PersistentListInterface
+    {
+        $items = $fnList->toArray();
+        /** @var PersistentVectorInterface<mixed> $params */
+        $params = $items[1];
+        $items[1] = $transform($params);
+
+        return Phel::list($items)->copyLocationFrom($fnList);
+    }
+
+    /**
+     * @param PersistentListInterface<mixed>                                               $fnList
+     * @param callable(PersistentVectorInterface<mixed>): PersistentVectorInterface<mixed> $transform
+     *
+     * @return PersistentListInterface<mixed>
+     */
+    private function rewriteMultiArity(PersistentListInterface $fnList, callable $transform): PersistentListInterface
+    {
+        $items = $fnList->toArray();
+        for ($i = 1, $n = count($items); $i < $n; ++$i) {
+            $arity = $items[$i];
+            if (!$arity instanceof PersistentListInterface) {
+                continue;
+            }
+
+            $arityItems = $arity->toArray();
+            if ($arityItems === []) {
+                continue;
+            }
+
+            if (!$arityItems[0] instanceof PersistentVectorInterface) {
+                continue;
+            }
+
+            $arityItems[0] = $transform($arityItems[0]);
+            $items[$i] = Phel::list($arityItems)->copyLocationFrom($arity);
+        }
+
+        return Phel::list($items)->copyLocationFrom($fnList);
+    }
+
+    /**
+     * @param PersistentVectorInterface<mixed> $params
+     *
+     * @return PersistentVectorInterface<mixed>
+     */
+    private function withReturnTypeTag(PersistentVectorInterface $params, mixed $tag): PersistentVectorInterface
+    {
+        $existing = $params->getMeta();
+        if ($existing instanceof PersistentMapInterface
+            && $existing->find(Keyword::create('tag')) !== null
+        ) {
+            return $params;
+        }
+
+        $merged = ($existing ?? Phel::map())->put(Keyword::create('tag'), $tag);
+
+        return $params->withMeta($merged);
+    }
+
+    /**
+     * @param PersistentVectorInterface<mixed> $params
+     *
+     * @return PersistentVectorInterface<mixed>
+     */
+    private function prependImplicitParams(PersistentVectorInterface $params): PersistentVectorInterface
+    {
+        // Idempotency / shadowing guard: if the first two params are already `&form` and `&env`,
+        // leave the vector untouched so users can explicitly shadow.
+        if (count($params) >= 2) {
+            $first = $params->get(0);
+            $second = $params->get(1);
+            if (
+                $first instanceof Symbol && $first->getName() === '&form'
+                && $second instanceof Symbol && $second->getName() === '&env'
+            ) {
+                return $params;
+            }
+        }
+
+        $formSymbol = Symbol::create('&form')->copyLocationFrom($params);
+        $envSymbol = Symbol::create('&env')->copyLocationFrom($params);
+
+        return Phel::vector([$formSymbol, $envSymbol, ...$params->toArray()])
+            ->copyLocationFrom($params);
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
@@ -11,24 +11,14 @@ use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
-use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\RecurNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ThrowNode;
-use Phel\Lang\Collections\Vector\PersistentVectorInterface;
-use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Shared\CompilerConstants;
 
 use function array_unique;
 use function count;
-use function in_array;
-use function is_float;
-use function is_int;
-use function is_object;
-use function is_string;
-use function strlen;
 
 /**
  * Walks a fn body to surface conservative param-type contracts. Results
@@ -46,152 +36,12 @@ use function strlen;
  *   - disagreeing observations across branches (e.g. compared to int and
  *     concatenated as string)
  *
- * Three cross-fn propagation channels extend the basic primitive-op
- * inference:
- *   - callee `:param-tags` (Step 1): when the call target's params are
- *     already tagged with a pure primitive, the matching call-site args
- *     inherit that tag.
- *   - PHP host signature table (Step 2): a curated allowlist of stdlib
- *     functions whose arg types are stable across versions.
- *   - expected-type back-pressure (Step 3): a tag flowing in from a
- *     callee or signature table can push down into nested numeric ops,
- *     so `(php/random_int 0 (php/- hi lo))` flows int into `hi`/`lo`.
- *   - `:int-stable` core fns (Step 4): an allowlist of `phel.core`
- *     arithmetic fns that, given an `int` expectation from above, behave
- *     like a numeric op for the purposes of propagation.
+ * Call-shape classification (which ops constrain, which guard, which carry
+ * cross-fn `:param-tags`) lives in {@see CallTypeExpectationResolver}; this
+ * class owns the walk and its mutable observation state.
  */
 final class ParamTypeInferrer
 {
-    /** @var list<string> */
-    private const array NUMERIC_OPS = [
-        '+', '-', '*', '/', '%', '**', '<<', '>>', '|', '&', '^',
-    ];
-
-    private const string STRING_CONCAT_OP = '.';
-
-    /** @var list<string> */
-    private const array IDENTITY_OPS = ['===', '!==', '==', '!='];
-
-    /** @var list<string> */
-    private const array ORDERING_OPS = ['<', '>', '<=', '>=', '<=>'];
-
-    /**
-     * Tags that translate directly to a single PHP scalar and therefore
-     * survive being grafted onto a param without losing valid runtime
-     * inputs. Nullable (`?int`), union (`int|null`), and FQN tags are
-     * deliberately excluded: tightening them to bare `int` rejects
-     * callers that the callee already accepts.
-     *
-     * @var list<string>
-     */
-    private const array PURE_PRIMITIVE_TAGS = ['int', 'float', 'string', 'bool', 'array'];
-
-    /**
-     * Curated allowlist of PHP stdlib fns whose arg types are stable
-     * across supported versions. Each entry's value lists the scalar tag
-     * inferred per positional arg (use `null` to skip a slot). Unions
-     * and nullable types stay out so the inferrer never tightens a slot
-     * the runtime accepts more loosely.
-     *
-     * @var array<string, list<?string>>
-     */
-    private const array PHP_FN_SIGNATURES = [
-        'random_int' => ['int', 'int'],
-        'intdiv' => ['int', 'int'],
-        'strlen' => ['string'],
-        'mb_strlen' => ['string'],
-        'str_repeat' => ['string', 'int'],
-        'count' => ['array'],
-    ];
-
-    /**
-     * `phel.core` arithmetic fns whose return is `int` when every arg
-     * is `int`. The inferrer treats them as conditional numeric ops:
-     * propagation only fires when an `int` expectation flows in from
-     * above. Without that expectation we leave the runtime contract
-     * permissive so `BigInt` / `Ratio` polymorphism keeps
-     * working at the call site.
-     *
-     * @var list<string>
-     */
-    private const array INT_STABLE_CORE_FNS = ['+', '-', '*', 'inc', 'dec'];
-
-    /**
-     * `phel.core` arithmetic wrappers whose dispatch reduces to a PHP
-     * numeric op only when a literal sibling proves the operand is
-     * `float`. An `int` literal stays ambiguous (it coerces to float
-     * inside the runtime defn when the LocalVar is float at the call
-     * site), so the wrapper observer only commits when the literal is
-     * unambiguously float. `php/+`, `php/-` keep their own int
-     * inference path because the user reached for the PHP-native op
-     * directly.
-     *
-     * @var list<string>
-     */
-    private const array NUMERIC_CORE_OBSERVERS = ['+', '-', '*', 'inc', 'dec'];
-
-    /**
-     * `phel.core` ordering wrappers. Each one reduces to the matching
-     * `php/<`, `php/<=`, ... when no `BigInt` / `Ratio` shows up at
-     * runtime, so the ordering walker can lift a numeric tag the same
-     * way it does for the PHP-native op.
-     *
-     * @var list<string>
-     */
-    private const array ORDERING_CORE_OBSERVERS = ['<', '<=', '>', '>=', '<=>'];
-
-    /**
-     * Static fallback for `phel.core` callees whose compile-time
-     * `:param-tags` channel is not available (the runtime registry is
-     * populated from a precompiled cache, so the analyzer never sees
-     * the sub-namespaces' defns and the `:param-tags` vector stays
-     * empty). The mapping mirrors the strict slot-by-slot
-     * primitive-tag contract that the runtime fn already enforces.
-     *
-     * @var array<string, list<?string>>
-     */
-    private const array CORE_FN_SIGNATURES = [
-        'rand-int' => ['int'],
-    ];
-
-    /**
-     * Globals that signal "the function defensively rejects bad inputs at
-     * runtime". A param threaded through any of these escapes inference
-     * even when later used by a primitive op, so deliberate negative tests
-     * (e.g. `(bit-and nil 1)` against an `assert-non-nil` guard) keep
-     * compiling and reach the runtime guard.
-     *
-     * @var list<string>
-     */
-    private const array GUARD_GLOBALS = [
-        'assert-non-nil',
-        'assert',
-    ];
-
-    /**
-     * PHP type predicates used as type-discriminating guards. When a
-     * param is fed to one of these, the user is admitting the value
-     * could be of multiple types, so the runtime contract must stay
-     * permissive even if a sibling branch concatenates or arithmetic's
-     * the same param.
-     *
-     * @var list<string>
-     */
-    private const array GUARD_PHP_FNS = [
-        'is_int', 'is_integer', 'is_long',
-        'is_float', 'is_double',
-        'is_string',
-        'is_bool',
-        'is_null',
-        'is_array',
-        'is_object',
-        'is_callable',
-        'is_numeric',
-        'is_iterable',
-        'is_countable',
-        'is_scalar',
-    ];
-
     /** @var array<string, list<string>> */
     private array $observations = [];
 
@@ -204,6 +54,10 @@ final class ParamTypeInferrer
     private ?string $selfNamespace = null;
 
     private ?string $selfName = null;
+
+    public function __construct(
+        private readonly CallTypeExpectationResolver $resolver = new CallTypeExpectationResolver(),
+    ) {}
 
     /**
      * `$selfNamespace` / `$selfName` short-circuit cross-fn propagation
@@ -332,7 +186,7 @@ final class ParamTypeInferrer
         // fn-position itself from acting as a constraint source.
         $this->walk($fn);
 
-        if ($fn instanceof GlobalVarNode && $this->isGuardGlobal($fn)) {
+        if ($fn instanceof GlobalVarNode && $this->resolver->isGuardGlobal($fn)) {
             $this->walkArgsAsGuarded($node);
             return;
         }
@@ -357,33 +211,34 @@ final class ParamTypeInferrer
     {
         $op = $fn->getName();
 
-        if (in_array($op, self::GUARD_PHP_FNS, true)) {
+        if ($this->resolver->isGuardPhpFn($op)) {
             $this->walkArgsAsGuarded($node);
             return;
         }
 
-        if ($op === self::STRING_CONCAT_OP) {
+        if ($this->resolver->isStringConcatOp($op)) {
             $this->walkArgsExpecting($node, 'string');
             return;
         }
 
-        if (in_array($op, self::NUMERIC_OPS, true)) {
+        if ($this->resolver->isNumericOp($op)) {
             $this->walkNumericCall($node, $expected);
             return;
         }
 
-        if (in_array($op, self::IDENTITY_OPS, true)) {
+        if ($this->resolver->isIdentityOp($op)) {
             $this->walkIdentityCall($node);
             return;
         }
 
-        if (in_array($op, self::ORDERING_OPS, true)) {
+        if ($this->resolver->isOrderingOp($op)) {
             $this->walkOrderingCall($node);
             return;
         }
 
-        if (isset(self::PHP_FN_SIGNATURES[$op])) {
-            $this->walkArgsBySignature($node, self::PHP_FN_SIGNATURES[$op]);
+        $signature = $this->resolver->phpFnSignature($op);
+        if ($signature !== null) {
+            $this->walkArgsBySignature($node, $signature);
             return;
         }
 
@@ -401,53 +256,29 @@ final class ParamTypeInferrer
         }
 
         if ($expected === 'int'
-            && $this->isIntStableCoreFn($fn)
-            && !$this->hasNonIntLiteralArg($node)
+            && $this->resolver->isIntStableCoreFn($fn)
+            && !$this->resolver->hasNonIntLiteralArg($node)
         ) {
             $this->walkArgsExpecting($node, 'int');
             return;
         }
 
-        if ($this->isCoreNumericObserver($fn) && !$this->hasNumericObjectLiteralArg($node)) {
+        if ($this->resolver->isCoreNumericObserver($fn) && !$this->resolver->hasNumericObjectLiteralArg($node)) {
             $this->walkCoreNumericCall($node, $expected);
             return;
         }
 
-        if ($this->isCoreOrderingObserver($fn) && !$this->hasNumericObjectLiteralArg($node)) {
+        if ($this->resolver->isCoreOrderingObserver($fn) && !$this->resolver->hasNumericObjectLiteralArg($node)) {
             $this->walkCoreNumericCall($node, $expected);
             return;
         }
 
-        if ($this->isCoreEqualityObserver($fn)) {
+        if ($this->resolver->isCoreEqualityObserver($fn)) {
             $this->walkIdentityCall($node);
             return;
         }
 
-        $this->walkArgsBySignature($node, $this->calleeParamExpectations($fn));
-    }
-
-    private function isCoreNumericObserver(GlobalVarNode $fn): bool
-    {
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
-            return false;
-        }
-
-        return in_array($fn->getName()->getName(), self::NUMERIC_CORE_OBSERVERS, true);
-    }
-
-    private function isCoreOrderingObserver(GlobalVarNode $fn): bool
-    {
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
-            return false;
-        }
-
-        return in_array($fn->getName()->getName(), self::ORDERING_CORE_OBSERVERS, true);
-    }
-
-    private function isCoreEqualityObserver(GlobalVarNode $fn): bool
-    {
-        return $fn->getNamespace() === CompilerConstants::PHEL_CORE_NAMESPACE
-            && $fn->getName()->getName() === '=';
+        $this->walkArgsBySignature($node, $this->resolver->calleeParamExpectations($fn));
     }
 
     /**
@@ -463,7 +294,7 @@ final class ParamTypeInferrer
      */
     private function walkCoreNumericCall(CallNode $node, ?string $expected = null): void
     {
-        $type = $this->literalNumericType($node->getArguments());
+        $type = $this->resolver->literalNumericType($node->getArguments());
 
         if ($type === 'float') {
             $this->walkArgsExpecting($node, 'float');
@@ -478,66 +309,12 @@ final class ParamTypeInferrer
         $this->walkArgsExpecting($node, null);
     }
 
-    /**
-     * `BigInt`, `Ratio`, `BigDecimal` literals route through
-     * `NumericOperations` at runtime; the int / float observer path
-     * must skip the call so the inferrer never narrows a param that
-     * a numeric-object literal disambiguates as polymorphic. Unlike
-     * {@see self::hasNonIntLiteralArg()}, a float literal is treated
-     * as a valid numeric signal here, not as noise.
-     */
-    private function hasNumericObjectLiteralArg(CallNode $node): bool
-    {
-        return array_any(
-            $node->getArguments(),
-            static fn(AbstractNode $arg): bool => $arg instanceof LiteralNode
-                && is_object($arg->getValue()),
-        );
-    }
-
     private function isSelfReference(GlobalVarNode $fn): bool
     {
         return $this->selfNamespace !== null
             && $this->selfName !== null
             && $fn->getNamespace() === $this->selfNamespace
             && $fn->getName()->getName() === $this->selfName;
-    }
-
-    /**
-     * Builds a per-slot list of expected pure-primitive tags for the
-     * callee. Compile-time `:param-tags` win; if that channel is empty
-     * (e.g. core sub-namespaces loaded from a precompiled cache that
-     * the analyzer never sees), `phel.core` fns fall back to the
-     * `CORE_FN_SIGNATURES` allowlist so cross-namespace inference can
-     * still propagate.
-     *
-     * @return list<?string>
-     */
-    private function calleeParamExpectations(GlobalVarNode $fn): array
-    {
-        $paramTags = $fn->getMeta()->find(Keyword::create('param-tags'));
-        if ($paramTags instanceof PersistentVectorInterface && count($paramTags) > 0) {
-            $expectations = [];
-            $hasPrimitive = false;
-            foreach ($paramTags as $tag) {
-                if (is_string($tag) && in_array($tag, self::PURE_PRIMITIVE_TAGS, true)) {
-                    $expectations[] = $tag;
-                    $hasPrimitive = true;
-                } else {
-                    $expectations[] = null;
-                }
-            }
-
-            if ($hasPrimitive) {
-                return $expectations;
-            }
-        }
-
-        if ($fn->getNamespace() === CompilerConstants::PHEL_CORE_NAMESPACE) {
-            return self::CORE_FN_SIGNATURES[$fn->getName()->getName()] ?? [];
-        }
-
-        return [];
     }
 
     /**
@@ -551,23 +328,12 @@ final class ParamTypeInferrer
      */
     private function walkIdentityCall(CallNode $node): void
     {
-        $hasNullableLiteral = array_any(
-            $node->getArguments(),
-            static fn(AbstractNode $a): bool => $a instanceof LiteralNode
-                && self::isNullableLiteral($a->getValue()),
-        );
-
-        if ($hasNullableLiteral) {
+        if ($this->resolver->hasNullableLiteralArg($node)) {
             $this->walkArgsAsGuarded($node);
             return;
         }
 
         $this->walkArgsExpecting($node, null);
-    }
-
-    private static function isNullableLiteral(mixed $value): bool
-    {
-        return in_array($value, [null, true, false], true);
     }
 
     /**
@@ -580,41 +346,8 @@ final class ParamTypeInferrer
      */
     private function walkOrderingCall(CallNode $node): void
     {
-        $type = $this->literalNumericType($node->getArguments());
+        $type = $this->resolver->literalNumericType($node->getArguments());
         $this->walkArgsExpecting($node, $type);
-    }
-
-    /**
-     * Reads a numeric type hint from the literal args of a call: `float`
-     * if any literal is float, `int` if any literal is int and none are
-     * float, otherwise `null`. Both `walkNumericCall` and
-     * `walkOrderingCall` need this so they only constrain a param when
-     * the call actually disambiguates the runtime type.
-     *
-     * @param list<AbstractNode> $args
-     */
-    private function literalNumericType(array $args): ?string
-    {
-        $hasFloat = false;
-        $hasInt = false;
-        foreach ($args as $arg) {
-            if (!$arg instanceof LiteralNode) {
-                continue;
-            }
-
-            $value = $arg->getValue();
-            if (is_float($value)) {
-                $hasFloat = true;
-            } elseif (is_int($value)) {
-                $hasInt = true;
-            }
-        }
-
-        if ($hasFloat) {
-            return 'float';
-        }
-
-        return $hasInt ? 'int' : null;
     }
 
     /**
@@ -628,7 +361,7 @@ final class ParamTypeInferrer
      */
     private function walkNumericCall(CallNode $node, ?string $expected = null): void
     {
-        $type = $this->literalNumericType($node->getArguments());
+        $type = $this->resolver->literalNumericType($node->getArguments());
         if ($type === null && ($expected === 'int' || $expected === 'float')) {
             $type = $expected;
         }
@@ -692,55 +425,5 @@ final class ParamTypeInferrer
 
         $name = $arg->getName()->getName();
         return isset($this->params[$name]) ? $name : null;
-    }
-
-    private function isGuardGlobal(GlobalVarNode $fn): bool
-    {
-        $name = $fn->getName()->getName();
-        if (in_array($name, self::GUARD_GLOBALS, true)) {
-            return true;
-        }
-
-        // Phel convention: predicate names end in `?`. Calling one on a
-        // param signals "this value can be of multiple types, I'm
-        // type-discriminating" (same intent as the explicit `assert*`
-        // guards), so mark the arg guarded.
-        return $name !== '' && $name[strlen($name) - 1] === '?';
-    }
-
-    /**
-     * Detects literal args that the int-stable core fns explicitly
-     * accept via runtime polymorphism (`BigInt`, `Ratio`,
-     * `BigDecimal`, floats). Their presence signals that the caller
-     * is deliberately routing through `NumericOperations`, so the
-     * sibling param's runtime contract must stay permissive even when
-     * an `int` expectation flows in from above.
-     */
-    private function hasNonIntLiteralArg(CallNode $node): bool
-    {
-        return array_any(
-            $node->getArguments(),
-            static function (AbstractNode $arg): bool {
-                if (!$arg instanceof LiteralNode) {
-                    return false;
-                }
-
-                $value = $arg->getValue();
-                if (is_int($value)) {
-                    return false;
-                }
-
-                return is_float($value) || is_object($value);
-            },
-        );
-    }
-
-    private function isIntStableCoreFn(GlobalVarNode $fn): bool
-    {
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
-            return false;
-        }
-
-        return in_array($fn->getName()->getName(), self::INT_STABLE_CORE_FNS, true);
     }
 }

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -6,16 +6,12 @@ namespace Phel\Run\Infrastructure\Command;
 
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
-use InvalidArgumentException;
-use Phel\Lang\ProfilerHookInterface;
-use Phel\Lang\Registry;
 use Phel\Run\Domain\Test\TestCommandOptions;
 use Phel\Run\Domain\Test\TestNamespacePruner;
 use Phel\Run\RunFacade;
 use Phel\Shared\CompileOptions;
 use Phel\Shared\Exceptions\CompilerException;
 use Phel\Shared\NamespaceInformation;
-use Phel\Shared\PhelProjectDirectory;
 use Phel\Shared\ResourceUsageFormatter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -25,12 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 use function count;
-use function getcwd;
-use function in_array;
-use function is_numeric;
-use function is_string;
 use function sprintf;
-use function strtolower;
 
 /**
  * @method RunFacade getFacade()
@@ -42,42 +33,6 @@ final class TestCommand extends Command
 
     public const string COMMAND_NAME = 'test';
 
-    private const string ARG_PATHS = 'paths';
-
-    private const string OPT_FILTER = 'filter';
-
-    private const string OPT_TESTDOX = 'testdox';
-
-    private const string OPT_FAIL_FAST = 'fail-fast';
-
-    private const string OPT_STACK_TRACE = 'stack-trace';
-
-    private const string OPT_REPORTER = 'reporter';
-
-    private const string OPT_OUTPUT = 'output';
-
-    private const string OPT_INCLUDE = 'include';
-
-    private const string OPT_EXCLUDE = 'exclude';
-
-    private const string OPT_NS = 'ns';
-
-    private const string OPT_LIST = 'list';
-
-    private const string OPT_LAST_FAILED = 'last-failed';
-
-    private const string OPT_SLOWEST = 'slowest';
-
-    private const string OPT_REPEAT = 'repeat';
-
-    private const string OPT_SEED = 'seed';
-
-    private const string OPT_RANDOM_ORDER = 'random-order';
-
-    private const string OPT_PARALLEL = 'parallel';
-
-    private const string LAST_FAILED_FILENAME = 'last-failed.txt';
-
     protected function configure(): void
     {
         $this->setName(self::COMMAND_NAME)
@@ -85,94 +40,94 @@ final class TestCommand extends Command
                 'Tests the given files. If no filenames are provided all tests in the "tests" directory are executed',
             )
             ->addArgument(
-                self::ARG_PATHS,
+                TestCommandOptionParser::ARG_PATHS,
                 InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
                 'The file paths that you want to test.',
                 [],
             )->addOption(
-                self::OPT_FILTER,
+                TestCommandOptionParser::OPT_FILTER,
                 'f',
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 "Regex or substring matched against test names. Repeatable; matches are OR'd.",
                 [],
             )->addOption(
-                self::OPT_TESTDOX,
+                TestCommandOptionParser::OPT_TESTDOX,
                 null,
                 InputOption::VALUE_NONE,
                 'Report test execution progress in TestDox format. Shortcut for --reporter=testdox.',
             )->addOption(
-                self::OPT_FAIL_FAST,
+                TestCommandOptionParser::OPT_FAIL_FAST,
                 null,
                 InputOption::VALUE_NONE,
                 'Stop running tests after the first failure or error.',
             )->addOption(
-                self::OPT_STACK_TRACE,
+                TestCommandOptionParser::OPT_STACK_TRACE,
                 null,
                 InputOption::VALUE_NONE,
                 'Print the full PHP stack trace for each errored test.',
             )->addOption(
-                self::OPT_REPORTER,
+                TestCommandOptionParser::OPT_REPORTER,
                 null,
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Reporter to emit test events through. Repeatable. Built-ins: default, testdox, dot, tap, junit-xml.',
                 [],
             )->addOption(
-                self::OPT_OUTPUT,
+                TestCommandOptionParser::OPT_OUTPUT,
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Write the junit-xml reporter to a file instead of stdout.',
             )->addOption(
-                self::OPT_INCLUDE,
+                TestCommandOptionParser::OPT_INCLUDE,
                 null,
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 "Tag name (e.g. integration). Only tests carrying this tag run. Repeatable; tags are OR'd.",
                 [],
             )->addOption(
-                self::OPT_EXCLUDE,
+                TestCommandOptionParser::OPT_EXCLUDE,
                 null,
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Tag name (e.g. slow). Tests carrying this tag are skipped. Repeatable; wins over --include.',
                 [],
             )->addOption(
-                self::OPT_NS,
+                TestCommandOptionParser::OPT_NS,
                 null,
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 "Namespace glob (e.g. phel.http.*). Repeatable; globs are OR'd. `*` matches one segment, `**` any.",
                 [],
             )->addOption(
-                self::OPT_LIST,
+                TestCommandOptionParser::OPT_LIST,
                 null,
                 InputOption::VALUE_NONE,
                 'List discovered tests after applying filters/selectors. Does not run them.',
             )->addOption(
-                self::OPT_LAST_FAILED,
+                TestCommandOptionParser::OPT_LAST_FAILED,
                 null,
                 InputOption::VALUE_NONE,
                 'Re-run only tests that failed on the previous run. Reads `<phel-dir>/last-failed.txt` from the current project. Combine with --repeat to hammer flaky tests.',
             )->addOption(
-                self::OPT_SLOWEST,
+                TestCommandOptionParser::OPT_SLOWEST,
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Print the N slowest tests after the summary. 0 disables.',
                 0,
             )->addOption(
-                self::OPT_REPEAT,
+                TestCommandOptionParser::OPT_REPEAT,
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Run the selected tests N times in a row. Useful for catching flaky tests. Must be >= 1.',
                 1,
             )->addOption(
-                self::OPT_SEED,
+                TestCommandOptionParser::OPT_SEED,
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Integer seed for the test-order RNG. Printed at the start of every randomized run so failures can be reproduced.',
             )->addOption(
-                self::OPT_RANDOM_ORDER,
+                TestCommandOptionParser::OPT_RANDOM_ORDER,
                 null,
                 InputOption::VALUE_NONE,
                 'Shuffle the order of tests within each namespace. Uses --seed when provided, otherwise picks a fresh random seed.',
             )->addOption(
-                self::OPT_PARALLEL,
+                TestCommandOptionParser::OPT_PARALLEL,
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Run namespaces in parallel using subprocess workers. Accepts an integer worker count, "auto" (CPU detection capped at 8), or "max" (every core the kernel reports, uncapped). Auto-disabled for --reporter=tap, --list, or when a profiler hook is installed.',
@@ -181,13 +136,15 @@ final class TestCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $optionParser = new TestCommandOptionParser();
+
         try {
             /** @var list<string> $paths */
-            $paths = (array) $input->getArgument(self::ARG_PATHS);
+            $paths = (array) $input->getArgument(TestCommandOptionParser::ARG_PATHS);
             $namespacesInformation = $this->getFacade()->getDependenciesFromPaths($paths);
-            $failFast = (bool) $input->getOption(self::OPT_FAIL_FAST);
+            $failFast = (bool) $input->getOption(TestCommandOptionParser::OPT_FAIL_FAST);
             /** @var list<string> $nsPatterns */
-            $nsPatterns = (array) $input->getOption(self::OPT_NS);
+            $nsPatterns = (array) $input->getOption(TestCommandOptionParser::OPT_NS);
             $namespacesInformation = new TestNamespacePruner()->prune($namespacesInformation, $nsPatterns);
 
             // Suppress output during file loading phase and filter out integration test fixtures
@@ -226,8 +183,12 @@ final class TestCommand extends Command
                 return ($compileErrors === []) ? self::SUCCESS : self::FAILURE;
             }
 
-            $workerCount = $this->decideParallelism($input, $output);
-            $options = $this->collectOptions($input);
+            $workerCount = $optionParser->decideParallelism(
+                $input,
+                $output,
+                $this->getFacade()->createCpuCountDetector(),
+            );
+            $options = $optionParser->collectOptions($input);
 
             if ($workerCount !== null) {
                 $success = $this->getFacade()
@@ -334,175 +295,6 @@ final class TestCommand extends Command
             TestCommandOptions::fromArray($options)->asPhelHashMap(),
             $this->namespacesAsString($namespacesInformation),
         );
-    }
-
-    /**
-     * Returns the parallel worker count, or null when the run must stay
-     * serial. Auto-disable rules:
-     *  - `--parallel` not passed
-     *  - `--parallel=1` (explicit one-worker run)
-     *  - `--reporter=tap` (TAP requires monotonic counter across all tests)
-     *  - `--list` (discovery only, no execution)
-     *  - Registry profiler hook installed (counts run in parent only)
-     */
-    private function decideParallelism(InputInterface $input, OutputInterface $output): ?int
-    {
-        $raw = $input->getOption(self::OPT_PARALLEL);
-        if ($raw === null || $raw === '') {
-            return null;
-        }
-
-        $disabledReason = $this->parallelDisabledReason($input);
-        if ($disabledReason !== null) {
-            if ($output->isVerbose()) {
-                $output->writeln(sprintf('<comment>Ignoring --parallel: %s.</comment>', $disabledReason));
-            }
-
-            return null;
-        }
-
-        if (is_string($raw)) {
-            $keyword = strtolower($raw);
-            if ($keyword === 'auto') {
-                return $this->getFacade()->createCpuCountDetector()->detect();
-            }
-
-            if ($keyword === 'max') {
-                return $this->getFacade()->createCpuCountDetector()->detectMax();
-            }
-        }
-
-        if (!is_numeric($raw)) {
-            throw new InvalidArgumentException(sprintf(
-                '--parallel must be an integer >= 1, "auto", or "max", got %s.',
-                is_string($raw) ? $raw : (string) $raw,
-            ));
-        }
-
-        $value = (int) $raw;
-        if ($value < 1) {
-            throw new InvalidArgumentException('--parallel must be >= 1.');
-        }
-
-        return $value === 1 ? null : $value;
-    }
-
-    private function parallelDisabledReason(InputInterface $input): ?string
-    {
-        if ((bool) $input->getOption(self::OPT_LIST)) {
-            return '--list bypasses execution';
-        }
-
-        /** @var list<string> $reporters */
-        $reporters = (array) $input->getOption(self::OPT_REPORTER);
-        if (in_array('tap', $reporters, true)) {
-            return 'TAP reporter requires a monotonic test counter';
-        }
-
-        if (Registry::$profilerHook instanceof ProfilerHookInterface) {
-            return 'profiler hook only collects counts in the parent process';
-        }
-
-        return null;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function collectOptions(InputInterface $input): array
-    {
-        $output = $input->getOption(self::OPT_OUTPUT);
-        $listOnly = (bool) $input->getOption(self::OPT_LIST);
-        $lastFailed = (bool) $input->getOption(self::OPT_LAST_FAILED);
-
-        $lastFailedFile = $this->lastFailedFilePath();
-
-        if (!$listOnly && $lastFailedFile !== null) {
-            PhelProjectDirectory::ensure((string) getcwd());
-        }
-
-        return [
-            TestCommandOptions::FILTER => null,
-            TestCommandOptions::TESTDOX => (bool) $input->getOption(self::OPT_TESTDOX),
-            TestCommandOptions::FAIL_FAST => (bool) $input->getOption(self::OPT_FAIL_FAST),
-            TestCommandOptions::STACK_TRACE => (bool) $input->getOption(self::OPT_STACK_TRACE),
-            TestCommandOptions::REPORTERS => (array) $input->getOption(self::OPT_REPORTER),
-            TestCommandOptions::JUNIT_OUTPUT => is_string($output) ? $output : null,
-            TestCommandOptions::INCLUDE => (array) $input->getOption(self::OPT_INCLUDE),
-            TestCommandOptions::EXCLUDE => (array) $input->getOption(self::OPT_EXCLUDE),
-            TestCommandOptions::NS_PATTERNS => (array) $input->getOption(self::OPT_NS),
-            TestCommandOptions::FILTERS => (array) $input->getOption(self::OPT_FILTER),
-            TestCommandOptions::LIST_ONLY => $listOnly,
-            TestCommandOptions::ONLY_TESTS => $lastFailed ? $this->readLastFailed() : [],
-            TestCommandOptions::LAST_FAILED_FILE => $listOnly ? null : $lastFailedFile,
-            TestCommandOptions::SLOWEST => (int) $input->getOption(self::OPT_SLOWEST),
-            TestCommandOptions::REPEAT => $this->parseRepeat($input),
-            TestCommandOptions::SEED => $this->parseSeed($input),
-            TestCommandOptions::RANDOM_ORDER => (bool) $input->getOption(self::OPT_RANDOM_ORDER),
-        ];
-    }
-
-    private function lastFailedFilePath(): ?string
-    {
-        $cwd = getcwd();
-        if (!is_string($cwd)) {
-            return null;
-        }
-
-        return PhelProjectDirectory::path($cwd, self::LAST_FAILED_FILENAME);
-    }
-
-    private function parseRepeat(InputInterface $input): int
-    {
-        $raw = $input->getOption(self::OPT_REPEAT);
-        if (!is_numeric($raw) || (int) $raw < 1) {
-            throw new InvalidArgumentException(sprintf(
-                '--repeat must be a positive integer, got %s.',
-                (string) $raw,
-            ));
-        }
-
-        return (int) $raw;
-    }
-
-    private function parseSeed(InputInterface $input): ?int
-    {
-        $raw = $input->getOption(self::OPT_SEED);
-        if ($raw === null || $raw === '') {
-            return null;
-        }
-
-        if (!is_numeric($raw)) {
-            throw new InvalidArgumentException(sprintf('--seed must be an integer, got %s.', (string) $raw));
-        }
-
-        return (int) $raw;
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function readLastFailed(): array
-    {
-        $path = $this->lastFailedFilePath();
-        if ($path === null || !is_file($path)) {
-            return [];
-        }
-
-        $contents = @file_get_contents($path);
-        if (!is_string($contents) || $contents === '') {
-            return [];
-        }
-
-        $entries = [];
-        foreach (preg_split('/\R/', $contents) ?: [] as $line) {
-            $line = trim($line);
-            if ($line !== '') {
-                $entries[] = $line;
-            }
-        }
-
-        return $entries;
     }
 
     /**

--- a/src/php/Run/Infrastructure/Command/TestCommandOptionParser.php
+++ b/src/php/Run/Infrastructure/Command/TestCommandOptionParser.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Infrastructure\Command;
+
+use InvalidArgumentException;
+use Phel\Lang\ProfilerHookInterface;
+use Phel\Lang\Registry;
+use Phel\Run\Application\Test\CpuCountDetector;
+use Phel\Run\Domain\Test\TestCommandOptions;
+use Phel\Shared\PhelProjectDirectory;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function getcwd;
+use function in_array;
+use function is_numeric;
+use function is_string;
+use function sprintf;
+use function strtolower;
+
+/**
+ * Parses and coerces the `test` command's CLI options into the runtime
+ * `$options` array and the parallelism decision. {@see TestCommand} declares
+ * the options (using the constants here) and orchestrates the run; all the
+ * input reading, validation, and coercion lives in this stateless collaborator.
+ */
+final readonly class TestCommandOptionParser
+{
+    public const string ARG_PATHS = 'paths';
+
+    public const string OPT_FILTER = 'filter';
+
+    public const string OPT_TESTDOX = 'testdox';
+
+    public const string OPT_FAIL_FAST = 'fail-fast';
+
+    public const string OPT_STACK_TRACE = 'stack-trace';
+
+    public const string OPT_REPORTER = 'reporter';
+
+    public const string OPT_OUTPUT = 'output';
+
+    public const string OPT_INCLUDE = 'include';
+
+    public const string OPT_EXCLUDE = 'exclude';
+
+    public const string OPT_NS = 'ns';
+
+    public const string OPT_LIST = 'list';
+
+    public const string OPT_LAST_FAILED = 'last-failed';
+
+    public const string OPT_SLOWEST = 'slowest';
+
+    public const string OPT_REPEAT = 'repeat';
+
+    public const string OPT_SEED = 'seed';
+
+    public const string OPT_RANDOM_ORDER = 'random-order';
+
+    public const string OPT_PARALLEL = 'parallel';
+
+    private const string LAST_FAILED_FILENAME = 'last-failed.txt';
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function collectOptions(InputInterface $input): array
+    {
+        $output = $input->getOption(self::OPT_OUTPUT);
+        $listOnly = (bool) $input->getOption(self::OPT_LIST);
+        $lastFailed = (bool) $input->getOption(self::OPT_LAST_FAILED);
+
+        $lastFailedFile = $this->lastFailedFilePath();
+
+        if (!$listOnly && $lastFailedFile !== null) {
+            PhelProjectDirectory::ensure((string) getcwd());
+        }
+
+        return [
+            TestCommandOptions::FILTER => null,
+            TestCommandOptions::TESTDOX => (bool) $input->getOption(self::OPT_TESTDOX),
+            TestCommandOptions::FAIL_FAST => (bool) $input->getOption(self::OPT_FAIL_FAST),
+            TestCommandOptions::STACK_TRACE => (bool) $input->getOption(self::OPT_STACK_TRACE),
+            TestCommandOptions::REPORTERS => (array) $input->getOption(self::OPT_REPORTER),
+            TestCommandOptions::JUNIT_OUTPUT => is_string($output) ? $output : null,
+            TestCommandOptions::INCLUDE => (array) $input->getOption(self::OPT_INCLUDE),
+            TestCommandOptions::EXCLUDE => (array) $input->getOption(self::OPT_EXCLUDE),
+            TestCommandOptions::NS_PATTERNS => (array) $input->getOption(self::OPT_NS),
+            TestCommandOptions::FILTERS => (array) $input->getOption(self::OPT_FILTER),
+            TestCommandOptions::LIST_ONLY => $listOnly,
+            TestCommandOptions::ONLY_TESTS => $lastFailed ? $this->readLastFailed() : [],
+            TestCommandOptions::LAST_FAILED_FILE => $listOnly ? null : $lastFailedFile,
+            TestCommandOptions::SLOWEST => (int) $input->getOption(self::OPT_SLOWEST),
+            TestCommandOptions::REPEAT => $this->parseRepeat($input),
+            TestCommandOptions::SEED => $this->parseSeed($input),
+            TestCommandOptions::RANDOM_ORDER => (bool) $input->getOption(self::OPT_RANDOM_ORDER),
+        ];
+    }
+
+    /**
+     * Returns the parallel worker count, or null when the run must stay
+     * serial. Auto-disable rules:
+     *  - `--parallel` not passed
+     *  - `--parallel=1` (explicit one-worker run)
+     *  - `--reporter=tap` (TAP requires monotonic counter across all tests)
+     *  - `--list` (discovery only, no execution)
+     *  - Registry profiler hook installed (counts run in parent only)
+     */
+    public function decideParallelism(InputInterface $input, OutputInterface $output, CpuCountDetector $detector): ?int
+    {
+        $raw = $input->getOption(self::OPT_PARALLEL);
+        if ($raw === null || $raw === '') {
+            return null;
+        }
+
+        $disabledReason = $this->parallelDisabledReason($input);
+        if ($disabledReason !== null) {
+            if ($output->isVerbose()) {
+                $output->writeln(sprintf('<comment>Ignoring --parallel: %s.</comment>', $disabledReason));
+            }
+
+            return null;
+        }
+
+        if (is_string($raw)) {
+            $keyword = strtolower($raw);
+            if ($keyword === 'auto') {
+                return $detector->detect();
+            }
+
+            if ($keyword === 'max') {
+                return $detector->detectMax();
+            }
+        }
+
+        if (!is_numeric($raw)) {
+            throw new InvalidArgumentException(sprintf(
+                '--parallel must be an integer >= 1, "auto", or "max", got %s.',
+                is_string($raw) ? $raw : (string) $raw,
+            ));
+        }
+
+        $value = (int) $raw;
+        if ($value < 1) {
+            throw new InvalidArgumentException('--parallel must be >= 1.');
+        }
+
+        return $value === 1 ? null : $value;
+    }
+
+    private function parallelDisabledReason(InputInterface $input): ?string
+    {
+        if ((bool) $input->getOption(self::OPT_LIST)) {
+            return '--list bypasses execution';
+        }
+
+        /** @var list<string> $reporters */
+        $reporters = (array) $input->getOption(self::OPT_REPORTER);
+        if (in_array('tap', $reporters, true)) {
+            return 'TAP reporter requires a monotonic test counter';
+        }
+
+        if (Registry::$profilerHook instanceof ProfilerHookInterface) {
+            return 'profiler hook only collects counts in the parent process';
+        }
+
+        return null;
+    }
+
+    private function lastFailedFilePath(): ?string
+    {
+        $cwd = getcwd();
+        if (!is_string($cwd)) {
+            return null;
+        }
+
+        return PhelProjectDirectory::path($cwd, self::LAST_FAILED_FILENAME);
+    }
+
+    private function parseRepeat(InputInterface $input): int
+    {
+        $raw = $input->getOption(self::OPT_REPEAT);
+        if (!is_numeric($raw) || (int) $raw < 1) {
+            throw new InvalidArgumentException(sprintf(
+                '--repeat must be a positive integer, got %s.',
+                (string) $raw,
+            ));
+        }
+
+        return (int) $raw;
+    }
+
+    private function parseSeed(InputInterface $input): ?int
+    {
+        $raw = $input->getOption(self::OPT_SEED);
+        if ($raw === null || $raw === '') {
+            return null;
+        }
+
+        if (!is_numeric($raw)) {
+            throw new InvalidArgumentException(sprintf('--seed must be an integer, got %s.', (string) $raw));
+        }
+
+        return (int) $raw;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readLastFailed(): array
+    {
+        $path = $this->lastFailedFilePath();
+        if ($path === null || !is_file($path)) {
+            return [];
+        }
+
+        $contents = @file_get_contents($path);
+        if (!is_string($contents) || $contents === '') {
+            return [];
+        }
+
+        $entries = [];
+        foreach (preg_split('/\R/', $contents) ?: [] as $line) {
+            $line = trim($line);
+            if ($line !== '') {
+                $entries[] = $line;
+            }
+        }
+
+        return $entries;
+    }
+}

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/CallTypeExpectationResolverTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/CallTypeExpectationResolverTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\CallTypeExpectationResolver;
+use PHPUnit\Framework\TestCase;
+
+final class CallTypeExpectationResolverTest extends TestCase
+{
+    private CallTypeExpectationResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new CallTypeExpectationResolver();
+    }
+
+    public function test_numeric_ops_are_classified(): void
+    {
+        self::assertTrue($this->resolver->isNumericOp('+'));
+        self::assertTrue($this->resolver->isNumericOp('<<'));
+        self::assertFalse($this->resolver->isNumericOp('<'));
+        self::assertFalse($this->resolver->isNumericOp('.'));
+    }
+
+    public function test_string_concat_op_is_classified(): void
+    {
+        self::assertTrue($this->resolver->isStringConcatOp('.'));
+        self::assertFalse($this->resolver->isStringConcatOp('+'));
+    }
+
+    public function test_identity_and_ordering_ops_are_disjoint(): void
+    {
+        self::assertTrue($this->resolver->isIdentityOp('==='));
+        self::assertFalse($this->resolver->isOrderingOp('==='));
+
+        self::assertTrue($this->resolver->isOrderingOp('<='));
+        self::assertFalse($this->resolver->isIdentityOp('<='));
+    }
+
+    public function test_guard_php_fns_are_recognised(): void
+    {
+        self::assertTrue($this->resolver->isGuardPhpFn('is_int'));
+        self::assertTrue($this->resolver->isGuardPhpFn('is_string'));
+        self::assertFalse($this->resolver->isGuardPhpFn('strlen'));
+    }
+
+    public function test_php_fn_signature_returns_per_slot_tags_or_null(): void
+    {
+        self::assertSame(['int', 'int'], $this->resolver->phpFnSignature('random_int'));
+        self::assertSame(['string', 'int'], $this->resolver->phpFnSignature('str_repeat'));
+        self::assertNull($this->resolver->phpFnSignature('unlisted_fn'));
+    }
+
+    public function test_literal_numeric_type_is_null_without_literal_args(): void
+    {
+        self::assertNull($this->resolver->literalNumericType([]));
+    }
+}

--- a/tests/php/Unit/Run/Infrastructure/Command/TestCommandRepeatSeedTest.php
+++ b/tests/php/Unit/Run/Infrastructure/Command/TestCommandRepeatSeedTest.php
@@ -7,8 +7,8 @@ namespace PhelTest\Unit\Run\Infrastructure\Command;
 use InvalidArgumentException;
 use Phel\Run\Domain\Test\TestCommandOptions;
 use Phel\Run\Infrastructure\Command\TestCommand;
+use Phel\Run\Infrastructure\Command\TestCommandOptionParser;
 use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
 use Symfony\Component\Console\Input\ArrayInput;
 
 final class TestCommandRepeatSeedTest extends TestCase
@@ -107,10 +107,7 @@ final class TestCommandRepeatSeedTest extends TestCase
         $command = new TestCommand();
         $input = new ArrayInput($arguments, $command->getDefinition());
 
-        $method = new ReflectionMethod(TestCommand::class, 'collectOptions');
-
-        /** @var array<string, mixed> $collected */
-        $collected = $method->invoke($command, $input);
+        $collected = new TestCommandOptionParser()->collectOptions($input);
 
         return TestCommandOptions::fromArray($collected)->asPhelHashMap();
     }


### PR DESCRIPTION
## 🤔 Background

Part 2 of 4 in the modular-architecture cleanup. Low risk: extract stateless collaborators, no public-API change. Mirrors the proven `CallSpecialization` split. Independent of part 1 (disjoint files).

## 💡 Goal

Break three large multi-responsibility classes into focused, `final readonly`, stateless collaborators with no external callers, keeping behavior identical.

## 🔖 Changes

- **`DefSymbol` (734 LOC)** delegates to:
  - `MacroFormRewriter` — macro `&form`/`&env` implicit-param injection and `^:tag` return-type form rewriting. The single-arity and multi-arity walkers (previously duplicated across the two transforms) are unified behind one param-vector dispatch taking a transform callable.
  - `DefArglistBuilder` — `:arglists` string formatting.
- **`ParamTypeInferrer` (746 LOC)** delegates to `CallTypeExpectationResolver` — stateless PHP-call and `phel.core`-call shape analysis (op classification, literal/callee type hints, guard detection). The AST walker and its mutable observation state stay in `ParamTypeInferrer`, which now takes the resolver via a defaulted constructor arg so existing `new ParamTypeInferrer()` callers are unchanged.
- **`TestCommand` (520 LOC)** delegates to `TestCommandOptionParser` — option parsing/coercion plus the parallelism decision. The parser owns the CLI option-name constants; `configure()` declares the options using them and `execute()` calls the parser. The `CpuCountDetector` is passed in so the parser stays free of the facade.

## ✅ Tests

- New `CallTypeExpectationResolverTest` covers the extracted op/signature classifiers directly.
- `TestCommandRepeatSeedTest` now exercises `TestCommandOptionParser::collectOptions()` directly (no reflection).
- `MacroFormRewriter` / `DefArglistBuilder` stay covered by the existing `DefSymbol`/macro suites.

### Refactor pass

The DRY unification of the macro/return-type arity walkers was done inline in the change. The mandatory post-review pass over every touched file surfaced no further changes (imports tidy, no dangling references, no orphaned constants).

### Verification

`composer phpstan`, `composer psalm`, `composer test-quality`, `composer test-compiler` (3865 tests), and `composer test-core` (5772 tests) all green.

Closes #2262