### PR TITLE
feat(http): add json-response and html-response builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `phel.http`: `request-from-globals` decodes `application/json` request bodies into `:parsed-body` (nil for an empty or malformed body); `request-from-globals-args` gains an optional trailing `raw-body` arg
+- `phel.http`: `json-response` and `html-response` builders set the content-type header and (for JSON) encode the body, so apps stop hand-rolling the header map (#2271). The `http-json-api` example now uses them instead of a private copy
 - Compiler internals: regression test pinning that AST source locations survive every phase
 
 ### Changed

--- a/resources/agents/examples/http-json-api/src/handlers.phel
+++ b/resources/agents/examples/http-json-api/src/handlers.phel
@@ -1,23 +1,16 @@
 (ns http-json-api\handlers
-  (:require phel\http :as h)
-  (:require phel\json :as json))
-
-(defn- json-response [status data]
-  (h/response-from-map
-    {:status status
-     :headers {:content-type "application/json"}
-     :body (json/encode data)}))
+  (:require phel\http :as h))
 
 (defn health [_request]
-  (json-response 200 {:status "ok" :ts (php/time)}))
+  (h/json-response 200 {:status "ok" :ts (php/time)}))
 
 (defn echo [request]
-  (json-response 200 {:message (get-in request [:attributes :match :path-params :msg])}))
+  (h/json-response 200 {:message (get-in request [:attributes :match :path-params :msg])}))
 
 (defn sum [request]
   (let [body (get request :parsed-body {})
-        a (get body :a)
-        b (get body :b)]
+        a    (get body :a)
+        b    (get body :b)]
     (if (and (number? a) (number? b))
-      (json-response 200 {:sum (+ a b)})
-      (json-response 400 {:error "expected numeric :a and :b"}))))
+      (h/json-response 200 {:sum (+ a b)})
+      (h/json-response 400 {:error "expected numeric :a and :b"}))))

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -387,6 +387,28 @@
   [s]
   (response-from-map {:body s}))
 
+(defn json-response
+  "Creates a response with `status` and a JSON-encoded `data` body and a
+  `Content-Type: application/json` header."
+  {:example "(json-response 200 {:message \"pong\"}) ; => (response 200 {:content-type \"application/json\"} \"{\\\"message\\\":\\\"pong\\\"}\" \"1.1\" \"OK\")"
+   :see-also ["response-from-map" "html-response"]}
+  [status data]
+  (response-from-map
+   {:status  status
+    :headers {:content-type "application/json"}
+    :body    (json/encode data)}))
+
+(defn html-response
+  "Creates a response with `status` and an HTML `body` and a
+  `Content-Type: text/html; charset=utf-8` header."
+  {:example "(html-response 200 \"<h1>Hi</h1>\") ; => (response 200 {:content-type \"text/html; charset=utf-8\"} \"<h1>Hi</h1>\" \"1.1\" \"OK\")"
+   :see-also ["response-from-map" "json-response"]}
+  [status body]
+  (response-from-map
+   {:status  status
+    :headers {:content-type "text/html; charset=utf-8"}
+    :body    body}))
+
 (defn- emit-status-line [{:status status :reason reason :version version}]
   (when-not (php/headers_sent)
     (let [version (or version "1.1")

--- a/tests/phel/http.phel
+++ b/tests/phel/http.phel
@@ -1,5 +1,6 @@
 (ns phel-test.http
   (:require phel.http :as h)
+  (:require phel.json :as json)
   (:require phel.test :refer [deftest is]))
 
 ;; Tests adopted from nyholm/psr7-server
@@ -339,6 +340,21 @@
   (is (=
        (h/response 200 {} "test" "1.1" "OK")
        (h/response-from-string "test")) "response-from-string"))
+
+(deftest test-json-response
+  (let [res (h/json-response 200 {:message "pong"})]
+    (is (= 200 (:status res)) "json-response status")
+    (is (= "OK" (:reason res)) "json-response fills the reason phrase")
+    (is (= "application/json" (get-in res [:headers :content-type])) "json-response content-type")
+    (is (= {:message "pong"} (json/decode (:body res))) "json-response encodes the body"))
+  (is (= 400 (:status (h/json-response 400 {:error "nope"}))) "json-response arbitrary status"))
+
+(deftest test-html-response
+  (let [res (h/html-response 200 "<h1>Hi</h1>")]
+    (is (= 200 (:status res)) "html-response status")
+    (is (= "text/html; charset=utf-8" (get-in res [:headers :content-type])) "html-response content-type")
+    (is (= "<h1>Hi</h1>" (:body res)) "html-response passes the body through"))
+  (is (= 404 (:status (h/html-response 404 "nope"))) "html-response arbitrary status"))
 
 (def send-response-examples [["send body"
                               (h/response 200 {:content-type "text/plain"} "Content!" nil nil)


### PR DESCRIPTION
## What

Adds `json-response` and `html-response` builders to `phel.http`:

```phel
(h/json-response 200 {:message "pong"})
;; => content-type application/json, body (json/encode data)

(h/html-response 200 "<h1>Hi</h1>")
;; => content-type text/html; charset=utf-8
```

## Why

Every Phel web app re-implements the same one-liner to set a content-type header and encode a body. The duplication shipped *in this repo* twice:

- `resources/agents/examples/http-json-api/src/handlers.phel` defined a private `json-response`.
- The `phel-lang/web-skeleton` starter defined the byte-identical helper.

When the official example *and* the official skeleton both copy the same private function, it belongs in core. `phel.http` already owns the status→reason phrase table, so it's the natural home.

## Changes

- `src/phel/http.phel`: `json-response`, `html-response` (with docstrings + `:example` + `:see-also`).
- `resources/agents/examples/http-json-api/src/handlers.phel`: drop the private copy, use `h/json-response`.
- `tests/phel/http.phel`: `test-json-response`, `test-html-response`.
- `CHANGELOG.md`: Unreleased → Added.

## Notes

- Scoped to the two builders the issue identified. Semantic sugar (`ok`/`bad-request`/`not-found`, à la `ring.util.response`) is intentionally left out — happy to add in a follow-up if wanted, but those make response-shape decisions (e.g. is `not-found` HTML or JSON?) that are better debated separately.
- `phel.http` core test suite passes (69 tests). The example's isolated suite needs its own `composer install` against this branch; the change there is logic-equivalent (same response struct), and the new core fns are covered by tests.

Closes #2271