### PR TITLE
ref(build): split CompiledCodeCache god-class into focused collaborators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Architecture: modular-architecture cleanup of `src/php/` (#2261, #2262, #2263, #2264) — relocated leaky cross-module value objects to their proper homes (`NamespaceInformation`, the parse-tree nodes + lexer `Token`, and the stateful `LoadClasspath`) and split four oversized analyzer/command classes (`DefSymbol`, `ParamTypeInferrer`, `TestCommand`, and `ConstantFolder`/`FnSymbol`) into focused collaborators. Pure refactors, no behavior change
 - Compiler internals: split the 1325-LOC `CallSpecialization` god-class into eight focused collaborators (pure refactor, output unchanged)
 - Compiler internals: split the 959-LOC `CallEmitter` god-class into eight per-family `Specialized/*CallEmitter` collaborators behind a thin dispatcher (pure refactor, emitted PHP unchanged)
+- Build internals: split the 510-LOC `CompiledCodeCache` god-class into `CacheDirectory`, `CacheIndexFile`, and `NamespaceEnvironmentStore` collaborators, leaving the cache as a thin policy orchestrator and de-duplicating the index entry-normalization (pure refactor, cache behavior unchanged)
 - Compiler internals: centralized the emitters' bare-expression capture into `OutputEmitter::captureNodeAsExpression()`
 - Tests: `RegistryTest` and `PhelVarTest` snapshot and restore the global `Registry`, fixing order-dependent `phel.core` suite failures (#2256)
 - Docs: condensed every `docs/` guide (~17% smaller), verified against the runtime, and cross-linked to phel-lang.org

--- a/src/php/Build/CLAUDE.md
+++ b/src/php/Build/CLAUDE.md
@@ -41,6 +41,9 @@ Build/
 ├── Application/        ProjectCompiler, FileCompiler, FileEvaluator, NamespaceExtractor (cached)
 ├── Domain/             Cache/, Compile/, Extractor/, IO/ (interfaces, value objects, sorters)
 ├── Infrastructure/     Cache/, IO/ (concrete implementations)
+│                       Cache/ `CompiledCodeCache` is the policy orchestrator; it delegates to
+│                       `CacheDirectory` (layout), `CacheIndexFile` (index load/save/merge),
+│                       `NamespaceEnvironmentStore` (env data), `CachePathResolver`, `AtomicFileWriter`
 └── Gacela files        Facade, Factory, Config, Provider
 ```
 

--- a/src/php/Build/Infrastructure/Cache/CacheDirectory.php
+++ b/src/php/Build/Infrastructure/Cache/CacheDirectory.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Infrastructure\Cache;
+
+/**
+ * Owns the on-disk layout of the compiled-code cache: the root directory,
+ * the `compiled/` subdirectory that holds every compiled and environment
+ * file, and the index file that lists the entries.
+ *
+ * Creating `compiled/` with a recursive `mkdir` also guarantees the root
+ * directory exists, so callers only ever need {@see ensure()}.
+ */
+final readonly class CacheDirectory
+{
+    public function __construct(
+        private string $cacheDir,
+    ) {}
+
+    public function root(): string
+    {
+        return $this->cacheDir;
+    }
+
+    public function compiledDir(): string
+    {
+        return $this->cacheDir . '/compiled';
+    }
+
+    public function indexFile(): string
+    {
+        return $this->cacheDir . '/compiled-index.php';
+    }
+
+    public function ensure(): void
+    {
+        $compiledDir = $this->compiledDir();
+        if (!is_dir($compiledDir)) {
+            $oldUmask = umask(0);
+            try {
+                @mkdir($compiledDir, 0755, true);
+            } finally {
+                umask($oldUmask);
+            }
+        }
+    }
+}

--- a/src/php/Build/Infrastructure/Cache/CacheIndexFile.php
+++ b/src/php/Build/Infrastructure/Cache/CacheIndexFile.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Infrastructure\Cache;
+
+use function function_exists;
+use function is_array;
+use function is_string;
+
+/**
+ * Reads and writes the compiled-code cache index (`compiled-index.php`), a
+ * version-stamped map of source path to cache entry.
+ *
+ * Writes go through an exclusive `flock` and merge the current on-disk
+ * entries before truncating, so a nested cache instance created by a
+ * `(load ...)` form cannot clobber the entries written by the outer
+ * instance. Entry shapes are validated on every read so a partially
+ * written or version-mismatched index degrades to "empty" rather than
+ * surfacing malformed data.
+ *
+ * @phpstan-type CacheEntry array{namespace: string, source_hash: string, compiled_path: string, last_accessed: int}
+ */
+final readonly class CacheIndexFile
+{
+    private const string VERSION = '1.2';
+
+    public function __construct(
+        private CacheDirectory $directory,
+        private string $phelVersion = '',
+    ) {}
+
+    public function version(): string
+    {
+        return self::VERSION . ':' . $this->phelVersion;
+    }
+
+    /**
+     * Loads and validates the on-disk entries, or returns an empty map when
+     * the index is missing, unreadable, or stamped with a different version.
+     *
+     * @return array<string, CacheEntry>
+     */
+    public function load(): array
+    {
+        $indexFile = $this->directory->indexFile();
+        if (!file_exists($indexFile)) {
+            return [];
+        }
+
+        $data = @include $indexFile;
+
+        return $this->normalize($data);
+    }
+
+    /**
+     * Merges `$entries` over the current on-disk index (dropping
+     * `$tombstones`) under an exclusive lock and rewrites the index.
+     * Returns the merged map that is now on disk; on any I/O failure the
+     * passed-in `$entries` are returned unchanged.
+     *
+     * @param array<string, CacheEntry> $entries
+     * @param array<string, true>       $tombstones
+     *
+     * @return array<string, CacheEntry>
+     */
+    public function save(array $entries, array $tombstones): array
+    {
+        $this->directory->ensure();
+
+        $dir = $this->directory->root();
+        if (!is_dir($dir) || !is_writable($dir)) {
+            return $entries;
+        }
+
+        $indexFile = $this->directory->indexFile();
+        $handle = @fopen($indexFile, 'c+');
+        if ($handle === false) {
+            return $entries;
+        }
+
+        if (!flock($handle, LOCK_EX)) {
+            fclose($handle);
+            return $entries;
+        }
+
+        try {
+            // Merge on-disk entries with in-memory entries. A (load ...) form
+            // creates a nested cache instance that writes its own sub-file
+            // entries to disk; without this merge, the outer instance would
+            // truncate those entries when it saves its own, forcing sub-files
+            // to recompile on the next run.
+            $merged = $this->mergeWithDiskEntries($handle, $entries, $tombstones);
+
+            ftruncate($handle, 0);
+            rewind($handle);
+            $content = '<?php return ' . var_export([
+                'version' => $this->version(),
+                'entries' => $merged,
+            ], true) . ';';
+            fwrite($handle, $content);
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+
+        if (function_exists('opcache_invalidate')) {
+            @opcache_invalidate($indexFile, true);
+        }
+
+        return $merged;
+    }
+
+    /**
+     * Reads the current on-disk index and merges it with in-memory entries.
+     * In-memory entries win on conflict so a fresh `put` overrides older data.
+     *
+     * @param resource                  $handle     Open, exclusively-locked file handle for the index file
+     * @param array<string, CacheEntry> $entries
+     * @param array<string, true>       $tombstones
+     *
+     * @return array<string, CacheEntry>
+     */
+    private function mergeWithDiskEntries($handle, array $entries, array $tombstones): array
+    {
+        rewind($handle);
+        $currentContent = stream_get_contents($handle);
+        if ($currentContent === false || $currentContent === '') {
+            return $entries;
+        }
+
+        $diskEntries = $this->parseIndexContent($currentContent);
+        foreach (array_keys($tombstones) as $tombstoned) {
+            unset($diskEntries[$tombstoned]);
+        }
+
+        return array_merge($diskEntries, $entries);
+    }
+
+    /**
+     * @return array<string, CacheEntry>
+     */
+    private function parseIndexContent(string $content): array
+    {
+        $tempFile = @tempnam(sys_get_temp_dir(), 'phel_cache_merge_');
+        if ($tempFile === false) {
+            return [];
+        }
+
+        try {
+            if (file_put_contents($tempFile, $content) === false) {
+                return [];
+            }
+
+            /** @psalm-suppress UnresolvableInclude */
+            $data = @include $tempFile;
+        } finally {
+            @unlink($tempFile);
+        }
+
+        return $this->normalize($data);
+    }
+
+    /**
+     * Validates the raw decoded index payload and copies through only
+     * well-formed entries, defaulting `last_accessed` when absent.
+     *
+     * @return array<string, CacheEntry>
+     */
+    private function normalize(mixed $data): array
+    {
+        if (!is_array($data) || !isset($data['version']) || $data['version'] !== $this->version()) {
+            return [];
+        }
+
+        $entries = [];
+        foreach ($data['entries'] ?? [] as $sourcePath => $entryData) {
+            if (is_array($entryData)
+                && isset($entryData['namespace'], $entryData['source_hash'], $entryData['compiled_path'])
+                && is_string($entryData['namespace'])
+                && is_string($entryData['source_hash'])
+                && is_string($entryData['compiled_path'])
+            ) {
+                $entries[$sourcePath] = [
+                    'namespace' => $entryData['namespace'],
+                    'source_hash' => $entryData['source_hash'],
+                    'compiled_path' => $entryData['compiled_path'],
+                    'last_accessed' => $entryData['last_accessed'] ?? time(),
+                ];
+            }
+        }
+
+        return $entries;
+    }
+}

--- a/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
+++ b/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
@@ -7,12 +7,8 @@ namespace Phel\Build\Infrastructure\Cache;
 use ParseError;
 use Phel\Build\Domain\Cache\CompiledCodeCacheInterface;
 
-use function array_key_exists;
 use function count;
 use function function_exists;
-use function is_array;
-use function is_string;
-
 use function token_get_all;
 
 use const TOKEN_PARSE;
@@ -22,19 +18,23 @@ use const TOKEN_PARSE;
  * validation. Multiple files that share a namespace via `(in-ns ...)`
  * each get their own cache entry, so they do not clobber one another.
  *
- * Environment data (refers/aliases) is keyed by namespace because it
- * is shared across all files of the namespace.
+ * This class owns the cache policy: the live entry index, LRU eviction, and
+ * the put-time PHP-validity gate. It delegates the on-disk concerns to
+ * collaborators: {@see CacheIndexFile} serialises the entry index,
+ * {@see NamespaceEnvironmentStore} stores per-namespace env data,
+ * {@see CachePathResolver} computes paths, {@see AtomicFileWriter} writes
+ * files, and {@see CacheDirectory} owns the directory layout.
+ *
+ * @phpstan-type CacheEntry array{namespace: string, source_hash: string, compiled_path: string, last_accessed: int}
  */
 final class CompiledCodeCache implements CompiledCodeCacheInterface
 {
-    private const string VERSION = '1.2';
-
-    /** @var array<string, array{namespace: string, source_hash: string, compiled_path: string, last_accessed: int}> */
+    /** @var array<string, CacheEntry> */
     private array $entries = [];
 
     /**
      * Source paths invalidated in this process that have not been re-`put`.
-     * Used as tombstones so the disk-merge in `saveEntries()` cannot
+     * Used as tombstones so the disk-merge in `CacheIndexFile::save()` cannot
      * resurrect entries that downstream cascades meant to remove.
      *
      * @var array<string, true>
@@ -54,29 +54,32 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
 
     private bool $loaded = false;
 
-    /**
-     * In-memory memo of per-namespace environment data, keyed by
-     * env-file path. Every secondary in a `(load ...)` chain for the
-     * same namespace would otherwise re-`require` the same env file,
-     * which without opcache is a fresh parse each time.
-     *
-     * @var array<string, array<string, mixed>|null>
-     */
-    private array $envMemo = [];
+    private readonly CacheDirectory $directory;
 
     private readonly CachePathResolver $pathResolver;
 
     private readonly AtomicFileWriter $fileWriter;
 
+    private readonly CacheIndexFile $indexFile;
+
+    private readonly NamespaceEnvironmentStore $environmentStore;
+
     public function __construct(
-        private readonly string $cacheDir,
-        private readonly string $phelVersion = '',
+        string $cacheDir,
+        string $phelVersion = '',
         private readonly int $maxEntries = 500,
         ?CachePathResolver $pathResolver = null,
         ?AtomicFileWriter $fileWriter = null,
+        ?CacheDirectory $directory = null,
+        ?CacheIndexFile $indexFile = null,
+        ?NamespaceEnvironmentStore $environmentStore = null,
     ) {
-        $this->pathResolver = $pathResolver ?? new CachePathResolver($this->cacheDir);
+        $this->directory = $directory ?? new CacheDirectory($cacheDir);
+        $this->pathResolver = $pathResolver ?? new CachePathResolver($cacheDir);
         $this->fileWriter = $fileWriter ?? new AtomicFileWriter();
+        $this->indexFile = $indexFile ?? new CacheIndexFile($this->directory, $phelVersion);
+        $this->environmentStore = $environmentStore
+            ?? new NamespaceEnvironmentStore($this->directory, $this->pathResolver, $this->fileWriter);
     }
 
     /**
@@ -129,7 +132,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
     public function put(string $sourcePath, string $namespace, string $sourceHash, string $phpCode): void
     {
         $this->loadEntries();
-        $this->ensureCacheDir();
+        $this->directory->ensure();
 
         $compiledPath = $this->getCompiledPath($sourcePath, $namespace);
         $fullPhpCode = "<?php\n" . $phpCode;
@@ -138,7 +141,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
             return;
         }
 
-        if (!$this->atomicWrite($compiledPath, $fullPhpCode)) {
+        if (!$this->fileWriter->write($compiledPath, $fullPhpCode)) {
             return;
         }
 
@@ -164,7 +167,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
      */
     public function getCompiledPath(string $sourcePath, string $namespace): string
     {
-        return $this->getCachePath($namespace, $sourcePath, '.php');
+        return $this->pathResolver->compiledPath($namespace, $sourcePath, '.php');
     }
 
     /**
@@ -174,7 +177,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
      */
     public function getEnvironmentPath(string $namespace): string
     {
-        return $this->pathResolver->environmentPath($namespace);
+        return $this->environmentStore->path($namespace);
     }
 
     /**
@@ -182,13 +185,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
      */
     public function putEnvironment(string $namespace, array $envData): void
     {
-        $this->ensureCacheDir();
-
-        $envPath = $this->getEnvironmentPath($namespace);
-        $content = '<?php return ' . var_export($envData, true) . ';';
-
-        $this->atomicWrite($envPath, $content);
-        $this->envMemo[$envPath] = $envData;
+        $this->environmentStore->put($namespace, $envData);
     }
 
     /**
@@ -196,20 +193,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
      */
     public function getEnvironment(string $namespace): ?array
     {
-        $envPath = $this->getEnvironmentPath($namespace);
-
-        if (array_key_exists($envPath, $this->envMemo)) {
-            return $this->envMemo[$envPath];
-        }
-
-        if (!file_exists($envPath)) {
-            return $this->envMemo[$envPath] = null;
-        }
-
-        /** @var array<string, mixed>|null $data */
-        $data = require $envPath;
-
-        return $this->envMemo[$envPath] = $data;
+        return $this->environmentStore->get($namespace);
     }
 
     /**
@@ -241,7 +225,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
      */
     public function clear(): void
     {
-        $compiledDir = $this->cacheDir . '/compiled';
+        $compiledDir = $this->directory->compiledDir();
         if (is_dir($compiledDir)) {
             $files = glob($compiledDir . '/*.php');
             if ($files !== false) {
@@ -255,12 +239,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
         $this->tombstones = [];
         $this->touchedThisProcess = [];
         $this->saveEntries();
-        $this->envMemo = [];
-    }
-
-    private function getCacheVersion(): string
-    {
-        return self::VERSION . ':' . $this->phelVersion;
+        $this->environmentStore->clearMemo();
     }
 
     private function loadEntries(): void
@@ -269,190 +248,13 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
             return;
         }
 
-        $indexFile = $this->getIndexFile();
-        if (!file_exists($indexFile)) {
-            $this->entries = [];
-            $this->loaded = true;
-            return;
-        }
-
-        $data = @include $indexFile;
-        if (!is_array($data) || !isset($data['version']) || $data['version'] !== $this->getCacheVersion()) {
-            $this->entries = [];
-            $this->loaded = true;
-            return;
-        }
-
-        $entries = [];
-        foreach ($data['entries'] ?? [] as $sourcePath => $entryData) {
-            if (is_array($entryData)
-                && isset($entryData['namespace'], $entryData['source_hash'], $entryData['compiled_path'])
-                && is_string($entryData['namespace'])
-                && is_string($entryData['source_hash'])
-                && is_string($entryData['compiled_path'])
-            ) {
-                $entries[$sourcePath] = [
-                    'namespace' => $entryData['namespace'],
-                    'source_hash' => $entryData['source_hash'],
-                    'compiled_path' => $entryData['compiled_path'],
-                    'last_accessed' => $entryData['last_accessed'] ?? time(),
-                ];
-            }
-        }
-
-        $this->entries = $entries;
+        $this->entries = $this->indexFile->load();
         $this->loaded = true;
     }
 
     private function saveEntries(): void
     {
-        $this->ensureCacheDir();
-
-        $dir = $this->cacheDir;
-        if (!is_dir($dir) || !is_writable($dir)) {
-            return;
-        }
-
-        $indexFile = $this->getIndexFile();
-        $handle = @fopen($indexFile, 'c+');
-        if ($handle === false) {
-            return;
-        }
-
-        if (!flock($handle, LOCK_EX)) {
-            fclose($handle);
-            return;
-        }
-
-        try {
-            // Merge on-disk entries with in-memory entries. A (load ...) form
-            // creates a nested cache instance that writes its own sub-file
-            // entries to disk; without this merge, the outer instance would
-            // truncate those entries when it saves its own, forcing sub-files
-            // to recompile on the next run.
-            $merged = $this->mergeWithDiskEntries($handle);
-
-            ftruncate($handle, 0);
-            rewind($handle);
-            $content = '<?php return ' . var_export([
-                'version' => $this->getCacheVersion(),
-                'entries' => $merged,
-            ], true) . ';';
-            fwrite($handle, $content);
-            $this->entries = $merged;
-        } finally {
-            flock($handle, LOCK_UN);
-            fclose($handle);
-        }
-
-        if (function_exists('opcache_invalidate')) {
-            @opcache_invalidate($indexFile, true);
-        }
-    }
-
-    /**
-     * Reads the current on-disk index and merges it with in-memory entries.
-     * In-memory entries win on conflict so a fresh `put` overrides older data.
-     *
-     * @param resource $handle Open, exclusively-locked file handle for the index file
-     *
-     * @return array<string, array{namespace: string, source_hash: string, compiled_path: string, last_accessed: int}>
-     */
-    private function mergeWithDiskEntries($handle): array
-    {
-        rewind($handle);
-        $currentContent = stream_get_contents($handle);
-        if ($currentContent === false || $currentContent === '') {
-            return $this->entries;
-        }
-
-        $diskEntries = $this->parseIndexContent($currentContent);
-        foreach (array_keys($this->tombstones) as $tombstoned) {
-            unset($diskEntries[$tombstoned]);
-        }
-
-        return array_merge($diskEntries, $this->entries);
-    }
-
-    /**
-     * @return array<string, array{namespace: string, source_hash: string, compiled_path: string, last_accessed: int}>
-     */
-    private function parseIndexContent(string $content): array
-    {
-        $tempFile = @tempnam(sys_get_temp_dir(), 'phel_cache_merge_');
-        if ($tempFile === false) {
-            return [];
-        }
-
-        try {
-            if (file_put_contents($tempFile, $content) === false) {
-                return [];
-            }
-
-            /** @psalm-suppress UnresolvableInclude */
-            $data = @include $tempFile;
-        } finally {
-            @unlink($tempFile);
-        }
-
-        if (!is_array($data) || !isset($data['version']) || $data['version'] !== $this->getCacheVersion()) {
-            return [];
-        }
-
-        $entries = [];
-        foreach ($data['entries'] ?? [] as $sourcePath => $entryData) {
-            if (is_array($entryData)
-                && isset($entryData['namespace'], $entryData['source_hash'], $entryData['compiled_path'])
-                && is_string($entryData['namespace'])
-                && is_string($entryData['source_hash'])
-                && is_string($entryData['compiled_path'])
-            ) {
-                $entries[$sourcePath] = [
-                    'namespace' => $entryData['namespace'],
-                    'source_hash' => $entryData['source_hash'],
-                    'compiled_path' => $entryData['compiled_path'],
-                    'last_accessed' => $entryData['last_accessed'] ?? time(),
-                ];
-            }
-        }
-
-        return $entries;
-    }
-
-    private function getIndexFile(): string
-    {
-        return $this->cacheDir . '/compiled-index.php';
-    }
-
-    /**
-     * Compiled-file path includes both the munged namespace (so files
-     * remain debuggable) and a short hash of the source path (so files
-     * sharing a namespace do not collide).
-     */
-    private function getCachePath(string $namespace, string $sourcePath, string $suffix): string
-    {
-        return $this->pathResolver->compiledPath($namespace, $sourcePath, $suffix);
-    }
-
-    /**
-     * @return bool True on success, false on failure
-     */
-    private function atomicWrite(string $path, string $content): bool
-    {
-        return $this->fileWriter->write($path, $content);
-    }
-
-    private function ensureCacheDir(): void
-    {
-        $compiledDir = $this->cacheDir . '/compiled';
-        if (!is_dir($compiledDir)) {
-            $oldUmask = umask(0);
-            try {
-                @mkdir($compiledDir, 0755, true);
-            } finally {
-                umask($oldUmask);
-            }
-        }
+        $this->entries = $this->indexFile->save($this->entries, $this->tombstones);
     }
 
     private function isValidPhp(string $phpCode): bool

--- a/src/php/Build/Infrastructure/Cache/NamespaceEnvironmentStore.php
+++ b/src/php/Build/Infrastructure/Cache/NamespaceEnvironmentStore.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Infrastructure\Cache;
+
+use function array_key_exists;
+use function var_export;
+
+/**
+ * Stores per-namespace environment data (refers/aliases) as a `require`-able
+ * PHP file under the cache's `compiled/` directory.
+ *
+ * Environment data is shared across every file of a namespace, so it is
+ * keyed by namespace alone. Reads are memoised by env-file path: a
+ * `(load ...)` chain for one namespace would otherwise re-`require` (and,
+ * without opcache, re-parse) the same env file once per secondary.
+ */
+final class NamespaceEnvironmentStore
+{
+    /**
+     * In-memory memo of per-namespace environment data, keyed by env-file
+     * path. Mutable across calls, so the class is not `readonly`.
+     *
+     * @var array<string, array<string, mixed>|null>
+     */
+    private array $memo = [];
+
+    public function __construct(
+        private readonly CacheDirectory $directory,
+        private readonly CachePathResolver $pathResolver,
+        private readonly AtomicFileWriter $fileWriter,
+    ) {}
+
+    public function path(string $namespace): string
+    {
+        return $this->pathResolver->environmentPath($namespace);
+    }
+
+    /**
+     * @param array<string, mixed> $envData
+     */
+    public function put(string $namespace, array $envData): void
+    {
+        $this->directory->ensure();
+
+        $envPath = $this->path($namespace);
+        $content = '<?php return ' . var_export($envData, true) . ';';
+
+        $this->fileWriter->write($envPath, $content);
+        $this->memo[$envPath] = $envData;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function get(string $namespace): ?array
+    {
+        $envPath = $this->path($namespace);
+
+        if (array_key_exists($envPath, $this->memo)) {
+            return $this->memo[$envPath];
+        }
+
+        if (!file_exists($envPath)) {
+            return $this->memo[$envPath] = null;
+        }
+
+        /** @var array<string, mixed>|null $data */
+        $data = require $envPath;
+
+        return $this->memo[$envPath] = $data;
+    }
+
+    public function clearMemo(): void
+    {
+        $this->memo = [];
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`CompiledCodeCache` (Build module) had grown to 510 LOC and conflated five concerns: cache policy, index-file serialization with `flock` concurrency, namespace environment-data storage, LRU eviction, and a put-time PHP-validity gate. The entry-shape normalization was even duplicated verbatim between `loadEntries()` and `parseIndexContent()`.

It is the next god-class after `CallEmitter` (#2273), and a clean structural target: pure I/O orchestration with strong unit + integration coverage, no arithmetic correctness risk.

## 💡 Goal

Reduce `CompiledCodeCache` to a thin policy orchestrator while keeping cache behavior byte-for-byte identical (including the existing index/merge quirks), and remove the duplicated normalization.

## 🔖 Changes

- Extract three single-responsibility collaborators under `Build/Infrastructure/Cache/` (alongside the existing `CachePathResolver` / `AtomicFileWriter`):
  - **`CacheDirectory`** — on-disk layout: root, `compiled/` subdir, index-file path, and the recursive `mkdir`.
  - **`CacheIndexFile`** — index (de)serialization: version-stamped `load()`, `flock`-guarded merge-and-`save()`, and entry-shape validation. Collapses the normalization that was duplicated between `loadEntries()` and `parseIndexContent()` into a single `normalize()`.
  - **`NamespaceEnvironmentStore`** — per-namespace env data with the read memo (`get` / `put` / `path` / `clearMemo`).
- `CompiledCodeCache` keeps the cache policy (live entry index, LRU eviction, PHP-validity gate) and delegates disk concerns to the collaborators. It drops from **510 to ~310 LOC**.
- Public constructor signature preserved: the new collaborators are optional trailing params that default-build, so the `BuildFactory` wiring and all test construction sites are untouched.
- Updated `src/php/Build/CLAUDE.md` and added a `CHANGELOG.md` note under Unreleased.

### ✅ Verification

- `CompiledCodeCacheTest`, `CompiledCodeCacheIntegrationTest`, `FileEvaluatorTest`, `DependencyTrackerTest`: 56 pass.
- `composer test-compiler` (unit + integration): 3885 pass. `composer test-core`: 5788 pass.
- `composer test-quality` (cs-fixer, psalm lvl 1, phpstan lvl 6, rector): clean.
- PHPBench `LoadChainBench` (cache-sensitive load chain), 12 iterations vs `main` baseline: warm **+0.46%**, fresh **-0.54%**, memory **+0.01%** — within noise. Perf-neutral.

### 📌 Remaining god-classes (follow-ups)

`BigInt` (747) / `NumericOperations` (637) in `Lang` (runtime math, correctness-sensitive), `PhelFnLoader` (514, `Api`), `Parser` (498). Each warrants its own PR.
