### PR TITLE
ref(lang): extract NumericCoercion and IntegerOverflow from NumericOperations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Compiler internals: split the 959-LOC `CallEmitter` god-class into eight per-family `Specialized/*CallEmitter` collaborators behind a thin dispatcher (pure refactor, emitted PHP unchanged)
 - Build internals: split the 510-LOC `CompiledCodeCache` god-class into `CacheDirectory`, `CacheIndexFile`, and `NamespaceEnvironmentStore` collaborators, leaving the cache as a thin policy orchestrator and de-duplicating the index entry-normalization (pure refactor, cache behavior unchanged)
 - Lang internals: split the 747-LOC `BigInt` god-class by extracting the sign-agnostic base-10^9 digit-array kernels into a stateless `BigIntMagnitude`, leaving `BigInt` as the signed value object (pure refactor, arithmetic unchanged; guarded by new algebraic-invariant property tests)
+- Lang internals: split the 637-LOC `NumericOperations` god-class by extracting numeric type lifting into `NumericCoercion` and native-int overflow detection into `IntegerOverflow`, leaving the dispatch table to own only the contagion ladders (pure refactor, arithmetic unchanged; new units covered by direct unit tests)
 - Compiler internals: centralized the emitters' bare-expression capture into `OutputEmitter::captureNodeAsExpression()`
 - Tests: `RegistryTest` and `PhelVarTest` snapshot and restore the global `Registry`, fixing order-dependent `phel.core` suite failures (#2256)
 - Docs: condensed every `docs/` guide (~17% smaller), verified against the runtime, and cross-linked to phel-lang.org

--- a/src/php/Lang/CLAUDE.md
+++ b/src/php/Lang/CLAUDE.md
@@ -38,7 +38,9 @@ Foundational leaf module with no Facade, Factory, or DependencyProvider. All typ
 - **LazySeq**: lazy sequence implementation with chunking
 
 **Utilities**
-- **NumericOperations**: static dispatch for `+`/`-`/`*`/`/`, comparisons, predicates across PHP numbers, `BigInt`, `Ratio`
+- **NumericOperations**: static dispatch for `+`/`-`/`*`/`/`, comparisons, predicates across PHP numbers, `BigInt`, `Ratio`, `BigDecimal`. Owns only the contagion ladders; delegates type lifting to **NumericCoercion** and native-int overflow detection to **IntegerOverflow**
+- **NumericCoercion**: stateless numeric type lifting/validation (`ensureNumeric`, `toFloat`/`toBigInt`/`toBigDecimal`, `rationalOperand`, `collapseBigInt`, `toIntExponent`, `truncateToInt`) shared by `NumericOperations`
+- **IntegerOverflow**: pure native-int overflow predicates (`onAdd`/`onSubtract`/`onMultiply`); tells `NumericOperations` when to promote an int op to `BigInt`
 - **DynamicScope**: dynamic variable binding context
 - **Truthy**: coercion to boolean
 - **TypeStringifier**: `__toString` rendering

--- a/src/php/Lang/IntegerOverflow.php
+++ b/src/php/Lang/IntegerOverflow.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+use function abs;
+use function intdiv;
+
+/**
+ * Detects whether a native PHP `int` arithmetic operation would leave the
+ * signed 64-bit range, so {@see NumericOperations} can promote to
+ * {@see BigInt} before the silent float coercion or wrap-around happens.
+ *
+ * Each predicate is pure and only inspects the operands; it performs no
+ * arithmetic that could itself overflow.
+ */
+final class IntegerOverflow
+{
+    public static function onAdd(int $a, int $b): bool
+    {
+        if ($a > 0 && $b > 0) {
+            return $a > PHP_INT_MAX - $b;
+        }
+
+        if ($a < 0 && $b < 0) {
+            return $a < PHP_INT_MIN - $b;
+        }
+
+        return false;
+    }
+
+    public static function onSubtract(int $a, int $b): bool
+    {
+        if ($a >= 0 && $b < 0) {
+            // a - b > PHP_INT_MAX when b < a - PHP_INT_MAX.
+            return $a > PHP_INT_MAX + $b;
+        }
+
+        if ($a < 0 && $b > 0) {
+            return $a < PHP_INT_MIN + $b;
+        }
+
+        return false;
+    }
+
+    public static function onMultiply(int $a, int $b): bool
+    {
+        if ($a === 0 || $b === 0 || $a === 1 || $b === 1) {
+            return false;
+        }
+
+        // PHP_INT_MIN cannot be negated within int range, so any multiply of
+        // PHP_INT_MIN by anything other than 0 or 1 leaves the int range.
+        if ($a === PHP_INT_MIN || $b === PHP_INT_MIN) {
+            return true;
+        }
+
+        // Compare against PHP_INT_MAX magnitude using truncating intdiv.
+        // Both operands are now safe to negate within int range.
+        return intdiv(PHP_INT_MAX, abs($a)) < abs($b);
+    }
+}

--- a/src/php/Lang/NumericCoercion.php
+++ b/src/php/Lang/NumericCoercion.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+use InvalidArgumentException;
+
+use function is_float;
+use function is_int;
+use function sprintf;
+
+/**
+ * Numeric type lifting and validation shared by {@see NumericOperations}.
+ *
+ * The dispatch ladders need to coerce a mixed operand up to a common type
+ * (`float`, {@see BigInt}, {@see BigDecimal}, or a rational operand) and to
+ * collapse an exact {@see BigInt} result back to a native `int` when it fits.
+ * Those rules live here so the dispatch table stays focused on contagion
+ * order rather than per-type conversion plumbing.
+ */
+final class NumericCoercion
+{
+    public static function ensureNumeric(mixed $value): void
+    {
+        if (is_int($value) || is_float($value)) {
+            return;
+        }
+
+        if ($value instanceof BigInt || $value instanceof Ratio || $value instanceof BigDecimal) {
+            return;
+        }
+
+        throw new InvalidArgumentException(
+            sprintf('Expected a number, got %s', get_debug_type($value)),
+        );
+    }
+
+    public static function toBigDecimal(mixed $value): BigDecimal
+    {
+        if ($value instanceof BigDecimal) {
+            return $value;
+        }
+
+        if ($value instanceof BigInt) {
+            return BigDecimal::fromBigInt($value);
+        }
+
+        if (is_int($value)) {
+            return BigDecimal::fromInt($value);
+        }
+
+        if (is_float($value)) {
+            return BigDecimal::fromFloat($value);
+        }
+
+        if ($value instanceof Ratio) {
+            return BigDecimal::fromBigInt($value->numerator())
+                ->divideExact(BigDecimal::fromBigInt($value->denominator()));
+        }
+
+        throw new InvalidArgumentException(
+            sprintf('Cannot lift %s to BigDecimal', get_debug_type($value)),
+        );
+    }
+
+    public static function toFloat(mixed $value): float
+    {
+        if ($value instanceof Ratio) {
+            return $value->toFloat();
+        }
+
+        if ($value instanceof BigInt || $value instanceof BigDecimal) {
+            return (float) (string) $value;
+        }
+
+        return (float) $value;
+    }
+
+    public static function toBigInt(mixed $value): BigInt
+    {
+        if ($value instanceof BigInt) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return BigInt::fromInt($value);
+        }
+
+        throw new InvalidArgumentException(
+            sprintf('Cannot lift %s to BigInt', get_debug_type($value)),
+        );
+    }
+
+    public static function rationalOperand(mixed $value): Ratio|BigInt|int
+    {
+        if ($value instanceof Ratio || $value instanceof BigInt || is_int($value)) {
+            return $value;
+        }
+
+        throw new InvalidArgumentException(
+            sprintf('Cannot use %s as a rational operand', get_debug_type($value)),
+        );
+    }
+
+    public static function collapseBigInt(BigInt $value): BigInt|int
+    {
+        return $value->fitsInPhpInt() ? $value->toInt() : $value;
+    }
+
+    public static function toIntExponent(mixed $value): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if ($value instanceof BigInt) {
+            if (!$value->fitsInPhpInt()) {
+                throw new InvalidArgumentException('Exponent does not fit in PHP int range');
+            }
+
+            return $value->toInt();
+        }
+
+        throw new InvalidArgumentException(
+            sprintf('Cannot use %s as an integer exponent', get_debug_type($value)),
+        );
+    }
+
+    public static function truncateToInt(mixed $value): mixed
+    {
+        if (is_int($value) || $value instanceof BigInt) {
+            return $value;
+        }
+
+        if ($value instanceof Ratio) {
+            return self::collapseBigInt($value->numerator()->divide($value->denominator()));
+        }
+
+        return (int) $value;
+    }
+}

--- a/src/php/Lang/NumericOperations.php
+++ b/src/php/Lang/NumericOperations.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phel\Lang;
 
 use DivisionByZeroError;
-use InvalidArgumentException;
 
 use function abs;
 use function ceil;
@@ -13,14 +12,16 @@ use function fdiv;
 use function floor;
 use function intdiv;
 use function is_float;
-use function is_int;
-use function sprintf;
 
 /**
  * Runtime numeric dispatch for `+ - * /` and friends across native PHP
  * numbers, {@see BigInt}, and {@see Ratio}. Native PHP operators
  * cannot dispatch on objects, so the compiler routes Phel arithmetic
  * through these helpers.
+ *
+ * Type lifting and validation live in {@see NumericCoercion}; native-int
+ * overflow detection lives in {@see IntegerOverflow}. This class owns only
+ * the contagion ladders.
  *
  * Contagion rules (left to right yields the result type):
  *
@@ -35,34 +36,34 @@ final class NumericOperations
 {
     public static function add(mixed $a, mixed $b): mixed
     {
-        self::ensureNumeric($a);
-        self::ensureNumeric($b);
+        NumericCoercion::ensureNumeric($a);
+        NumericCoercion::ensureNumeric($b);
 
         if (is_float($a) || is_float($b)) {
             // Float wins over BigDecimal: `(+ 1.0M 2.0)` returns a float, not a
             // BigDecimal. BigDecimal also cannot represent `##Inf`/`##NaN`, so a
             // non-finite float operand still routes here.
-            return self::toFloat($a) + self::toFloat($b);
+            return NumericCoercion::toFloat($a) + NumericCoercion::toFloat($b);
         }
 
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
-            return self::toBigDecimal($a)->add(self::toBigDecimal($b));
+            return NumericCoercion::toBigDecimal($a)->add(NumericCoercion::toBigDecimal($b));
         }
 
         if ($a instanceof Ratio) {
-            return $a->add(self::rationalOperand($b));
+            return $a->add(NumericCoercion::rationalOperand($b));
         }
 
         if ($b instanceof Ratio) {
-            return $b->add(self::rationalOperand($a));
+            return $b->add(NumericCoercion::rationalOperand($a));
         }
 
         if ($a instanceof BigInt || $b instanceof BigInt) {
-            return self::collapseBigInt(self::toBigInt($a)->add(self::toBigInt($b)));
+            return NumericCoercion::collapseBigInt(NumericCoercion::toBigInt($a)->add(NumericCoercion::toBigInt($b)));
         }
 
-        if (self::addOverflows($a, $b)) {
-            return self::collapseBigInt(BigInt::fromInt($a)->add(BigInt::fromInt($b)));
+        if (IntegerOverflow::onAdd($a, $b)) {
+            return NumericCoercion::collapseBigInt(BigInt::fromInt($a)->add(BigInt::fromInt($b)));
         }
 
         return $a + $b;
@@ -70,32 +71,32 @@ final class NumericOperations
 
     public static function subtract(mixed $a, mixed $b): mixed
     {
-        self::ensureNumeric($a);
-        self::ensureNumeric($b);
+        NumericCoercion::ensureNumeric($a);
+        NumericCoercion::ensureNumeric($b);
 
         if (is_float($a) || is_float($b)) {
-            return self::toFloat($a) - self::toFloat($b);
+            return NumericCoercion::toFloat($a) - NumericCoercion::toFloat($b);
         }
 
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
-            return self::toBigDecimal($a)->subtract(self::toBigDecimal($b));
+            return NumericCoercion::toBigDecimal($a)->subtract(NumericCoercion::toBigDecimal($b));
         }
 
         if ($a instanceof Ratio) {
-            return $a->subtract(self::rationalOperand($b));
+            return $a->subtract(NumericCoercion::rationalOperand($b));
         }
 
         if ($b instanceof Ratio) {
             // a - b == -(b - a)
-            return self::negate($b->subtract(self::rationalOperand($a)));
+            return self::negate($b->subtract(NumericCoercion::rationalOperand($a)));
         }
 
         if ($a instanceof BigInt || $b instanceof BigInt) {
-            return self::collapseBigInt(self::toBigInt($a)->subtract(self::toBigInt($b)));
+            return NumericCoercion::collapseBigInt(NumericCoercion::toBigInt($a)->subtract(NumericCoercion::toBigInt($b)));
         }
 
-        if (self::subtractOverflows($a, $b)) {
-            return self::collapseBigInt(BigInt::fromInt($a)->subtract(BigInt::fromInt($b)));
+        if (IntegerOverflow::onSubtract($a, $b)) {
+            return NumericCoercion::collapseBigInt(BigInt::fromInt($a)->subtract(BigInt::fromInt($b)));
         }
 
         return $a - $b;
@@ -103,31 +104,31 @@ final class NumericOperations
 
     public static function multiply(mixed $a, mixed $b): mixed
     {
-        self::ensureNumeric($a);
-        self::ensureNumeric($b);
+        NumericCoercion::ensureNumeric($a);
+        NumericCoercion::ensureNumeric($b);
 
         if (is_float($a) || is_float($b)) {
-            return self::toFloat($a) * self::toFloat($b);
+            return NumericCoercion::toFloat($a) * NumericCoercion::toFloat($b);
         }
 
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
-            return self::toBigDecimal($a)->multiply(self::toBigDecimal($b));
+            return NumericCoercion::toBigDecimal($a)->multiply(NumericCoercion::toBigDecimal($b));
         }
 
         if ($a instanceof Ratio) {
-            return $a->multiply(self::rationalOperand($b));
+            return $a->multiply(NumericCoercion::rationalOperand($b));
         }
 
         if ($b instanceof Ratio) {
-            return $b->multiply(self::rationalOperand($a));
+            return $b->multiply(NumericCoercion::rationalOperand($a));
         }
 
         if ($a instanceof BigInt || $b instanceof BigInt) {
-            return self::collapseBigInt(self::toBigInt($a)->multiply(self::toBigInt($b)));
+            return NumericCoercion::collapseBigInt(NumericCoercion::toBigInt($a)->multiply(NumericCoercion::toBigInt($b)));
         }
 
-        if (self::multiplyOverflows($a, $b)) {
-            return self::collapseBigInt(BigInt::fromInt($a)->multiply(BigInt::fromInt($b)));
+        if (IntegerOverflow::onMultiply($a, $b)) {
+            return NumericCoercion::collapseBigInt(BigInt::fromInt($a)->multiply(BigInt::fromInt($b)));
         }
 
         return $a * $b;
@@ -139,12 +140,12 @@ final class NumericOperations
      */
     public static function divide(mixed $a, mixed $b): mixed
     {
-        self::ensureNumeric($a);
-        self::ensureNumeric($b);
+        NumericCoercion::ensureNumeric($a);
+        NumericCoercion::ensureNumeric($b);
 
         if (is_float($a) || is_float($b)) {
-            $left = self::toFloat($a);
-            $right = self::toFloat($b);
+            $left = NumericCoercion::toFloat($a);
+            $right = NumericCoercion::toFloat($b);
             // Route any float-over-zero division through `fdiv` so
             // `(/ 1.0 0)` => `INF`, `(/ -1.0 0)` => `-INF`, `(/ 0.0 0)` => `NAN`,
             // and `(/ ##Inf 0)` / `(/ ##NaN 0)` keep their IEEE-754 results.
@@ -157,11 +158,11 @@ final class NumericOperations
         }
 
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
-            return self::toBigDecimal($a)->divideExact(self::toBigDecimal($b));
+            return NumericCoercion::toBigDecimal($a)->divideExact(NumericCoercion::toBigDecimal($b));
         }
 
         if ($a instanceof Ratio) {
-            return $a->divide(self::rationalOperand($b));
+            return $a->divide(NumericCoercion::rationalOperand($b));
         }
 
         if ($b instanceof Ratio) {
@@ -170,7 +171,7 @@ final class NumericOperations
         }
 
         if ($a instanceof BigInt || $b instanceof BigInt) {
-            return Ratio::create(self::toBigInt($a), self::toBigInt($b));
+            return Ratio::create(NumericCoercion::toBigInt($a), NumericCoercion::toBigInt($b));
         }
 
         if ($b === 0) {
@@ -186,14 +187,14 @@ final class NumericOperations
 
     public static function negate(mixed $a): mixed
     {
-        self::ensureNumeric($a);
+        NumericCoercion::ensureNumeric($a);
 
         if ($a instanceof Ratio) {
             return $a->negate();
         }
 
         if ($a instanceof BigInt) {
-            return self::collapseBigInt($a->negate());
+            return NumericCoercion::collapseBigInt($a->negate());
         }
 
         if ($a instanceof BigDecimal) {
@@ -205,27 +206,27 @@ final class NumericOperations
 
     public static function compare(mixed $a, mixed $b): int
     {
-        self::ensureNumeric($a);
-        self::ensureNumeric($b);
+        NumericCoercion::ensureNumeric($a);
+        NumericCoercion::ensureNumeric($b);
 
         if (is_float($a) || is_float($b)) {
-            return self::toFloat($a) <=> self::toFloat($b);
+            return NumericCoercion::toFloat($a) <=> NumericCoercion::toFloat($b);
         }
 
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
-            return self::toBigDecimal($a)->compareTo(self::toBigDecimal($b));
+            return NumericCoercion::toBigDecimal($a)->compareTo(NumericCoercion::toBigDecimal($b));
         }
 
         if ($a instanceof Ratio) {
-            return $a->compareTo(self::rationalOperand($b));
+            return $a->compareTo(NumericCoercion::rationalOperand($b));
         }
 
         if ($b instanceof Ratio) {
-            return -$b->compareTo(self::rationalOperand($a));
+            return -$b->compareTo(NumericCoercion::rationalOperand($a));
         }
 
         if ($a instanceof BigInt || $b instanceof BigInt) {
-            return self::toBigInt($a)->compareTo(self::toBigInt($b));
+            return NumericCoercion::toBigInt($a)->compareTo(NumericCoercion::toBigInt($b));
         }
 
         return $a <=> $b;
@@ -233,15 +234,15 @@ final class NumericOperations
 
     public static function isEqual(mixed $a, mixed $b): bool
     {
-        self::ensureNumeric($a);
-        self::ensureNumeric($b);
+        NumericCoercion::ensureNumeric($a);
+        NumericCoercion::ensureNumeric($b);
 
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
             return self::compare($a, $b) === 0;
         }
 
         if (is_float($a) || is_float($b)) {
-            return self::toFloat($a) === self::toFloat($b);
+            return NumericCoercion::toFloat($a) === NumericCoercion::toFloat($b);
         }
 
         if ($a instanceof Ratio) {
@@ -253,7 +254,7 @@ final class NumericOperations
         }
 
         if ($a instanceof BigInt || $b instanceof BigInt) {
-            return self::toBigInt($a)->equals(self::toBigInt($b));
+            return NumericCoercion::toBigInt($a)->equals(NumericCoercion::toBigInt($b));
         }
 
         return $a === $b;
@@ -280,14 +281,14 @@ final class NumericOperations
 
     public static function abs(mixed $a): mixed
     {
-        self::ensureNumeric($a);
+        NumericCoercion::ensureNumeric($a);
 
         if ($a instanceof Ratio) {
             return $a->abs();
         }
 
         if ($a instanceof BigInt) {
-            return self::collapseBigInt($a->abs());
+            return NumericCoercion::collapseBigInt($a->abs());
         }
 
         if ($a instanceof BigDecimal) {
@@ -305,16 +306,16 @@ final class NumericOperations
 
     public static function power(mixed $base, mixed $exp): mixed
     {
-        self::ensureNumeric($base);
-        self::ensureNumeric($exp);
+        NumericCoercion::ensureNumeric($base);
+        NumericCoercion::ensureNumeric($exp);
 
         // Float exponent or float base falls back to native ** for parity
         // with PHP semantics, including fractional exponents.
         if (is_float($base) || is_float($exp) || $exp instanceof Ratio) {
-            return self::toFloat($base) ** self::toFloat($exp);
+            return NumericCoercion::toFloat($base) ** NumericCoercion::toFloat($exp);
         }
 
-        $exponent = self::toIntExponent($exp);
+        $exponent = NumericCoercion::toIntExponent($exp);
 
         if ($base instanceof Ratio) {
             return self::rationalPower($base, $exponent);
@@ -322,13 +323,13 @@ final class NumericOperations
 
         // Route int^int and BigInt^int through BigInt so overflow
         // auto-promotes; cheap exponents collapse back to int.
-        $baseBig = self::toBigInt($base);
+        $baseBig = NumericCoercion::toBigInt($base);
 
         if ($exponent < 0) {
             return Ratio::create(BigInt::one(), $baseBig->pow(-$exponent));
         }
 
-        return self::collapseBigInt($baseBig->pow($exponent));
+        return NumericCoercion::collapseBigInt($baseBig->pow($exponent));
     }
 
     /**
@@ -336,15 +337,15 @@ final class NumericOperations
      */
     public static function quot(mixed $a, mixed $b): mixed
     {
-        self::ensureNumeric($a);
-        self::ensureNumeric($b);
+        NumericCoercion::ensureNumeric($a);
+        NumericCoercion::ensureNumeric($b);
 
         if (self::isZero($b)) {
             throw new DivisionByZeroError('Division by zero');
         }
 
         if (is_float($a) || is_float($b)) {
-            $ratio = self::toFloat($a) / self::toFloat($b);
+            $ratio = NumericCoercion::toFloat($a) / NumericCoercion::toFloat($b);
             // Float operands keep float result; truncate toward zero.
             // Float wins over BigDecimal (`(quot 1.0M 1.0)` returns a float).
             return $ratio < 0 ? ceil($ratio) : floor($ratio);
@@ -352,18 +353,18 @@ final class NumericOperations
 
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
             return self::truncateBigDecimalQuot(
-                self::toBigDecimal($a),
-                self::toBigDecimal($b),
+                NumericCoercion::toBigDecimal($a),
+                NumericCoercion::toBigDecimal($b),
             );
         }
 
         if ($a instanceof Ratio || $b instanceof Ratio) {
             $quotient = self::divide($a, $b);
-            return self::truncateToInt($quotient);
+            return NumericCoercion::truncateToInt($quotient);
         }
 
         if ($a instanceof BigInt || $b instanceof BigInt) {
-            return self::collapseBigInt(self::toBigInt($a)->divide(self::toBigInt($b)));
+            return NumericCoercion::collapseBigInt(NumericCoercion::toBigInt($a)->divide(NumericCoercion::toBigInt($b)));
         }
 
         return intdiv((int) $a, (int) $b);
@@ -374,8 +375,8 @@ final class NumericOperations
      */
     public static function rem(mixed $a, mixed $b): mixed
     {
-        self::ensureNumeric($a);
-        self::ensureNumeric($b);
+        NumericCoercion::ensureNumeric($a);
+        NumericCoercion::ensureNumeric($b);
 
         if (self::isZero($b)) {
             throw new DivisionByZeroError('Division by zero');
@@ -384,12 +385,12 @@ final class NumericOperations
         if (is_float($a) || is_float($b)) {
             // Float wins over BigDecimal (`(rem 1.0M 1.0)` returns a float).
             $q = (float) self::quot($a, $b);
-            return self::toFloat($a) - (self::toFloat($b) * $q);
+            return NumericCoercion::toFloat($a) - (NumericCoercion::toFloat($b) * $q);
         }
 
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
-            $aBig = self::toBigDecimal($a);
-            $bBig = self::toBigDecimal($b);
+            $aBig = NumericCoercion::toBigDecimal($a);
+            $bBig = NumericCoercion::toBigDecimal($b);
             $q = self::truncateBigDecimalQuot($aBig, $bBig);
             return $aBig->subtract($bBig->multiply($q));
         }
@@ -400,10 +401,10 @@ final class NumericOperations
         }
 
         if ($a instanceof BigInt || $b instanceof BigInt) {
-            $aBig = self::toBigInt($a);
-            $bBig = self::toBigInt($b);
+            $aBig = NumericCoercion::toBigInt($a);
+            $bBig = NumericCoercion::toBigInt($b);
             $q = $aBig->divide($bBig);
-            return self::collapseBigInt($aBig->subtract($bBig->multiply($q)));
+            return NumericCoercion::collapseBigInt($aBig->subtract($bBig->multiply($q)));
         }
 
         return ((int) $a) % ((int) $b);
@@ -415,8 +416,8 @@ final class NumericOperations
      */
     public static function mod(mixed $a, mixed $b): mixed
     {
-        self::ensureNumeric($a);
-        self::ensureNumeric($b);
+        NumericCoercion::ensureNumeric($a);
+        NumericCoercion::ensureNumeric($b);
 
         if (self::isZero($b)) {
             throw new DivisionByZeroError('Modulo by zero');
@@ -438,65 +439,6 @@ final class NumericOperations
         return $rem;
     }
 
-    private static function addOverflows(int $a, int $b): bool
-    {
-        if ($a > 0 && $b > 0) {
-            return $a > PHP_INT_MAX - $b;
-        }
-
-        if ($a < 0 && $b < 0) {
-            return $a < PHP_INT_MIN - $b;
-        }
-
-        return false;
-    }
-
-    private static function subtractOverflows(int $a, int $b): bool
-    {
-        if ($a >= 0 && $b < 0) {
-            // a - b > PHP_INT_MAX when b < a - PHP_INT_MAX.
-            return $a > PHP_INT_MAX + $b;
-        }
-
-        if ($a < 0 && $b > 0) {
-            return $a < PHP_INT_MIN + $b;
-        }
-
-        return false;
-    }
-
-    private static function multiplyOverflows(int $a, int $b): bool
-    {
-        if ($a === 0 || $b === 0 || $a === 1 || $b === 1) {
-            return false;
-        }
-
-        // PHP_INT_MIN cannot be negated within int range, so any multiply of
-        // PHP_INT_MIN by anything other than 0 or 1 leaves the int range.
-        if ($a === PHP_INT_MIN || $b === PHP_INT_MIN) {
-            return true;
-        }
-
-        // Compare against PHP_INT_MAX magnitude using truncating intdiv.
-        // Both operands are now safe to negate within int range.
-        return intdiv(PHP_INT_MAX, abs($a)) < abs($b);
-    }
-
-    private static function ensureNumeric(mixed $value): void
-    {
-        if (is_int($value) || is_float($value)) {
-            return;
-        }
-
-        if ($value instanceof BigInt || $value instanceof Ratio || $value instanceof BigDecimal) {
-            return;
-        }
-
-        throw new InvalidArgumentException(
-            sprintf('Expected a number, got %s', get_debug_type($value)),
-        );
-    }
-
     /**
      * Truncates `a / b` toward zero and returns the result as a scale-0
      * `BigDecimal`. Used by `quot` and `rem` for BigDecimal operands.
@@ -508,78 +450,6 @@ final class NumericOperations
         $bLifted = $b->mantissa()->multiply(BigInt::fromInt(10)->pow($scale - $b->scale()));
 
         return BigDecimal::fromBigInt($aLifted->divide($bLifted));
-    }
-
-    private static function toBigDecimal(mixed $value): BigDecimal
-    {
-        if ($value instanceof BigDecimal) {
-            return $value;
-        }
-
-        if ($value instanceof BigInt) {
-            return BigDecimal::fromBigInt($value);
-        }
-
-        if (is_int($value)) {
-            return BigDecimal::fromInt($value);
-        }
-
-        if (is_float($value)) {
-            return BigDecimal::fromFloat($value);
-        }
-
-        if ($value instanceof Ratio) {
-            return BigDecimal::fromBigInt($value->numerator())
-                ->divideExact(BigDecimal::fromBigInt($value->denominator()));
-        }
-
-        throw new InvalidArgumentException(
-            sprintf('Cannot lift %s to BigDecimal', get_debug_type($value)),
-        );
-    }
-
-    private static function toFloat(mixed $value): float
-    {
-        if ($value instanceof Ratio) {
-            return $value->toFloat();
-        }
-
-        if ($value instanceof BigInt || $value instanceof BigDecimal) {
-            return (float) (string) $value;
-        }
-
-        return (float) $value;
-    }
-
-    private static function toBigInt(mixed $value): BigInt
-    {
-        if ($value instanceof BigInt) {
-            return $value;
-        }
-
-        if (is_int($value)) {
-            return BigInt::fromInt($value);
-        }
-
-        throw new InvalidArgumentException(
-            sprintf('Cannot lift %s to BigInt', get_debug_type($value)),
-        );
-    }
-
-    private static function rationalOperand(mixed $value): Ratio|BigInt|int
-    {
-        if ($value instanceof Ratio || $value instanceof BigInt || is_int($value)) {
-            return $value;
-        }
-
-        throw new InvalidArgumentException(
-            sprintf('Cannot use %s as a rational operand', get_debug_type($value)),
-        );
-    }
-
-    private static function collapseBigInt(BigInt $value): BigInt|int
-    {
-        return $value->fitsInPhpInt() ? $value->toInt() : $value;
     }
 
     private static function rationalPower(Ratio $base, int $exponent): mixed
@@ -601,37 +471,5 @@ final class NumericOperations
         $num = $base->numerator()->pow($exponent);
         $den = $base->denominator()->pow($exponent);
         return Ratio::create($num, $den);
-    }
-
-    private static function toIntExponent(mixed $value): int
-    {
-        if (is_int($value)) {
-            return $value;
-        }
-
-        if ($value instanceof BigInt) {
-            if (!$value->fitsInPhpInt()) {
-                throw new InvalidArgumentException('Exponent does not fit in PHP int range');
-            }
-
-            return $value->toInt();
-        }
-
-        throw new InvalidArgumentException(
-            sprintf('Cannot use %s as an integer exponent', get_debug_type($value)),
-        );
-    }
-
-    private static function truncateToInt(mixed $value): mixed
-    {
-        if (is_int($value) || $value instanceof BigInt) {
-            return $value;
-        }
-
-        if ($value instanceof Ratio) {
-            return self::collapseBigInt($value->numerator()->divide($value->denominator()));
-        }
-
-        return (int) $value;
     }
 }

--- a/tests/php/Unit/Lang/IntegerOverflowTest.php
+++ b/tests/php/Unit/Lang/IntegerOverflowTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang;
+
+use Phel\Lang\IntegerOverflow;
+use PHPUnit\Framework\TestCase;
+
+final class IntegerOverflowTest extends TestCase
+{
+    public function test_on_add_is_false_for_small_operands(): void
+    {
+        self::assertFalse(IntegerOverflow::onAdd(2, 3));
+        self::assertFalse(IntegerOverflow::onAdd(-2, -3));
+        self::assertFalse(IntegerOverflow::onAdd(PHP_INT_MAX - 1, 1));
+    }
+
+    public function test_on_add_detects_positive_overflow(): void
+    {
+        self::assertTrue(IntegerOverflow::onAdd(PHP_INT_MAX, 1));
+    }
+
+    public function test_on_add_detects_negative_overflow(): void
+    {
+        self::assertTrue(IntegerOverflow::onAdd(PHP_INT_MIN, -1));
+    }
+
+    public function test_on_add_mixed_signs_never_overflow(): void
+    {
+        self::assertFalse(IntegerOverflow::onAdd(PHP_INT_MAX, -1));
+        self::assertFalse(IntegerOverflow::onAdd(PHP_INT_MIN, 1));
+    }
+
+    public function test_on_subtract_is_false_for_safe_operands(): void
+    {
+        self::assertFalse(IntegerOverflow::onSubtract(5, 3));
+        self::assertFalse(IntegerOverflow::onSubtract(PHP_INT_MAX, PHP_INT_MAX));
+        self::assertFalse(IntegerOverflow::onSubtract(PHP_INT_MIN, PHP_INT_MIN));
+    }
+
+    public function test_on_subtract_detects_overflow_subtracting_negative(): void
+    {
+        self::assertTrue(IntegerOverflow::onSubtract(PHP_INT_MAX, -1));
+    }
+
+    public function test_on_subtract_detects_underflow_subtracting_positive(): void
+    {
+        self::assertTrue(IntegerOverflow::onSubtract(PHP_INT_MIN, 1));
+    }
+
+    public function test_on_multiply_is_false_for_zero_and_one(): void
+    {
+        self::assertFalse(IntegerOverflow::onMultiply(0, PHP_INT_MAX));
+        self::assertFalse(IntegerOverflow::onMultiply(PHP_INT_MAX, 1));
+        self::assertFalse(IntegerOverflow::onMultiply(1, PHP_INT_MIN));
+    }
+
+    public function test_on_multiply_php_int_min_overflows_for_any_other_factor(): void
+    {
+        self::assertTrue(IntegerOverflow::onMultiply(PHP_INT_MIN, 2));
+        self::assertTrue(IntegerOverflow::onMultiply(2, PHP_INT_MIN));
+        self::assertTrue(IntegerOverflow::onMultiply(PHP_INT_MIN, -1));
+    }
+
+    public function test_on_multiply_detects_large_product_overflow(): void
+    {
+        self::assertTrue(IntegerOverflow::onMultiply(PHP_INT_MAX, 2));
+        self::assertTrue(IntegerOverflow::onMultiply(1_000_000_000, 1_000_000_000_000));
+    }
+
+    public function test_on_multiply_is_false_for_safe_product(): void
+    {
+        self::assertFalse(IntegerOverflow::onMultiply(1000, 1000));
+        self::assertFalse(IntegerOverflow::onMultiply(-7, 8));
+    }
+}

--- a/tests/php/Unit/Lang/NumericCoercionTest.php
+++ b/tests/php/Unit/Lang/NumericCoercionTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang;
+
+use InvalidArgumentException;
+use Phel\Lang\BigDecimal;
+use Phel\Lang\BigInt;
+use Phel\Lang\NumericCoercion;
+use Phel\Lang\Ratio;
+use PHPUnit\Framework\TestCase;
+
+final class NumericCoercionTest extends TestCase
+{
+    public function test_ensure_numeric_accepts_every_numeric_type(): void
+    {
+        NumericCoercion::ensureNumeric(1);
+        NumericCoercion::ensureNumeric(1.5);
+        NumericCoercion::ensureNumeric(BigInt::fromInt(1));
+        NumericCoercion::ensureNumeric(Ratio::create(1, 2));
+        NumericCoercion::ensureNumeric(BigDecimal::fromString('1.5'));
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function test_ensure_numeric_rejects_non_numeric(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        NumericCoercion::ensureNumeric('1');
+    }
+
+    public function test_to_float(): void
+    {
+        self::assertSame(2.0, NumericCoercion::toFloat(2));
+        self::assertSame(2.5, NumericCoercion::toFloat(2.5));
+        self::assertSame(3.0, NumericCoercion::toFloat(BigInt::fromInt(3)));
+        self::assertSame(0.5, NumericCoercion::toFloat(Ratio::create(1, 2)));
+        self::assertSame(1.5, NumericCoercion::toFloat(BigDecimal::fromString('1.5')));
+    }
+
+    public function test_to_big_int_from_int_and_big_int(): void
+    {
+        self::assertSame('5', (string) NumericCoercion::toBigInt(5));
+        $big = BigInt::fromInt(7);
+        self::assertSame($big, NumericCoercion::toBigInt($big));
+    }
+
+    public function test_to_big_int_rejects_float(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        NumericCoercion::toBigInt(1.5);
+    }
+
+    public function test_to_big_decimal_from_each_numeric_type(): void
+    {
+        self::assertSame(0, NumericCoercion::toBigDecimal(2)->compareTo(BigDecimal::fromInt(2)));
+        self::assertSame(0, NumericCoercion::toBigDecimal(BigInt::fromInt(2))->compareTo(BigDecimal::fromInt(2)));
+        self::assertSame(0, NumericCoercion::toBigDecimal(Ratio::create(1, 2))->compareTo(BigDecimal::fromString('0.5')));
+    }
+
+    public function test_rational_operand_passes_through_int_big_int_ratio(): void
+    {
+        self::assertSame(3, NumericCoercion::rationalOperand(3));
+        $big = BigInt::fromInt(4);
+        self::assertSame($big, NumericCoercion::rationalOperand($big));
+        $ratio = Ratio::create(1, 2);
+        self::assertSame($ratio, NumericCoercion::rationalOperand($ratio));
+    }
+
+    public function test_rational_operand_rejects_float(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        NumericCoercion::rationalOperand(1.5);
+    }
+
+    public function test_collapse_big_int_returns_native_int_when_it_fits(): void
+    {
+        self::assertSame(5, NumericCoercion::collapseBigInt(BigInt::fromInt(5)));
+        self::assertSame(PHP_INT_MAX, NumericCoercion::collapseBigInt(BigInt::fromInt(PHP_INT_MAX)));
+    }
+
+    public function test_collapse_big_int_keeps_big_int_when_out_of_range(): void
+    {
+        $huge = BigInt::fromString('99999999999999999999999999');
+        self::assertSame($huge, NumericCoercion::collapseBigInt($huge));
+    }
+
+    public function test_to_int_exponent(): void
+    {
+        self::assertSame(4, NumericCoercion::toIntExponent(4));
+        self::assertSame(4, NumericCoercion::toIntExponent(BigInt::fromInt(4)));
+    }
+
+    public function test_to_int_exponent_rejects_out_of_range_big_int(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        NumericCoercion::toIntExponent(BigInt::fromString('99999999999999999999999999'));
+    }
+
+    public function test_to_int_exponent_rejects_float(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        NumericCoercion::toIntExponent(1.5);
+    }
+
+    public function test_truncate_to_int(): void
+    {
+        self::assertSame(3, NumericCoercion::truncateToInt(3));
+        self::assertSame(3, NumericCoercion::truncateToInt(Ratio::create(7, 2)));
+        self::assertSame(-3, NumericCoercion::truncateToInt(Ratio::create(-7, 2)));
+        $big = BigInt::fromInt(9);
+        self::assertSame($big, NumericCoercion::truncateToInt($big));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`NumericOperations` (Lang module) was 637 LOC. It carried the runtime numeric dispatch (13 contagion ladders for `+ - * /` and friends across PHP numbers, `BigInt`, `Ratio`, `BigDecimal`) *and* two independent helper clusters bolted onto the same class: numeric type lifting/validation, and native-int overflow detection.

Next god-class after `BigInt` (#2275). The dispatch ladders are one cohesive table and stay put; the helper clusters are genuinely separate, reusable, independently-testable concerns.

## 💡 Goal

Leave `NumericOperations` owning only the contagion ladders, and lift the two helper clusters into focused, directly-testable units — with **zero** change to arithmetic results.

## 🔖 Changes

- Extract **`NumericCoercion`** — numeric type lifting and validation: `ensureNumeric`, `toFloat` / `toBigInt` / `toBigDecimal`, `rationalOperand`, `collapseBigInt`, `toIntExponent`, `truncateToInt`.
- Extract **`IntegerOverflow`** — pure native-int overflow predicates `onAdd` / `onSubtract` / `onMultiply` that drive promotion to `BigInt`.
- `NumericOperations` keeps the public ops (`add`/`subtract`/`multiply`/`divide`/`negate`/`compare`/`isEqual`/`isZero`/`abs`/`power`/`quot`/`rem`/`mod`) and the op-specific `truncateBigDecimalQuot` / `rationalPower`, delegating coercion and overflow. It drops from **637 to ~475 LOC**.
- Public static API and all call sites are unchanged.

### ✅ Verification

- The existing **69** `NumericOperationsTest` cases (explicit overflow / `PHP_INT_MAX`/`MIN` boundary / promotion / contagion coverage) and the **9** `NumericOperationSpecializationTest` cases stay green — confirmed against the original *before* extracting.
- Added **25** direct unit tests for the new units (`IntegerOverflowTest`, `NumericCoercionTest`) covering the overflow boundaries and every coercion/lift/collapse path.
- `composer test-compiler`: 3948 pass. `composer test-core`: 5788 pass. `composer test-quality` (cs-fixer, psalm lvl 1, phpstan lvl 6, rector): clean.
- PHPBench `TypedSignatureBench` (untyped paths route through `NumericOperations`), 12 iterations vs `main` baseline: `fib_untyped` +1.07%, `sum_squares` -0.4%, `mandel` +1.09% — within ±2% noise; memory identical. Perf-neutral.

### 📌 Remaining god-classes (follow-ups)

`PhelFnLoader` (514, `Api` — mostly a native-symbol data table), `Parser` (498, `Compiler` — cohesive). Each its own PR.
