### PR TITLE
feat(emitter): emit PHP attributes and typed properties on defstruct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 - `phel.http`: `request-from-globals` decodes `application/json` request bodies into `:parsed-body` (nil for an empty or malformed body); `request-from-globals-args` gains an optional trailing `raw-body` arg
 - `phel.http`: `json-response` and `html-response` builders set the content-type header and encode the body, so apps stop hand-rolling the header map; the `http-json-api` example now uses them (#2271)
+- `defstruct`: fields tagged with `^{:tag <type>}` now emit a typed PHP property, and `^{:php/attr [...]}` metadata on the struct name or a field emits PHP 8 attributes (e.g. `#[\ORM\Column(length: 255)]`) on the generated class/property — both opt-in, untagged structs unchanged (#2280)
 - Compiler internals: regression test pinning that AST source locations survive every phase
 
 ### Changed

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -75,6 +75,10 @@ Compiler/
 
 Analyzer tracks param and return types via `ParamTypeInferrer`, `ReturnTypeInferrer`, grafting `:tag` meta onto binding symbols. Call-site *eligibility* lives on `*Specialization` classes (`NumericOperationSpecialization`, `TypePredicateSpecialization`, `TypedValueSpecialization`, `TypedCollectionMethodSpecialization`, `AssocConjSpecialization`, `AtomMethodSpecialization`, `NilAndBooleanCheckSpecialization`); `CallSpecialization` aggregates them. The matching PHP *emission* lives on per-family collaborators under `NodeEmitter/Specialized/` (one `*CallEmitter implements SpecializedCallEmitterInterface` per eligibility class); `CallEmitter` builds them once and dispatches by looping `tryEmit()` over them before the generic call path. Family predicates are disjoint, so chain order between families is not significant. Add a new specialization family as a `*Specialization` eligibility class, register it in `CallSpecialization::isSpecialized()`, and add the matching `Specialized/*CallEmitter` to `CallEmitter`'s ordered list. Contract: propagate only analyzer-published types, never fabricate.
 
+## Struct Attributes & Typed Properties
+
+`DefStructEmitter` reads per-symbol metadata to enrich the generated PHP class: a field's `^{:tag <type>}` emits a typed property (`protected int $id;`), and `^{:php/attr [...]}` on the struct name (class-level) or a field (property-level) emits PHP 8 attributes via the shared `Phel\Shared\PhpAttributeRenderer`. Both opt-in; untagged structs are byte-identical to before.
+
 ## Global Environment
 
 Process-wide singleton in `Domain/Analyzer/Environment/GlobalEnvironmentRegistry`. `GlobalEnvironmentManager` (Application) and `GlobalEnvironmentSingleton` (Infrastructure) both read/write the same slot. `GlobalEnvironmentSingleton` is retained as ABI shim; emitter writes literal calls to `\Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton::getInstance()` into generated PHP (baked into cached `.phel` files).

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -8,16 +8,22 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DefStructNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
+use Phel\Shared\PhpAttributeRenderer;
 
 use function assert;
 use function count;
+use function is_string;
 
 final readonly class DefStructEmitter implements NodeEmitterInterface
 {
     public function __construct(
         private OutputEmitterInterface $outputEmitter,
         private MethodEmitter $methodEmitter,
+        private PhpAttributeRenderer $attributeRenderer = new PhpAttributeRenderer(),
     ) {}
 
     public function emit(AbstractNode $node): void
@@ -104,6 +110,8 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
 
     private function emitClassHeader(DefStructNode $node): void
     {
+        $this->emitAttributes($node->getName()->getMeta(), $node->getStartSourceLocation());
+
         $this->outputEmitter->emitStr(
             'final class ' . $this->outputEmitter->mungeEncode($node->getName()->getName()) . ' extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct',
             $node->getStartSourceLocation(),
@@ -149,12 +157,58 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
     {
         $params = $node->getParams();
         foreach ($params as $param) {
+            $meta = $param->getMeta();
+            $this->emitAttributes($meta, $node->getStartSourceLocation());
+
             $this->outputEmitter->emitStr('protected ');
+            $tag = $this->extractTag($meta);
+            if ($tag !== null) {
+                $this->outputEmitter->emitStr($tag . ' ');
+            }
+
             $this->outputEmitter->emitPhpVariable($param);
             $this->outputEmitter->emitLine(';');
         }
 
         $this->outputEmitter->emitLine();
+    }
+
+    /**
+     * Emits one `#[...]` line per `:php/attr` spec carried by the symbol meta,
+     * at the current indentation, before the annotated construct.
+     *
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
+     */
+    private function emitAttributes(?PersistentMapInterface $meta, ?SourceLocation $sourceLocation): void
+    {
+        if (!$meta instanceof PersistentMapInterface) {
+            return;
+        }
+
+        $specs = $meta->find(Keyword::create('attr', 'php'));
+        foreach ($this->attributeRenderer->render($specs) as $attribute) {
+            $this->outputEmitter->emitLine($attribute, $sourceLocation);
+        }
+    }
+
+    /**
+     * Reads the PHP type hint from a symbol's `:tag` meta, mirroring the
+     * convention used for typed function parameters. Returns null when absent.
+     *
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
+     */
+    private function extractTag(?PersistentMapInterface $meta): ?string
+    {
+        if (!$meta instanceof PersistentMapInterface) {
+            return null;
+        }
+
+        $tag = $meta->find(Keyword::create('tag'));
+        if ($tag instanceof Symbol) {
+            $tag = $tag->getName();
+        }
+
+        return is_string($tag) && $tag !== '' ? $tag : null;
     }
 
     private function emitConstructor(DefStructNode $node): void

--- a/src/php/Shared/CLAUDE.md
+++ b/src/php/Shared/CLAUDE.md
@@ -61,6 +61,7 @@ Strategy pattern via `TypePrinter/`: one class per Phel/PHP type; `WithColorTrai
 - `PhelProjectDirectory`: manages `.phel/` directory; respects `PHEL_DIR` env var and `PhelConfig::setPhelDir()`
 - `VersionFinder`: resolves project version from git state or official release tag
 - `CompileOptions`: constants for source maps, emit-only mode, optimization levels
+- `PhpAttributeRenderer`: renders `^{:php/attr [...]}` metadata specs (vectors keyed by namespaced keywords) into PHP 8 attribute source lines (`#[\ORM\Column(length: 255)]`); pure, stateless. Consumed by the compiler's `DefStructEmitter` (and reusable by the Interop export generator)
 
 ## Dependencies
 

--- a/src/php/Shared/PhpAttributeRenderer.php
+++ b/src/php/Shared/PhpAttributeRenderer.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared;
+
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Keyword;
+
+use function implode;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_string;
+use function str_replace;
+use function var_export;
+
+/**
+ * Renders the `^{:php/attr [...]}` metadata value into PHP 8 attribute source.
+ *
+ * Each spec is a vector `[:Ns/Name & args]`:
+ *
+ *   [:Route]                       => #[\Route]
+ *   [:ORM/Column]                  => #[\ORM\Column]
+ *   [:Route "/p"]                  => #[\Route("/p")]
+ *   [:ORM/Column {:length 255}]    => #[\ORM\Column(length: 255)]
+ *   [:Route "/p" {:methods ["GET"]}] => #[\Route("/p", methods: ['GET'])]
+ *
+ * The class name is rendered fully-qualified (leading `\`) so generated PHP
+ * needs no `use` imports. A namespaced keyword maps `.` to `\`, so
+ * `:Symfony.Component.Routing.Attribute/Route` becomes
+ * `\Symfony\Component\Routing\Attribute\Route`.
+ *
+ * Pure, stateless, no I/O.
+ */
+final class PhpAttributeRenderer
+{
+    /**
+     * @return list<string> one `#[...]` line per spec; empty when no attributes
+     */
+    public function render(mixed $specs): array
+    {
+        if (!$specs instanceof PersistentVectorInterface) {
+            return [];
+        }
+
+        $lines = [];
+        foreach ($specs as $spec) {
+            $line = $this->renderSpec($spec);
+            if ($line !== null) {
+                $lines[] = $line;
+            }
+        }
+
+        return $lines;
+    }
+
+    private function renderSpec(mixed $spec): ?string
+    {
+        if (!$spec instanceof PersistentVectorInterface) {
+            return null;
+        }
+
+        $name = null;
+        $args = [];
+        $index = 0;
+        foreach ($spec as $element) {
+            if ($index === 0) {
+                $name = $element;
+            } elseif ($element instanceof PersistentMapInterface) {
+                foreach ($element as $key => $value) {
+                    if ($key instanceof Keyword) {
+                        $args[] = $key->getName() . ': ' . $this->renderValue($value);
+                    }
+                }
+            } else {
+                $args[] = $this->renderValue($element);
+            }
+
+            ++$index;
+        }
+
+        if (!$name instanceof Keyword) {
+            return null;
+        }
+
+        $fqcn = $this->renderClassName($name);
+
+        return $args === []
+            ? '#[' . $fqcn . ']'
+            : '#[' . $fqcn . '(' . implode(', ', $args) . ')]';
+    }
+
+    private function renderClassName(Keyword $name): string
+    {
+        $namespace = $name->getNamespace();
+        if ($namespace === null || $namespace === '') {
+            return '\\' . $name->getName();
+        }
+
+        return '\\' . str_replace('.', '\\', $namespace) . '\\' . $name->getName();
+    }
+
+    private function renderValue(mixed $value): string
+    {
+        if (is_string($value) || is_bool($value) || is_int($value) || is_float($value)) {
+            return var_export($value, true);
+        }
+
+        if ($value instanceof Keyword) {
+            return var_export($value->getName(), true);
+        }
+
+        if ($value instanceof PersistentVectorInterface) {
+            $items = [];
+            foreach ($value as $item) {
+                $items[] = $this->renderValue($item);
+            }
+
+            return '[' . implode(', ', $items) . ']';
+        }
+
+        if ($value instanceof PersistentMapInterface) {
+            $items = [];
+            foreach ($value as $key => $val) {
+                $items[] = $this->renderValue($key) . ' => ' . $this->renderValue($val);
+            }
+
+            return '[' . implode(', ', $items) . ']';
+        }
+
+        return 'null';
+    }
+}

--- a/tests/php/Integration/Fixtures/Def/defstruct-php-attributes.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-php-attributes.test
@@ -1,0 +1,25 @@
+--PHEL--
+(defstruct* ^{:php/attr [[:ORM/Entity]]} my-entity
+  [^{:tag int :php/attr [[:ORM/Id] [:ORM/Column]]} id
+   ^{:tag string :php/attr [[:ORM/Column {:length 255}]]} name])
+--PHP--
+if (!class_exists('user\my_entity')) {
+#[\ORM\Entity]
+final class my_entity extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
+
+  protected const array ALLOWED_KEYS = ['id', 'name'];
+
+  #[\ORM\Id]
+  #[\ORM\Column]
+  protected int $id;
+  #[\ORM\Column(length: 255)]
+  protected string $name;
+
+  public function __construct($id, $name, $meta = null) {
+    parent::__construct();
+    $this->id = $id;
+    $this->name = $name;
+    $this->meta = $meta;
+  }
+}
+}

--- a/tests/php/Integration/Fixtures/Def/defstruct-typed-properties.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-typed-properties.test
@@ -1,0 +1,19 @@
+--PHEL--
+(defstruct* my-typed-type [^{:tag int} a ^{:tag string} b])
+--PHP--
+if (!class_exists('user\my_typed_type')) {
+final class my_typed_type extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
+
+  protected const array ALLOWED_KEYS = ['a', 'b'];
+
+  protected int $a;
+  protected string $b;
+
+  public function __construct($a, $b, $meta = null) {
+    parent::__construct();
+    $this->a = $a;
+    $this->b = $b;
+    $this->meta = $meta;
+  }
+}
+}

--- a/tests/php/Unit/Shared/PhpAttributeRendererTest.php
+++ b/tests/php/Unit/Shared/PhpAttributeRendererTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared;
+
+use Phel\Lang\Keyword;
+use Phel\Lang\TypeFactory;
+use Phel\Shared\PhpAttributeRenderer;
+use PHPUnit\Framework\TestCase;
+
+final class PhpAttributeRendererTest extends TestCase
+{
+    private PhpAttributeRenderer $renderer;
+
+    protected function setUp(): void
+    {
+        $this->renderer = new PhpAttributeRenderer();
+    }
+
+    public function test_non_vector_input_renders_nothing(): void
+    {
+        self::assertSame([], $this->renderer->render(null));
+        self::assertSame([], $this->renderer->render('not-a-vector'));
+    }
+
+    public function test_empty_vector_renders_nothing(): void
+    {
+        self::assertSame([], $this->renderer->render($this->vec()));
+    }
+
+    public function test_bare_attribute_without_namespace(): void
+    {
+        $specs = $this->vec($this->vec(Keyword::create('Route')));
+
+        self::assertSame(['#[\Route]'], $this->renderer->render($specs));
+    }
+
+    public function test_namespaced_attribute(): void
+    {
+        $specs = $this->vec($this->vec(Keyword::create('Column', 'ORM')));
+
+        self::assertSame(['#[\ORM\Column]'], $this->renderer->render($specs));
+    }
+
+    public function test_dotted_namespace_maps_to_backslash(): void
+    {
+        $specs = $this->vec($this->vec(
+            Keyword::create('Route', 'Symfony.Component.Routing.Attribute'),
+        ));
+
+        self::assertSame(
+            ['#[\Symfony\Component\Routing\Attribute\Route]'],
+            $this->renderer->render($specs),
+        );
+    }
+
+    public function test_positional_string_argument(): void
+    {
+        $specs = $this->vec($this->vec(Keyword::create('Route'), '/products/{id}'));
+
+        self::assertSame(["#[\Route('/products/{id}')]"], $this->renderer->render($specs));
+    }
+
+    public function test_named_arguments_from_map(): void
+    {
+        $specs = $this->vec($this->vec(
+            Keyword::create('Column', 'ORM'),
+            $this->map(Keyword::create('length'), 255),
+        ));
+
+        self::assertSame(['#[\ORM\Column(length: 255)]'], $this->renderer->render($specs));
+    }
+
+    public function test_positional_and_named_and_vector_argument(): void
+    {
+        $specs = $this->vec($this->vec(
+            Keyword::create('Route'),
+            '/p',
+            $this->map(Keyword::create('methods'), $this->vec('GET', 'POST')),
+        ));
+
+        self::assertSame(
+            ["#[\Route('/p', methods: ['GET', 'POST'])]"],
+            $this->renderer->render($specs),
+        );
+    }
+
+    public function test_boolean_argument(): void
+    {
+        $specs = $this->vec($this->vec(
+            Keyword::create('Entity', 'ORM'),
+            $this->map(Keyword::create('readOnly'), true),
+        ));
+
+        self::assertSame(['#[\ORM\Entity(readOnly: true)]'], $this->renderer->render($specs));
+    }
+
+    public function test_multiple_attributes(): void
+    {
+        $specs = $this->vec(
+            $this->vec(Keyword::create('Id', 'ORM')),
+            $this->vec(Keyword::create('Column', 'ORM')),
+        );
+
+        self::assertSame(
+            ['#[\ORM\Id]', '#[\ORM\Column]'],
+            $this->renderer->render($specs),
+        );
+    }
+
+    public function test_spec_without_keyword_name_is_skipped(): void
+    {
+        $specs = $this->vec($this->vec('not-a-keyword'));
+
+        self::assertSame([], $this->renderer->render($specs));
+    }
+
+    private function vec(mixed ...$values): mixed
+    {
+        return TypeFactory::getInstance()->persistentVectorFromArray($values);
+    }
+
+    private function map(mixed ...$kvs): mixed
+    {
+        return TypeFactory::getInstance()->persistentMapFromKVs(...$kvs);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Phel generates real PHP classes for `defstruct`, but every field landed as an untyped `protected $x;` and there was no way to attach PHP 8 attributes to the generated class. That blocks Phel from being a first-class citizen in attribute-driven PHP frameworks, and gives up the IDE/static-analysis benefits of typed properties. See #2280.

## 💡 Goal

Let `defstruct` emit **typed properties** (from the existing `:tag` convention) and **PHP 8 attributes** (from a new `^{:php/attr [...]}` metadata key) on the generated class — both opt-in, with untagged structs compiling byte-identically to before.

```phel
(defstruct* ^{:php/attr [[:ORM/Entity]]} product
  [^{:tag int    :php/attr [[:ORM/Id] [:ORM/Column]]}      id
   ^{:tag string :php/attr [[:ORM/Column {:length 255}]]}  name])
```

```php
#[\ORM\Entity]
final class product extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
  protected const array ALLOWED_KEYS = ['id', 'name'];

  #[\ORM\Id]
  #[\ORM\Column]
  protected int $id;
  #[\ORM\Column(length: 255)]
  protected string $name;
  // ...
}
```

## 🔖 Changes

- **New `Phel\Shared\PhpAttributeRenderer`** — pure, stateless. Renders `:php/attr` specs (vectors keyed by namespaced keywords) into PHP attribute source. Supports bare (`[:Route]` → `#[\Route]`), namespaced (`[:ORM/Column]` → `#[\ORM\Column]`, dotted namespaces map `.`→`\`), positional args, named args (from a map → `length: 255`), and vector/scalar/bool values. Class names are fully-qualified so generated PHP needs no `use` imports.
- **`DefStructEmitter`** now emits class-level attributes (from the struct-name symbol meta), per-property attributes, and a typed property when a field carries `:tag` (mirrors the typed-parameter convention). Refactored the attribute helper to take a `?SourceLocation` rather than the whole node.
- **Tests**: 11-case unit test for the renderer; two integration fixtures (`defstruct-typed-properties.test`, `defstruct-php-attributes.test`) pinning exact emitted PHP.
- **Docs**: `CHANGELOG.md` (Unreleased), `Shared/CLAUDE.md`, `Compiler/CLAUDE.md`.

### Scope / follow-up

This is the first increment of #2280, covering `defstruct`. Because export discovery already reads full `defn` metadata (`getDefinitionMetaData`), the renderer is ready to be reused for **`phel export` wrapper method attributes** (e.g. `#[Route]`) and **`definterface` typing** — tracked as follow-up so this PR stays focused on one code path. `Related to #2280`.

Full gate green locally: `composer test-compiler` (3964) + `composer test-quality` (cs-fixer, psalm L1, phpstan, rector all clean).
