### PR TITLE
feat(interop): emit :php/attr as PHP attributes on export wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - `phel.http`: `request-from-globals` decodes `application/json` request bodies into `:parsed-body` (nil for an empty or malformed body); `request-from-globals-args` gains an optional trailing `raw-body` arg
 - `phel.http`: `json-response` and `html-response` builders set the content-type header and encode the body, so apps stop hand-rolling the header map; the `http-json-api` example now uses them (#2271)
 - `defstruct`: fields tagged with `^{:tag <type>}` now emit a typed PHP property, and `^{:php/attr [...]}` metadata on the struct name or a field emits PHP 8 attributes (e.g. `#[\ORM\Column(length: 255)]`) on the generated class/property — both opt-in, untagged structs unchanged (#2280)
+- `phel export`: `^{:php/attr [...]}` metadata on an exported `defn` emits PHP 8 attributes (e.g. `#[\Symfony\Component\Routing\Attribute\Route('/p')]`) above the generated wrapper method, so exported Phel functions can carry framework attributes like routes and console-command markers (#2280)
 - Compiler internals: regression test pinning that AST source locations survive every phase
 
 ### Changed

--- a/src/php/Interop/CLAUDE.md
+++ b/src/php/Interop/CLAUDE.md
@@ -44,3 +44,4 @@ Interop/
 - Phel namespaces to PHP: hyphens become CamelCase (my-lib -> MyLib)
 - Generated classes use PhelCallerTrait for cached definition resolution
 - Export directory wiped and regenerated each run
+- `^{:php/attr [...]}` metadata on an exported `defn` is threaded through `FunctionToExport` and rendered (via `Phel\Shared\PhpAttributeRenderer`) as PHP 8 attributes above the wrapper method (e.g. `#[\…\Route('/p')]`)

--- a/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
+++ b/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
@@ -80,9 +80,13 @@ final readonly class FunctionsToExportFinder implements FunctionsToExportFinderI
 
         foreach (Phel::getNamespaces() as $ns) {
             foreach (Phel::getDefinitionInNamespace($ns) as $fnName => $fn) {
-                if ($this->isExport($ns, $fnName)) {
+                $meta = $this->definitionMeta($ns, $fnName);
+                if ($this->isExport($meta)) {
                     $functionsToExport[$ns] ??= [];
-                    $functionsToExport[$ns][] = new FunctionToExport($fn);
+                    $functionsToExport[$ns][] = new FunctionToExport(
+                        $fn,
+                        $meta->find(Keyword::create('attr', 'php')),
+                    );
                 }
             }
         }
@@ -90,12 +94,23 @@ final readonly class FunctionsToExportFinder implements FunctionsToExportFinderI
         return $functionsToExport;
     }
 
-    private function isExport(string $ns, string $fnName): bool
+    /**
+     * @return PersistentMapInterface<mixed, mixed>
+     */
+    private function definitionMeta(string $ns, string $fnName): PersistentMapInterface
     {
         /** @var PersistentMapInterface<mixed, mixed> $meta */
         $meta = Phel::getDefinitionMetaData($ns, $fnName)
-            ?? Phel::list();
+            ?? Phel::map();
 
+        return $meta;
+    }
+
+    /**
+     * @param PersistentMapInterface<mixed, mixed> $meta
+     */
+    private function isExport(PersistentMapInterface $meta): bool
+    {
         return (bool) ($meta[Keyword::create('export')] ?? false);
     }
 }

--- a/src/php/Interop/Domain/Generator/Builder/CompiledPhpMethodBuilder.php
+++ b/src/php/Interop/Domain/Generator/Builder/CompiledPhpMethodBuilder.php
@@ -5,12 +5,20 @@ declare(strict_types=1);
 namespace Phel\Interop\Domain\Generator\Builder;
 
 use Phel\Interop\Domain\ReadModel\FunctionToExport;
+use Phel\Shared\PhpAttributeRenderer;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionParameter;
 
-final class CompiledPhpMethodBuilder
+use function array_map;
+use function implode;
+
+final readonly class CompiledPhpMethodBuilder
 {
+    public function __construct(
+        private PhpAttributeRenderer $attributeRenderer = new PhpAttributeRenderer(),
+    ) {}
+
     public function build(string $phelNs, FunctionToExport $functionToExport): string
     {
         $ref = new ReflectionClass($functionToExport->fn());
@@ -18,18 +26,34 @@ final class CompiledPhpMethodBuilder
         $refInvoke = $ref->getMethod('__invoke');
 
         return str_replace([
+            '$ATTRIBUTES$',
             '$METHOD_NAME$',
             '$ARGS$',
             '$RETURN_TYPE$',
             '$PHEL_NAMESPACE$',
             '$PHEL_FUNCTION_NAME$',
         ], [
+            $this->buildAttributes($functionToExport),
             $this->buildMethodName($boundTo),
             $this->buildArgs($refInvoke),
             $this->buildReturnType($refInvoke),
             str_replace(['_', '\\'], ['-', '\\\\'], $phelNs),
             $this->buildPhelFunctionName($boundTo),
         ], $this->methodTemplate());
+    }
+
+    /**
+     * Renders the function's `:php/attr` specs as indented PHP attribute lines
+     * placed directly above the generated method, or '' when none are present.
+     */
+    private function buildAttributes(FunctionToExport $functionToExport): string
+    {
+        $lines = $this->attributeRenderer->render($functionToExport->attributes());
+
+        return implode('', array_map(
+            static fn(string $line): string => '    ' . $line . "\n",
+            $lines,
+        ));
     }
 
     private function buildMethodName(string $boundTo): string
@@ -104,7 +128,7 @@ final class CompiledPhpMethodBuilder
     {
         return <<<'TXT'
 
-    public static function $METHOD_NAME$($ARGS$)$RETURN_TYPE$
+$ATTRIBUTES$    public static function $METHOD_NAME$($ARGS$)$RETURN_TYPE$
     {
         return self::callPhel('$PHEL_NAMESPACE$', '$PHEL_FUNCTION_NAME$', $ARGS$);
     }

--- a/src/php/Interop/Domain/ReadModel/FunctionToExport.php
+++ b/src/php/Interop/Domain/ReadModel/FunctionToExport.php
@@ -8,10 +8,22 @@ use Phel\Lang\FnInterface;
 
 final readonly class FunctionToExport
 {
-    public function __construct(private FnInterface $fn) {}
+    /**
+     * @param mixed $attributes the `:php/attr` metadata spec (a vector of
+     *                          attribute specs), or null when none is present
+     */
+    public function __construct(
+        private FnInterface $fn,
+        private mixed $attributes = null,
+    ) {}
 
     public function fn(): FnInterface
     {
         return $this->fn;
+    }
+
+    public function attributes(): mixed
+    {
+        return $this->attributes;
     }
 }

--- a/tests/php/Integration/Interop/Command/Export/ExportCommandTest.php
+++ b/tests/php/Integration/Interop/Command/Export/ExportCommandTest.php
@@ -43,6 +43,11 @@ final class ExportCommandTest extends TestCase
 
         self::assertSame(3, Adder::adder1(1, 2));
         self::assertSame(9, Multiplier::multiplier2(3, 3));
+
+        // `:php/attr` metadata is emitted as a PHP attribute above the method
+        $adder = (string) file_get_contents(__DIR__ . '/PhelGenerated/TestCmdExportMultiple/Adder.php');
+        self::assertStringContainsString("#[\\My\\Routing\\Route('/add')]", $adder);
+        self::assertSame(5, Adder::adder3(2, 3));
     }
 
     private function stubOutput(): OutputInterface

--- a/tests/php/Integration/Interop/Command/Export/src/test-cmd-export-multiple/adder.phel
+++ b/tests/php/Integration/Interop/Command/Export/src/test-cmd-export-multiple/adder.phel
@@ -9,3 +9,9 @@
   {:export true}
   [a b]
   (php/+ a b))
+
+(defn adder-3
+  {:export true
+   :php/attr [[:My.Routing/Route "/add"]]}
+  [a b]
+  (php/+ a b))

--- a/tests/php/Unit/Interop/Generator/CompiledPhpMethodBuilderTest.php
+++ b/tests/php/Unit/Interop/Generator/CompiledPhpMethodBuilderTest.php
@@ -7,6 +7,8 @@ namespace PhelTest\Unit\Interop\Generator;
 use Phel\Interop\Domain\Generator\Builder\CompiledPhpMethodBuilder;
 use Phel\Interop\Domain\ReadModel\FunctionToExport;
 use Phel\Lang\FnInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\TypeFactory;
 use PHPUnit\Framework\TestCase;
 
 final class CompiledPhpMethodBuilderTest extends TestCase
@@ -82,5 +84,38 @@ final class CompiledPhpMethodBuilderTest extends TestCase
         $result = $this->methodBuilder->build('test_ns', $functionToExport);
 
         self::assertStringContainsString(': mixed', $result);
+    }
+
+    public function test_renders_php_attributes_above_method(): void
+    {
+        $typeFactory = TypeFactory::getInstance();
+        $functionToExport = new FunctionToExport(
+            new class() implements FnInterface {
+                public const BOUND_TO = 'test_ns\\show_product';
+
+                public function __invoke(): mixed
+                {
+                    return null;
+                }
+            },
+            $typeFactory->persistentVectorFromArray([
+                $typeFactory->persistentVectorFromArray([
+                    Keyword::create('Route', 'Symfony.Component.Routing.Attribute'),
+                    '/products/{id}',
+                    $typeFactory->persistentMapFromKVs(
+                        Keyword::create('methods'),
+                        $typeFactory->persistentVectorFromArray(['GET']),
+                    ),
+                ]),
+            ]),
+        );
+
+        $result = $this->methodBuilder->build('test_ns', $functionToExport);
+
+        self::assertStringContainsString(
+            "    #[\\Symfony\\Component\\Routing\\Attribute\\Route('/products/{id}', methods: ['GET'])]\n"
+            . '    public static function showProduct(',
+            $result,
+        );
     }
 }


### PR DESCRIPTION
## 🤔 Background

Follow-up to #2283 (the `defstruct` half of #2280). Exporting a Phel function to PHP via `phel export` generates a wrapper method, but there was no way to attach the PHP 8 attributes that frameworks rely on — `#[Route]`, `#[AsCommand]`, DI autowiring — so a Phel controller/command still needed a hand-written PHP shim. This is the **highest-value** target named in #2280.

## 💡 Goal

Let an exported `defn` carry `^{:php/attr [...]}` metadata that renders as PHP 8 attributes directly above the generated wrapper method.

```phel
(defn show-product
  {:export true
   :php/attr [[:Symfony.Component.Routing.Attribute/Route "/products/{id}" {:methods ["GET"]}]]}
  [id]
  ...)
```

```php
    #[\Symfony\Component\Routing\Attribute\Route('/products/{id}', methods: ['GET'])]
    public static function showProduct($id): mixed
    {
        return self::callPhel('shop.catalog', 'show-product', $id);
    }
```

## 🔖 Changes

- **`FunctionsToExportFinder`** reads the `:php/attr` value from the definition metadata (same `getDefinitionMetaData` it already reads `:export` from) and passes it to `FunctionToExport`. Split the meta fetch into `definitionMeta()` and a meta-typed `isExport()`.
- **`FunctionToExport`** carries the spec (`attributes(): mixed`); defaults to `null`, so existing call sites are unaffected.
- **`CompiledPhpMethodBuilder`** renders the spec via the shared `Phel\Shared\PhpAttributeRenderer` (introduced in #2283) into a new `$ATTRIBUTES$` template slot above the method.
- **Tests**: a unit case on the builder (positional + named + vector args) and an end-to-end `ExportCommandTest` assertion (a real exported `defn` with `:php/attr` → generated `#[\My\Routing\Route('/add')]`, and the wrapper still calls through).
- **Docs**: `CHANGELOG.md` (Unreleased), `Interop/CLAUDE.md`.

With this, #2280 covers both compiler-generated `defstruct` classes and `phel export` wrappers. Remaining (smaller) follow-up tracked on the issue: `definterface` param/return typing. `Related to #2280`.

Full gate green locally: `composer test-compiler` (3965) + `composer test-quality` (cs-fixer, psalm L1, phpstan, rector all clean).
