### PR TITLE
feat(emitter): emit :php/attr and :tag types on definterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - `phel.http`: `json-response` and `html-response` builders set the content-type header and encode the body, so apps stop hand-rolling the header map; the `http-json-api` example now uses them (#2271)
 - `defstruct`: fields tagged with `^{:tag <type>}` now emit a typed PHP property, and `^{:php/attr [...]}` metadata on the struct name or a field emits PHP 8 attributes (e.g. `#[\ORM\Column(length: 255)]`) on the generated class/property — both opt-in, untagged structs unchanged (#2280)
 - `phel export`: `^{:php/attr [...]}` metadata on an exported `defn` emits PHP 8 attributes (e.g. `#[\Symfony\Component\Routing\Attribute\Route('/p')]`) above the generated wrapper method, so exported Phel functions can carry framework attributes like routes and console-command markers (#2280)
+- `definterface`: method params/return tagged with `^{:tag <type>}` emit a typed PHP signature, and `^{:php/attr [...]}` on the interface name or a method emits PHP 8 attributes on the generated interface/method — completing the `:php/attr` + `:tag` support across `defstruct`, `phel export`, and `definterface` (#2280)
 - Compiler internals: regression test pinning that AST source locations survive every phase
 
 ### Changed

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -75,9 +75,14 @@ Compiler/
 
 Analyzer tracks param and return types via `ParamTypeInferrer`, `ReturnTypeInferrer`, grafting `:tag` meta onto binding symbols. Call-site *eligibility* lives on `*Specialization` classes (`NumericOperationSpecialization`, `TypePredicateSpecialization`, `TypedValueSpecialization`, `TypedCollectionMethodSpecialization`, `AssocConjSpecialization`, `AtomMethodSpecialization`, `NilAndBooleanCheckSpecialization`); `CallSpecialization` aggregates them. The matching PHP *emission* lives on per-family collaborators under `NodeEmitter/Specialized/` (one `*CallEmitter implements SpecializedCallEmitterInterface` per eligibility class); `CallEmitter` builds them once and dispatches by looping `tryEmit()` over them before the generic call path. Family predicates are disjoint, so chain order between families is not significant. Add a new specialization family as a `*Specialization` eligibility class, register it in `CallSpecialization::isSpecialized()`, and add the matching `Specialized/*CallEmitter` to `CallEmitter`'s ordered list. Contract: propagate only analyzer-published types, never fabricate.
 
-## Struct Attributes & Typed Properties
+## Generated-Class Attributes & Typed Signatures
 
-`DefStructEmitter` reads per-symbol metadata to enrich the generated PHP class: a field's `^{:tag <type>}` emits a typed property (`protected int $id;`), and `^{:php/attr [...]}` on the struct name (class-level) or a field (property-level) emits PHP 8 attributes via the shared `Phel\Shared\PhpAttributeRenderer`. Both opt-in; untagged structs are byte-identical to before.
+`DefStructEmitter` and `DefInterfaceEmitter` read per-symbol metadata to enrich the PHP they generate, sharing `PhpAttributeEmitterTrait` (tag + `:php/attr` reading) and the pure `Phel\Shared\PhpAttributeRenderer`:
+
+- `defstruct`: a field's `^{:tag <type>}` emits a typed property (`protected int $id;`); `^{:php/attr [...]}` on the struct name (class-level) or a field (property-level) emits PHP 8 attributes.
+- `definterface`: a method's arg `^{:tag <type>}` emits a typed param and the method name's `:tag` the return type; `^{:php/attr [...]}` on the interface name or a method emits interface-/method-level attributes.
+
+All opt-in; untagged forms are byte-identical to before. Export wrappers carry the same `:php/attr` via `Interop`'s `CompiledPhpMethodBuilder` (see `src/php/Interop/CLAUDE.md`).
 
 ## Global Environment
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefInterfaceEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefInterfaceEmitter.php
@@ -8,12 +8,21 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DefInterfaceMethod;
 use Phel\Compiler\Domain\Analyzer\Ast\DefInterfaceNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\SourceLocation;
+use Phel\Shared\PhpAttributeRenderer;
 
 use function assert;
 
-final class DefInterfaceEmitter implements NodeEmitterInterface
+final readonly class DefInterfaceEmitter implements NodeEmitterInterface
 {
-    use WithOutputEmitterTrait;
+    use PhpAttributeEmitterTrait;
+
+    public function __construct(
+        private OutputEmitterInterface $outputEmitter,
+        private PhpAttributeRenderer $attributeRenderer = new PhpAttributeRenderer(),
+    ) {}
 
     public function emit(AbstractNode $node): void
     {
@@ -79,9 +88,12 @@ final class DefInterfaceEmitter implements NodeEmitterInterface
 
     private function emitInterfaceBody(DefInterfaceNode $node): void
     {
+        $sourceLocation = $node->getStartSourceLocation();
+        $this->emitAttributes($node->getName()->getMeta(), $sourceLocation);
+
         $this->outputEmitter->emitLine(
             'interface ' . $this->outputEmitter->mungeEncode($node->getName()->getName()) . ' {',
-            $node->getStartSourceLocation(),
+            $sourceLocation,
         );
         $this->outputEmitter->increaseIndentLevel();
 
@@ -90,27 +102,51 @@ final class DefInterfaceEmitter implements NodeEmitterInterface
         }
 
         $this->outputEmitter->decreaseIndentLevel();
-        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+        $this->outputEmitter->emitLine('}', $sourceLocation);
     }
 
     private function emitMethod(DefInterfaceNode $node, DefInterfaceMethod $method): void
     {
-        $this->outputEmitter->emitStr('public function ', $node->getStartSourceLocation());
+        $sourceLocation = $node->getStartSourceLocation();
+        $this->emitAttributes($method->getName()->getMeta(), $sourceLocation);
+
+        $this->outputEmitter->emitStr('public function ', $sourceLocation);
         $this->outputEmitter->emitStr(
             $this->outputEmitter->mungeEncode($method->getName()->getName()),
-            $node->getStartSourceLocation(),
+            $sourceLocation,
         );
-        $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('(', $sourceLocation);
 
         foreach ($method->getArgumentsWithoutFirst() as $i => $argument) {
-            $this->outputEmitter->emitPhpVariable($argument, $node->getStartSourceLocation());
+            $argumentTag = $this->tagTypeFromMeta($argument->getMeta());
+            if ($argumentTag !== null) {
+                $this->outputEmitter->emitStr($argumentTag . ' ', $sourceLocation);
+            }
+
+            $this->outputEmitter->emitPhpVariable($argument, $sourceLocation);
 
             if ($i < $method->getArgumentCount() - 2) {
-                $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
+                $this->outputEmitter->emitStr(', ', $sourceLocation);
             }
         }
 
-        $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr(')', $sourceLocation);
+
+        $returnTag = $this->tagTypeFromMeta($method->getName()->getMeta());
+        if ($returnTag !== null) {
+            $this->outputEmitter->emitStr(': ' . $returnTag, $sourceLocation);
+        }
+
         $this->outputEmitter->emitLine(';');
+    }
+
+    /**
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
+     */
+    private function emitAttributes(?PersistentMapInterface $meta, ?SourceLocation $sourceLocation): void
+    {
+        foreach ($this->phpAttributeLines($this->attributeRenderer, $meta) as $attribute) {
+            $this->outputEmitter->emitLine($attribute, $sourceLocation);
+        }
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -9,17 +9,17 @@ use Phel\Compiler\Domain\Analyzer\Ast\DefStructNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
-use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use Phel\Shared\PhpAttributeRenderer;
 
 use function assert;
 use function count;
-use function is_string;
 
 final readonly class DefStructEmitter implements NodeEmitterInterface
 {
+    use PhpAttributeEmitterTrait;
+
     public function __construct(
         private OutputEmitterInterface $outputEmitter,
         private MethodEmitter $methodEmitter,
@@ -161,7 +161,7 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
             $this->emitAttributes($meta, $node->getStartSourceLocation());
 
             $this->outputEmitter->emitStr('protected ');
-            $tag = $this->extractTag($meta);
+            $tag = $this->tagTypeFromMeta($meta);
             if ($tag !== null) {
                 $this->outputEmitter->emitStr($tag . ' ');
             }
@@ -181,34 +181,9 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
      */
     private function emitAttributes(?PersistentMapInterface $meta, ?SourceLocation $sourceLocation): void
     {
-        if (!$meta instanceof PersistentMapInterface) {
-            return;
-        }
-
-        $specs = $meta->find(Keyword::create('attr', 'php'));
-        foreach ($this->attributeRenderer->render($specs) as $attribute) {
+        foreach ($this->phpAttributeLines($this->attributeRenderer, $meta) as $attribute) {
             $this->outputEmitter->emitLine($attribute, $sourceLocation);
         }
-    }
-
-    /**
-     * Reads the PHP type hint from a symbol's `:tag` meta, mirroring the
-     * convention used for typed function parameters. Returns null when absent.
-     *
-     * @param PersistentMapInterface<mixed, mixed>|null $meta
-     */
-    private function extractTag(?PersistentMapInterface $meta): ?string
-    {
-        if (!$meta instanceof PersistentMapInterface) {
-            return null;
-        }
-
-        $tag = $meta->find(Keyword::create('tag'));
-        if ($tag instanceof Symbol) {
-            $tag = $tag->getName();
-        }
-
-        return is_string($tag) && $tag !== '' ? $tag : null;
     }
 
     private function emitConstructor(DefStructNode $node): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpAttributeEmitterTrait.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpAttributeEmitterTrait.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Shared\PhpAttributeRenderer;
+
+use function is_string;
+
+/**
+ * Shared reading of PHP-interop metadata off a Phel symbol: the `:tag` type
+ * hint and the `:php/attr` attribute specs. Used by the emitters that generate
+ * PHP classes/interfaces from Phel forms (`defstruct`, `definterface`).
+ */
+trait PhpAttributeEmitterTrait
+{
+    /**
+     * Reads the PHP type hint from a symbol's `:tag` meta, mirroring the
+     * convention used for typed function parameters. Returns null when absent.
+     *
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
+     */
+    private function tagTypeFromMeta(?PersistentMapInterface $meta): ?string
+    {
+        if (!$meta instanceof PersistentMapInterface) {
+            return null;
+        }
+
+        $tag = $meta->find(Keyword::create('tag'));
+        if ($tag instanceof Symbol) {
+            $tag = $tag->getName();
+        }
+
+        return is_string($tag) && $tag !== '' ? $tag : null;
+    }
+
+    /**
+     * Renders the `:php/attr` specs carried by the symbol meta into PHP
+     * attribute lines (`#[...]`), or an empty list when none are present.
+     *
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
+     *
+     * @return list<string>
+     */
+    private function phpAttributeLines(PhpAttributeRenderer $renderer, ?PersistentMapInterface $meta): array
+    {
+        if (!$meta instanceof PersistentMapInterface) {
+            return [];
+        }
+
+        return $renderer->render($meta->find(Keyword::create('attr', 'php')));
+    }
+}

--- a/tests/php/Integration/Fixtures/Def/definterface-typed-and-attributes.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-typed-and-attributes.test
@@ -1,0 +1,11 @@
+--PHEL--
+(definterface* ^{:php/attr [[:My/Marker]]} TypedRepo
+  (^{:tag int :php/attr [[:My/M]]} find-by-id [this ^{:tag string} id]))
+--PHP--
+if (!interface_exists('user\TypedRepo')) {
+#[\My\Marker]
+interface TypedRepo {
+  #[\My\M]
+  public function find_by_id(string $id): int;
+}
+}


### PR DESCRIPTION
## 🤔 Background

Final piece of #2280, after #2283 (`defstruct`) and #2284 (`phel export` wrappers). `definterface` generated a PHP interface with untyped method signatures and no way to attach attributes.

## 💡 Goal

Bring `definterface` to parity: typed method params/return from `:tag`, and PHP 8 attributes from `^{:php/attr [...]}` on the interface name or a method.

```phel
(definterface* ^{:php/attr [[:My/Marker]]} TypedRepo
  (^{:tag int :php/attr [[:My/M]]} find-by-id [this ^{:tag string} id]))
```

```php
#[\My\Marker]
interface TypedRepo {
  #[\My\M]
  public function find_by_id(string $id): int;
}
```

## 🔖 Changes

- **`DefInterfaceEmitter`**: emits interface-level attributes (from the name symbol), method-level attributes (from the method name symbol), typed params (arg `:tag`), and the return type (method name `:tag`). Swapped `WithOutputEmitterTrait` for an explicit constructor so it can hold a `PhpAttributeRenderer`.
- **`PhpAttributeEmitterTrait`** (new): the shared `:tag` + `:php/attr` reading, now used by both `DefStructEmitter` and `DefInterfaceEmitter`. `DefStructEmitter` drops its private duplicates (pure refactor, covered by its existing fixtures).
- **Test**: integration fixture pinning the typed + attributed interface output.
- **Docs**: `CHANGELOG.md`, `Compiler/CLAUDE.md`.

All opt-in; untagged interfaces compile byte-identically. `Closes #2280` — `:php/attr` + `:tag` now span `defstruct`, `phel export`, and `definterface`.

Full gate green locally: `composer test-compiler` (3966) + `composer test-quality` (cs-fixer, psalm L1, phpstan, rector all clean).
