### PR TITLE
docs(examples): add runnable SQLite products CRUD example (maps, not entities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - `phel export`: `^{:php/attr [...]}` metadata on an exported `defn` emits PHP 8 attributes (e.g. `#[\Symfony\Component\Routing\Attribute\Route('/p')]`) above the generated wrapper method, so exported Phel functions can carry framework attributes like routes and console-command markers (#2280)
 - `definterface`: method params/return tagged with `^{:tag <type>}` emit a typed PHP signature, and `^{:php/attr [...]}` on the interface name or a method emits PHP 8 attributes on the generated interface/method — completing the `:php/attr` + `:tag` support across `defstruct`, `phel export`, and `definterface` (#2280)
 - Compiler internals: regression test pinning that AST source locations survive every phase
+- `docs/examples/13_database-crud.phel`: runnable SQLite products CRUD demonstrating the FP persistence pattern — rows as immutable maps (not ORM entities), a repository boundary, and pure service transforms (#2281)
 
 ### Changed
 

--- a/docs/examples/13_database-crud.phel
+++ b/docs/examples/13_database-crud.phel
@@ -1,0 +1,71 @@
+(ns examples.database-crud)
+
+;; Products are plain immutable maps - never mutable ORM entities.
+;; Only the repository functions below touch the database; everything
+;; else is pure transformation over maps, and the single side effect
+;; (the SQL write) lives at the edge.
+;;
+;; Persistence here is raw PDO interop so the file runs standalone. A
+;; real app swaps this repository layer for phel-sql (data -> [sql params])
+;; + phel-pdo, reusing the framework's connection - see the "Persistence"
+;; section of docs/framework-integration.md.
+
+(def db
+  (let [pdo (php/new \PDO "sqlite::memory:")]
+    (php/-> pdo (exec "CREATE TABLE products (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, price REAL NOT NULL)"))
+    pdo))
+
+;; --- Repository: the only layer that talks to the database ---
+
+(defn- row->product
+  "Maps a raw DB row (string-keyed PHP array) to a domain map."
+  [row]
+  (let [m (php-array-to-map row)]
+    {:id (get m "id") :name (get m "name") :price (get m "price")}))
+
+(defn find-by-id [id]
+  (let [stmt (php/-> db (prepare "SELECT id, name, price FROM products WHERE id = ?"))]
+    (php/-> stmt (execute (php/array id)))
+    (let [row (php/-> stmt (fetch (php/:: \PDO FETCH_ASSOC)))]
+      (if row (row->product row) nil))))
+
+(defn all-products []
+  (let [stmt (php/-> db (query "SELECT id, name, price FROM products ORDER BY id"))]
+    (map row->product (php/-> stmt (fetchAll (php/:: \PDO FETCH_ASSOC))))))
+
+(defn create-product! [product]
+  (let [stmt (php/-> db (prepare "INSERT INTO products (name, price) VALUES (?, ?)"))]
+    (php/-> stmt (execute (php/array (get product :name) (get product :price))))
+    (find-by-id (php/-> db (lastInsertId)))))
+
+(defn update-price! [id new-price]
+  (let [stmt (php/-> db (prepare "UPDATE products SET price = ? WHERE id = ?"))]
+    (php/-> stmt (execute (php/array new-price id)))
+    (find-by-id id)))
+
+(defn delete-product! [id]
+  (let [stmt (php/-> db (prepare "DELETE FROM products WHERE id = ?"))]
+    (php/-> stmt (execute (php/array id)))
+    nil))
+
+;; --- Service: pure transformations over product maps ---
+
+(defn apply-discount
+  "Pure: a new product map with the price reduced by `pct` (0.0 .. 1.0)."
+  [product pct]
+  (update product :price (fn [p] (* p (- 1 pct)))))
+
+(defn main []
+  (let [keyboard (create-product! {:name "Keyboard" :price 49.9})
+        mouse    (create-product! {:name "Mouse" :price 19.9})]
+    (println "created:" keyboard)
+    (println "created:" mouse)
+    (println "all:" (all-products))
+    ;; transform purely, then persist the result at the edge
+    (let [discounted (apply-discount keyboard 0.10)]
+      (update-price! (get keyboard :id) (get discounted :price)))
+    (println "after discount:" (find-by-id (get keyboard :id)))
+    (delete-product! (get mouse :id))
+    (println "after delete:" (all-products))))
+
+(main)

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -22,6 +22,7 @@ Standalone scripts from primitive literals through concurrency to a full CLI. Ru
 | 10 | `10_html-rendering.phel` | HTML templating with `phel.html` |
 | 11 | `11_async-concurrency.phel` | AMPHP + fiber concurrency (`async`, `await`, `promise`) |
 | 12 | `12_cli.phel` | A todo-list CLI on `phel.cli` with subcommands and tables |
+| 13 | `13_database-crud.phel` | SQLite products CRUD: rows as immutable maps (not ORM entities), repository boundary, pure service transforms |
 | extra | `transducers.phel` | Composable transformations: `into`, `transduce`, `sequence` |
 
 Copy any file into your project and tweak it.


### PR DESCRIPTION
## 🤔 Background

#2281 asked for a runnable Symfony + Phel products CRUD showing the maps-not-entities approach. Two CI/repo realities shaped the deliverable:

- The `examples` CI job **executes** every `docs/examples/*.phel` via `./bin/phel run`, so an example cannot depend on external libraries (phel-sql / phel-pdo are not phel-lang dependencies) or a bootable Symfony kernel.
- A full Symfony app can't be meaningfully verified in this repo's CI and would bloat it.

So this PR delivers the **runnable, CI-verified pattern**; the Symfony + phel-sql + phel-pdo + DBAL wiring (which is documentation, not executable here) is the companion issue #2282 (`framework-integration.md` Persistence section).

## 💡 Goal

A single-file, runnable example that teaches the FP persistence architecture: rows as immutable maps, a repository boundary, pure service transforms, effect at the edge.

## 🔖 Changes

- **`docs/examples/13_database-crud.phel`** — SQLite (via PDO interop, standalone) products CRUD:
  - domain values are plain maps, never mutable ORM entities;
  - `row->product` maps a raw DB row to a domain map at the repository boundary;
  - only the repository fns (`find-by-id`, `all-products`, `create-product!`, `update-price!`, `delete-product!`) touch the DB;
  - `apply-discount` is a pure transform; `main` runs a full CRUD scenario.
  - A header comment points to the production swap (phel-sql + phel-pdo) documented in #2282.
- README table + `CHANGELOG.md` updated.

Runs clean via `./bin/phel run docs/examples/13_database-crud.phel` (the exact command the `examples` CI job runs).

```
created: {:id 1, :name Keyboard, :price 49.9}
all: @[{:id 1, :name Keyboard, :price 49.9} {:id 2, :name Mouse, :price 19.9}]
after discount: {:id 1, :name Keyboard, :price 44.91}
after delete: @[{:id 1, :name Keyboard, :price 44.91}]
```

`Closes #2281`. (If a full standalone Symfony example *app repo* is wanted on top of this pattern + the #2282 docs, that's a separate downstream repo, not a fit for phel-lang's CI-run examples.)
