### PR TITLE
docs(framework-integration): add a Persistence section (maps, not entities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - `definterface`: method params/return tagged with `^{:tag <type>}` emit a typed PHP signature, and `^{:php/attr [...]}` on the interface name or a method emits PHP 8 attributes on the generated interface/method — completing the `:php/attr` + `:tag` support across `defstruct`, `phel export`, and `definterface` (#2280)
 - Compiler internals: regression test pinning that AST source locations survive every phase
 - `docs/examples/13_database-crud.phel`: runnable SQLite products CRUD demonstrating the FP persistence pattern — rows as immutable maps (not ORM entities), a repository boundary, and pure service transforms (#2281)
+- Docs: `framework-integration.md` gains a Persistence section — maps-not-entities rationale, phel-sql + phel-pdo stack, reusing a framework's DBAL connection, and `#[Route]` on exported wrappers (#2282)
 
 ### Changed
 

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -229,6 +229,52 @@ echo $greet('World') . "\n";
 
 ---
 
+## Persistence: maps, not entities
+
+Phel models data as immutable values, not mutable identity-tracked objects. An ORM entity (Doctrine, Eloquent) is the opposite: a mutable object the framework hydrates and dirty-tracks. Trying to make a Phel struct *be* an ORM entity fights the language. The functional path keeps rows as plain maps and pushes the database write to the edge.
+
+Two small libraries cover it:
+
+- [phel-sql](https://github.com/phel-lang/phel-sql) — HoneySQL-style. Map in, `[sql params]` out. No driver.
+- [phel-pdo](https://github.com/phel-lang/phel-pdo) — runs `[sql params]`, returns rows as maps.
+
+```phel
+(ns shop.catalog
+  (:require phel.sql :as sql)
+  (:require phel.pdo :as pdo))
+
+(defn find-product [conn id]
+  (let [[query params] (sql/format {:select [:id :name :price]
+                                    :from   [:products]
+                                    :where  [:= :id id]})]
+    (-> (pdo/prepare conn query)
+        (pdo/execute params)
+        (pdo/fetch))))                       ; => {:id 1 :name "Keyboard" :price 49.9}
+
+(defn apply-discount [product pct]           ; pure: no DB, no mutation
+  (update product :price (fn [p] (* p (- 1 pct)))))
+```
+
+For a runnable, dependency-free version of this pattern (raw PDO + SQLite), see [`docs/examples/13_database-crud.phel`](examples/13_database-crud.phel).
+
+### Reuse the framework connection
+
+Don't open a second connection. phel-sql is driver-agnostic, so its `[sql params]` feeds straight into the connection your framework already configured — e.g. Doctrine DBAL in Symfony:
+
+```php
+// Symfony service, $conn injected (Doctrine\DBAL\Connection)
+[$sql, $params] = Catalog::buildProductQuery($id);   // exported Phel fn calling sql/format
+$rows = $conn->executeQuery($sql, $params)->fetchAllAssociative();
+```
+
+phel-pdo can also wrap an existing PDO handle so its map-returning helpers run on the host's pooled connection.
+
+### Controllers, transactions, migrations
+
+- **Routes/commands:** an exported `defn` can carry `^{:php/attr [[:Symfony.Component.Routing.Attribute/Route "/products/{id}"]]}`, so `phel export` emits the `#[Route]` on the generated wrapper — no hand-written controller shim.
+- **Transactions:** wrap writes with phel-pdo's transaction helpers; keep the pure work outside the transaction and only the effect inside.
+- **Migrations:** stay in PHP-land — reuse `doctrine/migrations` or your framework's tool. Phel does not need its own.
+
 ## Notes
 
 - Namespace path matches directory: `phel/shop/pricing.phel` to `(ns shop.pricing)`.
@@ -243,6 +289,8 @@ echo $greet('World') . "\n";
 
 - [PHP/Phel Interop](php-interop.md)
 - [Quickstart](quickstart.md)
+- [Database CRUD example](examples/13_database-crud.phel) — runnable maps-not-entities pattern
+- [phel-sql](https://github.com/phel-lang/phel-sql) and [phel-pdo](https://github.com/phel-lang/phel-pdo) — data-driven SQL + PDO wrapper
 
 ---
 


### PR DESCRIPTION
## 🤔 Background

`framework-integration.md` covered export/build/boot but had no persistence guidance, so users reached for a Doctrine entity. Companion to #2281 (the runnable example).

## 💡 Goal

Make the FP persistence path discoverable: maps, not entities.

## 🔖 Changes

New **Persistence** section in `docs/framework-integration.md`:
- **maps-not-entities rationale** — why a Phel struct shouldn't be a mutable ORM entity.
- **the stack** — [phel-sql](https://github.com/phel-lang/phel-sql) (`map -> [sql params]`) + [phel-pdo](https://github.com/phel-lang/phel-pdo) (rows as maps), with a query + pure-transform snippet.
- **reuse the framework connection** — phel-sql's `[sql params]` fed straight into a Doctrine DBAL `Connection` (the Symfony path), avoiding a second connection.
- **controllers/transactions/migrations** — `#[Route]` via exported-wrapper attributes (shipped in #2280), phel-pdo transactions, migrations staying in PHP-land.
- links the runnable [`13_database-crud.phel`](https://github.com/phel-lang/phel-lang/blob/main/docs/examples/13_database-crud.phel) example + both libs from "See also".

`CHANGELOG.md` updated. `Closes #2282`.

Markdown only; the `phel` snippet is illustrative (uses `;` comments, `sql/format`/`pdo/*` from the libs' READMEs) and is not CI-executed (only `docs/examples/*.phel` are run).
