### PR TITLE
feat(emitter): terser :php/attr shorthand (single spec + bare keyword)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `phel.http`: JSON request bodies decode into `:parsed-body`, plus `json-response`/`html-response` builders that set the content-type and encode the body (#2271)
-- PHP interop: `^{:php/attr [...]}` emits PHP 8 attributes (e.g. `#[\ORM\Column(length: 255)]`) and `^{:tag <type>}` emits typed signatures on `defstruct`, `phel export` wrappers, and `definterface` — opt-in, untagged forms unchanged (#2280)
+- PHP interop: `^{:php/attr [...]}` emits PHP 8 attributes (e.g. `#[\ORM\Column(length: 255)]`) and `^{:tag <type>}` emits typed signatures on `defstruct`, `phel export` wrappers, and `definterface` — opt-in, untagged forms unchanged (#2280). The metadata also accepts terser shorthands: a bare keyword (`^{:php/attr :ORM/Entity}`) or a single spec without the outer vector (`^{:php/attr [:ORM/Column {:length 255}]}`) (#2289)
 - Docs: runnable `docs/examples/13_database-crud.phel` (maps-not-entities CRUD) and a Persistence section in `framework-integration.md` covering phel-sql + phel-pdo (#2281, #2282)
 
 ### Changed

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -271,7 +271,7 @@ phel-pdo can also wrap an existing PDO handle so its map-returning helpers run o
 
 ### Controllers, transactions, migrations
 
-- **Routes/commands:** an exported `defn` can carry `^{:php/attr [[:Symfony.Component.Routing.Attribute/Route "/products/{id}"]]}`, so `phel export` emits the `#[Route]` on the generated wrapper — no hand-written controller shim.
+- **Routes/commands:** an exported `defn` can carry `^{:php/attr [:Symfony.Component.Routing.Attribute/Route "/products/{id}"]}`, so `phel export` emits the `#[Route]` on the generated wrapper — no hand-written controller shim.
 - **Transactions:** wrap writes with phel-pdo's transaction helpers; keep the pure work outside the transaction and only the effect inside.
 - **Migrations:** stay in PHP-land — reuse `doctrine/migrations` or your framework's tool. Phel does not need its own.
 

--- a/src/php/Shared/CLAUDE.md
+++ b/src/php/Shared/CLAUDE.md
@@ -61,7 +61,7 @@ Strategy pattern via `TypePrinter/`: one class per Phel/PHP type; `WithColorTrai
 - `PhelProjectDirectory`: manages `.phel/` directory; respects `PHEL_DIR` env var and `PhelConfig::setPhelDir()`
 - `VersionFinder`: resolves project version from git state or official release tag
 - `CompileOptions`: constants for source maps, emit-only mode, optimization levels
-- `PhpAttributeRenderer`: renders `^{:php/attr [...]}` metadata specs (vectors keyed by namespaced keywords) into PHP 8 attribute source lines (`#[\ORM\Column(length: 255)]`); pure, stateless. Consumed by the compiler's `DefStructEmitter` (and reusable by the Interop export generator)
+- `PhpAttributeRenderer`: renders `^{:php/attr ...}` metadata specs into PHP 8 attribute source lines (`#[\ORM\Column(length: 255)]`); pure, stateless. Accepts a bare keyword (`:ORM/Entity`), a single spec vector (`[:ORM/Column {:length 255}]`, first element is the name keyword), or a vector of specs (`[[:ORM/Id] [:ORM/Column]]`). Consumed by `DefStructEmitter`/`DefInterfaceEmitter` and the Interop export generator
 
 ## Dependencies
 

--- a/src/php/Shared/PhpAttributeRenderer.php
+++ b/src/php/Shared/PhpAttributeRenderer.php
@@ -41,8 +41,22 @@ final class PhpAttributeRenderer
      */
     public function render(mixed $specs): array
     {
+        // Bare keyword: a single zero-arg attribute (`^{:php/attr :ORM/Entity}`).
+        if ($specs instanceof Keyword) {
+            return ['#[' . $this->renderClassName($specs) . ']'];
+        }
+
         if (!$specs instanceof PersistentVectorInterface) {
             return [];
+        }
+
+        // A single spec is a vector whose first element is the attribute-name
+        // keyword (`[:ORM/Column {:length 255}]`); a list of specs has vectors
+        // as its elements (`[[:ORM/Id] [:ORM/Column]]`).
+        if ($this->firstElement($specs) instanceof Keyword) {
+            $line = $this->renderSpec($specs);
+
+            return $line === null ? [] : [$line];
         }
 
         $lines = [];
@@ -54,6 +68,18 @@ final class PhpAttributeRenderer
         }
 
         return $lines;
+    }
+
+    /**
+     * @param PersistentVectorInterface<mixed> $vector
+     */
+    private function firstElement(PersistentVectorInterface $vector): mixed
+    {
+        foreach ($vector as $element) {
+            return $element;
+        }
+
+        return null;
     }
 
     private function renderSpec(mixed $spec): ?string

--- a/tests/php/Integration/Fixtures/Def/defstruct-php-attributes-shorthand.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-php-attributes-shorthand.test
@@ -1,0 +1,20 @@
+--PHEL--
+(defstruct* ^{:php/attr :ORM/Entity} my-short
+  [^{:tag int :php/attr [:ORM/Id]} id])
+--PHP--
+if (!class_exists('user\my_short')) {
+#[\ORM\Entity]
+final class my_short extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
+
+  protected const array ALLOWED_KEYS = ['id'];
+
+  #[\ORM\Id]
+  protected int $id;
+
+  public function __construct($id, $meta = null) {
+    parent::__construct();
+    $this->id = $id;
+    $this->meta = $meta;
+  }
+}
+}

--- a/tests/php/Unit/Shared/PhpAttributeRendererTest.php
+++ b/tests/php/Unit/Shared/PhpAttributeRendererTest.php
@@ -43,6 +43,30 @@ final class PhpAttributeRendererTest extends TestCase
         self::assertSame(['#[\ORM\Column]'], $this->renderer->render($specs));
     }
 
+    public function test_bare_keyword_is_a_single_zero_arg_attribute(): void
+    {
+        self::assertSame(['#[\ORM\Entity]'], $this->renderer->render(Keyword::create('Entity', 'ORM')));
+        self::assertSame(['#[\Route]'], $this->renderer->render(Keyword::create('Route')));
+    }
+
+    public function test_single_spec_vector_without_outer_wrapper(): void
+    {
+        // First element is the attribute-name keyword => one attribute.
+        $specs = $this->vec(
+            Keyword::create('Column', 'ORM'),
+            $this->map(Keyword::create('length'), 255),
+        );
+
+        self::assertSame(['#[\ORM\Column(length: 255)]'], $this->renderer->render($specs));
+    }
+
+    public function test_single_spec_zero_arg_without_outer_wrapper(): void
+    {
+        $specs = $this->vec(Keyword::create('Entity', 'ORM'));
+
+        self::assertSame(['#[\ORM\Entity]'], $this->renderer->render($specs));
+    }
+
     public function test_dotted_namespace_maps_to_backslash(): void
     {
         $specs = $this->vec($this->vec(


### PR DESCRIPTION
## 🤔 Background

The `^{:php/attr [...]}` metadata shipped in #2280 forces double brackets even for a single marker attribute: `^{:php/attr [[:ORM/Entity]]}`.

## 💡 Goal

Cut the ceremony for the common case, backward-compatibly.

## 🔖 Changes

`Phel\Shared\PhpAttributeRenderer::render` now accepts three input shapes:

| Phel | PHP |
|------|-----|
| `^{:php/attr :ORM/Entity}` | `#[\ORM\Entity]` |
| `^{:php/attr [:ORM/Column {:length 255}]}` | `#[\ORM\Column(length: 255)]` |
| `^{:php/attr [[:ORM/Id] [:ORM/Column]]}` | `#[\ORM\Id]` + `#[\ORM\Column]` (unchanged) |

Disambiguation: a **single spec** is a vector whose first element is the attribute-name keyword; a **list of specs** has vectors as its elements; a **bare keyword** is a single zero-arg attribute.

- Unit tests for the three new forms + existing multi-spec (no regression).
- Integration fixture `defstruct-php-attributes-shorthand.test` exercising the shorthand on a `defstruct` (class-level bare keyword + field single spec).
- Docs: `Shared/CLAUDE.md`, `framework-integration.md` snippet uses the shorthand, `CHANGELOG.md`.

Applies everywhere `:php/attr` is read (`defstruct`, `definterface`, `phel export`) since they share the renderer. `Closes #2289`.

Full gate green: `composer test-compiler` (3970) + `composer test-quality` clean.
