### PR TITLE
feat(compiler): add defenum for native PHP backed enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - `phel.http`: JSON request bodies decode into `:parsed-body`, plus `json-response`/`html-response` builders that set the content-type and encode the body (#2271)
 - PHP interop: `^{:php/attr [...]}` emits PHP 8 attributes (e.g. `#[\ORM\Column(length: 255)]`) and `^{:tag <type>}` emits typed signatures on `defstruct`, `phel export` wrappers, and `definterface` — opt-in, untagged forms unchanged (#2280). The metadata also accepts terser shorthands: a bare keyword (`^{:php/attr :ORM/Entity}`) or a single spec without the outer vector (`^{:php/attr [:ORM/Column {:length 255}]}`) (#2289)
 - Docs: runnable `docs/examples/13_database-crud.phel` (maps-not-entities CRUD) and a Persistence section in `framework-integration.md` covering phel-sql + phel-pdo (#2281, #2282)
+- `defenum`: compiles to a native PHP backed enum (`enum Status: string { case active = 'active'; ... }`) with a generated `Name?` predicate; cases take an optional `int`/`string` value (all-or-none), and class-level `^{:php/attr [...]}` is supported (#2291)
 
 ### Changed
 

--- a/docs/internals/special-forms.md
+++ b/docs/internals/special-forms.md
@@ -49,13 +49,14 @@ Each handler returns one `AbstractNode`. Emitter has 1:1 mapping to `*Emitter.ph
 
 ## Type definitions (low-level)
 
-Trailing `*` means not user-facing. Macros `defstruct`, `definterface`, `defexception`, `reify` expand into these.
+Trailing `*` means not user-facing. Macros `defstruct`, `definterface`, `defexception`, `defenum`, `reify` expand into these.
 
 | Form | Const | Handler | Node |
 |------|-------|---------|------|
 | `defstruct*` | `NAME_DEF_STRUCT` | `DefStructSymbol` | `DefStructNode` |
 | `definterface*` | `NAME_DEF_INTERFACE` | `DefInterfaceSymbol` | `DefInterfaceNode` |
 | `defexception*` | `NAME_DEF_EXCEPTION` | `DefExceptionSymbol` | `DefExceptionNode` |
+| `defenum*` | `NAME_DEF_ENUM` | `DefEnumSymbol` | `DefEnumNode` |
 | `reify*` | `NAME_REIFY` | `ReifySymbol` | `ReifyNode` |
 
 ## PHP interop
@@ -75,7 +76,7 @@ Trailing `*` means not user-facing. Macros `defstruct`, `definterface`, `defexce
 ## Not special forms
 
 - `if-let`, `when`, `cond`, `case`, `match`, `->`, `->>`: macros in `phel.core`
-- `defn`, `defmacro`, `defstruct`, `definterface`, `defexception`, `reify`: macros over `*` forms
+- `defn`, `defmacro`, `defstruct`, `definterface`, `defexception`, `defenum`, `reify`: macros over `*` forms
 - `+`, `-`, `=`, `map`, `filter`, ...: functions in `phel.core`
 
 Run `(macroexpand-1 'form)` to see the truth.

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -141,6 +141,22 @@
                  (newInstanceArgs (to-php-array args))))
        (defn ~is-name ~(php/. "Checks if `x` is an instance of the " name " exception.") [x] (php/is_a x ~class-name-str)))))
 
+(defmacro defenum
+  "Defines a native PHP backed enum. Each case is named by a keyword followed
+  by an optional scalar value (all `int` or all `string`); value-less cases
+  produce a pure enum. Also defines a `Name?` predicate.
+
+      (defenum Status :active \"active\" :inactive \"inactive\")
+      (Status? Status/active) # => true"
+  [name & cases]
+  (let [name-str       (php/-> name (getName))
+        munge          (php/new Munge)
+        class-name-str (php/. (php/-> munge (encodePhpNs *ns*)) "\\" (php/-> munge (encode name-str)))
+        is-name        (php/:: Symbol (create (php/. name-str "?")))]
+    `(do
+       (defenum* ~name ~@cases)
+       (defn ~is-name ~(php/. "Checks if `x` is a case of the " name " enum.") [x] (php/is_a x ~class-name-str)))))
+
 (defmacro comment
   "Ignores the body of the comment."
   [&])

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -267,7 +267,7 @@
   `let`, and `try`."
   (hash-set 'def 'ns 'in-ns 'load 'fn 'quote 'var 'do 'if 'apply
             'let 'recur 'try 'throw 'loop 'foreach 'set-var
-            'defstruct* 'definterface* 'defexception* 'reify*
+            'defstruct* 'definterface* 'defexception* 'defenum* 'reify*
             'php/new 'php/-> 'php/:: 'php/aget 'php/aget-in
             'php/aset 'php/aset-in 'php/apush 'php/apush-in
             'php/aunset 'php/aunset-in 'php/oset
@@ -425,7 +425,7 @@
     (php/is_numeric x)                  (= 0 x)
     (php/is_string x)                   (true? (php/empty x))
     (php/instanceof x LazySeqInterface) (nil? (first x))
-    (php/instanceof x Cons)         false
+    (php/instanceof x Cons)             false
     :else                               (= 0 (count x))))
 
 (defn not-empty

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -81,6 +81,7 @@ Analyzer tracks param and return types via `ParamTypeInferrer`, `ReturnTypeInfer
 
 - `defstruct`: a field's `^{:tag <type>}` emits a typed property (`protected int $id;`); `^{:php/attr [...]}` on the struct name (class-level) or a field (property-level) emits PHP 8 attributes.
 - `definterface`: a method's arg `^{:tag <type>}` emits a typed param and the method name's `:tag` the return type; `^{:php/attr [...]}` on the interface name or a method emits interface-/method-level attributes.
+- `defenum` (`defenum*`, `DefEnumSymbol`/`DefEnumNode`/`DefEnumEmitter`): emits a native PHP `enum`; cases are keyword-named with an optional `int`/`string` value (all-or-none → backed vs pure enum), and `^{:php/attr [...]}` on the enum name emits class-level attributes. Guarded by `enum_exists`.
 
 All opt-in; untagged forms are byte-identical to before. Export wrappers carry the same `:php/attr` via `Interop`'s `CompiledPhpMethodBuilder` (see `src/php/Interop/CLAUDE.md`).
 

--- a/src/php/Compiler/Domain/Analyzer/Ast/DefEnumCase.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/DefEnumCase.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Ast;
+
+/**
+ * A single case of a `defenum*`: the keyword-derived case name and its
+ * optional backing scalar value (`int`/`string`, or `null` for a pure enum).
+ */
+final readonly class DefEnumCase
+{
+    public function __construct(
+        private string $name,
+        private int|string|null $value,
+    ) {}
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getValue(): int|string|null
+    {
+        return $this->value;
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/Ast/DefEnumNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/DefEnumNode.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Ast;
+
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+
+final class DefEnumNode extends AbstractNode
+{
+    /**
+     * @param list<DefEnumCase> $cases
+     */
+    public function __construct(
+        NodeEnvironmentInterface $env,
+        private readonly string $namespace,
+        private readonly Symbol $name,
+        private readonly array $cases,
+        private readonly ?string $backingType,
+        ?SourceLocation $sourceLocation = null,
+    ) {
+        parent::__construct($env, $sourceLocation);
+    }
+
+    public function getNamespace(): string
+    {
+        return $this->namespace;
+    }
+
+    public function getName(): Symbol
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return list<DefEnumCase>
+     */
+    public function getCases(): array
+    {
+        return $this->cases;
+    }
+
+    /**
+     * The native PHP backing type (`int`/`string`), or null for a pure enum.
+     */
+    public function getBackingType(): ?string
+    {
+        return $this->backingType;
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -14,6 +14,7 @@ use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ApplySymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\BindingValidator;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefEnumSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefExceptionSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefInterfaceSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefStructSymbol;
@@ -339,6 +340,7 @@ final class AnalyzePersistentList
             Symbol::NAME_FOREACH => new ForeachSymbol($this->analyzer),
             Symbol::NAME_DEF_STRUCT => new DefStructSymbol($this->analyzer, $this->munge, new MethodBodyAnalyzer($this->analyzer)),
             Symbol::NAME_DEF_EXCEPTION => new DefExceptionSymbol($this->analyzer),
+            Symbol::NAME_DEF_ENUM => new DefEnumSymbol($this->analyzer),
             Symbol::NAME_PHP_OBJECT_SET => new PhpOSetSymbol($this->analyzer),
             Symbol::NAME_SET_VAR => new SetVarSymbol($this->analyzer),
             Symbol::NAME_DEF_INTERFACE => new DefInterfaceSymbol($this->analyzer),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefEnumSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefEnumSymbol.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\Ast\DefEnumCase;
+use Phel\Compiler\Domain\Analyzer\Ast\DefEnumNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+
+use function array_slice;
+use function count;
+use function is_int;
+use function is_string;
+
+/**
+ * (defenum* Name :case-a value-a :case-b value-b ...).
+ *
+ * Defines a native PHP backed enum. Each case is named by a keyword; an
+ * optional scalar value (all `int` or all `string`) makes it a backed enum,
+ * while value-less cases produce a pure enum.
+ */
+final class DefEnumSymbol implements SpecialFormAnalyzerInterface
+{
+    use WithAnalyzerTrait;
+
+    /**
+     * @param PersistentListInterface<mixed> $list
+     */
+    public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): DefEnumNode
+    {
+        if (count($list) < 2) {
+            throw AnalyzerException::withLocation("At least one argument is required for 'defenum", $list);
+        }
+
+        $name = $list->get(1);
+        if (!$name instanceof Symbol) {
+            throw AnalyzerException::wrongArgumentType("First argument of 'defenum", 'Symbol', $name, $list);
+        }
+
+        $cases = $this->cases($list);
+        if ($cases === []) {
+            throw AnalyzerException::withLocation("'defenum requires at least one case", $list);
+        }
+
+        return new DefEnumNode(
+            $env,
+            $this->analyzer->getNamespace(),
+            $name,
+            $cases,
+            $this->backingType($cases, $list),
+            $list->getStartLocation(),
+        );
+    }
+
+    /**
+     * @param PersistentListInterface<mixed> $list
+     *
+     * @return list<DefEnumCase>
+     */
+    private function cases(PersistentListInterface $list): array
+    {
+        $elements = [];
+        foreach ($list as $element) {
+            $elements[] = $element;
+        }
+
+        // Drop the leading `defenum*` symbol and the enum name.
+        $elements = array_slice($elements, 2);
+        $count = count($elements);
+
+        $cases = [];
+        $index = 0;
+        while ($index < $count) {
+            $caseKeyword = $elements[$index];
+            if (!$caseKeyword instanceof Keyword) {
+                throw AnalyzerException::withLocation('Each enum case must be a keyword', $list);
+            }
+
+            $value = null;
+            $next = $elements[$index + 1] ?? null;
+            if ($next !== null && !$next instanceof Keyword) {
+                if (!is_int($next) && !is_string($next)) {
+                    throw AnalyzerException::withLocation('Enum case values must be int or string', $list);
+                }
+
+                $value = $next;
+                ++$index;
+            }
+
+            $cases[] = new DefEnumCase($caseKeyword->getName(), $value);
+            ++$index;
+        }
+
+        return $cases;
+    }
+
+    /**
+     * @param list<DefEnumCase>              $cases
+     * @param PersistentListInterface<mixed> $list
+     */
+    private function backingType(array $cases, PersistentListInterface $list): ?string
+    {
+        $hasValue = false;
+        $hasNull = false;
+        $type = null;
+        foreach ($cases as $case) {
+            $value = $case->getValue();
+            if ($value === null) {
+                $hasNull = true;
+                continue;
+            }
+
+            $hasValue = true;
+            $currentType = is_int($value) ? 'int' : 'string';
+            if ($type === null) {
+                $type = $currentType;
+            } elseif ($type !== $currentType) {
+                throw AnalyzerException::withLocation('Enum case values must be all int or all string', $list);
+            }
+        }
+
+        if ($hasValue && $hasNull) {
+            throw AnalyzerException::withLocation('Enum cases must either all have a value or none', $list);
+        }
+
+        return $type;
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEnumEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEnumEmitter.php
@@ -17,6 +17,7 @@ use function var_export;
 
 final readonly class DefEnumEmitter implements NodeEmitterInterface
 {
+    use EvalGuardedEmitterTrait;
     use PhpAttributeEmitterTrait;
 
     public function __construct(
@@ -33,20 +34,6 @@ final readonly class DefEnumEmitter implements NodeEmitterInterface
         } else {
             $this->emitInline($node);
         }
-    }
-
-    /**
-     * The enum declaration must be lifted into an `eval()` when it would
-     * otherwise land somewhere PHP forbids: inside a function wrapper in
-     * statement mode (namespace not allowed), or inside another class's body.
-     */
-    private function shouldEmitViaEval(): bool
-    {
-        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
-            return true;
-        }
-
-        return $this->outputEmitter->isInsideClassScope();
     }
 
     private function emitViaEval(DefEnumNode $node): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEnumEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEnumEmitter.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DefEnumNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\SourceLocation;
+use Phel\Shared\PhpAttributeRenderer;
+
+use function assert;
+use function var_export;
+
+final readonly class DefEnumEmitter implements NodeEmitterInterface
+{
+    use PhpAttributeEmitterTrait;
+
+    public function __construct(
+        private OutputEmitterInterface $outputEmitter,
+        private PhpAttributeRenderer $attributeRenderer = new PhpAttributeRenderer(),
+    ) {}
+
+    public function emit(AbstractNode $node): void
+    {
+        assert($node instanceof DefEnumNode);
+
+        if ($this->shouldEmitViaEval()) {
+            $this->emitViaEval($node);
+        } else {
+            $this->emitInline($node);
+        }
+    }
+
+    /**
+     * The enum declaration must be lifted into an `eval()` when it would
+     * otherwise land somewhere PHP forbids: inside a function wrapper in
+     * statement mode (namespace not allowed), or inside another class's body.
+     */
+    private function shouldEmitViaEval(): bool
+    {
+        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
+            return true;
+        }
+
+        return $this->outputEmitter->isInsideClassScope();
+    }
+
+    private function emitViaEval(DefEnumNode $node): void
+    {
+        $ns = $this->outputEmitter->mungeEncodePhpNs($node->getNamespace());
+        $fqcn = $ns . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
+
+        ob_start();
+        $this->emitEnumBody($node);
+        $enumBody = (string) ob_get_clean();
+
+        $this->outputEmitter->emitLine("if (!enum_exists('" . $fqcn . "')) {", $node->getStartSourceLocation());
+        $this->outputEmitter->increaseIndentLevel();
+
+        $evalCode = 'namespace ' . $ns . ";\n" . $enumBody;
+        $this->outputEmitter->emitLine(
+            'eval(' . var_export($evalCode, true) . ');',
+            $node->getStartSourceLocation(),
+        );
+
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+    }
+
+    /**
+     * In file/cache mode the NsEmitter already declared the namespace at the
+     * top of the file, so the enum is emitted inline.
+     */
+    private function emitInline(DefEnumNode $node): void
+    {
+        $fqcn = $this->outputEmitter->mungeEncodePhpNs($node->getNamespace())
+            . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
+        $this->outputEmitter->emitLine("if (!enum_exists('" . $fqcn . "')) {", $node->getStartSourceLocation());
+
+        $this->emitEnumBody($node);
+
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+    }
+
+    private function emitEnumBody(DefEnumNode $node): void
+    {
+        $this->emitAttributes($node->getName()->getMeta(), $node->getStartSourceLocation());
+
+        $header = 'enum ' . $this->outputEmitter->mungeEncode($node->getName()->getName());
+        $backingType = $node->getBackingType();
+        if ($backingType !== null) {
+            $header .= ': ' . $backingType;
+        }
+
+        $this->outputEmitter->emitLine($header . ' {', $node->getStartSourceLocation());
+        $this->outputEmitter->increaseIndentLevel();
+
+        foreach ($node->getCases() as $case) {
+            $line = 'case ' . $this->outputEmitter->mungeEncode($case->getName());
+            $value = $case->getValue();
+            if ($value !== null) {
+                $line .= ' = ' . var_export($value, true);
+            }
+
+            $this->outputEmitter->emitLine($line . ';', $node->getStartSourceLocation());
+        }
+
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+    }
+
+    /**
+     * Emits one `#[...]` line per `:php/attr` spec carried by the enum name
+     * meta, at the current indentation, before the enum declaration.
+     *
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
+     */
+    private function emitAttributes(?PersistentMapInterface $meta, ?SourceLocation $sourceLocation): void
+    {
+        foreach ($this->phpAttributeLines($this->attributeRenderer, $meta) as $attribute) {
+            $this->outputEmitter->emitLine($attribute, $sourceLocation);
+        }
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefExceptionEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefExceptionEmitter.php
@@ -13,6 +13,8 @@ use function assert;
 
 final readonly class DefExceptionEmitter implements NodeEmitterInterface
 {
+    use EvalGuardedEmitterTrait;
+
     public function __construct(private OutputEmitterInterface $outputEmitter) {}
 
     public function emit(AbstractNode $node): void
@@ -24,15 +26,6 @@ final readonly class DefExceptionEmitter implements NodeEmitterInterface
         } else {
             $this->emitInline($node);
         }
-    }
-
-    private function shouldEmitViaEval(): bool
-    {
-        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
-            return true;
-        }
-
-        return $this->outputEmitter->isInsideClassScope();
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -18,6 +18,7 @@ use function count;
 
 final readonly class DefStructEmitter implements NodeEmitterInterface
 {
+    use EvalGuardedEmitterTrait;
     use PhpAttributeEmitterTrait;
 
     public function __construct(
@@ -35,21 +36,6 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
         } else {
             $this->emitInline($node);
         }
-    }
-
-    /**
-     * The class declaration must be lifted into an `eval()` when it would
-     * otherwise land somewhere PHP forbids: inside a function wrapper in
-     * statement mode (namespace not allowed), or inside another class's
-     * method body, e.g. `defrecord` used inside a `deftest` body.
-     */
-    private function shouldEmitViaEval(): bool
-    {
-        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
-            return true;
-        }
-
-        return $this->outputEmitter->isInsideClassScope();
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/EvalGuardedEmitterTrait.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/EvalGuardedEmitterTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
+
+/**
+ * Shared decision for emitters that generate a top-level PHP type declaration
+ * (`defstruct`, `defexception`, `defenum`). The declaration must be lifted into
+ * an `eval()` when it would otherwise land somewhere PHP forbids: inside a
+ * function wrapper in statement mode (namespace not allowed), or inside another
+ * class's method body, e.g. used inside a `deftest` body.
+ *
+ * Using emitters must expose the `$outputEmitter` property (as every node
+ * emitter already does).
+ *
+ * @property-read OutputEmitterInterface $outputEmitter
+ */
+trait EvalGuardedEmitterTrait
+{
+    private function shouldEmitViaEval(): bool
+    {
+        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
+            return true;
+        }
+
+        return $this->outputEmitter->isInsideClassScope();
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\ApplyNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CatchNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DefEnumNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DefExceptionNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DefInterfaceNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DefNode;
@@ -49,6 +50,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\CallEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\CatchEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\ClosureEmitterHelper;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\DefEmitter;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\DefEnumEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\DefExceptionEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\DefInterfaceEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\DefStructEmitter;
@@ -149,6 +151,7 @@ final class NodeEmitterFactory
             ForeachNode::class => new ForeachEmitter($outputEmitter),
             DefStructNode::class => new DefStructEmitter($outputEmitter, $methodEmitter),
             DefExceptionNode::class => new DefExceptionEmitter($outputEmitter),
+            DefEnumNode::class => new DefEnumEmitter($outputEmitter),
             PhpObjectSetNode::class => new PhpObjectSetEmitter($outputEmitter),
             MapNode::class => new MapEmitter($outputEmitter),
             SetVarNode::class => new SetVarEmitter($outputEmitter),

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -99,6 +99,8 @@ final class Symbol extends AbstractType implements IdenticalInterface, FnInterfa
 
     public const string NAME_DEF_EXCEPTION = 'defexception*';
 
+    public const string NAME_DEF_ENUM = 'defenum*';
+
     public const string NAME_REIFY = 'reify*';
 
     public const string NAME_DOLLAR = '$';

--- a/tests/phel/core/defenum.phel
+++ b/tests/phel/core/defenum.phel
@@ -1,0 +1,28 @@
+(ns phel-test.core.defenum
+  (:require phel.test :refer [deftest is]))
+
+;; String-backed enum
+(defenum Status :active "active" :inactive "inactive")
+
+;; Int-backed enum
+(defenum Priority :low 1 :high 10)
+
+;; Pure enum (no backing values)
+(defenum Color :red :green :blue)
+
+(deftest string-backed-enum
+  (let [active (php/:: \phel_test\core\defenum\Status (from "active"))]
+    (is (= "active" (php/-> active value)) "case carries its string value")
+    (is (= "active" (php/-> active name)) "case name matches the keyword")
+    (is (true? (Status? active)) "predicate recognises its own case")
+    (is (false? (Status? :active)) "predicate rejects a plain keyword")))
+
+(deftest int-backed-enum
+  (let [high (php/:: \phel_test\core\defenum\Priority (from 10))]
+    (is (= 10 (php/-> high value)) "int case carries its value")
+    (is (true? (Priority? high)) "int predicate works")))
+
+(deftest pure-enum
+  (let [cases (php/:: \phel_test\core\defenum\Color (cases))]
+    (is (= 3 (count cases)) "pure enum exposes all cases")
+    (is (true? (Color? (php/aget cases 0))) "pure case satisfies predicate")))

--- a/tests/php/Integration/Fixtures/Def/defenum-int.test
+++ b/tests/php/Integration/Fixtures/Def/defenum-int.test
@@ -1,0 +1,9 @@
+--PHEL--
+(defenum* Priority :low 1 :high 10)
+--PHP--
+if (!enum_exists('user\Priority')) {
+enum Priority: int {
+  case low = 1;
+  case high = 10;
+}
+}

--- a/tests/php/Integration/Fixtures/Def/defenum-php-attributes.test
+++ b/tests/php/Integration/Fixtures/Def/defenum-php-attributes.test
@@ -1,0 +1,10 @@
+--PHEL--
+(defenum* ^{:php/attr :ORM/Suit} Suit :hearts "H" :spades "S")
+--PHP--
+if (!enum_exists('user\Suit')) {
+#[\ORM\Suit]
+enum Suit: string {
+  case hearts = 'H';
+  case spades = 'S';
+}
+}

--- a/tests/php/Integration/Fixtures/Def/defenum-pure.test
+++ b/tests/php/Integration/Fixtures/Def/defenum-pure.test
@@ -1,0 +1,10 @@
+--PHEL--
+(defenum* Color :red :green :blue)
+--PHP--
+if (!enum_exists('user\Color')) {
+enum Color {
+  case red;
+  case green;
+  case blue;
+}
+}

--- a/tests/php/Integration/Fixtures/Def/defenum-string.test
+++ b/tests/php/Integration/Fixtures/Def/defenum-string.test
@@ -1,0 +1,9 @@
+--PHEL--
+(defenum* Status :active "active" :inactive "inactive")
+--PHP--
+if (!enum_exists('user\Status')) {
+enum Status: string {
+  case active = 'active';
+  case inactive = 'inactive';
+}
+}

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefEnumSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefEnumSymbolTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm;
+
+use Phel;
+use Phel\Compiler\Application\Analyzer;
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Compiler\Domain\Analyzer\Ast\DefEnumNode;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefEnumSymbol;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Shared\Exceptions\AbstractLocatedException;
+use PHPUnit\Framework\TestCase;
+
+final class DefEnumSymbolTest extends TestCase
+{
+    private AnalyzerInterface $analyzer;
+
+    protected function setUp(): void
+    {
+        $this->analyzer = new Analyzer(new GlobalEnvironment());
+    }
+
+    public function test_with_no_arguments(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage("At least one argument is required for 'defenum");
+
+        $list = Phel::list([Symbol::create(Symbol::NAME_DEF_ENUM)]);
+
+        new DefEnumSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_first_arg_is_not_symbol(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage("First argument of 'defenum must be a Symbol");
+
+        $list = Phel::list([Symbol::create(Symbol::NAME_DEF_ENUM), 'no-symbol']);
+
+        new DefEnumSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_requires_at_least_one_case(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage("'defenum requires at least one case");
+
+        $list = Phel::list([Symbol::create(Symbol::NAME_DEF_ENUM), Symbol::create('Empty')]);
+
+        new DefEnumSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_case_must_be_a_keyword(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage('Each enum case must be a keyword');
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_DEF_ENUM),
+            Symbol::create('Bad'),
+            'not-a-keyword',
+        ]);
+
+        new DefEnumSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_mixed_value_types_are_rejected(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage('Enum case values must be all int or all string');
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_DEF_ENUM),
+            Symbol::create('Mixed'),
+            Keyword::create('a'), 1,
+            Keyword::create('b'), 'two',
+        ]);
+
+        new DefEnumSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_partial_values_are_rejected(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage('Enum cases must either all have a value or none');
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_DEF_ENUM),
+            Symbol::create('Partial'),
+            Keyword::create('a'), 1,
+            Keyword::create('b'),
+        ]);
+
+        new DefEnumSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_string_backed_enum(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_DEF_ENUM),
+            Symbol::create('Status'),
+            Keyword::create('active'), 'active',
+            Keyword::create('inactive'), 'inactive',
+        ]);
+
+        $node = new DefEnumSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+
+        self::assertInstanceOf(DefEnumNode::class, $node);
+        self::assertSame('string', $node->getBackingType());
+        self::assertCount(2, $node->getCases());
+        self::assertSame('active', $node->getCases()[0]->getName());
+        self::assertSame('active', $node->getCases()[0]->getValue());
+    }
+
+    public function test_int_backed_enum(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_DEF_ENUM),
+            Symbol::create('Priority'),
+            Keyword::create('low'), 1,
+            Keyword::create('high'), 10,
+        ]);
+
+        $node = new DefEnumSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+
+        self::assertSame('int', $node->getBackingType());
+        self::assertSame(10, $node->getCases()[1]->getValue());
+    }
+
+    public function test_pure_enum_has_no_backing_type(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_DEF_ENUM),
+            Symbol::create('Color'),
+            Keyword::create('red'),
+            Keyword::create('green'),
+        ]);
+
+        $node = new DefEnumSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+
+        self::assertNull($node->getBackingType());
+        self::assertCount(2, $node->getCases());
+        self::assertNull($node->getCases()[0]->getValue());
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Phel keywords are the idiomatic enum, but they cannot satisfy a typed PHP `enum` parameter. Doctrine columns, Symfony DTOs and many framework signatures expect a native PHP 8.1 backed enum, so a Phel app integrating with such code had to hand-write the enum in PHP.

## 💡 Goal

Add a `defenum` form that compiles to a native PHP backed enum, keeping the Phel surface data-first (keyword in, native enum out) while producing the real typed enum the PHP ecosystem demands.

Closes #2291

## 🔖 Changes

- New special form `defenum*` (`NAME_DEF_ENUM`) with `DefEnumSymbol` analyzer, `DefEnumNode` + `DefEnumCase` AST, and `DefEnumEmitter`.
- Backing type inferred from the case values: all `int` → `: int`, all `string` → `: string`, value-less cases → pure enum. Mixed or partial values are rejected with clear analyzer errors.
- Case names come from the keywords (munged to valid identifiers); class-level `^{:php/attr [...]}` on the enum name emits PHP 8 attributes.
- `defenum` macro (in `phel.core`) expands to `defenum*` plus a generated `Name?` predicate.

```phel
(defenum Status :active "active" :inactive "inactive")
;; => enum Status: string { case active = 'active'; case inactive = 'inactive'; }
(Status? x)            ;; generated predicate
(defenum Color :red :green :blue) ;; pure enum
```

- **Refactor (separate commit):** extracted the identical `shouldEmitViaEval()` shared by the defstruct/defexception/defenum emitters into `EvalGuardedEmitterTrait`.

### Tests
- Unit: `DefEnumSymbolTest` (errors + string/int/pure analysis).
- Integration fixtures: `defenum-string`, `defenum-int`, `defenum-pure`, `defenum-php-attributes`.
- Phel-level: `tests/phel/core/defenum.phel` exercises the generated enum + predicate (`from`/`value`/`name`/`cases`).

Docs (`special-forms.md`) and the Compiler module `CLAUDE.md` updated; CHANGELOG `## Unreleased` noted.