### PR TITLE
feat(emitter): defstruct opt-in JsonSerializable and Stringable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - PHP interop: `^{:php/attr [...]}` emits PHP 8 attributes (e.g. `#[\ORM\Column(length: 255)]`) and `^{:tag <type>}` emits typed signatures on `defstruct`, `phel export` wrappers, and `definterface` — opt-in, untagged forms unchanged (#2280). The metadata also accepts terser shorthands: a bare keyword (`^{:php/attr :ORM/Entity}`) or a single spec without the outer vector (`^{:php/attr [:ORM/Column {:length 255}]}`) (#2289)
 - Docs: runnable `docs/examples/13_database-crud.phel` (maps-not-entities CRUD) and a Persistence section in `framework-integration.md` covering phel-sql + phel-pdo (#2281, #2282)
 - `defenum`: compiles to a native PHP backed enum (`enum Status: string { case active = 'active'; ... }`) with a generated `Name?` predicate; cases take an optional `int`/`string` value (all-or-none), and class-level `^{:php/attr [...]}` is supported (#2291)
+- `defstruct`: opt-in `^{:php/json true}` implements `\JsonSerializable` (emitting a `jsonSerialize()` that returns the field map, so `json_encode` works), and `^{:php/stringable true}` declares `\Stringable`; untagged structs are unchanged (#2292)
 
 ### Changed
 

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -79,7 +79,7 @@ Analyzer tracks param and return types via `ParamTypeInferrer`, `ReturnTypeInfer
 
 `DefStructEmitter` and `DefInterfaceEmitter` read per-symbol metadata to enrich the PHP they generate, sharing `PhpAttributeEmitterTrait` (tag + `:php/attr` reading) and the pure `Phel\Shared\PhpAttributeRenderer`:
 
-- `defstruct`: a field's `^{:tag <type>}` emits a typed property (`protected int $id;`); `^{:php/attr [...]}` on the struct name (class-level) or a field (property-level) emits PHP 8 attributes.
+- `defstruct`: a field's `^{:tag <type>}` emits a typed property (`protected int $id;`); `^{:php/attr [...]}` on the struct name (class-level) or a field (property-level) emits PHP 8 attributes. `^{:php/json true}` on the struct name implements `\JsonSerializable` (emitting a `jsonSerialize()` that returns the field map) and `^{:php/stringable true}` declares `\Stringable`.
 - `definterface`: a method's arg `^{:tag <type>}` emits a typed param and the method name's `:tag` the return type; `^{:php/attr [...]}` on the interface name or a method emits interface-/method-level attributes.
 - `defenum` (`defenum*`, `DefEnumSymbol`/`DefEnumNode`/`DefEnumEmitter`): emits a native PHP `enum`; cases are keyword-named with an optional `int`/`string` value (all-or-none → backed vs pure enum), and `^{:php/attr [...]}` on the enum name emits class-level attributes. Guarded by `enum_exists`.
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -9,12 +9,14 @@ use Phel\Compiler\Domain\Analyzer\Ast\DefStructNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use Phel\Shared\PhpAttributeRenderer;
 
 use function assert;
 use function count;
+use function implode;
 
 final readonly class DefStructEmitter implements NodeEmitterInterface
 {
@@ -91,6 +93,7 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
         $this->emitProperties($node);
         $this->emitConstructor($node);
         $this->emitInterfaces($node);
+        $this->emitJsonSerialize($node);
         $this->emitClassFooter($node);
     }
 
@@ -103,23 +106,79 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
             $node->getStartSourceLocation(),
         );
 
-        if ($node->getInterfaces() !== []) {
-            $this->outputEmitter->emitStr(' implements ');
-        }
-
-        $interfaces = $node->getInterfaces();
-        $interfacesCount = count($interfaces);
-        foreach ($interfaces as $i => $defStruct) {
-            $this->outputEmitter->emitStr($defStruct->getAbsoluteInterfaceName());
-            if ($i < $interfacesCount - 1) {
-                $this->outputEmitter->emitStr(', ');
-            }
+        $interfaces = $this->interfaceNames($node);
+        if ($interfaces !== []) {
+            $this->outputEmitter->emitStr(' implements ' . implode(', ', $interfaces));
         }
 
         $this->outputEmitter->emitLine(' {');
 
         $this->outputEmitter->increaseIndentLevel();
         $this->outputEmitter->emitLine();
+    }
+
+    /**
+     * The full `implements` list: the Phel protocol interfaces plus the
+     * opt-in PHP marker interfaces requested via the struct-name meta
+     * (`^{:php/json true}` => `\JsonSerializable`, `^{:php/stringable true}`
+     * => `\Stringable`, satisfied by the inherited `__toString`).
+     *
+     * @return list<string>
+     */
+    private function interfaceNames(DefStructNode $node): array
+    {
+        $names = [];
+        foreach ($node->getInterfaces() as $defStruct) {
+            $names[] = $defStruct->getAbsoluteInterfaceName();
+        }
+
+        $meta = $node->getName()->getMeta();
+        if ($this->metaFlag($meta, 'json')) {
+            $names[] = '\JsonSerializable';
+        }
+
+        if ($this->metaFlag($meta, 'stringable')) {
+            $names[] = '\Stringable';
+        }
+
+        return $names;
+    }
+
+    /**
+     * Emits a `jsonSerialize(): array` returning the field map when the struct
+     * opts in with `^{:php/json true}`.
+     */
+    private function emitJsonSerialize(DefStructNode $node): void
+    {
+        if (!$this->metaFlag($node->getName()->getMeta(), 'json')) {
+            return;
+        }
+
+        $pairs = [];
+        foreach ($node->getParams() as $param) {
+            $pairs[] = "'" . $param->getName() . "' => \$this->" . $this->outputEmitter->mungeEncode($param->getName());
+        }
+
+        $this->outputEmitter->emitLine();
+        $this->outputEmitter->emitLine('public function jsonSerialize(): array {', $node->getStartSourceLocation());
+        $this->outputEmitter->increaseIndentLevel();
+        $this->outputEmitter->emitLine('return [' . implode(', ', $pairs) . '];', $node->getStartSourceLocation());
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+    }
+
+    /**
+     * Reads a boolean `:php/<name>` flag off the struct-name meta.
+     *
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
+     */
+    private function metaFlag(?PersistentMapInterface $meta, string $name): bool
+    {
+        if (!$meta instanceof PersistentMapInterface) {
+            return false;
+        }
+
+        return $meta->find(Keyword::create($name, 'php')) === true;
     }
 
     private function emitAllowedKeys(DefStructNode $node): void

--- a/tests/phel/core/defstruct-json.phel
+++ b/tests/phel/core/defstruct-json.phel
@@ -1,0 +1,19 @@
+(ns phel-test.core.defstruct-json
+  (:require phel.test :refer [deftest is]))
+
+(defstruct ^{:php/json true} point [x y])
+(defstruct ^{:php/stringable true} label [text])
+(defstruct plain [a])
+
+(deftest json-serializable-struct
+  (let [p (point 1 2)]
+    (is (php/is_a p "JsonSerializable") "opted-in struct implements JsonSerializable")
+    (is (= "{\"x\":1,\"y\":2}" (php/json_encode p)) "json_encode emits the field map")))
+
+(deftest stringable-struct
+  (is (php/is_a (label "hi") "Stringable") "opted-in struct implements Stringable"))
+
+(deftest plain-struct-unaffected
+  (let [p (plain 1)]
+    (is (not (php/is_a p "JsonSerializable")) "untagged struct is not JsonSerializable")
+    (is (= 1 (p :a)) "untagged struct still behaves as a map")))

--- a/tests/php/Integration/Fixtures/Def/defstruct-json-serializable.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-json-serializable.test
@@ -1,0 +1,23 @@
+--PHEL--
+(defstruct* ^{:php/json true} point [x y])
+--PHP--
+if (!class_exists('user\point')) {
+final class point extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct implements \JsonSerializable {
+
+  protected const array ALLOWED_KEYS = ['x', 'y'];
+
+  protected $x;
+  protected $y;
+
+  public function __construct($x, $y, $meta = null) {
+    parent::__construct();
+    $this->x = $x;
+    $this->y = $y;
+    $this->meta = $meta;
+  }
+
+  public function jsonSerialize(): array {
+    return ['x' => $this->x, 'y' => $this->y];
+  }
+}
+}

--- a/tests/php/Integration/Fixtures/Def/defstruct-stringable.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-stringable.test
@@ -1,0 +1,17 @@
+--PHEL--
+(defstruct* ^{:php/stringable true} label [text])
+--PHP--
+if (!class_exists('user\label')) {
+final class label extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct implements \Stringable {
+
+  protected const array ALLOWED_KEYS = ['text'];
+
+  protected $text;
+
+  public function __construct($text, $meta = null) {
+    parent::__construct();
+    $this->text = $text;
+    $this->meta = $meta;
+  }
+}
+}


### PR DESCRIPTION
## 🤔 Background

`defstruct` already supports an `implements` clause, but the method bodies stay manual. The most common need when handing a struct to `json_encode`, the Symfony serializer or Twig is `JsonSerializable`. Structs store fields in protected properties, so `json_encode` of a struct yields `{}` today.

## 💡 Goal

Let a struct opt in to the two PHP marker interfaces frameworks expect, keeping untagged structs byte-identical.

Closes #2292

## 🔖 Changes

- `^{:php/json true}` on the struct name → `implements \JsonSerializable` plus a generated `jsonSerialize(): array` returning the field map (`['x' => $this->x, ...]`), so `json_encode` emits `{"x":1,"y":2}`.
- `^{:php/stringable true}` → `implements \Stringable` (satisfied by the inherited `__toString`).
- Pure emitter feature: reads the struct-name meta, no analyzer/AST change. The `implements` list is now built once (protocol interfaces + opt-in markers) instead of looping.

```phel
(defstruct ^{:php/json true} point [x y])
(php/json_encode (point 1 2)) # => {"x":1,"y":2}
```

### Tests
- Integration fixtures: `defstruct-json-serializable`, `defstruct-stringable`.
- Phel-level `tests/phel/core/defstruct-json.phel`: `json_encode` output, `is_a` checks, and an untagged-struct control.

CHANGELOG `## Unreleased` and the Compiler module `CLAUDE.md` updated.

### Refactor pass
The header-emission cleanup (single `implements` list) landed in the feature commit; the post-implementation review surfaced no further changes, so there is no separate `ref(...)` commit.