### PR TITLE
feat(emitter): union and intersection :tag types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Docs: runnable `docs/examples/13_database-crud.phel` (maps-not-entities CRUD) and a Persistence section in `framework-integration.md` covering phel-sql + phel-pdo (#2281, #2282)
 - `defenum`: compiles to a native PHP backed enum (`enum Status: string { case active = 'active'; ... }`) with a generated `Name?` predicate; cases take an optional `int`/`string` value (all-or-none), and class-level `^{:php/attr [...]}` is supported (#2291)
 - `defstruct`: opt-in `^{:php/json true}` implements `\JsonSerializable` (emitting a `jsonSerialize()` that returns the field map, so `json_encode` works), and `^{:php/stringable true}` declares `\Stringable`; untagged structs are unchanged (#2292)
+- `:tag` type hints (on `defstruct` fields and `definterface` params/returns) now accept composite types: a list is a union (`^{:tag (int string)}` => `int|string`) and a vector is an intersection (`^{:tag [Countable Stringable]}` => `Countable&Stringable`); nullable/`self`/`static`/FQN tags continue to pass through verbatim (#2293)
 
 ### Changed
 

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -77,7 +77,7 @@ Analyzer tracks param and return types via `ParamTypeInferrer`, `ReturnTypeInfer
 
 ## Generated-Class Attributes & Typed Signatures
 
-`DefStructEmitter` and `DefInterfaceEmitter` read per-symbol metadata to enrich the PHP they generate, sharing `PhpAttributeEmitterTrait` (tag + `:php/attr` reading) and the pure `Phel\Shared\PhpAttributeRenderer`:
+`DefStructEmitter` and `DefInterfaceEmitter` read per-symbol metadata to enrich the PHP they generate, sharing `PhpAttributeEmitterTrait` (tag + `:php/attr` reading) and the pure `Phel\Shared\PhpAttributeRenderer`. A `:tag` value can be a bare symbol/string (verbatim, so `?int`/`self`/`\DateTime` pass through), a list (union → `a|b`), or a vector (intersection → `a&b`):
 
 - `defstruct`: a field's `^{:tag <type>}` emits a typed property (`protected int $id;`); `^{:php/attr [...]}` on the struct name (class-level) or a field (property-level) emits PHP 8 attributes. `^{:php/json true}` on the struct name implements `\JsonSerializable` (emitting a `jsonSerialize()` that returns the field map) and `^{:php/stringable true}` declares `\Stringable`.
 - `definterface`: a method's arg `^{:tag <type>}` emits a typed param and the method name's `:tag` the return type; `^{:php/attr [...]}` on the interface name or a method emits interface-/method-level attributes.

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpAttributeEmitterTrait.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpAttributeEmitterTrait.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use Phel\Shared\PhpAttributeRenderer;
 
+use function implode;
 use function is_string;
 
 /**
@@ -30,12 +33,51 @@ trait PhpAttributeEmitterTrait
             return null;
         }
 
-        $tag = $meta->find(Keyword::create('tag'));
+        return $this->renderTag($meta->find(Keyword::create('tag')));
+    }
+
+    /**
+     * Resolves a `:tag` value into a PHP type string. A bare symbol/string is
+     * used verbatim (so `?int`, `self`, `\DateTime` pass through); a list is a
+     * union (`(int string)` => `int|string`); a vector is an intersection
+     * (`[Countable Stringable]` => `Countable&Stringable`).
+     */
+    private function renderTag(mixed $tag): ?string
+    {
+        if ($tag instanceof PersistentListInterface) {
+            return $this->joinTagParts($tag, '|');
+        }
+
+        if ($tag instanceof PersistentVectorInterface) {
+            return $this->joinTagParts($tag, '&');
+        }
+
         if ($tag instanceof Symbol) {
             $tag = $tag->getName();
         }
 
         return is_string($tag) && $tag !== '' ? $tag : null;
+    }
+
+    /**
+     * Joins the symbol/string members of a composite tag with `$separator`.
+     *
+     * @param iterable<mixed> $parts
+     */
+    private function joinTagParts(iterable $parts, string $separator): ?string
+    {
+        $names = [];
+        foreach ($parts as $part) {
+            if ($part instanceof Symbol) {
+                $part = $part->getName();
+            }
+
+            if (is_string($part) && $part !== '') {
+                $names[] = $part;
+            }
+        }
+
+        return $names === [] ? null : implode($separator, $names);
     }
 
     /**

--- a/tests/phel/core/tag-types.phel
+++ b/tests/phel/core/tag-types.phel
@@ -1,0 +1,22 @@
+(ns phel-test.core.tag-types
+  (:require phel.test :refer [deftest is]))
+
+;; Union type: PHP enforces int|string on the generated property
+(defstruct boxed [^{:tag (int string)} value])
+
+;; Nullable type
+(defstruct opt [^{:tag ?int} n])
+
+(deftest union-accepts-either-member
+  (is (= 1 ((boxed 1) :value)) "union property accepts an int")
+  (is (= "x" ((boxed "x") :value)) "union property accepts a string"))
+
+(deftest nullable-accepts-nil-and-value
+  (is (nil? ((opt nil) :n)) "nullable property accepts nil")
+  (is (= 3 ((opt 3) :n)) "nullable property accepts the int"))
+
+(deftest typed-struct-still-persistent
+  (let [a (boxed 1)
+        b (put a :value "two")]
+    (is (= 1 (a :value)) "original is unchanged")
+    (is (= "two" (b :value)) "put returns an updated copy")))

--- a/tests/php/Integration/Fixtures/Def/definterface-union-tag.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-union-tag.test
@@ -1,0 +1,9 @@
+--PHEL--
+(definterface* Repo
+  (^{:tag (int string)} find [this ^{:tag ?string} id]))
+--PHP--
+if (!interface_exists('user\Repo')) {
+interface Repo {
+  public function find(?string $id): int|string;
+}
+}

--- a/tests/php/Integration/Fixtures/Def/defstruct-intersection-tag.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-intersection-tag.test
@@ -1,0 +1,17 @@
+--PHEL--
+(defstruct* wrap [^{:tag [Countable Stringable]} item])
+--PHP--
+if (!class_exists('user\wrap')) {
+final class wrap extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
+
+  protected const array ALLOWED_KEYS = ['item'];
+
+  protected Countable&Stringable $item;
+
+  public function __construct($item, $meta = null) {
+    parent::__construct();
+    $this->item = $item;
+    $this->meta = $meta;
+  }
+}
+}

--- a/tests/php/Integration/Fixtures/Def/defstruct-nullable-tag.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-nullable-tag.test
@@ -1,0 +1,19 @@
+--PHEL--
+(defstruct* opt [^{:tag ?int} a ^{:tag \DateTimeImmutable} b])
+--PHP--
+if (!class_exists('user\opt')) {
+final class opt extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
+
+  protected const array ALLOWED_KEYS = ['a', 'b'];
+
+  protected ?int $a;
+  protected \DateTimeImmutable $b;
+
+  public function __construct($a, $b, $meta = null) {
+    parent::__construct();
+    $this->a = $a;
+    $this->b = $b;
+    $this->meta = $meta;
+  }
+}
+}

--- a/tests/php/Integration/Fixtures/Def/defstruct-union-tag.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-union-tag.test
@@ -1,0 +1,17 @@
+--PHEL--
+(defstruct* boxed [^{:tag (int string)} value])
+--PHP--
+if (!class_exists('user\boxed')) {
+final class boxed extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
+
+  protected const array ALLOWED_KEYS = ['value'];
+
+  protected int|string $value;
+
+  public function __construct($value, $meta = null) {
+    parent::__construct();
+    $this->value = $value;
+    $this->meta = $meta;
+  }
+}
+}


### PR DESCRIPTION
## 🤔 Background

Typed emission for `defstruct` fields and `definterface` params/returns read a single bare `:tag`. Real framework signatures need more of the PHP 8 type system: nullable columns (`?int`), union returns (`int|string`), intersection types.

## 💡 Goal

Extend the `:tag` vocabulary to cover composite PHP types, with no new forms (pure metadata) and existing single-`:tag` output unchanged.

Closes #2293

## 🔖 Changes

In the shared `PhpAttributeEmitterTrait`, a `:tag` value now resolves as:

- **bare symbol/string** — verbatim, so `?int`, `self`, `static`, `\DateTimeImmutable` already pass through.
- **list** — union: `^{:tag (int string)}` → `int|string`.
- **vector** — intersection: `^{:tag [Countable Stringable]}` → `Countable&Stringable`.

Applies uniformly to `defstruct` properties and `definterface` params/return types (both use the trait).

```phel
(defstruct boxed [^{:tag (int string)} value])  ;; protected int|string $value;
(definterface Repo (^{:tag (int string)} find [this ^{:tag ?string} id]))
```

### Not included: per-field `readonly`

The issue also listed `^:readonly` fields. Phel structs are **persistent maps**: `put`/`assoc` returns a modified copy by cloning and writing the property, which a `readonly` property forbids at runtime (`Cannot modify readonly property`). Emitting `readonly` would silently break `put` on the struct, so it is intentionally left out. (A real `readonly` story would require reworking `AbstractPersistentStruct` to rebuild via the constructor — out of scope here.)

### Tests
- Integration fixtures: `defstruct-union-tag`, `defstruct-intersection-tag`, `defstruct-nullable-tag`, `definterface-union-tag`.
- Phel-level `tests/phel/core/tag-types.phel`: union accepts either member, nullable accepts nil/value, and a typed struct stays persistent across `put`.

CHANGELOG `## Unreleased` and the Compiler module `CLAUDE.md` updated.

### Refactor pass
Reviewed the touched trait; the new `renderTag`/`joinTagParts` helpers are single-purpose with no duplication, so there is no separate `ref(...)` commit.