### PR TITLE
feat(emitter): emit :php/doc PHPDoc blocks on generated classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - `defstruct`: opt-in `^{:php/json true}` implements `\JsonSerializable` (emitting a `jsonSerialize()` that returns the field map, so `json_encode` works), and `^{:php/stringable true}` declares `\Stringable`; untagged structs are unchanged (#2292)
 - `:tag` type hints (on `defstruct` fields and `definterface` params/returns) now accept composite types: a list is a union (`^{:tag (int string)}` => `int|string`) and a vector is an intersection (`^{:tag [Countable Stringable]}` => `Countable&Stringable`); nullable/`self`/`static`/FQN tags continue to pass through verbatim (#2293)
 - `definterface`: `^{:php/attr [...]}` on a method parameter now emits an inline PHP parameter attribute (`public function show(#[\Autowire] string $repo)`), complementing the existing method- and interface-level attributes (#2294)
+- `^{:php/doc ...}` emits a PHPDoc block on generated `defstruct` classes/fields and `definterface` interfaces/methods, so phpstan/psalm see Phel-generated code as typed; the value is a one-line string (`"@var list<int>"`) or a list/vector of strings for a multi-line block (#2295)
 
 ### Changed
 

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -83,6 +83,8 @@ Analyzer tracks param and return types via `ParamTypeInferrer`, `ReturnTypeInfer
 - `definterface`: a method's arg `^{:tag <type>}` emits a typed param and the method name's `:tag` the return type; `^{:php/attr [...]}` on the interface name, a method, or a method **parameter** emits interface-/method-/parameter-level attributes (the parameter form is emitted inline: `show(#[\Autowire] string $repo)`).
 - `defenum` (`defenum*`, `DefEnumSymbol`/`DefEnumNode`/`DefEnumEmitter`): emits a native PHP `enum`; cases are keyword-named with an optional `int`/`string` value (all-or-none → backed vs pure enum), and `^{:php/attr [...]}` on the enum name emits class-level attributes. Guarded by `enum_exists`.
 
+`^{:php/doc <str|[str...]>}` on any of those names/fields/methods emits a PHPDoc block (one-line string or multi-line list/vector) above the construct, so phpstan/psalm see generated classes as typed.
+
 All opt-in; untagged forms are byte-identical to before. Export wrappers carry the same `:php/attr` via `Interop`'s `CompiledPhpMethodBuilder` (see `src/php/Interop/CLAUDE.md`).
 
 ## Global Environment

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefInterfaceEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefInterfaceEmitter.php
@@ -89,6 +89,7 @@ final readonly class DefInterfaceEmitter implements NodeEmitterInterface
     private function emitInterfaceBody(DefInterfaceNode $node): void
     {
         $sourceLocation = $node->getStartSourceLocation();
+        $this->emitDocBlock($node->getName()->getMeta(), $sourceLocation);
         $this->emitAttributes($node->getName()->getMeta(), $sourceLocation);
 
         $this->outputEmitter->emitLine(
@@ -108,6 +109,7 @@ final readonly class DefInterfaceEmitter implements NodeEmitterInterface
     private function emitMethod(DefInterfaceNode $node, DefInterfaceMethod $method): void
     {
         $sourceLocation = $node->getStartSourceLocation();
+        $this->emitDocBlock($method->getName()->getMeta(), $sourceLocation);
         $this->emitAttributes($method->getName()->getMeta(), $sourceLocation);
 
         $this->outputEmitter->emitStr('public function ', $sourceLocation);
@@ -151,6 +153,19 @@ final readonly class DefInterfaceEmitter implements NodeEmitterInterface
     {
         foreach ($this->phpAttributeLines($this->attributeRenderer, $meta) as $attribute) {
             $this->outputEmitter->emitLine($attribute, $sourceLocation);
+        }
+    }
+
+    /**
+     * Emits the `:php/doc` PHPDoc block carried by the symbol meta, before the
+     * annotated construct (above any attributes).
+     *
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
+     */
+    private function emitDocBlock(?PersistentMapInterface $meta, ?SourceLocation $sourceLocation): void
+    {
+        foreach ($this->phpDocLines($meta) as $line) {
+            $this->outputEmitter->emitLine($line, $sourceLocation);
         }
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -99,6 +99,7 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
 
     private function emitClassHeader(DefStructNode $node): void
     {
+        $this->emitDocBlock($node->getName()->getMeta(), $node->getStartSourceLocation());
         $this->emitAttributes($node->getName()->getMeta(), $node->getStartSourceLocation());
 
         $this->outputEmitter->emitStr(
@@ -203,6 +204,7 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
         $params = $node->getParams();
         foreach ($params as $param) {
             $meta = $param->getMeta();
+            $this->emitDocBlock($meta, $node->getStartSourceLocation());
             $this->emitAttributes($meta, $node->getStartSourceLocation());
 
             $this->outputEmitter->emitStr('protected ');
@@ -228,6 +230,19 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
     {
         foreach ($this->phpAttributeLines($this->attributeRenderer, $meta) as $attribute) {
             $this->outputEmitter->emitLine($attribute, $sourceLocation);
+        }
+    }
+
+    /**
+     * Emits the `:php/doc` PHPDoc block carried by the symbol meta, before the
+     * annotated construct (above any attributes).
+     *
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
+     */
+    private function emitDocBlock(?PersistentMapInterface $meta, ?SourceLocation $sourceLocation): void
+    {
+        foreach ($this->phpDocLines($meta) as $line) {
+            $this->outputEmitter->emitLine($line, $sourceLocation);
         }
     }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpAttributeEmitterTrait.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpAttributeEmitterTrait.php
@@ -96,4 +96,54 @@ trait PhpAttributeEmitterTrait
 
         return $renderer->render($meta->find(Keyword::create('attr', 'php')));
     }
+
+    /**
+     * Renders the `:php/doc` metadata into PHPDoc lines, so generated classes
+     * carry the phpstan/psalm annotations a mixed PHP codebase needs. The value
+     * is a verbatim string (one line => `/** ... *​/`) or a list/vector of
+     * strings (a multi-line block). Empty list when absent.
+     *
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
+     *
+     * @return list<string>
+     */
+    private function phpDocLines(?PersistentMapInterface $meta): array
+    {
+        if (!$meta instanceof PersistentMapInterface) {
+            return [];
+        }
+
+        $doc = $meta->find(Keyword::create('doc', 'php'));
+        if (is_string($doc) && $doc !== '') {
+            return ['/** ' . $doc . ' */'];
+        }
+
+        $lines = $this->docBlockBody($doc);
+        if ($lines === []) {
+            return [];
+        }
+
+        return ['/**', ...$lines, ' */'];
+    }
+
+    /**
+     * Maps the string members of a composite `:php/doc` value to ` * <line>`.
+     *
+     * @return list<string>
+     */
+    private function docBlockBody(mixed $doc): array
+    {
+        if (!$doc instanceof PersistentListInterface && !$doc instanceof PersistentVectorInterface) {
+            return [];
+        }
+
+        $lines = [];
+        foreach ($doc as $line) {
+            if (is_string($line) && $line !== '') {
+                $lines[] = ' * ' . $line;
+            }
+        }
+
+        return $lines;
+    }
 }

--- a/tests/phel/core/phpdoc-emission.phel
+++ b/tests/phel/core/phpdoc-emission.phel
@@ -1,0 +1,14 @@
+(ns phel-test.core.phpdoc-emission
+  (:require phel.test :refer [deftest is]))
+
+(defstruct ^{:php/doc "@implements \\IteratorAggregate<int, string>"} bag
+  [^{:php/doc "@var list<int>"} items])
+
+(deftest class-and-property-docblocks-are-emitted
+  (let [rc       (php/new \ReflectionClass "phel_test\\core\\phpdoc_emission\\bag")
+        class-doc (php/-> rc (getDocComment))
+        prop-doc  (php/-> (php/-> rc (getProperty "items")) (getDocComment))]
+    (is (php/str_contains class-doc "@implements \\IteratorAggregate<int, string>")
+        "class docblock carries the :php/doc string")
+    (is (php/str_contains prop-doc "@var list<int>")
+        "property docblock carries the :php/doc string")))

--- a/tests/php/Integration/Fixtures/Def/definterface-phpdoc.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-phpdoc.test
@@ -1,0 +1,13 @@
+--PHEL--
+(definterface* Repo
+  (^{:php/doc ["@param list<int> $ids" "@return array<string>"]} find [this ids]))
+--PHP--
+if (!interface_exists('user\Repo')) {
+interface Repo {
+  /**
+   * @param list<int> $ids
+   * @return array<string>
+   */
+  public function find($ids);
+}
+}

--- a/tests/php/Integration/Fixtures/Def/defstruct-phpdoc.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-phpdoc.test
@@ -1,0 +1,19 @@
+--PHEL--
+(defstruct* ^{:php/doc "@implements \\IteratorAggregate<int, string>"} bag [^{:php/doc "@var list<int>"} items])
+--PHP--
+if (!class_exists('user\bag')) {
+/** @implements \IteratorAggregate<int, string> */
+final class bag extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
+
+  protected const array ALLOWED_KEYS = ['items'];
+
+  /** @var list<int> */
+  protected $items;
+
+  public function __construct($items, $meta = null) {
+    parent::__construct();
+    $this->items = $items;
+    $this->meta = $meta;
+  }
+}
+}


### PR DESCRIPTION
## 🤔 Background

In a mixed PHP + Phel codebase, phpstan/psalm see Phel-generated classes (structs, interfaces) as largely untyped. Native `:tag` types help, but generics and array shapes can only travel through PHPDoc.

## 💡 Goal

Let any generated construct carry a PHPDoc block from metadata, so static analyzers treat Phel-generated code as first-class.

Closes #2295

## 🔖 Changes

- New `phpDocLines()` in the shared `PhpAttributeEmitterTrait`: reads `:php/doc` and renders it as a one-line block (string) or a multi-line block (list/vector of strings).
- `DefStructEmitter` emits it above the class and above each property; `DefInterfaceEmitter` above the interface and above each method. The docblock is emitted above any `#[...]` attributes.

```phel
(defstruct ^{:php/doc "@implements \\IteratorAggregate<int, string>"} bag
  [^{:php/doc "@var list<int>"} items])

(definterface Repo
  (^{:php/doc ["@param list<int> $ids" "@return array<string>"]} find [this ids]))
```
emits:
```php
/** @implements \IteratorAggregate<int, string> */
final class bag extends ... {
  /** @var list<int> */
  protected $items;
  ...
}
```

### Tests
- Integration fixtures: `defstruct-phpdoc` (one-line class + field), `definterface-phpdoc` (multi-line method block).
- Phel-level `tests/phel/core/phpdoc-emission.phel`: reflects `getDocComment()` on the class and property.

CHANGELOG `## Unreleased` and the Compiler module `CLAUDE.md` updated.

### Refactor pass
`emitDocBlock` mirrors the pre-existing `emitAttributes` helper in both emitters (same shape, same duplication already present for attributes). Kept consistent with that pattern rather than introducing trait/property coupling; no separate `ref(...)` commit.