### PR TITLE
feat(core): hydrate and bean map<->object helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - `:tag` type hints (on `defstruct` fields and `definterface` params/returns) now accept composite types: a list is a union (`^{:tag (int string)}` => `int|string`) and a vector is an intersection (`^{:tag [Countable Stringable]}` => `Countable&Stringable`); nullable/`self`/`static`/FQN tags continue to pass through verbatim (#2293)
 - `definterface`: `^{:php/attr [...]}` on a method parameter now emits an inline PHP parameter attribute (`public function show(#[\Autowire] string $repo)`), complementing the existing method- and interface-level attributes (#2294)
 - `^{:php/doc ...}` emits a PHPDoc block on generated `defstruct` classes/fields and `definterface` interfaces/methods, so phpstan/psalm see Phel-generated code as typed; the value is a one-line string (`"@var list<int>"`) or a list/vector of strings for a multi-line block (#2295)
+- `hydrate`/`bean` bridge Phel maps and PHP objects: `hydrate` builds an instance of a class (bypassing its constructor, ORM/serializer style) and sets the declared properties from a map; `bean` reads a PHP object's public properties back into a keyword-keyed map (#2296)
 
 ### Changed
 

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -269,6 +269,17 @@ $rows = $conn->executeQuery($sql, $params)->fetchAllAssociative();
 
 phel-pdo can also wrap an existing PDO handle so its map-returning helpers run on the host's pooled connection.
 
+### When you really need the object
+
+Some host APIs demand a concrete instance (a typed DTO, a value object a library type-hints). Bridge at the boundary instead of modeling your domain as objects: `hydrate` builds an instance from a map without running its constructor (the ORM/serializer pattern), and `bean` reads a public-property object back into a keyword-keyed map.
+
+```phel
+(def dto (hydrate "App\\Dto\\Product" {:id 1 :name "Keyboard" :price 49.9}))
+(bean dto)  ; => {:id 1 :name "Keyboard" :price 49.9}
+```
+
+Keep maps as the working representation; reach for `hydrate`/`bean` only at the edge where a typed object is unavoidable.
+
 ### Controllers, transactions, migrations
 
 - **Routes/commands:** an exported `defn` can carry `^{:php/attr [:Symfony.Component.Routing.Attribute/Route "/products/{id}"]}`, so `phel export` emits the `#[Route]` on the generated wrapper — no hand-written controller shim.

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -835,6 +835,31 @@
 
     true                   x))
 
+(defn bean
+  "Returns a Phel map of the public properties of PHP object `obj`, with
+  keyword keys. Inverse of `hydrate` for public-property objects."
+  {:example "(bean (hydrate \"My\\\\Dto\" {:id 1})) ; => {:id 1}"
+   :see-also ["hydrate" "php-array-to-map" "php->phel"]}
+  [obj]
+  (let [res (transient {})]
+    (foreach [k v (php/get_object_vars obj)]
+      (assoc res (keyword k) v))
+    (persistent res)))
+
+(defn hydrate
+  "Creates an instance of PHP class `class-name` (a class-string) without
+  invoking its constructor, then sets each declared property named by the
+  keyword keys of map `m`. Mirrors how ORMs/serializers rebuild entities from
+  raw data; pairs with `bean` for the reverse direction."
+  {:example "(hydrate \"My\\\\Dto\" {:id 1 :name \"x\"})"
+   :see-also ["bean"]}
+  [class-name m]
+  (let [rc  (php/new \ReflectionClass class-name)
+        obj (php/-> rc (newInstanceWithoutConstructor))]
+    (foreach [k v m]
+      (php/-> (php/-> rc (getProperty (name k))) (setValue obj v)))
+    obj))
+
 (defn contains-value?
   "Returns true if the value is present in the given collection, otherwise returns false."
   {:example "(contains-value? {:a 1 :b 2} 2) ; => true"

--- a/tests/phel/core/hydration.phel
+++ b/tests/phel/core/hydration.phel
@@ -1,0 +1,19 @@
+(ns phel-test.core.hydration
+  (:require phel.test :refer [deftest is]))
+
+(def target "PhelTest\\Fixtures\\Interop\\HydrationTarget")
+
+(deftest hydrate-sets-public-properties
+  (let [t (hydrate target {:id 7 :name "kb"})]
+    (is (instance? \PhelTest\Fixtures\Interop\HydrationTarget t)
+        "hydrate returns an instance of the target class")
+    (is (= 7 (php/-> t id)) "id property is set")
+    (is (= "kb" (php/-> t name)) "name property is set")))
+
+(deftest bean-reads-public-properties
+  (is (= {:id 7 :name "kb"} (bean (hydrate target {:id 7 :name "kb"})))
+      "bean is the inverse of hydrate for public properties"))
+
+(deftest hydrate-bypasses-the-constructor
+  (is (= {:id 0 :name ""} (bean (hydrate target {})))
+      "an empty map yields the class' property defaults, constructor not called"))

--- a/tests/php/Fixtures/Interop/HydrationTarget.php
+++ b/tests/php/Fixtures/Interop/HydrationTarget.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Fixtures\Interop;
+
+use LogicException;
+
+/**
+ * Plain public-property DTO used by the Phel-level `hydrate`/`bean` tests.
+ *
+ * The constructor throws so the tests prove `hydrate` rebuilds the object
+ * without invoking it (the ORM/serializer pattern).
+ */
+final class HydrationTarget
+{
+    public int $id = 0;
+
+    public string $name = '';
+
+    public function __construct()
+    {
+        throw new LogicException('constructor must not run during hydration');
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Bridging Phel maps and PHP DTOs/entities meant manual field plucking on both sides. Phel already ships `phel->php`/`php->phel`/`php-array-to-map` for array bridging and an `instance?` macro, but nothing for the object direction.

## 💡 Goal

Add two small, FP-friendly helpers that smooth the boundary without any compiler change.

Closes #2296

## 🔖 Changes

In `phel.core` (next to the existing PHP/Phel bridges):

- `(hydrate class-name m)` — instantiates `class-name` (a class-string) via `newInstanceWithoutConstructor` and sets each declared property named by the map's keyword keys. This is the ORM/serializer hydration pattern: rebuild an object from raw data without running its constructor.
- `(bean obj)` — reads a PHP object's public properties into a keyword-keyed Phel map; the inverse of `hydrate` for public-property objects.

```phel
(def dto (hydrate "App\\Dto\\Product" {:id 1 :name "Keyboard"}))
(bean dto)  ; => {:id 1 :name "Keyboard"}
```

### Tests
- Phel-level `tests/phel/core/hydration.phel`: hydrate sets props + returns the right instance, `bean` round-trips, and (via a fixture whose constructor throws) hydrate provably bypasses the constructor.
- `tests/php/Fixtures/Interop/HydrationTarget.php`: public-property DTO whose constructor throws, proving the bypass.

CHANGELOG `## Unreleased` updated; `docs/framework-integration.md` gains a "When you really need the object" subsection tying this to the maps-not-entities guidance.

### Refactor pass
Both helpers are single-purpose and reuse existing core fns (`keyword`, `name`, transients); review surfaced no duplication, so there is no separate `ref(...)` commit.