### PR TITLE
feat(compiler): defexception custom parent and php attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - `definterface`: `^{:php/attr [...]}` on a method parameter now emits an inline PHP parameter attribute (`public function show(#[\Autowire] string $repo)`), complementing the existing method- and interface-level attributes (#2294)
 - `^{:php/doc ...}` emits a PHPDoc block on generated `defstruct` classes/fields and `definterface` interfaces/methods, so phpstan/psalm see Phel-generated code as typed; the value is a one-line string (`"@var list<int>"`) or a list/vector of strings for a multi-line block (#2295)
 - `hydrate`/`bean` bridge Phel maps and PHP objects: `hydrate` builds an instance of a class (bypassing its constructor, ORM/serializer style) and sets the declared properties from a map; `bean` reads a PHP object's public properties back into a keyword-keyed map (#2296)
+- `defexception`: takes an optional parent class to extend (`(defexception ProductNotFound \RuntimeException)`, defaults to `\Exception`) so frameworks can catch it by type, and `^{:php/attr [...]}` on the name emits class-level PHP attributes (#2297)
 
 ### Changed
 

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -128,14 +128,16 @@
        (defn ~is-name ~(php/. "Checks if `x` is an instance of the " name " struct.") [x] (php/is_a x ~class-name-str)))))
 
 (defmacro defexception
-  "Define a new exception."
-  [name]
+  "Define a new exception. Optionally pass a parent class to extend (defaults to
+  `\\Exception`), so frameworks can catch it by type, e.g.
+  `(defexception ProductNotFound \\RuntimeException)`."
+  [name & [parent]]
   (let [name-str       (php/-> name (getName))
         munge          (php/new Munge)
         class-name-str (php/. (php/-> munge (encodePhpNs *ns*)) "\\" (php/-> munge (encode name-str)))
         is-name        (php/:: Symbol (create (php/. name-str "?")))]
     `(do
-       (defexception* ~name)
+       (defexception* ~name ~@(if parent [parent] []))
        (defn ~name ~(php/. "Creates a new " name " exception.") [& args]
          (php/-> (php/new \ReflectionClass ~class-name-str)
                  (newInstanceArgs (to-php-array args))))

--- a/src/php/Api/Infrastructure/NativeSymbolCatalog.php
+++ b/src/php/Api/Infrastructure/NativeSymbolCatalog.php
@@ -111,12 +111,13 @@ Evaluates the expressions in order and returns the value of the last expression.
         Symbol::NAME_DEF_EXCEPTION => [
             'doc' => '```phel
 (defexception my-ex)
+(defexception my-ex \RuntimeException)
 ```
-Define a new exception.',
+Define a new exception, optionally extending a custom parent class (defaults to \Exception).',
             'docUrl' => '/documentation/exceptions',
-            'signatures' => ['(defexception name)'],
-            'desc' => 'Defines a new exception.',
-            'example' => '(defexception my-error)',
+            'signatures' => ['(defexception name)', '(defexception name parent)'],
+            'desc' => 'Defines a new exception, optionally extending a custom parent class.',
+            'example' => '(defexception my-error \RuntimeException)',
         ],
         Symbol::NAME_DEF_INTERFACE => [
             'doc' => '```phel

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefExceptionSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefExceptionSymbol.php
@@ -28,8 +28,8 @@ final class DefExceptionSymbol implements SpecialFormAnalyzerInterface
      */
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): DefExceptionNode
     {
-        if (count($list) !== 2) {
-            throw AnalyzerException::withLocation("Exact one argument is required for 'defexception", $list);
+        if (count($list) < 2 || count($list) > 3) {
+            throw AnalyzerException::withLocation("One or two arguments are required for 'defexception", $list);
         }
 
         $name = $list->get(1);
@@ -37,9 +37,17 @@ final class DefExceptionSymbol implements SpecialFormAnalyzerInterface
             throw AnalyzerException::wrongArgumentType("First argument of 'defexception", 'Symbol', $name, $list);
         }
 
+        $parentSymbol = Symbol::create('\\Exception');
+        if (count($list) === 3) {
+            $parentSymbol = $list->get(2);
+            if (!$parentSymbol instanceof Symbol) {
+                throw AnalyzerException::wrongArgumentType("Second argument of 'defexception", 'Symbol', $parentSymbol, $list);
+            }
+        }
+
         $parent = new PhpClassNameNode(
             $env,
-            Symbol::create('\\Exception'),
+            $parentSymbol,
             $list->getStartLocation(),
         );
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefExceptionEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefExceptionEmitter.php
@@ -8,14 +8,19 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DefExceptionNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
+use Phel\Shared\PhpAttributeRenderer;
 
 use function assert;
 
 final readonly class DefExceptionEmitter implements NodeEmitterInterface
 {
     use EvalGuardedEmitterTrait;
+    use PhpAttributeEmitterTrait;
 
-    public function __construct(private OutputEmitterInterface $outputEmitter) {}
+    public function __construct(
+        private OutputEmitterInterface $outputEmitter,
+        private PhpAttributeRenderer $attributeRenderer = new PhpAttributeRenderer(),
+    ) {}
 
     public function emit(AbstractNode $node): void
     {
@@ -71,6 +76,10 @@ final readonly class DefExceptionEmitter implements NodeEmitterInterface
 
     private function emitClassBody(DefExceptionNode $node): void
     {
+        foreach ($this->phpAttributeLines($this->attributeRenderer, $node->getName()->getMeta()) as $attribute) {
+            $this->outputEmitter->emitLine($attribute, $node->getStartSourceLocation());
+        }
+
         $this->outputEmitter->emitStr(
             'class ' . $this->outputEmitter->mungeEncode($node->getName()->getName()) . ' extends ',
             $node->getStartSourceLocation(),

--- a/tests/phel/core/defexception-parent.phel
+++ b/tests/phel/core/defexception-parent.phel
@@ -1,0 +1,17 @@
+(ns phel-test.core.defexception-parent
+  (:require phel.test :refer [deftest is]))
+
+(defexception NotFound \RuntimeException)
+(defexception Plain)
+
+(deftest custom-parent-is-catchable-by-parent-type
+  (is (= "boom"
+         (try
+           (throw (NotFound "boom"))
+           (catch \RuntimeException e (php/-> e (getMessage)))))
+      "an exception with :extends parent is caught as that parent")
+  (is (instance? \RuntimeException (NotFound "x")) "instance of the custom parent")
+  (is (NotFound? (NotFound "x")) "its own predicate still works"))
+
+(deftest default-parent-is-exception
+  (is (instance? \Exception (Plain "y")) "without a parent it still extends \\Exception"))

--- a/tests/php/Integration/Fixtures/Def/defexception-custom-parent.test
+++ b/tests/php/Integration/Fixtures/Def/defexception-custom-parent.test
@@ -1,0 +1,10 @@
+--PHEL--
+(defexception* MyError \RuntimeException)
+--PHP--
+if (!class_exists('user\MyError')) {
+class MyError extends \RuntimeException {
+  public function __construct($message = "", $code = 0, ?\Throwable $previous = null) {
+    parent::__construct($message, $code, $previous);
+  }
+}
+}

--- a/tests/php/Integration/Fixtures/Def/defexception-php-attributes.test
+++ b/tests/php/Integration/Fixtures/Def/defexception-php-attributes.test
@@ -1,0 +1,11 @@
+--PHEL--
+(defexception* ^{:php/attr :My/Tag} TaggedError)
+--PHP--
+if (!class_exists('user\TaggedError')) {
+#[\My\Tag]
+class TaggedError extends \Exception {
+  public function __construct($message = "", $code = 0, ?\Throwable $previous = null) {
+    parent::__construct($message, $code, $previous);
+  }
+}
+}

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefExceptionSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefExceptionSymbolTest.php
@@ -28,16 +28,39 @@ final class DefExceptionSymbolTest extends TestCase
     public function test_with_wrong_number_of_arguments(): void
     {
         $this->expectException(AbstractLocatedException::class);
-        $this->expectExceptionMessage("Exact one argument is required for 'defexception");
+        $this->expectExceptionMessage("One or two arguments are required for 'defexception");
 
         $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF_EXCEPTION),
             Symbol::create('A'),
             Symbol::create('B'),
+            Symbol::create('C'),
         ]);
 
         new DefExceptionSymbol($this->analyzer)
             ->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_custom_parent_class(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_DEF_EXCEPTION),
+            Symbol::create('MyExc'),
+            Symbol::create('\\RuntimeException'),
+        ]);
+
+        $defExceptionNode = new DefExceptionSymbol($this->analyzer)
+            ->analyze($list, NodeEnvironment::empty());
+
+        self::assertEquals(
+            new DefExceptionNode(
+                NodeEnvironment::empty(),
+                'user',
+                Symbol::create('MyExc'),
+                new PhpClassNameNode(NodeEnvironment::empty(), Symbol::create('\\RuntimeException')),
+            ),
+            $defExceptionNode,
+        );
     }
 
     public function test_first_arg_is_not_symbol(): void


### PR DESCRIPTION
## 🤔 Background

`defexception` always emitted `class X extends \Exception {}` with no way to choose the parent or attach attributes. Frameworks catch by type, so a domain exception often needs to extend `\RuntimeException`/`\DomainException` (or a project base) to slot into an existing catch hierarchy.

## 💡 Goal

Let `defexception` pick its parent and carry PHP attributes, staying fully backward-compatible.

Closes #2297

## 🔖 Changes

- `(defexception Name)` unchanged (extends `\Exception`).
- `(defexception Name \RuntimeException)` — optional parent class; `DefExceptionSymbol` reads the second argument, the macro splices it into `defexception*`.
- `^{:php/attr [...]}` on the exception name emits class-level PHP attributes (`DefExceptionEmitter` now uses the shared `PhpAttributeRenderer`).

```phel
(defexception ProductNotFound \RuntimeException)
(try (throw (ProductNotFound "missing"))
     (catch \RuntimeException e (php/-> e (getMessage))))  ; caught by parent type
```

### Tests
- Unit `DefExceptionSymbolTest`: updated arg-count rule + message, new custom-parent node assertion.
- Integration fixtures: `defexception-custom-parent`, `defexception-php-attributes` (existing `defexception` fixture still passes).
- Phel-level `tests/phel/core/defexception-parent.phel`: throws a custom-parent exception and catches it as the parent type; default still extends `\Exception`.

CHANGELOG `## Unreleased` and the `defexception` entry in `NativeSymbolCatalog` (signatures/example) updated.

### Scope note
Typed constructor **fields** (from the original issue) are deferred: the generated exception constructor has a fixed `($message, $code, $previous)` shape, so adding field props is a separate constructor redesign. This PR delivers the parent + attribute parts, which cover the "catch by type" use case.

### Refactor pass
The attribute emission reuses the shared renderer/trait already used by the struct/interface emitters; no new duplication, so there is no separate `ref(...)` commit.