### PR TITLE
fix(core): phel->php handles non-named map keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Lexer: error/source-map columns are now counted in code points, not bytes, so locations are correct for multibyte (UTF-8) source
 - Printer: structs print with the `.` separator (`(my.ns.point 1 2)`) instead of `\` (#2255)
 - Docs: function `:example` outputs now match what the REPL prints, so `phel doc` and the phel-lang.org API reference are accurate
+- `phel->php`: maps with non-named keys (integers, strings) now convert correctly instead of throwing `getName() on int`; this unblocks int-keyed PHP arrays such as PDO option maps (`{\PDO/ATTR_TIMEOUT 5}`) (#2298)
 
 ### Added
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -781,6 +781,16 @@
     (persistent res)))
 
 
+(defn- phel->php-key
+  "Converts a Phel map key into a valid PHP array key: named keys
+  (keyword/symbol) use their name, scalar `int`/`string` keys pass through
+  unchanged, and anything else is stringified."
+  [k]
+  (cond
+    (or (keyword? k) (symbol? k)) (name k)
+    (or (int? k) (string? k))     k
+    true                          (str k)))
+
 (defn phel->php
   "Recursively converts a Phel data structure to a PHP array."
   {:example "(phel->php {:a [1 2 3] :b {:c 4}}) ; => <PHP-Array [\"a\":<PHP-Array [1, 2, 3]>, \"b\":<PHP-Array [\"c\":4]>]>"
@@ -802,7 +812,7 @@
     (associative? x)
     (let [arr (php/array)]
       (foreach [k v x]
-        (php/aset arr (name k) (phel->php v)))
+        (php/aset arr (phel->php-key k) (phel->php v)))
       arr)
 
     (set? x)

--- a/tests/phel/core/sequence-functions.phel
+++ b/tests/phel/core/sequence-functions.phel
@@ -588,6 +588,17 @@
     (php/aset m "a" (php/array 1 inner))
     (is (= m (phel->php (php->phel m))) "php->phel -> phel->php roundtrip")))
 
+;; Issue #2298: phel->php must accept non-named map keys (int/string), not only keywords
+(deftest test-phel-php-integer-keys
+  (let [arr (phel->php {1 "a"})]
+    (is (= "a" (php/aget arr 1)) "integer map key passes through unchanged"))
+  (let [arr (phel->php {"k" 1})]
+    (is (= 1 (php/aget arr "k")) "string map key passes through unchanged"))
+  (let [arr (phel->php {:k 1})]
+    (is (= 1 (php/aget arr "k")) "keyword map key uses its name"))
+  (let [arr (phel->php {2 [3 4]})]
+    (is (= 3 (php/aget (php/aget arr 2) 0)) "integer-keyed value is converted recursively")))
+
 ;; =============================================================================
 ;; String Seqability Tests
 ;; Strings are fully seqable in Phel - all sequence functions work directly


### PR DESCRIPTION
## 🤔 Background

`phel->php` converted map keys with an unconditional `(name k)`, which calls `getName()` on the key. Integer (and other non-named) keys raised a fatal `Call to a member function getName() on int`, so any int-keyed map could not be bridged to PHP.

## 💡 Goal

Convert any valid PHP array key (int or string), not only keywords/symbols.

Closes #2298

## 🔖 Changes

- New private `phel->php-key`: named keys (keyword/symbol) use their name, scalar `int`/`string` keys pass through unchanged, anything else is stringified.
- The `associative?` branch of `phel->php` now routes keys through it.

```phel
(phel->php {1 "a"})   ; => [1 => "a"]   (previously threw)
(phel->php {"a" 1})   ; => ["a" => 1]
(phel->php {:k 1})    ; => ["k" => 1]
```

This unblocks int-keyed PHP arrays such as PDO option maps (`{\PDO/ATTR_TIMEOUT 5 \PDO/ATTR_PERSISTENT true}`), removing the `php-associative-array` shim phel-pdo needed.

### Tests
- `tests/phel/core/sequence-functions.phel`: `test-phel-php-integer-keys` covers int, string, keyword, and recursive int-keyed values.

CHANGELOG `## Unreleased` → Fixed updated.