### PR TITLE
feat(compiler): php/ref for by-reference PHP interop arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - `^{:php/doc ...}` emits a PHPDoc block on generated `defstruct` classes/fields and `definterface` interfaces/methods, so phpstan/psalm see Phel-generated code as typed; the value is a one-line string (`"@var list<int>"`) or a list/vector of strings for a multi-line block (#2295)
 - `hydrate`/`bean` bridge Phel maps and PHP objects: `hydrate` builds an instance of a class (bypassing its constructor, ORM/serializer style) and sets the declared properties from a map; `bean` reads a PHP object's public properties back into a keyword-keyed map (#2296)
 - `defexception`: takes an optional parent class to extend (`(defexception ProductNotFound \RuntimeException)`, defaults to `\Exception`) so frameworks can catch it by type, and `^{:php/attr [...]}` on the name emits class-level PHP attributes (#2297)
+- `php/ref`: marks a local as passed by reference in a `php/->`/`php/::` interop call (`(php/-> stmt (bindColumn 1 (php/ref out) ...))`), so the wrapping closure captures it with `use(&$out)` and an output-parameter PHP method writes back into the Phel binding (#2299)
 
 ### Changed
 

--- a/docs/internals/special-forms.md
+++ b/docs/internals/special-forms.md
@@ -66,6 +66,7 @@ Trailing `*` means not user-facing. Macros `defstruct`, `definterface`, `defexce
 | `php/new` (`new`) | `NAME_PHP_NEW` / `NAME_NEW` | `new Foo(...)` |
 | `php/->` | `NAME_PHP_OBJECT_CALL` | `$obj->method(...)` / `$obj->prop` |
 | `php/::` | `NAME_PHP_OBJECT_STATIC_CALL` | `Foo::method(...)` / `Foo::CONST` |
+| `php/ref` | `NAME_PHP_REF` | by-ref interop arg: captures the local `use(&$x)` so an output parameter writes back |
 | `php/oset` | `NAME_PHP_OBJECT_SET` | `$obj->prop = $v` |
 | `php/aget` | `NAME_PHP_ARRAY_GET` | `$arr[$k]` |
 | `php/aset` | `NAME_PHP_ARRAY_SET` | `$arr[$k] = $v` |

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -268,7 +268,7 @@
   (hash-set 'def 'ns 'in-ns 'load 'fn 'quote 'var 'do 'if 'apply
             'let 'recur 'try 'throw 'loop 'foreach 'set-var
             'defstruct* 'definterface* 'defexception* 'defenum* 'reify*
-            'php/new 'php/-> 'php/:: 'php/aget 'php/aget-in
+            'php/new 'php/-> 'php/:: 'php/ref 'php/aget 'php/aget-in
             'php/aset 'php/aset-in 'php/apush 'php/apush-in
             'php/aunset 'php/aunset-in 'php/oset
             '& 'catch 'finally))

--- a/src/php/Api/Infrastructure/NativeSymbolCatalog.php
+++ b/src/php/Api/Infrastructure/NativeSymbolCatalog.php
@@ -357,6 +357,16 @@ Calls a static method or property from a PHP class. Both method-name and propert
             'desc' => 'Calls a static method or property from a PHP class. Both method-name and property must be symbols and cannot be an evaluated value.',
             'example' => '(php/:: DateTime (createFromFormat "Y-m-d" "2024-01-01"))',
         ],
+        Symbol::NAME_PHP_REF => [
+            'doc' => '```phel
+(php/-> object (method (php/ref local)))
+```
+Marks a local variable as passed by reference in a `php/->`/`php/::` interop call, so an output-parameter PHP method can write back into the Phel binding.',
+            'docUrl' => '/documentation/php-interop/',
+            'signatures' => ['(php/ref local)'],
+            'desc' => 'Passes a local variable by reference into a PHP interop call.',
+            'example' => '(php/-> stmt (bindColumn 1 (php/ref out)))',
+        ],
         Symbol::NAME_QUOTE => [
             'doc' => '```phel
 (quote form)

--- a/src/php/Compiler/Domain/Analyzer/Ast/PhpRefNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/PhpRefNode.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Ast;
+
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+
+/**
+ * (php/ref local) — marks a local variable as passed by reference in a PHP
+ * interop call, so the wrapping closure captures it with `use(&$local)` and a
+ * by-ref PHP parameter can write back into the Phel binding.
+ */
+final class PhpRefNode extends AbstractNode
+{
+    public function __construct(
+        NodeEnvironmentInterface $env,
+        private readonly LocalVarNode $local,
+        ?SourceLocation $sourceLocation = null,
+    ) {
+        parent::__construct($env, $sourceLocation);
+    }
+
+    public function getLocal(): LocalVarNode
+    {
+        return $this->local;
+    }
+
+    public function getName(): Symbol
+    {
+        return $this->local->getName();
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -41,6 +41,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpAUnsetSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpNewSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpObjectCallSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpOSetSymbol;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpRefSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\QuoteSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\RecurSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ReifySymbol;
@@ -325,6 +326,7 @@ final class AnalyzePersistentList
             Symbol::NAME_PHP_NEW, Symbol::NAME_NEW => new PhpNewSymbol($this->analyzer),
             Symbol::NAME_PHP_OBJECT_CALL => new PhpObjectCallSymbol($this->analyzer, isStatic: false),
             Symbol::NAME_PHP_OBJECT_STATIC_CALL => new PhpObjectCallSymbol($this->analyzer, isStatic: true),
+            Symbol::NAME_PHP_REF => new PhpRefSymbol($this->analyzer),
             Symbol::NAME_PHP_ARRAY_GET => new PhpAGetSymbol($this->analyzer),
             Symbol::NAME_PHP_ARRAY_GET_IN => new PhpAGetInSymbol($this->analyzer),
             Symbol::NAME_PHP_ARRAY_SET => new PhpASetSymbol($this->analyzer),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpRefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpRefSymbol.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpRefNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Symbol;
+
+use function count;
+
+/**
+ * (php/ref local).
+ *
+ * Marks a local variable as passed by reference inside a PHP interop call.
+ * Only valid in argument position of `php/->`/`php/::`; the inner form must be
+ * a local binding so the emitted closure can capture it with `use(&$local)`.
+ */
+final class PhpRefSymbol implements SpecialFormAnalyzerInterface
+{
+    use WithAnalyzerTrait;
+
+    /**
+     * @param PersistentListInterface<mixed> $list
+     */
+    public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): PhpRefNode
+    {
+        if (count($list) !== 2) {
+            throw AnalyzerException::withLocation("Exactly one argument is required for 'php/ref", $list);
+        }
+
+        $symbol = $list->get(1);
+        if (!$symbol instanceof Symbol) {
+            throw AnalyzerException::wrongArgumentType("First argument of 'php/ref", 'Symbol', $symbol, $list);
+        }
+
+        $resolved = $this->analyzer->analyze($symbol, $env->withExpressionContext());
+        if (!$resolved instanceof LocalVarNode) {
+            throw AnalyzerException::withLocation("'php/ref expects a local variable", $list);
+        }
+
+        return new PhpRefNode($env, $resolved, $list->getStartLocation());
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter.php
@@ -21,6 +21,7 @@ use function array_pop;
 use function array_values;
 use function count;
 use function end;
+use function in_array;
 use function is_null;
 use function strlen;
 
@@ -208,10 +209,13 @@ final class OutputEmitter implements OutputEmitterInterface
         }
     }
 
-    public function emitFnWrapPrefix(NodeEnvironmentInterface $env, ?SourceLocation $sl = null): void
+    /**
+     * @param list<string> $byRefLocalNames local names to capture by reference
+     */
+    public function emitFnWrapPrefix(NodeEnvironmentInterface $env, ?SourceLocation $sl = null, array $byRefLocalNames = []): void
     {
         $this->emitStr('(function()', $sl);
-        $this->emitUseClauseForWrap($env, $sl);
+        $this->emitUseClauseForWrap($env, $sl, $byRefLocalNames);
         $this->emitLine(' {', $sl);
         $this->increaseIndentLevel();
     }
@@ -283,7 +287,10 @@ final class OutputEmitter implements OutputEmitterInterface
         return $this->classScopeDepth > 0;
     }
 
-    private function emitUseClauseForWrap(NodeEnvironmentInterface $env, ?SourceLocation $sl): void
+    /**
+     * @param list<string> $byRefLocalNames local names to capture by reference
+     */
+    private function emitUseClauseForWrap(NodeEnvironmentInterface $env, ?SourceLocation $sl, array $byRefLocalNames = []): void
     {
         $locals = array_values($env->getLocals());
         $scope = $this->currentConstantScope();
@@ -300,7 +307,9 @@ final class OutputEmitter implements OutputEmitterInterface
         foreach ($locals as $local) {
             $first = $this->emitUseSeparator($first, $sl);
             $shadowed = $env->getShadowed($local);
-            $this->emitPhpVariable($shadowed instanceof Symbol ? $shadowed : $local, $sl);
+            $emitSymbol = $shadowed instanceof Symbol ? $shadowed : $local;
+            $byReference = in_array($emitSymbol->getName(), $byRefLocalNames, true);
+            $this->emitPhpVariable($emitSymbol, $sl, $byReference);
         }
 
         for ($i = 0; $i < $constantSlots; ++$i) {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectCallEmitter.php
@@ -8,6 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MethodCallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpRefNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PropertyOrConstantAccessNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Symbol;
@@ -40,7 +41,11 @@ final class PhpObjectCallEmitter implements NodeEmitterInterface
             $this->outputEmitter->emitStr($targetExpr->getAbsolutePhpName(), $targetExpr->getName()->getStartLocation());
             $this->outputEmitter->emitStr($fnCode, $node->getStartSourceLocation());
         } else {
-            $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
+            $this->outputEmitter->emitFnWrapPrefix(
+                $node->getEnv(),
+                $node->getStartSourceLocation(),
+                $this->byRefLocalNames($node),
+            );
 
             $targetSym = Symbol::gen('target_');
             $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
@@ -68,6 +73,30 @@ final class PhpObjectCallEmitter implements NodeEmitterInterface
         } else {
             throw new RuntimeException('Not supported ' . $callExpr::class);
         }
+    }
+
+    /**
+     * Local names marked `(php/ref x)` in this call's arguments; the wrapping
+     * closure must capture them by reference so a by-ref PHP parameter writes
+     * back into the Phel binding.
+     *
+     * @return list<string>
+     */
+    private function byRefLocalNames(PhpObjectCallNode $node): array
+    {
+        $callExpr = $node->getCallExpr();
+        if (!$callExpr instanceof MethodCallNode) {
+            return [];
+        }
+
+        $names = [];
+        foreach ($callExpr->getArgs() as $arg) {
+            if ($arg instanceof PhpRefNode) {
+                $names[] = $arg->getName()->getName();
+            }
+        }
+
+        return $names;
     }
 
     private function emitPhpObjectCallEnd(PhpObjectCallNode $node): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpRefEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpRefEmitter.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpRefNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+
+use function assert;
+
+/**
+ * Emits a `(php/ref local)` argument as the plain `$local` variable. PHP forbids
+ * call-time pass-by-reference (`f(&$x)`), so by-ref is realised by capturing
+ * the local with `use(&$local)` in the wrapping closure (see
+ * `PhpObjectCallEmitter` and `OutputEmitter::emitFnWrapPrefix`).
+ */
+final class PhpRefEmitter implements NodeEmitterInterface
+{
+    use WithOutputEmitterTrait;
+
+    public function emit(AbstractNode $node): void
+    {
+        assert($node instanceof PhpRefNode);
+
+        $this->outputEmitter->emitPhpVariable($node->getName(), $node->getStartSourceLocation());
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -33,6 +33,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpNewNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectSetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpRefNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
 use Phel\Compiler\Domain\Analyzer\Ast\RecurNode;
@@ -76,6 +77,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpClassNameEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpNewEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpObjectCallEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpObjectSetEmitter;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpRefEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpVarEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\QuoteEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\RecurEmitter;
@@ -139,6 +141,7 @@ final class NodeEmitterFactory
             PhpNewNode::class => new PhpNewEmitter($outputEmitter),
             PhpVarNode::class => new PhpVarEmitter($outputEmitter),
             PhpObjectCallNode::class => new PhpObjectCallEmitter($outputEmitter),
+            PhpRefNode::class => new PhpRefEmitter($outputEmitter),
             RecurNode::class => new RecurEmitter($outputEmitter),
             ThrowNode::class => new ThrowEmitter($outputEmitter),
             TryNode::class => new TryEmitter($outputEmitter),

--- a/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
@@ -57,7 +57,10 @@ interface OutputEmitterInterface
 
     public function emitContextSuffix(NodeEnvironmentInterface $env, ?SourceLocation $sl = null): void;
 
-    public function emitFnWrapPrefix(NodeEnvironmentInterface $env, ?SourceLocation $sl = null): void;
+    /**
+     * @param list<string> $byRefLocalNames local names to capture by reference
+     */
+    public function emitFnWrapPrefix(NodeEnvironmentInterface $env, ?SourceLocation $sl = null, array $byRefLocalNames = []): void;
 
     public function emitPhpVariable(
         Symbol $symbol,

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -63,6 +63,8 @@ final class Symbol extends AbstractType implements IdenticalInterface, FnInterfa
 
     public const string NAME_PHP_OBJECT_CALL = 'php/->';
 
+    public const string NAME_PHP_REF = 'php/ref';
+
     public const string NAME_PHP_OBJECT_STATIC_CALL = 'php/::';
 
     public const string NAME_QUOTE = 'quote';

--- a/tests/phel/core/interop-by-ref.phel
+++ b/tests/phel/core/interop-by-ref.phel
@@ -1,0 +1,16 @@
+(ns phel-test.core.interop-by-ref
+  (:require phel.test :refer [deftest is]))
+
+(def target "PhelTest\\Fixtures\\Interop\\ByRefTarget")
+
+(deftest php-ref-observes-by-reference-write
+  (let [t   (php/new target)
+        out "init"]
+    (php/-> t (writeInto (php/ref out) "written"))
+    (is (= "written" out) "a by-ref method writes back into the Phel local")))
+
+(deftest without-php-ref-the-write-is-not-observed
+  (let [t   (php/new target)
+        out "init"]
+    (php/-> t (writeInto out "written"))
+    (is (= "init" out) "a value-captured local is unaffected by the by-ref write")))

--- a/tests/php/Fixtures/Interop/ByRefTarget.php
+++ b/tests/php/Fixtures/Interop/ByRefTarget.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Fixtures\Interop;
+
+/**
+ * Exposes a by-reference parameter so the Phel-level `php/ref` interop tests
+ * can observe a write made through an output parameter.
+ */
+final class ByRefTarget
+{
+    public function writeInto(mixed &$out, mixed $value): void
+    {
+        $out = $value;
+    }
+}

--- a/tests/php/Integration/Fixtures/Call/php-method-call-by-ref.test
+++ b/tests/php/Integration/Fixtures/Call/php-method-call-by-ref.test
@@ -1,0 +1,9 @@
+--PHEL--
+(let [x 1 o (php/new \ArrayObject)] (php/-> o (offsetSet 0 (php/ref x))))
+--PHP--
+$x_1 = 1;
+$o_2 = (new \ArrayObject());
+(function() use(&$x_1,$o_2) {
+  $target_3 = $o_2;
+  return $target_3->offsetSet(0, $x_1);
+})();


### PR DESCRIPTION
## 🤔 Background

There was no way to pass an interop argument by reference. Instance-method calls are wrapped in a closure that captures locals **by value** (`use($x)`), so a PHP by-ref parameter writes into a copy and the result is invisible to Phel. This blocks every output-parameter API: `PDOStatement::bindColumn`, `bindParam`, etc. (e.g. phel-pdo's `bind-column` was closed wontfix because of this).

## 💡 Goal

A marker that makes the wrapping closure capture a chosen local by reference, so a by-ref PHP parameter writes back into the Phel binding.

Closes #2299

## 🔖 Changes

New special form `(php/ref local)`, valid in argument position of a `php/->`/`php/::` call:

- `PhpRefSymbol` resolves the inner symbol to a local binding → `PhpRefNode`; `PhpRefEmitter` emits the plain `$local` (PHP forbids call-time `&$x`).
- `PhpObjectCallEmitter` collects the `php/ref` locals of a call and passes them to `emitFnWrapPrefix`, which now captures them with `use(&$local)`. The new `array $byRefLocalNames = []` parameter defaults to empty, so every other closure-wrap is byte-identical (full compiler suite confirms no drift).

```phel
(let [stmt (php/-> pdo (query "select name from t"))
      out  "INIT"]
  (php/-> stmt (bindColumn 1 (php/ref out) \PDO/PARAM_STR))
  (php/-> stmt (fetch \PDO/FETCH_BOUND))
  out)                                  ; => "phel"   (was "INIT")
```

generated closure: `(function() use(..., &$out_x) { return $target->bindColumn(1, $out_x, ...); })();`

> Note: the issue sketched `(php/& ...)`, but `php/&` is already the bitwise-AND interop operator, so the form is named **`php/ref`**.

### Tests
- Integration fixture `Call/php-method-call-by-ref` (verifies `use(&$x,...)` + plain-variable arg).
- Phel-level `tests/phel/core/interop-by-ref.phel`: a by-ref method writes back through `php/ref`, and a control proves a value-captured local is unaffected.
- `tests/php/Fixtures/Interop/ByRefTarget.php`: a class with a `&$out` parameter.

CHANGELOG, `docs/internals/special-forms.md`, and the `NativeSymbolCatalog` updated.

### Scope note
This covers `php/->`/`php/::` method/static calls (the PDO `bindColumn`/`bindParam` use case). By-ref into plain global-function interop (`preg_match`, `sort`, `settype`) goes through a different emission path and can follow as a separate change.

### Refactor pass
The new nodes/emitter are single-purpose and the closure threading is a minimal additive parameter; review surfaced no duplication, so there is no separate `ref(...)` commit.