### PR TITLE
ref(corelib): optional commas between single-line map pairs

### DIFF
--- a/.agnostic-ai/AGNOSTIC_AI.md
+++ b/.agnostic-ai/AGNOSTIC_AI.md
@@ -31,6 +31,10 @@ auto-format and rely on Rector for mechanical refactors.
 Phel source uses `;` for line comments (not `#`), `;;` for standalone comments, and kebab-case for functions and
 variables. Public functions should have `:doc`, `:see-also`, and `:example` metadata.
 
+Commas are optional whitespace (Clojure-aligned): use them between key/value pairs of a single-line map (`{:a 1, :b 2}`),
+not in multi-line maps, vectors, lists, or calls. Inside a `` ` `` quasiquote `,` is unquote, so never put commas in
+quasiquoted maps. `phel format` preserves commas but never inserts them.
+
 ## Testing Guidelines
 
 PHPUnit tests live alongside fixtures in `tests/php/{Unit,Integration}`, named `*Test.php` with snake_case method names

--- a/.agnostic-ai/rules/coding-style-naming-conventions.md
+++ b/.agnostic-ai/rules/coding-style-naming-conventions.md
@@ -9,3 +9,7 @@ auto-format and rely on Rector for mechanical refactors.
 
 Phel source uses `;` for line comments (not `#`), `;;` for standalone comments, and kebab-case for functions and
 variables. Public functions should have `:doc`, `:see-also`, and `:example` metadata.
+
+Commas are optional whitespace (Clojure-aligned): use them between key/value pairs of a single-line map (`{:a 1, :b 2}`),
+not in multi-line maps, vectors, lists, or calls. Inside a `` ` `` quasiquote `,` is unquote, so never put commas in
+quasiquoted maps. `phel format` preserves commas but never inserts them.

--- a/.agnostic-ai/rules/phel.md
+++ b/.agnostic-ai/rules/phel.md
@@ -37,3 +37,13 @@ Editing a `defmacro` body or `` ` `` quasiquote? Load [macro-hygiene.md](macro-h
 ## Formatting
 
 `*.phel` files auto-formatted by `.claude/hooks/format-phel.sh` after Edit/Write (runs `./bin/phel format <file>`). No manual run needed. Check without writing: `./bin/phel format --dry-run <file>`.
+
+## Commas
+
+Commas are optional whitespace — match Clojure:
+
+- Use them **between key/value pairs of a single-line map** to group visually: `{:a 1, :b 2}`.
+- Multi-line maps: no commas (the newline separates pairs).
+- Not in vectors, lists, or function calls.
+- `,` is **unquote** inside a `` ` `` quasiquote, so never add commas to quasiquoted maps.
+- `phel format` preserves commas but never inserts them (like cljfmt) — they are author's choice.

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -141,7 +141,7 @@
   (let [api-key (resolve-api-key cfg)
         base    (resolve-base-url cfg :openai)
         msgs    (if system-prompt
-                  (concat [{:role "system" :content system-prompt}] messages)
+                  (concat [{:role "system", :content system-prompt}] messages)
                   messages)
         body    {:model (get cfg :model)
                  :max_tokens (get cfg :max-tokens)
@@ -307,7 +307,7 @@
     :api-key    - Override the configured API key"
   {:example "(chat [{:role \"user\" :content \"Hello!\"}])"
    :see-also ["complete" "configure" "with-config"]}
-  [messages & [{:keys [system] :as opts}]]
+  [messages & [{:keys [system], :as opts}]]
   (let [cfg      (apply-opts @config opts)
         provider (get cfg :provider)
         req      (if (= provider :openai)
@@ -325,7 +325,7 @@
   {:example "(complete \"Explain monads in one sentence\")"
    :see-also ["chat" "configure"]}
   [prompt & [opts]]
-  (chat [{:role "user" :content prompt}] opts))
+  (chat [{:role "user", :content prompt}] opts))
 
 (defn chat-with-history
   "Appends a new user message to an existing conversation history,
@@ -337,9 +337,9 @@
                              \"How are you?\")"
    :see-also ["chat" "complete"]}
   [history user-message & [opts]]
-  (let [messages (concat history [{:role "user" :content user-message}])
+  (let [messages (concat history [{:role "user", :content user-message}])
         response (chat messages opts)]
-    (concat messages [{:role "assistant" :content response}])))
+    (concat messages [{:role "assistant", :content response}])))
 
 ;; -----------
 ;; Schema helpers
@@ -362,8 +362,8 @@
     (= v "integer") {:type "integer"}
     (= v "number")  {:type "number"}
     (= v "boolean") {:type "boolean"}
-    (string? v)     {:type "string" :description v}
-    :else           {:type "string" :description (str v)}))
+    (string? v)     {:type "string", :description v}
+    :else           {:type "string", :description (str v)}))
 
 (defn- schema->json-schema
   "Converts a field schema map to a JSON Schema object for tool use."
@@ -504,7 +504,7 @@
   {:example "(chat-with-tools [{:role \"user\" :content \"What's the weather?\"}]
                              [(tool \"get-weather\" \"Gets weather\" {:city {:type \"string\"}})])"
    :see-also ["tool" "tool-calls" "tool-result" "extract" "run-tools"]}
-  [messages tools & [{:keys [system] :as opts}]]
+  [messages tools & [{:keys [system], :as opts}]]
   (let [cfg         (apply-opts @config opts)
         provider    (get cfg :provider)
         req         (if (= provider :openai)
@@ -672,7 +672,7 @@
     :provider - :openai (default) or :voyageai"
   {:example "(embed [\"hello world\"]) ; => [[0.123 -0.456 ...]]"
    :see-also ["embed-one" "cosine-similarity" "nearest"]}
-  [texts & [{:keys [model provider] :or {provider :openai}}]]
+  [texts & [{:keys [model provider], :or {provider :openai}}]]
   (embed-request provider texts model))
 
 (defn embed-one
@@ -715,7 +715,7 @@
   [texts & [opts]]
   (let [embeddings (embed texts opts)]
     (map (fn [text embedding]
-           {:text text :embedding embedding})
+           {:text text, :embedding embedding})
          texts embeddings)))
 
 (defn search
@@ -725,6 +725,6 @@
   Returns a vector of {:text, :embedding, :similarity} maps."
   {:example "(search \"greeting\" my-index 3)"
    :see-also ["nearest" "build-index" "embed-one"]}
-  [query index & [{:keys [k model provider] :or {k 5}}]]
-  (let [query-embedding (embed-one query {:model model :provider provider})]
+  [query index & [{:keys [k model provider], :or {k 5}}]]
+  (let [query-embedding (embed-one query {:model model, :provider provider})]
     (nearest query-embedding index k)))

--- a/src/phel/cli.phel
+++ b/src/phel/cli.phel
@@ -392,7 +392,7 @@
                              (php/:: \Closure (fromCallable (fn [e] (on-err e)))))))
     d))
 
-(def- signal-numbers {:sigint 2 :sigterm 15 :sighup 1 :sigquit 3})
+(def- signal-numbers {:sigint 2, :sigterm 15, :sighup 1, :sigquit 3})
 
 (defn- register-signals [app sig-map]
   (foreach [entry sig-map]
@@ -426,7 +426,7 @@
   [name-or-spec & [commands]]
   (let [spec (if (map? name-or-spec)
                name-or-spec
-               {:name name-or-spec :commands commands})
+               {:name name-or-spec, :commands commands})
         app  (php/new Application
                       (get spec :name "console")
                       (or (get spec :version) "UNKNOWN"))]

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -28,7 +28,7 @@
       (apply php/array coll))))
 
 (def defn-builder
-  {:macro true :private true}
+  {:macro true, :private true}
   (fn [name meta & fdecl]
     (let [sym-meta        (php/-> name (getMeta))
           meta            (if sym-meta (php/-> sym-meta (merge meta)) meta)
@@ -112,7 +112,7 @@
 (defmacro defmacro-
   "Define a private macro that will not be exported."
   [name & fdecl]
-  (apply defn-builder &form &env name {:macro true :private true} fdecl))
+  (apply defn-builder &form &env name {:macro true, :private true} fdecl))
 
 (defmacro defstruct
   "A Struct is a special kind of Map. It only supports a predefined number of keys and is associated to a global name. The Struct not only defines itself but also a predicate function."

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -204,14 +204,14 @@
              t (swap! tick #(php/+ 1 %))]
          (if (contains? c args)
            (let [entry (get c args)]
-             (swap! cache assoc args {:value (get entry :value) :accessed t})
+             (swap! cache assoc args {:value (get entry :value), :accessed t})
              (get entry :value))
            ;; Compute first so any recursive populates land in the atom; then
            ;; merge against the *current* cache and apply the LRU eviction.
            (let [res (apply f args)]
              (swap! cache
                     (fn [latest]
-                      (let [merged    (assoc latest args {:value res :accessed t})]
+                      (let [merged    (assoc latest args {:value res, :accessed t})]
                         (if (php/> (count merged) max-size)
                           (let [ks      (keys merged)
                                 lru-key (reduce

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -46,7 +46,7 @@
 
 (def ^:private *hierarchy*
   "Global hierarchy for keyword/symbol taxonomies."
-  (atom {:parents {} :descendants {} :ancestors {}}))
+  (atom {:parents {}, :descendants {}, :ancestors {}}))
 
 (defn make-hierarchy
   "Creates a fresh, empty hierarchy.
@@ -56,7 +56,7 @@
   destructure any of the three relationship views."
   {:see-also ["derive" "isa?" "parents" "ancestors" "descendants"]}
   []
-  {:parents {} :descendants {} :ancestors {}})
+  {:parents {}, :descendants {}, :ancestors {}})
 
 (defn- php-class-tag?
   "Returns true when tag is a PHP class/interface/trait name string."

--- a/src/phel/http-client.phel
+++ b/src/phel/http-client.phel
@@ -25,7 +25,7 @@
 
 (defn- build-options-array
   "Converts Phel options to a PHP associative array for the transport."
-  [{:timeout timeout :follow-redirects follow-redirects :verify-ssl verify-ssl}]
+  [{:timeout timeout, :follow-redirects follow-redirects, :verify-ssl verify-ssl}]
   (let [arr (php/array)]
     (when timeout (php/aset arr "timeout" timeout))
     (when-not (nil? follow-redirects) (php/aset arr "follow_redirects" follow-redirects))

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -373,7 +373,7 @@
 (defn response-from-map
   "Creates a response struct from a map with optional keys :status, :headers, :body, :version, and :reason."
   {:example "(response-from-map {:status 200 :body \"Hello World\"}) ; => (response 200 {} \"Hello World\" \"1.1\" \"OK\")"}
-  [{:status status :headers headers :body body :version version :reason reason}]
+  [{:status status, :headers headers, :body body, :version version, :reason reason}]
   (let [status  (or status 200)
         headers (or headers {})
         body    (or body "")
@@ -409,7 +409,7 @@
     :headers {:content-type "text/html; charset=utf-8"}
     :body    body}))
 
-(defn- emit-status-line [{:status status :reason reason :version version}]
+(defn- emit-status-line [{:status status, :reason reason, :version version}]
   (when-not (php/headers_sent)
     (let [version (or version "1.1")
           status  (or status 200)
@@ -435,7 +435,7 @@
     (throw (php/new InvalidArgumentException (str "Header must be a keyword or string. Given: " header-name))))
   (assert-no-crlf (php/ucwords (name header-name) "-")))
 
-(defn- emit-headers [{:status status :headers headers}]
+(defn- emit-headers [{:status status, :headers headers}]
   (when-not (php/headers_sent)
     (dofor [[header values] :pairs headers
             :let [normalized-name (normalize-header-name header)

--- a/src/phel/json.phel
+++ b/src/phel/json.phel
@@ -31,7 +31,7 @@
 (defn encode
   "Encodes a Phel value to a JSON string."
   {:example "(encode {:name \"Alice\"}) ; => \"{\\\"name\\\":\\\"Alice\\\"}\""}
-  [value & [{:flags flags :depth depth}]]
+  [value & [{:flags flags, :depth depth}]]
   (let [flags (or flags 0)
         depth (or depth 512)]
     (when (php/is_resource value) (throw (php/new JsonException "Value can be any type except a resource.")))
@@ -55,7 +55,7 @@
 (defn decode
   "Decodes a JSON string to a Phel value."
   {:example "(decode \"{\\\"name\\\":\\\"Alice\\\"}\") ; => {:name \"Alice\"}"}
-  [json & [{:flags flags :depth depth}]]
+  [json & [{:flags flags, :depth depth}]]
   (let [flags (or flags 0)
         depth (or depth 512)]
     (when-not (string? json) (throw (php/new JsonException "Json must be a string.")))

--- a/src/phel/match.phel
+++ b/src/phel/match.phel
@@ -82,13 +82,13 @@
   `(if ~shape ~(and-checks inner-checks) false))
 
 (defn- compile-wildcard [_target _pattern]
-  {:check true :bindings []})
+  {:check true, :bindings []})
 
 (defn- compile-binding [target pattern]
-  {:check true :bindings [pattern target]})
+  {:check true, :bindings [pattern target]})
 
 (defn- compile-literal [target pattern]
-  {:check `(= ~target '~pattern) :bindings []})
+  {:check `(= ~target '~pattern), :bindings []})
 
 (defn- compile-as
   "(inner :as name): bind target to name, recurse on inner."
@@ -113,7 +113,7 @@
                     `(~pred ~target)
                     `(let ~bindings (~pred ~target)))
         combined  (and-checks [sub-check pred-expr])]
-    {:check combined :bindings bindings}))
+    {:check combined, :bindings bindings}))
 
 (defn- compile-or
   "(:or p1 p2 ...): succeeds if any alternative matches. Alternatives
@@ -129,7 +129,7 @@
                (throw (php/new \InvalidArgumentException
                                "match :or alternatives must not introduce bindings"))))
       (let [checks (for [c :in compiled] (get c :check))]
-        {:check `(or ~@checks) :bindings []}))))
+        {:check `(or ~@checks), :bindings []}))))
 
 (defn- index-of-rest
   "Linear scan for `&` inside a vector, comparing with `=` so that
@@ -189,7 +189,7 @@
                           [tail-sym `(vec (slice ~target ~fixed-len))]
                           [])
         all-bindings    (apply vector (concat elem-bindings tail-binding))]
-    {:check outer-check :bindings all-bindings}))
+    {:check outer-check, :bindings all-bindings}))
 
 (defn- compile-map
   "Map pattern: shape check, key-presence check, recurse on each value."
@@ -214,7 +214,7 @@
                                (apply concat
                                       (for [k :in key-specs]
                                         (get k :bindings))))]
-    {:check outer-check :bindings all-bindings}))
+    {:check outer-check, :bindings all-bindings}))
 
 (defn- compile-pattern
   "Dispatches on pattern shape and delegates to the kind-specific

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -732,6 +732,6 @@
   {:doc "Searches a namespace index for functions matching a query."
    :example "(search-ns \"transform collections\" my-ns-index 5)"
    :see-also ["embed-ns" "ai/nearest" "ai/search"]}
-  [query ns-index & [{:k k :model model :provider provider}]]
-  (let [query-embedding (ai/embed-one query {:model model :provider provider})]
+  [query ns-index & [{:k k, :model model, :provider provider}]]
+  (let [query-embedding (ai/embed-one query {:model model, :provider provider})]
     (ai/nearest query-embedding ns-index (or k 5))))

--- a/src/phel/router.phel
+++ b/src/phel/router.phel
@@ -113,7 +113,7 @@
         (get methods :default))))
 
 (defn- default-response [status body]
-  (constantly (h/response-from-map {:status status :body body})))
+  (constantly (h/response-from-map {:status status, :body body})))
 
 (definterface Router
               (routes [this] "Returns all registered routes as a vector of [path data] tuples.")
@@ -174,7 +174,7 @@
    by-name match response. Returns nil when the tuple is nil."
   [route]
   (when-let [[template data] route]
-    {:template template :data data}))
+    {:template template, :data data}))
 
 (defstruct SymfonyRouter [normalized-routes route-collection matcher generator]
            Router
@@ -210,10 +210,10 @@
   {:example "(router [[\"/ping\" {:get {:handler pong}}]])"
    :see-also ["compiled-router" "handler" "match-by-path"]}
   [raw-routes & [options]]
-  (let [{:path path :data data :or {path "" data {}}} (or options {})
-        normalized                                    (vec (flatten-routes raw-routes path data))
-        coll                                          (build-route-collection normalized)
-        ctx                                           (php/new RequestContext)]
+  (let [{:path path, :data data, :or {path "", data {}}} (or options {})
+        normalized                                       (vec (flatten-routes raw-routes path data))
+        coll                                             (build-route-collection normalized)
+        ctx                                              (php/new RequestContext)]
     (SymfonyRouter normalized coll
                    (php/new UrlMatcher coll ctx)
                    (php/new UrlGenerator coll ctx))))
@@ -240,16 +240,16 @@
   {:example "(compiled-router [[\"/ping\" {:get {:handler pong}}]])"
    :see-also ["router" "handler"]}
   [raw-routes & [options]]
-  (let [{:path path :data data :or {path "" data {}}} (or (eval options) {})
-        flattened-routes                              (vec (flatten-routes (eval raw-routes) path data))
-        indexed-routes                                (persistent
+  (let [{:path path, :data data, :or {path "", data {}}} (or (eval options) {})
+        flattened-routes                                 (vec (flatten-routes (eval raw-routes) path data))
+        indexed-routes                                   (persistent
                                                        (for [route :in flattened-routes
                                                              :reduce [acc (transient {})]]
                                                          (assoc! acc (route-name-of route) route)))
-        route-collection                              (build-route-collection flattened-routes)
-        compiled-matcher-routes                       (php/-> (php/new CompiledUrlMatcherDumper route-collection) (getCompiledRoutes))
-        compiled-generator-routes                     (php/-> (php/new CompiledUrlGeneratorDumper route-collection) (getCompiledRoutes))
-        ctx                                           (gensym)]
+        route-collection                                 (build-route-collection flattened-routes)
+        compiled-matcher-routes                          (php/-> (php/new CompiledUrlMatcherDumper route-collection) (getCompiledRoutes))
+        compiled-generator-routes                        (php/-> (php/new CompiledUrlGeneratorDumper route-collection) (getCompiledRoutes))
+        ctx                                              (gensym)]
     `(let [,ctx (php/new \Symfony\Component\Routing\RequestContext)]
        (CompiledSymfonyRouter
         ,flattened-routes

--- a/src/phel/schema/explainer.phel
+++ b/src/phel/schema/explainer.phel
@@ -222,7 +222,7 @@
   (let [errors (-explain schema value [] [])]
     (if (empty? errors)
       nil
-      {:schema schema :value value :errors errors})))
+      {:schema schema, :value value, :errors errors})))
 
 (defn- format-error
   [err]

--- a/src/phel/schema/instrument.phel
+++ b/src/phel/schema/instrument.phel
@@ -135,7 +135,7 @@
    :see-also ["unstrument!" "*schema-check*"]}
   [name f schema]
   (let [wrapped (wrap-with-function-schema f schema)]
-    (swap! instrumented assoc name {:original f :wrapped wrapped :schema schema})
+    (swap! instrumented assoc name {:original f, :wrapped wrapped, :schema schema})
     wrapped))
 
 (defn unstrument!

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -74,7 +74,7 @@
 
 (defn- should-stop? []
   (and (deref fail-fast?)
-       (let [{:failed f :error e} (get (deref stats) :counts)]
+       (let [{:failed f, :error e} (get (deref stats) :counts)]
          (pos? (+ f e)))))
 
 (defn- testing-contexts-str []
@@ -402,7 +402,7 @@
                     (str "deftest requires a symbol name as its first argument, got "
                          (type test-name) ". Example: (deftest test-add ...)."))))
   (let [sym-meta (or (php/-> test-name (getMeta)) {})
-        base     {:test true :test-name (name test-name)}
+        base     {:test true, :test-name (name test-name)}
         merged   (merge sym-meta base)]
     `(defn ~test-name ~merged []
        (binding [*current-test-name* ~(name test-name)]
@@ -464,7 +464,7 @@
 ;; Built-in reporters
 ;; ---------------------
 
-(defn- print-headline [prefix {:test-name test-name :message message :location location}]
+(defn- print-headline [prefix {:test-name test-name, :message message, :location location}]
   (print prefix)
   (when message
     (print (str " in (" test-name " '" message "')")))
@@ -621,9 +621,9 @@
 
 (defn- print-error [data]
   (print-error-headline data)
-  (let [{:exception exception :form form} data
-        command-facade                    (php/new CommandFacade)
-        printer                           (php/-> command-facade (getExceptionPrinter))]
+  (let [{:exception exception, :form form} data
+        command-facade                     (php/new CommandFacade)
+        printer                            (php/-> command-facade (getExceptionPrinter))]
     (print-label "              Form" form)
     (println "             threw:" (php/get_class exception))
     (when-let [exception-message (ex-message exception)]
@@ -631,17 +631,17 @@
     (when (deref print-stack-trace?)
       (php/-> printer (printStackTrace exception)))))
 
-(defn- print-predicate-failure [{:pred pred :value value :result result}]
+(defn- print-predicate-failure [{:pred pred, :value value, :result result}]
   (print-form-evaluated "                 Form" value
                         "         evaluated to" result)
   (print-label "  but doesn't satisfy" pred))
 
-(defn- print-predicate-not-failure [{:pred pred :value value :result result}]
+(defn- print-predicate-not-failure [{:pred pred, :value value, :result result}]
   (print-form-evaluated "              Form" value
                         "      evaluated to" result)
   (print-label "  but does satisfy" pred " (it shouldn't)"))
 
-(defn- print-binary-failure [{:pred pred :expected expected :actual actual :result result}]
+(defn- print-binary-failure [{:pred pred, :expected expected, :actual actual, :result result}]
   (print-form-evaluated "          Form" actual
                         "  evaluated to" result)
   (print-label "    but is not" pred "to" (readable-str expected))
@@ -649,7 +649,7 @@
              (collection-diff-applicable? expected result))
     (print-collection-diff expected result)))
 
-(defn- print-binary-not-failure [{:pred pred :expected expected :actual actual :result result}]
+(defn- print-binary-not-failure [{:pred pred, :expected expected, :actual actual, :result result}]
   (print-form-evaluated "          Form" actual
                         "  evaluated to" result)
   (print-label "        but is" pred "to" (readable-str expected) "(it shouldn't be)")
@@ -657,11 +657,11 @@
              (collection-diff-applicable? expected result))
     (print-collection-diff expected result)))
 
-(defn- print-thrown-failure [{:form form :exception-symbol exception-symbol}]
+(defn- print-thrown-failure [{:form form, :exception-symbol exception-symbol}]
   (print-label "    expected" form)
   (println "  to throw a:" exception-symbol "(it didn't)"))
 
-(defn- print-thrown-with-msg-failure [{:form form :exception-symbol exception-symbol :expected-message expected-message :actual-message actual-message}]
+(defn- print-thrown-with-msg-failure [{:form form, :exception-symbol exception-symbol, :expected-message expected-message, :actual-message actual-message}]
   (if (nil? actual-message)
     (do
       (print-label "    expected" form)
@@ -672,7 +672,7 @@
       (println "  with message:" expected-message)
       (println "       but got:" actual-message))))
 
-(defn- print-any-failure [{:form form :result result}]
+(defn- print-any-failure [{:form form, :result result}]
   (print-label "          Form" form)
   (print-label "  evaluated to" result "(which is not truthy)"))
 
@@ -925,7 +925,7 @@
 
 (defn- junit-render [state]
   (let [suites (get state :testsuites)
-        parts  (for [{:name ns-name :tests t :failures f :errors e :time tm :cases cases} :in suites]
+        parts  (for [{:name ns-name, :tests t, :failures f, :errors e, :time tm, :cases cases} :in suites]
                  (str "<testsuite "
                       (junit-attr :name ns-name) " "
                       (junit-attr :tests t) " "
@@ -944,7 +944,7 @@
          "</testsuites>")))
 
 (def- empty-junit-suite
-  {:tests 0 :failures 0 :errors 0 :time 0.0 :cases []})
+  {:tests 0, :failures 0, :errors 0, :time 0.0, :cases []})
 
 (defn- junit-finalize-current [state]
   (let [current (:current state)]
@@ -1078,11 +1078,11 @@
 
 (defn- summary-event
   [snapshot]
-  (let [{:failed failed :error error :pass pass :skipped skipped}
+  (let [{:failed failed, :error error, :pass pass, :skipped skipped}
         (:counts snapshot)
-        failures                                                  (:failed snapshot)
-        skips                                                     (:skipped snapshot)
-        total                                                     (+ failed error pass)]
+        failures                                                     (:failed snapshot)
+        skips                                                        (:skipped snapshot)
+        total                                                        (+ failed error pass)]
     {:type :summary
      :failures failures
      :skips skips
@@ -1204,15 +1204,15 @@
   [options ns-name tests]
   (let [sel-opts (selector-options options)]
     (reduce
-     (fn [acc {:fn f :meta m}]
+     (fn [acc {:fn f, :meta m}]
        (if-let [reason (skip-reason sel-opts ns-name m)]
-         (update acc :skip conj {:fn f :meta m :reason reason})
-         (update acc :keep conj {:fn f :meta m})))
-     {:keep [] :skip []}
+         (update acc :skip conj {:fn f, :meta m, :reason reason})
+         (update acc :keep conj {:fn f, :meta m})))
+     {:keep [], :skip []}
      tests)))
 
 (defn- emit-skip-events! [ns-name skipped]
-  (dofor [{:meta m :reason reason} :in skipped]
+  (dofor [{:meta m, :reason reason} :in skipped]
     (report {:type :skipped
              :ns ns-name
              :test-name (:test-name m)
@@ -1241,11 +1241,11 @@
              (only-tests-matches? only-tests ns tname))))))
 
 (defn- failure-count []
-  (let [{:failed f :error e} (get (deref stats) :counts)]
+  (let [{:failed f, :error e} (get (deref stats) :counts)]
     (+ f e)))
 
 (defn- record-test-time! [ns test-name duration-ms]
-  (swap! timings conj {:ns ns :test-name test-name :duration-ms duration-ms}))
+  (swap! timings conj {:ns ns, :test-name test-name, :duration-ms duration-ms}))
 
 (defn- maybe-shuffle-tests
   "Returns `tests` shuffled when `:random-order` is set in `options` (or
@@ -1270,7 +1270,7 @@
    options
    (vec (filter (visible-test-pred options ns) (find-test-vars ns)))))
 
-(defn- run-one-test! [options ns each-wrap {:fn f :meta m}]
+(defn- run-one-test! [options ns each-wrap {:fn f, :meta m}]
   (let [test-name      (:test-name m)
         track-slowest? (pos? (or (:slowest options) 0))
         t0             (when track-slowest? (php/microtime true))
@@ -1359,9 +1359,9 @@
 
 (defn- run-one-ns! [options namespace]
   (let [ns-name (name namespace)]
-    (fan-out! {:type :begin-test-ns :ns ns-name})
+    (fan-out! {:type :begin-test-ns, :ns ns-name})
     (run-test options ns-name)
-    (fan-out! {:type :end-test-ns :ns ns-name})))
+    (fan-out! {:type :end-test-ns, :ns ns-name})))
 
 (defn- list-tests-for-ns! [options ns-name]
   (let [sel-opts (selector-options options)]
@@ -1466,7 +1466,7 @@
   "Checks if all tests passed."
   {:example "(successful?) # => true"}
   []
-  (let [{:failed failed :error error} (get (deref stats) :counts)]
+  (let [{:failed failed, :error error} (get (deref stats) :counts)]
     (zero? (+ failed error))))
 
 (defn get-stats

--- a/src/phel/test/gen.phel
+++ b/src/phel/test/gen.phel
@@ -317,7 +317,7 @@
   "Runs `g` once and returns a single value. Accepts `:size` and `:seed`."
   {:example "(generate int) ; => 42"}
   ([g] (generate g {}))
-  ([g {:size size :seed seed}]
+  ([g {:size size, :seed seed}]
    (seed-rng! seed)
    (g (or size default-size))))
 
@@ -327,7 +327,7 @@
   {:example "(sample int 5) ; => [3 -7 0 1 -2]"}
   ([g] (sample g 10 {}))
   ([g num-samples] (sample g num-samples {}))
-  ([g num-samples {:size size :seed seed}]
+  ([g num-samples {:size size, :seed seed}]
    (seed-rng! seed)
    (let [s (or size default-size)]
      (into [] (for [_ :range [0 num-samples]] (g s))))))
@@ -344,16 +344,16 @@
 (defn- run-trials [property args-gen num-tests size]
   (loop [i 0]
     (if (>= i num-tests)
-      {:result :pass :num-tests i}
+      {:result :pass, :num-tests i}
       (let [args    (args-gen size)
             outcome (trial-result property args)]
         (cond
           (= :pass outcome)
           (recur (inc i))
           (php/instanceof outcome \Throwable)
-          {:result :error :num-tests (inc i) :args args :exception outcome}
+          {:result :error, :num-tests (inc i), :args args, :exception outcome}
           :else
-          {:result :failed :num-tests (inc i) :args args})))))
+          {:result :failed, :num-tests (inc i), :args args})))))
 
 (defn- shrink-outcome
   "Given a failing trial `outcome`, runs the shrink driver on its args
@@ -389,7 +389,7 @@
   {:example "(quick-check 50 (tuple int int) (fn [a b] (= (+ a b) (+ b a))))"}
   ([num-tests args-gen property]
    (quick-check num-tests args-gen property {}))
-  ([num-tests args-gen property {:size size :seed seed :shrink? shrink?}]
+  ([num-tests args-gen property {:size size, :seed seed, :shrink? shrink?}]
    (let [effective-seed (or seed (fresh-seed))
          _              (seed-rng! effective-seed)
          outcome        (run-trials property args-gen num-tests (or size default-size))

--- a/src/phel/test/rose.phel
+++ b/src/phel/test/rose.phel
@@ -54,7 +54,7 @@
   {:example "(rose-pure 42)"
    :see-also ["rose-tree" "rose-fmap"]}
   [x]
-  {:root x :children (lazy-seq nil)})
+  {:root x, :children (lazy-seq nil)})
 
 (defn rose-tree
   "Rose tree constructor. `children` should be a lazy sequence of rose
@@ -62,7 +62,7 @@
   {:example "(rose-tree 1 (list (rose-pure 0)))"
    :see-also ["rose-pure" "rose-fmap"]}
   [root children]
-  {:root root :children children})
+  {:root root, :children children})
 
 (defn rose-root
   "Returns the root value of rose tree `t`."


### PR DESCRIPTION
## 🤔 Background

Commas are optional whitespace in Phel (Clojure-aligned). The printer already renders single-line maps with commas (`{:a 1, :b 2}`), but the corelib source didn't use them. Adding them between map key/value pairs improves readability of grouped pairs.

## 💡 Goal

Apply the Clojure comma convention to `src/phel/` and document it, with zero behavior change.

## 🔖 Changes

- Inserted commas **between key/value pairs of single-line map literals** only.
- Left untouched: multi-line maps (newline already separates), vectors, lists, function calls, and **quasiquoted maps** — inside a `` ` `` backtick `,` is the unquote operator (`T_UNQUOTE`), not whitespace, so commas there would change meaning.
- Generated via a parser-based transform (reuses Phel's own lexer/parser, so strings/comments are never touched) + `phel format` to keep alignment canonical. The script is not committed.
- Documented the convention in the agnostic-ai rule specs (`phel.md`, coding-style, root) → regenerated `.claude/`, `.codex/`, `AGENTS.md`.

```phel
{:check true, :bindings []}                 ; was {:check true :bindings []}
(merge ~report-data {:type :binary :state :pass})  ; quasiquoted → unchanged
```

## ✅ Safety

- Comma is reader-whitespace outside quasiquote → compiled PHP is byte-identical.
- `composer test` green (5826 core tests, quality, compiler).
- `phel format --dry-run` clean on all changed files (format-stable; commas survive the format hook).
- Diff is symmetric (a comma per touched pair, plus a few `AlignPairsRule` re-alignments in `router`/`test`).

No `CHANGELOG` entry — internal style only, no user-facing change.