### PR TITLE
feat(compiler): php/ref for by-reference args to plain PHP functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Richer PHP interop for bridging Phel to typed PHP / framework code (all opt-in, 
 
 - Generated classes carry opt-in metadata: `^{:php/attr}` PHP 8 attributes (class/method/parameter), `^{:tag}` typed signatures (incl. union/intersection), `^{:php/doc}` PHPDoc, and `^{:php/json}`/`^{:php/stringable}` on structs (#2280, #2289, #2292, #2293, #2294, #2295)
 - `defenum` native backed enums, and `defexception` with an optional parent class (#2291, #2297)
-- `php/ref` passes a local by reference into a `php/->`/`php/::` call (PDO `bindColumn`) (#2299)
+- `php/ref` passes a local by reference into a `php/->`/`php/::` call (PDO `bindColumn`) (#2299), and now also into plain PHP function calls (`preg_match`, `sort`, `settype`, ...); the local is captured by reference even when the call is wrapped in a closure (#2310)
 - `hydrate`/`bean` bridge a Phel map and a typed PHP object both ways (#2296)
 
 ### Changed

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -86,7 +86,15 @@ Some PHP methods write into an argument (`PDOStatement::bindColumn`, `bindParam`
   out)                              ; => the fetched column value
 ```
 
-`php/ref` takes a local binding and works in `php/->`/`php/::` calls.
+It works the same way for plain PHP functions with output parameters (`preg_match`, `sort`, `settype`, `array_push`, ...):
+
+```phel
+(let [matches nil]
+  (php/preg_match "/(\\d+)/" "abc123" (php/ref matches))
+  (php/aget matches 1))             ; => "123"
+```
+
+`php/ref` takes a local binding and works in `php/->`/`php/::` and plain function calls. The local stays bound by reference even when the call sits inside an expression the compiler wraps in a closure.
 
 ### Working with PHP Arrays
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpRefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpRefSymbol.php
@@ -17,9 +17,11 @@ use function count;
 /**
  * (php/ref local).
  *
- * Marks a local variable as passed by reference inside a PHP interop call.
- * Only valid in argument position of `php/->`/`php/::`; the inner form must be
- * a local binding so the emitted closure can capture it with `use(&$local)`.
+ * Marks a local variable as passed by reference inside a PHP interop call,
+ * for both method/static calls (`php/->`, `php/::`) and plain function calls
+ * (`php/preg_match`, `php/sort`, ...). The inner form must be a local binding;
+ * where the call site is wrapped in a closure, the local is captured with
+ * `use(&$local)` so a by-reference PHP parameter writes back into the binding.
  */
 final class PhpRefSymbol implements SpecialFormAnalyzerInterface
 {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/ByRefLocalCollector.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/ByRefLocalCollector.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ApplyNode;
+use Phel\Compiler\Domain\Analyzer\Ast\BindingNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CatchNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DefNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ForeachNode;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MethodCallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MultiFnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayGetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayPushNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpArraySetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayUnsetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpNewNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectSetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpRefNode;
+use Phel\Compiler\Domain\Analyzer\Ast\RecurNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ReifyNode;
+use Phel\Compiler\Domain\Analyzer\Ast\SetVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ThrowNode;
+use Phel\Compiler\Domain\Analyzer\Ast\TryNode;
+use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
+
+use function array_values;
+
+/**
+ * Collects the shadow names of locals marked `(php/ref x)` inside a node
+ * subtree, so an emitter that wraps the subtree in an IIFE can capture those
+ * locals with `use(&$x)` rather than by value (otherwise a by-reference PHP
+ * parameter writes into the closure copy and the result is lost).
+ *
+ * Traversal stops at closure boundaries (`FnNode`, `MultiFnNode`, `ReifyNode`):
+ * a `php/ref` inside a user closure binds against that closure's own capture,
+ * not the wrapping IIFE, so forcing the outer capture by reference would not
+ * help. Unknown node types are treated as leaves; under-collecting only leaves
+ * the pre-existing by-value behaviour untouched, never a wrong reference.
+ */
+final class ByRefLocalCollector
+{
+    /**
+     * @return list<string> de-duplicated shadow names of by-reference locals
+     */
+    public function collect(AbstractNode $node): array
+    {
+        $names = [];
+        $this->walk($node, $names);
+
+        return array_values(array_unique($names));
+    }
+
+    /**
+     * @param list<string> $names
+     */
+    private function walk(AbstractNode $node, array &$names): void
+    {
+        if ($node instanceof PhpRefNode) {
+            $names[] = $node->getName()->getName();
+            return;
+        }
+
+        if ($node instanceof FnNode || $node instanceof MultiFnNode || $node instanceof ReifyNode) {
+            return;
+        }
+
+        foreach ($this->children($node) as $child) {
+            $this->walk($child, $names);
+        }
+    }
+
+    /**
+     * @return list<AbstractNode>
+     */
+    private function children(AbstractNode $node): array
+    {
+        return match (true) {
+            $node instanceof DoNode => [...$node->getStmts(), $node->getRet()],
+            $node instanceof LetNode => [...$node->getBindings(), $node->getBodyExpr()],
+            $node instanceof BindingNode => [$node->getInitExpr()],
+            $node instanceof IfNode => [$node->getTestExpr(), $node->getThenExpr(), $node->getElseExpr()],
+            $node instanceof CallNode => [$node->getFn(), ...$node->getArguments()],
+            $node instanceof ApplyNode => [$node->getFn(), ...$node->getArguments()],
+            $node instanceof VectorNode => $node->getArgs(),
+            $node instanceof MapNode => $node->getKeyValues(),
+            $node instanceof ThrowNode => [$node->getExceptionExpr()],
+            $node instanceof TryNode => [$node->getBody(), ...$node->getCatches(), ...$this->maybe($node->getFinally())],
+            $node instanceof CatchNode => [$node->getBody()],
+            $node instanceof ForeachNode => [$node->getListExpr(), $node->getBodyExpr()],
+            $node instanceof PhpObjectCallNode => [$node->getTargetExpr(), $node->getCallExpr()],
+            $node instanceof PhpObjectSetNode => [$node->getLeftExpr(), $node->getRightExpr()],
+            $node instanceof MethodCallNode => $node->getArgs(),
+            $node instanceof PhpNewNode => [$node->getClassExpr(), ...$node->getArgs()],
+            $node instanceof RecurNode => $node->getExpressions(),
+            $node instanceof SetVarNode => [$node->getSymbol(), $node->getValueExpr()],
+            $node instanceof PhpArraySetNode => [$node->getArrayExpr(), ...$node->getAccessExprs(), $node->getValueExpr()],
+            $node instanceof PhpArrayPushNode => [$node->getArrayExpr(), ...$node->getAccessExprs(), $node->getValueExpr()],
+            $node instanceof PhpArrayUnsetNode => [$node->getArrayExpr(), ...$node->getAccessExprs()],
+            $node instanceof PhpArrayGetNode => [$node->getArrayExpr(), ...$node->getAccessExprs()],
+            $node instanceof DefNode => [$node->getInit()],
+            default => [],
+        };
+    }
+
+    /**
+     * @return list<AbstractNode>
+     */
+    private function maybe(?AbstractNode $node): array
+    {
+        return $node instanceof AbstractNode ? [$node] : [];
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DoEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DoEmitter.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 
 use function assert;
@@ -31,7 +32,11 @@ final class DoEmitter implements NodeEmitterInterface
         $isWrapFn = $isExpression && ($node->getStmts() !== [] || $retNeedsReturn);
 
         if ($isWrapFn) {
-            $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
+            $this->outputEmitter->emitFnWrapPrefix(
+                $node->getEnv(),
+                $node->getStartSourceLocation(),
+                new ByRefLocalCollector()->collect($node),
+            );
         }
 
         foreach ($node->getStmts() as $stmt) {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ForeachEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ForeachEmitter.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ForeachNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\IterableTarget;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Seq;
@@ -24,7 +25,11 @@ final class ForeachEmitter implements NodeEmitterInterface
 
         if (!$node->getEnv()->isContext(NodeEnvironment::CONTEXT_STATEMENT)) {
             $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-            $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
+            $this->outputEmitter->emitFnWrapPrefix(
+                $node->getEnv(),
+                $node->getStartSourceLocation(),
+                new ByRefLocalCollector()->collect($node),
+            );
         }
 
         // `Seq::toIterable` is only needed to coerce `nil` to `[]` and

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LetEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LetEmitter.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
@@ -39,7 +40,11 @@ final class LetEmitter implements NodeEmitterInterface
 
         $isWrapFn = $node->getEnv()->isContext(NodeEnvironment::CONTEXT_EXPRESSION);
         if ($isWrapFn) {
-            $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
+            $this->outputEmitter->emitFnWrapPrefix(
+                $node->getEnv(),
+                $node->getStartSourceLocation(),
+                new ByRefLocalCollector()->collect($node),
+            );
         }
 
         foreach ($node->getBindings() as $bindingNode) {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpNewEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpNewEmitter.php
@@ -8,6 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpNewNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Symbol;
 
@@ -37,7 +38,11 @@ final class PhpNewEmitter implements NodeEmitterInterface
             $this->outputEmitter->emitStr($classExpr->getAbsolutePhpName(), $classExpr->getName()->getStartLocation());
             $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
         } else {
-            $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
+            $this->outputEmitter->emitFnWrapPrefix(
+                $node->getEnv(),
+                $node->getStartSourceLocation(),
+                new ByRefLocalCollector()->collect($node),
+            );
 
             $targetSym = Symbol::gen('target_');
             $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectCallEmitter.php
@@ -8,8 +8,8 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MethodCallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
-use Phel\Compiler\Domain\Analyzer\Ast\PhpRefNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PropertyOrConstantAccessNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Symbol;
 use RuntimeException;
@@ -44,7 +44,7 @@ final class PhpObjectCallEmitter implements NodeEmitterInterface
             $this->outputEmitter->emitFnWrapPrefix(
                 $node->getEnv(),
                 $node->getStartSourceLocation(),
-                $this->byRefLocalNames($node),
+                new ByRefLocalCollector()->collect($node),
             );
 
             $targetSym = Symbol::gen('target_');
@@ -73,30 +73,6 @@ final class PhpObjectCallEmitter implements NodeEmitterInterface
         } else {
             throw new RuntimeException('Not supported ' . $callExpr::class);
         }
-    }
-
-    /**
-     * Local names marked `(php/ref x)` in this call's arguments; the wrapping
-     * closure must capture them by reference so a by-ref PHP parameter writes
-     * back into the Phel binding.
-     *
-     * @return list<string>
-     */
-    private function byRefLocalNames(PhpObjectCallNode $node): array
-    {
-        $callExpr = $node->getCallExpr();
-        if (!$callExpr instanceof MethodCallNode) {
-            return [];
-        }
-
-        $names = [];
-        foreach ($callExpr->getArgs() as $arg) {
-            if ($arg instanceof PhpRefNode) {
-                $names[] = $arg->getName()->getName();
-            }
-        }
-
-        return $names;
     }
 
     private function emitPhpObjectCallEnd(PhpObjectCallNode $node): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectSetEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectSetEmitter.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectSetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PropertyOrConstantAccessNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Symbol;
 
@@ -27,7 +28,11 @@ final class PhpObjectSetEmitter implements NodeEmitterInterface
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
 
-        $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
+        $this->outputEmitter->emitFnWrapPrefix(
+            $node->getEnv(),
+            $node->getStartSourceLocation(),
+            new ByRefLocalCollector()->collect($node),
+        );
 
         $targetSym = Symbol::gen('target_');
         $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ThrowEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ThrowEmitter.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ThrowNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 
 use function assert;
@@ -20,7 +21,11 @@ final class ThrowEmitter implements NodeEmitterInterface
         assert($node instanceof ThrowNode);
 
         if ($node->getEnv()->isContext(NodeEnvironment::CONTEXT_EXPRESSION)) {
-            $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
+            $this->outputEmitter->emitFnWrapPrefix(
+                $node->getEnv(),
+                $node->getStartSourceLocation(),
+                new ByRefLocalCollector()->collect($node),
+            );
         }
 
         $this->outputEmitter->emitStr('throw ', $node->getStartSourceLocation());

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/TryEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/TryEmitter.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\TryNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 
 use function assert;
@@ -25,7 +26,11 @@ final class TryEmitter implements NodeEmitterInterface
         }
 
         if ($node->getEnv()->isContext(NodeEnvironment::CONTEXT_EXPRESSION)) {
-            $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
+            $this->outputEmitter->emitFnWrapPrefix(
+                $node->getEnv(),
+                $node->getStartSourceLocation(),
+                new ByRefLocalCollector()->collect($node),
+            );
         }
 
         $this->emitTry($node);

--- a/tests/phel/core/interop-by-ref.phel
+++ b/tests/phel/core/interop-by-ref.phel
@@ -14,3 +14,27 @@
         out "init"]
     (php/-> t (writeInto out "written"))
     (is (= "init" out) "a value-captured local is unaffected by the by-ref write")))
+
+(deftest php-ref-on-a-plain-function-call
+  (let [m nil]
+    (php/preg_match "/(\\d+)/" "abc123" (php/ref m))
+    (is (= "123" (php/aget m 1)) "preg_match writes its matches into the local")))
+
+(deftest php-ref-on-a-plain-function-mutating-in-place
+  (let [arr (php/array 3 1 2)]
+    (php/sort (php/ref arr))
+    (is (and (= 1 (php/aget arr 0)) (= 2 (php/aget arr 1)) (= 3 (php/aget arr 2)))
+        "sort reorders the local array in place")))
+
+(deftest php-ref-survives-an-enclosing-closure-wrap
+  (let [m nil]
+    ; the `do` sits in expression position, so the emitter wraps it in an IIFE;
+    ; the by-ref local must still be captured by reference through that wrap.
+    (php/intval (do (php/preg_match "/(\\d+)/" "abc123" (php/ref m)) 0))
+    (is (= "123" (php/aget m 1)) "by-ref survives an enclosing IIFE wrap")))
+
+(deftest php-method-ref-survives-an-enclosing-closure-wrap
+  (let [t   (php/new target)
+        out "init"]
+    (php/intval (do (php/-> t (writeInto (php/ref out) "written")) 0))
+    (is (= "written" out) "method by-ref survives an enclosing IIFE wrap")))

--- a/tests/php/Integration/Fixtures/Call/php-fn-call-by-ref.test
+++ b/tests/php/Integration/Fixtures/Call/php-fn-call-by-ref.test
@@ -1,0 +1,5 @@
+--PHEL--
+(let [m nil] (php/preg_match "/(\d+)/" "abc123" (php/ref m)))
+--PHP--
+$m_1 = null;
+preg_match("/(\\d+)/", "abc123", $m_1);

--- a/tests/php/Integration/Fixtures/Do/do-wrap-by-ref.test
+++ b/tests/php/Integration/Fixtures/Do/do-wrap-by-ref.test
@@ -1,0 +1,8 @@
+--PHEL--
+(let [m nil] (php/intval (do (php/preg_match "/(\d+)/" "abc123" (php/ref m)) 0)))
+--PHP--
+$m_1 = null;
+intval((function() use(&$m_1) {
+  preg_match("/(\\d+)/", "abc123", $m_1);
+  return 0;
+})());

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ByRefLocalCollectorTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ByRefLocalCollectorTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpRefNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class ByRefLocalCollectorTest extends TestCase
+{
+    public function test_collects_a_direct_php_ref_node(): void
+    {
+        self::assertSame(['x'], $this->collect($this->ref('x')));
+    }
+
+    public function test_collects_php_ref_from_a_call_argument(): void
+    {
+        $call = new CallNode($this->env(), $this->phpVar('preg_match'), [$this->ref('m')]);
+
+        self::assertSame(['m'], $this->collect($call));
+    }
+
+    public function test_descends_through_nested_wrapping_nodes(): void
+    {
+        $inner = new DoNode($this->env(), [], new CallNode($this->env(), $this->phpVar('sort'), [$this->ref('m')]));
+        $outer = new DoNode($this->env(), [$this->literal()], $inner);
+
+        self::assertSame(['m'], $this->collect($outer));
+    }
+
+    public function test_de_duplicates_repeated_locals(): void
+    {
+        $call = new CallNode($this->env(), $this->phpVar('f'), [$this->ref('m'), $this->ref('m')]);
+
+        self::assertSame(['m'], $this->collect($call));
+    }
+
+    public function test_stops_at_a_closure_boundary(): void
+    {
+        $fn = new FnNode(
+            $this->env(),
+            [],
+            new CallNode($this->env(), $this->phpVar('f'), [$this->ref('m')]),
+            [],
+            false,
+            false,
+        );
+        $do = new DoNode($this->env(), [], $fn);
+
+        self::assertSame([], $this->collect($do));
+    }
+
+    public function test_unknown_leaf_node_collects_nothing(): void
+    {
+        self::assertSame([], $this->collect($this->local('m')));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collect(AbstractNode $node): array
+    {
+        return new ByRefLocalCollector()->collect($node);
+    }
+
+    private function ref(string $name): PhpRefNode
+    {
+        return new PhpRefNode($this->env(), $this->local($name));
+    }
+
+    private function local(string $name): LocalVarNode
+    {
+        return new LocalVarNode($this->env(), Symbol::create($name));
+    }
+
+    private function phpVar(string $name): PhpVarNode
+    {
+        return new PhpVarNode($this->env(), $name);
+    }
+
+    private function literal(): LiteralNode
+    {
+        return new LiteralNode($this->env(), 0);
+    }
+
+    private function env(): NodeEnvironment
+    {
+        return NodeEnvironment::empty()->withExpressionContext();
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`php/ref` (#2299) lets a local be passed by reference into a `php/->`/`php/::` interop call (e.g. PDO `bindColumn`). Plain global-function interop could not use it, so the whole PHP output-parameter family stayed out of reach: `preg_match($re, $s, $matches)`, `sort()`, `usort()`, `settype()`, `array_push()`, `array_splice()`.

The `php/ref` special form is already generic, so the **direct** plain-call case happened to work. The remaining gap was correctness when the call sits in expression position: the compiler then wraps the surrounding `do`/`let`/`try`/... in an IIFE that captured the local **by value**, so the by-reference write was lost — and this affected `php/->` too, not just plain calls.

## 💡 Goal

Make `php/ref` work for plain PHP function calls, and keep the by-reference binding observable even when the call is wrapped in a closure — closing the by-reference interop story started in #2299.

Closes #2310

## 🔖 Changes

- New `ByRefLocalCollector` walks a wrapped subtree and returns the shadow names of locals marked `(php/ref x)`, so the enclosing IIFE can capture them with `use(&$x)`. Traversal stops at closure boundaries (`FnNode`, `MultiFnNode`, `ReifyNode`); unknown node types are treated as leaves, so under-collecting only leaves the pre-existing by-value behaviour untouched (never a wrong reference).
- Wired the collector into every emitter that wraps a subtree in an IIFE: `Do`, `Let`, `Try`, `Foreach`, `Throw`, `PhpNew`, `PhpObjectSet`, and `PhpObjectCall` (the last replaces its bespoke arg-only scan, now also handling refs nested in argument expressions).
- Tests: `ByRefLocalCollectorTest` (unit), `Call/php-fn-call-by-ref.test` + `Do/do-wrap-by-ref.test` (integration, asserting the emitted `use(&$m)`), and Phel-level scenarios in `interop-by-ref.phel` covering `preg_match`, `sort`, and the closure-wrapped case for both plain and method calls.
- Docs: `php-interop.md` plain-function output-parameter example; `PhpRefSymbol` docstring and `CHANGELOG.md` updated.

A final refactor pass over the touched files surfaced no further cleanups: the per-emitter `collect($node)` call is the natural shape and the static-analysis gate (cs-fixer, psalm, phpstan, rector) is green.
