### PR TITLE
feat(compiler): PHP 8 named arguments in interop (php/new, php/->, php/::)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Richer PHP interop for bridging Phel to typed PHP / framework code (all opt-in, 
 - `defenum` native backed enums, and `defexception` with an optional parent class (#2291, #2297)
 - `php/ref` passes a local by reference into a `php/->`/`php/::` call (PDO `bindColumn`) (#2299), and now also into plain PHP function calls (`preg_match`, `sort`, `settype`, ...); the local is captured by reference even when the call is wrapped in a closure (#2310)
 - `hydrate`/`bean` bridge a Phel map and a typed PHP object both ways (#2296)
+- PHP 8 named arguments in interop via the `:&` marker: `(php/new \App\Mailer :& :host "smtp" :port 25)`, also in `php/->`/`php/::` and mixable after positional args (#2311)
 
 ### Changed
 

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -13,6 +13,7 @@ Call PHP from Phel and Phel from PHP.
 | Property access | `$obj->prop` | `(php/-> obj prop)` or `(.-prop obj)` |
 | Array access | `$arr[$key]` | `(php/aget arr key)` |
 | By-reference arg | `$obj->m($out)` (writes back into `$out`) | `(php/-> obj (m (php/ref out)))` |
+| Named arguments | `new Mailer(host: "smtp", port: 25)` | `(php/new \Mailer :& :host "smtp" :port 25)` |
 
 ## Calling PHP from Phel
 
@@ -95,6 +96,26 @@ It works the same way for plain PHP functions with output parameters (`preg_matc
 ```
 
 `php/ref` takes a local binding and works in `php/->`/`php/::` and plain function calls. The local stays bound by reference even when the call sits inside an expression the compiler wraps in a closure.
+
+### Named arguments
+
+Use the `:&` marker to pass PHP 8 named arguments in `php/new`, `php/->`, and `php/::`. Positional args come first; everything after `:&` is `:name value` pairs, where each keyword must match the PHP parameter name exactly:
+
+```phel
+(php/new \App\Mailer :& :host "smtp" :port 25 :secure true)
+;; => new \App\Mailer(host: "smtp", port: 25, secure: true)
+
+(php/new \DateTime "now" :& :timezone tz)        ; positional + named mix
+;; => new \DateTime("now", timezone: $tz)
+
+(php/-> client (request "POST" :& :uri "/x" :timeout 5))
+;; => $client->request("POST", uri: "/x", timeout: 5)
+
+(php/:: \DateTime (createFromFormat :& :format "Y-m-d" :datetime "2024-01-15"))
+;; => \DateTime::createFromFormat(format: "Y-m-d", datetime: "2024-01-15")
+```
+
+Without the `:&` marker a keyword is just a positional value, so existing calls are unaffected. `php/ref` may be used as a named-argument value (`:out (php/ref x)`).
 
 ### Working with PHP Arrays
 

--- a/src/php/Compiler/Domain/Analyzer/Ast/PhpNamedArgNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/PhpNamedArgNode.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Ast;
+
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Lang\SourceLocation;
+
+/**
+ * A single PHP 8 named argument in a `php/new`/`php/->`/`php/::` call,
+ * introduced after the `:&` marker. Emits as `name: <value>` so the value
+ * binds to the PHP parameter by name rather than by position.
+ */
+final class PhpNamedArgNode extends AbstractNode
+{
+    public function __construct(
+        NodeEnvironmentInterface $env,
+        private readonly string $name,
+        private readonly AbstractNode $valueExpr,
+        ?SourceLocation $sourceLocation = null,
+    ) {
+        parent::__construct($env, $sourceLocation);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getValueExpr(): AbstractNode
+    {
+        return $this->valueExpr;
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpInteropArgsAnalyzer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpInteropArgsAnalyzer.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpNamedArgNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Lang\Keyword;
+use Phel\Lang\TypeInterface;
+
+use function array_slice;
+use function count;
+use function sprintf;
+
+/**
+ * Analyzes the argument forms of a `php/new`/`php/->`/`php/::` call,
+ * supporting PHP 8 named arguments after a `:&` marker:
+ *
+ *     (php/new \App\Mailer "smtp" :& :port 25 :secure true)
+ *     ; => new \App\Mailer("smtp", port: 25, secure: true)
+ *
+ * Positional args come first; everything after `:&` must be `:keyword value`
+ * pairs, each emitted as a PHP named argument (see {@see PhpNamedArgNode}).
+ */
+final readonly class PhpInteropArgsAnalyzer
+{
+    /** The marker keyword (`:&`) that switches the arg list to named mode. */
+    private const string NAMED_ARGS_MARKER = '&';
+
+    public function __construct(
+        private AnalyzerInterface $analyzer,
+    ) {}
+
+    /**
+     * @param list<mixed> $forms argument forms without the callee
+     *
+     * @return list<AbstractNode>
+     */
+    public function analyze(array $forms, NodeEnvironmentInterface $env, string $context, TypeInterface $location): array
+    {
+        $args = [];
+        $count = count($forms);
+
+        for ($i = 0; $i < $count; ++$i) {
+            $form = $forms[$i];
+
+            if ($this->isNamedArgsMarker($form)) {
+                $namedForms = array_slice($forms, $i + 1);
+                foreach ($this->analyzeNamedArgs($namedForms, $env, $context, $location) as $namedArg) {
+                    $args[] = $namedArg;
+                }
+
+                return $args;
+            }
+
+            $args[] = $this->analyzer->analyze($form, $env);
+        }
+
+        return $args;
+    }
+
+    /**
+     * @param list<mixed> $forms the forms following the `:&` marker
+     *
+     * @return list<PhpNamedArgNode>
+     */
+    private function analyzeNamedArgs(array $forms, NodeEnvironmentInterface $env, string $context, TypeInterface $location): array
+    {
+        $count = count($forms);
+        if ($count === 0) {
+            throw AnalyzerException::withLocation(
+                sprintf("':&' in '%s' must be followed by :key value pairs", $context),
+                $location,
+            );
+        }
+
+        $named = [];
+        for ($i = 0; $i < $count; $i += 2) {
+            $key = $forms[$i];
+            if (!$key instanceof Keyword || $key->getNamespace() !== null) {
+                throw AnalyzerException::withLocation(
+                    sprintf("Named arguments after ':&' in '%s' must be :key value pairs", $context),
+                    $key instanceof TypeInterface ? $key : $location,
+                );
+            }
+
+            if ($i + 1 >= $count) {
+                throw AnalyzerException::withLocation(
+                    sprintf("Missing value for named argument ':%s' in '%s'", $key->getName(), $context),
+                    $key,
+                );
+            }
+
+            $named[] = new PhpNamedArgNode(
+                $env,
+                $key->getName(),
+                $this->analyzer->analyze($forms[$i + 1], $env),
+                $key->getStartLocation(),
+            );
+        }
+
+        return $named;
+    }
+
+    private function isNamedArgsMarker(mixed $form): bool
+    {
+        return $form instanceof Keyword
+            && $form->getNamespace() === null
+            && $form->getName() === self::NAMED_ARGS_MARKER;
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpNewSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpNewSymbol.php
@@ -34,13 +34,13 @@ final class PhpNewSymbol implements SpecialFormAnalyzerInterface
 
         $classEnv = $env->withExpressionContext()->withDisallowRecurFrame();
         $classExpr = $this->analyzeClassExpr($list->get(1), $classEnv);
-        $args = [];
-        for ($forms = $list->rest()->cdr(); $forms !== null; $forms = $forms->cdr()) {
-            $args[] = $this->analyzer->analyze(
-                $forms->first(),
-                $classEnv,
-            );
+
+        $forms = [];
+        for ($rest = $list->rest()->cdr(); $rest !== null; $rest = $rest->cdr()) {
+            $forms[] = $rest->first();
         }
+
+        $args = new PhpInteropArgsAnalyzer($this->analyzer)->analyze($forms, $classEnv, 'php/new', $list);
 
         return new PhpNewNode(
             $env,

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
@@ -84,14 +84,18 @@ final readonly class PhpObjectCallSymbol implements SpecialFormAnalyzerInterface
      */
     private function callExprForMethodCall(NodeEnvironmentInterface $env, PersistentListInterface $segment): MethodCallNode
     {
-        $args = [];
-        $forms = $segment->cdr();
-        for (; $forms !== null; $forms = $forms->cdr()) {
-            $args[] = $this->analyzer->analyze(
-                $forms->first(),
-                $env->withExpressionContext()->withDisallowRecurFrame(),
-            );
+        $forms = [];
+        for ($rest = $segment->cdr(); $rest !== null; $rest = $rest->cdr()) {
+            $forms[] = $rest->first();
         }
+
+        $context = $this->isStatic ? 'php/::' : 'php/->';
+        $args = new PhpInteropArgsAnalyzer($this->analyzer)->analyze(
+            $forms,
+            $env->withExpressionContext()->withDisallowRecurFrame(),
+            $context,
+            $segment,
+        );
 
         /** @psalm-suppress PossiblyNullArgument */
         /** @var Symbol $callSymbol */

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/ByRefLocalCollector.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/ByRefLocalCollector.php
@@ -22,6 +22,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayGetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayPushNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArraySetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayUnsetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpNamedArgNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpNewNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectSetNode;
@@ -101,6 +102,7 @@ final class ByRefLocalCollector
             $node instanceof PhpObjectSetNode => [$node->getLeftExpr(), $node->getRightExpr()],
             $node instanceof MethodCallNode => $node->getArgs(),
             $node instanceof PhpNewNode => [$node->getClassExpr(), ...$node->getArgs()],
+            $node instanceof PhpNamedArgNode => [$node->getValueExpr()],
             $node instanceof RecurNode => $node->getExpressions(),
             $node instanceof SetVarNode => [$node->getSymbol(), $node->getValueExpr()],
             $node instanceof PhpArraySetNode => [$node->getArrayExpr(), ...$node->getAccessExprs(), $node->getValueExpr()],

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpNamedArgEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpNamedArgEmitter.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpNamedArgNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+
+use function assert;
+
+/**
+ * Emits a `(... :& :name value)` argument as a PHP 8 named argument
+ * `name: <value>`. The parameter name is emitted verbatim, so the keyword
+ * must match the PHP parameter name exactly (like interop method names).
+ */
+final class PhpNamedArgEmitter implements NodeEmitterInterface
+{
+    use WithOutputEmitterTrait;
+
+    public function emit(AbstractNode $node): void
+    {
+        assert($node instanceof PhpNamedArgNode);
+
+        $this->outputEmitter->emitStr($node->getName() . ': ', $node->getStartSourceLocation());
+        $this->outputEmitter->emitNode($node->getValueExpr());
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -30,6 +30,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayPushNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArraySetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayUnsetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpNamedArgNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpNewNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectSetNode;
@@ -74,6 +75,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpArrayPushEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpArraySetEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpArrayUnsetEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpClassNameEmitter;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpNamedArgEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpNewEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpObjectCallEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpObjectSetEmitter;
@@ -139,6 +141,7 @@ final class NodeEmitterFactory
             VectorNode::class => new VectorEmitter($outputEmitter),
             SetNode::class => new SetEmitter($outputEmitter),
             PhpNewNode::class => new PhpNewEmitter($outputEmitter),
+            PhpNamedArgNode::class => new PhpNamedArgEmitter($outputEmitter),
             PhpVarNode::class => new PhpVarEmitter($outputEmitter),
             PhpObjectCallNode::class => new PhpObjectCallEmitter($outputEmitter),
             PhpRefNode::class => new PhpRefEmitter($outputEmitter),

--- a/tests/phel/core/interop-named-args.phel
+++ b/tests/phel/core/interop-named-args.phel
@@ -1,0 +1,27 @@
+(ns phel-test.core.interop-named-args
+  (:require phel.test :refer [deftest is]))
+
+(def by-ref-target "PhelTest\\Fixtures\\Interop\\ByRefTarget")
+
+(deftest php-new-with-named-args
+  (let [ao (php/new \ArrayObject :& :array (php/array 1 2 3))]
+    (is (= 3 (php/-> ao (count))) "named args bind to the constructor parameters")))
+
+(deftest php-new-with-positional-then-named-args
+  (let [dt (php/new \DateTime "2024-01-15 00:00:00" :& :timezone nil)]
+    (is (= "2024-01-15" (php/-> dt (format "Y-m-d"))) "positional args mix with trailing named args")))
+
+(deftest php-static-call-with-named-args
+  (let [dt (php/:: \DateTime (createFromFormat :& :format "Y-m-d" :datetime "2024-01-15"))]
+    (is (= "2024-01-15" (php/-> dt (format "Y-m-d"))) "static interop calls accept named args")))
+
+(deftest php-method-call-with-named-args
+  (let [ao (php/new \ArrayObject (php/array 1 2))]
+    (php/-> ao (setFlags :& :flags \ArrayObject/ARRAY_AS_PROPS))
+    (is (= 2 (php/-> ao (count))) "method interop calls accept named args")))
+
+(deftest php-ref-inside-a-named-arg-writes-back
+  (let [t   (php/new by-ref-target)
+        out "init"]
+    (php/-> t (writeInto :& :out (php/ref out) :value "written"))
+    (is (= "written" out) "php/ref still writes back when passed as a named argument")))

--- a/tests/php/Integration/Fixtures/Call/php-method-call-named-args.test
+++ b/tests/php/Integration/Fixtures/Call/php-method-call-named-args.test
@@ -1,0 +1,8 @@
+--PHEL--
+(let [o (php/new \ArrayObject)] (php/-> o (setFlags :& :flags 1)))
+--PHP--
+$o_1 = (new \ArrayObject());
+(function() use($o_1) {
+  $target_2 = $o_1;
+  return $target_2->setFlags(flags: 1);
+})();

--- a/tests/php/Integration/Fixtures/Call/php-static-call-named-args.test
+++ b/tests/php/Integration/Fixtures/Call/php-static-call-named-args.test
@@ -1,0 +1,4 @@
+--PHEL--
+(php/:: \DateTime (createFromFormat :& :format "Y" :datetime "2024"))
+--PHP--
+(\DateTime::createFromFormat(format: "Y", datetime: "2024"));

--- a/tests/php/Integration/Fixtures/New/new-named-args.test
+++ b/tests/php/Integration/Fixtures/New/new-named-args.test
@@ -1,0 +1,4 @@
+--PHEL--
+(php/new \ArrayObject :& :array (php/array 1 2) :flags 0)
+--PHP--
+(new \ArrayObject(array: array(1, 2), flags: 0));

--- a/tests/php/Integration/Fixtures/New/new-positional-and-named-args.test
+++ b/tests/php/Integration/Fixtures/New/new-positional-and-named-args.test
@@ -1,0 +1,4 @@
+--PHEL--
+(php/new \DateTime "now" :& :timezone nil)
+--PHP--
+(new \DateTime("now", timezone: null));

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/PhpNewSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/PhpNewSymbolTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm;
+
+use Phel;
+use Phel\Compiler\Application\Analyzer;
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpNamedArgNode;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpNewSymbol;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Shared\Exceptions\AbstractLocatedException;
+use PHPUnit\Framework\TestCase;
+
+final class PhpNewSymbolTest extends TestCase
+{
+    private AnalyzerInterface $analyzer;
+
+    protected function setUp(): void
+    {
+        $this->analyzer = new Analyzer(new GlobalEnvironment());
+    }
+
+    public function test_named_args_after_marker_become_named_arg_nodes(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_PHP_NEW),
+            Symbol::create('\\DateTime'),
+            'now',
+            Keyword::create('&'),
+            Keyword::create('timezone'),
+            null,
+        ]);
+
+        $node = new PhpNewSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+
+        $args = $node->getArgs();
+        self::assertCount(2, $args, 'one positional arg and one named arg');
+        self::assertNotInstanceOf(PhpNamedArgNode::class, $args[0]);
+        self::assertInstanceOf(PhpNamedArgNode::class, $args[1]);
+        self::assertSame('timezone', $args[1]->getName());
+    }
+
+    public function test_keywords_before_the_marker_stay_positional(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_PHP_NEW),
+            Symbol::create('\\DateTime'),
+            Keyword::create('not-a-name'),
+        ]);
+
+        $node = new PhpNewSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+
+        $args = $node->getArgs();
+        self::assertCount(1, $args);
+        self::assertNotInstanceOf(PhpNamedArgNode::class, $args[0]);
+    }
+
+    public function test_missing_value_for_named_arg_throws(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage("Missing value for named argument ':timezone'");
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_PHP_NEW),
+            Symbol::create('\\DateTime'),
+            Keyword::create('&'),
+            Keyword::create('timezone'),
+        ]);
+
+        new PhpNewSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_non_keyword_after_marker_throws(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage('must be :key value pairs');
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_PHP_NEW),
+            Symbol::create('\\DateTime'),
+            Keyword::create('&'),
+            'not-a-keyword',
+            1,
+        ]);
+
+        new PhpNewSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_empty_after_marker_throws(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage('must be followed by :key value pairs');
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_PHP_NEW),
+            Symbol::create('\\DateTime'),
+            Keyword::create('&'),
+        ]);
+
+        new PhpNewSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+    }
+}

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ByRefLocalCollectorTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ByRefLocalCollectorTest.php
@@ -10,6 +10,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
 use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpNamedArgNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpRefNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
@@ -37,6 +38,13 @@ final class ByRefLocalCollectorTest extends TestCase
         $outer = new DoNode($this->env(), [$this->literal()], $inner);
 
         self::assertSame(['m'], $this->collect($outer));
+    }
+
+    public function test_collects_php_ref_from_a_named_argument_value(): void
+    {
+        $named = new PhpNamedArgNode($this->env(), 'out', $this->ref('m'));
+
+        self::assertSame(['m'], $this->collect($named));
     }
 
     public function test_de_duplicates_repeated_locals(): void


### PR DESCRIPTION
## 🤔 Background

PHP 8 named arguments are the idiomatic, readable call form for constructors and methods with long optional-parameter lists (Doctrine/Symfony DTOs, value objects). Phel interop (`php/new`, `php/->`, `php/::`) could only emit positional arguments.

## 💡 Goal

Let interop calls emit PHP 8 named arguments, mixable after positional args, without changing the meaning of any existing call.

Closes #2311

## 🔖 Changes

Syntax: a `:&` marker separates positional args from trailing `:name value` pairs. The explicit marker was chosen over "trailing keywords" or "trailing map" because it is unambiguous — keywords and maps stay valid positional values, so existing calls are untouched — and it mirrors Phel's own `&` rest-arg marker.

```phel
(php/new \App\Mailer :& :host "smtp" :port 25 :secure true)
;; => new \App\Mailer(host: "smtp", port: 25, secure: true)

(php/new \DateTime "now" :& :timezone tz)                  ; positional + named
(php/-> client (request "POST" :& :uri "/x" :timeout 5))
(php/:: \DateTime (createFromFormat :& :format "Y-m-d" :datetime "2024-01-15"))
```

- New `PhpNamedArgNode` + `PhpNamedArgEmitter` render `name: <value>` (parameter name emitted verbatim, like interop method names). Registered in `NodeEmitterFactory`; no change to `emitArgList`.
- New `PhpInteropArgsAnalyzer` parses the argument forms (positional → marker → `:key value` pairs) for both `PhpNewSymbol` and `PhpObjectCallSymbol`, with clear errors for a missing value, a non-keyword after `:&`, or an empty `:&`.
- `ByRefLocalCollector` descends into named-arg values, so `php/ref` works as a named-argument value (`:out (php/ref x)`).
- Tests: `PhpNewSymbolTest` (named args + error cases), a `ByRefLocalCollectorTest` case, four integration fixtures (new / new+positional / static / method), and Phel-level runtime tests in `interop-named-args.phel` (incl. by-ref-as-named-arg). Docs in `php-interop.md` and a `CHANGELOG.md` entry.

A final refactor pass surfaced no further cleanups; the static-analysis gate (cs-fixer, psalm, phpstan, rector) is green.
