### PR TITLE
feat(core): iterator-seq lazy bridge over PHP Iterator/Generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `iterator-seq`: wraps a PHP `Traversable` (Iterator/Generator/IteratorAggregate) as a lazy seq, pulling one element at a time so a large or infinite cursor streams instead of materialising via `iterator_to_array` (#2312)
 - `phel.http`: JSON request bodies decode into `:parsed-body`, plus `json-response`/`html-response` builders (#2271)
 - Docs: runnable `docs/examples/13_database-crud.phel` and a maps-not-entities Persistence section in `framework-integration.md` (#2281, #2282)
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -995,6 +995,17 @@
   [f x]
   (lazy-seq-from-generator (php/:: Seq (iterate f x))))
 
+(defn iterator-seq
+  "Returns a lazy sequence over a PHP `Traversable` (Iterator, Generator,
+  IteratorAggregate, ...), pulling one element at a time. Unlike the eager
+  coercion that materialises a `Traversable` via `iterator_to_array`, this
+  streams a large or infinite source (DB cursor, stream reader, paginated
+  API), so `take`/`map`/`filter` only pull what they consume."
+  {:example "(take 3 (iterator-seq (php/new \\ArrayIterator (php/array 1 2 3 4 5)))) ; => @[1 2 3]"
+   :see-also ["lazy-seq" "map" "take"]}
+  [traversable]
+  (php/:: LazySeq (fromTraversable (php/new Hasher) (php/new Equalizer) traversable)))
+
 (defn cycle
   "Returns an infinite lazy sequence that cycles through the elements of
   collection. Maps are iterated as `[key value]` pairs."

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -90,6 +90,36 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
     }
 
     /**
+     * Creates a LazySeq from any PHP Traversable (Iterator, Generator,
+     * IteratorAggregate, ...), pulling one element at a time.
+     *
+     * Unlike {@see fromIterable}, a non-array, non-Generator Traversable is
+     * NOT materialised eagerly, so a large or infinite cursor (DB result,
+     * stream reader, paginated API) streams lazily.
+     *
+     * @template U
+     *
+     * @param Traversable<mixed, U>                     $traversable
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
+     *
+     * @return self<U>
+     */
+    public static function fromTraversable(
+        HasherInterface $hasher,
+        EqualizerInterface $equalizer,
+        Traversable $traversable,
+        ?PersistentMapInterface $meta = null,
+    ): self {
+        $generator = $traversable instanceof Generator
+            ? $traversable
+            : (static function () use ($traversable): Generator {
+                yield from $traversable;
+            })();
+
+        return self::fromGenerator($hasher, $equalizer, $generator, $meta);
+    }
+
+    /**
      * Creates a LazySeq from any iterable.
      *
      * @template U

--- a/tests/phel/core/iterator-seq.phel
+++ b/tests/phel/core/iterator-seq.phel
@@ -1,0 +1,29 @@
+(ns phel-test.core.iterator-seq
+  (:require phel.test :refer [deftest is]))
+
+(defn- array-iterator [& xs]
+  (php/new \ArrayIterator (apply php/array xs)))
+
+(defn- naturals []
+  (loop [i 0]
+    (php/yield i)
+    (recur (inc i))))
+
+(deftest iterator-seq-over-a-finite-traversable
+  (is (= [1 2 3] (vec (iterator-seq (array-iterator 1 2 3))))
+      "wraps a PHP Traversable as a seq"))
+
+(deftest iterator-seq-is-composable-with-lazy-ops
+  (is (= [2 3 4] (vec (->> (array-iterator 1 2 3 4 5)
+                              (iterator-seq)
+                              (map inc)
+                              (take 3))))
+      "map/take compose over an iterator-seq"))
+
+(deftest iterator-seq-empty-traversable
+  (is (= [] (vec (iterator-seq (array-iterator))))
+      "an empty Traversable yields an empty seq"))
+
+(deftest iterator-seq-streams-an-infinite-generator
+  (is (= [0 1 2 3 4] (vec (take 5 (iterator-seq (naturals)))))
+      "take pulls only what it consumes, so an infinite generator terminates"))

--- a/tests/php/Unit/Lang/Collections/LazySeq/LazySeqTest.php
+++ b/tests/php/Unit/Lang/Collections/LazySeq/LazySeqTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Lang\Collections\LazySeq;
 
+use ArrayIterator;
 use Generator;
+use Iterator;
+use IteratorAggregate;
 use Phel\Lang\Collections\LazySeq\Cons;
 use Phel\Lang\Collections\LazySeq\LazySeq;
 use Phel\Lang\Collections\LazySeq\LazySeqInterface;
@@ -91,6 +94,58 @@ final class LazySeqTest extends TestCase
 
         $this->assertSame(1, $lazySeq->first());
         $this->assertSame([1, 2, 3], $lazySeq->toArray());
+    }
+
+    public function test_creates_from_traversable_iterator(): void
+    {
+        $lazySeq = LazySeq::fromTraversable($this->hasher, $this->equalizer, new ArrayIterator([1, 2, 3]));
+
+        $this->assertSame([1, 2, 3], $lazySeq->toArray());
+    }
+
+    public function test_creates_from_traversable_iterator_aggregate(): void
+    {
+        $aggregate = new class() implements IteratorAggregate {
+            public function getIterator(): Iterator
+            {
+                return new ArrayIterator(['a', 'b']);
+            }
+        };
+
+        $lazySeq = LazySeq::fromTraversable($this->hasher, $this->equalizer, $aggregate);
+
+        $this->assertSame(['a', 'b'], $lazySeq->toArray());
+    }
+
+    public function test_from_traversable_delegates_a_generator(): void
+    {
+        $generator = (static function (): Generator {
+            yield 1;
+            yield 2;
+        })();
+
+        $lazySeq = LazySeq::fromTraversable($this->hasher, $this->equalizer, $generator);
+
+        $this->assertSame([1, 2], $lazySeq->toArray());
+    }
+
+    public function test_from_traversable_pulls_lazily_from_an_infinite_iterator(): void
+    {
+        $pulled = 0;
+        $infinite = (static function () use (&$pulled): Generator {
+            $i = 0;
+            while (true) {
+                ++$pulled;
+                yield $i;
+                ++$i;
+            }
+        })();
+
+        $lazySeq = LazySeq::fromTraversable($this->hasher, $this->equalizer, $infinite);
+
+        $this->assertSame(0, $lazySeq->first());
+        $this->assertSame(1, $lazySeq->cdr()?->first());
+        $this->assertLessThan(5, $pulled, 'only the consumed elements are pulled, never the whole iterator');
     }
 
     public function test_first_returns_first_element(): void


### PR DESCRIPTION
## 🤔 Background

`Seq` materialises a PHP `Traversable` eagerly via `iterator_to_array`, so consuming a large or infinite `Generator`/`Iterator` (DB cursor, file/stream reader, paginated API) loads everything into memory or never returns.

## 💡 Goal

A lazy bridge that wraps a PHP `Iterator`/`Generator`/`IteratorAggregate` as a Phel lazy seq, pulling one element at a time and composing with `map`/`filter`/`take`. Existing eager coercion stays intact (this is opt-in for streaming).

Closes #2312

## 🔖 Changes

- `LazySeq::fromTraversable(hasher, equalizer, Traversable, ?meta)`: wraps a non-Generator `Traversable` in a `yield from` generator (Generators pass straight through) and delegates to the existing one-at-a-time `fromGenerator`. No `iterator_to_array`.
- Core fn `iterator-seq` (in `seq-fns.phel`) exposing it, with `:doc`/`:see-also`/`:example`.

```phel
(->> (php/-> $pdo (query "select * from big"))   ; PDOStatement is Traversable
     (iterator-seq)
     (map row->record)
     (take 10))                                  ; only ~10 rows pulled
```

- Tests: `LazySeqTest` cases for an `ArrayIterator`, an `IteratorAggregate`, a delegated `Generator`, and lazy pulling from an infinite iterator (asserts only the consumed elements are pulled); Phel-level `iterator-seq.phel` covering a finite Traversable, `map`/`take` composition, an empty Traversable, and a `take` from an infinite generator that terminates. `CHANGELOG.md` updated.

A final refactor pass surfaced no further cleanups; the static-analysis gate (cs-fixer, psalm, phpstan, rector) is green.
