### PR TITLE
feat(lang): plain string offsets for struct array access ($s['x'])

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Printer: structs print with the `.` separator (`(my.ns.point 1 2)`) instead of `\` (#2255)
 - Docs: function `:example` outputs now match what the REPL prints, so `phel doc` and the phel-lang.org API reference are accurate
 - `phel->php`: integer/string map keys now convert instead of throwing `getName() on int` (unblocks PDO option maps) (#2298)
+- Structs: `$struct['field']` array access now accepts a plain PHP string offset (previously threw `getName() on string`); structs already implement `\Countable`/`\ArrayAccess`/`\IteratorAggregate`, so `count`/`$s['x']`/`foreach` work from PHP. Iteration keeps keyword keys to preserve the Phel map contract (#2313)
 
 ### Added
 

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -297,6 +297,8 @@ When the generated PHP must satisfy a framework's type expectations, opt-in meta
    ^{:tag string} name])
 ```
 
+Every struct already implements `\Countable`, `\ArrayAccess`, and `\IteratorAggregate` (no opt-in needed), so PHP code can `count($s)` and read fields by a plain string offset (`$s['name']`) as well as a keyword. Structs are immutable, so writing an offset throws. Iteration keeps Phel's map contract (keyword keys), so `(into {} s)` and `(keys s)` stay keyword-keyed.
+
 Two related forms:
 
 - `(defenum Status :active "active" :inactive "inactive")` — native PHP backed enum (Doctrine/Symfony columns) plus a `Status?` predicate.

--- a/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
+++ b/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
@@ -18,6 +18,7 @@ use Traversable;
 
 use function count;
 use function in_array;
+use function is_string;
 use function sprintf;
 
 /**
@@ -85,6 +86,28 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
         return $this->{$stringKey};
     }
 
+    /**
+     * Accepts a PHP-idiomatic string offset (`$s['x']`) in addition to a
+     * keyword, so array access works from plain PHP. Keyword access is
+     * unchanged.
+     *
+     * @param Keyword|string $offset
+     */
+    #[Override]
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->find($this->normalizeOffset($offset));
+    }
+
+    /**
+     * @param Keyword|string $offset
+     */
+    #[Override]
+    public function offsetExists(mixed $offset): bool
+    {
+        return $this->contains($this->normalizeOffset($offset));
+    }
+
     public function getIterator(): Traversable
     {
         foreach (static::ALLOWED_KEYS as $key) {
@@ -126,6 +149,17 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
 
         $structName = static::class;
         throw new InvalidArgumentException(sprintf("This key '%s' is not allowed for struct %s", (string) $key, $structName));
+    }
+
+    /**
+     * Coerces a string field name to its keyword; passes other offsets
+     * through unchanged.
+     *
+     * @param Keyword|string $offset
+     */
+    private function normalizeOffset(mixed $offset): mixed
+    {
+        return is_string($offset) ? Phel::keyword($offset) : $offset;
     }
 
     /**

--- a/tests/phel/core/struct-array-access.phel
+++ b/tests/phel/core/struct-array-access.phel
@@ -1,0 +1,26 @@
+(ns phel-test.core.struct-array-access
+  (:require phel.test :refer [deftest is]))
+
+(defstruct point [x y])
+
+(deftest struct-reads-via-string-offset
+  (let [p (point 3 4)]
+    (is (= 3 (php/aget p "x")) "a plain PHP string offset reads the field")
+    (is (= 4 (php/aget p "y")) "string offset works for every field")))
+
+(deftest struct-keyword-offset-still-works
+  (let [p (point 3 4)]
+    (is (= 3 (php/aget p :x)) "keyword offset is unchanged")
+    (is (= 3 (get p :x)) "the map protocol is unchanged")))
+
+(deftest struct-satisfies-spl-interfaces
+  (let [p (point 3 4)]
+    (is (php/is_a p "Countable") "structs are Countable")
+    (is (php/is_a p "ArrayAccess") "structs are ArrayAccess")
+    (is (php/is_a p "IteratorAggregate") "structs are IteratorAggregate")
+    (is (= 2 (php/count p)) "count returns the field count")))
+
+(deftest struct-iteration-keeps-keyword-keys
+  (let [p (point 3 4)]
+    (is (= [:x :y] (keys p)) "iteration stays keyword-keyed (Phel map contract)")
+    (is (= {:x 3 :y 4} (into {} p)) "into a map keeps keyword keys")))

--- a/tests/php/Unit/Lang/Collections/Struct/StructTest.php
+++ b/tests/php/Unit/Lang/Collections/Struct/StructTest.php
@@ -69,6 +69,19 @@ final class StructTest extends TestCase
         $s[Keyword::create('c')];
     }
 
+    public function test_offset_get_with_string_key(): void
+    {
+        $s = FakeStruct::fromKVs(Keyword::create('a'), 1, Keyword::create('b'), 2);
+        self::assertSame(1, $s['a'], 'a plain PHP string offset reads the field');
+    }
+
+    public function test_offset_exists_with_string_key(): void
+    {
+        $s = FakeStruct::fromKVs(Keyword::create('a'), 1, Keyword::create('b'), 2);
+        self::assertArrayHasKey('a', $s, 'string offset exists for an allowed field');
+        self::assertArrayNotHasKey('c', $s, 'string offset is absent for an unknown field');
+    }
+
     public function test_count(): void
     {
         $s = FakeStruct::fromKVs(Keyword::create('a'), 1, Keyword::create('b'), 2);


### PR DESCRIPTION
## 🤔 Background

#2292 added opt-in `^{:php/json}` / `^{:php/stringable}` markers. This issue proposed opt-in `^{:php/countable}`, `^{:php/array-access}`, `^{:php/iterable}` markers to add the matching SPL interfaces.

While investigating, I found that structs **already** implement all three interfaces via `AbstractPersistentMap`: `count($s)`, `instanceof Countable/ArrayAccess/IteratorAggregate`, keyword access `$s[:x]`, and `foreach` already work on a plain struct, no marker needed. The only genuine gap was PHP-idiomatic **string** access `$s['x']`, which threw `Call to a member function getName() on string` because the inherited offset methods expected a keyword.

So opt-in markers would be redundant. After confirming with the maintainer, the chosen direction is **universal string-key access** (no marker).

## 💡 Goal

Make `$struct['field']` work from plain PHP for every struct, without changing keyword access or Phel's map semantics.

Closes #2313

## 🔖 Changes

- `AbstractPersistentStruct` overrides `offsetGet`/`offsetExists` to coerce a string offset to its keyword (`$s['x']` now reads the field). Keyword access (`$s[:x]`, `(get s :x)`) is unchanged; immutable offset writes still throw (inherited).
- **Iteration intentionally keeps keyword keys.** `getIterator` is the same method Phel uses for `(into {} s)`, `(keys s)`, and `(foreach [k v s] …)`, which must stay keyword-keyed to preserve the Phel map contract; switching it to string keys would silently change those results. PHP code needing a string key uses array access (`$s['x']`).
- Tests: `StructTest` string-offset get/exists; Phel-level `struct-array-access.phel` (string + keyword read, the three `instanceof`s, `count`, and a guard that `keys`/`into {}` stay keyword-keyed). Docs in `framework-integration.md` and a `CHANGELOG.md` entry.

A final refactor pass surfaced no further cleanups; the static-analysis gate (cs-fixer, psalm, phpstan, rector) is green.
