### PR TITLE
feat(reflect): read PHP 8 attributes at runtime (class/method/property)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `phel.reflect`: `class-attributes`/`method-attributes`/`property-attributes`/`attributes` read PHP 8 attributes off a class, method, or property as `{:name fqcn :args {...}}` maps (named args keyword-keyed, positional indexed), so Phel can consume attribute-annotated PHP/framework code (#2314)
 - `iterator-seq`: wraps a PHP `Traversable` (Iterator/Generator/IteratorAggregate) as a lazy seq, pulling one element at a time so a large or infinite cursor streams instead of materialising via `iterator_to_array` (#2312)
 - `phel.http`: JSON request bodies decode into `:parsed-body`, plus `json-response`/`html-response` builders (#2271)
 - Docs: runnable `docs/examples/13_database-crud.phel` and a maps-not-entities Persistence section in `framework-integration.md` (#2281, #2282)

--- a/src/phel/reflect.phel
+++ b/src/phel/reflect.phel
@@ -79,6 +79,54 @@
       (conj! names iface))
     (persistent! names)))
 
+(defn- attribute-args
+  "Builds the `:args` map for a `ReflectionAttribute`: named arguments become
+  keyword keys, positional arguments keep their integer index."
+  [a]
+  (let [res (transient {})]
+    (foreach [k v (php/-> a (getArguments))]
+      (php/-> res (put (if (string? k) (keyword k) k) v)))
+    (persistent res)))
+
+(defn- attribute->map [a]
+  {:name (php/-> a (getName))
+   :args (attribute-args a)})
+
+(defn- attributes-of [reflectable]
+  (vec (for [a :in (php/-> reflectable (getAttributes))]
+         (attribute->map a))))
+
+(defn class-attributes
+  "Returns a vector of attribute maps for the class `class-or-name` (string FQN
+  or object). Each map is `{:name <attribute-fqcn> :args {...}}`, where `:args`
+  keys named arguments as keywords and positional arguments by index."
+  {:example "(class-attributes \\App\\Controller\\ProductController)"
+   :see-also ["method-attributes" "property-attributes" "attributes"]}
+  [class-or-name]
+  (attributes-of (reflection-class class-or-name)))
+
+(defn method-attributes
+  "Returns a vector of attribute maps for method `method-name` on `class-or-name`."
+  {:example "(method-attributes \\App\\Foo \"handle\")"
+   :see-also ["class-attributes" "property-attributes"]}
+  [class-or-name method-name]
+  (attributes-of (php/-> (reflection-class class-or-name) (getMethod method-name))))
+
+(defn property-attributes
+  "Returns a vector of attribute maps for property `property-name` on `class-or-name`."
+  {:example "(property-attributes \\App\\Foo \"id\")"
+   :see-also ["class-attributes" "method-attributes"]}
+  [class-or-name property-name]
+  (attributes-of (php/-> (reflection-class class-or-name) (getProperty property-name))))
+
+(defn attributes
+  "Returns the class-level attribute maps for `obj-or-class`; an instance uses
+  its class. Convenience alias of `class-attributes`."
+  {:example "(attributes my-controller)"
+   :see-also ["class-attributes" "method-attributes" "property-attributes"]}
+  [obj-or-class]
+  (class-attributes obj-or-class))
+
 (defn class-info
   "Returns a map describing `class-or-name` with `:name`, `:methods`,
   `:properties`, `:parents`, and `:interfaces` keys."

--- a/tests/phel/reflect.phel
+++ b/tests/phel/reflect.phel
@@ -53,3 +53,29 @@
         "ArrayObject implements Countable")
     (is (contains? sset "Traversable")
         "ArrayObject implements Traversable")))
+
+(def- annotated "PhelTest\\Fixtures\\Reflection\\AnnotatedController")
+(def- route-attr "PhelTest\\Fixtures\\Reflection\\Route")
+
+(deftest class-attributes-reads-class-level-attributes
+  (let [attrs (r/class-attributes annotated)
+        attr  (first attrs)]
+    (is (= 1 (count attrs)) "one class-level attribute")
+    (is (= route-attr (get attr :name)) ":name is the attribute FQCN")
+    (testing "positional args are indexed, named args are keyword-keyed"
+             (is (= "/products" (get-in attr [:args 0])))
+             (is (= "GET" (get-in attr [:args :method]))))))
+
+(deftest method-attributes-reads-method-level-attributes
+  (let [attr (first (r/method-attributes annotated "create"))]
+    (is (= route-attr (get attr :name)))
+    (is (= "POST" (get-in attr [:args :method])) "method attribute named arg")))
+
+(deftest property-attributes-reads-property-level-attributes
+  (let [attr (first (r/property-attributes annotated "id"))]
+    (is (= route-attr (get attr :name)))
+    (is (= "/products/{id}" (get-in attr [:args 0])) "property attribute positional arg")))
+
+(deftest attributes-alias-works-on-an-instance
+  (let [attr (first (r/attributes (php/new annotated)))]
+    (is (= route-attr (get attr :name)) "an instance reflects its class' attributes")))

--- a/tests/php/Fixtures/Reflection/AnnotatedController.php
+++ b/tests/php/Fixtures/Reflection/AnnotatedController.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Fixtures\Reflection;
+
+/**
+ * Carries attributes at class, method, and property level so the Phel
+ * reflection helpers can read each back.
+ */
+#[Route('/products', method: 'GET')]
+final class AnnotatedController
+{
+    #[Route('/products/{id}')]
+    public string $id = '';
+
+    #[Route('/products', method: 'POST')]
+    public function create(): string
+    {
+        return $this->id;
+    }
+}

--- a/tests/php/Fixtures/Reflection/Route.php
+++ b/tests/php/Fixtures/Reflection/Route.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Fixtures\Reflection;
+
+use Attribute;
+
+/**
+ * A small route-like attribute so the Phel attribute-reflection tests can
+ * read both positional and named arguments back as a Phel map.
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
+final class Route
+{
+    public function __construct(
+        public string $path,
+        public string $method = 'GET',
+    ) {}
+}


### PR DESCRIPTION
## 🤔 Background

Phel can emit `#[Attr]` (the `:php/attr` family) but had no way to *read* attributes off existing PHP classes/methods/properties — the basis for routers, validators, serializers, and DI wiring that consume attribute-annotated PHP/framework code.

## 💡 Goal

Reflection-backed helpers that return PHP 8 attribute data as Phel maps, complementing the `:php/attr` emission features.

Closes #2314

## 🔖 Changes

Added to `phel.reflect` (wrapping `ReflectionClass`/`ReflectionMethod`/`ReflectionProperty` `getAttributes()`):

- `class-attributes` (string FQN or instance), `method-attributes`, `property-attributes`, and an `attributes` alias (an instance reflects its class).
- Each attribute is `{:name <fqcn> :args {...}}`, where `:args` keys **named** arguments as keywords and **positional** arguments by index:

```phel
(class-attributes \App\Controller\ProductController)
;; => [{:name "...\\Route" :args {0 "/products" :method "GET"}}]
```

- Tests: a `PhelTest\Fixtures\Reflection\{Route, AnnotatedController}` fixture carrying class/method/property attributes, with Phel-level tests asserting the `:name`/`:args` shape (positional + named) at each level and via the instance alias.
- `CHANGELOG.md` updated. (`phel.reflect` is documented through `:doc`/`:example` metadata, which feeds `phel doc` and the API reference.)

A final refactor pass surfaced no further cleanups; the static-analysis gate (cs-fixer, psalm, phpstan, rector) is green.
