### PR TITLE
feat(reflect): native PHP enum <-> keyword bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `phel.reflect`: `class-attributes`/`method-attributes`/`property-attributes`/`attributes` read PHP 8 attributes off a class, method, or property as `{:name fqcn :args {...}}` maps (named args keyword-keyed, positional indexed), so Phel can consume attribute-annotated PHP/framework code (#2314)
+- `phel.reflect`: `enum->keyword`/`keyword->enum`/`enum-values` bridge a native PHP enum (Symfony/Doctrine column enums, library enums) to Phel keywords and back, round-tripping with `defenum`-generated enums (#2315)
 - `iterator-seq`: wraps a PHP `Traversable` (Iterator/Generator/IteratorAggregate) as a lazy seq, pulling one element at a time so a large or infinite cursor streams instead of materialising via `iterator_to_array` (#2312)
 - `phel.http`: JSON request bodies decode into `:parsed-body`, plus `json-response`/`html-response` builders (#2271)
 - Docs: runnable `docs/examples/13_database-crud.phel` and a maps-not-entities Persistence section in `framework-integration.md` (#2281, #2282)

--- a/src/phel/reflect.phel
+++ b/src/phel/reflect.phel
@@ -145,3 +145,34 @@
                                  (conj acc (php/-> p (getName))))
                           acc)))
      :interfaces (vec (php/-> rc (getInterfaceNames)))}))
+
+;; Bridge native PHP enums (Symfony/Doctrine column enums, library enums)
+;; to Phel keywords and back. Works with `defenum`-generated enums and any
+;; native PHP enum.
+
+(defn enum->keyword
+  "Returns the keyword for a native PHP enum `enum-case`, using the case name
+  verbatim (`Status/Active` => `:Active`). Round-trips with `keyword->enum`."
+  {:example "(enum->keyword Status/Active)"
+   :see-also ["keyword->enum" "enum-values"]}
+  [enum-case]
+  (keyword (php/-> enum-case name)))
+
+(defn keyword->enum
+  "Returns the case of the native PHP enum `enum-class` (string FQN) whose name
+  matches keyword `kw`, or nil when no case matches. Inverse of `enum->keyword`."
+  {:example "(keyword->enum \\App\\Status :Active)"
+   :see-also ["enum->keyword" "enum-values"]}
+  [enum-class kw]
+  (let [case-name (name kw)]
+    (first (filter (fn [c] (= case-name (php/-> c name)))
+                   (php/:: enum-class (cases))))))
+
+(defn enum-values
+  "Returns a vector of keywords, one per case of the native PHP enum
+  `enum-class` (string FQN), in declaration order."
+  {:example "(enum-values \\App\\Status)"
+   :see-also ["enum->keyword" "keyword->enum"]}
+  [enum-class]
+  (vec (for [c :in (php/:: enum-class (cases))]
+         (enum->keyword c))))

--- a/tests/phel/reflect.phel
+++ b/tests/phel/reflect.phel
@@ -79,3 +79,24 @@
 (deftest attributes-alias-works-on-an-instance
   (let [attr (first (r/attributes (php/new annotated)))]
     (is (= route-attr (get attr :name)) "an instance reflects its class' attributes")))
+
+(def- status-class "PhelTest\\Fixtures\\Enum\\Status")
+(def- status-active (php/:: \PhelTest\Fixtures\Enum\Status Active))
+
+(deftest enum->keyword-uses-the-case-name
+  (is (= :Active (r/enum->keyword status-active))
+      "an enum case maps to a keyword of its case name"))
+
+(deftest keyword->enum-resolves-the-case
+  (is (= status-active (r/keyword->enum status-class :Active))
+      "a keyword resolves back to the matching case")
+  (is (nil? (r/keyword->enum status-class :Missing))
+      "an unknown keyword resolves to nil"))
+
+(deftest enum-keyword-round-trips
+  (is (= status-active (r/keyword->enum status-class (r/enum->keyword status-active)))
+      "enum->keyword then keyword->enum returns the original case"))
+
+(deftest enum-values-lists-every-case
+  (is (= [:Active :Inactive] (r/enum-values status-class))
+      "enum-values returns a keyword per case in declaration order"))

--- a/tests/php/Fixtures/Enum/Status.php
+++ b/tests/php/Fixtures/Enum/Status.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Fixtures\Enum;
+
+/**
+ * A native backed enum so the Phel enum<->keyword bridge tests can round-trip
+ * an external PHP enum.
+ */
+enum Status: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+}


### PR DESCRIPTION
## 🤔 Background

`defenum` (#2291) *produces* native backed enums, but consuming an **external** PHP enum (Symfony/Doctrine column enums, library enums) into Phel data — and back — had no helper, so values crossed the boundary as opaque enum objects.

## 💡 Goal

A keyword bridge for native PHP enums, round-tripping with `defenum`-generated enums and any native PHP enum.

Closes #2315

## 🔖 Changes

Added to `phel.reflect`:

- `enum->keyword` — a case to a keyword of its name verbatim (`Status/Active` => `:Active`).
- `keyword->enum` — a keyword back to the matching case via `cases()` (`nil` when none).
- `enum-values` — every case of an enum class as a vector of keywords, in declaration order.

```phel
(enum->keyword Status/Active)        ;; => :Active
(keyword->enum \App\Status :Active)  ;; => the matching case
(enum-values \App\Status)            ;; => [:Active :Inactive]
```

Case names are used **verbatim** (the proposal's `(keyword (php/-> case name))`), so `enum->keyword`/`keyword->enum` round-trip exactly regardless of the enum's naming convention.

- Tests: a `PhelTest\Fixtures\Enum\Status` backed-enum fixture with Phel-level tests for each helper, the round-trip, and the `nil` miss case. `CHANGELOG.md` updated; helpers carry `:doc`/`:example`/`:see-also` (which feed `phel doc` and the API reference).

These live in `phel.reflect` (not core) alongside the other "consume external PHP types as Phel data" helpers, avoiding a core load-order constraint (`keyword`/`filter`/`vec` are defined after `defs.phel`).

A final refactor pass surfaced no further cleanups; the static-analysis gate (cs-fixer, psalm, phpstan, rector) is green.
