### PR TITLE
ref(test): private test-local interop constants

### DIFF
--- a/tests/phel/core/interop-by-ref.phel
+++ b/tests/phel/core/interop-by-ref.phel
@@ -1,7 +1,7 @@
 (ns phel-test.core.interop-by-ref
   (:require phel.test :refer [deftest is]))
 
-(def target "PhelTest\\Fixtures\\Interop\\ByRefTarget")
+(def- target "PhelTest\\Fixtures\\Interop\\ByRefTarget")
 
 (deftest php-ref-observes-by-reference-write
   (let [t   (php/new target)

--- a/tests/phel/core/interop-named-args.phel
+++ b/tests/phel/core/interop-named-args.phel
@@ -1,7 +1,7 @@
 (ns phel-test.core.interop-named-args
   (:require phel.test :refer [deftest is]))
 
-(def by-ref-target "PhelTest\\Fixtures\\Interop\\ByRefTarget")
+(def- by-ref-target "PhelTest\\Fixtures\\Interop\\ByRefTarget")
 
 (deftest php-new-with-named-args
   (let [ao (php/new \ArrayObject :& :array (php/array 1 2 3))]


### PR DESCRIPTION
## 🤔 Background

Follow-up to the interop feature batch (#2310–#2315). The newer test namespaces (`reflect`, `iterator-seq`) use `def-`/`defn-` for test-local helpers, keeping each namespace's public surface to just its `deftest`s. Two interop test namespaces still declared their fixture-class constant with public `def`.

## 💡 Goal

Make the convention consistent: test-local helpers are private.

## 🔖 Changes

- `interop-by-ref.phel`: `(def target …)` → `(def- target …)`.
- `interop-named-args.phel`: `(def by-ref-target …)` → `(def- by-ref-target …)`.

Test-only, no production change. Both suites stay green (11 assertions).
