### PR TITLE
ref: repo-wide code & documentation quality pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `if-let`/`when-let`/`if-some`/`when-first`: now hygienic — a user binding named `temp-sym` is no longer shadowed by the macros' internal temporary
+- Quasiquote of an empty list (`` `() ``) no longer throws `Index out of bounds`; it yields an empty list, like empty vectors/maps already did
+- `str/index-of`: returns `nil` for an empty string instead of leaking a raw PHP `ValueError` (`(index-of "" "a")` => `nil`, `(index-of "" "")` => `0`)
 - Lexer: error/source-map columns are now counted in code points, not bytes, so locations are correct for multibyte (UTF-8) source
 - Printer: structs print with the `.` separator (`(my.ns.point 1 2)`) instead of `\` (#2255)
 - Docs: function `:example` outputs now match what the REPL prints, so `phel doc` and the phel-lang.org API reference are accurate
@@ -34,6 +37,7 @@ Richer PHP interop for bridging Phel to typed PHP / framework code (all opt-in, 
 - Internals: split seven oversized god-classes into focused single-responsibility collaborators across the compiler, runtime, build, and api modules (pure refactors, behavior unchanged): `CallSpecialization`, `CallEmitter` (#2273), `CompiledCodeCache` (#2274), `BigInt` (#2275), `NumericOperations` (#2276), `PhelFnLoader` (#2277), and `Parser` (#2278); also centralized the emitters' bare-expression capture into `OutputEmitter::captureNodeAsExpression()`
 - Tests: `RegistryTest` and `PhelVarTest` snapshot and restore the global `Registry`, fixing order-dependent `phel.core` suite failures (#2256)
 - Docs: condensed every `docs/` guide (~17% smaller), verified against the runtime, and cross-linked to phel-lang.org
+- Quality: repo-wide maintainability pass — explanatory docblocks and `:doc`/`:see-also`/`:example` metadata across modules, safe dead-code/type/naming cleanups, behavior-identical helper extractions, and ~40 new unit tests for previously untested utilities (no behavior change)
 
 ## [0.41.0](https://github.com/phel-lang/phel-lang/compare/v0.40.0...v0.41.0) - 2026-06-01
 

--- a/src/phel/base64.phel
+++ b/src/phel/base64.phel
@@ -8,7 +8,9 @@
   (php/base64_encode s))
 
 (defn decode
-  "Decodes a Base64 string. Optional `strict?` flag validates characters."
+  "Decodes a Base64 string. When `strict?` is true, validates that the
+  input contains only characters from the Base64 alphabet and returns
+  false on invalid input (defaults to false)."
   {:example "(decode \"SGVsbG8=\") ; => \"Hello\""}
   [s & [strict?]]
   (php/base64_decode s (or strict? false)))
@@ -23,7 +25,9 @@
       (s/replace "=" "")))
 
 (defn decode-url
-  "Decodes a URL-safe Base64 string. Adds padding automatically."
+  "Decodes a URL-safe Base64 string, adding padding automatically. When
+  `strict?` is true, validates that the input contains only valid Base64
+  characters (defaults to false)."
   {:example "(decode-url \"SGVsbG8\") ; => \"Hello\""}
   [s & [strict?]]
   (let [s   (s/replace s "-" "+")

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -279,6 +279,8 @@
 (defn not-every?
   "Returns false if `(pred x)` is logical true for every `x` in collection `coll`
    or if `coll` is empty. Otherwise returns true."
+  {:example "(not-every? even? [2 3 4]) ; => true"
+   :see-also ["every?" "all?" "not-any?"]}
   [pred coll]
   (not (all? pred coll)))
 
@@ -299,6 +301,8 @@
 (defn not-any?
   "Returns true if `(pred x)` is logical false for every `x` in `coll`
    or if `coll` is empty. Otherwise returns false."
+  {:example "(not-any? even? [1 3 5]) ; => true"
+   :see-also ["some?" "some" "not-every?"]}
   [pred coll]
   (not (some? pred coll)))
 
@@ -437,9 +441,11 @@
   integer, zero, or a positive integer when `x` is less than, equal to, or
   greater than `y`.
 
-  `nil` is less than every non-nil value and equal to itself. Throws
-  `InvalidArgumentException` when `x` and `y` come from mutually incomparable
-  categories (e.g. `(compare 1 [])`)."
+  `nil` is less than every non-nil value and equal to itself. Numbers are
+  compared across the numeric tower (int, float, `Ratio`, `BigInt`,
+  `BigDecimal`). Throws `InvalidArgumentException` when `x` and `y` come from
+  mutually incomparable categories (e.g. `(compare 1 [])`)."
+  {:see-also ["<=>" "sort" "sort-by"]}
   [x y]
   (cond
     (php/=== x nil) (if (php/=== y nil) 0 -1)

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -133,9 +133,12 @@
      fs)))
 
 (defn partial
-  "Takes a function `f` and fewer than normal arguments of `f` and returns a function
-  that a variable number of additional arguments. When call `f` will be called
-  with `args` and the additional arguments."
+  "Takes a function `f` and fewer than the normal number of arguments to `f`,
+  and returns a function that takes a variable number of additional arguments.
+  When called, `f` will be invoked with the bound `args` prepended to the
+  additional arguments."
+  {:example "((partial + 10) 1 2) ; => 13"
+   :see-also ["comp" "apply"]}
   [f & args]
   #(apply f (concat args %&)))
 

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -266,10 +266,9 @@
   of that binding, then binds name to that result, repeating for each
   successive form, returning the result of the last form."
   [expr name & forms]
-  (let [x (gensym)]
-    `(let [~name ~expr
-           ~@(interleave (repeat (count forms) name) forms)]
-       ~name)))
+  `(let [~name ~expr
+         ~@(interleave (repeat (count forms) name) forms)]
+     ~name))
 
 (defmacro doto
   "Evaluates x then calls all of the methods and functions with the

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -107,7 +107,7 @@
       content)))
 
 (defn spit
-  "Writes data to file, returning number of bytest that were written or `nil`
+  "Writes data to file, returning number of bytes that were written or `nil`
   on failure. Accepts `opts` map for overriding default PHP file_put_contents
   arguments, as example to append to file use `{:flags php/FILE_APPEND}`.
 

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -73,22 +73,34 @@
   (php/>> x n))
 
 (defn bit-set
-  "Set bit an index `n`."
+  "Returns the integer `x` with the bit at index `n` (0-based, least
+  significant first) set to 1."
+  {:example "(bit-set 0 2) ; => 4"
+   :see-also ["bit-clear" "bit-flip" "bit-test"]}
   [x n]
   (bit-or x (bit-shift-left 1 n)))
 
 (defn bit-clear
-  "Clear bit an index `n`."
+  "Returns the integer `x` with the bit at index `n` (0-based, least
+  significant first) cleared to 0."
+  {:example "(bit-clear 7 1) ; => 5"
+   :see-also ["bit-set" "bit-flip" "bit-test"]}
   [x n]
   (bit-and x (bit-not (bit-shift-left 1 n))))
 
 (defn bit-flip
-  "Flip bit at index `n`."
+  "Returns the integer `x` with the bit at index `n` (0-based, least
+  significant first) toggled."
+  {:example "(bit-flip 5 1) ; => 7"
+   :see-also ["bit-set" "bit-clear" "bit-test"]}
   [x n]
   (bit-xor x (bit-shift-left 1 n)))
 
 (defn bit-test
-  "Test bit at index `n`."
+  "Returns `true` if the bit at index `n` (0-based, least significant
+  first) of the integer `x` is set, `false` otherwise."
+  {:example "(bit-test 5 0) ; => true"
+   :see-also ["bit-set" "bit-clear" "bit-flip"]}
   [x n]
   (php/!= 0 (bit-and x (bit-shift-left 1 n))))
 

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -876,10 +876,10 @@
       (err (str "if-let requires bindings to have 2 elements, "
                 (count bindings) " given"))))
 
-  (let [form (bindings 0) tst (bindings 1) temp-sym (gensym)]
-    `(let [temp-sym ~tst]
-       (if temp-sym
-         (let [~form temp-sym]
+  (let [form (bindings 0) tst (bindings 1)]
+    `(let [temp-sym# ~tst]
+       (if temp-sym#
+         (let [~form temp-sym#]
            ~then)
          ~else))))
 
@@ -896,10 +896,10 @@
       (err (str "when-let requires bindings to have 2 elements, "
                 (count bindings) " given"))))
 
-  (let [form (bindings 0) tst (bindings 1) temp-sym (gensym)]
-    `(let [temp-sym ~tst]
-       (when temp-sym
-         (let [~form temp-sym]
+  (let [form (bindings 0) tst (bindings 1)]
+    `(let [temp-sym# ~tst]
+       (when temp-sym#
+         (let [~form temp-sym#]
            ~@body)))))
 
 (defmacro if-some
@@ -918,10 +918,10 @@
       (err (str "if-some requires bindings to have 2 elements, "
                 (count bindings) " given"))))
 
-  (let [form (bindings 0) tst (bindings 1) temp-sym (gensym)]
-    `(let [temp-sym ~tst]
-       (if (not (nil? temp-sym))
-         (let [~form temp-sym]
+  (let [form (bindings 0) tst (bindings 1)]
+    `(let [temp-sym# ~tst]
+       (if (not (nil? temp-sym#))
+         (let [~form temp-sym#]
            ~then)
          ~else))))
 
@@ -948,10 +948,10 @@
       (err (str "when-first requires bindings to have 2 elements, "
                 (count bindings) " given"))))
 
-  (let [sym (bindings 0) coll (bindings 1) temp-sym (gensym)]
-    `(let [temp-sym (first ~coll)]
-       (when (not (nil? temp-sym))
-         (let [~sym temp-sym]
+  (let [sym (bindings 0) coll (bindings 1)]
+    `(let [temp-sym# (first ~coll)]
+       (when (not (nil? temp-sym#))
+         (let [~sym temp-sym#]
            ~@body)))))
 
 (defmacro letfn

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -57,6 +57,8 @@
    followed by applying `f` to all the second items in each coll until anyone of the colls is exhausted.
 
   When given a single collection, applies the function to each element.
+  When applied to a map, iterates over entries as `[key value]` pairs,
+  matching Clojure semantics.
   With multiple collections, applies the function to corresponding elements from each collection,
   stopping when the shortest collection is exhausted."
   {:example "(map inc [1 2 3]) ; => @[2 3 4]"

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -193,7 +193,7 @@
                               (php/. "Cannot convert into type " (type to))))))))
     (throw (php/new InvalidArgumentException "into expects 1, 2, or 3 arguments"))))
 
-(defn- conj-single
+(defn- conj-impl
   [coll value]
   (cond
     (php/=== coll nil)                            (list value)
@@ -218,9 +218,9 @@
   ([] [])
   ([coll] coll)
   ([coll value]
-   (conj-single coll value))
+   (conj-impl coll value))
   ([coll value & more]
-   (reduce conj-single (conj-single coll value) more)))
+   (reduce conj-impl (conj-impl coll value) more)))
 
 (defn- disj-single
   [coll k]

--- a/src/phel/edn.phel
+++ b/src/phel/edn.phel
@@ -118,7 +118,7 @@
   Options:
     :readers  map of tag (symbol, keyword, or string) to 1-arg handler fn
     :eof      value returned for empty input"
-  {:example "(read-string \"{:a 1 :b 2}\") ; => {:a 1, :b 2}"
+  {:example "(read-string \"{:a 1 :b 2}\") ; => {:a 1, :b 2}\n(read-string \"\" {:eof :default}) ; => :default"
    :see-also ["read-string-all" "write-string"]}
   ([s] (read-string s {}))
   ([s opts]
@@ -155,7 +155,7 @@
 (defn write-string-all
   "Serialises a sequence of values to EDN, separating top-level forms
   with a single space. Inverse of `read-string-all`."
-  {:example "(write-string-all [1 2 3]) ; => \"1 2 3\""
+  {:example "(write-string-all [1 2 3]) ; => \"1 2 3\"\n(write-string-all [1 \"hi\" :kw]) ; => \"1 \\\"hi\\\" :kw\""
    :see-also ["read-string-all" "write-string"]}
   [xs]
   (php/implode " "

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -150,8 +150,13 @@
   `(str ~@(compile-seq content)))
 
 (defmacro html
-  "Compiles Phel vectors to HTML strings."
-  {:example "(html [:div \"Hello\"]) ; => \"<div>Hello</div>\""}
+  "Compiles nested Phel vectors to HTML strings at compile-time. A vector
+  `[tag attrs? children*]` becomes an element; `tag` is a keyword or string,
+  the optional `attrs` is a map, and children are strings, keywords, raw
+  strings, or nested vectors. Special list forms `for`, `if`, `when`, and
+  `when-not` are supported for dynamic content."
+  {:example "(html [:div \"Hello\"]) ; => \"<div>Hello</div>\""
+   :see-also ["raw-string" "doctype"]}
   [& content]
   (apply compile-html content))
 
@@ -165,7 +170,9 @@
    :html5              "<!DOCTYPE html>\n"})
 
 (defn doctype
-  "Returns an HTML doctype declaration."
-  {:example "(doctype :html5) ; => \"<!DOCTYPE html>\\n\""}
+  "Returns an HTML doctype declaration for the given type. Supports `:html4`,
+  `:xhtml-strict`, `:xhtml-transitional`, and `:html5`. Defaults to `:html5`."
+  {:example "(doctype :html5) ; => \"<!DOCTYPE html>\\n\""
+   :see-also ["html"]}
   [type]
   (raw-string (get doctypes type (:html5 doctypes))))

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -52,8 +52,12 @@
       [server-name server-port])))
 
 (defn uri-from-globals
-  "Extracts the URI from the `$_SERVER` variable."
-  {:example "(uri-from-globals) ; => (uri \"https\" nil \"example.com\" 443 \"/path\" \"foo=bar\" nil)"}
+  "Extracts the URI from the `$_SERVER` variable. The scheme is read from
+  `HTTP_X_FORWARDED_PROTO`, `REQUEST_SCHEME`, or `HTTPS`; the path from
+  `REQUEST_URI`; and the host/port via the `$_SERVER` host fields. Returns a
+  uri struct."
+  {:example "(uri-from-globals) ; => (uri \"https\" nil \"example.com\" 443 \"/path\" \"foo=bar\" nil)"
+   :see-also ["uri-from-string" "request-from-globals"]}
   [& [server]]
   (let [server (or server php/$_SERVER)
         scheme (cond
@@ -76,8 +80,11 @@
    url))
 
 (defn uri-from-string
-  "Create a uri struct from a string."
-  {:example "(uri-from-string \"https://example.com/path?foo=bar\") ; => (uri \"https\" nil \"example.com\" nil \"/path\" \"foo=bar\" nil)"}
+  "Parses a URI string into a uri struct. Handles UTF-8 URLs and IPv6
+  addresses in brackets. Throws `InvalidArgumentException` on a malformed
+  string."
+  {:example "(uri-from-string \"https://example.com/path?foo=bar\") ; => (uri \"https\" nil \"example.com\" nil \"/path\" \"foo=bar\" nil)"
+   :see-also ["uri-from-globals" "request-from-map"]}
   [url]
   (let [matches      (php/array)
         [prefix url] (if (one? (php/preg_match "%^(.*://\\[[0-9:a-f]+\\])(.*?)$%" url matches))
@@ -144,8 +151,11 @@
     (persistent res)))
 
 (defn files-from-globals
-  "Extracts the files from `$_FILES` and normalizes them to a map of \"uploaded-file\"."
-  {:example "(files-from-globals) ; => {:avatar (uploaded-file \"/tmp/phpYzdqkD\" 1024 0 \"photo.jpg\" \"image/jpeg\")}"}
+  "Extracts uploaded files from `$_FILES` and normalizes them to uploaded-file
+  structs. Handles both flat and nested file specs from multipart uploads.
+  Returns a map of field name to uploaded-file(s)."
+  {:example "(files-from-globals) ; => {:avatar (uploaded-file \"/tmp/phpYzdqkD\" 1024 0 \"photo.jpg\" \"image/jpeg\")}"
+   :see-also ["request-from-globals"]}
   [& [files]]
   (normalize-files (or files php/$_FILES)))
 
@@ -154,8 +164,11 @@
 ;; -------
 
 (defn headers-from-server
-  "Extracts all headers from the `$_SERVER` variable."
-  {:example "(headers-from-server) ; => {:host \"example.com\" :content-type \"application/json\"}"}
+  "Extracts all HTTP headers from the `$_SERVER` variable. Strips the `HTTP_`
+  prefix, normalizes underscores to hyphens, handles `CONTENT_*` keys, and
+  resolves `REDIRECT_*` keys. Returns a map with keyword keys."
+  {:example "(headers-from-server) ; => {:host \"example.com\" :content-type \"application/json\"}"
+   :see-also ["request-from-globals"]}
   [& [server]]
   (let [headers (transient {})
         server  (or server php/$_SERVER)]
@@ -233,7 +246,8 @@
   "Extracts a request from args. The optional `raw-body` (the raw request body
   string) is decoded into `:parsed-body` when the `Content-Type` is
   `application/json`; form bodies still come from `post-parameter`."
-  {:example "(request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES (php/file_get_contents \"php://input\")) ; => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"}
+  {:example "(request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES (php/file_get_contents \"php://input\")) ; => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"
+   :see-also ["request-from-globals" "request-from-map"]}
   [server get-parameter post-parameter cookies files & [raw-body]]
   (let [method          (get-method-from-globals server)
         uri             (uri-from-globals server)
@@ -266,15 +280,23 @@
 
 (defn request-from-globals
   "Extracts a request from `$_SERVER`, `$_GET`, `$_POST`, `$_COOKIE`, `$_FILES`
-  and, for JSON requests, the raw request body (`php://input`)."
-  {:example "(request-from-globals) ; => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"}
+  and, for JSON requests, the raw request body (`php://input`). Requires a web
+  request context (PHP-FPM, mod_php, or `php -S`); it cannot be used from the
+  REPL or a CLI script - use `request-from-map` for testing."
+  {:example "(request-from-globals) ; => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"
+   :see-also ["request-from-globals-args" "request-from-map"]}
   []
   (request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES
                              (json-request-body php/$_SERVER)))
 
 (defn request-from-map
-  "Creates a request struct from a map with optional keys :method, :uri, :headers, etc."
-  {:example "(request-from-map {:method \"POST\" :uri \"https://api.example.com/users\"}) ; => (request \"POST\" (uri ...) {} nil {} {} {} [] \"1.1\" {})"}
+  "Creates a request struct from a map. Supports the optional keys `:method`,
+  `:uri` (a string parsed via `uri-from-string`, or a uri struct used as-is),
+  `:headers`, `:parsed-body`, `:query-params`, `:cookie-params`,
+  `:server-params`, `:uploaded-files`, `:version`, and `:attributes`. Missing
+  keys default to nil, `{}`, `[]`, or `\"1.1\"` as appropriate."
+  {:example "(request-from-map {:method \"POST\" :uri \"https://api.example.com/users\"}) ; => (request \"POST\" (uri ...) {} nil {} {} {} [] \"1.1\" {})"
+   :see-also ["request-from-globals" "response-from-map"]}
   [{:method method
     :uri uri
     :headers headers
@@ -371,8 +393,11 @@
                         511 "Network Authentication Required"})
 
 (defn response-from-map
-  "Creates a response struct from a map with optional keys :status, :headers, :body, :version, and :reason."
-  {:example "(response-from-map {:status 200 :body \"Hello World\"}) ; => (response 200 {} \"Hello World\" \"1.1\" \"OK\")"}
+  "Creates a response struct from a map. Optional keys: `:status` (defaults
+  200), `:headers` (`{}`), `:body` (`\"\"`), `:version` (`\"1.1\"`), and
+  `:reason` (auto-filled from the HTTP status code when omitted)."
+  {:example "(response-from-map {:status 200 :body \"Hello World\"}) ; => (response 200 {} \"Hello World\" \"1.1\" \"OK\")"
+   :see-also ["response-from-string" "json-response" "html-response"]}
   [{:status status, :headers headers, :body body, :version version, :reason reason}]
   (let [status  (or status 200)
         headers (or headers {})
@@ -382,8 +407,10 @@
     (response status headers body version reason)))
 
 (defn response-from-string
-  "Create a response from a string."
-  {:example "(response-from-string \"Hello World\") ; => (response 200 {} \"Hello World\" \"1.1\" \"OK\")"}
+  "Creates a 200 OK response with the given body string. Shorthand for
+  `(response-from-map {:body s})`."
+  {:example "(response-from-string \"Hello World\") ; => (response 200 {} \"Hello World\" \"1.1\" \"OK\")"
+   :see-also ["response-from-map" "json-response"]}
   [s]
   (response-from-map {:body s}))
 

--- a/src/phel/json.phel
+++ b/src/phel/json.phel
@@ -7,7 +7,7 @@
   [v]
   (or (int? v) (float? v) (symbol? v) (keyword? v) (string? v)))
 
-(declare encode-value [x])
+(declare encode-value)
 
 (defn- encode-value-iterable [x]
   (let [arr (php/array)]

--- a/src/phel/json.phel
+++ b/src/phel/json.phel
@@ -19,7 +19,8 @@
 
 (defn encode-value
   "Converts a Phel value to JSON-compatible format."
-  {:example "(encode-value :name) ; => \"name\""}
+  {:example "(encode-value :name) ; => \"name\""
+   :see-also ["encode" "decode-value"]}
   [x]
   (cond
     (php/is_iterable x) (encode-value-iterable x)
@@ -42,7 +43,8 @@
 
 (defn decode-value
   "Converts a JSON value to Phel format."
-  {:example "(decode-value [1 2 3]) ; => [1 2 3]"}
+  {:example "(decode-value [1 2 3]) ; => [1 2 3]"
+   :see-also ["decode" "encode-value"]}
   [x]
   (cond
     (indexed? x)   (for [v :in x] (decode-value v))

--- a/src/phel/match.phel
+++ b/src/phel/match.phel
@@ -43,17 +43,23 @@
       (php/is_string form)
       (keyword? form)))
 
-(defn- or-pattern? [form]
+(defn- or-pattern?
+  "An `(:or alt ...)` list: matches when any alternative matches."
+  [form]
   (and (list? form)
        (not (empty? form))
        (= (first form) or-keyword)))
 
-(defn- guard-pattern? [form]
+(defn- guard-pattern?
+  "A `(pattern :guard pred)` list: matches `pattern` then tests `pred`."
+  [form]
   (and (list? form)
        (= (count form) 3)
        (= (get form 1) guard-keyword)))
 
-(defn- as-pattern? [form]
+(defn- as-pattern?
+  "A `(pattern :as sym)` list: matches `pattern` and binds it to `sym`."
+  [form]
   (and (list? form)
        (= (count form) 3)
        (= (get form 1) as-keyword)

--- a/src/phel/mock.phel
+++ b/src/phel/mock.phel
@@ -49,8 +49,10 @@
      call-history)))
 
 (defn spy
-  "Wraps an existing function to track calls while preserving original behavior."
-  {:example "(def original-fn (fn [x] (* x 2)))"}
+  "Wraps an existing function to track calls while preserving original behavior.
+  Alias for `mock-fn`."
+  {:example "(def original-fn (fn [x] (* x 2)))"
+   :see-also ["mock-fn"]}
   [f]
   (mock-fn f))
 

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -56,7 +56,7 @@
       dirs)))
 
 (defn- eval-namespace [namespace]
-  (let [canonical    (php/:: Munge (canonicalNs namespace))
+  (let [canonical    (canonical-ns namespace)
         dependencies (php/-> build-facade (getDependenciesForNamespace (get-src-dirs) (php/array canonical)))
         found        (php/> (php/count dependencies) 0)]
     (when-not found
@@ -386,7 +386,7 @@
   {:example "(find-ns \"phel.core\") ; => \"phel.core\""
    :see-also ["create-ns" "remove-ns" "loaded-namespaces"]}
   [ns-str]
-  (let [canonical (php/:: Munge (canonicalNs ns-str))]
+  (let [canonical (canonical-ns ns-str)]
     (when (php/:: Phel (hasNamespace (munge-ns canonical)))
       (php/:: Munge (displayNs canonical)))))
 
@@ -396,7 +396,7 @@
   {:example "(create-ns \"my-app.tmp\") ; => \"my-app.tmp\""
    :see-also ["find-ns" "remove-ns" "intern"]}
   [ns-str]
-  (let [canonical (php/:: Munge (canonicalNs ns-str))]
+  (let [canonical (canonical-ns ns-str)]
     (php/:: Phel (registerNamespace (munge-ns canonical)))
     (php/:: Munge (displayNs canonical))))
 
@@ -417,7 +417,7 @@
   {:example "(intern \"user\" \"x\" 42) ; => user/x"
    :see-also ["find-ns" "create-ns" "ns-interns"]}
   [ns-str name-str & rest]
-  (let [canonical    (php/:: Munge (canonicalNs ns-str))
+  (let [canonical    (canonical-ns ns-str)
         encoded-ns   (munge-ns canonical)
         encoded-name (php/-> (php/new Munge) (encode name-str))
         value        (first rest)]
@@ -461,7 +461,7 @@
    :see-also ["ns-publics" "ns-refers" "loaded-namespaces"]}
   [ns-str]
   (let [env     (get-global-env)
-        aliases (php/-> env (getRequireAliases (php/:: Munge (canonicalNs ns-str))))
+        aliases (php/-> env (getRequireAliases (canonical-ns ns-str)))
         result  (transient {})]
     (foreach [alias-name target-sym aliases]
       (assoc! result alias-name (php/:: Munge (displayNs (php/-> target-sym (getName))))))
@@ -474,7 +474,7 @@
    :see-also ["ns-publics" "ns-aliases" "loaded-namespaces"]}
   [ns-str]
   (let [env    (get-global-env)
-        refers (php/-> env (getRefers (php/:: Munge (canonicalNs ns-str))))
+        refers (php/-> env (getRefers (canonical-ns ns-str)))
         result (transient {})]
     (foreach [refer-name source-sym refers]
       (assoc! result refer-name (php/:: Munge (displayNs (php/-> source-sym (getName))))))

--- a/src/phel/schema.phel
+++ b/src/phel/schema.phel
@@ -98,8 +98,9 @@
   (c/conform schema value))
 
 (def invalid-marker
-  "Sentinel returned by `conform` when a value cannot be made to fit a
-  schema."
+  "Sentinel value (`:phel.schema/invalid`) returned by `conform` when a
+  value cannot be coerced to fit a schema. `conform` returns this marker
+  instead of throwing, so compare against it to detect failure."
   c/invalid-marker)
 
 (defn generate

--- a/src/phel/schema/coercer.phel
+++ b/src/phel/schema/coercer.phel
@@ -15,6 +15,9 @@
 
 (def invalid-marker :phel.schema/invalid)
 
+;; Coerces to int: parses integer-shaped strings, accepts floats only when
+;; they have no fractional part, and maps booleans to 1/0. Anything else
+;; (including floats like 1.5) passes through unchanged for validation.
 (defn- coerce-int [value]
   (cond
     (int? value)                                                          value
@@ -26,6 +29,8 @@
     (false? value)                                                        0
     :else                                                                 value))
 
+;; Coerces to float: promotes ints and parses numeric strings (with an
+;; optional decimal part). Non-numeric input passes through unchanged.
 (defn- coerce-float [value]
   (cond
     (float? value)                                                                             value
@@ -35,6 +40,9 @@
     (php/floatval value)
     :else                                                                                      value))
 
+;; Coerces to boolean: recognises the usual truthy/falsy strings
+;; ("true"/"false", "1"/"0", "yes"/"no", "on"/"off") and the ints 1/0.
+;; Unrecognised input passes through unchanged.
 (defn- coerce-boolean [value]
   (cond
     (boolean? value) value
@@ -53,6 +61,7 @@
     (= value 0)      false
     :else            value))
 
+;; Coerces strings and symbols to keywords; other input is unchanged.
 (defn- coerce-keyword [value]
   (cond
     (keyword? value) value
@@ -60,6 +69,7 @@
     (symbol? value)  (keyword (name value))
     :else            value))
 
+;; Coerces strings and keywords to symbols; other input is unchanged.
 (defn- coerce-symbol [value]
   (cond
     (symbol? value)  value
@@ -67,12 +77,17 @@
     (keyword? value) (symbol (name value))
     :else            value))
 
+;; Coerces UUID-shaped strings via `parse-uuid`; unparseable input is
+;; returned unchanged so validation can flag it.
 (defn- coerce-uuid [value]
   (cond
     (uuid? value)   value
     (string? value) (or (parse-uuid value) value)
     :else           value))
 
+;; Coerces to a `\DateTimeImmutable`: parses date strings and treats ints
+;; as UNIX timestamps. Invalid strings/timestamps are caught and the
+;; original value is returned unchanged.
 (defn- coerce-inst [value]
   (cond
     (php/instanceof value \DateTimeInterface) value
@@ -109,6 +124,10 @@
                           (fn [target] (coerce target value))
                           value)))
 
+;; Coerces a sequence into a target collection type. Each element is
+;; coerced against the element schema (the first schema arg, if any), and
+;; `type-ctor` is then applied to the resulting vector to build the final
+;; collection. Non-sequential input passes through unchanged.
 (defn- coerce-collection
   [schema value type-ctor]
   (let [args (v/schema-args schema)]

--- a/src/phel/schema/explainer.phel
+++ b/src/phel/schema/explainer.phel
@@ -19,6 +19,7 @@
 
 (declare -explain)
 
+;; Builds one error entry for the `:errors` vector returned by `explain`.
 (defn- make-error
   [path in schema value type]
   {:path   path
@@ -27,6 +28,8 @@
    :value  value
    :type   type})
 
+;; Explains a keyword schema: resolves registered refs, otherwise emits a
+;; single `:mismatch` error when the scalar predicate rejects the value.
 (defn- -explain-kind-keyword
   [schema value path in]
   (if (v/valid? schema value)
@@ -35,6 +38,8 @@
       (-explain (reg/deref-ref schema) value path in)
       [(make-error path in schema value :mismatch)])))
 
+;; Explains a homogeneous collection: checks the container type, then
+;; recurses into each element, accumulating per-element errors.
 (defn- -explain-collection
   [schema value type-pred path in]
   (let [head (v/schema-head schema)
@@ -54,6 +59,8 @@
                     sub         (-explain elem-schema (get items i) nested-path nested-in)]
                 (recur (+ i 1) (into acc sub))))))))))
 
+;; Explains a `:map-of` schema: recurses into every key and value,
+;; accumulating errors from both the key and value sub-schemas.
 (defn- -explain-map-of
   [schema value path in]
   (if (not (map? value))
@@ -73,6 +80,8 @@
                 vsub  (-explain val-schema val (conj path :map-of 1) (conj in k))]
             (recur (+ i 1) (into (into acc ksub) vsub))))))))
 
+;; Explains a `:tuple` schema: checks the length matches, then recurses
+;; positionally into each element against its corresponding sub-schema.
 (defn- -explain-tuple
   [schema value path in]
   (if (not (vector? value))
@@ -88,6 +97,9 @@
                                 (conj in i))]
               (recur (+ i 1) (into acc sub)))))))))
 
+;; Explains a `:map` schema: reports `:missing` for absent required keys,
+;; recurses into present entries, and (when `:closed`) reports `:extra`
+;; for keys not declared in the schema.
 (defn- -explain-map
   [schema value path in]
   (if (not (map? value))
@@ -132,6 +144,8 @@
             [])]
       (into entry-errors extra-errors))))
 
+;; Explains an `:enum` schema: a single `:mismatch` error when the value
+;; is not one of the allowed members.
 (defn- -explain-enum
   [schema value path in]
   (let [args (v/schema-args schema)]
@@ -139,6 +153,8 @@
       []
       [(make-error path in schema value :mismatch)])))
 
+;; Explains an `:and` schema: collects errors from every conjoined
+;; sub-schema (all must pass), accumulating across all of them.
 (defn- -explain-and
   [schema value path in]
   (let [args (v/schema-args schema)]
@@ -151,6 +167,8 @@
             (recur (next sch) (+ idx 1) acc)
             (recur (next sch) (+ idx 1) (into acc sub))))))))
 
+;; Explains an `:or` schema: succeeds (no errors) if any branch matches;
+;; otherwise emits a top-level `:mismatch` plus each branch's errors.
 (defn- -explain-or
   [schema value path in]
   (let [args (v/schema-args schema)]
@@ -163,6 +181,8 @@
           (let [sub (-explain (first sch) value (conj path :or idx) in)]
             (recur (next sch) (+ idx 1) (into acc sub))))))))
 
+;; Explains a `:ref` schema: resolves the referenced schema and recurses
+;; into it; emits a `:mismatch` when the ref is not registered.
 (defn- -explain-ref
   [schema value path in]
   (let [name   (first (v/schema-args schema))

--- a/src/phel/schema/generator.phel
+++ b/src/phel/schema/generator.phel
@@ -51,20 +51,19 @@
     (v/resolve-or-throw "no default generator for schema kind" head
                         (fn [target] (schema->gen target)))))
 
-(defn- vector-of-gen [args]
+(defn- collection-gen [type-ctor args]
   (if (empty? args)
-    (g/vector-of g/int)
-    (g/vector-of (schema->gen (first args)))))
+    (type-ctor g/int)
+    (type-ctor (schema->gen (first args)))))
+
+(defn- vector-of-gen [args]
+  (collection-gen g/vector-of args))
 
 (defn- list-of-gen [args]
-  (if (empty? args)
-    (g/list-of g/int)
-    (g/list-of (schema->gen (first args)))))
+  (collection-gen g/list-of args))
 
 (defn- set-of-gen [args]
-  (if (empty? args)
-    (g/set-of g/int)
-    (g/set-of (schema->gen (first args)))))
+  (collection-gen g/set-of args))
 
 (defn- map-of-gen [args]
   (g/map-of (schema->gen (get args 0))

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -183,15 +183,17 @@
 
 (defn contains?
   "True if s contains substr."
-  {:example "(contains? \"hello world\" \"lo wo\") ; => true"}
+  {:example "(contains? \"hello world\" \"lo wo\") ; => true"
+   :see-also ["includes?" "starts-with?" "ends-with?" "index-of"]}
   [s substr]
   (assert-string s)
   (assert-string substr)
   (php/str_contains s substr))
 
 (defn includes?
-  "True if s includes substr."
-  {:example "(includes? \"hello world\" \"world\") ; => true"}
+  "True if s includes substr. Synonym for `contains?`."
+  {:example "(includes? \"hello world\" \"world\") ; => true"
+   :see-also ["contains?" "starts-with?" "ends-with?"]}
   [s substr]
   (assert-string s)
   (assert-string substr)
@@ -214,8 +216,11 @@
     (php/implode "" mapped)))
 
 (defn index-of
-  "Returns the index of value in s, or nil if not found."
-  {:example "(index-of \"hello world\" \"world\") ; => 6"}
+  "Returns the index of the first occurrence of value in s, or nil if not
+  found. The optional from-index sets where the search begins; a negative
+  from-index counts back from the end of s."
+  {:example "(index-of \"hello world\" \"world\") ; => 6"
+   :see-also ["last-index-of" "contains?"]}
   [s value & [from-index]]
   (let [from-index (or from-index 0)
         from-index (let [abs (php/abs from-index)
@@ -229,8 +234,11 @@
       result)))
 
 (defn last-index-of
-  "Returns the last index of value in s, or nil if not found."
-  {:example "(last-index-of \"hello world world\" \"world\") ; => 12"}
+  "Returns the index of the last occurrence of value in s, or nil if not
+  found. The optional from-index sets the upper bound for the match; a
+  negative from-index counts back from the end of s."
+  {:example "(last-index-of \"hello world world\" \"world\") ; => 12"
+   :see-also ["index-of" "contains?"]}
   [s value & [from-index]]
   (let [len        (php/mb_strlen s)
         max-index  (dec len)

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -224,7 +224,10 @@
   [s value & [from-index]]
   (let [from-index (or from-index 0)
         from-index (let [abs (php/abs from-index)
-                         v   (min abs (dec (php/mb_strlen s)))]
+                         ;; Clamp to a valid mb_strpos offset: (dec (mb_strlen s))
+                         ;; is -1 for an empty string, which would otherwise raise
+                         ;; a ValueError instead of yielding nil.
+                         v   (max 0 (min abs (dec (php/mb_strlen s))))]
                      (if (< from-index 0)
                        (* v -1)
                        v))

--- a/src/phel/transit.phel
+++ b/src/phel/transit.phel
@@ -186,7 +186,7 @@
                       unknown tag (both scalar and array forms). Receives
                       the bare tag name (e.g. \"point\", \":\", \"~\") and
                       the already-decoded representation."
-  {:example "(read-string \"[\\\"~:foo\\\", 1]\") ; => [:foo 1]"
+  {:example "(read-string \"[\\\"~:foo\\\", 1]\") ; => [:foo 1]\n(read-string \"[\\\"~#point\\\", [1, 2]]\" {:handlers {\"point\" (fn [v] v)}}) ; => [1 2]"
    :see-also ["write-string"]}
   ([s] (read-string s {}))
   ([s opts]

--- a/src/php/Api/Application/DocstringSignatureParser.php
+++ b/src/php/Api/Application/DocstringSignatureParser.php
@@ -21,6 +21,9 @@ use function trim;
  *
  * The parser returns `{signatures, description}`; the surrounding
  * ```phel fence and trailing newline are stripped.
+ *
+ * The regex is forgiving: if the docstring lacks a ```phel code fence,
+ * `signatures` is empty and `description` is the entire docstring.
  */
 final class DocstringSignatureParser
 {

--- a/src/php/Api/Application/PhelFnNormalizer.php
+++ b/src/php/Api/Application/PhelFnNormalizer.php
@@ -28,6 +28,16 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
     ) {}
 
     /**
+     * Normalizes raw Phel function metadata into a sorted, de-duplicated list.
+     *
+     * Pipeline:
+     * 1. Load metadata for the requested namespaces (defaults to all known).
+     * 2. Skip entries flagged `:private`.
+     * 3. Parse each docstring into signatures + description.
+     * 4. Group by generated group key, build {@see PhelFunction} DTOs, sort each group.
+     * 5. Prepend native symbols (special forms / built-ins) so they override
+     *    any homonymous runtime def, then drop duplicate `namespace/name` pairs.
+     *
      * @param list<string> $namespaces
      *
      * @return list<PhelFunction>

--- a/src/php/Api/Application/ReplCompleter.php
+++ b/src/php/Api/Application/ReplCompleter.php
@@ -17,7 +17,13 @@ use function str_starts_with;
 use function trim;
 
 /**
- * Autocompleter for REPL suggestions in both PHP and Phel contexts.
+ * Lazy-loading autocompleter for REPL suggestions in both PHP and Phel contexts.
+ *
+ * The first call to {@see complete()} / {@see completeWithTypes()} pays a one-time
+ * setup cost: all Phel functions are loaded via the loader and the flag
+ * {@see $phelFunctionsLoaded} is set so subsequent calls reuse the registry.
+ * PHP builtin symbols are cached eagerly in the {@see PhpSymbolCatalog} created
+ * in the constructor.
  */
 final class ReplCompleter implements ReplCompleterInterface
 {

--- a/src/php/Api/Infrastructure/NativeSymbolCatalog.php
+++ b/src/php/Api/Infrastructure/NativeSymbolCatalog.php
@@ -12,6 +12,11 @@ use Phel\Lang\Symbol;
  * symbols (`*file*`, `*ns*`). Their `:doc`/`:signatures`/`:example` metadata
  * cannot be read from the registry, so it is maintained here and merged by
  * {@see PhelFnLoader} with the runtime-loaded function metadata.
+ *
+ * Maintenance: adding a native symbol means appending an entry to the
+ * {@see self::DEFINITIONS} array by hand (there is no generator); if it
+ * introduces a new namespace, also register that namespace in
+ * {@see \Phel\Api\ApiConfig::allNamespaces()} so it is surfaced by the loader.
  */
 final class NativeSymbolCatalog
 {

--- a/src/php/Build/Infrastructure/Cache/CacheIndexFile.php
+++ b/src/php/Build/Infrastructure/Cache/CacheIndexFile.php
@@ -23,7 +23,9 @@ use function is_string;
  */
 final readonly class CacheIndexFile
 {
-    private const string VERSION = '1.2';
+    // Bump when entry structure changes (namespace/source_hash/compiled_path/last_accessed keys).
+    // Decoupled from the Phel version for cache stability across minor releases.
+    private const string INDEX_FORMAT_VERSION = '1.2';
 
     public function __construct(
         private CacheDirectory $directory,
@@ -32,7 +34,7 @@ final readonly class CacheIndexFile
 
     public function version(): string
     {
-        return self::VERSION . ':' . $this->phelVersion;
+        return self::INDEX_FORMAT_VERSION . ':' . $this->phelVersion;
     }
 
     /**

--- a/src/php/Command/Application/CommandExceptionWriter.php
+++ b/src/php/Command/Application/CommandExceptionWriter.php
@@ -16,6 +16,11 @@ use Throwable;
 use function sprintf;
 use function str_ends_with;
 
+/**
+ * Delegates exception rendering to the {@see ExceptionPrinterInterface} and persists the
+ * full stack trace via the {@see ErrorLogInterface}, unwrapping compiled PHP locations
+ * back to the originating Phel source for user-facing errors.
+ */
 final readonly class CommandExceptionWriter implements CommandExceptionWriterInterface
 {
     public function __construct(
@@ -56,6 +61,15 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
         return $this->exceptionPrinter->getStackTraceString($e);
     }
 
+    /**
+     * Renders a user-facing error, mapping the compiled PHP file/line back to its
+     * original Phel source via the source map when available.
+     *
+     * When the source map resolves to a different file, the original location is
+     * shown alongside the compiled one. Otherwise only the raw location is shown,
+     * and a stale-output hint is appended when the failing file is generated PHP
+     * (`.php`), since that usually signals an out-of-date build.
+     */
     private function writeUserError(OutputInterface $output, Throwable $cause): void
     {
         $file = $cause->getFile();

--- a/src/php/Command/Application/TextExceptionPrinter.php
+++ b/src/php/Command/Application/TextExceptionPrinter.php
@@ -24,6 +24,12 @@ use function strlen;
 
 use const PHP_EOL;
 
+/**
+ * Renders Phel exceptions and stack traces as styled terminal text, with blue
+ * message headers, the offending code snippet, and a red caret pointer under the
+ * exact error span. Compiled PHP locations are mapped back to their Phel source
+ * via the {@see FilePositionExtractorInterface}.
+ */
 final readonly class TextExceptionPrinter implements ExceptionPrinterInterface
 {
     public function __construct(
@@ -45,6 +51,15 @@ final readonly class TextExceptionPrinter implements ExceptionPrinterInterface
         $this->errorLog->writeln($this->getExceptionString($e, $codeSnippet));
     }
 
+    /**
+     * Builds the full error string: a styled message header, the source location,
+     * and each line of the code snippet prefixed with its absolute line number.
+     *
+     * The loop maps a snippet-relative offset (`$index`) to an absolute source line
+     * by adding the snippet's first line. A caret pointer is appended only when the
+     * error spans a single line and that line matches the one currently being
+     * printed; multi-line errors are not underlined.
+     */
     public function getExceptionString(AbstractLocatedException $e, CodeSnippet $codeSnippet): string
     {
         $str = '';

--- a/src/php/Command/Domain/Exceptions/ExceptionArgsPrinter.php
+++ b/src/php/Command/Domain/Exceptions/ExceptionArgsPrinter.php
@@ -63,7 +63,12 @@ final readonly class ExceptionArgsPrinter implements ExceptionArgsPrinterInterfa
     }
 
     /**
-     * Converts a PHP type to a string.
+     * Formats a single PHP value for display in a stack trace frame.
+     *
+     * Strings are quoted and truncated to 15 characters to keep trace lines
+     * readable; resources are rendered as their resource id, objects as their
+     * class name. This differs from {@see parseArgsAsString()}, which formats
+     * Phel function arguments via the {@see PrinterInterface}.
      */
     private function buildPhpArg(mixed $arg): string
     {

--- a/src/php/Command/Domain/Exceptions/ExceptionArgsPrinter.php
+++ b/src/php/Command/Domain/Exceptions/ExceptionArgsPrinter.php
@@ -18,6 +18,8 @@ final readonly class ExceptionArgsPrinter implements ExceptionArgsPrinterInterfa
 {
     private const int MAX_ARG_LENGTH = 200;
 
+    private const int MAX_STRING_ARG_LENGTH = 15;
+
     public function __construct(
         private PrinterInterface $printer,
     ) {}
@@ -32,12 +34,7 @@ final readonly class ExceptionArgsPrinter implements ExceptionArgsPrinterInterfa
             $frameArgs,
         );
 
-        $argString = implode(' ', $argParts);
-        if ($argParts !== []) {
-            return ' ' . $argString;
-        }
-
-        return $argString;
+        return $argParts !== [] ? ' ' . implode(' ', $argParts) : '';
     }
 
     /**
@@ -78,8 +75,8 @@ final readonly class ExceptionArgsPrinter implements ExceptionArgsPrinterInterfa
 
         if (is_string($arg)) {
             $s = $arg;
-            if (strlen($s) > 15) {
-                $s = substr($s, 0, 15) . '...';
+            if (strlen($s) > self::MAX_STRING_ARG_LENGTH) {
+                $s = substr($s, 0, self::MAX_STRING_ARG_LENGTH) . '...';
             }
 
             return sprintf("'%s'", $s);

--- a/src/php/Command/Infrastructure/SourceMapExtractor.php
+++ b/src/php/Command/Infrastructure/SourceMapExtractor.php
@@ -11,8 +11,19 @@ use function fclose;
 use function fgets;
 use function fopen;
 
+/**
+ * Reads the first two lines of a generated PHP file, which Phel emits as source
+ * map metadata comments (a `// ` filename comment followed by a `// ` source map
+ * comment). Both lines are returned verbatim for the caller to parse.
+ */
 final class SourceMapExtractor implements SourceMapExtractorInterface
 {
+    /**
+     * Returns the raw first two lines of the file. Empty strings indicate that no
+     * source map is available, i.e. the file is missing, unreadable, or shorter
+     * than two lines; an empty string is therefore indistinguishable from a truly
+     * blank line, so callers must treat empty as "no source map".
+     */
     public function extractFromFile(string $filename): SourceMapInformation
     {
         if (!file_exists($filename)) {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -65,8 +65,6 @@ use function substr;
 
 final class AnalyzePersistentList
 {
-    private const string EMPTY_SYMBOL_NAME = '';
-
     /** @var array<string, SpecialFormAnalyzerInterface> */
     private array $symbolAnalyzerCache = [];
 
@@ -108,7 +106,7 @@ final class AnalyzePersistentList
         $first = $list->first();
         return $first instanceof Symbol
             ? $first->getFullName()
-            : self::EMPTY_SYMBOL_NAME;
+            : '';
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -157,6 +157,14 @@ final readonly class DefSymbol implements SpecialFormAnalyzerInterface
     }
 
     /**
+     * Separates the def's compile-time metadata from its init expression.
+     *
+     * Returns `[$metaMap, $init]`. The meta map normalizes the explicit
+     * metadata form (string `:doc`, keyword flag, or map), then folds in
+     * flags attached to the name symbol (e.g. `^:dynamic`, `^:private`),
+     * any list-level meta, and the def's start/end source locations so
+     * runtime code and the emitter can read them off the var.
+     *
      * @param PersistentListInterface<mixed> $list
      *
      * @return array{0:PersistentMapInterface<mixed, mixed>, 1:mixed}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter.php
@@ -46,6 +46,13 @@ final class OutputEmitter implements OutputEmitterInterface
         private readonly OutputEmitterOptions $options,
     ) {}
 
+    /**
+     * Pushes a new constant-cache scope onto the stack.
+     *
+     * Scopes nest (fn bodies, let bindings, etc.); the innermost one is
+     * consulted by {@see currentConstantScope()} to decide which constants
+     * get a cached slot. Must be paired with a matching {@see popConstantScope()}.
+     */
     public function pushConstantScope(ConstantScope $scope): void
     {
         $this->constantScopes[] = $scope;

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -48,7 +48,7 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
     private function emitViaEval(DefStructNode $node): void
     {
         $ns = $this->outputEmitter->mungeEncodePhpNs($node->getNamespace());
-        $fqcn = $ns . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
+        $fqcn = $this->buildFqcn($node);
 
         ob_start();
         $this->emitClassBody($node);
@@ -81,9 +81,18 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
 
     private function emitClassExistsGuard(DefStructNode $node): void
     {
-        $fqcn = $this->outputEmitter->mungeEncodePhpNs($node->getNamespace())
-            . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
+        $fqcn = $this->buildFqcn($node);
         $this->outputEmitter->emitLine("if (!class_exists('" . $fqcn . "')) {", $node->getStartSourceLocation());
+    }
+
+    /**
+     * Builds the fully qualified PHP class name for the generated struct,
+     * encoding both the namespace and the class name through the munger.
+     */
+    private function buildFqcn(DefStructNode $node): string
+    {
+        return $this->outputEmitter->mungeEncodePhpNs($node->getNamespace())
+            . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
     }
 
     private function emitClassBody(DefStructNode $node): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -93,6 +93,15 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\VarEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\VectorEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
 
+/**
+ * Creates and caches node emitters per OutputEmitter instance.
+ *
+ * Caches are keyed by the OutputEmitter's object identity (spl_object_id),
+ * so the same OutputEmitter reuses its emitter, method-emitter, and
+ * closure-helper instances across calls, while a different OutputEmitter
+ * gets a fresh set. This keeps stateful collaborators bound to the emitter
+ * that owns them without leaking instances between unrelated emitters.
+ */
 final class NodeEmitterFactory
 {
     /** @var array<int, array<string, NodeEmitterInterface>> */

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -179,15 +179,15 @@ final class NodeEmitterFactory
 
     private function getMethodEmitter(OutputEmitterInterface $outputEmitter): MethodEmitter
     {
-        $key = spl_object_id($outputEmitter);
+        $outputEmitterId = spl_object_id($outputEmitter);
 
-        return $this->methodEmitterCache[$key] ??= new MethodEmitter($outputEmitter, $this->getClosureHelper($outputEmitter));
+        return $this->methodEmitterCache[$outputEmitterId] ??= new MethodEmitter($outputEmitter, $this->getClosureHelper($outputEmitter));
     }
 
     private function getClosureHelper(OutputEmitterInterface $outputEmitter): ClosureEmitterHelper
     {
-        $key = spl_object_id($outputEmitter);
+        $outputEmitterId = spl_object_id($outputEmitter);
 
-        return $this->closureHelperCache[$key] ??= new ClosureEmitterHelper($outputEmitter);
+        return $this->closureHelperCache[$outputEmitterId] ??= new ClosureEmitterHelper($outputEmitter);
     }
 }

--- a/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
+++ b/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
@@ -40,10 +40,8 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
      * @param bool|float|int|string|TypeInterface|null $form The form to quasiqoute
      *
      * @throws SpliceNotInListException
-     *
-     * @return bool|float|int|string|TypeInterface|null
      */
-    public function transform($form)
+    public function transform($form): TypeInterface|string|float|int|bool|null
     {
         $context = new GensymContext();
 
@@ -51,13 +49,9 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
     }
 
     /**
-     * @param bool|float|int|string|TypeInterface|null $form
-     *
      * @throws SpliceNotInListException
-     *
-     * @return bool|float|int|string|TypeInterface|null
      */
-    private function doTransform($form, GensymContext $context)
+    private function doTransform(TypeInterface|string|float|int|bool|null $form, GensymContext $context): TypeInterface|string|float|int|bool|null
     {
         if ($this->isUnquote($form)) {
             /** @var PersistentList<mixed> $form */
@@ -190,7 +184,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
     /**
      * @param bool|float|int|string|TypeInterface|null $x The form to check
      */
-    private function isLiteral($x): bool
+    private function isLiteral(bool|float|int|TypeInterface|string|null $x): bool
     {
         return is_string($x)
             || is_float($x)
@@ -200,10 +194,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
             || $x instanceof Keyword;
     }
 
-    /**
-     * @param bool|float|int|string|TypeInterface|null $form
-     */
-    private function createOtherwise($form, GensymContext $context): PersistentListInterface|TypeInterface
+    private function createOtherwise(bool|float|int|TypeInterface|string|null $form, GensymContext $context): PersistentListInterface|TypeInterface
     {
         if ($form instanceof Symbol) {
             $name = $form->getFullName();

--- a/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
+++ b/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
@@ -86,7 +86,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
      */
     private function isUnquote($form): bool
     {
-        return $form instanceof PersistentListInterface && $form->get(0) == Symbol::NAME_UNQUOTE;
+        return $form instanceof PersistentListInterface && count($form) > 0 && $form->get(0) == Symbol::NAME_UNQUOTE;
     }
 
     /**
@@ -94,7 +94,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
      */
     private function isUnquoteSplicing($form): bool
     {
-        return $form instanceof PersistentListInterface && $form->get(0) == Symbol::NAME_UNQUOTE_SPLICING;
+        return $form instanceof PersistentListInterface && count($form) > 0 && $form->get(0) == Symbol::NAME_UNQUOTE_SPLICING;
     }
 
     /**

--- a/src/php/Config/CLAUDE.md
+++ b/src/php/Config/CLAUDE.md
@@ -24,7 +24,7 @@ Immutable `final readonly class`. Every mutation returns new instance via `with*
 - Validation: `validate(): list<string>` (empty if valid)
 - Serialization: `jsonSerialize(): array<string, mixed>`
 
-**Deprecated (since 0.37)**: `setX()` and `useLayout()`/`useNestedLayout()`/`useFlatLayout()` shim to `with*()` counterparts (marked `#[Deprecated]`).
+**Deprecated (since 0.37)**: `setX()` and `useLayout()`/`useNestedLayout()`/`useFlatLayout()` shim to `with*()` counterparts (marked `#[Deprecated]`). These are permanent backward-compatibility aliases: they are not scheduled for removal in a minor release. Use `with*()` for new code; any eventual removal would require a major version bump.
 
 ### PhelBuildConfig
 

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -578,7 +578,7 @@ final readonly class PhelConfig implements JsonSerializable
      */
     public function validate(): array
     {
-        return new PhelConfigValidator()->validate($this->srcDirs, $this->testDirs, $this->vendorDir);
+        return new PhelConfigValidator()->validate($this);
     }
 
     // ========================================
@@ -612,8 +612,9 @@ final readonly class PhelConfig implements JsonSerializable
     }
 
     /**
-     * Returns a new instance with the supplied fields overridden. Internal
-     * plumbing for every `with*()` method — keeps each wither one line.
+     * Internal builder: returns a new instance with the supplied fields
+     * overridden. Each public `with*()` method delegates to this, allowing
+     * single-line immutable updates.
      *
      * @param array<string, mixed> $overrides
      */

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -216,7 +216,11 @@ final readonly class PhelConfig implements JsonSerializable
 
     /**
      * Apply a project layout (nested or flat). Returns a new instance with src,
-     * test, format, and export-from directories aligned with the layout.
+     * test, format, and export-from directories fully reset to the layout's
+     * defaults. This is a complete directory reconfiguration, not a partial
+     * patch: any previously customised directory in those four groups is
+     * overwritten. Non-directory config (build, export prefix, caching, flags)
+     * is left untouched.
      */
     public function withLayout(ProjectLayout $layout): self
     {
@@ -287,8 +291,12 @@ final readonly class PhelConfig implements JsonSerializable
     }
 
     /**
-     * Flattens the build namespace onto PhelConfig. Sets the entry-point PHP
-     * path to `out/index.php` when none has been configured yet.
+     * Flattens the build namespace onto PhelConfig.
+     *
+     * Defaults the entry-point PHP path to `out/index.php` only when no custom
+     * path has been set yet, i.e. the current value is still empty or already
+     * the default `out/index.php`. Any other (custom) path is preserved, so
+     * calling this repeatedly is idempotent for zero-config projects.
      */
     public function withMainPhelNamespace(string $namespace): self
     {

--- a/src/php/Config/PhelConfigValidator.php
+++ b/src/php/Config/PhelConfigValidator.php
@@ -9,17 +9,14 @@ use function sprintf;
 final class PhelConfigValidator
 {
     /**
-     * @param list<string> $srcDirs
-     * @param list<string> $testDirs
-     *
      * @return list<string>
      */
-    public function validate(array $srcDirs, array $testDirs, string $vendorDir): array
+    public function validate(PhelConfig $config): array
     {
         return [
-            ...$this->validateRelativeDirs($srcDirs, 'Source'),
-            ...$this->validateRelativeDirs($testDirs, 'Test'),
-            ...$this->validateVendorDir($vendorDir),
+            ...$this->validateRelativeDirs($config->srcDirs, 'Source'),
+            ...$this->validateRelativeDirs($config->testDirs, 'Test'),
+            ...$this->validateVendorDir($config->vendorDir),
         ];
     }
 

--- a/src/php/Config/PhelExportConfig.php
+++ b/src/php/Config/PhelExportConfig.php
@@ -64,6 +64,10 @@ final readonly class PhelExportConfig implements JsonSerializable
     }
 
     /**
+     * Serializes to the Gacela wire format consumed by `AbstractConfig::get()`.
+     * The keys come from the `*_DIRECTORY`/`*_DIRECTORIES`/`*_PREFIX` constants
+     * and must never be renamed or recased without updating that contract.
+     *
      * @return array{target-directory: string, from-directories: list<string>, namespace-prefix: string}
      */
     public function jsonSerialize(): array

--- a/src/php/Console/Application/ArgvInputSanitizer.php
+++ b/src/php/Console/Application/ArgvInputSanitizer.php
@@ -10,7 +10,14 @@ use function in_array;
 
 final class ArgvInputSanitizer
 {
-    /** @var list<string> */
+    /**
+     * Options understood by `phel run` itself, recognized only while they appear
+     * before the command name. Once the command token is reached, every remaining
+     * argument is forwarded verbatim after a `--` separator, so script options
+     * stay distinct from arguments meant for the user command.
+     *
+     * @var list<string>
+     */
     private const array RUN_OPTIONS = ['-t', '--with-time', '--clear-opcache'];
 
     /**

--- a/src/php/Console/ConsoleFactory.php
+++ b/src/php/Console/ConsoleFactory.php
@@ -19,6 +19,10 @@ use function in_array;
  */
 final class ConsoleFactory extends AbstractFactory
 {
+    /**
+     * Application name passed to ConsoleBootstrap; shown in the Symfony Console
+     * header and the --version output.
+     */
     public const string CONSOLE_NAME = 'Phel';
 
     public function createConsoleBootstrap(): ConsoleBootstrap

--- a/src/php/Console/ConsoleProvider.php
+++ b/src/php/Console/ConsoleProvider.php
@@ -43,6 +43,10 @@ final class ConsoleProvider extends AbstractProvider
     }
 
     /**
+     * Aggregates every CLI command from the per-module providers listed in
+     * commandProviders(); command order follows that list. Exposed as the
+     * COMMANDS dependency consumed by ConsoleBootstrap.
+     *
      * @return list<Command>
      */
     #[Provides(self::COMMANDS)]
@@ -90,6 +94,11 @@ final class ConsoleProvider extends AbstractProvider
         return InstalledVersions::getReference(self::PACKAGE_NAME) ?? '';
     }
 
+    /**
+     * Runs a git command and returns its first output line trimmed, or an empty
+     * string when git is unavailable or the command fails. Callers treat the
+     * empty result as the signal to fall back to Composer's InstalledVersions.
+     */
     private function execGitCommand(string $command): string
     {
         $output = [];

--- a/src/php/Console/Domain/ConsoleCommandProviderInterface.php
+++ b/src/php/Console/Domain/ConsoleCommandProviderInterface.php
@@ -6,6 +6,11 @@ namespace Phel\Console\Domain;
 
 use Symfony\Component\Console\Command\Command;
 
+/**
+ * Per-module provider of Symfony Console commands. Each module implements this
+ * to expose its own commands; ConsoleProvider aggregates every implementation
+ * via its COMMANDS dependency to build the full CLI.
+ */
 interface ConsoleCommandProviderInterface
 {
     /**

--- a/src/php/Console/Infrastructure/ConsoleBootstrap.php
+++ b/src/php/Console/Infrastructure/ConsoleBootstrap.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function array_slice;
 use function array_values;
 use function in_array;
+use function str_starts_with;
 
 #[ServiceMap(method: 'getFactory', className: ConsoleFactory::class)]
 final class ConsoleBootstrap extends Application

--- a/src/php/Console/Infrastructure/ConsoleBootstrap.php
+++ b/src/php/Console/Infrastructure/ConsoleBootstrap.php
@@ -24,6 +24,14 @@ final class ConsoleBootstrap extends Application
 {
     use ServiceResolverAwareTrait;
 
+    /**
+     * Sanitizes argv, strips deprecation flags, rewrites a bare --help/-h into the
+     * `list` command, then runs the Symfony application with auto-exit disabled.
+     *
+     * Does not return: after the application finishes it clears the filesystem
+     * cache and terminates via exit() with the resolved exit code, so any code
+     * placed after the call site is unreachable.
+     */
     #[Override]
     public function run(?InputInterface $input = null, ?OutputInterface $output = null): int
     {

--- a/src/php/Fiber/Domain/Awaitable.php
+++ b/src/php/Fiber/Domain/Awaitable.php
@@ -19,8 +19,12 @@ interface Awaitable
     public function isRealized(): bool;
 
     /**
-     * Blocks until realized and returns the stored value. If the stored
-     * value is a Throwable it is rethrown.
+     * Blocks until realized and returns the stored value.
+     *
+     * A {@see Promise} returns its delivered value verbatim, even when that
+     * value is itself a Throwable. A {@see Future} additionally rethrows the
+     * exception its body threw (captured during execution), rather than
+     * returning it as a value.
      *
      * When called from inside a Fiber, suspends cooperatively. Outside a
      * Fiber context, falls back to a bounded usleep poll.

--- a/src/php/Fiber/Domain/Future.php
+++ b/src/php/Fiber/Domain/Future.php
@@ -38,6 +38,9 @@ final class Future implements Awaitable
     ) {
         $this->promise = new Promise($scheduler);
         $this->fiber = new Fiber(function () use ($body): void {
+            // Run the body and capture its outcome: a normal return is
+            // delivered as the promise value; a throw is recorded in
+            // $failed/$error and rethrown later on deref().
             try {
                 $result = $body();
                 $this->promise->deliver($result);

--- a/src/php/Fiber/Domain/Promise.php
+++ b/src/php/Fiber/Domain/Promise.php
@@ -47,7 +47,9 @@ final class Promise implements Awaitable, FnInterface
 
     /**
      * Deliver $value and freeze the promise. Returns true on the first
-     * delivery, false when the promise is already delivered.
+     * delivery, false when the promise is already delivered. Callers that
+     * must enforce a deliver-exactly-once invariant should check the return
+     * value; a false result means another caller (or fiber) won the race.
      */
     public function deliver(mixed $value): bool
     {

--- a/src/php/Fiber/Domain/Scheduler.php
+++ b/src/php/Fiber/Domain/Scheduler.php
@@ -103,6 +103,11 @@ final class Scheduler
      * need every scheduled fiber to make progress. Fibers that re-suspend
      * during a tick are re-enqueued by the awaitable they block on, so this
      * loop terminates only when nothing is left to run.
+     *
+     * WARNING: a fiber that loops without ever calling Fiber::suspend() never
+     * leaves the ready queue, so this blocks indefinitely. Use it for test
+     * harnesses and top-level event loops, not for unbounded production async
+     * work.
      */
     public function runUntilIdle(): void
     {

--- a/src/php/Fiber/FiberConfig.php
+++ b/src/php/Fiber/FiberConfig.php
@@ -6,6 +6,15 @@ namespace Phel\Fiber;
 
 use Gacela\Framework\AbstractConfig;
 
+/**
+ * Scheduler configuration.
+ *
+ * The default sleep is the latency/CPU trade-off for the top-level busy-poll
+ * used when awaiting outside a Fiber: shorter sleeps lower wake-up latency but
+ * burn more CPU while idle-waiting, longer sleeps do the reverse. The default
+ * of 500 microseconds balances the two; override it when a workload is
+ * latency-sensitive or, conversely, mostly idle.
+ */
 final class FiberConfig extends AbstractConfig
 {
     private const int DEFAULT_SLEEP_MICROSECONDS = 500;

--- a/src/php/Fiber/FiberFacade.php
+++ b/src/php/Fiber/FiberFacade.php
@@ -15,6 +15,11 @@ use Phel\Fiber\Domain\Scheduler;
  * primitives used by Phel's async library: {@see Promise}, {@see Future},
  * and the shared {@see Scheduler}.
  *
+ * A Future body is enqueued on the process-wide {@see Scheduler} eagerly,
+ * the moment {@see Future()} constructs it; it is not deferred until
+ * {@see await()}. The body then runs cooperatively whenever any fiber ticks
+ * the scheduler.
+ *
  * @extends AbstractFacade<FiberFactory>
  */
 final class FiberFacade extends AbstractFacade implements FiberFacadeInterface

--- a/src/php/Fiber/FiberFactory.php
+++ b/src/php/Fiber/FiberFactory.php
@@ -40,6 +40,16 @@ final class FiberFactory extends AbstractFactory
         return new Future($this->scheduler(), $body);
     }
 
+    /**
+     * Block until $awaitable is realized.
+     *
+     * With $timeoutMs === null the wait is unbounded: it delegates to
+     * {@see Scheduler::await()}, which surfaces a failed Future's exception
+     * via its {@see Future::deref()}. With a timeout it delegates to
+     * {@see Awaitable::derefWithTimeout()}, returning null on timeout and
+     * rethrowing a failed Future's exception only once the Future is realized
+     * within the deadline.
+     */
     public function await(Awaitable $awaitable, ?int $timeoutMs = null): mixed
     {
         if ($timeoutMs === null) {

--- a/src/php/Filesystem/Application/FileIo.php
+++ b/src/php/Filesystem/Application/FileIo.php
@@ -6,6 +6,10 @@ namespace Phel\Filesystem\Application;
 
 use Phel\Filesystem\Domain\FileIoInterface;
 
+/**
+ * Thin adapter around PHP's is_writable() so permission checks can be
+ * stubbed/mocked in tests instead of touching the real filesystem.
+ */
 final class FileIo implements FileIoInterface
 {
     public function isWritable(string $tempDir): bool

--- a/src/php/Filesystem/Application/TempDirFinder.php
+++ b/src/php/Filesystem/Application/TempDirFinder.php
@@ -19,7 +19,7 @@ use Phel\Shared\Exceptions\FileException;
  */
 final class TempDirFinder
 {
-    private string $finalTempDir = '';
+    private string $cachedTempDir = '';
 
     public function __construct(
         private readonly FileIoInterface $fileIo,
@@ -34,8 +34,8 @@ final class TempDirFinder
      */
     public function getOrCreateTempDir(): string
     {
-        if ($this->finalTempDir !== '') {
-            return $this->finalTempDir;
+        if ($this->cachedTempDir !== '') {
+            return $this->cachedTempDir;
         }
 
         $tempDir = $this->configTempDir;
@@ -59,12 +59,12 @@ final class TempDirFinder
 
             // @phpstan-ignore-next-line if.alwaysFalse
             if ($this->fileIo->isWritable($tempDir)) {
-                return $this->finalTempDir = $tempDir;
+                return $this->cachedTempDir = $tempDir;
             }
 
             throw FileException::directoryIsNotWritable($tempDir);
         }
 
-        return $this->finalTempDir = $tempDir;
+        return $this->cachedTempDir = $tempDir;
     }
 }

--- a/src/php/Filesystem/Application/TempDirFinder.php
+++ b/src/php/Filesystem/Application/TempDirFinder.php
@@ -7,6 +7,16 @@ namespace Phel\Filesystem\Application;
 use Phel\Filesystem\Domain\FileIoInterface;
 use Phel\Shared\Exceptions\FileException;
 
+/**
+ * Resolves the configured temp directory, creating it if missing and ensuring
+ * it is writable.
+ *
+ * The resolved path is cached on the instance after the first successful call,
+ * so subsequent calls return immediately without touching the filesystem.
+ * Creation is idempotent (a concurrently-created directory is tolerated), and
+ * a non-writable directory triggers a chmod 0777 retry before giving up with a
+ * FileException.
+ */
 final class TempDirFinder
 {
     private string $finalTempDir = '';
@@ -42,6 +52,8 @@ final class TempDirFinder
             }
         }
 
+        // Directory exists but is not writable: try to broaden permissions
+        // and re-check before failing.
         if (!$this->fileIo->isWritable($tempDir)) {
             @chmod($tempDir, 0777);
 

--- a/src/php/Filesystem/Application/TempDirFinder.php
+++ b/src/php/Filesystem/Application/TempDirFinder.php
@@ -40,17 +40,7 @@ final class TempDirFinder
 
         $tempDir = $this->configTempDir;
 
-        if (!is_dir($tempDir)) {
-            $oldUmask = umask(0);
-            if (!mkdir($tempDir, 0777, true) && !is_dir($tempDir)) {
-                throw FileException::canNotCreateDirectory($tempDir);
-            }
-
-            umask($oldUmask);
-            if (!is_dir($tempDir)) {
-                throw FileException::canNotCreateDirectory($tempDir);
-            }
-        }
+        $this->ensureDirectoryExists($tempDir);
 
         // Directory exists but is not writable: try to broaden permissions
         // and re-check before failing.
@@ -66,5 +56,31 @@ final class TempDirFinder
         }
 
         return $this->cachedTempDir = $tempDir;
+    }
+
+    /**
+     * Creates the directory if it does not already exist.
+     *
+     * Idempotent: an already-existing directory (or one created concurrently
+     * between the mkdir attempt and the is_dir re-check) is tolerated. umask is
+     * reset to 0 around mkdir so the 0777 mode is applied as requested.
+     *
+     * @throws FileException if the directory cannot be created
+     */
+    private function ensureDirectoryExists(string $tempDir): void
+    {
+        if (is_dir($tempDir)) {
+            return;
+        }
+
+        $oldUmask = umask(0);
+        if (!mkdir($tempDir, 0777, true) && !is_dir($tempDir)) {
+            throw FileException::canNotCreateDirectory($tempDir);
+        }
+
+        umask($oldUmask);
+        if (!is_dir($tempDir)) {
+            throw FileException::canNotCreateDirectory($tempDir);
+        }
     }
 }

--- a/src/php/Filesystem/Application/TempDirHealthCheck.php
+++ b/src/php/Filesystem/Application/TempDirHealthCheck.php
@@ -13,6 +13,14 @@ use function is_writable;
 use function mkdir;
 use function sprintf;
 
+/**
+ * Gacela module health check for the temp directory.
+ *
+ * Reports healthy only when the temp directory exists and is writable. The
+ * directory is auto-created on first check (idempotently), mirroring
+ * TempDirFinder's creation logic. It is kept separate from TempDirFinder so a
+ * health probe can run without caching the resolved path on a finder instance.
+ */
 final readonly class TempDirHealthCheck implements ModuleHealthCheckInterface
 {
     public function __construct(

--- a/src/php/Filesystem/Domain/FileIoInterface.php
+++ b/src/php/Filesystem/Domain/FileIoInterface.php
@@ -6,5 +6,10 @@ namespace Phel\Filesystem\Domain;
 
 interface FileIoInterface
 {
+    /**
+     * Returns true if the directory is writable by the current process.
+     *
+     * Abstraction over PHP's is_writable() so callers can be mocked in tests.
+     */
     public function isWritable(string $tempDir): bool;
 }

--- a/src/php/Filesystem/Domain/FilesystemInterface.php
+++ b/src/php/Filesystem/Domain/FilesystemInterface.php
@@ -4,9 +4,21 @@ declare(strict_types=1);
 
 namespace Phel\Filesystem\Domain;
 
+/**
+ * Tracks compiled artifacts for later cleanup.
+ *
+ * Implemented as a strategy: RealFilesystem performs real tracking/deletion,
+ * NullFilesystem is a no-op used when generated temp files should be kept.
+ */
 interface FilesystemInterface
 {
+    /**
+     * Registers a file path to be deleted on the next clearAll() call.
+     */
     public function addFile(string $file): void;
 
+    /**
+     * Deletes every previously registered file and resets the tracking state.
+     */
     public function clearAll(): void;
 }

--- a/src/php/Filesystem/Domain/NullFilesystem.php
+++ b/src/php/Filesystem/Domain/NullFilesystem.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace Phel\Filesystem\Domain;
 
+/**
+ * Null-object implementation of FilesystemInterface.
+ *
+ * Selected by FilesystemFactory when KEEP_GENERATED_TEMP_FILES is true: both
+ * addFile() and clearAll() are no-ops so generated temp files are never tracked
+ * or deleted. Paired with RealFilesystem as the active-cleanup strategy.
+ */
 final class NullFilesystem implements FilesystemInterface
 {
     public function addFile(string $file): void {}

--- a/src/php/Filesystem/FilesystemConfig.php
+++ b/src/php/Filesystem/FilesystemConfig.php
@@ -9,11 +9,19 @@ use Phel\Config\PhelConfig;
 
 final class FilesystemConfig extends AbstractConfig
 {
+    /**
+     * Whether generated temp files should be kept instead of cleaned up.
+     * Defaults to false when KEEP_GENERATED_TEMP_FILES is not configured.
+     */
     public function shouldKeepGeneratedTempFiles(): bool
     {
         return (bool) $this->get(PhelConfig::KEEP_GENERATED_TEMP_FILES, false);
     }
 
+    /**
+     * The configured temp directory, defaulting to sys_get_temp_dir()
+     * when TEMP_DIR is not configured.
+     */
     public function getTempDir(): string
     {
         return (string) $this->get(PhelConfig::TEMP_DIR, sys_get_temp_dir());

--- a/src/php/Filesystem/FilesystemFacade.php
+++ b/src/php/Filesystem/FilesystemFacade.php
@@ -12,6 +12,11 @@ use Gacela\Framework\Health\ModuleHealthCheckInterface;
  */
 final class FilesystemFacade extends AbstractFacade implements FilesystemFacadeInterface
 {
+    /**
+     * Registers a file for cleanup on the next clearAll() call.
+     *
+     * No-op when KEEP_GENERATED_TEMP_FILES is true (NullFilesystem strategy).
+     */
     public function addFile(string $file): void
     {
         $this->getFactory()
@@ -19,6 +24,11 @@ final class FilesystemFacade extends AbstractFacade implements FilesystemFacadeI
             ->addFile($file);
     }
 
+    /**
+     * Deletes all tracked files and resets the tracking state.
+     *
+     * No-op when KEEP_GENERATED_TEMP_FILES is true (NullFilesystem strategy).
+     */
     public function clearAll(): void
     {
         $this->getFactory()
@@ -26,6 +36,9 @@ final class FilesystemFacade extends AbstractFacade implements FilesystemFacadeI
             ->clearAll();
     }
 
+    /**
+     * Returns the temp directory path, creating and caching it if needed.
+     */
     public function getTempDir(): string
     {
         return $this->getFactory()

--- a/src/php/Filesystem/FilesystemFactory.php
+++ b/src/php/Filesystem/FilesystemFactory.php
@@ -17,6 +17,11 @@ use Phel\Filesystem\Infrastructure\RealFilesystem;
  */
 final class FilesystemFactory extends AbstractFactory
 {
+    /**
+     * Selects the cleanup strategy: NullFilesystem when
+     * KEEP_GENERATED_TEMP_FILES is true (debug mode, files are kept),
+     * otherwise RealFilesystem (tracks and deletes files on demand).
+     */
     public function createFilesystem(): FilesystemInterface
     {
         if ($this->getConfig()->shouldKeepGeneratedTempFiles()) {

--- a/src/php/Filesystem/Infrastructure/RealFilesystem.php
+++ b/src/php/Filesystem/Infrastructure/RealFilesystem.php
@@ -6,6 +6,17 @@ namespace Phel\Filesystem\Infrastructure;
 
 use Phel\Filesystem\Domain\FilesystemInterface;
 
+/**
+ * Tracks compiled files in a process-local static array and deletes them
+ * via unlink() on clearAll().
+ *
+ * Note: the tracking array is static, so it is shared across every instance:
+ * addFile() and clearAll() operate on the same global state regardless of the
+ * instance they are called on. reset() clears the array and exists primarily
+ * to isolate tests.
+ *
+ * NullFilesystem is used instead when KEEP_GENERATED_TEMP_FILES is true.
+ */
 final class RealFilesystem implements FilesystemInterface
 {
     /** @var list<string> */

--- a/src/php/Formatter/Application/PathsFormatter.php
+++ b/src/php/Formatter/Application/PathsFormatter.php
@@ -17,6 +17,14 @@ use Throwable;
 
 final readonly class PathsFormatter
 {
+    /**
+     * @param CommandFacadeInterface $commandFacade Writes located exceptions and
+     *                                              stack traces to the CLI output
+     * @param FormatterInterface     $formatter     Formats a single file's source
+     * @param PathFilterInterface    $pathFilter    Expands the input paths into the
+     *                                              concrete `.phel` files to format
+     * @param FileIoInterface        $fileIo        Reads and writes file contents
+     */
     public function __construct(
         private CommandFacadeInterface $commandFacade,
         private FormatterInterface $formatter,

--- a/src/php/Formatter/Domain/Rules/Indenter/BlockIndenter.php
+++ b/src/php/Formatter/Domain/Rules/Indenter/BlockIndenter.php
@@ -11,10 +11,22 @@ use Phel\Shared\Parser\Node\SymbolNode;
 
 use function is_null;
 
+/**
+ * Indents the body of a block form (e.g. `if`, `let`, `do`) under its symbol.
+ *
+ * When the form's head matches {@see self::$symbol}, the first
+ * {@see self::$index} value-nodes are treated as the form's "arguments" and
+ * stay on the head line; everything after them is indented as a block.
+ */
 final readonly class BlockIndenter implements IndenterInterface
 {
     private ListIndenter $listIndenter;
 
+    /**
+     * @param string $symbol The Phel form symbol to match (e.g. `if`, `let`)
+     * @param int    $index  Number of leading value-nodes to skip before the
+     *                       block indent applies (the form's fixed arguments)
+     */
     public function __construct(
         private string $symbol,
         private int $index,

--- a/src/php/Formatter/Domain/Rules/Indenter/InnerIndenter.php
+++ b/src/php/Formatter/Domain/Rules/Indenter/InnerIndenter.php
@@ -8,10 +8,22 @@ use Phel\Formatter\Domain\Rules\Zipper\ParseTreeZipper;
 use Phel\Lang\Symbol;
 use Phel\Shared\Parser\Node\SymbolNode;
 
+/**
+ * Indents a form's body by one extra level relative to its head line.
+ *
+ * Matches either the current location's head symbol or the head symbol of the
+ * ancestor reached by walking {@see self::$depth} levels up, allowing nested
+ * constructs to be matched at a fixed ancestry distance.
+ */
 final readonly class InnerIndenter implements IndenterInterface
 {
     private LineIndenter $lineIndenter;
 
+    /**
+     * @param string $symbol The Phel form symbol to match (e.g. `defn`, `fn`)
+     * @param int    $depth  Number of ancestor levels to climb (skipping
+     *                       whitespace) before checking the indent match
+     */
     public function __construct(
         private string $symbol,
         private int $depth,

--- a/src/php/Formatter/Domain/Rules/Indenter/LineIndenter.php
+++ b/src/php/Formatter/Domain/Rules/Indenter/LineIndenter.php
@@ -13,7 +13,7 @@ use function strlen;
  * Computes the left margin (indentation width) of a location by reconstructing
  * the text of the line that precedes it and measuring that line's length.
  */
-final class LineIndenter implements IndenterInterface
+final readonly class LineIndenter implements IndenterInterface
 {
     public function getMargin(ParseTreeZipper $loc, int $indentWidth): int
     {

--- a/src/php/Formatter/Domain/Rules/Indenter/LineIndenter.php
+++ b/src/php/Formatter/Domain/Rules/Indenter/LineIndenter.php
@@ -9,6 +9,10 @@ use Phel\Shared\Parser\Node\InnerNodeInterface;
 
 use function strlen;
 
+/**
+ * Computes the left margin (indentation width) of a location by reconstructing
+ * the text of the line that precedes it and measuring that line's length.
+ */
 final class LineIndenter implements IndenterInterface
 {
     public function getMargin(ParseTreeZipper $loc, int $indentWidth): int
@@ -16,6 +20,12 @@ final class LineIndenter implements IndenterInterface
         return strlen($this->lastLineInString($this->priorLineString($loc)));
     }
 
+    /**
+     * Walks backwards (left, then up) from the given location, prepending each
+     * node's code, until a node containing a newline is reached or the root is
+     * hit. The returned string holds the source from the start of the current
+     * line up to the location.
+     */
     private function priorLineString(ParseTreeZipper $form): string
     {
         $loc = $form;
@@ -40,6 +50,10 @@ final class LineIndenter implements IndenterInterface
         return $str;
     }
 
+    /**
+     * Returns the substring after the last newline (the final line), or the
+     * whole string when it contains no newline.
+     */
     private function lastLineInString(string $s): string
     {
         $pos = strrpos($s, "\n");

--- a/src/php/Formatter/Domain/Rules/Pair/PairAligner.php
+++ b/src/php/Formatter/Domain/Rules/Pair/PairAligner.php
@@ -24,7 +24,18 @@ use function strlen;
 final readonly class PairAligner
 {
     /**
+     * Returns $children unchanged unless the pairs span multiple lines and have
+     * a uniform single-line key column to align under.
+     *
      * @param list<NodeInterface> $children
+     * @param int                 $skipValueCount      Number of leading
+     *                                                 non-trivia children to
+     *                                                 exclude before pairing
+     *                                                 starts (e.g. the form head)
+     * @param bool                $allowTrailingSingle Whether an odd trailing
+     *                                                 value is permitted and
+     *                                                 dropped from pairing
+     *                                                 (e.g. a `cond` default)
      *
      * @return list<NodeInterface>
      */
@@ -57,11 +68,15 @@ final readonly class PairAligner
             }
         }
 
+        // Skip the leading non-trivia children (e.g. the form head/keyword)
+        // that are not part of the key/value pairs.
         $pairIndices = array_slice($valueIndices, $skipValueCount);
         if ($allowTrailingSingle && count($pairIndices) % 2 === 1) {
             array_pop($pairIndices);
         }
 
+        // Need at least two complete pairs (4 values) for alignment to matter;
+        // an odd count means the values are not key/value pairs at all.
         if (count($pairIndices) % 2 !== 0 || count($pairIndices) < 4) {
             return [];
         }

--- a/src/php/Formatter/Domain/Rules/RemoveSurroundingWhitespaceRule.php
+++ b/src/php/Formatter/Domain/Rules/RemoveSurroundingWhitespaceRule.php
@@ -8,7 +8,7 @@ use Phel\Formatter\Domain\Rules\Zipper\ParseTreeZipper;
 use Phel\Formatter\Domain\Rules\Zipper\ZipperException;
 use Phel\Shared\Parser\Node\NodeInterface;
 
-final class RemoveSurroundingWhitespaceRule implements RuleInterface
+final readonly class RemoveSurroundingWhitespaceRule implements RuleInterface
 {
     /**
      * @throws ZipperException

--- a/src/php/Formatter/Domain/Rules/RemoveTrailingWhitespaceRule.php
+++ b/src/php/Formatter/Domain/Rules/RemoveTrailingWhitespaceRule.php
@@ -8,7 +8,7 @@ use Phel\Formatter\Domain\Rules\Zipper\ParseTreeZipper;
 use Phel\Formatter\Domain\Rules\Zipper\ZipperException;
 use Phel\Shared\Parser\Node\NodeInterface;
 
-final class RemoveTrailingWhitespaceRule implements RuleInterface
+final readonly class RemoveTrailingWhitespaceRule implements RuleInterface
 {
     public function transform(NodeInterface $node): NodeInterface
     {

--- a/src/php/Formatter/Domain/Rules/UnindentRule.php
+++ b/src/php/Formatter/Domain/Rules/UnindentRule.php
@@ -9,7 +9,13 @@ use Phel\Formatter\Domain\Rules\Zipper\ZipperException;
 use Phel\Shared\Parser\Node\NodeInterface;
 
 /**
- * This rule removes all indentations. It is used as a preprocessor for the IndentRule.
+ * Removes all existing indentation: every whitespace node that directly follows
+ * a line break is stripped (unless the next non-whitespace node is a comment,
+ * whose leading indentation is preserved).
+ *
+ * Runs as a preprocessor for IndentRule to normalize the tree to a known,
+ * unindented state. This is safe because IndentRule then recalculates every
+ * line's indentation from scratch.
  */
 final class UnindentRule implements RuleInterface
 {

--- a/src/php/Formatter/Domain/Rules/Zipper/AbstractZipper.php
+++ b/src/php/Formatter/Domain/Rules/Zipper/AbstractZipper.php
@@ -10,6 +10,21 @@ use RuntimeException;
 use function assert;
 
 /**
+ * Functional zipper for navigating and editing an immutable parse tree.
+ *
+ * A zipper represents a "location": the focused {@see self::$node} plus enough
+ * context (its $parent, and the $leftSiblings/$rightSiblings around it) to walk
+ * in any direction and rebuild the whole tree. Movement methods
+ * (left/right/up/down/next/prev) return a *new* location rather than mutating
+ * in place, so traversal is side-effect free.
+ *
+ * Edits (replace/insert/remove) set the {@see self::$hasChanged} flag on the
+ * location. When {@see self::up()} is called on a changed location,
+ * {@see self::reconstructParentFromChange()} rebuilds the parent node from the
+ * current siblings so the edit propagates upward; unchanged locations simply
+ * return the cached parent. {@see self::$isEnd} marks a completed depth-first
+ * walk (see {@see self::next()}).
+ *
  * @template T of NodeInterface
  *
  * @psalm-consistent-constructor

--- a/src/php/HttpClient/ResponseParser.php
+++ b/src/php/HttpClient/ResponseParser.php
@@ -9,15 +9,18 @@ namespace Phel\HttpClient;
  * into a structured associative array.
  *
  * Header names are lowercased. For duplicate header names (e.g. Set-Cookie),
- * only the last value is kept. Redirect chains are handled by resetting
- * status/version/reason on each new HTTP status line encountered.
+ * only the last value is kept: this is a deliberate trade-off to keep the
+ * returned map flat (string => string); callers needing every value of a
+ * multi-valued header must read the raw lines themselves. Redirect chains are
+ * handled by resetting status/version/reason on each new HTTP status line
+ * encountered.
  */
 final class ResponseParser
 {
     /**
      * @param list<string> $rawHeaders Raw header lines from $http_response_header
      *
-     * @return array{status: int, version: string, reason: string, headers: array<string, string>}
+     * @return array{status: int, version: string, reason: string, headers: array<string, string>} 'headers' keys are lowercased header names
      */
     public static function parse(array $rawHeaders): array
     {

--- a/src/php/HttpClient/ResponseParser.php
+++ b/src/php/HttpClient/ResponseParser.php
@@ -37,10 +37,9 @@ final class ResponseParser
                 continue;
             }
 
-            $colonPos = strpos($line, ':');
-            if ($colonPos !== false) {
-                $name = strtolower(trim(substr($line, 0, $colonPos)));
-                $value = trim(substr($line, $colonPos + 1));
+            $header = self::parseHeaderLine($line);
+            if ($header !== null) {
+                [$name, $value] = $header;
                 $headers[$name] = $value;
             }
         }
@@ -51,5 +50,23 @@ final class ResponseParser
             'reason' => $reason,
             'headers' => $headers,
         ];
+    }
+
+    /**
+     * Parses a single (non-status) header line into a lowercased name/value pair.
+     *
+     * @return array{0: string, 1: string}|null Null when the line has no colon separator
+     */
+    private static function parseHeaderLine(string $line): ?array
+    {
+        $colonPos = strpos($line, ':');
+        if ($colonPos === false) {
+            return null;
+        }
+
+        $name = strtolower(trim(substr($line, 0, $colonPos)));
+        $value = trim(substr($line, $colonPos + 1));
+
+        return [$name, $value];
     }
 }

--- a/src/php/HttpClient/StreamTransport.php
+++ b/src/php/HttpClient/StreamTransport.php
@@ -30,9 +30,14 @@ final class StreamTransport
         $context = self::buildContext($method, $headers, $body, $options);
 
         $http_response_header = [];
+        // Suppress the warning fopen/file_get_contents emits on failure; the
+        // precise reason is recovered via error_get_last() so the exception
+        // carries an accurate message instead of a generic "request failed".
         $responseBody = @file_get_contents($url, false, $context);
 
         if ($responseBody === false) {
+            // error_get_last() may return null (or an array without a 'message'
+            // key) in edge cases, so fall back to a safe default.
             $error = error_get_last();
             throw new RuntimeException(
                 sprintf('HTTP request to %s failed: %s', $url, $error['message'] ?? 'Unknown error'),
@@ -67,10 +72,17 @@ final class StreamTransport
             $headerLines[] = sprintf('%s: %s', $name, $value);
         }
 
+        // Coerce option values defensively: a numeric-string timeout or a
+        // truthy/falsy redirect/ssl flag is accepted and normalised here.
         $timeout = (float) ($options['timeout'] ?? 30.0);
         $followRedirects = (bool) ($options['follow_redirects'] ?? true);
         $verifySsl = (bool) ($options['verify_ssl'] ?? true);
 
+        // Stream context describes the request: HTTP method, headers, body,
+        // timeout and redirect policy under 'http', SSL peer verification
+        // (hostname + certificate) under 'ssl'. ignore_errors => true makes
+        // file_get_contents() return the body for non-2xx responses instead
+        // of false, so error statuses can still be parsed.
         return stream_context_create([
             'http' => [
                 'method' => strtoupper($method),

--- a/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
+++ b/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
@@ -72,6 +72,10 @@ final readonly class FunctionsToExportFinder implements FunctionsToExportFinderI
     }
 
     /**
+     * Scans every loaded Phel namespace and collects the definitions whose metadata
+     * carries `:export true`, grouped by namespace so the generator can emit one
+     * wrapper class per namespace.
+     *
      * @return array<string, list<FunctionToExport>>
      */
     private function findAllFunctionsToExport(): array

--- a/src/php/Interop/Domain/FileCreator/FileIoInterface.php
+++ b/src/php/Interop/Domain/FileCreator/FileIoInterface.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace Phel\Interop\Domain\FileCreator;
 
+use RuntimeException;
+
 interface FileIoInterface
 {
+    /**
+     * Creates the directory (including missing parents); a no-op if it already exists.
+     *
+     * @throws RuntimeException if the directory could not be created
+     */
     public function createDirectory(string $directory): void;
 
     public function filePutContents(string $filename, string $content): void;

--- a/src/php/Interop/Domain/Generator/Builder/CompiledPhpClassBuilder.php
+++ b/src/php/Interop/Domain/Generator/Builder/CompiledPhpClassBuilder.php
@@ -29,6 +29,13 @@ final readonly class CompiledPhpClassBuilder
         ], $this->classTemplate());
     }
 
+    /**
+     * Derives the PHP namespace for the wrapper from the Phel namespace.
+     *
+     * The last Phel segment names the class (built separately in buildClassName());
+     * the remaining segments become the PHP namespace after PascalCase conversion,
+     * prepended with the configured prefix namespace when one is set.
+     */
     private function buildNamespace(string $phelNs): string
     {
         $phelNsWords = $this->splitNamespace($phelNs);

--- a/src/php/Interop/Domain/Generator/Builder/CompiledPhpMethodBuilder.php
+++ b/src/php/Interop/Domain/Generator/Builder/CompiledPhpMethodBuilder.php
@@ -19,6 +19,16 @@ final readonly class CompiledPhpMethodBuilder
         private PhpAttributeRenderer $attributeRenderer = new PhpAttributeRenderer(),
     ) {}
 
+    /**
+     * Generates the PHP source of a single wrapper method for an exported Phel function.
+     *
+     * The compiled Phel function is a class whose `BOUND_TO` constant holds its
+     * fully qualified Phel name; reflection on its `__invoke` method provides the
+     * parameter list and return type. These are rendered into the method template,
+     * replacing the `$ATTRIBUTES$`, `$METHOD_NAME$`, `$ARGS$`, `$RETURN_TYPE$`,
+     * `$PHEL_NAMESPACE$` and `$PHEL_FUNCTION_NAME$` tokens, so the generated method
+     * delegates to `self::callPhel(...)` at runtime.
+     */
     public function build(string $phelNs, FunctionToExport $functionToExport): string
     {
         $ref = new ReflectionClass($functionToExport->fn());

--- a/src/php/Interop/Domain/Generator/Builder/WrapperRelativeFilenamePathBuilder.php
+++ b/src/php/Interop/Domain/Generator/Builder/WrapperRelativeFilenamePathBuilder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Interop\Domain\Generator\Builder;
 
-final class WrapperRelativeFilenamePathBuilder
+final readonly class WrapperRelativeFilenamePathBuilder
 {
     public function build(string $phelNs): string
     {

--- a/src/php/Interop/Infrastructure/IO/FileSystemIo.php
+++ b/src/php/Interop/Infrastructure/IO/FileSystemIo.php
@@ -9,7 +9,7 @@ use RuntimeException;
 
 use function sprintf;
 
-final class FileSystemIo implements FileIoInterface
+final readonly class FileSystemIo implements FileIoInterface
 {
     public function createDirectory(string $directory): void
     {

--- a/src/php/Interop/Infrastructure/IO/FileSystemIo.php
+++ b/src/php/Interop/Infrastructure/IO/FileSystemIo.php
@@ -17,10 +17,6 @@ final class FileSystemIo implements FileIoInterface
             return;
         }
 
-        if (is_dir($directory)) {
-            return;
-        }
-
         throw new RuntimeException(sprintf('Directory "%s" was not created', $directory));
     }
 

--- a/src/php/Interop/PhelCallerTrait.php
+++ b/src/php/Interop/PhelCallerTrait.php
@@ -6,9 +6,19 @@ namespace Phel\Interop;
 
 use Phel;
 
+/**
+ * Mixed into every generated wrapper class to resolve and invoke Phel definitions.
+ *
+ * Resolved definitions are memoized in a process-wide static cache shared across
+ * all classes that use the trait, keyed by `namespace::definitionName`. The cache
+ * is populated lazily on first call and never invalidated, so its lifetime equals
+ * the process lifetime. This is safe for single-request contexts (CLI, per-request
+ * FPM) but a wrapper will keep calling the originally resolved definition even if
+ * the Phel runtime redefines it mid-process.
+ */
 trait PhelCallerTrait
 {
-    /** @var array<string, mixed> Cache of resolved Phel definitions */
+    /** @var array<string, mixed> Process-wide cache of resolved Phel definitions, keyed by "namespace::definitionName" */
     private static array $definitionCache = [];
 
     private static function callPhel(string $namespace, string $definitionName, mixed ...$arguments): mixed

--- a/src/php/Lang/Atom.php
+++ b/src/php/Lang/Atom.php
@@ -86,6 +86,11 @@ final class Atom extends AbstractType
         return $this->validator;
     }
 
+    /**
+     * Atoms compare by identity (`===`), never by their dereferenced value.
+     * This keeps watch callbacks and validators bound to the container itself,
+     * so two distinct atoms holding equal values are still considered different.
+     */
     public function equals(mixed $other): bool
     {
         return $this === $other;

--- a/src/php/Lang/CLAUDE.md
+++ b/src/php/Lang/CLAUDE.md
@@ -13,7 +13,7 @@ Foundational leaf module with no Facade, Factory, or DependencyProvider. All typ
 - **Keyword**: interned pool; callable to access map values; implements `FnInterface`
 - **Atom**: mutable box with watches, validators, `deref` (Clojure-aligned; was `Variable`)
 - **PhelVar**: first-class handle to global `def`. Methods: `deref`, `meta`, `alterRoot`, `addWatch`/`removeWatch`, `alterMeta`/`resetMeta`, `isDynamic` (cached). Callable via `__invoke` to current root. Produced by `Registry::addDefinition`/`getVar` and `(var sym)` form
-- **PhelVarStateRegistry**: singleton side table for per-var watches, metadata, dynamic-flag cache keyed by `(ns, name)`; enables `PhelVar` to stay `readonly` while `alter-meta!` and `add-watch` mutate canonical state
+- **PhelVarStateRegistry**: singleton side table for per-var watches, metadata, dynamic-flag cache keyed by `(ns, name)`; enables `PhelVar` to stay `readonly` while `alter-meta!` and `add-watch` mutate canonical state. The `isDynamic` cache is cleared here via `invalidateDynamicCache(ns, name)` whenever metadata changes (`alter-meta!`/`reset-meta!` or a re-`def`), not in `PhelVar` itself
 
 **Numeric Types**
 - **BigInt**: arbitrary-precision signed integer (`final readonly`, `TypeInterface`); base-10^9 with sign. Methods: `fromInt`, `fromFloat`, `fromString`, `add`/`subtract`/`multiply`/`divide`/`mod`/`gcd`/`pow`/`negate`/`abs`, `compareTo`, `equals`, `hash`, `toInt`, `fitsInPhpInt`. No I/O or static state. Owns sign + metadata + signed semantics; delegates the sign-agnostic digit-array kernels to **BigIntMagnitude**
@@ -30,7 +30,7 @@ Foundational leaf module with no Facade, Factory, or DependencyProvider. All typ
 - **MapEntry**: typed two-element entry (`final readonly`, `TypeInterface, Countable, IteratorAggregate, FirstInterface, CdrInterface`). Equal by value to 2-element vector (both directions). Accessors: `key()`/`value()`; `first()` = key, `cdr()` = 1-vector with value
 
 **Lazy and Mutable**
-- **Delay**: lazy evaluation with caching
+- **Delay**: single-value lazy computation; `deref()` runs the thunk once and caches the result, `isRealized()` reports whether it has run. Use for single-value laziness (distinct from **LazySeq**, which is for sequences)
 - **Volatile**: lightweight mutable container for transducer state (no watches/validators)
 - **Reduced**: signals early termination from reduce/transduce
 - **Future**: Amphp adapter; exposes Phel deref/realized? protocol

--- a/src/php/Lang/MetaTrait.php
+++ b/src/php/Lang/MetaTrait.php
@@ -20,6 +20,11 @@ trait MetaTrait
     }
 
     /**
+     * Mutates `$meta` in place and returns the same instance rather than a
+     * fresh copy. Callers that need value-immutability (e.g. when the receiver
+     * is interned or shared) must clone before calling, or a type using this
+     * trait must override this method.
+     *
      * @param PersistentMapInterface<mixed, mixed>|null $meta
      */
     public function withMeta(?PersistentMapInterface $meta): static

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -70,6 +70,12 @@ final class Registry
     }
 
     /**
+     * Stores a definition and returns a handle to it.
+     *
+     * Side effect: when {@see self::$profilerHook} is installed and `$value`
+     * is an `AbstractFn`, the stored value is the profiling wrapper, not the
+     * original function. Also clears the dynamic-flag cache for the slot.
+     *
      * @param PersistentMapInterface<mixed, mixed>|null $metaData
      */
     public function addDefinition(string $ns, string $name, mixed $value, ?PersistentMapInterface $metaData = null): PhelVar

--- a/src/php/Lang/Volatile.php
+++ b/src/php/Lang/Volatile.php
@@ -8,6 +8,10 @@ namespace Phel\Lang;
  * A lightweight mutable container for transducer state.
  * Unlike Atom, has no watches or validators.
  *
+ * Prefer Volatile over Atom when you need plain mutation without observation,
+ * e.g. transducer accumulators or internal compiler state. It is unobservable
+ * and therefore cheaper; reach for Atom only when watches/validation matter.
+ *
  * @template T
  */
 final class Volatile

--- a/src/php/Lint/Application/Formatter/FormatterRegistry.php
+++ b/src/php/Lint/Application/Formatter/FormatterRegistry.php
@@ -7,6 +7,8 @@ namespace Phel\Lint\Application\Formatter;
 use InvalidArgumentException;
 use Phel\Lint\Domain\DiagnosticFormatterInterface;
 
+use function array_keys;
+use function implode;
 use function sprintf;
 
 /**

--- a/src/php/Lint/Application/Formatter/HumanFormatter.php
+++ b/src/php/Lint/Application/Formatter/HumanFormatter.php
@@ -8,6 +8,7 @@ use Phel\Api\Transfer\Diagnostic;
 use Phel\Lint\Domain\DiagnosticFormatterInterface;
 use Phel\Lint\Transfer\LintResult;
 
+use function implode;
 use function sprintf;
 
 /**
@@ -54,13 +55,13 @@ final class HumanFormatter implements DiagnosticFormatterInterface
             $diagnostic->uri,
             $diagnostic->startLine,
             $diagnostic->startCol,
-            $this->severityLabel($diagnostic->severity),
+            $this->formatSeverity($diagnostic->severity),
             $diagnostic->code,
             $diagnostic->message,
         );
     }
 
-    private function severityLabel(string $severity): string
+    private function formatSeverity(string $severity): string
     {
         return match ($severity) {
             Diagnostic::SEVERITY_ERROR => '[error]',

--- a/src/php/Lint/Application/LintRunner.php
+++ b/src/php/Lint/Application/LintRunner.php
@@ -86,6 +86,12 @@ final readonly class LintRunner
     }
 
     /**
+     * Builds the project-wide symbol index that rules consume for cross-file
+     * resolution. Only directories are indexed: individual files are already
+     * analysed in the main loop, so passing a directory lets the index cover
+     * sibling definitions. When no directories are given the index is empty
+     * and rules degrade gracefully (no cross-file resolution).
+     *
      * @param list<string> $paths
      */
     private function buildProjectIndex(array $paths): ProjectIndex

--- a/src/php/Lint/Application/Rule/DiscouragedVarRule.php
+++ b/src/php/Lint/Application/Rule/DiscouragedVarRule.php
@@ -16,7 +16,9 @@ use Phel\Lint\Domain\LintRuleInterface;
 use function count;
 use function in_array;
 use function is_string;
+use function preg_match;
 use function sprintf;
+use function str_starts_with;
 
 /**
  * Flags references to definitions marked `^:deprecated` or

--- a/src/php/Lint/Application/Rule/ShadowedBindingRule.php
+++ b/src/php/Lint/Application/Rule/ShadowedBindingRule.php
@@ -150,8 +150,11 @@ final readonly class ShadowedBindingRule implements LintRuleInterface
                 continue;
             }
 
-            // Each arity introduces its own scope extension at analyze-time;
-            // still flag inner shadowing of the outer scope.
+            // Each arity introduces its own independent scope at analyze-time,
+            // but shadowing is reported relative to the shared outer scope, so
+            // every additional arity is walked against the same $newScope and
+            // its result is intentionally discarded (only the first arity's
+            // scope is propagated to the caller).
             $this->walkParams($paramVector, $newScope, $uri, $result);
         }
 

--- a/src/php/Lint/Application/Rule/UnusedImportRule.php
+++ b/src/php/Lint/Application/Rule/UnusedImportRule.php
@@ -105,7 +105,7 @@ final readonly class UnusedImportRule implements LintRuleInterface
             }
 
             $result[] = [
-                'alias' => $alias ?? $this->defaultAlias($item),
+                'alias' => $alias ?? $this->lastSegmentAlias($item),
                 'display' => $item->getName(),
                 'anchor' => $item,
             ];
@@ -114,7 +114,7 @@ final readonly class UnusedImportRule implements LintRuleInterface
         return $result;
     }
 
-    private function defaultAlias(Symbol $symbol): string
+    private function lastSegmentAlias(Symbol $symbol): string
     {
         $name = $symbol->getName();
         $parts = explode('\\', $name);

--- a/src/php/Lint/Application/Rule/UnusedRequireRule.php
+++ b/src/php/Lint/Application/Rule/UnusedRequireRule.php
@@ -13,6 +13,7 @@ use Phel\Lint\Domain\FileAnalysis;
 use Phel\Lint\Domain\LintRuleInterface;
 
 use function count;
+use function explode;
 use function sprintf;
 
 /**

--- a/src/php/Lint/Infrastructure/Command/LintCommand.php
+++ b/src/php/Lint/Infrastructure/Command/LintCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 use function getcwd;
+use function implode;
 use function is_dir;
 use function is_file;
 use function is_string;

--- a/src/php/Lint/Transfer/LintResult.php
+++ b/src/php/Lint/Transfer/LintResult.php
@@ -17,7 +17,8 @@ final readonly class LintResult
 {
     /**
      * @param list<Diagnostic> $diagnostics
-     * @param list<string>     $scannedFiles
+     * @param list<string>     $scannedFiles absolute paths of the files analysed,
+     *                                       used to report coverage; empty when nothing was scanned
      */
     public function __construct(
         public array $diagnostics,

--- a/src/php/Lsp/Application/Convert/SymbolKindMapper.php
+++ b/src/php/Lsp/Application/Convert/SymbolKindMapper.php
@@ -12,12 +12,13 @@ use Phel\Api\Transfer\Definition;
  * `documentSymbol` and `workspace/symbol` responses consistent.
  *
  * Reference: LSP `SymbolKind` (1..26). Values used here:
- *  - 5  Class
- *  - 6  Method
- *  - 11 Interface
- *  - 12 Function
- *  - 13 Variable
- *  - 18 Struct
+ *  - 5  Class      (`defexception` — exceptions are class-like)
+ *  - 6  Method     (`defmacro` — macros expand at compile time, akin to a
+ *                   class-bound operation rather than a runtime callable)
+ *  - 11 Interface  (`defprotocol`, `definterface` — abstract contracts)
+ *  - 12 Function   (`defn` — runtime callable, the closest LSP analogue)
+ *  - 13 Variable   (default — `def` and any other plain binding)
+ *  - 18 Struct     (`defstruct` — record-like data shapes)
  */
 final class SymbolKindMapper
 {

--- a/src/php/Lsp/Application/Handler/DocumentSymbolHandler.php
+++ b/src/php/Lsp/Application/Handler/DocumentSymbolHandler.php
@@ -14,6 +14,8 @@ use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
 
+use function array_values;
+
 /**
  * Lists all top-level definitions in the open document. Uses the project
  * index when available; otherwise runs a single-file indexing pass so the
@@ -84,11 +86,7 @@ final readonly class DocumentSymbolHandler implements HandlerInterface
         }
 
         $index = $this->apiFacade->indexProject([$path]);
-        $result = [];
-        foreach ($index->definitions as $def) {
-            $result[] = $def;
-        }
 
-        return $result;
+        return array_values($index->definitions);
     }
 }

--- a/src/php/Lsp/Application/Handler/ExitHandler.php
+++ b/src/php/Lsp/Application/Handler/ExitHandler.php
@@ -7,6 +7,12 @@ namespace Phel\Lsp\Application\Handler;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
 
+/**
+ * Handles the LSP `exit` notification: instructs the server to terminate.
+ * Per the LSP lifecycle this is sent after a `shutdown` request (see
+ * {@see ShutdownHandler}); unlike `shutdown` it is a notification (no response),
+ * hence {@see self::isNotification()} returns true.
+ */
 final class ExitHandler implements HandlerInterface
 {
     public function method(): string

--- a/src/php/Lsp/Application/Handler/ShutdownHandler.php
+++ b/src/php/Lsp/Application/Handler/ShutdownHandler.php
@@ -7,6 +7,12 @@ namespace Phel\Lsp\Application\Handler;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
 
+/**
+ * Handles the LSP `shutdown` request: marks the session as shutting down so the
+ * server stops processing further requests, but does not terminate the process.
+ * Per the LSP lifecycle, the client must follow up with an `exit` notification
+ * (see {@see ExitHandler}) to actually end the server.
+ */
 final class ShutdownHandler implements HandlerInterface
 {
     public function method(): string

--- a/src/php/Nrepl/Application/Op/EvalOp.php
+++ b/src/php/Nrepl/Application/Op/EvalOp.php
@@ -34,6 +34,9 @@ final readonly class EvalOp implements OpHandlerInterface
             )];
         }
 
+        // structuredEval compiles and evaluates the code in the session's
+        // current namespace. CompileOptions is left empty: there is currently
+        // no nREPL-specific tuning (no optimization flags) to pass through.
         $result = $this->runFacade->structuredEval($code, new CompileOptions());
 
         return $this->responder->respond($request, $result, 'Evaluation failed.');

--- a/src/php/Nrepl/Application/Op/EvalResultResponder.php
+++ b/src/php/Nrepl/Application/Op/EvalResultResponder.php
@@ -29,6 +29,11 @@ final readonly class EvalResultResponder
     ) {}
 
     /**
+     * @param OpRequest  $request              the nREPL request context (carries id/session routing)
+     * @param EvalResult $result               the evaluated result produced by RunFacade
+     * @param string     $errorFallbackMessage error text used when the failure carries no EvalError object
+     * @param ?string    $fileName             optional source file name, woven into the error framing for load-file ops
+     *
      * @return list<OpResponse>
      */
     public function respond(

--- a/src/php/Nrepl/Application/Op/InterruptOp.php
+++ b/src/php/Nrepl/Application/Op/InterruptOp.php
@@ -14,7 +14,7 @@ use Phel\Nrepl\Domain\Op\OpStatus;
  * background work to interrupt; this handler simply acknowledges the op to
  * keep editors happy.
  */
-final class InterruptOp implements OpHandlerInterface
+final readonly class InterruptOp implements OpHandlerInterface
 {
     public function name(): string
     {

--- a/src/php/Nrepl/Application/Op/InterruptOp.php
+++ b/src/php/Nrepl/Application/Op/InterruptOp.php
@@ -9,6 +9,11 @@ use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Op\OpResponse;
 use Phel\Nrepl\Domain\Op\OpStatus;
 
+/**
+ * Interrupt op (no-op stub). Phel evaluates synchronously, so there is no
+ * background work to interrupt; this handler simply acknowledges the op to
+ * keep editors happy.
+ */
 final class InterruptOp implements OpHandlerInterface
 {
     public function name(): string

--- a/src/php/Nrepl/Application/Op/LookupOp.php
+++ b/src/php/Nrepl/Application/Op/LookupOp.php
@@ -36,10 +36,7 @@ final readonly class LookupOp implements OpHandlerInterface
 
     public function handle(OpRequest $request): array
     {
-        $symbol = $request->stringParam('sym');
-        if ($symbol === '') {
-            $symbol = $request->stringParam('symbol');
-        }
+        $symbol = $this->extractSymbol($request);
 
         if ($symbol === '') {
             return [OpResponse::errorDone(
@@ -73,6 +70,16 @@ final readonly class LookupOp implements OpHandlerInterface
             ['info' => $info, 'eldoc' => $fn->signatures],
             [OpStatus::DONE],
         )];
+    }
+
+    private function extractSymbol(OpRequest $request): string
+    {
+        $symbol = $request->stringParam('sym');
+        if ($symbol === '') {
+            return $request->stringParam('symbol');
+        }
+
+        return $symbol;
     }
 
     private function resolveCurrentNamespace(OpRequest $request): string

--- a/src/php/Nrepl/Domain/Bencode/BencodeDecoder.php
+++ b/src/php/Nrepl/Domain/Bencode/BencodeDecoder.php
@@ -45,6 +45,12 @@ final class BencodeDecoder
         return [$value, $position];
     }
 
+    /**
+     * Recursive entry point shared by all internal decoders.
+     *
+     * @param int &$position IN/OUT: the offset to start at; on return it is
+     *                       advanced to the first byte after the decoded value
+     */
     private function decodeAt(string $input, int &$position): mixed
     {
         if ($position >= strlen($input)) {

--- a/src/php/Nrepl/Domain/Op/OpRequest.php
+++ b/src/php/Nrepl/Domain/Op/OpRequest.php
@@ -12,7 +12,10 @@ use function is_string;
 final readonly class OpRequest
 {
     /**
-     * @param array<string, mixed> $raw
+     * @param string               $op      the op name from the nREPL message
+     * @param ?string              $id      optional message id used to route responses back to the caller
+     * @param ?string              $session optional session id; when null the request applies globally
+     * @param array<string, mixed> $raw     the raw decoded message; prefer stringParam() over direct access
      */
     public function __construct(
         public string $op,

--- a/src/php/Nrepl/Domain/Session/Session.php
+++ b/src/php/Nrepl/Domain/Session/Session.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Phel\Nrepl\Domain\Session;
 
+/**
+ * Mutable state for a single nREPL session: tracks the current namespace
+ * scope and the most recently evaluated value (the future basis for *1/*2/*3
+ * history; for now only the single last value is kept).
+ */
 final class Session
 {
     private mixed $lastValue = null;
@@ -13,21 +18,33 @@ final class Session
         private string $namespace = 'user',
     ) {}
 
+    /**
+     * The namespace eval ops run in for this session.
+     */
     public function namespace(): string
     {
         return $this->namespace;
     }
 
+    /**
+     * Switch the session's active namespace (e.g. after an `in-ns` form).
+     */
     public function setNamespace(string $ns): void
     {
         $this->namespace = $ns;
     }
 
+    /**
+     * The value of the most recent successful evaluation in this session.
+     */
     public function lastValue(): mixed
     {
         return $this->lastValue;
     }
 
+    /**
+     * Remember the latest evaluated value as the session's last value.
+     */
     public function recordValue(mixed $value): void
     {
         $this->lastValue = $value;

--- a/src/php/Nrepl/NreplFactory.php
+++ b/src/php/Nrepl/NreplFactory.php
@@ -58,7 +58,9 @@ final class NreplFactory extends AbstractFactory
         $dispatcher->register(new LookupOp($this->getApiFacade(), 'info', $sessions));
         $dispatcher->register(new LookupOp($this->getApiFacade(), 'eldoc', $sessions));
 
-        // Describe needs to inspect known ops, register last.
+        // DescribeOp reports the dispatcher's known ops, so it must be
+        // registered last (after every other handler); registering it earlier
+        // would omit later ops from the describe response.
         $dispatcher->register(new DescribeOp($dispatcher, $this->getRunFacade()));
 
         return $dispatcher;

--- a/src/php/Profile/Domain/Formatter/JsonFormatter.php
+++ b/src/php/Profile/Domain/Formatter/JsonFormatter.php
@@ -13,6 +13,11 @@ use const JSON_UNESCAPED_SLASHES;
 
 final class JsonFormatter
 {
+    /**
+     * Serialize the report to a pretty-printed JSON string with top-level keys
+     * `wall_clock_ms`, `compile_phases` (per-source phase times) and `fns`
+     * (per-fn records exposing both nanosecond and millisecond figures).
+     */
     public function render(ProfileReport $report): string
     {
         $fns = [];

--- a/src/php/Profile/Domain/Formatter/TableFormatter.php
+++ b/src/php/Profile/Domain/Formatter/TableFormatter.php
@@ -49,6 +49,30 @@ final class TableFormatter
     private function renderCompilePhases(ProfileReport $report): string
     {
         $phases = ['lex', 'parse', 'read', 'analyze', 'emit'];
+        $rows = $this->buildPhaseRows($report, $phases);
+
+        $sourceWidth = $this->calculateColumnWidth(array_map(static fn(array $r): string => (string) $r['source'], $rows));
+        $header = $this->phaseHeader($sourceWidth, $phases);
+        $body = '';
+        foreach ($rows as $row) {
+            $body .= '  ' . str_pad((string) $row['source'], $sourceWidth);
+            foreach ($phases as $p) {
+                $body .= '  ' . str_pad($this->fmt((float) $row[$p]), 8, ' ', STR_PAD_LEFT);
+            }
+
+            $body .= '  ' . str_pad($this->fmt((float) $row['total']), 8, ' ', STR_PAD_LEFT) . "\n";
+        }
+
+        return "Compile-time phases (ms)\n" . $header . $body;
+    }
+
+    /**
+     * @param list<string> $phases
+     *
+     * @return list<array<string, float|string>>
+     */
+    private function buildPhaseRows(ProfileReport $report, array $phases): array
+    {
         $rows = [];
         foreach ($report->phaseMs() as $source => $byPhase) {
             $row = ['source' => $this->shortenSource($source)];
@@ -65,19 +89,7 @@ final class TableFormatter
 
         uasort($rows, static fn(array $a, array $b): int => $b['total'] <=> $a['total']);
 
-        $sourceWidth = max(20, ...array_map(static fn(array $r): int => strlen($r['source']), $rows));
-        $header = $this->phaseHeader($sourceWidth, $phases);
-        $body = '';
-        foreach ($rows as $row) {
-            $body .= '  ' . str_pad($row['source'], $sourceWidth);
-            foreach ($phases as $p) {
-                $body .= '  ' . str_pad($this->fmt($row[$p]), 8, ' ', STR_PAD_LEFT);
-            }
-
-            $body .= '  ' . str_pad($this->fmt($row['total']), 8, ' ', STR_PAD_LEFT) . "\n";
-        }
-
-        return "Compile-time phases (ms)\n" . $header . $body;
+        return $rows;
     }
 
     /**
@@ -104,35 +116,47 @@ final class TableFormatter
         $rows = array_slice($stats, 0, $top, true);
 
         $names = array_map($this->displayName(...), array_keys($rows));
-        $nameWidth = max(20, ...array_map(strlen(...), $names));
+        $nameWidth = $this->calculateColumnWidth($names);
 
         $out = sprintf("Runtime fn profile (top %d, sort by %s)\n", count($rows), $sort->value);
-        $out .= '  ' . str_pad('fn', $nameWidth) . '  '
-            . str_pad('calls', 9, ' ', STR_PAD_LEFT) . '  '
-            . str_pad('self ms', 10, ' ', STR_PAD_LEFT) . '  '
-            . str_pad('total ms', 10, ' ', STR_PAD_LEFT) . '  '
-            . str_pad('avg us', 10, ' ', STR_PAD_LEFT) . '  '
-            . str_pad('max us', 10, ' ', STR_PAD_LEFT) . "\n";
+        $out .= $this->renderFnHeader($nameWidth);
 
         foreach ($rows as $boundTo => $r) {
-            $name = $this->displayName($boundTo);
-            $avgUs = $r['calls'] > 0 ? ((float) $r['totalNs'] / (float) $r['calls']) / 1_000.0 : 0.0;
-            $maxUs = (float) $r['maxNs'] / 1_000.0;
-            $selfMs = (float) $r['selfNs'] / 1_000_000.0;
-            $totalMs = (float) $r['totalNs'] / 1_000_000.0;
-
-            $out .= '  ' . str_pad($name, $nameWidth) . '  '
-                . str_pad((string) $r['calls'], 9, ' ', STR_PAD_LEFT) . '  '
-                . str_pad($this->fmt($selfMs), 10, ' ', STR_PAD_LEFT) . '  '
-                . str_pad($this->fmt($totalMs), 10, ' ', STR_PAD_LEFT) . '  '
-                . str_pad($this->fmt($avgUs), 10, ' ', STR_PAD_LEFT) . '  '
-                . str_pad($this->fmt($maxUs), 10, ' ', STR_PAD_LEFT) . "\n";
+            $out .= $this->renderFnRow($this->displayName($boundTo), $r, $nameWidth);
         }
 
         $totalSelfMs = array_sum(array_map(static fn(array $r): float => (float) $r['selfNs'] / 1_000_000.0, $stats));
         $totalCalls = array_sum(array_map(static fn(array $r): int => $r['calls'], $stats));
 
         return $out . sprintf("\nTotals: %d fns, %d calls, %s ms self.\n", count($stats), $totalCalls, $this->fmt($totalSelfMs));
+    }
+
+    private function renderFnHeader(int $nameWidth): string
+    {
+        return '  ' . str_pad('fn', $nameWidth) . '  '
+            . str_pad('calls', 9, ' ', STR_PAD_LEFT) . '  '
+            . str_pad('self ms', 10, ' ', STR_PAD_LEFT) . '  '
+            . str_pad('total ms', 10, ' ', STR_PAD_LEFT) . '  '
+            . str_pad('avg us', 10, ' ', STR_PAD_LEFT) . '  '
+            . str_pad('max us', 10, ' ', STR_PAD_LEFT) . "\n";
+    }
+
+    /**
+     * @param array{calls:int, totalNs:int, selfNs:int, maxNs:int} $r
+     */
+    private function renderFnRow(string $name, array $r, int $nameWidth): string
+    {
+        $avgUs = $r['calls'] > 0 ? ((float) $r['totalNs'] / (float) $r['calls']) / 1_000.0 : 0.0;
+        $maxUs = (float) $r['maxNs'] / 1_000.0;
+        $selfMs = (float) $r['selfNs'] / 1_000_000.0;
+        $totalMs = (float) $r['totalNs'] / 1_000_000.0;
+
+        return '  ' . str_pad($name, $nameWidth) . '  '
+            . str_pad((string) $r['calls'], 9, ' ', STR_PAD_LEFT) . '  '
+            . str_pad($this->fmt($selfMs), 10, ' ', STR_PAD_LEFT) . '  '
+            . str_pad($this->fmt($totalMs), 10, ' ', STR_PAD_LEFT) . '  '
+            . str_pad($this->fmt($avgUs), 10, ' ', STR_PAD_LEFT) . '  '
+            . str_pad($this->fmt($maxUs), 10, ' ', STR_PAD_LEFT) . "\n";
     }
 
     /**
@@ -146,6 +170,14 @@ final class TableFormatter
             SortOrder::Avg => static fn(array $a, array $b): int => ((float) $b['totalNs'] / (float) max($b['calls'], 1)) <=> ((float) $a['totalNs'] / (float) max($a['calls'], 1)),
             SortOrder::SelfTime => static fn(array $a, array $b): int => $b['selfNs'] <=> $a['selfNs'],
         };
+    }
+
+    /**
+     * @param list<string> $values
+     */
+    private function calculateColumnWidth(array $values, int $minWidth = 20): int
+    {
+        return max($minWidth, ...array_map(strlen(...), $values));
     }
 
     private function displayName(string $boundTo): string

--- a/src/php/Profile/Domain/Formatter/TableFormatter.php
+++ b/src/php/Profile/Domain/Formatter/TableFormatter.php
@@ -25,6 +25,14 @@ use function uasort;
 
 final class TableFormatter
 {
+    /**
+     * Build the multi-section report: an optional compile-phase table, the
+     * runtime fn table (top `$top` rows ordered by `$sort`), and a wall-clock
+     * footer. Empty sections are omitted.
+     *
+     * @param int  $top                  Maximum fn rows to show; the rest are truncated
+     * @param bool $includeCompilePhases Prepend the compile-phase table when phase data exists
+     */
     public function render(ProfileReport $report, int $top, SortOrder $sort, bool $includeCompilePhases): string
     {
         $out = '';

--- a/src/php/Profile/Domain/ProfileReport.php
+++ b/src/php/Profile/Domain/ProfileReport.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Phel\Profile\Domain;
 
+/**
+ * Immutable snapshot of a profiling run: per-fn call stats (keyed by
+ * `BOUND_TO` name, times in nanoseconds), per-source compile-phase times
+ * (in milliseconds), and the total wall-clock time in milliseconds.
+ */
 final readonly class ProfileReport
 {
     /**
@@ -17,6 +22,8 @@ final readonly class ProfileReport
     ) {}
 
     /**
+     * Per-fn stats keyed by fn name; all `*Ns` values are nanoseconds.
+     *
      * @return array<string, array{calls:int, totalNs:int, selfNs:int, maxNs:int}>
      */
     public function fnStats(): array
@@ -25,6 +32,8 @@ final readonly class ProfileReport
     }
 
     /**
+     * Compile-phase times keyed by source then phase name, in milliseconds.
+     *
      * @return array<string, array<string, float>>
      */
     public function phaseMs(): array
@@ -32,6 +41,9 @@ final readonly class ProfileReport
         return $this->phaseMs;
     }
 
+    /**
+     * Total wall-clock time of the run, in milliseconds.
+     */
     public function wallClockMs(): float
     {
         return $this->wallClockMs;

--- a/src/php/Profile/Domain/ProfilerSession.php
+++ b/src/php/Profile/Domain/ProfilerSession.php
@@ -36,6 +36,10 @@ final class ProfilerSession implements ProfilerHookInterface
         $this->startedAtNs = hrtime(true);
     }
 
+    /**
+     * Wrap a fn in a {@see ProfilingFn} proxy. Idempotent: an already-wrapped
+     * fn is returned unchanged so the registry hook never double-wraps.
+     */
     public function wrapFn(AbstractFn $fn): ProfilingFn
     {
         if ($fn instanceof ProfilingFn) {
@@ -45,12 +49,22 @@ final class ProfilerSession implements ProfilerHookInterface
         return new ProfilingFn($fn, $this);
     }
 
+    /**
+     * Push a call frame onto the stack. Must be paired with `exit()`.
+     *
+     * @param string $name Fully-qualified fn name (the proxy's `BOUND_TO` value)
+     */
     public function enter(string $name): void
     {
         $this->stack[] = [$name, hrtime(true), 0];
         ++$this->depth;
     }
 
+    /**
+     * Pop the current frame and fold its inclusive time into the parent's
+     * child total (so the parent's self-time excludes this call). An unmatched
+     * exit on an empty stack is silently ignored.
+     */
     public function exit(): void
     {
         $frame = array_pop($this->stack);
@@ -68,11 +82,23 @@ final class ProfilerSession implements ProfilerHookInterface
         }
     }
 
+    /**
+     * Record elapsed time for one compile phase of one source. Accumulates:
+     * repeated calls for the same source/phase pair add up.
+     *
+     * @param string $phase     Compile phase name (e.g. lex, parse, read, analyze, emit)
+     * @param string $source    File path or namespace being compiled
+     * @param float  $elapsedMs Elapsed milliseconds to add to the running total
+     */
     public function recordPhase(string $phase, string $source, float $elapsedMs): void
     {
         $this->phaseMs[$source][$phase] = ($this->phaseMs[$source][$phase] ?? 0.0) + $elapsedMs;
     }
 
+    /**
+     * Finalize the session and snapshot the collected stats into an immutable
+     * report. Intended to be called once after the profiled run completes.
+     */
     public function stop(): ProfileReport
     {
         return new ProfileReport(

--- a/src/php/Profile/Domain/ProfilingFn.php
+++ b/src/php/Profile/Domain/ProfilingFn.php
@@ -12,8 +12,10 @@ use function is_string;
 
 /**
  * Proxy that wraps a user `defn` so every call routed via `Registry`
- * is timed. Self-recursive calls that the compiler emits as `$this(...)`
- * bypass this proxy by design (see commit bee78ffe).
+ * is timed. Self-recursive calls are emitted by the compiler as
+ * `$this(...)` rather than a registry lookup, so they never reach this
+ * proxy and stay untimed; that bypass is a compiler emit detail, not a
+ * constraint of this class (see commit bee78ffe).
  */
 final class ProfilingFn extends AbstractFn
 {

--- a/src/php/Profile/Infrastructure/Command/ProfileCommand.php
+++ b/src/php/Profile/Infrastructure/Command/ProfileCommand.php
@@ -72,6 +72,11 @@ final class ProfileCommand extends Command
             ->addOption(self::OPT_NO_COMPILE_PHASES, null, InputOption::VALUE_NONE, 'Skip the compile-time phase report.');
     }
 
+    /**
+     * Resolve the target script, validate `--sort`/`--format`, run it under the
+     * profiler hook, then render the report. Returns FAILURE when the path is
+     * unresolved, an option is invalid, or the script throws; SUCCESS otherwise.
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $path = $this->resolvePath($input, $output);
@@ -107,6 +112,13 @@ final class ProfileCommand extends Command
         return self::SUCCESS;
     }
 
+    /**
+     * Run the target file or namespace with `Registry::$profilerHook` installed,
+     * always clearing the hook in `finally`. The hook is global and not
+     * reentrant, so this must not run inside another profiling context.
+     *
+     * @return ProfileReport|null The collected report, or null if the run threw
+     */
     private function runWithProfiler(string $path, OutputInterface $output): ?ProfileReport
     {
         $runFacade = $this->getFactory()->getRunFacade();

--- a/src/php/Profile/ProfileFacade.php
+++ b/src/php/Profile/ProfileFacade.php
@@ -14,16 +14,31 @@ use Phel\Profile\Domain\SortOrder;
  */
 final class ProfileFacade extends AbstractFacade
 {
+    /**
+     * Start a new profiling session.
+     *
+     * Install the returned session as `Registry::$profilerHook` for the run,
+     * then call `stop()` to collect the {@see ProfileReport}.
+     */
     public function startSession(): ProfilerSession
     {
         return $this->getFactory()->createSession();
     }
 
+    /**
+     * Render the report as a formatted ASCII table.
+     *
+     * @param int  $top                  Maximum number of fns shown; results are truncated
+     * @param bool $includeCompilePhases When true, prepend the per-source compile-phase breakdown
+     */
     public function renderTable(ProfileReport $report, int $top, SortOrder $sort, bool $includeCompilePhases): string
     {
         return $this->getFactory()->createTableFormatter()->render($report, $top, $sort, $includeCompilePhases);
     }
 
+    /**
+     * Serialize the report to a JSON string.
+     */
     public function renderJson(ProfileReport $report): string
     {
         return $this->getFactory()->createJsonFormatter()->render($report);

--- a/src/php/Run/Application/FileRunner.php
+++ b/src/php/Run/Application/FileRunner.php
@@ -55,13 +55,19 @@ final readonly class FileRunner
     }
 
     /**
-     * Seed the dependency walk with the script namespace, only the bundled
-     * `phel.*` modules the script actually references via fully qualified
-     * form (so `phel.async/delay` resolves without an explicit require),
-     * and the script's direct requires. The script's direct requires are
-     * kept because an ad-hoc script in `dirname` rather than configured
-     * `srcDirs` is not itself discoverable, so its transitive deps would
-     * otherwise be missed even when they live under `srcDirs`/vendor.
+     * Seeds the dependency walk. The union of four sources, in order:
+     *
+     * - the script's own namespace;
+     * - {@see CompilerConstants::PHEL_CORE_NAMESPACE}, always present;
+     * - bundled `phel.*` modules referenced via fully qualified form (so
+     *   `phel.async/delay` resolves without an explicit require) plus
+     *   Clojure-compatible requires remapped to their Phel equivalent
+     *   (e.g. `clojure.test` -> `phel.test`);
+     * - the script's own direct requires, kept because an ad-hoc script in
+     *   `dirname` rather than a configured `srcDir` is not itself
+     *   discoverable, so its transitive deps would otherwise be missed even
+     *   when they live under `srcDirs`/vendor. Missing seeds are ignored by
+     *   dependency resolution, so raw `clojure.*` deps are preserved.
      *
      * @return list<string>
      */
@@ -74,8 +80,6 @@ final readonly class FileRunner
             CompilerConstants::PHEL_CORE_NAMESPACE,
             ...$this->bundledNamespaceDetector->detect($filename),
             ...$this->bundledNamespaceDetector->remapClojureDependencies($dependencies),
-            // Missing seeds are ignored by dependency resolution, so keeping
-            // raw `clojure.*` deps preserves user-defined Clojure namespaces.
             ...$dependencies,
         ]));
     }

--- a/src/php/Run/Application/Test/ParallelTestOrchestrator.php
+++ b/src/php/Run/Application/Test/ParallelTestOrchestrator.php
@@ -29,7 +29,9 @@ use function stream_select;
  * stays deterministic across runs.
  *
  * Concurrency primitive: blocking {@see stream_select} over worker stdouts
- * with a generous timeout. No threads, no pcntl, no shared memory.
+ * with a generous timeout ({@see self::SELECT_TIMEOUT_MICROS}). No threads,
+ * no pcntl, no shared memory. Parent and workers exchange length-prefixed
+ * JSON frames ({@see WorkerFrame}).
  */
 final readonly class ParallelTestOrchestrator
 {

--- a/src/php/Run/Domain/Repl/ReplErrorFormatter.php
+++ b/src/php/Run/Domain/Repl/ReplErrorFormatter.php
@@ -22,6 +22,12 @@ use const PHP_EOL;
 
 final readonly class ReplErrorFormatter
 {
+    /**
+     * Stack-frame paths belonging to the compiler, runtime, build, and CLI
+     * infrastructure that are filtered out of REPL error traces to keep them
+     * user-focused. When adding a new compiler/framework module, append its
+     * path here so its frames stay hidden.
+     */
     private const array INTERNAL_FRAME_PATHS = [
         '/phel-lang/src/php/Compiler/',
         '/phel-lang/src/php/Run/',

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -105,6 +105,12 @@ class RunFactory extends AbstractFactory
         return Printer::readableWithColor();
     }
 
+    /**
+     * Builds the REPL input handler. Prefers the readline-backed
+     * {@see ReplCommandSystemIo} (line editing plus persisted history) when the
+     * `readline` extension is loaded, falling back to {@see ReplCommandFallbackIo}
+     * for environments without it (e.g. CI, web SAPI).
+     */
     public function createReplCommandIo(): ReplCommandIoInterface
     {
         if (extension_loaded('readline')) {

--- a/src/php/Shared/CompileOptions.php
+++ b/src/php/Shared/CompileOptions.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace Phel\Shared;
 
+/**
+ * Mutable configuration builder for a single compilation. Setters customize
+ * the source label, starting line, source-map emission, emit-only mode, and
+ * optimization level before the options are passed to
+ * {@see Facade\CompilerFacadeInterface::compile()}. Each setter returns `$this`
+ * for fluent chaining.
+ */
 final class CompileOptions
 {
     public const string DEFAULT_SOURCE = 'string';

--- a/src/php/Shared/Exceptions/AbstractLocatedException.php
+++ b/src/php/Shared/Exceptions/AbstractLocatedException.php
@@ -36,6 +36,11 @@ abstract class AbstractLocatedException extends RuntimeException
         return $this->errorCode;
     }
 
+    /**
+     * Attaches a standardized error identifier to this exception. Subclasses
+     * call this (typically from their constructor) to tag the located error
+     * with its PHELxxx {@see ErrorCode} for reporting.
+     */
     protected function setErrorCode(ErrorCode $errorCode): void
     {
         $this->errorCode = $errorCode;

--- a/src/php/Shared/Munge.php
+++ b/src/php/Shared/Munge.php
@@ -6,11 +6,11 @@ namespace Phel\Shared;
 
 final readonly class Munge implements MungeInterface
 {
-    private const array DEFAULT_NS_MAPPING = [
+    private const array NAMESPACE_MAPPING = [
         '-' => '_',
     ];
 
-    private const array DEFAULT_MAPPING = [
+    private const array SYMBOL_MAPPING = [
         '-' => '_',
         '.' => '_DOT_',
         ':' => '_COLON_',
@@ -44,8 +44,8 @@ final readonly class Munge implements MungeInterface
      * @param array<string, string> $nsMapping
      */
     public function __construct(
-        private array $mapping = self::DEFAULT_MAPPING,
-        private array $nsMapping = self::DEFAULT_NS_MAPPING,
+        private array $mapping = self::SYMBOL_MAPPING,
+        private array $nsMapping = self::NAMESPACE_MAPPING,
     ) {}
 
     /**

--- a/src/php/Shared/Munge.php
+++ b/src/php/Shared/Munge.php
@@ -48,6 +48,11 @@ final readonly class Munge implements MungeInterface
         private array $nsMapping = self::DEFAULT_NS_MAPPING,
     ) {}
 
+    /**
+     * Encodes a symbol name into a valid PHP identifier by replacing every
+     * special character per the configured mapping. `this` is special-cased
+     * because it is a reserved PHP variable name.
+     */
     public function encode(string $str): string
     {
         if ($str === 'this') {
@@ -73,6 +78,10 @@ final readonly class Munge implements MungeInterface
         return $this->encodeWithMap(self::canonicalNs($str), $this->nsMapping);
     }
 
+    /**
+     * Inverse of the namespace encoding: maps an encoded namespace string back
+     * to its canonical (dot) source form by applying the flipped mapping.
+     */
     public function decodeNs(string $str): string
     {
         return $this->encodeWithMap($str, array_flip($this->nsMapping));

--- a/src/php/Shared/VersionFinder.php
+++ b/src/php/Shared/VersionFinder.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Shared;
 
-use function in_array;
-
 final class VersionFinder
 {
     public const string LATEST_VERSION = 'v0.41.0';
@@ -54,7 +52,7 @@ final class VersionFinder
             return null;
         }
 
-        if (in_array(preg_match('/^[0-9a-f]{8,40}$/i', $reference), [0, false], true)) {
+        if (preg_match('/^[0-9a-f]{8,40}$/i', $reference) !== 1) {
             return null;
         }
 

--- a/src/php/Watch/Application/NullReloadEventPublisher.php
+++ b/src/php/Watch/Application/NullReloadEventPublisher.php
@@ -12,5 +12,9 @@ use Phel\Watch\Domain\ReloadEventPublisherInterface;
  */
 final class NullReloadEventPublisher implements ReloadEventPublisherInterface
 {
+    /**
+     * Intentionally discards the batch; the empty body is the whole point of
+     * this null object. See the class docblock for when to swap it out.
+     */
     public function publish(array $events, array $reloadedNamespaces): void {}
 }

--- a/src/php/Watch/Application/Watcher/AbstractShellWatcher.php
+++ b/src/php/Watch/Application/Watcher/AbstractShellWatcher.php
@@ -49,6 +49,17 @@ abstract class AbstractShellWatcher implements FileWatcherInterface
 
     private bool $running = false;
 
+    /**
+     * @param FileSystemScannerInterface $scanner    primes the mtime snapshot
+     *                                               before streaming starts so
+     *                                               diffing resolvers have state
+     * @param ClockInterface             $clock      drives idle sleeps and
+     *                                               debounce timing
+     * @param string                     $binaryPath external tool to invoke
+     *                                               (e.g. fswatch, inotifywait)
+     * @param int                        $debounceMs window for coalescing rapid
+     *                                               events into one batch
+     */
     public function __construct(
         protected readonly FileSystemScannerInterface $scanner,
         protected readonly ClockInterface $clock,

--- a/src/php/Watch/Domain/ReloadEventPublisherInterface.php
+++ b/src/php/Watch/Domain/ReloadEventPublisherInterface.php
@@ -14,6 +14,11 @@ use Phel\Watch\Transfer\WatchEvent;
 interface ReloadEventPublisherInterface
 {
     /**
+     * Called once per non-empty file-change batch with the originating events
+     * and the namespaces that were successfully reloaded. It is still invoked
+     * when $reloadedNamespaces is empty (e.g. namespace resolution failed or
+     * every reload threw), so implementers must not assume a reload happened.
+     *
      * @param list<WatchEvent> $events
      * @param list<string>     $reloadedNamespaces
      */

--- a/src/php/Watch/WatchFactory.php
+++ b/src/php/Watch/WatchFactory.php
@@ -85,6 +85,10 @@ final class WatchFactory extends AbstractFactory
         return new SystemClock();
     }
 
+    /**
+     * The no-op publisher used in standalone watch mode. Override via the
+     * `$publisher` arguments above (or DI) to plug in an nREPL-aware publisher.
+     */
     public function createDefaultPublisher(): ReloadEventPublisherInterface
     {
         return new NullReloadEventPublisher();

--- a/tests/phel/ai.phel
+++ b/tests/phel/ai.phel
@@ -539,6 +539,33 @@
       (is (thrown? \RuntimeException (ai/extract-many {:id "integer"} "text" {:api-key "k"}))
           "throws when response has no array"))))
 
+;; --- extract-json-from-response edge cases ---
+
+(deftest test-extract-json-surrounding-whitespace
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "  \n {\"x\":7} \n  "}]})))]
+    (binding [ai/*http-post* fake]
+      (is (= 7 (get (ai/extract {:x "integer"} "text" {:api-key "k"}) :x))
+          "leading/trailing whitespace is trimmed and bare json is parsed"))))
+
+(deftest test-extract-json-nested-object-via-substring
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "Result: {\"a\":{\"b\":1}} done"}]})))]
+    (binding [ai/*http-post* fake]
+      (let [result (ai/extract {:a "object"} "text" {:api-key "k"})]
+        (is (= 1 (get (get result :a) :b))
+            "substring extraction spans to the last brace, keeping a nested object intact")))))
+
+(deftest test-extract-json-fenced-block-without-language-tag
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "Here:\n```\n{\"x\":2}\n```"}]})))]
+    (binding [ai/*http-post* fake]
+      (is (= 2 (get (ai/extract {:x "integer"} "text" {:api-key "k"}) :x))
+          "fenced block without a json language tag is still parsed"))))
+
+(deftest test-extract-json-unclosed-brace-throws
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "open {\"x\":1 but never closes"}]})))]
+    (binding [ai/*http-post* fake]
+      (is (thrown? \RuntimeException (ai/extract {:x "integer"} "text" {:api-key "k"}))
+          "an unclosed brace yields no extractable object and throws"))))
+
 ;; --- chat-with-tools (happy paths) ---
 
 (deftest test-chat-with-tools-anthropic-returns-normalized-map

--- a/tests/phel/core/binding.phel
+++ b/tests/phel/core/binding.phel
@@ -90,3 +90,15 @@
       "when-first with empty list")
   (is (= :a (when-first [x [:a :b]] x))
       "when-first with keyword vector"))
+
+;; Regression: these macros use an internal gensym binding. A user binding
+;; named `temp-sym` (the historical internal name) must not be shadowed.
+(deftest test-binding-macros-are-hygienic
+  (is (= 42 (let [temp-sym 42] (if-let [x 1] temp-sym)))
+      "if-let does not capture an outer temp-sym")
+  (is (= 42 (let [temp-sym 42] (when-let [x 1] temp-sym)))
+      "when-let does not capture an outer temp-sym")
+  (is (= 42 (let [temp-sym 42] (if-some [x 1] temp-sym)))
+      "if-some does not capture an outer temp-sym")
+  (is (= 42 (let [temp-sym 42] (when-first [x [1]] temp-sym)))
+      "when-first does not capture an outer temp-sym"))

--- a/tests/phel/http.phel
+++ b/tests/phel/http.phel
@@ -364,6 +364,44 @@
   (foreach [[name response result] send-response-examples]
     (is (output? result (h/emit-response response)) name)))
 
+;; NOTE: The actual header strings sent by `emit-response` (via php/header)
+;; cannot be asserted from a test, since php/header writes to the SAPI and
+;; exposes nothing capturable. The tests below cover the observable parts of
+;; `emit-response`: it always echoes the body and returns nil, even when
+;; multiple-, list-, and empty-valued headers exercise the `emit-headers`
+;; branches that `test-send-response` (single string header) does not.
+
+(deftest test-emit-response-returns-nil
+  (is (nil? (h/emit-response (h/response-from-string "anything")))
+      "emit-response returns nil"))
+
+(deftest test-emit-response-echoes-body-with-multiple-headers
+  (is (output? "Body!"
+               (h/emit-response
+                (h/response 200
+                            {:content-type "text/plain" :x-custom "val"}
+                            "Body!"
+                            nil
+                            nil)))
+      "emit-response echoes the body even with several headers present"))
+
+(deftest test-emit-response-echoes-body-with-list-valued-header
+  ;; indexed (vector) header values exercise the `(indexed? values)` branch
+  ;; of emit-headers, e.g. multiple Set-Cookie lines.
+  (is (output? "Cookies"
+               (h/emit-response
+                (h/response 200
+                            {:set-cookie ["a=1" "b=2"]}
+                            "Cookies"
+                            nil
+                            nil)))
+      "emit-response echoes the body with a list-valued header"))
+
+(deftest test-emit-response-empty-body
+  (is (output? ""
+               (h/emit-response (h/response 204 {} "" nil nil)))
+      "emit-response emits no body output for an empty body"))
+
 ;; ---
 ;; Request body parsing
 ;; ---

--- a/tests/phel/json/encode/flags.phel
+++ b/tests/phel/json/encode/flags.phel
@@ -2,7 +2,8 @@
   (:require phel.json)
   (:require phel.test :refer [deftest is])
   (:use \JSON_HEX_TAG)
-  (:use \JSON_HEX_AMP))
+  (:use \JSON_HEX_AMP)
+  (:use \JSON_PRETTY_PRINT))
 
 (deftest test-json-encode-invalid-flag
   (is (thrown-with-msg?
@@ -27,3 +28,11 @@
         {:comparison "a > b"  :and "a & b"}
         {:flags (bit-or JSON_HEX_AMP JSON_HEX_TAG)}))
       "It tests flags parameter with two flags."))
+
+(deftest test-json-encode-pretty-print
+  (is (=
+       "{\n    \"name\": \"Alice\"\n}"
+       (json/encode
+        {:name "Alice"}
+        {:flags JSON_PRETTY_PRINT}))
+      "It tests JSON_PRETTY_PRINT flag produces indented multi-line output."))

--- a/tests/phel/schema/coerce.phel
+++ b/tests/phel/schema/coerce.phel
@@ -50,6 +50,20 @@
   (let [v (s/coerce :inst 1000000)]
     (is (= true (php/instanceof v \DateTimeInterface)))))
 
+(deftest test-coerce-inst-edge-cases
+  (testing "unparseable date string is returned unchanged for downstream validation"
+           (is (= "not-a-real-date" (s/coerce :inst "not-a-real-date"))
+               "invalid date string passes through as the original string")
+           (is (= "string" (php/gettype (s/coerce :inst "13/45/2026")))
+               "out-of-range date components stay a string"))
+  (testing "epoch boundary timestamps coerce to a DateTime"
+           (let [zero (s/coerce :inst 0)]
+             (is (= true (php/instanceof zero \DateTimeInterface)) "epoch 0 coerces")
+             (is (= "1970-01-01" (php/-> zero (format "Y-m-d"))) "epoch 0 is 1970-01-01"))
+           (let [neg (s/coerce :inst -1000000)]
+             (is (= true (php/instanceof neg \DateTimeInterface)) "negative epoch coerces")
+             (is (= "1969-12-20" (php/-> neg (format "Y-m-d"))) "negative epoch is before 1970"))))
+
 (deftest test-coerce-string
   (is (= "42" (s/coerce :string 42)))
   (is (= "1.5" (s/coerce :string 1.5)))

--- a/tests/phel/selectors.phel
+++ b/tests/phel/selectors.phel
@@ -279,6 +279,12 @@
   (is (selector/ns-matches? "**" "")
       "standalone `**` matches even the empty namespace"))
 
+(deftest test-ns-matches-literal-dot-is-not-wildcard
+  (is (selector/ns-matches? "phel.core" "phel.core")
+      "a `.` in the glob matches a literal dot")
+  (is (not (selector/ns-matches? "phel.core" "phelxcore"))
+      "a `.` in the glob is escaped and does not match an arbitrary character"))
+
 ;; ---------------------------------------------------------------------------
 ;; has-selectors? — each key in isolation
 ;; ---------------------------------------------------------------------------

--- a/tests/phel/string.phel
+++ b/tests/phel/string.phel
@@ -175,6 +175,26 @@
     (is (= nil (s/last-index-of sb "ｚ" 100)))
     (is (= nil (s/last-index-of sb "ｚ" -10)))))
 
+(deftest test-index-of-edge-cases
+  (is (= 0 (s/index-of "abc" "")) "empty needle is found at index 0")
+  (is (= nil (s/index-of "ab" "abc")) "needle longer than s returns nil")
+  (is (= 0 (s/index-of "abc" "a" 0)) "explicit from-index 0 finds a leading match")
+  (is (= 2 (s/index-of "abc" "c" 2)) "from-index at the last char still matches")
+  ;; NOTE: empty haystack with the default from-index leaks a raw PHP
+  ;; ValueError from mb_strpos (offset out of range) instead of returning
+  ;; nil (see bugsFound). Locking in the current (buggy) behavior so a
+  ;; future fix flips this assertion intentionally.
+  (is (thrown? \Throwable (s/index-of "" "a"))
+      "empty haystack currently raises rather than returning nil"))
+
+(deftest test-last-index-of-edge-cases
+  (is (= 3 (s/last-index-of "abc" "")) "empty needle is found at the string length")
+  (is (= nil (s/last-index-of "ab" "abc")) "needle longer than s returns nil")
+  (is (= nil (s/last-index-of "banana" "a" 0))
+      "from-index 0 cannot see the later 'a' occurrences")
+  (is (= 1 (s/last-index-of "banana" "a" 2))
+      "from-index 2 finds the first 'a' within bound"))
+
 (deftest test-starts-with?
   (is (= true (s/starts-with? "clojure west" "clojure")))
   (is (= false (s/starts-with? "conj" "clojure")))

--- a/tests/phel/string.phel
+++ b/tests/phel/string.phel
@@ -180,12 +180,8 @@
   (is (= nil (s/index-of "ab" "abc")) "needle longer than s returns nil")
   (is (= 0 (s/index-of "abc" "a" 0)) "explicit from-index 0 finds a leading match")
   (is (= 2 (s/index-of "abc" "c" 2)) "from-index at the last char still matches")
-  ;; NOTE: empty haystack with the default from-index leaks a raw PHP
-  ;; ValueError from mb_strpos (offset out of range) instead of returning
-  ;; nil (see bugsFound). Locking in the current (buggy) behavior so a
-  ;; future fix flips this assertion intentionally.
-  (is (thrown? \Throwable (s/index-of "" "a"))
-      "empty haystack currently raises rather than returning nil"))
+  (is (= nil (s/index-of "" "a")) "empty haystack with a needle returns nil")
+  (is (= 0 (s/index-of "" "")) "empty haystack and empty needle match at index 0"))
 
 (deftest test-last-index-of-edge-cases
   (is (= 3 (s/last-index-of "abc" "")) "empty needle is found at the string length")

--- a/tests/php/Unit/Api/Application/PhelFnGroupKeyGeneratorTest.php
+++ b/tests/php/Unit/Api/Application/PhelFnGroupKeyGeneratorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\PhelFnGroupKeyGenerator;
+use PHPUnit\Framework\TestCase;
+
+final class PhelFnGroupKeyGeneratorTest extends TestCase
+{
+    public function test_it_returns_plain_name_unchanged(): void
+    {
+        $generator = new PhelFnGroupKeyGenerator();
+
+        self::assertSame('map', $generator->generateGroupKey('phel\\core', 'map'));
+    }
+
+    public function test_it_lowercases_the_name(): void
+    {
+        $generator = new PhelFnGroupKeyGenerator();
+
+        self::assertSame('foo', $generator->generateGroupKey('phel\\core', 'Foo'));
+    }
+
+    public function test_it_replaces_slash_with_dash(): void
+    {
+        $generator = new PhelFnGroupKeyGenerator();
+
+        self::assertSame('foo-bar', $generator->generateGroupKey('phel\\core', 'foo/bar'));
+    }
+
+    public function test_it_strips_non_alphanumeric_characters(): void
+    {
+        $generator = new PhelFnGroupKeyGenerator();
+
+        self::assertSame('', $generator->generateGroupKey('phel\\core', '+'));
+    }
+
+    public function test_it_trims_trailing_dash(): void
+    {
+        $generator = new PhelFnGroupKeyGenerator();
+
+        self::assertSame('name', $generator->generateGroupKey('phel\\core', 'name-'));
+    }
+
+    public function test_it_ignores_the_namespace_argument(): void
+    {
+        $generator = new PhelFnGroupKeyGenerator();
+
+        self::assertSame(
+            $generator->generateGroupKey('', 'map'),
+            $generator->generateGroupKey('completely-different', 'map'),
+        );
+    }
+}

--- a/tests/php/Unit/Api/Application/SymbolExtractorTest.php
+++ b/tests/php/Unit/Api/Application/SymbolExtractorTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\SymbolExtractor;
+use Phel\Api\Transfer\Definition;
+use Phel\Lang\Keyword;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+use Phel\Lang\TypeFactory;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class SymbolExtractorTest extends TestCase
+{
+    public function test_it_marks_defn_dash_form_as_private(): void
+    {
+        $extractor = $this->extractor();
+        $form = $this->list([
+            Symbol::create('defn-'),
+            Symbol::create('secret'),
+            $this->vector([Symbol::create('x')]),
+        ]);
+
+        $definition = $extractor->definitionFromForm($form, 'user', 'x.phel');
+
+        self::assertInstanceOf(Definition::class, $definition);
+        self::assertTrue($definition->private);
+        self::assertSame('secret', $definition->name);
+        self::assertSame(Definition::KIND_DEFN, $definition->kind);
+    }
+
+    public function test_it_marks_plain_defn_form_as_public(): void
+    {
+        $extractor = $this->extractor();
+        $form = $this->list([
+            Symbol::create('defn'),
+            Symbol::create('public-fn'),
+            $this->vector([Symbol::create('x')]),
+        ]);
+
+        $definition = $extractor->definitionFromForm($form, 'user', 'x.phel');
+
+        self::assertInstanceOf(Definition::class, $definition);
+        self::assertFalse($definition->private);
+    }
+
+    public function test_it_marks_form_with_private_metadata_as_private(): void
+    {
+        $extractor = $this->extractor();
+        $meta = TypeFactory::getInstance()->persistentMapFromKVs(
+            Keyword::create('private'),
+            true,
+        );
+        $form = $this->list([
+            Symbol::create('defn'),
+            Symbol::create('hidden'),
+            $meta,
+            $this->vector([Symbol::create('x')]),
+        ]);
+
+        $definition = $extractor->definitionFromForm($form, 'user', 'x.phel');
+
+        self::assertInstanceOf(Definition::class, $definition);
+        self::assertTrue($definition->private);
+    }
+
+    public function test_it_extracts_signature_and_namespace(): void
+    {
+        $extractor = $this->extractor();
+        $form = $this->list([
+            Symbol::create('defn'),
+            Symbol::create('add'),
+            $this->vector([Symbol::create('a'), Symbol::create('b')]),
+        ]);
+
+        $definition = $extractor->definitionFromForm($form, 'user\\math', 'math.phel');
+
+        self::assertInstanceOf(Definition::class, $definition);
+        self::assertSame('user\\math', $definition->namespace);
+        self::assertSame(['[a b]'], $definition->signature);
+    }
+
+    public function test_it_uses_name_start_location_for_line_and_column(): void
+    {
+        $extractor = $this->extractor();
+        $name = Symbol::create('located');
+        $name->setStartLocation(new SourceLocation('x.phel', 7, 3));
+
+        $form = $this->list([
+            Symbol::create('defn'),
+            $name,
+            $this->vector([]),
+        ]);
+
+        $definition = $extractor->definitionFromForm($form, 'user', 'x.phel');
+
+        self::assertInstanceOf(Definition::class, $definition);
+        self::assertSame(7, $definition->line);
+        self::assertSame(3, $definition->col);
+    }
+
+    public function test_it_returns_null_for_non_definition_form(): void
+    {
+        $extractor = $this->extractor();
+        $form = $this->list([
+            Symbol::create('not-a-def'),
+            Symbol::create('foo'),
+        ]);
+
+        self::assertNull($extractor->definitionFromForm($form, 'user', 'x.phel'));
+    }
+
+    private function extractor(): SymbolExtractor
+    {
+        // definitionFromForm operates on already-read forms and never touches the facade.
+        return new SymbolExtractor($this->createStub(CompilerFacadeInterface::class));
+    }
+
+    /**
+     * @param list<mixed> $values
+     */
+    private function list(array $values): mixed
+    {
+        return TypeFactory::getInstance()->persistentListFromArray($values);
+    }
+
+    /**
+     * @param list<mixed> $values
+     */
+    private function vector(array $values): mixed
+    {
+        return TypeFactory::getInstance()->persistentVectorFromArray($values);
+    }
+}

--- a/tests/php/Unit/Build/Domain/Compile/BuildOptionsTest.php
+++ b/tests/php/Unit/Build/Domain/Compile/BuildOptionsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Build\Domain\Compile;
+
+use Phel\Build\Domain\Compile\BuildOptions;
+use PHPUnit\Framework\TestCase;
+
+final class BuildOptionsTest extends TestCase
+{
+    public function test_cache_and_source_map_both_enabled(): void
+    {
+        $options = new BuildOptions(enableCache: true, enableSourceMap: true);
+
+        self::assertTrue($options->isCacheEnabled());
+        self::assertTrue($options->isSourceMapEnabled());
+    }
+
+    public function test_cache_and_source_map_both_disabled(): void
+    {
+        $options = new BuildOptions(enableCache: false, enableSourceMap: false);
+
+        self::assertFalse($options->isCacheEnabled());
+        self::assertFalse($options->isSourceMapEnabled());
+    }
+
+    public function test_flags_are_independent(): void
+    {
+        $cacheOnly = new BuildOptions(enableCache: true, enableSourceMap: false);
+
+        self::assertTrue($cacheOnly->isCacheEnabled());
+        self::assertFalse($cacheOnly->isSourceMapEnabled());
+
+        $sourceMapOnly = new BuildOptions(enableCache: false, enableSourceMap: true);
+
+        self::assertFalse($sourceMapOnly->isCacheEnabled());
+        self::assertTrue($sourceMapOnly->isSourceMapEnabled());
+    }
+}

--- a/tests/php/Unit/Command/Infrastructure/ErrorLogTest.php
+++ b/tests/php/Unit/Command/Infrastructure/ErrorLogTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Command\Infrastructure;
+
+use Phel\Command\Infrastructure\ErrorLog;
+use Phel\Shared\PhelProjectDirectory;
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function sys_get_temp_dir;
+use function uniqid;
+
+use const DIRECTORY_SEPARATOR;
+
+final class ErrorLogTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phel-error-log-' . uniqid();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeRecursively($this->tmpDir);
+    }
+
+    public function test_it_writes_text_with_trailing_newline(): void
+    {
+        $filepath = $this->tmpDir . DIRECTORY_SEPARATOR . 'error.log';
+        $errorLog = new ErrorLog($filepath);
+
+        $errorLog->writeln('hello');
+
+        self::assertStringEqualsFile($filepath, 'hello' . PHP_EOL);
+    }
+
+    public function test_it_appends_subsequent_lines(): void
+    {
+        $filepath = $this->tmpDir . DIRECTORY_SEPARATOR . 'error.log';
+        $errorLog = new ErrorLog($filepath);
+
+        $errorLog->writeln('first');
+        $errorLog->writeln('second');
+
+        self::assertStringEqualsFile(
+            $filepath,
+            'first' . PHP_EOL . 'second' . PHP_EOL,
+        );
+    }
+
+    public function test_it_creates_missing_parent_directory(): void
+    {
+        $filepath = $this->tmpDir . DIRECTORY_SEPARATOR . 'nested' . DIRECTORY_SEPARATOR . 'error.log';
+        $errorLog = new ErrorLog($filepath);
+
+        self::assertDirectoryDoesNotExist(dirname($filepath));
+
+        $errorLog->writeln('line');
+
+        self::assertDirectoryExists(dirname($filepath));
+        self::assertStringEqualsFile($filepath, 'line' . PHP_EOL);
+    }
+
+    public function test_it_routes_phel_project_directory_through_shared_helper(): void
+    {
+        $projectRoot = $this->tmpDir;
+        $phelDir = $projectRoot . DIRECTORY_SEPARATOR . PhelProjectDirectory::DIRECTORY_NAME;
+        $filepath = $phelDir . DIRECTORY_SEPARATOR . 'error.log';
+        $errorLog = new ErrorLog($filepath);
+
+        $errorLog->writeln('logged');
+
+        // The shared helper seeds a .gitignore alongside the log file.
+        self::assertStringEqualsFile($filepath, 'logged' . PHP_EOL);
+        self::assertFileExists($phelDir . DIRECTORY_SEPARATOR . '.gitignore');
+    }
+
+    private function removeRecursively(string $path): void
+    {
+        if (!file_exists($path)) {
+            return;
+        }
+
+        if (is_file($path)) {
+            unlink($path);
+            return;
+        }
+
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.') {
+                continue;
+            }
+
+            if ($entry === '..') {
+                continue;
+            }
+
+            $this->removeRecursively($path . DIRECTORY_SEPARATOR . $entry);
+        }
+
+        rmdir($path);
+    }
+}

--- a/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
+++ b/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
@@ -145,6 +145,23 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
+    public function test_transform_empty_list_is_quoted(): void
+    {
+        // An empty list must not be mistaken for an (unquote ...)/(unquote-splicing ...)
+        // form: get(0) would throw on it. It skips the create-list branch and falls
+        // through to createOtherwise: (quote ()).
+        $emptyList = Phel::list([]);
+
+        $q = new QuasiquoteTransformer(new GlobalEnvironment());
+        self::assertEquals(
+            Phel::list([
+                Symbol::create(Symbol::NAME_QUOTE),
+                Phel::list([]),
+            ]),
+            $q->transform($emptyList),
+        );
+    }
+
     public function test_transform_empty_map_is_quoted(): void
     {
         // An empty map has count 0, so it skips the create-map branch and,

--- a/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
+++ b/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
@@ -129,6 +129,38 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
+    public function test_transform_empty_vector_is_quoted(): void
+    {
+        // An empty vector has count 0, so it skips the create-vector branch and,
+        // not being a literal, falls through to createOtherwise: (quote []).
+        $emptyVector = Phel::vector([]);
+
+        $q = new QuasiquoteTransformer(new GlobalEnvironment());
+        self::assertEquals(
+            Phel::list([
+                Symbol::create(Symbol::NAME_QUOTE),
+                Phel::vector([]),
+            ]),
+            $q->transform($emptyVector),
+        );
+    }
+
+    public function test_transform_empty_map_is_quoted(): void
+    {
+        // An empty map has count 0, so it skips the create-map branch and,
+        // not being a literal, falls through to createOtherwise: (quote {}).
+        $emptyMap = Phel::map();
+
+        $q = new QuasiquoteTransformer(new GlobalEnvironment());
+        self::assertEquals(
+            Phel::list([
+                Symbol::create(Symbol::NAME_QUOTE),
+                Phel::map(),
+            ]),
+            $q->transform($emptyMap),
+        );
+    }
+
     public function test_transform_int(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());

--- a/tests/php/Unit/Config/PhelConfigValidatorTest.php
+++ b/tests/php/Unit/Config/PhelConfigValidatorTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Config;
+
+use Phel\Config\PhelConfig;
+use Phel\Config\PhelConfigValidator;
+use PHPUnit\Framework\TestCase;
+
+final class PhelConfigValidatorTest extends TestCase
+{
+    private PhelConfigValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new PhelConfigValidator();
+    }
+
+    public function test_default_config_is_valid(): void
+    {
+        $errors = $this->validator->validate(new PhelConfig());
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_empty_dir_arrays_produce_no_errors(): void
+    {
+        $config = new PhelConfig()
+            ->withSrcDirs([])
+            ->withTestDirs([]);
+
+        $errors = $this->validator->validate($config);
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_empty_vendor_dir_is_allowed(): void
+    {
+        $config = new PhelConfig()->withVendorDir('');
+
+        $errors = $this->validator->validate($config);
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_relative_vendor_dir_with_dots_is_allowed(): void
+    {
+        $config = new PhelConfig()->withVendorDir('../vendor');
+
+        $errors = $this->validator->validate($config);
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_absolute_src_dir_reports_error_with_label_and_path(): void
+    {
+        $config = new PhelConfig()->withSrcDirs(['/absolute/src']);
+
+        $errors = $this->validator->validate($config);
+
+        self::assertSame(
+            ["Source directory '/absolute/src' should be relative, not absolute"],
+            $errors,
+        );
+    }
+
+    public function test_each_absolute_dir_reports_its_own_error(): void
+    {
+        $config = new PhelConfig()
+            ->withSrcDirs(['src', '/abs/one', '/abs/two']);
+
+        $errors = $this->validator->validate($config);
+
+        self::assertCount(2, $errors);
+        self::assertContains("Source directory '/abs/one' should be relative, not absolute", $errors);
+        self::assertContains("Source directory '/abs/two' should be relative, not absolute", $errors);
+    }
+
+    public function test_errors_from_src_test_and_vendor_are_aggregated(): void
+    {
+        $config = new PhelConfig()
+            ->withSrcDirs(['/abs/src'])
+            ->withTestDirs(['/abs/test'])
+            ->withVendorDir('/abs/vendor');
+
+        $errors = $this->validator->validate($config);
+
+        self::assertSame(
+            [
+                "Source directory '/abs/src' should be relative, not absolute",
+                "Test directory '/abs/test' should be relative, not absolute",
+                "Vendor directory '/abs/vendor' should be relative, not absolute",
+            ],
+            $errors,
+        );
+    }
+}

--- a/tests/php/Unit/Console/Application/ArgvInputSanitizerTest.php
+++ b/tests/php/Unit/Console/Application/ArgvInputSanitizerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Console\Application;
+
+use Phel\Console\Application\ArgvInputSanitizer;
+use PHPUnit\Framework\TestCase;
+
+final class ArgvInputSanitizerTest extends TestCase
+{
+    public function test_returns_argv_unchanged_when_not_a_run_invocation(): void
+    {
+        $argv = ['phel', 'test', '--filter=foo'];
+
+        self::assertSame($argv, new ArgvInputSanitizer()->sanitize($argv));
+    }
+
+    public function test_returns_argv_unchanged_when_argv_too_short(): void
+    {
+        $argv = ['phel'];
+
+        self::assertSame($argv, new ArgvInputSanitizer()->sanitize($argv));
+    }
+
+    public function test_keeps_bare_run_invocation_as_is(): void
+    {
+        $argv = ['phel', 'run'];
+
+        self::assertSame(['phel', 'run'], new ArgvInputSanitizer()->sanitize($argv));
+    }
+
+    public function test_collects_single_option_before_command(): void
+    {
+        $argv = ['phel', 'run', '-t', 'cmd'];
+
+        self::assertSame(
+            ['phel', 'run', '-t', 'cmd'],
+            new ArgvInputSanitizer()->sanitize($argv),
+        );
+    }
+
+    public function test_collects_multiple_options_before_command(): void
+    {
+        $argv = ['phel', 'run', '-t', '--with-time', '--clear-opcache', 'cmd'];
+
+        self::assertSame(
+            ['phel', 'run', '-t', '--with-time', '--clear-opcache', 'cmd'],
+            new ArgvInputSanitizer()->sanitize($argv),
+        );
+    }
+
+    public function test_only_options_without_command(): void
+    {
+        $argv = ['phel', 'run', '--with-time'];
+
+        self::assertSame(
+            ['phel', 'run', '--with-time'],
+            new ArgvInputSanitizer()->sanitize($argv),
+        );
+    }
+
+    public function test_separates_command_args_with_double_dash(): void
+    {
+        $argv = ['phel', 'run', '-t', 'cmd', 'arg1', 'arg2'];
+
+        self::assertSame(
+            ['phel', 'run', '-t', 'cmd', '--', 'arg1', 'arg2'],
+            new ArgvInputSanitizer()->sanitize($argv),
+        );
+    }
+
+    public function test_unknown_option_is_treated_as_command(): void
+    {
+        // --foo is not a known RUN_OPTION, so option collection stops and it
+        // becomes the command token; the rest is forwarded after a separator.
+        $argv = ['phel', 'run', '--foo', 'arg1'];
+
+        self::assertSame(
+            ['phel', 'run', '--foo', '--', 'arg1'],
+            new ArgvInputSanitizer()->sanitize($argv),
+        );
+    }
+
+    public function test_command_args_following_command_without_run_options(): void
+    {
+        $argv = ['phel', 'run', 'cmd', 'arg1'];
+
+        self::assertSame(
+            ['phel', 'run', 'cmd', '--', 'arg1'],
+            new ArgvInputSanitizer()->sanitize($argv),
+        );
+    }
+}

--- a/tests/php/Unit/Fiber/Domain/FutureTest.php
+++ b/tests/php/Unit/Fiber/Domain/FutureTest.php
@@ -173,4 +173,28 @@ final class FutureTest extends TestCase
 
         self::assertTrue($future->isCancelled());
     }
+
+    public function test_future_and_promise_interleave_on_concurrent_deref(): void
+    {
+        // A shared promise links two futures created back-to-back. The first
+        // future blocks on the promise (the consumer); the second delivers to
+        // it (the producer). Both fibers are enqueued in construction order,
+        // so the consumer must cooperatively yield until the producer runs and
+        // delivers, after which the consumer resumes with the delivered value.
+        $shared = new Promise($this->scheduler);
+
+        $consumer = new Future($this->scheduler, static fn(): mixed => $shared->deref());
+        $producer = new Future($this->scheduler, static function () use ($shared): string {
+            $shared->deliver('handed-off');
+            return 'delivered';
+        });
+
+        // Deref'ing the consumer drains the ready queue until both fibers
+        // complete; FIFO ordering guarantees the producer runs and delivers.
+        self::assertSame('handed-off', $consumer->deref());
+        self::assertSame('delivered', $producer->deref());
+        self::assertTrue($shared->isRealized());
+        self::assertTrue($consumer->isRealized());
+        self::assertTrue($producer->isRealized());
+    }
 }

--- a/tests/php/Unit/Filesystem/Domain/NullFilesystemTest.php
+++ b/tests/php/Unit/Filesystem/Domain/NullFilesystemTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Filesystem\Domain;
+
+use Phel\Filesystem\Domain\NullFilesystem;
+use PHPUnit\Framework\TestCase;
+
+final class NullFilesystemTest extends TestCase
+{
+    public function test_add_file_and_clear_all_are_no_ops(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'phel-nullfs-');
+        self::assertIsString($file);
+
+        $filesystem = new NullFilesystem();
+        $filesystem->addFile($file);
+        $filesystem->clearAll();
+
+        // clearAll() must not touch any tracked file: the path still exists.
+        self::assertFileExists($file);
+
+        unlink($file);
+    }
+}

--- a/tests/php/Unit/Filesystem/Infrastructure/RealFilesystemTest.php
+++ b/tests/php/Unit/Filesystem/Infrastructure/RealFilesystemTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Filesystem\Infrastructure;
+
+use Phel\Filesystem\Infrastructure\RealFilesystem;
+use PHPUnit\Framework\TestCase;
+
+final class RealFilesystemTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        RealFilesystem::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        RealFilesystem::reset();
+    }
+
+    public function test_clear_all_removes_all_tracked_files(): void
+    {
+        $fileA = $this->createTempFile();
+        $fileB = $this->createTempFile();
+
+        $filesystem = new RealFilesystem();
+        $filesystem->addFile($fileA);
+        $filesystem->addFile($fileB);
+
+        $filesystem->clearAll();
+
+        self::assertFileDoesNotExist($fileA);
+        self::assertFileDoesNotExist($fileB);
+    }
+
+    public function test_clear_all_resets_tracking_array(): void
+    {
+        $file = $this->createTempFile();
+
+        $filesystem = new RealFilesystem();
+        $filesystem->addFile($file);
+        $filesystem->clearAll();
+
+        // Re-create the same path; a second clearAll must NOT delete it,
+        // proving the tracking array was reset after the first call.
+        file_put_contents($file, 'kept');
+        $filesystem->clearAll();
+
+        self::assertFileExists($file);
+
+        unlink($file);
+    }
+
+    public function test_static_state_is_shared_across_instances(): void
+    {
+        $file = $this->createTempFile();
+
+        $registrar = new RealFilesystem();
+        $registrar->addFile($file);
+
+        // A different instance shares the same static $files array.
+        $cleaner = new RealFilesystem();
+        $cleaner->clearAll();
+
+        self::assertFileDoesNotExist($file);
+    }
+
+    private function createTempFile(): string
+    {
+        $file = tempnam(sys_get_temp_dir(), 'phel-realfs-');
+        self::assertIsString($file);
+        self::assertFileExists($file);
+
+        return $file;
+    }
+}

--- a/tests/php/Unit/Formatter/Domain/Rules/Indenter/BlockIndenterTest.php
+++ b/tests/php/Unit/Formatter/Domain/Rules/Indenter/BlockIndenterTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Formatter\Domain\Rules\Indenter;
+
+use Phel\Formatter\Domain\Rules\Indenter\BlockIndenter;
+use Phel\Formatter\Domain\Rules\Zipper\ParseTreeZipper;
+
+final class BlockIndenterTest extends IndenterTestCase
+{
+    public function test_it_returns_null_when_the_head_symbol_does_not_match(): void
+    {
+        // (foo\n bar) with a BlockIndenter for `if` must not match.
+        $list = $this->listNode([
+            $this->symbol('foo'),
+            $this->newline(),
+            $this->whitespace(' '),
+            $this->symbol('bar'),
+        ]);
+        $loc = ParseTreeZipper::createRoot($list)->down()->right()->right()->right();
+
+        $margin = new BlockIndenter('if', 1)->getMargin($loc, 2);
+
+        self::assertNull($margin);
+    }
+
+    public function test_it_returns_null_when_the_head_is_not_a_symbol(): void
+    {
+        // (:foo\n bar) — the head is a keyword, so formSymbol() is null and no
+        // BlockIndenter can match it.
+        $list = $this->listNode([
+            $this->keyword('foo'),
+            $this->newline(),
+            $this->whitespace(' '),
+            $this->symbol('bar'),
+        ]);
+        $loc = ParseTreeZipper::createRoot($list)->down()->right()->right()->right();
+
+        $margin = new BlockIndenter('foo', 1)->getMargin($loc, 2);
+
+        self::assertNull($margin);
+    }
+
+    public function test_it_indents_the_block_body_when_the_head_symbol_matches(): void
+    {
+        // (if\n bar) with index 1: the argument after the index is missing
+        // (nthForm out of bounds => null), so it falls back to the InnerIndenter
+        // path and produces a positive block indent.
+        $list = $this->listNode([
+            $this->symbol('if'),
+            $this->newline(),
+            $this->whitespace(' '),
+            $this->symbol('bar'),
+        ]);
+        $loc = ParseTreeZipper::createRoot($list)->down()->right()->right()->right();
+
+        $margin = new BlockIndenter('if', 1)->getMargin($loc, 2);
+
+        // InnerIndenter('if', 0): parent line margin (0 for the root list) plus
+        // the indent width (2).
+        self::assertSame(2, $margin);
+    }
+}

--- a/tests/php/Unit/Formatter/Domain/Rules/Indenter/IndenterTestCase.php
+++ b/tests/php/Unit/Formatter/Domain/Rules/Indenter/IndenterTestCase.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Formatter\Domain\Rules\Indenter;
+
+use Phel\Lang\Keyword;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+use Phel\Shared\Parser\Node\KeywordNode;
+use Phel\Shared\Parser\Node\ListNode;
+use Phel\Shared\Parser\Node\NewlineNode;
+use Phel\Shared\Parser\Node\NodeInterface;
+use Phel\Shared\Parser\Node\NumberNode;
+use Phel\Shared\Parser\Node\SymbolNode;
+use Phel\Shared\Parser\Node\Token;
+use Phel\Shared\Parser\Node\WhitespaceNode;
+use PHPUnit\Framework\TestCase;
+
+abstract class IndenterTestCase extends TestCase
+{
+    final protected function symbol(string $name): SymbolNode
+    {
+        return new SymbolNode($name, $this->loc(), $this->loc(), Symbol::create($name));
+    }
+
+    final protected function keyword(string $name): KeywordNode
+    {
+        return new KeywordNode(':' . $name, $this->loc(), $this->loc(), Keyword::create($name));
+    }
+
+    final protected function number(string $code): NumberNode
+    {
+        return new NumberNode($code, $this->loc(), $this->loc(), (int) $code);
+    }
+
+    final protected function whitespace(string $code = ' '): WhitespaceNode
+    {
+        return new WhitespaceNode($code, $this->loc(), $this->loc());
+    }
+
+    final protected function newline(): NewlineNode
+    {
+        return new NewlineNode("\n", $this->loc(), $this->loc());
+    }
+
+    /**
+     * @param list<NodeInterface> $children
+     */
+    final protected function listNode(array $children): ListNode
+    {
+        return new ListNode(Token::T_OPEN_PARENTHESIS, $this->loc(), $this->loc(), $children);
+    }
+
+    final protected function loc(): SourceLocation
+    {
+        return new SourceLocation('', 0, 0);
+    }
+}

--- a/tests/php/Unit/Formatter/Domain/Rules/Indenter/InnerIndenterTest.php
+++ b/tests/php/Unit/Formatter/Domain/Rules/Indenter/InnerIndenterTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Formatter\Domain\Rules\Indenter;
+
+use Phel\Formatter\Domain\Rules\Indenter\InnerIndenter;
+use Phel\Formatter\Domain\Rules\Zipper\ParseTreeZipper;
+use Phel\Formatter\Domain\Rules\Zipper\ZipperException;
+
+final class InnerIndenterTest extends IndenterTestCase
+{
+    public function test_it_returns_null_when_the_head_symbol_does_not_match(): void
+    {
+        // (foo\n bar) with an InnerIndenter for `defn` must not match.
+        $list = $this->listNode([
+            $this->symbol('foo'),
+            $this->newline(),
+            $this->whitespace(' '),
+            $this->symbol('bar'),
+        ]);
+        $loc = ParseTreeZipper::createRoot($list)->down()->right()->right()->right();
+
+        $margin = new InnerIndenter('defn', 0)->getMargin($loc, 2);
+
+        self::assertNull($margin);
+    }
+
+    public function test_it_returns_null_when_the_head_is_not_a_symbol(): void
+    {
+        // (:foo\n bar) — keyword head means formSymbol() is null, no match.
+        $list = $this->listNode([
+            $this->keyword('foo'),
+            $this->newline(),
+            $this->whitespace(' '),
+            $this->symbol('bar'),
+        ]);
+        $loc = ParseTreeZipper::createRoot($list)->down()->right()->right()->right();
+
+        $margin = new InnerIndenter('foo', 0)->getMargin($loc, 2);
+
+        self::assertNull($margin);
+    }
+
+    public function test_it_indents_one_level_past_the_parent_line_when_matching(): void
+    {
+        // (defn\n bar) with depth 0: parent line margin (0 for the root list)
+        // plus the indent width (2).
+        $list = $this->listNode([
+            $this->symbol('defn'),
+            $this->newline(),
+            $this->whitespace(' '),
+            $this->symbol('bar'),
+        ]);
+        $loc = ParseTreeZipper::createRoot($list)->down()->right()->right()->right();
+
+        $margin = new InnerIndenter('defn', 0)->getMargin($loc, 2);
+
+        self::assertSame(2, $margin);
+    }
+
+    public function test_it_throws_when_depth_exceeds_the_available_ancestry(): void
+    {
+        // depth 2 tries to climb two levels up from a node with a single
+        // ancestor (the root list), walking above the root.
+        $this->expectException(ZipperException::class);
+
+        $list = $this->listNode([
+            $this->symbol('defn'),
+            $this->newline(),
+            $this->whitespace(' '),
+            $this->symbol('bar'),
+        ]);
+        $loc = ParseTreeZipper::createRoot($list)->down()->right()->right()->right();
+
+        new InnerIndenter('defn', 2)->getMargin($loc, 2);
+    }
+}

--- a/tests/php/Unit/Formatter/Domain/Rules/Indenter/LineIndenterTest.php
+++ b/tests/php/Unit/Formatter/Domain/Rules/Indenter/LineIndenterTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Formatter\Domain\Rules\Indenter;
+
+use Phel\Formatter\Domain\Rules\Indenter\LineIndenter;
+use Phel\Formatter\Domain\Rules\Zipper\ParseTreeZipper;
+
+final class LineIndenterTest extends IndenterTestCase
+{
+    public function test_it_measures_the_prior_line_length_within_a_list(): void
+    {
+        // (foo bar) — positioned at `bar`, the prior line is "(foo " (5 chars).
+        $list = $this->listNode([
+            $this->symbol('foo'),
+            $this->whitespace(' '),
+            $this->symbol('bar'),
+        ]);
+        $loc = ParseTreeZipper::createRoot($list)->down()->right()->right();
+
+        $margin = new LineIndenter()->getMargin($loc, 2);
+
+        self::assertSame(5, $margin);
+    }
+
+    public function test_it_only_counts_the_last_line_after_a_newline(): void
+    {
+        // (foo\n  bar) — the newline resets the margin so only "  " counts (2).
+        $list = $this->listNode([
+            $this->symbol('foo'),
+            $this->newline(),
+            $this->whitespace('  '),
+            $this->symbol('bar'),
+        ]);
+        $loc = ParseTreeZipper::createRoot($list)->down()->right()->right()->right();
+
+        $margin = new LineIndenter()->getMargin($loc, 2);
+
+        self::assertSame(2, $margin);
+    }
+
+    public function test_it_returns_zero_margin_at_the_first_node_of_the_root(): void
+    {
+        // The head symbol of the root list has no prior content on its line, so
+        // the reconstructed prior line is just the list prefix "(" (1 char).
+        $list = $this->listNode([
+            $this->symbol('foo'),
+            $this->whitespace(' '),
+            $this->symbol('bar'),
+        ]);
+        $loc = ParseTreeZipper::createRoot($list)->down();
+
+        $margin = new LineIndenter()->getMargin($loc, 2);
+
+        self::assertSame(1, $margin);
+    }
+}

--- a/tests/php/Unit/Formatter/Domain/Rules/Indenter/ListIndenterTest.php
+++ b/tests/php/Unit/Formatter/Domain/Rules/Indenter/ListIndenterTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Formatter\Domain\Rules\Indenter;
+
+use Phel\Formatter\Domain\Rules\Indenter\ListIndenter;
+use Phel\Formatter\Domain\Rules\Zipper\ParseTreeZipper;
+
+final class ListIndenterTest extends IndenterTestCase
+{
+    public function test_it_aligns_under_the_head_when_only_one_value_precedes(): void
+    {
+        // (foo bar) at `bar`: indexOf == 1, so the margin aligns under the head
+        // `foo`, i.e. the prior line "(" => margin 1.
+        $list = $this->listNode([
+            $this->symbol('foo'),
+            $this->whitespace(' '),
+            $this->symbol('bar'),
+        ]);
+        $loc = ParseTreeZipper::createRoot($list)->down()->right()->right();
+
+        $margin = new ListIndenter()->getMargin($loc, 2);
+
+        self::assertSame(1, $margin);
+    }
+
+    public function test_it_aligns_under_the_first_argument_when_more_than_one_value_precedes(): void
+    {
+        // (foo bar baz) at `baz`: indexOf == 2 (> 1), so it aligns under the
+        // first argument `bar`, whose prior line is "(foo " => margin 5.
+        $list = $this->listNode([
+            $this->symbol('foo'),
+            $this->whitespace(' '),
+            $this->symbol('bar'),
+            $this->whitespace(' '),
+            $this->symbol('baz'),
+        ]);
+        $loc = ParseTreeZipper::createRoot($list)->down()->right()->right()->right()->right();
+
+        $margin = new ListIndenter()->getMargin($loc, 2);
+
+        self::assertSame(5, $margin);
+    }
+
+    public function test_it_ignores_trivia_siblings_when_counting_preceding_values(): void
+    {
+        // (foo<ws><ws>bar) at `bar`: the two whitespace lefts are trivia and do
+        // not count, so indexOf == 1 and it aligns under the head => margin 1.
+        $list = $this->listNode([
+            $this->symbol('foo'),
+            $this->whitespace(' '),
+            $this->whitespace('  '),
+            $this->symbol('bar'),
+        ]);
+        $loc = ParseTreeZipper::createRoot($list)->down()->right()->right()->right();
+
+        $margin = new ListIndenter()->getMargin($loc, 2);
+
+        self::assertSame(1, $margin);
+    }
+}

--- a/tests/php/Unit/Formatter/Domain/Rules/Pair/PairAlignerTest.php
+++ b/tests/php/Unit/Formatter/Domain/Rules/Pair/PairAlignerTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Formatter\Domain\Rules\Pair;
+
+use Phel\Formatter\Domain\Rules\Pair\PairAligner;
+use Phel\Lang\Keyword;
+use Phel\Lang\SourceLocation;
+use Phel\Shared\Parser\Node\CommentNode;
+use Phel\Shared\Parser\Node\KeywordNode;
+use Phel\Shared\Parser\Node\NewlineNode;
+use Phel\Shared\Parser\Node\NumberNode;
+use Phel\Shared\Parser\Node\WhitespaceNode;
+use PHPUnit\Framework\TestCase;
+
+use function strlen;
+
+final class PairAlignerTest extends TestCase
+{
+    public function test_it_aligns_values_under_a_common_column(): void
+    {
+        // {:a 1\n :longkey 2}
+        $children = [
+            $this->keyword('a'),
+            $this->whitespace(' '),
+            $this->number('1'),
+            $this->newline(),
+            $this->whitespace(' '),
+            $this->keyword('longkey'),
+            $this->whitespace(' '),
+            $this->number('2'),
+        ];
+
+        $result = new PairAligner()->align($children, 0, false);
+
+        // The whitespace after :a should be padded so that 1 and 2 align under
+        // column (strlen(":longkey") + 1).
+        $padAfterA = $result[1];
+        self::assertInstanceOf(WhitespaceNode::class, $padAfterA);
+        self::assertSame(strlen(':longkey') - strlen(':a') + 1, strlen($padAfterA->getCode()));
+
+        // The wider key keeps a single space before its value.
+        $padAfterLongkey = $result[6];
+        self::assertSame(' ', $padAfterLongkey->getCode());
+    }
+
+    public function test_it_returns_children_unmodified_when_fewer_than_two_pairs(): void
+    {
+        // Only a single pair (2 values) is below the minimum of 4 values.
+        $children = [
+            $this->keyword('a'),
+            $this->whitespace(' '),
+            $this->number('1'),
+        ];
+
+        $result = new PairAligner()->align($children, 0, false);
+
+        self::assertSame($children, $result);
+    }
+
+    public function test_it_returns_children_unmodified_when_pairs_are_on_a_single_line(): void
+    {
+        // {:a 1 :b 2} with no newline between pairs => no multi-line span.
+        $children = [
+            $this->keyword('a'),
+            $this->whitespace(' '),
+            $this->number('1'),
+            $this->whitespace(' '),
+            $this->keyword('b'),
+            $this->whitespace(' '),
+            $this->number('2'),
+        ];
+
+        $result = new PairAligner()->align($children, 0, false);
+
+        self::assertSame($children, $result);
+    }
+
+    public function test_it_returns_children_unmodified_when_odd_count_without_allow_trailing_single(): void
+    {
+        // Three non-trivia values => odd count, not key/value pairs.
+        $children = [
+            $this->keyword('a'),
+            $this->whitespace(' '),
+            $this->number('1'),
+            $this->newline(),
+            $this->keyword('b'),
+        ];
+
+        $result = new PairAligner()->align($children, 0, false);
+
+        self::assertSame($children, $result);
+    }
+
+    public function test_it_drops_the_trailing_single_value_when_allowed(): void
+    {
+        // (cond :a 1\n :longkey 2\n :else) => 5 values, last one dropped, the
+        // remaining 4 are aligned.
+        $children = [
+            $this->keyword('a'),
+            $this->whitespace(' '),
+            $this->number('1'),
+            $this->newline(),
+            $this->whitespace(' '),
+            $this->keyword('longkey'),
+            $this->whitespace(' '),
+            $this->number('2'),
+            $this->newline(),
+            $this->keyword('else'),
+        ];
+
+        $result = new PairAligner()->align($children, 0, true);
+
+        $padAfterA = $result[1];
+        self::assertInstanceOf(WhitespaceNode::class, $padAfterA);
+        self::assertSame(strlen(':longkey') - strlen(':a') + 1, strlen($padAfterA->getCode()));
+    }
+
+    public function test_it_skips_leading_values_via_skip_value_count(): void
+    {
+        // (case x :a 1\n :longkey 2) — skip the first 2 values (the head form
+        // is excluded by the caller; here we skip "case" head + "x").
+        $children = [
+            $this->keyword('head'),
+            $this->whitespace(' '),
+            $this->number('99'),
+            $this->whitespace(' '),
+            $this->keyword('a'),
+            $this->whitespace(' '),
+            $this->number('1'),
+            $this->newline(),
+            $this->whitespace(' '),
+            $this->keyword('longkey'),
+            $this->whitespace(' '),
+            $this->number('2'),
+        ];
+
+        $result = new PairAligner()->align($children, 2, false);
+
+        // The skipped leading whitespace (index 1, 3) must stay untouched.
+        self::assertSame(' ', $result[1]->getCode());
+        // The whitespace after the :a key (now a real key) must be padded.
+        $padAfterA = $result[5];
+        self::assertSame(strlen(':longkey') - strlen(':a') + 1, strlen($padAfterA->getCode()));
+    }
+
+    public function test_it_does_not_align_a_pair_with_a_comment_gap(): void
+    {
+        // The :a / 1 pair has a comment between key and value, so it must keep
+        // its original whitespace (gap is not horizontal).
+        $children = [
+            $this->keyword('a'),
+            $this->whitespace(' '),
+            $this->comment('; note'),
+            $this->newline(),
+            $this->number('1'),
+            $this->newline(),
+            $this->keyword('longkey'),
+            $this->whitespace(' '),
+            $this->number('2'),
+        ];
+
+        $result = new PairAligner()->align($children, 0, false);
+
+        // The whitespace right after :a is left as the original single space
+        // because the gap contains a comment/newline.
+        self::assertSame(' ', $result[1]->getCode());
+    }
+
+    public function test_it_returns_children_unmodified_when_a_key_spans_multiple_lines(): void
+    {
+        // A multi-line key code makes maxKeyWidth() bail out.
+        $children = [
+            $this->multilineKey(),
+            $this->whitespace(' '),
+            $this->number('1'),
+            $this->newline(),
+            $this->keyword('b'),
+            $this->whitespace(' '),
+            $this->number('2'),
+        ];
+
+        $result = new PairAligner()->align($children, 0, false);
+
+        self::assertSame($children, $result);
+    }
+
+    private function keyword(string $name): KeywordNode
+    {
+        return new KeywordNode(':' . $name, $this->loc(), $this->loc(), Keyword::create($name));
+    }
+
+    private function multilineKey(): KeywordNode
+    {
+        // A key whose code contains a newline (synthetic but exercises the guard).
+        return new KeywordNode(":a\nb", $this->loc(), $this->loc(), Keyword::create('a'));
+    }
+
+    private function number(string $code): NumberNode
+    {
+        return new NumberNode($code, $this->loc(), $this->loc(), (int) $code);
+    }
+
+    private function whitespace(string $code): WhitespaceNode
+    {
+        return new WhitespaceNode($code, $this->loc(), $this->loc());
+    }
+
+    private function newline(): NewlineNode
+    {
+        return new NewlineNode("\n", $this->loc(), $this->loc());
+    }
+
+    private function comment(string $code): CommentNode
+    {
+        return new CommentNode($code, $this->loc(), $this->loc());
+    }
+
+    private function loc(): SourceLocation
+    {
+        return new SourceLocation('', 0, 0);
+    }
+}

--- a/tests/php/Unit/HttpClient/StreamTransportTest.php
+++ b/tests/php/Unit/HttpClient/StreamTransportTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\HttpClient;
+
+use Phel\HttpClient\StreamTransport;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class StreamTransportTest extends TestCase
+{
+    public function test_send_throws_runtime_exception_on_unreachable_url(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('#^HTTP request to http://127\.0\.0\.1:1/ failed: #');
+
+        // Port 1 is reserved/closed, so the connection is refused immediately.
+        StreamTransport::send('GET', 'http://127.0.0.1:1/', [], null, ['timeout' => 0.5]);
+    }
+
+    public function test_send_returns_body_for_readable_stream(): void
+    {
+        // The data:// wrapper is honoured by file_get_contents() and lets us
+        // exercise the non-failure branch of send() fully offline. It does not
+        // populate $http_response_header, so ResponseParser falls back to its
+        // defaults — which is the documented behaviour for missing status lines.
+        $result = StreamTransport::send('GET', 'data://text/plain,hello-world', [], null, []);
+
+        self::assertSame('hello-world', $result['body']);
+    }
+
+    public function test_send_uses_response_parser_defaults_when_no_status_line(): void
+    {
+        $result = StreamTransport::send('GET', 'data://text/plain,payload', [], null, []);
+
+        self::assertSame(200, $result['status']);
+        self::assertSame('1.1', $result['version']);
+        self::assertSame('OK', $result['reason']);
+        self::assertSame([], $result['headers']);
+    }
+
+    public function test_send_returns_expected_shape(): void
+    {
+        $result = StreamTransport::send('GET', 'data://text/plain,x', [], null, []);
+
+        self::assertArrayHasKey('status', $result);
+        self::assertArrayHasKey('headers', $result);
+        self::assertArrayHasKey('body', $result);
+        self::assertArrayHasKey('version', $result);
+        self::assertArrayHasKey('reason', $result);
+    }
+}

--- a/tests/php/Unit/Interop/Generator/Builder/WrapperRelativeFilenamePathBuilderTest.php
+++ b/tests/php/Unit/Interop/Generator/Builder/WrapperRelativeFilenamePathBuilderTest.php
@@ -35,5 +35,31 @@ final class WrapperRelativeFilenamePathBuilderTest extends TestCase
             'the_project\\the_simple_file',
             'TheProject/TheSimpleFile.php',
         ];
+
+        yield 'single segment' => [
+            'export',
+            'Export.php',
+        ];
+
+        yield 'dot separator' => [
+            'test.export',
+            'Test/Export.php',
+        ];
+
+        yield 'multiple dot separators' => [
+            'a.b.c',
+            'A/B/C.php',
+        ];
+
+        yield 'mixed dot separators and underscores' => [
+            'my_lib.deep.export_util',
+            'MyLib/Deep/ExportUtil.php',
+        ];
+
+        // Hyphens are NOT treated as separators: only `\`, `.` and `_` are.
+        yield 'hyphen is left untouched' => [
+            'test-lib',
+            'Test-lib.php',
+        ];
     }
 }

--- a/tests/php/Unit/Lsp/Application/Rpc/MessageReaderTest.php
+++ b/tests/php/Unit/Lsp/Application/Rpc/MessageReaderTest.php
@@ -57,6 +57,42 @@ final class MessageReaderTest extends TestCase
         $reader->read($stream);
     }
 
+    public function test_it_returns_empty_array_on_zero_content_length(): void
+    {
+        $stream = $this->memoryStreamWith("Content-Length: 0\r\n\r\n");
+
+        $reader = new MessageReader();
+        $message = $reader->read($stream);
+
+        self::assertSame([], $message);
+    }
+
+    public function test_it_returns_empty_array_when_no_content_length_header_present(): void
+    {
+        $stream = $this->memoryStreamWith("Content-Type: application/vscode-jsonrpc\r\n\r\n");
+
+        $reader = new MessageReader();
+        $message = $reader->read($stream);
+
+        self::assertSame([], $message);
+    }
+
+    public function test_it_throws_when_header_block_exceeds_maximum_size(): void
+    {
+        $header = '';
+        for ($i = 0; $i < 40; ++$i) {
+            $header .= "X-Custom-Header-{$i}: value\r\n";
+        }
+
+        $stream = $this->memoryStreamWith($header . "Content-Length: 17\r\n\r\n{\"method\":\"ping\"}");
+
+        $reader = new MessageReader();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('LSP header block exceeded maximum size.');
+        $reader->read($stream);
+    }
+
     public function test_it_reads_two_messages_back_to_back(): void
     {
         $stream = $this->memoryStreamWith(

--- a/tests/php/Unit/Profile/Domain/Formatter/JsonFormatterTest.php
+++ b/tests/php/Unit/Profile/Domain/Formatter/JsonFormatterTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Profile\Domain\Formatter;
+
+use Phel\Profile\Domain\Formatter\JsonFormatter;
+use Phel\Profile\Domain\ProfileReport;
+use PHPUnit\Framework\TestCase;
+
+use function json_decode;
+
+final class JsonFormatterTest extends TestCase
+{
+    public function test_it_renders_empty_report_with_top_level_keys(): void
+    {
+        $json = new JsonFormatter()->render(new ProfileReport([], [], 0.0));
+
+        $decoded = json_decode($json, true);
+
+        self::assertSame(['wall_clock_ms', 'compile_phases', 'fns'], array_keys($decoded));
+        self::assertEquals(0, $decoded['wall_clock_ms']);
+        self::assertSame([], $decoded['compile_phases']);
+        self::assertSame([], $decoded['fns']);
+    }
+
+    public function test_it_serializes_fn_records_with_ns_and_ms_figures(): void
+    {
+        $report = new ProfileReport(
+            ['app\\main' => ['calls' => 4, 'totalNs' => 2_500_000, 'selfNs' => 1_500_000, 'maxNs' => 800_000]],
+            [],
+            12.5,
+        );
+
+        $decoded = json_decode(new JsonFormatter()->render($report), true);
+
+        self::assertSame(12.5, $decoded['wall_clock_ms']);
+        self::assertCount(1, $decoded['fns']);
+        $fn = $decoded['fns'][0];
+        self::assertSame('app\\main', $fn['bound_to']);
+        self::assertSame(4, $fn['calls']);
+        self::assertSame(1_500_000, $fn['self_ns']);
+        self::assertSame(2_500_000, $fn['total_ns']);
+        self::assertSame(800_000, $fn['max_ns']);
+        self::assertSame(1.5, $fn['self_ms']);
+        self::assertSame(2.5, $fn['total_ms']);
+    }
+
+    public function test_it_flattens_compile_phases_with_source_key(): void
+    {
+        $report = new ProfileReport(
+            [],
+            ['src/foo.phel' => ['lex' => 1.5, 'parse' => 2.25]],
+            5.0,
+        );
+
+        $decoded = json_decode(new JsonFormatter()->render($report), true);
+
+        self::assertCount(1, $decoded['compile_phases']);
+        self::assertSame(
+            ['source' => 'src/foo.phel', 'lex' => 1.5, 'parse' => 2.25],
+            $decoded['compile_phases'][0],
+        );
+    }
+
+    public function test_it_does_not_escape_slashes_in_output(): void
+    {
+        $report = new ProfileReport([], ['a/b/c.phel' => ['lex' => 1.0]], 0.0);
+
+        $json = new JsonFormatter()->render($report);
+
+        self::assertStringContainsString('a/b/c.phel', $json);
+        self::assertStringNotContainsString('a\\/b', $json);
+    }
+}

--- a/tests/php/Unit/Profile/Domain/Formatter/TableFormatterTest.php
+++ b/tests/php/Unit/Profile/Domain/Formatter/TableFormatterTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Profile\Domain\Formatter;
+
+use Phel\Profile\Domain\Formatter\TableFormatter;
+use Phel\Profile\Domain\ProfileReport;
+use Phel\Profile\Domain\SortOrder;
+use PHPUnit\Framework\TestCase;
+
+final class TableFormatterTest extends TestCase
+{
+    public function test_it_reports_no_calls_when_fn_stats_are_empty(): void
+    {
+        $out = new TableFormatter()->render(new ProfileReport([], [], 0.0), 10, SortOrder::SelfTime, true);
+
+        self::assertStringContainsString('Runtime fn profile: no profiled calls recorded.', $out);
+        self::assertStringContainsString('Wall-clock total: 0.00 ms', $out);
+    }
+
+    public function test_it_omits_compile_phase_section_when_no_phase_data(): void
+    {
+        $out = new TableFormatter()->render(new ProfileReport([], [], 0.0), 10, SortOrder::SelfTime, true);
+
+        self::assertStringNotContainsString('Compile-time phases', $out);
+    }
+
+    public function test_it_omits_compile_phase_section_when_flag_disabled(): void
+    {
+        $report = new ProfileReport([], ['src/a.phel' => ['lex' => 1.0]], 0.0);
+
+        $out = new TableFormatter()->render($report, 10, SortOrder::SelfTime, false);
+
+        self::assertStringNotContainsString('Compile-time phases', $out);
+    }
+
+    public function test_it_renders_compile_phase_section_and_per_phase_total(): void
+    {
+        $report = new ProfileReport(
+            [],
+            ['src/a.phel' => ['lex' => 1.0, 'parse' => 2.0, 'read' => 0.5, 'analyze' => 1.5, 'emit' => 0.0]],
+            0.0,
+        );
+
+        $out = new TableFormatter()->render($report, 10, SortOrder::SelfTime, true);
+
+        self::assertStringContainsString('Compile-time phases (ms)', $out);
+        self::assertStringContainsString('src/a.phel', $out);
+        // total = 1 + 2 + 0.5 + 1.5 + 0 = 5.00
+        self::assertStringContainsString('5.00', $out);
+    }
+
+    public function test_it_sorts_compile_phase_rows_by_descending_total(): void
+    {
+        $report = new ProfileReport(
+            [],
+            [
+                'small.phel' => ['lex' => 1.0],
+                'big.phel' => ['lex' => 9.0],
+            ],
+            0.0,
+        );
+
+        $out = new TableFormatter()->render($report, 10, SortOrder::SelfTime, true);
+
+        self::assertLessThan(
+            strpos($out, 'small.phel'),
+            strpos($out, 'big.phel'),
+            'big.phel (higher total) must appear before small.phel',
+        );
+    }
+
+    public function test_it_formats_namespaced_fn_name_as_slash_and_dots(): void
+    {
+        $report = new ProfileReport(
+            ['phel\\core\\my_fn' => ['calls' => 1, 'totalNs' => 0, 'selfNs' => 0, 'maxNs' => 0]],
+            [],
+            0.0,
+        );
+
+        $out = new TableFormatter()->render($report, 10, SortOrder::SelfTime, false);
+
+        self::assertStringContainsString('phel.core/my-fn', $out);
+    }
+
+    public function test_it_formats_unqualified_fn_name_by_replacing_underscores(): void
+    {
+        $report = new ProfileReport(
+            ['my_global_fn' => ['calls' => 1, 'totalNs' => 0, 'selfNs' => 0, 'maxNs' => 0]],
+            [],
+            0.0,
+        );
+
+        $out = new TableFormatter()->render($report, 10, SortOrder::SelfTime, false);
+
+        self::assertStringContainsString('my-global-fn', $out);
+    }
+
+    public function test_it_computes_self_total_avg_and_max_columns(): void
+    {
+        // calls=2, totalNs=4_000_000 (=4ms, avg 2ms=2000us), selfNs=3_000_000 (=3ms), maxNs=2_500_000 (=2500us)
+        $report = new ProfileReport(
+            ['app\\fn' => ['calls' => 2, 'totalNs' => 4_000_000, 'selfNs' => 3_000_000, 'maxNs' => 2_500_000]],
+            [],
+            0.0,
+        );
+
+        $out = new TableFormatter()->render($report, 10, SortOrder::SelfTime, false);
+
+        self::assertStringContainsString('3.00', $out);    // self ms
+        self::assertStringContainsString('4.00', $out);    // total ms
+        self::assertStringContainsString('2000.00', $out); // avg us
+        self::assertStringContainsString('2500.00', $out); // max us
+        self::assertStringContainsString('Totals: 1 fns, 2 calls, 3.00 ms self.', $out);
+    }
+
+    public function test_it_truncates_fn_rows_to_top_n_but_totals_count_all(): void
+    {
+        $report = new ProfileReport(
+            [
+                'app\\a' => ['calls' => 1, 'totalNs' => 1_000_000, 'selfNs' => 1_000_000, 'maxNs' => 1_000_000],
+                'app\\b' => ['calls' => 1, 'totalNs' => 2_000_000, 'selfNs' => 2_000_000, 'maxNs' => 2_000_000],
+                'app\\c' => ['calls' => 1, 'totalNs' => 3_000_000, 'selfNs' => 3_000_000, 'maxNs' => 3_000_000],
+            ],
+            [],
+            0.0,
+        );
+
+        $out = new TableFormatter()->render($report, 1, SortOrder::SelfTime, false);
+
+        // Only the top 1 (highest selfNs => app\c) is shown
+        self::assertStringContainsString('app/c', $out);
+        self::assertStringNotContainsString('app/a', $out);
+        self::assertStringContainsString('(top 1, sort by self)', $out);
+        // but the totals reflect all three
+        self::assertStringContainsString('Totals: 3 fns, 3 calls', $out);
+    }
+
+    public function test_it_orders_rows_by_calls_when_sorting_by_calls(): void
+    {
+        $report = new ProfileReport(
+            [
+                'app\\few' => ['calls' => 1, 'totalNs' => 9_000_000, 'selfNs' => 9_000_000, 'maxNs' => 9_000_000],
+                'app\\many' => ['calls' => 100, 'totalNs' => 1_000_000, 'selfNs' => 1_000_000, 'maxNs' => 100],
+            ],
+            [],
+            0.0,
+        );
+
+        $out = new TableFormatter()->render($report, 10, SortOrder::Calls, false);
+
+        self::assertLessThan(
+            strpos($out, 'app/few'),
+            strpos($out, 'app/many'),
+            'app/many (100 calls) must sort before app/few (1 call)',
+        );
+    }
+
+    public function test_it_shortens_long_source_paths_to_40_chars_with_ellipsis(): void
+    {
+        $longSource = '/very/deeply/nested/path/to/some/source/file/module.phel';
+        $report = new ProfileReport([], [$longSource => ['lex' => 1.0]], 0.0);
+
+        $out = new TableFormatter()->render($report, 10, SortOrder::SelfTime, true);
+
+        // Shortened to '…' + last 39 chars; full original path must not appear
+        self::assertStringNotContainsString($longSource, $out);
+        self::assertStringContainsString('…', $out);
+        self::assertStringContainsString('source/file/module.phel', $out);
+    }
+
+    public function test_it_keeps_short_source_paths_unchanged(): void
+    {
+        $report = new ProfileReport([], ['short.phel' => ['lex' => 1.0]], 0.0);
+
+        $out = new TableFormatter()->render($report, 10, SortOrder::SelfTime, true);
+
+        self::assertStringContainsString('short.phel', $out);
+        self::assertStringNotContainsString('…', $out);
+    }
+
+    public function test_it_handles_zero_call_fn_without_division_error(): void
+    {
+        $report = new ProfileReport(
+            ['app\\never' => ['calls' => 0, 'totalNs' => 0, 'selfNs' => 0, 'maxNs' => 0]],
+            [],
+            0.0,
+        );
+
+        $out = new TableFormatter()->render($report, 10, SortOrder::SelfTime, false);
+
+        self::assertStringContainsString('app/never', $out);
+        // avg us column is 0.00 when calls == 0
+        self::assertStringContainsString('0.00', $out);
+    }
+}

--- a/tests/php/Unit/Run/Application/Test/CpuCountDetectorTest.php
+++ b/tests/php/Unit/Run/Application/Test/CpuCountDetectorTest.php
@@ -84,4 +84,22 @@ final class CpuCountDetectorTest extends TestCase
         self::assertGreaterThanOrEqual(1, $count);
         self::assertLessThanOrEqual(CpuCountDetector::DEFAULT_CAP, $count);
     }
+
+    public function test_zero_env_var_is_clamped_to_one(): void
+    {
+        putenv('PHEL_TEST_WORKERS=0');
+
+        self::assertSame(1, new CpuCountDetector()->detect());
+        self::assertSame(1, new CpuCountDetector()->detectMax());
+    }
+
+    public function test_negative_env_var_falls_back_to_detection(): void
+    {
+        putenv('PHEL_TEST_WORKERS=-4');
+
+        $count = new CpuCountDetector()->detect();
+
+        self::assertGreaterThanOrEqual(1, $count);
+        self::assertLessThanOrEqual(CpuCountDetector::DEFAULT_CAP, $count);
+    }
 }

--- a/tests/php/Unit/Shared/MungeTest.php
+++ b/tests/php/Unit/Shared/MungeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared;
+
+use Phel\Shared\Munge;
+use PHPUnit\Framework\TestCase;
+
+final class MungeTest extends TestCase
+{
+    private Munge $munge;
+
+    protected function setUp(): void
+    {
+        $this->munge = new Munge();
+    }
+
+    public function test_encode_leaves_plain_identifier_untouched(): void
+    {
+        self::assertSame('foo', $this->munge->encode('foo'));
+    }
+
+    public function test_encode_special_cases_this(): void
+    {
+        self::assertSame('__phel_this', $this->munge->encode('this'));
+    }
+
+    public function test_encode_replaces_dash_with_underscore(): void
+    {
+        self::assertSame('my_function', $this->munge->encode('my-function'));
+    }
+
+    public function test_encode_replaces_special_characters(): void
+    {
+        self::assertSame('foo_QMARK_', $this->munge->encode('foo?'));
+        self::assertSame('foo_BANG_', $this->munge->encode('foo!'));
+        self::assertSame('_PLUS_', $this->munge->encode('+'));
+        self::assertSame('_GT_', $this->munge->encode('>'));
+        self::assertSame('_LT_', $this->munge->encode('<'));
+        self::assertSame('_EQ_', $this->munge->encode('='));
+        self::assertSame('_STAR_', $this->munge->encode('*'));
+        self::assertSame('_SLASH_', $this->munge->encode('/'));
+        self::assertSame('_DOT_', $this->munge->encode('.'));
+    }
+
+    public function test_encode_php_ns_replaces_dot_with_backslash(): void
+    {
+        self::assertSame('phel\\core', $this->munge->encodePhpNs('phel.core'));
+    }
+
+    public function test_encode_php_ns_replaces_dash_with_underscore(): void
+    {
+        self::assertSame('my_app\\sub_ns', $this->munge->encodePhpNs('my-app.sub-ns'));
+    }
+
+    public function test_encode_registry_key_uses_dot_form(): void
+    {
+        // Registry key canonicalises to dot form; the namespace mapping only
+        // rewrites '-' so dots are preserved.
+        self::assertSame('phel.core', $this->munge->encodeRegistryKey('phel\\core'));
+        self::assertSame('phel.core', $this->munge->encodeRegistryKey('phel.core'));
+    }
+
+    public function test_encode_registry_key_replaces_dash(): void
+    {
+        self::assertSame('my_app', $this->munge->encodeRegistryKey('my-app'));
+    }
+
+    public function test_decode_ns_is_inverse_of_namespace_encoding(): void
+    {
+        self::assertSame('my-app', $this->munge->decodeNs('my_app'));
+    }
+
+    public function test_canonical_ns_converts_backslash_to_dot(): void
+    {
+        self::assertSame('phel.core', Munge::canonicalNs('phel\\core'));
+        self::assertSame('a.b.c', Munge::canonicalNs('a\\b\\c'));
+    }
+
+    public function test_canonical_ns_leaves_dot_form_untouched(): void
+    {
+        self::assertSame('phel.core', Munge::canonicalNs('phel.core'));
+    }
+
+    public function test_display_ns_equals_canonical_ns(): void
+    {
+        self::assertSame('phel.core', Munge::displayNs('phel\\core'));
+        self::assertSame(Munge::canonicalNs('a\\b'), Munge::displayNs('a\\b'));
+    }
+
+    public function test_custom_mapping_injection(): void
+    {
+        $munge = new Munge(['a' => 'X'], ['b' => 'Y']);
+
+        self::assertSame('Xbc', $munge->encode('abc'));
+        self::assertSame('aYc', $munge->encodeRegistryKey('abc'));
+    }
+}

--- a/tests/php/Unit/Shared/PhelProjectDirectoryTest.php
+++ b/tests/php/Unit/Shared/PhelProjectDirectoryTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared;
+
+use Phel\Shared\PhelProjectDirectory;
+use PHPUnit\Framework\TestCase;
+
+use const DIRECTORY_SEPARATOR;
+
+final class PhelProjectDirectoryTest extends TestCase
+{
+    private const string SEP = DIRECTORY_SEPARATOR;
+
+    protected function setUp(): void
+    {
+        putenv(PhelProjectDirectory::DIR_ENV);
+    }
+
+    protected function tearDown(): void
+    {
+        putenv(PhelProjectDirectory::DIR_ENV);
+    }
+
+    public function test_path_without_subpath_defaults_to_dot_phel(): void
+    {
+        self::assertSame(
+            '/project' . self::SEP . '.phel',
+            PhelProjectDirectory::path('/project'),
+        );
+    }
+
+    public function test_path_with_subpath_is_appended(): void
+    {
+        self::assertSame(
+            '/project' . self::SEP . '.phel' . self::SEP . 'cache',
+            PhelProjectDirectory::path('/project', 'cache'),
+        );
+    }
+
+    public function test_path_strips_leading_separators_from_subpath(): void
+    {
+        self::assertSame(
+            '/project' . self::SEP . '.phel' . self::SEP . 'cache',
+            PhelProjectDirectory::path('/project', '/cache'),
+        );
+    }
+
+    public function test_configured_dir_overrides_default(): void
+    {
+        self::assertSame(
+            '/project' . self::SEP . 'custom-dir',
+            PhelProjectDirectory::path('/project', '', 'custom-dir'),
+        );
+    }
+
+    public function test_env_var_overrides_configured_dir(): void
+    {
+        putenv(PhelProjectDirectory::DIR_ENV . '=env-dir');
+
+        self::assertSame(
+            '/project' . self::SEP . 'env-dir',
+            PhelProjectDirectory::path('/project', '', 'configured-dir'),
+        );
+    }
+
+    public function test_absolute_configured_dir_ignores_project_root(): void
+    {
+        self::assertSame(
+            '/absolute/state',
+            PhelProjectDirectory::path('/project', '', '/absolute/state'),
+        );
+    }
+
+    public function test_resolve_returns_empty_for_empty_config_path(): void
+    {
+        self::assertSame('', PhelProjectDirectory::resolve('/project', ''));
+    }
+
+    public function test_resolve_returns_absolute_path_unchanged(): void
+    {
+        self::assertSame('/abs/log.txt', PhelProjectDirectory::resolve('/project', '/abs/log.txt'));
+    }
+
+    public function test_resolve_rewrites_dot_phel_prefix_through_state_dir(): void
+    {
+        self::assertSame(
+            '/project' . self::SEP . '.phel' . self::SEP . 'cache',
+            PhelProjectDirectory::resolve('/project', '.phel/cache'),
+        );
+    }
+
+    public function test_resolve_bare_dot_phel_maps_to_state_dir(): void
+    {
+        self::assertSame(
+            '/project' . self::SEP . '.phel',
+            PhelProjectDirectory::resolve('/project', '.phel'),
+        );
+    }
+
+    public function test_resolve_relative_path_joined_to_project_root(): void
+    {
+        self::assertSame(
+            '/project' . self::SEP . 'data/out',
+            PhelProjectDirectory::resolve('/project', 'data/out'),
+        );
+    }
+
+    public function test_resolve_dot_phel_prefix_honours_configured_dir(): void
+    {
+        self::assertSame(
+            '/project' . self::SEP . 'custom' . self::SEP . 'cache',
+            PhelProjectDirectory::resolve('/project', '.phel/cache', 'custom'),
+        );
+    }
+
+    public function test_phar_uri_is_treated_as_absolute(): void
+    {
+        self::assertSame(
+            'phar:///app/phel.phar/state',
+            PhelProjectDirectory::resolve('/project', 'phar:///app/phel.phar/state'),
+        );
+    }
+}

--- a/tests/php/Unit/Shared/PhpAttributeRendererTest.php
+++ b/tests/php/Unit/Shared/PhpAttributeRendererTest.php
@@ -8,6 +8,7 @@ use Phel\Lang\Keyword;
 use Phel\Lang\TypeFactory;
 use Phel\Shared\PhpAttributeRenderer;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 final class PhpAttributeRendererTest extends TestCase
 {
@@ -138,6 +139,99 @@ final class PhpAttributeRendererTest extends TestCase
         $specs = $this->vec($this->vec('not-a-keyword'));
 
         self::assertSame([], $this->renderer->render($specs));
+    }
+
+    public function test_non_vector_spec_in_list_is_skipped(): void
+    {
+        // Outer is a list-of-specs (first element is itself a vector), but one
+        // entry is a non-vector keyword spec and must be dropped silently.
+        $specs = $this->vec(
+            $this->vec(Keyword::create('Id', 'ORM')),
+            Keyword::create('not-a-spec'),
+        );
+
+        self::assertSame(['#[\ORM\Id]'], $this->renderer->render($specs));
+    }
+
+    public function test_nested_map_value_renders_as_php_array(): void
+    {
+        $specs = $this->vec($this->vec(
+            Keyword::create('Column', 'ORM'),
+            $this->map(
+                Keyword::create('options'),
+                $this->map(Keyword::create('default'), 0),
+            ),
+        ));
+
+        self::assertSame(
+            ["#[\\ORM\\Column(options: ['default' => 0])]"],
+            $this->renderer->render($specs),
+        );
+    }
+
+    public function test_nested_vector_of_vectors_renders_nested_arrays(): void
+    {
+        $specs = $this->vec($this->vec(
+            Keyword::create('Route'),
+            $this->vec($this->vec('GET'), $this->vec('POST')),
+        ));
+
+        self::assertSame(
+            ["#[\\Route([['GET'], ['POST']])]"],
+            $this->renderer->render($specs),
+        );
+    }
+
+    public function test_float_argument_is_rendered(): void
+    {
+        $specs = $this->vec($this->vec(
+            Keyword::create('Range'),
+            $this->map(Keyword::create('min'), 1.5),
+        ));
+
+        self::assertSame(['#[\Range(min: 1.5)]'], $this->renderer->render($specs));
+    }
+
+    public function test_keyword_value_renders_as_string(): void
+    {
+        $specs = $this->vec($this->vec(
+            Keyword::create('Column', 'ORM'),
+            $this->map(Keyword::create('type'), Keyword::create('integer')),
+        ));
+
+        self::assertSame(["#[\\ORM\\Column(type: 'integer')]"], $this->renderer->render($specs));
+    }
+
+    public function test_unsupported_value_renders_as_null(): void
+    {
+        $specs = $this->vec($this->vec(
+            Keyword::create('Thing'),
+            $this->map(Keyword::create('obj'), new stdClass()),
+        ));
+
+        self::assertSame(['#[\Thing(obj: null)]'], $this->renderer->render($specs));
+    }
+
+    public function test_non_keyword_map_key_is_skipped(): void
+    {
+        $specs = $this->vec($this->vec(
+            Keyword::create('Thing'),
+            $this->map('plainKey', 1, Keyword::create('kept'), 2),
+        ));
+
+        self::assertSame(['#[\Thing(kept: 2)]'], $this->renderer->render($specs));
+    }
+
+    public function test_empty_inner_spec_vector_is_skipped(): void
+    {
+        // Outer list-of-specs containing one valid spec and one empty vector
+        // (no name keyword) which must be dropped.
+        $specs = $this->vec(
+            $this->vec(Keyword::create('Id', 'ORM')),
+            $this->vec(),
+        );
+
+        self::assertSame(['#[\ORM\Id]'], $this->renderer->render($specs));
     }
 
     private function vec(mixed ...$values): mixed

--- a/tests/php/Unit/Shared/ResourceUsageFormatterTest.php
+++ b/tests/php/Unit/Shared/ResourceUsageFormatterTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared;
+
+use Phel\Shared\ResourceUsageFormatter;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class ResourceUsageFormatterTest extends TestCase
+{
+    private ResourceUsageFormatter $formatter;
+
+    /** @var float|null */
+    private mixed $originalRequestTimeFloat;
+
+    private bool $requestTimeFloatWasSet = false;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new ResourceUsageFormatter();
+        $this->requestTimeFloatWasSet = isset($_SERVER['REQUEST_TIME_FLOAT']);
+        $this->originalRequestTimeFloat = $_SERVER['REQUEST_TIME_FLOAT'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->requestTimeFloatWasSet) {
+            $_SERVER['REQUEST_TIME_FLOAT'] = $this->originalRequestTimeFloat;
+        } else {
+            unset($_SERVER['REQUEST_TIME_FLOAT']);
+        }
+    }
+
+    public function test_throws_when_request_time_float_missing(): void
+    {
+        unset($_SERVER['REQUEST_TIME_FLOAT']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('REQUEST_TIME_FLOAT');
+
+        $this->formatter->resourceUsageSinceStartOfRequest();
+    }
+
+    public function test_returns_time_and_memory_snapshot(): void
+    {
+        $_SERVER['REQUEST_TIME_FLOAT'] = microtime(true);
+
+        $result = $this->formatter->resourceUsageSinceStartOfRequest();
+
+        // Format: "Time: MM:SS[.mmm], Memory: X.XX <unit>" (hours optional).
+        self::assertMatchesRegularExpression(
+            '/^Time: (?:\d{2}:)?\d{2}:\d{2}(?:\.\d{3})?, Memory: (?:\d+(?:\.\d{2} (?:GB|MB|KB)| bytes?))$/',
+            $result,
+        );
+    }
+}

--- a/tests/php/Unit/Shared/VersionFinderTest.php
+++ b/tests/php/Unit/Shared/VersionFinderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared;
+
+use Phel\Shared\VersionFinder;
+use PHPUnit\Framework\TestCase;
+
+final class VersionFinderTest extends TestCase
+{
+    public function test_official_release_returns_latest_version(): void
+    {
+        $finder = new VersionFinder('abc1234abc1234abc1234abc1234abc1234abc1', 'def5678', true);
+
+        self::assertSame(VersionFinder::LATEST_VERSION, $finder->getVersion());
+    }
+
+    public function test_empty_current_commit_returns_latest_version(): void
+    {
+        $finder = new VersionFinder('abc1234', '', false);
+
+        self::assertSame(VersionFinder::LATEST_VERSION, $finder->getVersion());
+    }
+
+    public function test_current_commit_equal_to_tag_returns_latest_version(): void
+    {
+        $finder = new VersionFinder('abc1234', 'abc1234', false);
+
+        self::assertSame(VersionFinder::LATEST_VERSION, $finder->getVersion());
+    }
+
+    public function test_valid_commit_hash_returns_beta_with_short_hash(): void
+    {
+        $finder = new VersionFinder('tag1234', 'abcdef1234567890', false);
+
+        self::assertSame(VersionFinder::LATEST_VERSION . '-beta#abcdef1', $finder->getVersion());
+    }
+
+    public function test_full_40_char_sha_is_truncated_to_seven(): void
+    {
+        $sha = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+        $finder = new VersionFinder('tag', $sha, false);
+
+        self::assertSame(VersionFinder::LATEST_VERSION . '-beta#a1b2c3d', $finder->getVersion());
+    }
+
+    public function test_too_short_hash_falls_back_to_latest_version(): void
+    {
+        // 7 chars is below the 8-char minimum of the SHA pattern.
+        $finder = new VersionFinder('tag', 'abc1234', false);
+
+        self::assertSame(VersionFinder::LATEST_VERSION, $finder->getVersion());
+    }
+
+    public function test_non_hex_commit_falls_back_to_latest_version(): void
+    {
+        $finder = new VersionFinder('tag', 'zzzzzzzz', false);
+
+        self::assertSame(VersionFinder::LATEST_VERSION, $finder->getVersion());
+    }
+
+    public function test_whitespace_padded_hash_is_trimmed_and_valid(): void
+    {
+        $finder = new VersionFinder('tag', '  abcdef12  ', false);
+
+        self::assertSame(VersionFinder::LATEST_VERSION . '-beta#abcdef1', $finder->getVersion());
+    }
+
+    public function test_version_is_cached_across_calls(): void
+    {
+        $finder = new VersionFinder('tag', 'abcdef1234567890', false);
+
+        self::assertSame($finder->getVersion(), $finder->getVersion());
+    }
+}

--- a/tests/php/Unit/Watch/Application/Watcher/FswatchWatcherTest.php
+++ b/tests/php/Unit/Watch/Application/Watcher/FswatchWatcherTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Watch\Application\Watcher;
+
+use Phel\Watch\Application\Watcher\FswatchWatcher;
+use Phel\Watch\Domain\FileSystemScannerInterface;
+use PHPUnit\Framework\TestCase;
+
+final class FswatchWatcherTest extends TestCase
+{
+    public function test_name_is_fswatch(): void
+    {
+        $watcher = new FswatchWatcher($this->scanner());
+
+        self::assertSame('fswatch', $watcher->name());
+        self::assertSame(FswatchWatcher::NAME, $watcher->name());
+    }
+
+    public function test_is_available_is_false_for_missing_binary(): void
+    {
+        self::assertFalse(FswatchWatcher::isAvailable('definitely-not-a-real-binary-xyz'));
+    }
+
+    public function test_is_available_is_true_for_a_binary_on_path(): void
+    {
+        // `sh` is guaranteed on PATH in any POSIX CI environment; this proves the
+        // PATH-probing branch returns true (not just the missing-binary branch).
+        self::assertTrue(FswatchWatcher::isAvailable('sh'));
+    }
+
+    private function scanner(): FileSystemScannerInterface
+    {
+        return new class() implements FileSystemScannerInterface {
+            public function snapshot(array $paths): array
+            {
+                return [];
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 🤔 Background

A repo-wide pass to raise code and documentation quality so that a human Phel/PHP expert can read and maintain the codebase with zero friction — independent of any agentic tooling. Both source trees are covered: the PHP compiler/runtime (`src/php/`) and the Phel core library (`src/phel/`).

Driven by a per-module audit, then applied in verified, gated, bisectable waves. Every finding was checked against the real code before applying (the audit produced false positives — e.g. flagging the PHP 8.4 builtin `array_any` as undefined — all of which were rejected). Each wave was committed only after the full quality gate (php-cs-fixer, psalm lvl1, phpstan lvl5, rector, compiler suite, core suite) passed.

## 💡 Goal

Best-achievable maintainability with **no behavior change** outside three genuine bugs the work surfaced (each fixed with a regression test).

## 🔖 Changes

Phased into focused commits:

- **docs** — explanatory class/method docblocks (intent, caching, invariants, side effects) across PHP modules, and `:doc`/`:see-also`/`:example` metadata across Phel namespaces. Pure additions, zero behavior risk.
- **ref (cleanups)** — verified dead-code removal, native union types on private methods, clearer local/private names, interface/impl return-type alignment.
- **ref (structural)** — behavior-identical helper extractions (dedup), `readonly` on stateless final classes; all signature/API-changing suggestions deferred.
- **ref (repl)** — reuse the existing public `phel.core/canonical-ns` instead of six raw `(php/:: Munge (canonicalNs ...))` interop calls.
- **test** — ~40 focused unit/integration tests for previously untested utilities (Munge, VersionFinder, ResourceUsageFormatter, PhelProjectDirectory, Bencode, ArgvInputSanitizer, CpuCountDetector boundaries, formatter indenters, quasiquote empty collections, schema coercion, string edge cases). Compiler suite 4020 → 4173; core 5863 → 5894.

Three real bugs surfaced and fixed (with tests):

- `if-let`/`when-let`/`if-some`/`when-first` were **non-hygienic** — they bound an internal gensym but emitted the literal symbol `temp-sym`, silently shadowing a user binding of the same name. Switched to `temp-sym#` auto-gensym.
- Quasiquoting an **empty list** (`` `() ``) threw `Index out of bounds` (`get(0)` with no count guard); now yields an empty list like empty vectors/maps.
- `str/index-of` on an **empty string** leaked a raw PHP `ValueError` from `mb_strpos`; now returns `nil` (and `0` for an empty needle), matching Clojure.

CHANGELOG updated under `## Unreleased`.

### Known follow-ups (documented, intentionally not in this PR)

Surfaced by the new tests but out of scope here (need behavior decisions / hard-to-test environments): `FswatchWatcher::parseLine()` always reports `KIND_MODIFIED`; `ErrorLog` and `RealFilesystem::clearAll()` swallow I/O errors silently.
