### PR TITLE
fix: hygiene, empty-list quasiquote, and str/index-of edge-case bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `if-let`/`when-let`/`if-some`/`when-first`: now hygienic — a user binding named `temp-sym` is no longer shadowed by the macros' internal temporary
+- Quasiquote of an empty list (`` `() ``) no longer throws `Index out of bounds`; it yields an empty list, like empty vectors/maps already did
+- `str/index-of`: returns `nil` for an empty string instead of leaking a raw PHP `ValueError` (`(index-of "" "a")` => `nil`, `(index-of "" "")` => `0`)
 - Lexer: error/source-map columns are now counted in code points, not bytes, so locations are correct for multibyte (UTF-8) source
 - Printer: structs print with the `.` separator (`(my.ns.point 1 2)`) instead of `\` (#2255)
 - Docs: function `:example` outputs now match what the REPL prints, so `phel doc` and the phel-lang.org API reference are accurate

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -876,10 +876,10 @@
       (err (str "if-let requires bindings to have 2 elements, "
                 (count bindings) " given"))))
 
-  (let [form (bindings 0) tst (bindings 1) temp-sym (gensym)]
-    `(let [temp-sym ~tst]
-       (if temp-sym
-         (let [~form temp-sym]
+  (let [form (bindings 0) tst (bindings 1)]
+    `(let [temp-sym# ~tst]
+       (if temp-sym#
+         (let [~form temp-sym#]
            ~then)
          ~else))))
 
@@ -896,10 +896,10 @@
       (err (str "when-let requires bindings to have 2 elements, "
                 (count bindings) " given"))))
 
-  (let [form (bindings 0) tst (bindings 1) temp-sym (gensym)]
-    `(let [temp-sym ~tst]
-       (when temp-sym
-         (let [~form temp-sym]
+  (let [form (bindings 0) tst (bindings 1)]
+    `(let [temp-sym# ~tst]
+       (when temp-sym#
+         (let [~form temp-sym#]
            ~@body)))))
 
 (defmacro if-some
@@ -918,10 +918,10 @@
       (err (str "if-some requires bindings to have 2 elements, "
                 (count bindings) " given"))))
 
-  (let [form (bindings 0) tst (bindings 1) temp-sym (gensym)]
-    `(let [temp-sym ~tst]
-       (if (not (nil? temp-sym))
-         (let [~form temp-sym]
+  (let [form (bindings 0) tst (bindings 1)]
+    `(let [temp-sym# ~tst]
+       (if (not (nil? temp-sym#))
+         (let [~form temp-sym#]
            ~then)
          ~else))))
 
@@ -948,10 +948,10 @@
       (err (str "when-first requires bindings to have 2 elements, "
                 (count bindings) " given"))))
 
-  (let [sym (bindings 0) coll (bindings 1) temp-sym (gensym)]
-    `(let [temp-sym (first ~coll)]
-       (when (not (nil? temp-sym))
-         (let [~sym temp-sym]
+  (let [sym (bindings 0) coll (bindings 1)]
+    `(let [temp-sym# (first ~coll)]
+       (when (not (nil? temp-sym#))
+         (let [~sym temp-sym#]
            ~@body)))))
 
 (defmacro letfn

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -219,7 +219,10 @@
   [s value & [from-index]]
   (let [from-index (or from-index 0)
         from-index (let [abs (php/abs from-index)
-                         v   (min abs (dec (php/mb_strlen s)))]
+                         ;; Clamp to a valid mb_strpos offset: (dec (mb_strlen s))
+                         ;; is -1 for an empty string, which would otherwise raise
+                         ;; a ValueError instead of yielding nil.
+                         v   (max 0 (min abs (dec (php/mb_strlen s))))]
                      (if (< from-index 0)
                        (* v -1)
                        v))

--- a/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
+++ b/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
@@ -92,7 +92,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
      */
     private function isUnquote($form): bool
     {
-        return $form instanceof PersistentListInterface && $form->get(0) == Symbol::NAME_UNQUOTE;
+        return $form instanceof PersistentListInterface && count($form) > 0 && $form->get(0) == Symbol::NAME_UNQUOTE;
     }
 
     /**
@@ -100,7 +100,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
      */
     private function isUnquoteSplicing($form): bool
     {
-        return $form instanceof PersistentListInterface && $form->get(0) == Symbol::NAME_UNQUOTE_SPLICING;
+        return $form instanceof PersistentListInterface && count($form) > 0 && $form->get(0) == Symbol::NAME_UNQUOTE_SPLICING;
     }
 
     /**

--- a/tests/phel/core/binding.phel
+++ b/tests/phel/core/binding.phel
@@ -90,3 +90,15 @@
       "when-first with empty list")
   (is (= :a (when-first [x [:a :b]] x))
       "when-first with keyword vector"))
+
+;; Regression: these macros use an internal gensym binding. A user binding
+;; named `temp-sym` (the historical internal name) must not be shadowed.
+(deftest test-binding-macros-are-hygienic
+  (is (= 42 (let [temp-sym 42] (if-let [x 1] temp-sym)))
+      "if-let does not capture an outer temp-sym")
+  (is (= 42 (let [temp-sym 42] (when-let [x 1] temp-sym)))
+      "when-let does not capture an outer temp-sym")
+  (is (= 42 (let [temp-sym 42] (if-some [x 1] temp-sym)))
+      "if-some does not capture an outer temp-sym")
+  (is (= 42 (let [temp-sym 42] (when-first [x [1]] temp-sym)))
+      "when-first does not capture an outer temp-sym"))

--- a/tests/phel/string.phel
+++ b/tests/phel/string.phel
@@ -175,6 +175,22 @@
     (is (= nil (s/last-index-of sb "ｚ" 100)))
     (is (= nil (s/last-index-of sb "ｚ" -10)))))
 
+(deftest test-index-of-edge-cases
+  (is (= 0 (s/index-of "abc" "")) "empty needle is found at index 0")
+  (is (= nil (s/index-of "ab" "abc")) "needle longer than s returns nil")
+  (is (= 0 (s/index-of "abc" "a" 0)) "explicit from-index 0 finds a leading match")
+  (is (= 2 (s/index-of "abc" "c" 2)) "from-index at the last char still matches")
+  (is (= nil (s/index-of "" "a")) "empty haystack with a needle returns nil")
+  (is (= 0 (s/index-of "" "")) "empty haystack and empty needle match at index 0"))
+
+(deftest test-last-index-of-edge-cases
+  (is (= 3 (s/last-index-of "abc" "")) "empty needle is found at the string length")
+  (is (= nil (s/last-index-of "ab" "abc")) "needle longer than s returns nil")
+  (is (= nil (s/last-index-of "banana" "a" 0))
+      "from-index 0 cannot see the later 'a' occurrences")
+  (is (= 1 (s/last-index-of "banana" "a" 2))
+      "from-index 2 finds the first 'a' within bound"))
+
 (deftest test-starts-with?
   (is (= true (s/starts-with? "clojure west" "clojure")))
   (is (= false (s/starts-with? "conj" "clojure")))

--- a/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
+++ b/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
@@ -129,6 +129,55 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
+    public function test_transform_empty_vector_is_quoted(): void
+    {
+        // An empty vector has count 0, so it skips the create-vector branch and,
+        // not being a literal, falls through to createOtherwise: (quote []).
+        $emptyVector = Phel::vector([]);
+
+        $q = new QuasiquoteTransformer(new GlobalEnvironment());
+        self::assertEquals(
+            Phel::list([
+                Symbol::create(Symbol::NAME_QUOTE),
+                Phel::vector([]),
+            ]),
+            $q->transform($emptyVector),
+        );
+    }
+
+    public function test_transform_empty_list_is_quoted(): void
+    {
+        // An empty list must not be mistaken for an (unquote ...)/(unquote-splicing ...)
+        // form: get(0) would throw on it. It skips the create-list branch and falls
+        // through to createOtherwise: (quote ()).
+        $emptyList = Phel::list([]);
+
+        $q = new QuasiquoteTransformer(new GlobalEnvironment());
+        self::assertEquals(
+            Phel::list([
+                Symbol::create(Symbol::NAME_QUOTE),
+                Phel::list([]),
+            ]),
+            $q->transform($emptyList),
+        );
+    }
+
+    public function test_transform_empty_map_is_quoted(): void
+    {
+        // An empty map has count 0, so it skips the create-map branch and,
+        // not being a literal, falls through to createOtherwise: (quote {}).
+        $emptyMap = Phel::map();
+
+        $q = new QuasiquoteTransformer(new GlobalEnvironment());
+        self::assertEquals(
+            Phel::list([
+                Symbol::create(Symbol::NAME_QUOTE),
+                Phel::map(),
+            ]),
+            $q->transform($emptyMap),
+        );
+    }
+
     public function test_transform_int(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());


### PR DESCRIPTION
## 🤔 Background

Split out of the umbrella quality pass (#2325) so the only behavior-changing work lands in a small, high-scrutiny PR. Three genuine bugs surfaced during the repo-wide audit; each is fixed here with a regression test. No other changes ride along.

## 💡 Goal

Fix three real bugs, each independently reviewable and revertable.

## 🔖 Changes

- **`if-let`/`when-let`/`if-some`/`when-first` were non-hygienic** — they bound an internal gensym but emitted the literal symbol `temp-sym`, silently shadowing a user binding of the same name. Switched to `temp-sym#` auto-gensym.
- **Quasiquoting an empty list** (`` `() ``) threw `Index out of bounds` (`get(0)` with no count guard); now yields an empty list, like empty vectors/maps already did.
- **`str/index-of` on an empty string** leaked a raw PHP `ValueError` from `mb_strpos`; now returns `nil` (and `0` for an empty needle), matching Clojure.

CHANGELOG updated under `## Unreleased` → Fixed.
