### PR TITLE
ref: behavior-identical cleanups (dead code, types, naming, helpers)

### DIFF
--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -266,10 +266,9 @@
   of that binding, then binds name to that result, repeating for each
   successive form, returning the result of the last form."
   [expr name & forms]
-  (let [x (gensym)]
-    `(let [~name ~expr
-           ~@(interleave (repeat (count forms) name) forms)]
-       ~name)))
+  `(let [~name ~expr
+         ~@(interleave (repeat (count forms) name) forms)]
+     ~name))
 
 (defmacro doto
   "Evaluates x then calls all of the methods and functions with the

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -191,7 +191,7 @@
                               (php/. "Cannot convert into type " (type to))))))))
     (throw (php/new InvalidArgumentException "into expects 1, 2, or 3 arguments"))))
 
-(defn- conj-single
+(defn- conj-impl
   [coll value]
   (cond
     (php/=== coll nil)                            (list value)
@@ -216,9 +216,9 @@
   ([] [])
   ([coll] coll)
   ([coll value]
-   (conj-single coll value))
+   (conj-impl coll value))
   ([coll value & more]
-   (reduce conj-single (conj-single coll value) more)))
+   (reduce conj-impl (conj-impl coll value) more)))
 
 (defn- disj-single
   [coll k]

--- a/src/phel/json.phel
+++ b/src/phel/json.phel
@@ -7,7 +7,7 @@
   [v]
   (or (int? v) (float? v) (symbol? v) (keyword? v) (string? v)))
 
-(declare encode-value [x])
+(declare encode-value)
 
 (defn- encode-value-iterable [x]
   (let [arr (php/array)]

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -56,7 +56,7 @@
       dirs)))
 
 (defn- eval-namespace [namespace]
-  (let [canonical    (php/:: Munge (canonicalNs namespace))
+  (let [canonical    (canonical-ns namespace)
         dependencies (php/-> build-facade (getDependenciesForNamespace (get-src-dirs) (php/array canonical)))
         found        (php/> (php/count dependencies) 0)]
     (when-not found
@@ -386,7 +386,7 @@
   {:example "(find-ns \"phel.core\") ; => \"phel.core\""
    :see-also ["create-ns" "remove-ns" "loaded-namespaces"]}
   [ns-str]
-  (let [canonical (php/:: Munge (canonicalNs ns-str))]
+  (let [canonical (canonical-ns ns-str)]
     (when (php/:: Phel (hasNamespace (munge-ns canonical)))
       (php/:: Munge (displayNs canonical)))))
 
@@ -396,7 +396,7 @@
   {:example "(create-ns \"my-app.tmp\") ; => \"my-app.tmp\""
    :see-also ["find-ns" "remove-ns" "intern"]}
   [ns-str]
-  (let [canonical (php/:: Munge (canonicalNs ns-str))]
+  (let [canonical (canonical-ns ns-str)]
     (php/:: Phel (registerNamespace (munge-ns canonical)))
     (php/:: Munge (displayNs canonical))))
 
@@ -417,7 +417,7 @@
   {:example "(intern \"user\" \"x\" 42) ; => user/x"
    :see-also ["find-ns" "create-ns" "ns-interns"]}
   [ns-str name-str & rest]
-  (let [canonical    (php/:: Munge (canonicalNs ns-str))
+  (let [canonical    (canonical-ns ns-str)
         encoded-ns   (munge-ns canonical)
         encoded-name (php/-> (php/new Munge) (encode name-str))
         value        (first rest)]
@@ -461,7 +461,7 @@
    :see-also ["ns-publics" "ns-refers" "loaded-namespaces"]}
   [ns-str]
   (let [env     (get-global-env)
-        aliases (php/-> env (getRequireAliases (php/:: Munge (canonicalNs ns-str))))
+        aliases (php/-> env (getRequireAliases (canonical-ns ns-str)))
         result  (transient {})]
     (foreach [alias-name target-sym aliases]
       (assoc! result alias-name (php/:: Munge (displayNs (php/-> target-sym (getName))))))
@@ -474,7 +474,7 @@
    :see-also ["ns-publics" "ns-aliases" "loaded-namespaces"]}
   [ns-str]
   (let [env    (get-global-env)
-        refers (php/-> env (getRefers (php/:: Munge (canonicalNs ns-str))))
+        refers (php/-> env (getRefers (canonical-ns ns-str)))
         result (transient {})]
     (foreach [refer-name source-sym refers]
       (assoc! result refer-name (php/:: Munge (displayNs (php/-> source-sym (getName))))))

--- a/src/phel/schema/generator.phel
+++ b/src/phel/schema/generator.phel
@@ -51,20 +51,19 @@
     (v/resolve-or-throw "no default generator for schema kind" head
                         (fn [target] (schema->gen target)))))
 
-(defn- vector-of-gen [args]
+(defn- collection-gen [type-ctor args]
   (if (empty? args)
-    (g/vector-of g/int)
-    (g/vector-of (schema->gen (first args)))))
+    (type-ctor g/int)
+    (type-ctor (schema->gen (first args)))))
+
+(defn- vector-of-gen [args]
+  (collection-gen g/vector-of args))
 
 (defn- list-of-gen [args]
-  (if (empty? args)
-    (g/list-of g/int)
-    (g/list-of (schema->gen (first args)))))
+  (collection-gen g/list-of args))
 
 (defn- set-of-gen [args]
-  (if (empty? args)
-    (g/set-of g/int)
-    (g/set-of (schema->gen (first args)))))
+  (collection-gen g/set-of args))
 
 (defn- map-of-gen [args]
   (g/map-of (schema->gen (get args 0))

--- a/src/php/Build/Infrastructure/Cache/CacheIndexFile.php
+++ b/src/php/Build/Infrastructure/Cache/CacheIndexFile.php
@@ -23,7 +23,9 @@ use function is_string;
  */
 final readonly class CacheIndexFile
 {
-    private const string VERSION = '1.2';
+    // Bump when entry structure changes (namespace/source_hash/compiled_path/last_accessed keys).
+    // Decoupled from the Phel version for cache stability across minor releases.
+    private const string INDEX_FORMAT_VERSION = '1.2';
 
     public function __construct(
         private CacheDirectory $directory,
@@ -32,7 +34,7 @@ final readonly class CacheIndexFile
 
     public function version(): string
     {
-        return self::VERSION . ':' . $this->phelVersion;
+        return self::INDEX_FORMAT_VERSION . ':' . $this->phelVersion;
     }
 
     /**

--- a/src/php/Command/Domain/Exceptions/ExceptionArgsPrinter.php
+++ b/src/php/Command/Domain/Exceptions/ExceptionArgsPrinter.php
@@ -18,6 +18,8 @@ final readonly class ExceptionArgsPrinter implements ExceptionArgsPrinterInterfa
 {
     private const int MAX_ARG_LENGTH = 200;
 
+    private const int MAX_STRING_ARG_LENGTH = 15;
+
     public function __construct(
         private PrinterInterface $printer,
     ) {}
@@ -32,12 +34,7 @@ final readonly class ExceptionArgsPrinter implements ExceptionArgsPrinterInterfa
             $frameArgs,
         );
 
-        $argString = implode(' ', $argParts);
-        if ($argParts !== []) {
-            return ' ' . $argString;
-        }
-
-        return $argString;
+        return $argParts !== [] ? ' ' . implode(' ', $argParts) : '';
     }
 
     /**
@@ -73,8 +70,8 @@ final readonly class ExceptionArgsPrinter implements ExceptionArgsPrinterInterfa
 
         if (is_string($arg)) {
             $s = $arg;
-            if (strlen($s) > 15) {
-                $s = substr($s, 0, 15) . '...';
+            if (strlen($s) > self::MAX_STRING_ARG_LENGTH) {
+                $s = substr($s, 0, self::MAX_STRING_ARG_LENGTH) . '...';
             }
 
             return sprintf("'%s'", $s);

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -65,8 +65,6 @@ use function substr;
 
 final class AnalyzePersistentList
 {
-    private const string EMPTY_SYMBOL_NAME = '';
-
     /** @var array<string, SpecialFormAnalyzerInterface> */
     private array $symbolAnalyzerCache = [];
 
@@ -108,7 +106,7 @@ final class AnalyzePersistentList
         $first = $list->first();
         return $first instanceof Symbol
             ? $first->getFullName()
-            : self::EMPTY_SYMBOL_NAME;
+            : '';
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -48,7 +48,7 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
     private function emitViaEval(DefStructNode $node): void
     {
         $ns = $this->outputEmitter->mungeEncodePhpNs($node->getNamespace());
-        $fqcn = $ns . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
+        $fqcn = $this->buildFqcn($node);
 
         ob_start();
         $this->emitClassBody($node);
@@ -81,9 +81,18 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
 
     private function emitClassExistsGuard(DefStructNode $node): void
     {
-        $fqcn = $this->outputEmitter->mungeEncodePhpNs($node->getNamespace())
-            . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
+        $fqcn = $this->buildFqcn($node);
         $this->outputEmitter->emitLine("if (!class_exists('" . $fqcn . "')) {", $node->getStartSourceLocation());
+    }
+
+    /**
+     * Builds the fully qualified PHP class name for the generated struct,
+     * encoding both the namespace and the class name through the munger.
+     */
+    private function buildFqcn(DefStructNode $node): string
+    {
+        return $this->outputEmitter->mungeEncodePhpNs($node->getNamespace())
+            . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
     }
 
     private function emitClassBody(DefStructNode $node): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -170,15 +170,15 @@ final class NodeEmitterFactory
 
     private function getMethodEmitter(OutputEmitterInterface $outputEmitter): MethodEmitter
     {
-        $key = spl_object_id($outputEmitter);
+        $outputEmitterId = spl_object_id($outputEmitter);
 
-        return $this->methodEmitterCache[$key] ??= new MethodEmitter($outputEmitter, $this->getClosureHelper($outputEmitter));
+        return $this->methodEmitterCache[$outputEmitterId] ??= new MethodEmitter($outputEmitter, $this->getClosureHelper($outputEmitter));
     }
 
     private function getClosureHelper(OutputEmitterInterface $outputEmitter): ClosureEmitterHelper
     {
-        $key = spl_object_id($outputEmitter);
+        $outputEmitterId = spl_object_id($outputEmitter);
 
-        return $this->closureHelperCache[$key] ??= new ClosureEmitterHelper($outputEmitter);
+        return $this->closureHelperCache[$outputEmitterId] ??= new ClosureEmitterHelper($outputEmitter);
     }
 }

--- a/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
+++ b/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
@@ -40,10 +40,8 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
      * @param bool|float|int|string|TypeInterface|null $form The form to quasiqoute
      *
      * @throws SpliceNotInListException
-     *
-     * @return bool|float|int|string|TypeInterface|null
      */
-    public function transform($form)
+    public function transform($form): TypeInterface|string|float|int|bool|null
     {
         $context = new GensymContext();
 
@@ -51,13 +49,9 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
     }
 
     /**
-     * @param bool|float|int|string|TypeInterface|null $form
-     *
      * @throws SpliceNotInListException
-     *
-     * @return bool|float|int|string|TypeInterface|null
      */
-    private function doTransform($form, GensymContext $context)
+    private function doTransform(TypeInterface|string|float|int|bool|null $form, GensymContext $context): TypeInterface|string|float|int|bool|null
     {
         if ($this->isUnquote($form)) {
             /** @var PersistentList<mixed> $form */
@@ -190,7 +184,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
     /**
      * @param bool|float|int|string|TypeInterface|null $x The form to check
      */
-    private function isLiteral($x): bool
+    private function isLiteral(bool|float|int|TypeInterface|string|null $x): bool
     {
         return is_string($x)
             || is_float($x)
@@ -200,10 +194,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
             || $x instanceof Keyword;
     }
 
-    /**
-     * @param bool|float|int|string|TypeInterface|null $form
-     */
-    private function createOtherwise($form, GensymContext $context): PersistentListInterface|TypeInterface
+    private function createOtherwise(bool|float|int|TypeInterface|string|null $form, GensymContext $context): PersistentListInterface|TypeInterface
     {
         if ($form instanceof Symbol) {
             $name = $form->getFullName();

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -570,7 +570,7 @@ final readonly class PhelConfig implements JsonSerializable
      */
     public function validate(): array
     {
-        return new PhelConfigValidator()->validate($this->srcDirs, $this->testDirs, $this->vendorDir);
+        return new PhelConfigValidator()->validate($this);
     }
 
     // ========================================
@@ -604,8 +604,9 @@ final readonly class PhelConfig implements JsonSerializable
     }
 
     /**
-     * Returns a new instance with the supplied fields overridden. Internal
-     * plumbing for every `with*()` method — keeps each wither one line.
+     * Internal builder: returns a new instance with the supplied fields
+     * overridden. Each public `with*()` method delegates to this, allowing
+     * single-line immutable updates.
      *
      * @param array<string, mixed> $overrides
      */

--- a/src/php/Config/PhelConfigValidator.php
+++ b/src/php/Config/PhelConfigValidator.php
@@ -9,17 +9,14 @@ use function sprintf;
 final class PhelConfigValidator
 {
     /**
-     * @param list<string> $srcDirs
-     * @param list<string> $testDirs
-     *
      * @return list<string>
      */
-    public function validate(array $srcDirs, array $testDirs, string $vendorDir): array
+    public function validate(PhelConfig $config): array
     {
         return [
-            ...$this->validateRelativeDirs($srcDirs, 'Source'),
-            ...$this->validateRelativeDirs($testDirs, 'Test'),
-            ...$this->validateVendorDir($vendorDir),
+            ...$this->validateRelativeDirs($config->srcDirs, 'Source'),
+            ...$this->validateRelativeDirs($config->testDirs, 'Test'),
+            ...$this->validateVendorDir($config->vendorDir),
         ];
     }
 

--- a/src/php/Console/Infrastructure/ConsoleBootstrap.php
+++ b/src/php/Console/Infrastructure/ConsoleBootstrap.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function array_slice;
 use function array_values;
 use function in_array;
+use function str_starts_with;
 
 #[ServiceMap(method: 'getFactory', className: ConsoleFactory::class)]
 final class ConsoleBootstrap extends Application

--- a/src/php/Filesystem/Application/TempDirFinder.php
+++ b/src/php/Filesystem/Application/TempDirFinder.php
@@ -9,7 +9,7 @@ use Phel\Shared\Exceptions\FileException;
 
 final class TempDirFinder
 {
-    private string $finalTempDir = '';
+    private string $cachedTempDir = '';
 
     public function __construct(
         private readonly FileIoInterface $fileIo,
@@ -24,8 +24,8 @@ final class TempDirFinder
      */
     public function getOrCreateTempDir(): string
     {
-        if ($this->finalTempDir !== '') {
-            return $this->finalTempDir;
+        if ($this->cachedTempDir !== '') {
+            return $this->cachedTempDir;
         }
 
         $tempDir = $this->configTempDir;
@@ -47,12 +47,12 @@ final class TempDirFinder
 
             // @phpstan-ignore-next-line if.alwaysFalse
             if ($this->fileIo->isWritable($tempDir)) {
-                return $this->finalTempDir = $tempDir;
+                return $this->cachedTempDir = $tempDir;
             }
 
             throw FileException::directoryIsNotWritable($tempDir);
         }
 
-        return $this->finalTempDir = $tempDir;
+        return $this->cachedTempDir = $tempDir;
     }
 }

--- a/src/php/Filesystem/Application/TempDirFinder.php
+++ b/src/php/Filesystem/Application/TempDirFinder.php
@@ -30,17 +30,7 @@ final class TempDirFinder
 
         $tempDir = $this->configTempDir;
 
-        if (!is_dir($tempDir)) {
-            $oldUmask = umask(0);
-            if (!mkdir($tempDir, 0777, true) && !is_dir($tempDir)) {
-                throw FileException::canNotCreateDirectory($tempDir);
-            }
-
-            umask($oldUmask);
-            if (!is_dir($tempDir)) {
-                throw FileException::canNotCreateDirectory($tempDir);
-            }
-        }
+        $this->ensureDirectoryExists($tempDir);
 
         if (!$this->fileIo->isWritable($tempDir)) {
             @chmod($tempDir, 0777);
@@ -54,5 +44,31 @@ final class TempDirFinder
         }
 
         return $this->cachedTempDir = $tempDir;
+    }
+
+    /**
+     * Creates the directory if it does not already exist.
+     *
+     * Idempotent: an already-existing directory (or one created concurrently
+     * between the mkdir attempt and the is_dir re-check) is tolerated. umask is
+     * reset to 0 around mkdir so the 0777 mode is applied as requested.
+     *
+     * @throws FileException if the directory cannot be created
+     */
+    private function ensureDirectoryExists(string $tempDir): void
+    {
+        if (is_dir($tempDir)) {
+            return;
+        }
+
+        $oldUmask = umask(0);
+        if (!mkdir($tempDir, 0777, true) && !is_dir($tempDir)) {
+            throw FileException::canNotCreateDirectory($tempDir);
+        }
+
+        umask($oldUmask);
+        if (!is_dir($tempDir)) {
+            throw FileException::canNotCreateDirectory($tempDir);
+        }
     }
 }

--- a/src/php/Formatter/Domain/Rules/Indenter/LineIndenter.php
+++ b/src/php/Formatter/Domain/Rules/Indenter/LineIndenter.php
@@ -9,7 +9,11 @@ use Phel\Shared\Parser\Node\InnerNodeInterface;
 
 use function strlen;
 
-final class LineIndenter implements IndenterInterface
+/**
+ * Computes the left margin (indentation width) of a location by reconstructing
+ * the text of the line that precedes it and measuring that line's length.
+ */
+final readonly class LineIndenter implements IndenterInterface
 {
     public function getMargin(ParseTreeZipper $loc, int $indentWidth): int
     {

--- a/src/php/Formatter/Domain/Rules/RemoveSurroundingWhitespaceRule.php
+++ b/src/php/Formatter/Domain/Rules/RemoveSurroundingWhitespaceRule.php
@@ -8,7 +8,7 @@ use Phel\Formatter\Domain\Rules\Zipper\ParseTreeZipper;
 use Phel\Formatter\Domain\Rules\Zipper\ZipperException;
 use Phel\Shared\Parser\Node\NodeInterface;
 
-final class RemoveSurroundingWhitespaceRule implements RuleInterface
+final readonly class RemoveSurroundingWhitespaceRule implements RuleInterface
 {
     /**
      * @throws ZipperException

--- a/src/php/Formatter/Domain/Rules/RemoveTrailingWhitespaceRule.php
+++ b/src/php/Formatter/Domain/Rules/RemoveTrailingWhitespaceRule.php
@@ -8,7 +8,7 @@ use Phel\Formatter\Domain\Rules\Zipper\ParseTreeZipper;
 use Phel\Formatter\Domain\Rules\Zipper\ZipperException;
 use Phel\Shared\Parser\Node\NodeInterface;
 
-final class RemoveTrailingWhitespaceRule implements RuleInterface
+final readonly class RemoveTrailingWhitespaceRule implements RuleInterface
 {
     public function transform(NodeInterface $node): NodeInterface
     {

--- a/src/php/HttpClient/ResponseParser.php
+++ b/src/php/HttpClient/ResponseParser.php
@@ -34,10 +34,9 @@ final class ResponseParser
                 continue;
             }
 
-            $colonPos = strpos($line, ':');
-            if ($colonPos !== false) {
-                $name = strtolower(trim(substr($line, 0, $colonPos)));
-                $value = trim(substr($line, $colonPos + 1));
+            $header = self::parseHeaderLine($line);
+            if ($header !== null) {
+                [$name, $value] = $header;
                 $headers[$name] = $value;
             }
         }
@@ -48,5 +47,23 @@ final class ResponseParser
             'reason' => $reason,
             'headers' => $headers,
         ];
+    }
+
+    /**
+     * Parses a single (non-status) header line into a lowercased name/value pair.
+     *
+     * @return array{0: string, 1: string}|null Null when the line has no colon separator
+     */
+    private static function parseHeaderLine(string $line): ?array
+    {
+        $colonPos = strpos($line, ':');
+        if ($colonPos === false) {
+            return null;
+        }
+
+        $name = strtolower(trim(substr($line, 0, $colonPos)));
+        $value = trim(substr($line, $colonPos + 1));
+
+        return [$name, $value];
     }
 }

--- a/src/php/Interop/Domain/Generator/Builder/WrapperRelativeFilenamePathBuilder.php
+++ b/src/php/Interop/Domain/Generator/Builder/WrapperRelativeFilenamePathBuilder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Interop\Domain\Generator\Builder;
 
-final class WrapperRelativeFilenamePathBuilder
+final readonly class WrapperRelativeFilenamePathBuilder
 {
     public function build(string $phelNs): string
     {

--- a/src/php/Interop/Infrastructure/IO/FileSystemIo.php
+++ b/src/php/Interop/Infrastructure/IO/FileSystemIo.php
@@ -9,7 +9,7 @@ use RuntimeException;
 
 use function sprintf;
 
-final class FileSystemIo implements FileIoInterface
+final readonly class FileSystemIo implements FileIoInterface
 {
     public function createDirectory(string $directory): void
     {

--- a/src/php/Interop/Infrastructure/IO/FileSystemIo.php
+++ b/src/php/Interop/Infrastructure/IO/FileSystemIo.php
@@ -17,10 +17,6 @@ final class FileSystemIo implements FileIoInterface
             return;
         }
 
-        if (is_dir($directory)) {
-            return;
-        }
-
         throw new RuntimeException(sprintf('Directory "%s" was not created', $directory));
     }
 

--- a/src/php/Lint/Application/Formatter/FormatterRegistry.php
+++ b/src/php/Lint/Application/Formatter/FormatterRegistry.php
@@ -7,6 +7,8 @@ namespace Phel\Lint\Application\Formatter;
 use InvalidArgumentException;
 use Phel\Lint\Domain\DiagnosticFormatterInterface;
 
+use function array_keys;
+use function implode;
 use function sprintf;
 
 /**

--- a/src/php/Lint/Application/Formatter/HumanFormatter.php
+++ b/src/php/Lint/Application/Formatter/HumanFormatter.php
@@ -8,6 +8,7 @@ use Phel\Api\Transfer\Diagnostic;
 use Phel\Lint\Domain\DiagnosticFormatterInterface;
 use Phel\Lint\Transfer\LintResult;
 
+use function implode;
 use function sprintf;
 
 /**
@@ -54,13 +55,13 @@ final class HumanFormatter implements DiagnosticFormatterInterface
             $diagnostic->uri,
             $diagnostic->startLine,
             $diagnostic->startCol,
-            $this->severityLabel($diagnostic->severity),
+            $this->formatSeverity($diagnostic->severity),
             $diagnostic->code,
             $diagnostic->message,
         );
     }
 
-    private function severityLabel(string $severity): string
+    private function formatSeverity(string $severity): string
     {
         return match ($severity) {
             Diagnostic::SEVERITY_ERROR => '[error]',

--- a/src/php/Lint/Application/Rule/DiscouragedVarRule.php
+++ b/src/php/Lint/Application/Rule/DiscouragedVarRule.php
@@ -16,7 +16,9 @@ use Phel\Lint\Domain\LintRuleInterface;
 use function count;
 use function in_array;
 use function is_string;
+use function preg_match;
 use function sprintf;
+use function str_starts_with;
 
 /**
  * Flags references to definitions marked `^:deprecated` or

--- a/src/php/Lint/Application/Rule/UnusedImportRule.php
+++ b/src/php/Lint/Application/Rule/UnusedImportRule.php
@@ -105,7 +105,7 @@ final readonly class UnusedImportRule implements LintRuleInterface
             }
 
             $result[] = [
-                'alias' => $alias ?? $this->defaultAlias($item),
+                'alias' => $alias ?? $this->lastSegmentAlias($item),
                 'display' => $item->getName(),
                 'anchor' => $item,
             ];
@@ -114,7 +114,7 @@ final readonly class UnusedImportRule implements LintRuleInterface
         return $result;
     }
 
-    private function defaultAlias(Symbol $symbol): string
+    private function lastSegmentAlias(Symbol $symbol): string
     {
         $name = $symbol->getName();
         $parts = explode('\\', $name);

--- a/src/php/Lint/Application/Rule/UnusedRequireRule.php
+++ b/src/php/Lint/Application/Rule/UnusedRequireRule.php
@@ -13,6 +13,7 @@ use Phel\Lint\Domain\FileAnalysis;
 use Phel\Lint\Domain\LintRuleInterface;
 
 use function count;
+use function explode;
 use function sprintf;
 
 /**

--- a/src/php/Lint/Infrastructure/Command/LintCommand.php
+++ b/src/php/Lint/Infrastructure/Command/LintCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 use function getcwd;
+use function implode;
 use function is_dir;
 use function is_file;
 use function is_string;

--- a/src/php/Lsp/Application/Handler/DocumentSymbolHandler.php
+++ b/src/php/Lsp/Application/Handler/DocumentSymbolHandler.php
@@ -14,6 +14,8 @@ use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
 
+use function array_values;
+
 /**
  * Lists all top-level definitions in the open document. Uses the project
  * index when available; otherwise runs a single-file indexing pass so the
@@ -84,11 +86,7 @@ final readonly class DocumentSymbolHandler implements HandlerInterface
         }
 
         $index = $this->apiFacade->indexProject([$path]);
-        $result = [];
-        foreach ($index->definitions as $def) {
-            $result[] = $def;
-        }
 
-        return $result;
+        return array_values($index->definitions);
     }
 }

--- a/src/php/Nrepl/Application/Op/InterruptOp.php
+++ b/src/php/Nrepl/Application/Op/InterruptOp.php
@@ -9,7 +9,12 @@ use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Op\OpResponse;
 use Phel\Nrepl\Domain\Op\OpStatus;
 
-final class InterruptOp implements OpHandlerInterface
+/**
+ * Interrupt op (no-op stub). Phel evaluates synchronously, so there is no
+ * background work to interrupt; this handler simply acknowledges the op to
+ * keep editors happy.
+ */
+final readonly class InterruptOp implements OpHandlerInterface
 {
     public function name(): string
     {

--- a/src/php/Nrepl/Application/Op/LookupOp.php
+++ b/src/php/Nrepl/Application/Op/LookupOp.php
@@ -36,10 +36,7 @@ final readonly class LookupOp implements OpHandlerInterface
 
     public function handle(OpRequest $request): array
     {
-        $symbol = $request->stringParam('sym');
-        if ($symbol === '') {
-            $symbol = $request->stringParam('symbol');
-        }
+        $symbol = $this->extractSymbol($request);
 
         if ($symbol === '') {
             return [OpResponse::errorDone(
@@ -73,6 +70,16 @@ final readonly class LookupOp implements OpHandlerInterface
             ['info' => $info, 'eldoc' => $fn->signatures],
             [OpStatus::DONE],
         )];
+    }
+
+    private function extractSymbol(OpRequest $request): string
+    {
+        $symbol = $request->stringParam('sym');
+        if ($symbol === '') {
+            return $request->stringParam('symbol');
+        }
+
+        return $symbol;
     }
 
     private function resolveCurrentNamespace(OpRequest $request): string

--- a/src/php/Profile/Domain/Formatter/TableFormatter.php
+++ b/src/php/Profile/Domain/Formatter/TableFormatter.php
@@ -41,6 +41,30 @@ final class TableFormatter
     private function renderCompilePhases(ProfileReport $report): string
     {
         $phases = ['lex', 'parse', 'read', 'analyze', 'emit'];
+        $rows = $this->buildPhaseRows($report, $phases);
+
+        $sourceWidth = $this->calculateColumnWidth(array_map(static fn(array $r): string => (string) $r['source'], $rows));
+        $header = $this->phaseHeader($sourceWidth, $phases);
+        $body = '';
+        foreach ($rows as $row) {
+            $body .= '  ' . str_pad((string) $row['source'], $sourceWidth);
+            foreach ($phases as $p) {
+                $body .= '  ' . str_pad($this->fmt((float) $row[$p]), 8, ' ', STR_PAD_LEFT);
+            }
+
+            $body .= '  ' . str_pad($this->fmt((float) $row['total']), 8, ' ', STR_PAD_LEFT) . "\n";
+        }
+
+        return "Compile-time phases (ms)\n" . $header . $body;
+    }
+
+    /**
+     * @param list<string> $phases
+     *
+     * @return list<array<string, float|string>>
+     */
+    private function buildPhaseRows(ProfileReport $report, array $phases): array
+    {
         $rows = [];
         foreach ($report->phaseMs() as $source => $byPhase) {
             $row = ['source' => $this->shortenSource($source)];
@@ -57,19 +81,7 @@ final class TableFormatter
 
         uasort($rows, static fn(array $a, array $b): int => $b['total'] <=> $a['total']);
 
-        $sourceWidth = max(20, ...array_map(static fn(array $r): int => strlen($r['source']), $rows));
-        $header = $this->phaseHeader($sourceWidth, $phases);
-        $body = '';
-        foreach ($rows as $row) {
-            $body .= '  ' . str_pad($row['source'], $sourceWidth);
-            foreach ($phases as $p) {
-                $body .= '  ' . str_pad($this->fmt($row[$p]), 8, ' ', STR_PAD_LEFT);
-            }
-
-            $body .= '  ' . str_pad($this->fmt($row['total']), 8, ' ', STR_PAD_LEFT) . "\n";
-        }
-
-        return "Compile-time phases (ms)\n" . $header . $body;
+        return $rows;
     }
 
     /**
@@ -96,35 +108,47 @@ final class TableFormatter
         $rows = array_slice($stats, 0, $top, true);
 
         $names = array_map($this->displayName(...), array_keys($rows));
-        $nameWidth = max(20, ...array_map(strlen(...), $names));
+        $nameWidth = $this->calculateColumnWidth($names);
 
         $out = sprintf("Runtime fn profile (top %d, sort by %s)\n", count($rows), $sort->value);
-        $out .= '  ' . str_pad('fn', $nameWidth) . '  '
-            . str_pad('calls', 9, ' ', STR_PAD_LEFT) . '  '
-            . str_pad('self ms', 10, ' ', STR_PAD_LEFT) . '  '
-            . str_pad('total ms', 10, ' ', STR_PAD_LEFT) . '  '
-            . str_pad('avg us', 10, ' ', STR_PAD_LEFT) . '  '
-            . str_pad('max us', 10, ' ', STR_PAD_LEFT) . "\n";
+        $out .= $this->renderFnHeader($nameWidth);
 
         foreach ($rows as $boundTo => $r) {
-            $name = $this->displayName($boundTo);
-            $avgUs = $r['calls'] > 0 ? ((float) $r['totalNs'] / (float) $r['calls']) / 1_000.0 : 0.0;
-            $maxUs = (float) $r['maxNs'] / 1_000.0;
-            $selfMs = (float) $r['selfNs'] / 1_000_000.0;
-            $totalMs = (float) $r['totalNs'] / 1_000_000.0;
-
-            $out .= '  ' . str_pad($name, $nameWidth) . '  '
-                . str_pad((string) $r['calls'], 9, ' ', STR_PAD_LEFT) . '  '
-                . str_pad($this->fmt($selfMs), 10, ' ', STR_PAD_LEFT) . '  '
-                . str_pad($this->fmt($totalMs), 10, ' ', STR_PAD_LEFT) . '  '
-                . str_pad($this->fmt($avgUs), 10, ' ', STR_PAD_LEFT) . '  '
-                . str_pad($this->fmt($maxUs), 10, ' ', STR_PAD_LEFT) . "\n";
+            $out .= $this->renderFnRow($this->displayName($boundTo), $r, $nameWidth);
         }
 
         $totalSelfMs = array_sum(array_map(static fn(array $r): float => (float) $r['selfNs'] / 1_000_000.0, $stats));
         $totalCalls = array_sum(array_map(static fn(array $r): int => $r['calls'], $stats));
 
         return $out . sprintf("\nTotals: %d fns, %d calls, %s ms self.\n", count($stats), $totalCalls, $this->fmt($totalSelfMs));
+    }
+
+    private function renderFnHeader(int $nameWidth): string
+    {
+        return '  ' . str_pad('fn', $nameWidth) . '  '
+            . str_pad('calls', 9, ' ', STR_PAD_LEFT) . '  '
+            . str_pad('self ms', 10, ' ', STR_PAD_LEFT) . '  '
+            . str_pad('total ms', 10, ' ', STR_PAD_LEFT) . '  '
+            . str_pad('avg us', 10, ' ', STR_PAD_LEFT) . '  '
+            . str_pad('max us', 10, ' ', STR_PAD_LEFT) . "\n";
+    }
+
+    /**
+     * @param array{calls:int, totalNs:int, selfNs:int, maxNs:int} $r
+     */
+    private function renderFnRow(string $name, array $r, int $nameWidth): string
+    {
+        $avgUs = $r['calls'] > 0 ? ((float) $r['totalNs'] / (float) $r['calls']) / 1_000.0 : 0.0;
+        $maxUs = (float) $r['maxNs'] / 1_000.0;
+        $selfMs = (float) $r['selfNs'] / 1_000_000.0;
+        $totalMs = (float) $r['totalNs'] / 1_000_000.0;
+
+        return '  ' . str_pad($name, $nameWidth) . '  '
+            . str_pad((string) $r['calls'], 9, ' ', STR_PAD_LEFT) . '  '
+            . str_pad($this->fmt($selfMs), 10, ' ', STR_PAD_LEFT) . '  '
+            . str_pad($this->fmt($totalMs), 10, ' ', STR_PAD_LEFT) . '  '
+            . str_pad($this->fmt($avgUs), 10, ' ', STR_PAD_LEFT) . '  '
+            . str_pad($this->fmt($maxUs), 10, ' ', STR_PAD_LEFT) . "\n";
     }
 
     /**
@@ -138,6 +162,14 @@ final class TableFormatter
             SortOrder::Avg => static fn(array $a, array $b): int => ((float) $b['totalNs'] / (float) max($b['calls'], 1)) <=> ((float) $a['totalNs'] / (float) max($a['calls'], 1)),
             SortOrder::SelfTime => static fn(array $a, array $b): int => $b['selfNs'] <=> $a['selfNs'],
         };
+    }
+
+    /**
+     * @param list<string> $values
+     */
+    private function calculateColumnWidth(array $values, int $minWidth = 20): int
+    {
+        return max($minWidth, ...array_map(strlen(...), $values));
     }
 
     private function displayName(string $boundTo): string

--- a/src/php/Shared/Munge.php
+++ b/src/php/Shared/Munge.php
@@ -6,11 +6,11 @@ namespace Phel\Shared;
 
 final readonly class Munge implements MungeInterface
 {
-    private const array DEFAULT_NS_MAPPING = [
+    private const array NAMESPACE_MAPPING = [
         '-' => '_',
     ];
 
-    private const array DEFAULT_MAPPING = [
+    private const array SYMBOL_MAPPING = [
         '-' => '_',
         '.' => '_DOT_',
         ':' => '_COLON_',
@@ -44,8 +44,8 @@ final readonly class Munge implements MungeInterface
      * @param array<string, string> $nsMapping
      */
     public function __construct(
-        private array $mapping = self::DEFAULT_MAPPING,
-        private array $nsMapping = self::DEFAULT_NS_MAPPING,
+        private array $mapping = self::SYMBOL_MAPPING,
+        private array $nsMapping = self::NAMESPACE_MAPPING,
     ) {}
 
     public function encode(string $str): string

--- a/src/php/Shared/VersionFinder.php
+++ b/src/php/Shared/VersionFinder.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Shared;
 
-use function in_array;
-
 final class VersionFinder
 {
     public const string LATEST_VERSION = 'v0.41.0';
@@ -54,7 +52,7 @@ final class VersionFinder
             return null;
         }
 
-        if (in_array(preg_match('/^[0-9a-f]{8,40}$/i', $reference), [0, false], true)) {
+        if (preg_match('/^[0-9a-f]{8,40}$/i', $reference) !== 1) {
             return null;
         }
 

--- a/tests/php/Unit/Config/PhelConfigValidatorTest.php
+++ b/tests/php/Unit/Config/PhelConfigValidatorTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Config;
+
+use Phel\Config\PhelConfig;
+use Phel\Config\PhelConfigValidator;
+use PHPUnit\Framework\TestCase;
+
+final class PhelConfigValidatorTest extends TestCase
+{
+    private PhelConfigValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new PhelConfigValidator();
+    }
+
+    public function test_default_config_is_valid(): void
+    {
+        $errors = $this->validator->validate(new PhelConfig());
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_empty_dir_arrays_produce_no_errors(): void
+    {
+        $config = new PhelConfig()
+            ->withSrcDirs([])
+            ->withTestDirs([]);
+
+        $errors = $this->validator->validate($config);
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_empty_vendor_dir_is_allowed(): void
+    {
+        $config = new PhelConfig()->withVendorDir('');
+
+        $errors = $this->validator->validate($config);
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_relative_vendor_dir_with_dots_is_allowed(): void
+    {
+        $config = new PhelConfig()->withVendorDir('../vendor');
+
+        $errors = $this->validator->validate($config);
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_absolute_src_dir_reports_error_with_label_and_path(): void
+    {
+        $config = new PhelConfig()->withSrcDirs(['/absolute/src']);
+
+        $errors = $this->validator->validate($config);
+
+        self::assertSame(
+            ["Source directory '/absolute/src' should be relative, not absolute"],
+            $errors,
+        );
+    }
+
+    public function test_each_absolute_dir_reports_its_own_error(): void
+    {
+        $config = new PhelConfig()
+            ->withSrcDirs(['src', '/abs/one', '/abs/two']);
+
+        $errors = $this->validator->validate($config);
+
+        self::assertCount(2, $errors);
+        self::assertContains("Source directory '/abs/one' should be relative, not absolute", $errors);
+        self::assertContains("Source directory '/abs/two' should be relative, not absolute", $errors);
+    }
+
+    public function test_errors_from_src_test_and_vendor_are_aggregated(): void
+    {
+        $config = new PhelConfig()
+            ->withSrcDirs(['/abs/src'])
+            ->withTestDirs(['/abs/test'])
+            ->withVendorDir('/abs/vendor');
+
+        $errors = $this->validator->validate($config);
+
+        self::assertSame(
+            [
+                "Source directory '/abs/src' should be relative, not absolute",
+                "Test directory '/abs/test' should be relative, not absolute",
+                "Vendor directory '/abs/vendor' should be relative, not absolute",
+            ],
+            $errors,
+        );
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Split out of the umbrella quality pass (#2325): the behavior-identical refactors, isolated from docs and bug fixes so they can be reviewed as pure cleanups.

## 💡 Goal

Improve maintainability with zero behavior change.

## 🔖 Changes

- **Dead-code / type-safety / naming cleanups** — verified dead-code removal, native union types on private methods, clearer local/private names, interface/impl return-type alignment (`conj-single` → `conj-impl`, etc.).
- **Structural** — behavior-identical helper extractions (dedup), `readonly` on stateless `final` classes; all signature/API-changing suggestions deferred.
- **REPL** — reuse the existing public `phel.core/canonical-ns` instead of six raw `(php/:: Munge (canonicalNs ...))` interop calls.
- **Test** — covers `PhelConfigValidator` against its consolidated `validate(PhelConfig)` signature (travels with the signature change).

No behavior change. Full quality gate (php-cs-fixer, psalm lvl1, phpstan lvl5, rector, compiler + core suites) green.
