### PR TITLE
fix(agnostic-ai): correct stale paths, commands, and symbols in agent specs

### DIFF
--- a/.agnostic-ai/AGNOSTIC_AI.md
+++ b/.agnostic-ai/AGNOSTIC_AI.md
@@ -5,7 +5,7 @@
 Phel is a Lisp that compiles to PHP, inspired by Clojure. The codebase has two source trees:
 
 - **`src/php/`** — PHP runtime and compiler (PSR-4: `Phel\`). Key modules: `Lang` (persistent data types), `Compiler` (lex/parse/analyze/emit pipeline), `Run` (namespace execution and REPL), `Console` (Symfony CLI), `Command` (shared command helpers), `Build` (build orchestration), `Config` (configuration), and `Shared` (constants and facades).
-- **`src/phel/`** — Core library written in Phel itself: `core`, `str`, `html`, `http`, `json`, `test`, `repl`, `walk`, `pprint`, `debug`, `mock`.
+- **`src/phel/`** — Core library written in Phel itself: `core`, `string`, `html`, `http`, `json`, `test`, `repl`, `walk`, `pprint`, `reflect`, `mock`.
 
 Entry points live in `Phel.php` and `bin/`, distributable artifacts and scripts sit under `build/`, documentation and examples reside in `docs/`, and `tests/php` is split into `Unit`, `Integration`, and `Benchmark`; Phel-level tests are in `tests/phel/`. Temporary outputs land in `data/` or `var/`.
 

--- a/.agnostic-ai/agents/changelog-keeper.md
+++ b/.agnostic-ai/agents/changelog-keeper.md
@@ -48,7 +48,7 @@ You maintain CHANGELOG.md for the Phel project. Only update the `## Unreleased` 
 
 - `Add \`vec\` function to coerce collections to vectors` (good)
 - `Added stuff to core` (too vague)
-- `Refactored the EmitterNode to use visitor pattern` (too technical)
+- `Refactored the NodeEmitter to use visitor pattern` (too technical)
 
 ## Module Areas
 

--- a/.agnostic-ai/agents/clean-code-reviewer.md
+++ b/.agnostic-ai/agents/clean-code-reviewer.md
@@ -30,9 +30,9 @@ Analyze staged changes (`git diff --cached`), unstaged changes (`git diff`), or 
 ## SOLID in Phel Context
 
 - **SRP**: `Lexer` only tokenizes, doesn't parse
-- **OCP**: Extend via new `EmitterNode` classes, not modifying existing ones
+- **OCP**: Extend via new `NodeEmitterInterface` implementations (e.g. `ApplyEmitter`, `DefEmitter`), not modifying existing ones
 - **LSP**: All `TypeInterface` implementations must be substitutable
-- **ISP**: Small interfaces (`HasMetaInterface`, `CountableInterface`)
+- **ISP**: Small interfaces (`MetaInterface`, `HashableInterface`)
 - **DIP**: Facades expose module APIs, not concrete classes
 
 ## PHP Smells (src/php/)

--- a/.agnostic-ai/agents/debugger.md
+++ b/.agnostic-ai/agents/debugger.md
@@ -39,7 +39,7 @@ Every error originates in one compiler phase. Identify it first:
    - Parse: check if AST is well-formed
    - Analyze: check if the node tree is complete
    - Emit: check if PHP output matches expectations
-3. **Find the handler** — special forms have dedicated analyzers in `Domain/Analyzer/SpecialForm/`
+3. **Find the handler** — special forms have dedicated analyzers in `Domain/Analyzer/TypeAnalyzer/SpecialForm/`
 4. **Check the integration tests** — look for similar fixtures in `tests/php/Integration/Fixtures/`
 5. **Trace source locations** — verify `SourceLocation` propagates correctly for error messages
 

--- a/.agnostic-ai/agents/domain-architect.md
+++ b/.agnostic-ai/agents/domain-architect.md
@@ -21,7 +21,7 @@ Modular architecture expert for the Phel compiler and runtime. Maintains clean m
 |--------|---------------|-------------|
 | `Lang/` | Runtime types: Symbol, Keyword, PhelArray, Table, Set, Struct | None (foundational) |
 | `Compiler/` | Lexer → Parser → Analyzer → Emitter (Phel to PHP) | Lang |
-| `Printer/` | Value to string representation | Lang |
+| `Shared/Printer/` | Value to string representation (sub-module under `Shared/`) | Lang |
 | `Formatter/` | Code formatting | Compiler (parser) |
 | `Run/` | Script execution, test runner, REPL | Compiler, Lang |
 | `Command/` | CLI commands (Symfony Console) | Run, Compiler |

--- a/.agnostic-ai/agents/fixture-reviewer.md
+++ b/.agnostic-ai/agents/fixture-reviewer.md
@@ -28,7 +28,7 @@ Specialized reviewer for `.test` fixtures in `tests/php/Integration/Fixtures/`. 
 1. **Scope the impact**:
    - If the diff touches `src/php/Compiler/Domain/Lexer/` → fixtures most at risk: tokenizer edge cases (numeric literals, strings, keywords).
    - If it touches `Domain/Parser/` → AST-shape fixtures (`Apply`, `Call`, nested forms).
-   - If it touches `Domain/Analyzer/SpecialForm/*` → the fixture category matching that form (e.g. `Try`, `Let`, `Fn`, `Def`).
+   - If it touches `Domain/Analyzer/TypeAnalyzer/SpecialForm/*` → the fixture category matching that form (e.g. `Try`, `Let`, `Fn`, `Def`).
    - If it touches `Domain/Emitter/` → broadly every fixture; focus on node types the diff changed.
 
 2. **Run the integration suite** filtered to the most impacted categories:

--- a/.agnostic-ai/rules/macro-hygiene.md
+++ b/.agnostic-ai/rules/macro-hygiene.md
@@ -9,7 +9,7 @@ Phel macros non-hygienic. `let`/`binding` names in macro body silently shadow ho
 
 ## 1. Local names must not collide with referenced globals
 
-Canonical bug (`defn-builder`, fixed in `85be1479`):
+Canonical bug (`defn-builder`, fixed in `c1aec277`):
 
 ```phel
 ;; bad — local `memoize-lru` shadows global `memoize-lru` fn

--- a/.agnostic-ai/rules/project-structure-module-organization.md
+++ b/.agnostic-ai/rules/project-structure-module-organization.md
@@ -5,6 +5,6 @@ name: project-structure-module-organization
 Phel is a Lisp that compiles to PHP, inspired by Clojure. The codebase has two source trees:
 
 - **`src/php/`** — PHP runtime and compiler (PSR-4: `Phel\`). Key modules: `Lang` (persistent data types), `Compiler` (lex/parse/analyze/emit pipeline), `Run` (namespace execution and REPL), `Console` (Symfony CLI), `Command` (shared command helpers), `Build` (build orchestration), `Config` (configuration), and `Shared` (constants and facades).
-- **`src/phel/`** — Core library written in Phel itself: `core`, `str`, `html`, `http`, `json`, `test`, `repl`, `walk`, `pprint`, `debug`, `mock`.
+- **`src/phel/`** — Core library written in Phel itself: `core`, `string`, `html`, `http`, `json`, `test`, `repl`, `walk`, `pprint`, `reflect`, `mock`.
 
 Entry points live in `Phel.php` and `bin/`, distributable artifacts and scripts sit under `build/`, documentation and examples reside in `docs/`, and `tests/php` is split into `Unit`, `Integration`, and `Benchmark`; Phel-level tests are in `tests/phel/`. Temporary outputs land in `data/` or `var/`.

--- a/.agnostic-ai/scripts/claude/compact-context.sh
+++ b/.agnostic-ai/scripts/claude/compact-context.sh
@@ -10,7 +10,7 @@ cat <<'EOF'
 - Auto-fix: `composer fix` (rector + cs-fixer). PHP edits auto-format via PostToolUse hook.
 - Compiler: Lexer → Parser → Analyzer → Emitter (never skip phases)
 - Each `src/php/<Module>/CLAUDE.md` documents the module — read before modifying.
-- Protected files: `build/release.sh`, `.github/*`, `composer.lock`
+- Protected files: `tools/release.sh`, `.github/*`, `composer.lock`
 - PRs: follow `.github/PULL_REQUEST_TEMPLATE.md` exactly (with emoji prefixes).
 - `feat:`/`fix:` commits must update `CHANGELOG.md` under `## Unreleased`.
 EOF

--- a/.agnostic-ai/scripts/claude/protect-files.sh
+++ b/.agnostic-ai/scripts/claude/protect-files.sh
@@ -5,7 +5,7 @@ FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
 [[ -z "$FILE" ]] && exit 0
 
-if [[ "$FILE" == */build/release.sh ]] || \
+if [[ "$FILE" == */tools/release.sh ]] || \
    [[ "$FILE" == */composer.lock ]]; then
     echo "Protected file: $FILE — edit blocked. Ask user to confirm before retrying." >&2
     exit 2

--- a/.agnostic-ai/scripts/codex/protect-files.sh
+++ b/.agnostic-ai/scripts/codex/protect-files.sh
@@ -13,8 +13,8 @@ deny() {
 
 is_protected_path() {
   local path="$1"
-  [[ "$path" == */build/release.sh ]] \
-    || [[ "$path" == build/release.sh ]] \
+  [[ "$path" == */tools/release.sh ]] \
+    || [[ "$path" == tools/release.sh ]] \
     || [[ "$path" == */composer.lock ]] \
     || [[ "$path" == composer.lock ]] \
     || [[ "$path" == */.github/* ]] \
@@ -31,14 +31,14 @@ if [[ "$tool_name" == "Bash" ]]; then
 fi
 
 if [[ -n "$file_path" ]] && is_protected_path "$file_path"; then
-  deny "Protected file edit blocked. Ask the user to confirm before changing build/release.sh, composer.lock, or .github/*."
+  deny "Protected file edit blocked. Ask the user to confirm before changing tools/release.sh, composer.lock, or .github/*."
   exit 0
 fi
 
 if [[ "$tool_name" == "apply_patch" ]]; then
   while IFS= read -r path; do
     if is_protected_path "$path"; then
-      deny "Protected file edit blocked. Ask the user to confirm before changing build/release.sh, composer.lock, or .github/*."
+      deny "Protected file edit blocked. Ask the user to confirm before changing tools/release.sh, composer.lock, or .github/*."
       exit 0
     fi
   done < <(printf '%s' "$command" | sed -nE 's/^\*\*\* (Add|Update|Delete) File: (.*)$/\2/p')

--- a/.agnostic-ai/skills/compiler-guide/SKILL.md
+++ b/.agnostic-ai/skills/compiler-guide/SKILL.md
@@ -14,24 +14,24 @@ Source → Lexer → Token[] → Parser → AST (PhpArray of Nodes)
 
 | Phase | Location | Input | Output |
 |-------|----------|-------|--------|
-| Lexer | `Compiler/Lexer/` | Phel source string | `Token[]` |
-| Parser | `Compiler/Parser/` | `Token[]` | AST (`PhelArray` of nodes) |
-| Analyzer | `Compiler/Analyzer/` | AST nodes | `AnalyzedNode` tree |
-| Emitter | `Compiler/Emitter/` | `AnalyzedNode` tree | PHP code string |
+| Lexer | `Compiler/Domain/Lexer/` | Phel source string | `Token[]` |
+| Parser | `Compiler/Domain/Parser/` | `Token[]` | AST (`PhelArray` of nodes) |
+| Analyzer | `Compiler/Domain/Analyzer/` | AST nodes | `AnalyzedNode` tree |
+| Emitter | `Compiler/Domain/Emitter/` | `AnalyzedNode` tree | PHP code string |
 
 ## Key Patterns
 
 ### Special Forms (Analyzer)
-Special forms are handled in `Compiler/Analyzer/SpecialForm/`. Each implements analysis for a specific Phel form (`def`, `fn`, `let`, `if`, `do`, `quote`, etc.).
+Special forms are handled in `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`. Each implements analysis for a specific Phel form (`def`, `fn`, `let`, `if`, `do`, `quote`, etc.).
 
 To add a new special form:
 1. Create analyzer class in `SpecialForm/`
 2. Register in the special form registry
-3. Create corresponding `EmitterNode` if needed
+3. Create corresponding node emitter (`NodeEmitterInterface` implementation) if needed
 4. Add emitter handling
 
 ### Node Types (Analyzer → Emitter)
-Analyzed nodes live in `Compiler/Analyzer/Ast/`. Each node type has a corresponding emitter in `Compiler/Emitter/`.
+Analyzed nodes live in `Compiler/Domain/Analyzer/Ast/`. Each node type has a corresponding emitter in `Compiler/Domain/Emitter/`.
 
 ### Environment & Scope
 `NodeEnvironment` tracks:

--- a/.agnostic-ai/skills/module-new/SKILL.md
+++ b/.agnostic-ai/skills/module-new/SKILL.md
@@ -17,7 +17,7 @@ Scaffolds a new module under `src/php/<ModuleName>/` following the project Gacel
 
 1. **Validate `$ARGUMENTS`**: must be PascalCase, not clash with an existing dir. If missing, ask.
 
-2. **Read a reference module** (pick a small one, e.g. `src/php/Printer/` or `src/php/Formatter/`) to mirror its layout. Record:
+2. **Read a reference module** (pick a small one, e.g. `src/php/Filesystem/` or `src/php/Formatter/`) to mirror its layout. Record:
    - Facade method shape
    - DependencyProvider constant names
    - CLAUDE.md section order

--- a/.agnostic-ai/skills/phel-patterns/SKILL.md
+++ b/.agnostic-ai/skills/phel-patterns/SKILL.md
@@ -10,7 +10,7 @@ user-invocable: false
 | Module | Purpose |
 |--------|---------|
 | `core.phel` | Fundamental functions (map, filter, reduce, etc.) |
-| `str.phel` | String manipulation |
+| `string.phel` | String manipulation |
 | `html.phel` | HTML generation |
 | `http.phel` | HTTP request/response |
 | `json.phel` | JSON encoding/decoding |
@@ -18,14 +18,14 @@ user-invocable: false
 | `pprint.phel` | Pretty printing |
 | `walk.phel` | Tree walking (postwalk, prewalk) |
 | `mock.phel` | Mocking utilities for tests |
-| `debug.phel` | Debugging utilities |
+| `reflect.phel` | PHP reflection / attribute bridging |
 | `repl.phel` | REPL functionality |
 | `base64.phel` | Base64 encoding/decoding |
 
 ## Common Idioms
 
 ```phel
-# Function definition with metadata
+; Function definition with metadata
 (defn my-fn
   {:doc "Description of what it does"
    :see-also ["related-fn" "other-fn"]
@@ -33,22 +33,22 @@ user-invocable: false
   [arg]
   (body))
 
-# Private function (not exported)
+; Private function (not exported)
 (defn- helper-fn [x] ...)
 
-# Struct definition
+; Struct definition
 (defstruct my-struct [field-a field-b])
 
-# Threading macros
-(-> value (fn1 arg) (fn2 arg))   # thread-first
-(->> value (fn1 arg) (fn2 arg))  # thread-last
+; Threading macros
+(-> value (fn1 arg) (fn2 arg))   ; thread-first
+(->> value (fn1 arg) (fn2 arg))  ; thread-last
 ```
 
 ## Testing Patterns
 
 ```phel
-(ns phel-test\module-name
-  (:require phel\test :refer [deftest is are]))
+(ns phel-test.module-name
+  (:require phel.test :refer [deftest is are]))
 
 (deftest test-descriptive-name
   (is (= expected (function-under-test input)))

--- a/.agnostic-ai/skills/phel-repl/SKILL.md
+++ b/.agnostic-ai/skills/phel-repl/SKILL.md
@@ -13,12 +13,17 @@ Evaluate Phel expressions to verify behavior without writing test files.
 
 1. Take the expression from `$ARGUMENTS` (or ask for one if empty).
 
-2. Evaluate it using the Phel CLI:
+2. Evaluate it using the Phel CLI `eval` command:
    ```bash
-   echo '$ARGUMENTS' | timeout 10 ./bin/phel run --eval
+   timeout 10 ./bin/phel eval '$ARGUMENTS'
    ```
 
-   If `--eval` is not available, write a temp file:
+   Or read the expression from stdin with `-`:
+   ```bash
+   echo '$ARGUMENTS' | timeout 10 ./bin/phel eval -
+   ```
+
+   For multi-form snippets that need a namespace, write a temp file:
    ```bash
    echo '(ns repl-test) $ARGUMENTS' > /tmp/phel-repl-test.phel
    timeout 10 ./bin/phel run /tmp/phel-repl-test.phel

--- a/.agnostic-ai/skills/release/SKILL.md
+++ b/.agnostic-ai/skills/release/SKILL.md
@@ -10,7 +10,7 @@ disable-model-invocation: true
 
 !`git branch --show-current`
 !`git status --porcelain`
-!`grep "VERSION = " src/php/Console/Application/VersionFinder.php`
+!`grep "LATEST_VERSION = " src/php/Shared/VersionFinder.php`
 
 ## Instructions
 
@@ -32,12 +32,12 @@ disable-model-invocation: true
 
 4. **If `--dry-run`**, show what would happen and stop:
    ```bash
-   ./build/release.sh --dry-run <version>
+   ./tools/release.sh --dry-run <version>
    ```
 
 5. **Run the release script**:
    ```bash
-   ./build/release.sh <version>
+   ./tools/release.sh <version>
    ```
 
    The script handles: version bump, changelog update, commit, PHAR build, git tag, push, GitHub release with PHAR attachment.
@@ -54,5 +54,5 @@ disable-model-invocation: true
 ## Reference
 
 - Full guide: `.github/RELEASE.md`
-- Release script: `build/release.sh`
-- Version file: `src/php/Console/Application/VersionFinder.php`
+- Release script: `tools/release.sh`
+- Version file: `src/php/Shared/VersionFinder.php`


### PR DESCRIPTION
## 🤔 Background

The `.agnostic-ai/` specs (source of truth for the synced `.claude/`/`.codex/` agent config, plus the generated root `CLAUDE.md`/`AGENTS.md`) had drifted from the codebase after file moves and renames. Skills, agents, rules, and **protection hooks** referenced paths, commands, and symbols that no longer exist — so the generated agent tooling would mislead, fail outright, or silently stop protecting the right files.

Found while investigating why the `release` skill referenced a non-existent `build/release.sh`.

## 💡 Goal

Make every concrete reference in `.agnostic-ai/*` resolve against the current repo. Audited all 58 files; every claim verified against the working tree before editing.

## 🔖 Changes

**Broken protection (functional bug, not just docs)**
- `scripts/claude/protect-files.sh`, `scripts/codex/protect-files.sh`: guarded `build/release.sh` → now `tools/release.sh`. The hooks were failing to protect the real release script.
- `scripts/claude/compact-context.sh`: "Protected files" reminder corrected to `tools/release.sh`.

**skills/**
- `release`: `build/release.sh` → `tools/release.sh`; `src/php/Console/Application/VersionFinder.php` → `src/php/Shared/VersionFinder.php`; grep `VERSION =` → `LATEST_VERSION =`
- `phel-repl`: `./bin/phel run --eval` (no such flag) → `./bin/phel eval` (real command) + stdin variant
- `phel-patterns`: `str.phel` → `string.phel`; dropped non-existent `debug.phel` (added `reflect.phel`); code examples using `#` comments → `;` (Phel uses `;`); `phel\test` → `phel.test`
- `module-new`: reference module `src/php/Printer/` (doesn't exist) → `src/php/Filesystem/`
- `compiler-guide`: phase paths missing `Domain/` (`Compiler/Lexer/` etc.) → `Compiler/Domain/Lexer/…`; SpecialForm path → `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`; `EmitterNode` → `NodeEmitterInterface`

**agents/**
- `debugger`, `fixture-reviewer`: `Domain/Analyzer/SpecialForm/` → `Domain/Analyzer/TypeAnalyzer/SpecialForm/`
- `domain-architect`: `Printer/` listed as top-level module → `Shared/Printer/` sub-module
- `clean-code-reviewer`: non-existent `EmitterNode` → `NodeEmitterInterface` (e.g. `ApplyEmitter`); `HasMetaInterface`/`CountableInterface` → real `MetaInterface`/`HashableInterface`
- `changelog-keeper`: example mentioning `EmitterNode` → `NodeEmitter`

**rules/ + root spec**
- `macro-hygiene`: invalid commit `85be1479` → real fix commit `c1aec277` (`fix(defn-builder): rename local memoize-lru-arg…`)
- `project-structure-module-organization` + `AGNOSTIC_AI.md` (feeds root `CLAUDE.md`/`AGENTS.md`): core-lib list `str`/`debug` → `string`/`reflect`

Generated `.claude/`/`.codex/` + root `CLAUDE.md`/`AGENTS.md` refreshed via `agnostic-ai sync` (all gitignored, not committed). **Not an agnostic-ai bug** — sync copies source faithfully; the source specs had drifted.

`.agents/` (leading-dot, gitignored post-install path) references left intact — intentional, not drift.