### PR TITLE
ref(ai): update default model to claude-sonnet-4-6 and optimize nearest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Richer PHP interop for bridging Phel to typed PHP / framework code (all opt-in, 
 - Docs: condensed every `docs/` guide (~17% smaller), verified against the runtime, and cross-linked to phel-lang.org
 - Quality: repo-wide maintainability pass — explanatory docblocks and `:doc`/`:see-also`/`:example` metadata across modules, safe dead-code/type/naming cleanups, behavior-identical helper extractions, and ~40 new unit tests for previously untested utilities (no behavior change)
 - `agent-install`: simplified to just copying skill files and the `.agents/` docs tree; dropped version stamping, `--check`, and `--list`
+- `phel.ai`: default chat model bumped to `claude-sonnet-4-6`; `nearest` now precomputes the query embedding's magnitude once instead of recomputing it per index item (semantic search over large indexes), with `cosine-similarity` and `nearest` sharing one magnitude-aware helper
 
 ## [0.41.0](https://github.com/phel-lang/phel-lang/compare/v0.40.0...v0.41.0) - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Richer PHP interop for bridging Phel to typed PHP / framework code (all opt-in, 
 - Docs: condensed every `docs/` guide (~17% smaller), verified against the runtime, and cross-linked to phel-lang.org
 - Quality: repo-wide maintainability pass — explanatory docblocks and `:doc`/`:see-also`/`:example` metadata across modules, safe dead-code/type/naming cleanups, behavior-identical helper extractions, and ~40 new unit tests for previously untested utilities (no behavior change)
 - `agent-install`: simplified to just copying skill files and the `.agents/` docs tree; dropped version stamping, `--check`, and `--list`
-- `phel.ai`: default chat model bumped to `claude-sonnet-4-6`; `nearest` now precomputes the query embedding's magnitude once instead of recomputing it per index item (semantic search over large indexes), with `cosine-similarity` and `nearest` sharing one magnitude-aware helper
+- `phel.ai`: default chat model is now `claude-sonnet-4-6`; `nearest` computes the query magnitude once instead of per index item
 
 ## [0.41.0](https://github.com/phel-lang/phel-lang/compare/v0.40.0...v0.41.0) - 2026-06-01
 

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -28,7 +28,7 @@
 | Key | Default | Purpose |
 |-----|---------|---------|
 | `:provider` | `:anthropic` | `:anthropic`, `:openai`, `:voyageai` |
-| `:model` | `"claude-sonnet-4-5"` | Model name |
+| `:model` | `"claude-sonnet-4-6"` | Model name |
 | `:max-tokens` | `1024` | Output token cap |
 | `:api-key` | `nil` | Falls back to env var |
 | `:base-url` | `nil` | Override endpoint (proxies, self-hosted) |

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -9,7 +9,7 @@
 
 (def- default-config
   {:provider :anthropic
-   :model "claude-sonnet-4-5"
+   :model "claude-sonnet-4-6"
    :max-tokens 1024
    :api-key nil
    :base-url nil
@@ -38,7 +38,7 @@
     :base-url    - Override the API base URL
     :timeout     - HTTP timeout in seconds (default 120)
     :max-retries - Retry attempts on 429/5xx (default 2)"
-  {:example "(configure {:api-key \"sk-ant-...\" :model \"claude-sonnet-4-5\"})"
+  {:example "(configure {:api-key \"sk-ant-...\" :model \"claude-sonnet-4-6\"})"
    :see-also ["config" "complete" "chat" "with-config"]}
   [opts]
   (swap! config merge opts))
@@ -624,17 +624,21 @@
   [v]
   (php/sqrt (apply + (map #(* % %) v))))
 
+(defn- similarity-with-mags
+  "Cosine similarity given each vector's precomputed L2 magnitude. Returns 0.0
+  when either magnitude is zero (and skips the dot product in that case)."
+  [a mag-a b mag-b]
+  (if (or (zero? mag-a) (zero? mag-b))
+    0.0
+    (/ (dot-product a b) (* mag-a mag-b))))
+
 (defn cosine-similarity
   "Computes the cosine similarity between two numeric vectors.
   Returns a float between -1.0 and 1.0, where 1.0 means identical direction."
   {:example "(cosine-similarity [1 0] [0 1]) ; => 0"
    :see-also ["dot-product" "magnitude" "nearest"]}
   [a b]
-  (let [mag-a (magnitude a)
-        mag-b (magnitude b)]
-    (if (or (zero? mag-a) (zero? mag-b))
-      0.0
-      (/ (dot-product a b) (* mag-a mag-b)))))
+  (similarity-with-mags a (magnitude a) b (magnitude b)))
 
 ;; -----------
 ;; Embedding API
@@ -697,9 +701,11 @@
    :see-also ["cosine-similarity" "build-index" "embed-one"]}
   [query-embedding index & [k]]
   (let [k      (if (nil? k) 5 k)
+        q-mag  (magnitude query-embedding)
         scored (for [item :in index]
-                 (assoc item :similarity
-                        (cosine-similarity query-embedding (get item :embedding))))
+                 (let [emb (get item :embedding)]
+                   (assoc item :similarity
+                          (similarity-with-mags query-embedding q-mag emb (magnitude emb)))))
         sorted (sort-by #(- (get % :similarity)) scored)]
     (take k sorted)))
 

--- a/tests/phel/ai.phel
+++ b/tests/phel/ai.phel
@@ -86,7 +86,7 @@
 
 (deftest test-anthropic-response-extraction
   (let [response-body {:content [{:type "text" :text "Hello from Claude!"}]
-                       :model "claude-sonnet-4-5"
+                       :model "claude-sonnet-4-6"
                        :role "assistant"}]
     (is (= "Hello from Claude!"
            (get (first (get response-body :content)) :text))
@@ -304,6 +304,21 @@
   (let [results (ai/nearest [1 0] [{:text "a" :embedding [1 0]}])]
     (is (< (php/abs (- 1.0 (get (first results) :similarity))) 0.0001)
         "perfect match has similarity ~1.0")))
+
+(deftest test-nearest-similarity-matches-cosine-similarity
+  ;; nearest precomputes the query magnitude once; guard it never diverges
+  ;; from a direct per-pair cosine-similarity call.
+  (let [query   [0.2 -0.5 0.9]
+        index   [{:text "a" :embedding [0.1 0.3 -0.2]}
+                 {:text "b" :embedding [0.9 0.1 0.4]}
+                 {:text "c" :embedding [0 0 0]}]
+        results (ai/nearest query index 3)
+        by-text (reduce (fn [acc r] (put acc (get r :text) r)) {} results)]
+    (foreach [item index]
+      (let [r (get by-text (get item :text))]
+        (is (= (ai/cosine-similarity query (get item :embedding))
+               (get r :similarity))
+            (str "nearest similarity matches cosine-similarity for " (get item :text)))))))
 
 ;; --- Embedding API requires configuration ---
 


### PR DESCRIPTION
## 🤔 Background

`src/phel/ai.phel` defaulted to the now-legacy `claude-sonnet-4-5`, and `nearest` (semantic search) recomputed the query embedding's L2 magnitude once **per index item** because it called `cosine-similarity` in a loop. For an index of N vectors of dimension d, that is N−1 redundant magnitude passes per query.

## 💡 Goal

Keep the library current and make semantic search over large indexes cheaper, with no behavior change.

## 🔖 Changes

- **Default model** bumped `claude-sonnet-4-5` → `claude-sonnet-4-6` (config default, `configure` `:example`, and `docs/ai-guide.md`).
- **`nearest` optimization**: hoist the query magnitude to a single computation instead of recomputing it per item. `cosine-similarity` and `nearest` now share one private `similarity-with-mags` helper that keeps the zero-magnitude short-circuit (skips the dot product when a magnitude is zero). Numerically identical to before.
- **Regression test** `test-nearest-similarity-matches-cosine-similarity` asserts `nearest`'s score equals a direct `cosine-similarity` call for every item, guarding the refactor.
- `CHANGELOG.md` updated under `## Unreleased`.

Tests: `bin/phel test tests/phel/ai.phel` → 186 passed, 0 failed.
