### PR TITLE
ref: drop redundant (:require phel.core) from library namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Richer PHP interop for bridging Phel to typed PHP / framework code (all opt-in, 
 - Quality: repo-wide maintainability pass — explanatory docblocks and `:doc`/`:see-also`/`:example` metadata across modules, safe dead-code/type/naming cleanups, behavior-identical helper extractions, and ~40 new unit tests for previously untested utilities (no behavior change)
 - `agent-install`: simplified to just copying skill files and the `.agents/` docs tree; dropped version stamping, `--check`, and `--list`
 - `phel.ai`: default chat model is now `claude-sonnet-4-6`; `nearest` computes the query magnitude once instead of per index item
+- Dropped redundant `(:require phel.core)` from 14 library namespaces (`phel.core` is always preloaded); kept only in `phel.string`, which needs the `core/` alias to call `core/reverse` from inside its own `reverse`
 
 ## [0.41.0](https://github.com/phel-lang/phel-lang/compare/v0.40.0...v0.41.0) - 2026-06-01
 

--- a/src/phel/async.phel
+++ b/src/phel/async.phel
@@ -1,5 +1,4 @@
-(ns phel.async
-  (:require phel.core))
+(ns phel.async)
 
 ;; Historical home of Phel's async surface. As of #1548 the
 ;; Clojure-parity primitives (`async`, `await`, `await-all`, `await-any`,

--- a/src/phel/match.phel
+++ b/src/phel/match.phel
@@ -1,5 +1,4 @@
-(ns phel.match
-  (:require phel.core))
+(ns phel.match)
 
 ;; Pattern matching macro that expands to nested `cond` + `let` bindings.
 ;;

--- a/src/phel/pprint.phel
+++ b/src/phel/pprint.phel
@@ -1,5 +1,4 @@
 (ns phel.pprint
-  (:require phel.core)
   (:use Phel.Shared.Printer.Printer))
 
 (def- *default-width* 72)

--- a/src/phel/schema.phel
+++ b/src/phel/schema.phel
@@ -1,5 +1,4 @@
 (ns phel.schema
-  (:require phel.core)
   (:require phel.schema.registry :as reg)
   (:require phel.schema.validator :as v)
   (:require phel.schema.explainer :as e)

--- a/src/phel/schema/coercer.phel
+++ b/src/phel/schema/coercer.phel
@@ -1,5 +1,4 @@
 (ns phel.schema.coercer
-  (:require phel.core)
   (:require phel.schema.registry :as reg)
   (:require phel.schema.validator :as v))
 

--- a/src/phel/schema/explainer.phel
+++ b/src/phel/schema/explainer.phel
@@ -1,5 +1,4 @@
 (ns phel.schema.explainer
-  (:require phel.core)
   (:require phel.schema.registry :as reg)
   (:require phel.schema.validator :as v))
 

--- a/src/phel/schema/generator.phel
+++ b/src/phel/schema/generator.phel
@@ -1,5 +1,4 @@
 (ns phel.schema.generator
-  (:require phel.core)
   (:require phel.schema.registry :as reg)
   (:require phel.schema.validator :as v)
   (:require phel.test.gen :as g))

--- a/src/phel/schema/instrument.phel
+++ b/src/phel/schema/instrument.phel
@@ -1,5 +1,4 @@
 (ns phel.schema.instrument
-  (:require phel.core)
   (:require phel.schema.validator :as v)
   (:require phel.schema.explainer :as e))
 

--- a/src/phel/schema/registry.phel
+++ b/src/phel/schema/registry.phel
@@ -1,5 +1,4 @@
-(ns phel.schema.registry
-  (:require phel.core))
+(ns phel.schema.registry)
 
 ;; Named-schema registry.
 ;;

--- a/src/phel/schema/validator.phel
+++ b/src/phel/schema/validator.phel
@@ -1,5 +1,4 @@
 (ns phel.schema.validator
-  (:require phel.core)
   (:require phel.schema.registry :as reg))
 
 ;; Core validation engine.

--- a/src/phel/test/gen.phel
+++ b/src/phel/test/gen.phel
@@ -1,5 +1,4 @@
 (ns phel.test.gen
-  (:require phel.core)
   (:require phel.test :as t)
   (:require phel.test.shrink :as shrink)
   (:use InvalidArgumentException)

--- a/src/phel/test/rose.phel
+++ b/src/phel/test/rose.phel
@@ -1,5 +1,4 @@
-(ns phel.test.rose
-  (:require phel.core))
+(ns phel.test.rose)
 
 ;; Rose trees used to carry a value alongside lazy shrink candidates.
 ;;

--- a/src/phel/test/shrink.phel
+++ b/src/phel/test/shrink.phel
@@ -1,5 +1,4 @@
 (ns phel.test.shrink
-  (:require phel.core)
   (:require phel.test.rose :as r))
 
 ;; Shrink driver that walks a rose tree of candidate values and returns

--- a/src/phel/walk.phel
+++ b/src/phel/walk.phel
@@ -1,5 +1,4 @@
-(ns phel.walk
-  (:require phel.core))
+(ns phel.walk)
 
 (defn walk
   "Traverses `form`, an arbitrary data structure. Applies `inner` to each


### PR DESCRIPTION
## 🤔 Background

Several library namespaces declared a bare `(:require phel.core)`. `phel.core` is preloaded by the runtime for every namespace, so a bare require with no `:as`/`:refer` only does one thing: it establishes the `core/` alias. In namespaces that never write a `core/`-qualified symbol, the line is a no-op.

## 💡 Goal

Remove the dead requires; keep them only where the `core/` alias is actually used.

## 🔖 Changes

- Dropped `(:require phel.core)` from 14 namespaces: `phel.walk`, `phel.match`, `phel.pprint`, `phel.async`, `phel.schema`(+`registry`/`validator`/`coercer`/`generator`/`explainer`/`instrument`), `phel.test.rose`/`shrink`/`gen`.
- **Kept** it in `phel.string`: that namespace defines its own `reverse` and calls `core/reverse` inside it — it needs the `core/` alias to reach the core fn without self-shadowing. (`phel.async`'s only `core/` mentions were `clojure.core/delay` in comments, so it was safe to strip.)

## ✅ Validation

- `composer test-core` → 5897 passed, 0 failed (identical to baseline; no skipped/compile errors).
- `composer test-compiler` → 4185 tests pass.
- An initial blanket removal that also stripped `phel.string` surfaced `Cannot resolve symbol 'core/reverse'`, which is how `phel.string` was identified as the one genuine user.
