### PR TITLE
test: stop emit-response test leaking body into runner output

### DIFF
--- a/tests/phel/http.phel
+++ b/tests/phel/http.phel
@@ -372,8 +372,12 @@
 ;; branches that `test-send-response` (single string header) does not.
 
 (deftest test-emit-response-returns-nil
-  (is (nil? (h/emit-response (h/response-from-string "anything")))
-      "emit-response returns nil"))
+  ;; `emit-response` echoes the body straight to the SAPI; capture it in an
+  ;; output buffer so it doesn't leak into the test runner's progress output.
+  (let [result (atom :unset)]
+    (with-output-buffer
+     (reset! result (h/emit-response (h/response-from-string "anything"))))
+    (is (nil? @result) "emit-response returns nil")))
 
 (deftest test-emit-response-echoes-body-with-multiple-headers
   (is (output? "Body!"


### PR DESCRIPTION
## 🤔 Background

`bin/phel test` printed a stray `anything` in the middle of its progress dots:

```
........................................................anything........................
```

`h/emit-response` echoes the response body straight to the SAPI (uncapturable). `test-emit-response-returns-nil` called it with a `"anything"` body and did **not** wrap it in an output buffer, so the body leaked into the runner's dot stream. The sibling `emit-response` tests already use `output?` (which captures via `ob_start`).

## 💡 Goal

Silence the leak; keep asserting the nil return.

## 🔖 Changes

- Wrap the `emit-response` call in `with-output-buffer` to capture/discard the echoed body, and assert the captured return value is `nil`.

## ✅ Validation

`bin/phel test` → 5897 passed, 0 failed, and the progress output is clean dots with no stray text.
