### PR TITLE
ref: dedup and shared-helper cleanup across src/phel

### DIFF
--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -392,6 +392,18 @@
       s
       (str (php/substr s 0 limit) "... (" len " chars total)"))))
 
+(defn- slice-between
+  "Returns the substring of `trimmed` spanning the first `open` char to the
+  last `close` char (inclusive). Throws `RuntimeException` prefixed with
+  `error-prefix` when no balanced pair is found."
+  [trimmed open close error-prefix]
+  (let [start (php/strpos trimmed open)
+        end   (php/strrpos trimmed close)]
+    (if (and start end (>= end start))
+      (php/substr trimmed start (+ (- end start) 1))
+      (throw (php/new RuntimeException
+                      (str error-prefix (truncate-for-error trimmed)))))))
+
 (defn- extract-json-from-response
   "Extracts JSON from an AI response, handling markdown code blocks."
   [response]
@@ -402,13 +414,7 @@
             found   (php/preg_match "/```(?:json)?\\s*\\n?(\\{[\\s\\S]*?\\})\\s*\\n?```/" trimmed matches)]
         (if (one? found)
           (php/aget matches 1)
-          (let [start (php/strpos trimmed "{")
-                end   (php/strrpos trimmed "}")]
-            (if (and start end (>= end start))
-              (php/substr trimmed start (+ (- end start) 1))
-              (throw (php/new RuntimeException
-                              (str "Could not extract JSON from AI response: "
-                                   (truncate-for-error trimmed)))))))))))
+          (slice-between trimmed "{" "}" "Could not extract JSON from AI response: "))))))
 
 (def- default-extract-system
   "You are a precise data extraction assistant. Return only valid JSON.")
@@ -420,13 +426,7 @@
   (let [trimmed (php/trim response)]
     (if (php/str_starts_with trimmed "[")
       trimmed
-      (let [start (php/strpos trimmed "[")
-            end   (php/strrpos trimmed "]")]
-        (if (and start end (>= end start))
-          (php/substr trimmed start (+ (- end start) 1))
-          (throw (php/new RuntimeException
-                          (str "Could not extract JSON array from AI response: "
-                               (truncate-for-error trimmed)))))))))
+      (slice-between trimmed "[" "]" "Could not extract JSON array from AI response: "))))
 
 (defn- run-extraction
   "Drives a single-shot extraction call with the given prompt and opts."

--- a/src/phel/cli.phel
+++ b/src/phel/cli.phel
@@ -256,7 +256,7 @@
   start / advance / finish automatically."
   {:example "(run-with-progress ctx files (fn [f _] (process f)))"}
   [ctx coll step-fn & [opts]]
-  (let [bar (progress-bar ctx (put (or opts {}) :max (or (get opts :max) (count coll))))]
+  (let [bar (progress-bar ctx (assoc (or opts {}) :max (or (get opts :max) (count coll))))]
     (progress-start bar)
     (foreach [item coll]
       (step-fn item bar)

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -49,6 +49,12 @@
   [x]
   (php/instanceof x PhelVar))
 
+(defn- assert-var!
+  "Throws `InvalidArgumentException` with `msg` unless `v` is a `Var`."
+  [v msg]
+  (when-not (var? v)
+    (throw (php/new \InvalidArgumentException msg))))
+
 (defn reset!
   "Sets a new value on the given atom. Returns the new value."
   {:example "(def x (atom 10))"
@@ -114,9 +120,7 @@
   {:example "(def counter 0)\n(alter-var-root #'counter inc) ; => 1"
    :see-also ["var" "var?" "swap!"]}
   [v f & args]
-  (when-not (var? v)
-    (throw (php/new \InvalidArgumentException
-                    "alter-var-root expects a Var as first argument; use swap! for atoms")))
+  (assert-var! v "alter-var-root expects a Var as first argument; use swap! for atoms")
   (php/-> v (alterRoot (fn [current] (apply f current args)))))
 
 (defn bound?
@@ -125,9 +129,7 @@
   {:example "(bound? #'phel.core/map) ; => true"
    :see-also ["thread-bound?" "var-get" "find-var"]}
   [v]
-  (when-not (var? v)
-    (throw (php/new \InvalidArgumentException
-                    "bound? expects a Var as its argument")))
+  (assert-var! v "bound? expects a Var as its argument")
   (php/:: Phel (isDefined (php/-> v (getNamespace))
                           (php/-> v (getName)))))
 
@@ -137,9 +139,7 @@
   {:example "(binding [*foo* 1] (thread-bound? #'*foo*)) ; => true"
    :see-also ["bound?" "binding" "var-set"]}
   [v]
-  (when-not (var? v)
-    (throw (php/new \InvalidArgumentException
-                    "thread-bound? expects a Var as its argument")))
+  (assert-var! v "thread-bound? expects a Var as its argument")
   (let [scope (php/:: DynamicScope (getInstance))]
     (php/-> scope (hasBinding (php/-> v (getNamespace))
                               (php/-> v (getName))))))
@@ -151,9 +151,7 @@
   {:example "(def ^:dynamic *x* 0)\n(binding [*x* 1] (var-set #'*x* 2) *x*) ; => 2"
    :see-also ["binding" "thread-bound?" "alter-var-root"]}
   [v val]
-  (when-not (var? v)
-    (throw (php/new \InvalidArgumentException
-                    "var-set expects a Var as its first argument")))
+  (assert-var! v "var-set expects a Var as its first argument")
   (php/:: Phel (varSet (php/-> v (getNamespace))
                        (php/-> v (getName))
                        val)))

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -271,10 +271,7 @@
   {:example "(every? even? [2 4 6 8]) ; => true"
    :see-also ["all?" "not-every?"]}
   [pred coll]
-  (cond
-    (empty? coll)       true
-    (pred (first coll)) (recur pred (next coll))
-    false))
+  (all? pred coll))
 
 (defn not-every?
   "Returns false if `(pred x)` is logical true for every `x` in collection `coll`

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -67,11 +67,7 @@
   [s1 s2]
   (if (> (count s1) (count s2))
     false
-    (let [result (atom true)]
-      (foreach [item s1]
-        (when-not (php/-> s2 (contains item))
-          (reset! result false)))
-      (deref result))))
+    (every? #(php/-> s2 (contains %)) s1)))
 
 (defn superset?
   "Returns true if `s1` is a superset of `s2`, i.e. every element in `s2` is also in `s1`."

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -381,6 +381,19 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   [x]
   (int x))
 
+(defn- clamp-int
+  "Truncates a numeric `x` toward zero and range-checks it against `lo..hi`.
+   Raises `InvalidArgumentException` when `x` is non-numeric or out of range.
+   `label` names the target type for error messages."
+  [x lo hi label]
+  (if (number? x)
+    (let [truncated (int x)]
+      (if (or (php/< truncated lo) (php/> truncated hi))
+        (throw (php/new InvalidArgumentException
+                        (php/. "Value out of range for " label ": " (php/strval truncated))))
+        truncated))
+    (throw (php/new InvalidArgumentException (php/. label " expects a numeric value")))))
+
 (defn short
   "Coerces `x` to a signed 16-bit integer in the range `-32768..32767`.
    Decimal values are truncated toward zero. `Ratio` and `BigInt`
@@ -390,13 +403,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(short 32767) ; => 32767\n(short 1.9) ; => 1\n(short -32768) ; => -32768"
    :see-also ["int" "byte" "long"]}
   [x]
-  (if (number? x)
-    (let [truncated (int x)]
-      (if (or (php/< truncated -32768) (php/> truncated 32767))
-        (throw (php/new InvalidArgumentException
-                        (php/. "Value out of range for short: " (php/strval truncated))))
-        truncated))
-    (throw (php/new InvalidArgumentException "short expects a numeric value"))))
+  (clamp-int x -32768 32767 "short"))
 
 (defn byte
   "Coerces `x` to a signed 8-bit integer in the range `-128..127`.
@@ -407,13 +414,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(byte 127) ; => 127\n(byte 1.9) ; => 1\n(byte -128) ; => -128"
    :see-also ["int?" "float" "double"]}
   [x]
-  (if (number? x)
-    (let [truncated (int x)]
-      (if (or (php/< truncated -128) (php/> truncated 127))
-        (throw (php/new InvalidArgumentException
-                        (php/. "Value out of range for byte: " (php/strval truncated))))
-        truncated))
-    (throw (php/new InvalidArgumentException "byte expects a numeric value"))))
+  (clamp-int x -128 127 "byte"))
 
 (defn char
   "Coerces `x` to a single-character string representing the given

--- a/src/phel/core/ns.phel
+++ b/src/phel/core/ns.phel
@@ -81,6 +81,17 @@
   (php/:: Phel (removeNamespace (core-munge-ns ns-str)))
   nil)
 
+(defn- defs->map
+  "Builds a {decoded-name => value} map of the definitions in `encoded-ns`,
+  keeping only those whose encoded `fn-name` satisfies `keep?`."
+  [encoded-ns keep?]
+  (let [defs   (php/:: Phel (getDefinitionInNamespace encoded-ns))
+        result (transient {})]
+    (foreach [fn-name value defs]
+      (when (keep? fn-name)
+        (assoc! result (php/-> munge-instance (decodeNs fn-name)) value)))
+    (persistent result)))
+
 (defn ns-interns
   "Returns a hash-map of {name => value} for every definition in the
   given namespace, including private ones. Returns an empty map if the
@@ -88,12 +99,7 @@
   {:example "(ns-interns \"phel\\core\")"
    :see-also ["ns-publics" "intern" "find-ns"]}
   [ns-str]
-  (let [defs   (php/:: Phel (getDefinitionInNamespace (core-munge-ns ns-str)))
-        munge  (php/new Munge)
-        result (transient {})]
-    (foreach [fn-name value defs]
-      (assoc! result (php/-> munge (decodeNs fn-name)) value))
-    (persistent result)))
+  (defs->map (core-munge-ns ns-str) (constantly true)))
 
 (defn intern
   "Finds or creates a definition named by name-str in namespace ns-str.
@@ -178,15 +184,10 @@
   {:example "(ns-publics \"phel\\core\") ; => {\"map\" <fn> \"filter\" <fn> ...}"
    :see-also ["ns-aliases" "ns-refers" "loaded-namespaces"]}
   [ns-str]
-  (let [encoded (core-munge-ns ns-str)
-        defs    (php/:: Phel (getDefinitionInNamespace encoded))
-        munge   (php/new Munge)
-        result  (transient {})]
-    (foreach [fn-name value defs]
-      (let [meta (php/:: Phel (getDefinitionMetaData encoded fn-name))]
-        (when-not (get meta :private)
-          (assoc! result (php/-> munge (decodeNs fn-name)) value))))
-    (persistent result)))
+  (let [encoded (core-munge-ns ns-str)]
+    (defs->map encoded
+               (fn [fn-name]
+                 (not (get (php/:: Phel (getDefinitionMetaData encoded fn-name)) :private))))))
 
 (defn ns-aliases
   "Returns a hash-map of {alias => namespace} for all require aliases in the

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -488,6 +488,31 @@
                                       (str "No implementation of '" ~mname-str
                                            "' for type: " dk))))))))))))
 
+(defn- group-protocol-specs
+  "Splits a flat protocol spec list into `[[header [methods]] ...]` groups.
+  A spec for which `(header? spec)` is truthy starts a new group; every other
+  spec is a method appended to the current group. Used by `extend-type`,
+  `extend-protocol`, and `reify`, which differ only in the header predicate."
+  [specs header?]
+  (loop [remaining       specs
+         current-header  nil
+         current-methods []
+         result          []]
+    (if (nil? remaining)
+      (if current-header
+        (conj result [current-header current-methods])
+        result)
+      (let [item (first remaining)
+            rst  (next remaining)]
+        (if (header? item)
+          (recur rst item []
+                 (if current-header
+                   (conj result [current-header current-methods])
+                   result))
+          (recur rst current-header
+                 (conj current-methods item)
+                 result))))))
+
 (defmacro extend-type
   "Extends a type with protocol method implementations.
 
@@ -519,24 +544,7 @@
                    (let [munge    (php/new Munge)
                          name-str (php/-> type-spec (getName))]
                      (php/. (php/-> munge (encodePhpNs *ns*)) "\\" (php/-> munge (encode name-str)))))
-        groups   (loop [remaining       specs
-                        current-proto   nil
-                        current-methods []
-                        result          []]
-                   (if (nil? remaining)
-                     (if current-proto
-                       (conj result [current-proto current-methods])
-                       result)
-                     (let [item (first remaining)
-                           rst  (next remaining)]
-                       (if (php/instanceof item Symbol)
-                         (recur rst item []
-                                (if current-proto
-                                  (conj result [current-proto current-methods])
-                                  result))
-                         (recur rst current-proto
-                                (conj current-methods item)
-                                result)))))
+        groups   (group-protocol-specs specs #(php/instanceof % Symbol))
         swaps    (reduce
                   (fn [acc group]
                     (let [proto-name (first group)
@@ -593,22 +601,7 @@
   :int (describe [n] (str n)))"
    :see-also ["extend-type" "defprotocol"]}
   [protocol-name & specs]
-  (let [groups       (loop [remaining       specs
-                            current-type    nil
-                            current-methods []
-                            result          []]
-                       (if (nil? remaining)
-                         (if current-type
-                           (conj result [current-type current-methods])
-                           result)
-                         (let [item (first remaining)
-                               rst  (next remaining)]
-                           (if (list? item)
-                             (recur rst current-type (conj current-methods item) result)
-                             (recur rst item []
-                                    (if current-type
-                                      (conj result [current-type current-methods])
-                                      result))))))
+  (let [groups       (group-protocol-specs specs #(not (list? %)))
         extend-calls (for [[type-spec methods] :in groups]
                        `(extend-type ~type-spec ~protocol-name ~@methods))]
     `(do ~@extend-calls)))
@@ -633,24 +626,7 @@
         ;; Group specs into [[ProtocolSym [method1 method2 ...]] ...]
         ;; Same parsing pattern as extend-type: symbols start a new group,
         ;; lists are methods belonging to the current protocol.
-        proto-groups           (loop [remaining       specs
-                                      current-proto   nil
-                                      current-methods []
-                                      result          []]
-                                 (if (nil? remaining)
-                                   (if current-proto
-                                     (conj result [current-proto current-methods])
-                                     result)
-                                   (let [item (first remaining)
-                                         rst  (next remaining)]
-                                     (if (php/instanceof item Symbol)
-                                       (recur rst item []
-                                              (if current-proto
-                                                (conj result [current-proto current-methods])
-                                                result))
-                                       (recur rst current-proto
-                                              (conj current-methods item)
-                                              result)))))
+        proto-groups           (group-protocol-specs specs #(php/instanceof % Symbol))
         ;; Flatten all methods for the reify* special form (it only needs
         ;; method specs, protocol grouping is handled here for dispatch).
         all-methods            (reduce (fn [acc group] (concat acc (second group))) [] proto-groups)

--- a/src/phel/match.phel
+++ b/src/phel/match.phel
@@ -73,7 +73,7 @@
   "Combines a seq of boolean checks into a single expression, skipping
   `true` and collapsing a single check."
   [checks]
-  (let [effective (apply vector (filter (fn [c] (not (= c true))) checks))]
+  (let [effective (vec (filter (fn [c] (not (= c true))) checks))]
     (case (count effective)
       0 true
       1 (first effective)
@@ -102,7 +102,7 @@
         name  (get pattern 2)
         sub   (compile-pattern target inner)]
     {:check    (get sub :check)
-     :bindings (apply vector (concat [name target] (get sub :bindings)))}))
+     :bindings (vec (concat [name target] (get sub :bindings)))}))
 
 (defn- compile-guard
   "(inner :guard pred): compile inner, and-combine with (pred target)
@@ -124,7 +124,7 @@
   "(:or p1 p2 ...): succeeds if any alternative matches. Alternatives
   may not introduce bindings (keeps v1 simple and predictable)."
   [target pattern]
-  (let [alts (apply vector (next pattern))]
+  (let [alts (vec (next pattern))]
     (when (empty? alts)
       (throw (php/new \InvalidArgumentException
                       "match :or pattern requires at least one alternative")))
@@ -165,7 +165,7 @@
           (when-not (symbol? tail)
             (throw (php/new \InvalidArgumentException
                             (str "match vector pattern: `&` binding must be a symbol, got " tail))))
-          [(apply vector (take idx pattern)) tail])))))
+          [(vec (take idx pattern)) tail])))))
 
 (defn- compile-vector
   "Vector pattern: shape + length check, recursively compile each
@@ -177,14 +177,14 @@
         length-ok       (if tail-sym
                           `(>= (count ~target) ~fixed-len)
                           `(= (count ~target) ~fixed-len))
-        elem-specs      (apply vector
-                               (for [i :range [0 fixed-len]]
-                                 (let [elem-target `(get ~target ~i)
-                                       sub         (compile-pattern elem-target
-                                                                    (get head i))]
-                                   {:index    i
-                                    :check    (get sub :check)
-                                    :bindings (get sub :bindings)})))
+        elem-specs      (vec
+                         (for [i :range [0 fixed-len]]
+                           (let [elem-target `(get ~target ~i)
+                                 sub         (compile-pattern elem-target
+                                                              (get head i))]
+                             {:index    i
+                              :check    (get sub :check)
+                              :bindings (get sub :bindings)})))
         inner-checks    (for [e :in elem-specs] (get e :check))
         outer-check     (shape-gated-check shape (cons length-ok inner-checks))
         elem-bindings   (apply concat
@@ -193,32 +193,32 @@
         tail-binding    (if tail-sym
                           [tail-sym `(vec (slice ~target ~fixed-len))]
                           [])
-        all-bindings    (apply vector (concat elem-bindings tail-binding))]
+        all-bindings    (vec (concat elem-bindings tail-binding))]
     {:check outer-check, :bindings all-bindings}))
 
 (defn- compile-map
   "Map pattern: shape check, key-presence check, recurse on each value."
   [target pattern]
-  (let [entries         (apply vector
-                               (for [[k v] :pairs pattern] [k v]))
+  (let [entries         (vec
+                         (for [[k v] :pairs pattern] [k v]))
         shape           `(map? ~target)
-        key-specs       (apply vector
-                               (for [e :in entries]
-                                 (let [k   (first e)
-                                       p   (get e 1)
-                                       val `(get ~target ~k)
-                                       sub (compile-pattern val p)]
-                                   {:key      k
-                                    :check    (get sub :check)
-                                    :bindings (get sub :bindings)})))
+        key-specs       (vec
+                         (for [e :in entries]
+                           (let [k   (first e)
+                                 p   (get e 1)
+                                 val `(get ~target ~k)
+                                 sub (compile-pattern val p)]
+                             {:key      k
+                              :check    (get sub :check)
+                              :bindings (get sub :bindings)})))
         contains-checks (for [k :in key-specs]
                           `(contains? ~target ~(get k :key)))
         value-checks    (for [k :in key-specs] (get k :check))
-        outer-check     (shape-gated-check shape (apply vector (concat contains-checks value-checks)))
-        all-bindings    (apply vector
-                               (apply concat
-                                      (for [k :in key-specs]
-                                        (get k :bindings))))]
+        outer-check     (shape-gated-check shape (vec (concat contains-checks value-checks)))
+        all-bindings    (vec
+                         (apply concat
+                                (for [k :in key-specs]
+                                  (get k :bindings))))]
     {:check outer-check, :bindings all-bindings}))
 
 (defn- compile-pattern
@@ -246,13 +246,13 @@
                     (str "match: pattern count (" (count patterns)
                          ") does not match target count (" (count target-syms)
                          "): " patterns))))
-  (let [subs     (apply vector
-                        (for [i :range [0 (count patterns)]]
-                          (compile-pattern (get target-syms i) (get patterns i))))
+  (let [subs     (vec
+                  (for [i :range [0 (count patterns)]]
+                    (compile-pattern (get target-syms i) (get patterns i))))
         checks   (for [s :in subs] (get s :check))
-        bindings (apply vector
-                        (apply concat
-                               (for [s :in subs] (get s :bindings))))]
+        bindings (vec
+                  (apply concat
+                         (for [s :in subs] (get s :bindings))))]
     [(and-checks checks) bindings]))
 
 (defn- parse-clauses
@@ -281,7 +281,7 @@
                           "match: every pattern must be paired with an expression")))
         (let [pat  (first remaining)
               expr (get remaining 1)
-              rest (apply vector (drop 2 remaining))]
+              rest (vec (drop 2 remaining))]
           (when-not (vector? pat)
             (throw (php/new \InvalidArgumentException
                             (str "match: pattern must be a vector, got " pat))))
@@ -313,14 +313,14 @@
     (throw (php/new \InvalidArgumentException
                     (str "match: target list must be a vector, got " targets))))
   (let [n                 (count targets)
-        target-syms       (apply vector
-                                 (for [_ :range [0 n]]
-                                   (gensym "__m")))
-        target-binds      (apply vector
-                                 (apply concat
-                                        (for [i :range [0 n]]
-                                          [(get target-syms i) (get targets i)])))
-        [clauses default] (parse-clauses (apply vector body))
+        target-syms       (vec
+                           (for [_ :range [0 n]]
+                             (gensym "__m")))
+        target-binds      (vec
+                           (apply concat
+                                  (for [i :range [0 n]]
+                                    [(get target-syms i) (get targets i)])))
+        [clauses default] (parse-clauses (vec body))
         compiled          (for [c :in clauses]
                             (let [pat              (first c)
                                   expr             (get c 1)

--- a/src/phel/mock.phel
+++ b/src/phel/mock.phel
@@ -16,8 +16,9 @@
                                        :reset-fn reset-fn})
    mock-fn))
 
-(defn- get-mock-calls [mock-fn]
+(defn- get-mock-calls
   "Gets the call history for a mock function"
+  [mock-fn]
   (let [mock-data (get (deref mock-registry) mock-fn)]
     (when mock-data
       (get mock-data :call-history))))

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -16,6 +16,10 @@
 
 (def build-facade (php/new BuildFacade))
 
+(def- munge-instance
+  ;; Munge is a final readonly class; reuse one instance to avoid per-call allocation.
+  (php/new Munge))
+
 (def- src-dirs (php/array)) ; Set by ReplCommand; lazily resolved via get-src-dirs
 
 (defn- get-global-env []
@@ -27,7 +31,7 @@
   {:example "(loaded-namespaces) ; => [\"phel.core\" \"phel.repl\"]"}
   []
   (let [raw    (php/:: Phel (getNamespaces))
-        munge  (php/new Munge)
+        munge  munge-instance
         result (transient [])]
     (foreach [ns raw]
       (conj result (php/:: Munge (displayNs (php/-> munge (decodeNs ns))))))
@@ -230,7 +234,7 @@
 (defn- munge-ns
   "Encodes a namespace string for registry lookup."
   [ns-str]
-  (let [munge (php/new Munge)]
+  (let [munge munge-instance]
     (php/-> munge (encodeRegistryKey ns-str))))
 
 (defn get-symbol-info
@@ -243,7 +247,7 @@
   [ns-str name-str]
   (let [canonical    (canonical-ns ns-str)
         encoded-ns   (munge-ns canonical)
-        munge        (php/new Munge)
+        munge        munge-instance
         encoded-name (php/-> munge (encode name-str))
         meta         (php/:: Phel (getDefinitionMetaData encoded-ns encoded-name))]
     (when meta
@@ -284,7 +288,7 @@
   (let [ns-str  (name ns)
         encoded (munge-ns ns-str)
         defs    (php/:: Phel (getDefinitionInNamespace encoded))
-        munge   (php/new Munge)
+        munge   munge-instance
         names   (for [fn-name :keys defs
                       :let [meta (php/:: Phel (getDefinitionMetaData encoded fn-name))]
                       :when (not (get meta :private))]
@@ -308,7 +312,7 @@
   Searches across all loaded namespaces."
   {:example "(apropos \"map\") ; => [phel.core/flat-map phel.core/map ...]"}
   [search]
-  (let [munge   (php/new Munge)
+  (let [munge   munge-instance
         results (transient [])]
     (foreach [ns (php/:: Phel (getNamespaces))]
       (let [defs     (php/:: Phel (getDefinitionInNamespace ns))
@@ -328,7 +332,7 @@
   {:example "(find-fn \"map\") ; => [{:ns \"phel.core\" :name \"map\" ...} ...]"
    :see-also ["apropos" "search-doc" "get-symbol-info"]}
   [search]
-  (let [munge        (php/new Munge)
+  (let [munge        munge-instance
         search-lower (php/strtolower search)
         results      (transient [])]
     (foreach [ns (php/:: Phel (getNamespaces))]
@@ -419,7 +423,7 @@
   [ns-str name-str & rest]
   (let [canonical    (canonical-ns ns-str)
         encoded-ns   (munge-ns canonical)
-        encoded-name (php/-> (php/new Munge) (encode name-str))
+        encoded-name (php/-> munge-instance (encode name-str))
         value        (first rest)]
     (php/:: Phel (addDefinition encoded-ns encoded-name value))
     (php/:: Symbol (createForNamespace (php/:: Munge (displayNs canonical)) name-str))))
@@ -432,7 +436,7 @@
    :see-also ["ns-publics" "intern" "find-ns"]}
   [ns-str]
   (let [defs   (php/:: Phel (getDefinitionInNamespace (munge-ns ns-str)))
-        munge  (php/new Munge)
+        munge  munge-instance
         result (transient {})]
     (foreach [fn-name value defs]
       (assoc! result (php/-> munge (decodeNs fn-name)) value))
@@ -446,7 +450,7 @@
   [ns-str]
   (let [encoded (munge-ns ns-str)
         defs    (php/:: Phel (getDefinitionInNamespace encoded))
-        munge   (php/new Munge)
+        munge   munge-instance
         result  (transient {})]
     (foreach [fn-name value defs]
       (let [meta (php/:: Phel (getDefinitionMetaData encoded fn-name))]
@@ -485,7 +489,7 @@
   Prints matching function names and their documentation."
   {:example "(search-doc \"reduce\")"}
   [search]
-  (let [munge        (php/new Munge)
+  (let [munge        munge-instance
         search-lower (php/strtolower search)]
     (foreach [ns (php/:: Phel (getNamespaces))]
       (let [defs     (php/:: Phel (getDefinitionInNamespace ns))
@@ -620,6 +624,9 @@
          (when source
            (str "\nSource code:\n```phel\n" source "\n```\n")))))
 
+(def- phel-expert-preamble
+  "You are a Phel language expert. Phel is a Lisp that compiles to PHP.\n\n")
+
 (defn explain
   "Sends a Phel code string to the AI for explanation.
 
@@ -633,7 +640,7 @@
         expanded (try (let [form (eval-str (str "'" code-str))]
                         (str (macroexpand-form form)))
                       (catch \Throwable _e nil))
-        context  (str "You are a Phel language expert. Phel is a Lisp that compiles to PHP.\n\n"
+        context  (str phel-expert-preamble
                       "Explain the following Phel code clearly and concisely:\n\n"
                       "```phel\n" code-str "\n```\n"
                       (when compiled (str "\nCompiled PHP:\n```php\n" compiled "\n```\n"))
@@ -662,7 +669,7 @@
    :see-also ["explain" "fix"]}
   [description]
   (let [ns-context (build-namespace-context)
-        prompt     (str "You are a Phel language expert. Phel is a Lisp that compiles to PHP.\n\n"
+        prompt     (str phel-expert-preamble
                         "Environment:\n" ns-context "\n\n"
                         "Task: Write Phel code to accomplish the following:\n"
                         description "\n\n"
@@ -677,7 +684,7 @@
    :see-also ["explain" "suggest"]}
   [code-str error-msg]
   (let [ns-context (build-namespace-context)
-        prompt     (str "You are a Phel language expert. Phel is a Lisp that compiles to PHP.\n\n"
+        prompt     (str phel-expert-preamble
                         "Environment:\n" ns-context "\n\n"
                         "The following Phel code produced an error:\n\n"
                         "```phel\n" code-str "\n```\n\n"
@@ -693,7 +700,7 @@
    :see-also ["explain" "suggest" "fix"]}
   [code-str]
   (let [ns-context (build-namespace-context)
-        prompt     (str "You are a Phel language expert. Phel is a Lisp that compiles to PHP.\n\n"
+        prompt     (str phel-expert-preamble
                         "Environment:\n" ns-context "\n\n"
                         "Review the following Phel code for quality, idioms, and potential issues:\n\n"
                         "```phel\n" code-str "\n```\n\n"

--- a/src/phel/schema/coercer.phel
+++ b/src/phel/schema/coercer.phel
@@ -189,7 +189,7 @@
   (let [head (v/schema-head schema)
         args (v/schema-args schema)]
     (case head
-      :vector (coerce-collection schema value (fn [xs] (into [] xs)))
+      :vector (coerce-collection schema value vec)
       :list   (coerce-collection schema value (fn [xs] (apply list xs)))
       :set    (coerce-collection schema value (fn [xs] (into (hash-set) xs)))
       :map-of (coerce-map-of schema value)

--- a/src/phel/schema/explainer.phel
+++ b/src/phel/schema/explainer.phel
@@ -147,10 +147,9 @@
 ;; is not one of the allowed members.
 (defn- -explain-enum
   [schema value path in]
-  (let [args (v/schema-args schema)]
-    (if (v/valid? schema value)
-      []
-      [(make-error path in schema value :mismatch)])))
+  (if (v/valid? schema value)
+    []
+    [(make-error path in schema value :mismatch)]))
 
 ;; Explains an `:and` schema: collects errors from every conjoined
 ;; sub-schema (all must pass), accumulating across all of them.

--- a/src/phel/schema/validator.phel
+++ b/src/phel/schema/validator.phel
@@ -152,42 +152,21 @@
   "Generic collection validator used by `[:vector s]` and `[:set s]`."
   [schema value type-pred elem-schemas]
   (and (type-pred value)
-       (if (empty? elem-schemas)
-         true
-         (let [elem-schema (first elem-schemas)
-               items       (into [] value)]
-           (loop [i 0]
-             (cond
-               (>= i (count items))                     true
-               (not (valid? elem-schema (get items i))) false
-               :else                                    (recur (+ i 1))))))))
+       (or (empty? elem-schemas)
+           (let [elem-schema (first elem-schemas)]
+             (every? #(valid? elem-schema %) value)))))
 
 (defn- validate-map-of
   [value key-schema val-schema]
   (and (map? value)
-       (let [pairs (into [] (for [[k v] :pairs value] [k v]))]
-         (loop [i 0]
-           (cond
-             (>= i (count pairs)) true
-             :else
-             (let [entry (get pairs i)
-                   k     (get entry 0)
-                   v     (get entry 1)]
-               (cond
-                 (not (valid? key-schema k)) false
-                 (not (valid? val-schema v)) false
-                 :else                       (recur (+ i 1)))))))))
+       (every? (fn [[k v]] (and (valid? key-schema k) (valid? val-schema v)))
+               (for [[k v] :pairs value] [k v]))))
 
 (defn- validate-tuple
   [value elem-schemas]
   (and (vector? value)
        (= (count value) (count elem-schemas))
-       (loop [i 0]
-         (if (>= i (count elem-schemas))
-           true
-           (if (valid? (get elem-schemas i) (get value i))
-             (recur (+ i 1))
-             false)))))
+       (every? true? (map-indexed (fn [i s] (valid? s (get value i))) elem-schemas))))
 
 (defn map-entry-options
   "Options map for a `[:map ...]` entry `[key opts? schema]`. Returns an

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -181,23 +181,21 @@
   (assert-string substr)
   (php/str_ends_with s substr))
 
-(defn contains?
-  "True if s contains substr."
-  {:example "(contains? \"hello world\" \"lo wo\") ; => true"
-   :see-also ["includes?" "starts-with?" "ends-with?" "index-of"]}
+(defn includes?
+  "True if s includes substr."
+  {:example "(includes? \"hello world\" \"world\") ; => true"
+   :see-also ["contains?" "starts-with?" "ends-with?" "index-of"]}
   [s substr]
   (assert-string s)
   (assert-string substr)
   (php/str_contains s substr))
 
-(defn includes?
-  "True if s includes substr. Synonym for `contains?`."
-  {:example "(includes? \"hello world\" \"world\") ; => true"
-   :see-also ["contains?" "starts-with?" "ends-with?"]}
+(defn contains?
+  "True if s contains substr. Synonym for `includes?`."
+  {:example "(contains? \"hello world\" \"lo wo\") ; => true"
+   :see-also ["includes?" "starts-with?" "ends-with?"]}
   [s substr]
-  (assert-string s)
-  (assert-string substr)
-  (php/str_contains s substr))
+  (includes? s substr))
 
 (defn re-quote-replacement
   "Escapes special characters in a replacement string for literal use."

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -698,7 +698,7 @@
 (defn- print-failures-block [failures]
   (when-not (empty? failures)
     (println)
-    (for [data :in failures]
+    (dofor [data :in failures]
       (println "~~~~~~~~~~")
       (print-failure-or-error data))
     (println)))

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -234,7 +234,6 @@
   (let [pred               (first form)
         expected           (second form)
         actual             (second (next form))
-        type               (if negated :binary :binary-not)
         loc                (location form)
         expected-evaluated (gensym)
         actual-evaluated   (gensym)
@@ -244,8 +243,7 @@
            ~actual-evaluated   ~actual
            ~result             (~pred ~expected-evaluated ~actual-evaluated)
            ~result             (if ~negated (not ~result) ~result)
-           ~report-data        {:type ~type
-                                :message ~message
+           ~report-data        {:message ~message
                                 :location ~loc
                                 :pred '~pred
                                 :expected ~expected-evaluated

--- a/src/phel/transit.phel
+++ b/src/phel/transit.phel
@@ -240,23 +240,19 @@
         (php/apush pairs (encode v)))
       (php-indexed-array "~#cmap" pairs))))
 
-(defn- encode-vector [v]
+(defn- encode-sequential
+  "Encodes each element of `coll` into a PHP array. When `tag` is non-nil the
+  array is wrapped as a Transit tagged array (e.g. \"~#set\"); a nil `tag`
+  yields a bare array."
+  [coll tag]
   (let [arr (php/array)]
-    (foreach [x v]
+    (foreach [x coll]
       (php/apush arr (encode x)))
-    arr))
+    (if tag (php-indexed-array tag arr) arr)))
 
-(defn- encode-set [s]
-  (let [arr (php/array)]
-    (foreach [x s]
-      (php/apush arr (encode x)))
-    (php-indexed-array "~#set" arr)))
-
-(defn- encode-list [l]
-  (let [arr (php/array)]
-    (foreach [x l]
-      (php/apush arr (encode x)))
-    (php-indexed-array "~#list" arr)))
+(defn- encode-vector [v] (encode-sequential v nil))
+(defn- encode-set [s] (encode-sequential s "~#set"))
+(defn- encode-list [l] (encode-sequential l "~#list"))
 
 (defn- encode
   "Encodes a Phel value into the PHP-array shape consumed by


### PR DESCRIPTION
## 🤔 Background

While auditing `src/phel/` for clean-code opportunities, several core and library namespaces carried duplicated logic, dead bindings, and non-idiomatic patterns (manual index loops, `(apply vector ...)`, per-call object allocations, copy-pasted macro spec-grouping).

## 💡 Goal

Reduce duplication and dead code across the Phel-level source tree without any behavior change. Pure internal refactor.

## 🔖 Changes

**Dedup / dead-code (commit 1)**
- `booleans`: `every?` now delegates to `all?` instead of copy-pasting its body.
- `math`: `short`/`byte` share a new `clamp-int` helper.
- `fns-sets`: `subset?` uses short-circuiting `every?` instead of an atom + `foreach`.
- `string`: `contains?` delegates to `includes?` (duplicate body removed).
- `mock`: `get-mock-calls` docstring moved before the arg vector so `:doc` is actually captured.
- `test`: removed dead `type` binding in `assert-binary` (always overwritten by `merge`).

**Shared helpers (commit 2)**
- `protocols`: unified the spec-grouping loop in `extend-type`/`extend-protocol`/`reify` into `group-protocol-specs` taking a header predicate (~40 dup lines gone).
- `atoms`: extracted `assert-var!` for the four `Var` guards.
- `ns`: extracted `defs->map`; `ns-interns`/`ns-publics` reuse the `munge-instance` singleton.
- `ai`: extracted `slice-between` for JSON object/array extraction.
- `transit`: collapsed `encode-vector`/`encode-set`/`encode-list` into `encode-sequential`.
- `match`: replaced 15 `(apply vector ...)` with `vec`.
- `repl`: hoisted a `munge-instance` singleton and a `phel-expert-preamble` constant.
- `schema/validator`: replaced manual index loops with `every?`.
- `schema/coercer`: `(fn [xs] (into [] xs))` → `vec`.
- `schema/explainer`: dropped a dead `args` binding in `-explain-enum`.
- `cli`: deprecated `put` → `assoc`.
- `test`: `for` → `dofor` for the side-effecting failure print.

No user-facing changes, so no CHANGELOG entry. All 5897 Phel core/library tests pass; `phel format` clean.
