### PR TITLE
docs(api): expose load special form in API reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Docs: the `load` special form is now documented in the API reference and `phel doc load` (it was implemented but missing from the native symbol catalog)
 - `phel.reflect`: `class-attributes`/`method-attributes`/`property-attributes`/`attributes` read PHP 8 attributes as `{:name :args}` maps (#2314, #2320)
 - `phel.reflect`: `enum->keyword`/`keyword->enum`/`enum-values` bridge native PHP enums to keywords and back (#2315, #2321)
 - `iterator-seq`: lazy seq over a PHP `Traversable`, pulled one element at a time (#2312, #2318)

--- a/src/php/Api/Infrastructure/NativeSymbolCatalog.php
+++ b/src/php/Api/Infrastructure/NativeSymbolCatalog.php
@@ -209,6 +209,16 @@ Creates a new list. If no argument is provided, an empty list is created. Shortc
             'desc' => 'Creates a new list. If no argument is provided, an empty list is created.',
             'example' => "(list 1 2 3) ; => '(1 2 3)",
         ],
+        Symbol::NAME_LOAD => [
+            'doc' => '```phel
+(load path)
+```
+Loads a Phel source file into the caller namespace at runtime. Path resolution follows the spirit of Clojure\'s `clojure.core/load`: a path beginning with a slash is classpath-absolute (searched against the configured `phel\repl/src-dirs` roots); otherwise it is resolved relative to the caller file\'s compile-time location, so mutations to the runtime `*file*` value cannot break resolution. Pass the path without an extension (no `.phel`) and without a relative prefix (no `./` or `../`). Returns nil; the form runs for its side effects.',
+            'docUrl' => '/documentation/namespaces/',
+            'signatures' => ['(load path)'],
+            'desc' => 'Loads a Phel source file into the caller namespace at runtime, resolving the path relative to the caller file or against the configured classpath roots.',
+            'example' => '(load "core/meta") ; loads and evaluates core/meta into the current namespace',
+        ],
         Symbol::NAME_LOOP => [
             'doc' => '```phel
 (loop [bindings*] expr*)


### PR DESCRIPTION
## 🤔 Background

`load` is a Phel native special form (implemented in `LoadSymbol` / `LoadNode` / `LoadEmitter`, registered via `Symbol::NAME_LOAD`). Because special forms have no `.phel` source, their documentation metadata cannot be read from the registry at runtime; it must be declared by hand in `NativeSymbolCatalog`. `load` was never added there, so it was completely absent from `phel doc` and the phel-lang.org API reference, despite being used throughout the codebase (29 uses in `src/phel/core.phel` alone).

## 💡 Goal

Make the already-implemented `load` form discoverable and documented in the public API.

## 🔖 Changes

- Add a `Symbol::NAME_LOAD` entry to `NativeSymbolCatalog::DEFINITIONS` with `doc`, `signatures`, `desc`, `docUrl`, and `example`, mirroring the `LoadSymbol` semantics (runtime file load; classpath-absolute vs caller-relative path resolution; no extension / no relative prefix; returns nil).
- CHANGELOG entry under Unreleased → Added.

`phel doc load` now renders the entry; all 84 Api tests and `NativeSymbolCatalogTest` pass; cs-fixer and phpstan clean. No compiler/runtime change needed.
