### PR TITLE
test: stop compile-time stdout leaking into the test runner

### DIFF
--- a/tests/php/Integration/Compiler/CallInlineRuntimeTest.php
+++ b/tests/php/Integration/Compiler/CallInlineRuntimeTest.php
@@ -42,6 +42,16 @@ final class CallInlineRuntimeTest extends TestCase
         $this->compilerFacade = new CompilerFacade();
         self::$globalEnv->setNs('user');
         Symbol::resetGen();
+
+        // Phel compiles/evals by executing forms, so side-effecting callees
+        // (e.g. `php/printf`) emit to stdout during these cases. Capture it so
+        // it never leaks into the test runner output.
+        ob_start();
+    }
+
+    protected function tearDown(): void
+    {
+        ob_end_clean();
     }
 
     public function test_literal_call_folds_to_a_constant(): void

--- a/tests/php/Integration/IntegrationTest.php
+++ b/tests/php/Integration/IntegrationTest.php
@@ -55,8 +55,16 @@ final class IntegrationTest extends TestCase
             ->setSource($filename);
 
         BuildFacade::enableBuildMode();
-        $compiledCode = $this->compilerFacade->compile($phelCode, $options)->getPhpCode();
-        BuildFacade::disableBuildMode();
+        // Phel compiles by evaluating top-level forms, so a fixture with
+        // top-level side effects (e.g. `println`) runs during compilation.
+        // Capture that output so it never leaks into the test runner.
+        ob_start();
+        try {
+            $compiledCode = $this->compilerFacade->compile($phelCode, $options)->getPhpCode();
+        } finally {
+            ob_end_clean();
+            BuildFacade::disableBuildMode();
+        }
 
         self::assertSame(
             trim($expectedGeneratedCode),


### PR DESCRIPTION
## 🤔 Background

Running the PHPUnit suite printed stray output into the runner progress, e.g.:

```
.................................S.............5.............. 3477 / 4185 (83%)
..1
2
3
```

PHPUnit also flagged these as "Test Printed Unexpected Output". The cause: Phel compiles by **evaluating** top-level forms (Lisp-style load), so any fixture or snippet with a top-level side effect (`println`, `php/printf`) actually executes during `compile()`/`eval()` and writes straight to stdout.

Two tests triggered it:
- `IntegrationTest` compiles every `.test` fixture, including `Foreach/foreach-skips-adapter-for-vector-literal.test` → `(foreach [x [1 2 3]] (println x))` → leaks `1 2 3`.
- `CallInlineRuntimeTest::test_side_effecting_callee_is_not_inlined` evaluates `(defn log-it [x] (php/printf "%d" x))` paths → leaks `5`.

## 💡 Goal

Keep the test runner output clean without changing compiler behaviour (compile-time evaluation of forms is intentional).

## 🔖 Changes

- `IntegrationTest`: wrap the fixture compile in `ob_start()/ob_end_clean()` (covers all `.test` fixtures).
- `CallInlineRuntimeTest`: buffer per test via `setUp()`/`tearDown()`.

No production code touched. `composer test` is green (5897 core + 4185 compiler) and the suite no longer reports unexpected output. Mirrors the earlier fix in #2333.
