### PR TITLE
docs(api): expose in-ns/use/var special forms + guard against doc gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Docs: the `load` special form is now documented in the API reference and `phel doc load` (it was implemented but missing from the native symbol catalog)
+- Docs: the `in-ns`, `use`, and `var` special forms are now documented in the API reference and `phel doc`; a regression test now fails if any registered special form lacks a catalog entry
 - `phel.reflect`: `class-attributes`/`method-attributes`/`property-attributes`/`attributes` read PHP 8 attributes as `{:name :args}` maps (#2314, #2320)
 - `phel.reflect`: `enum->keyword`/`keyword->enum`/`enum-values` bridge native PHP enums to keywords and back (#2315, #2321)
 - `iterator-seq`: lazy seq over a PHP `Traversable`, pulled one element at a time (#2312, #2318)

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -14,7 +14,7 @@
   (:require phel.ai :as ai)
   (:require phel.test :as t))
 
-(def build-facade (php/new BuildFacade))
+(def- build-facade (php/new BuildFacade))
 
 (def- munge-instance
   ;; Munge is a final readonly class; reuse one instance to avoid per-call allocation.

--- a/src/phel/schema/coercer.phel
+++ b/src/phel/schema/coercer.phel
@@ -12,7 +12,10 @@
 
 (declare coerce)
 
-(def invalid-marker :phel.schema/invalid)
+(def invalid-marker
+  "Sentinel keyword returned by coercion when a value cannot be coerced to
+  the target schema. Re-exported as `phel.schema/invalid-marker`."
+  :phel.schema/invalid)
 
 ;; Coerces to int: parses integer-shaped strings, accepts floats only when
 ;; they have no fractional part, and maps booleans to 1/0. Anything else

--- a/src/php/Api/Infrastructure/NativeSymbolCatalog.php
+++ b/src/php/Api/Infrastructure/NativeSymbolCatalog.php
@@ -189,6 +189,16 @@ The test evaluates to false if its value is false or equal to nil. Every other v
             'desc' => 'A control flow structure. First evaluates test. If test evaluates to true, only the then form is evaluated and the result is returned. If test evaluates to false only the else form is evaluated and the result is returned. If no else form is given, nil will be returned.',
             'example' => '(if (> x 0) "positive" "non-positive")',
         ],
+        Symbol::NAME_IN_NS => [
+            'doc' => '```phel
+(in-ns namespace)
+```
+Switches to an existing namespace without creating it. Intended for REPL use, e.g. navigating into a namespace to inspect or test private functions interactively. Avoid in source files: the build system assumes one namespace per file, and `in-ns` causes collisions in the dependency resolver.',
+            'docUrl' => '/documentation/namespaces/',
+            'signatures' => ['(in-ns namespace)'],
+            'desc' => 'Switches to an existing namespace without creating it (REPL-oriented).',
+            'example' => '(in-ns my-app\\core)',
+        ],
         Symbol::NAME_LET => [
             'doc' => '```phel
 (let [bindings*] expr*)
@@ -453,6 +463,26 @@ Values that should be evaluated in a macro are marked with the unquote function.
             'signatures' => ['(unquote-splicing expr)'],
             'desc' => 'Values that should be evaluated in a macro are marked with the unquote function. Shortcut: ,@',
             'example' => '`(+ ,@[1 2 3]) ; => (+ 1 2 3)',
+        ],
+        Symbol::NAME_USE => [
+            'doc' => '```phel
+(use ClassName [:as Alias])
+```
+Registers PHP class aliases in the current namespace without the full `(ns ... (:use ...))` form. Intended for files that join an existing namespace via `(in-ns ...)` and only want to declare the imports they actually use. Pure compile-time registration; emits no runtime code.',
+            'docUrl' => '/documentation/namespaces/',
+            'signatures' => ['(use ClassName & options)'],
+            'desc' => 'Registers PHP class aliases in the current namespace (compile-time only).',
+            'example' => '(use \\DateTimeImmutable :as Date)',
+        ],
+        Symbol::NAME_VAR => [
+            'doc' => '```phel
+(var sym)
+```
+Resolves `sym` against the current namespace, require aliases, and refers, yielding the first-class `Var` handle for that global definition. The reader shorthand `#\'sym` expands to `(var sym)`. Throws if `sym` does not resolve to a known global.',
+            'docUrl' => '/documentation/global-and-local-bindings/#variables',
+            'signatures' => ['(var sym)'],
+            'desc' => "Returns the Var handle for a global definition; reader shorthand is #'sym.",
+            'example' => '(var map) ; resolves to the Var for phel.core/map',
         ],
         Symbol::NAME_VECTOR => [
             'doc' => '```phel

--- a/tests/php/Unit/Api/Infrastructure/NativeSymbolCatalogTest.php
+++ b/tests/php/Unit/Api/Infrastructure/NativeSymbolCatalogTest.php
@@ -7,11 +7,32 @@ namespace PhelTest\Unit\Api\Infrastructure;
 use Phel\Api\Infrastructure\NativeSymbolCatalog;
 use Phel\Lang\Symbol;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
+use function array_unique;
+use function dirname;
+use function file_get_contents;
+use function in_array;
+use function preg_match_all;
 use function sprintf;
+use function strpos;
+use function substr;
 
 final class NativeSymbolCatalogTest extends TestCase
 {
+    /**
+     * Special forms that are intentionally absent from the API reference:
+     * each is an internal `*` form or an alias whose user-facing counterpart
+     * (`defenum`, `reify`, `php/new`) is documented instead.
+     *
+     * @var list<string>
+     */
+    private const array INTERNAL_SPECIAL_FORMS = [
+        'new',
+        'defenum*',
+        'reify*',
+    ];
+
     public function test_definitions_is_non_empty(): void
     {
         self::assertNotSame([], NativeSymbolCatalog::definitions());
@@ -32,5 +53,65 @@ final class NativeSymbolCatalogTest extends TestCase
             self::assertArrayHasKey('signatures', $meta, sprintf('Entry "%s" should declare signatures', $symbol));
             self::assertNotSame([], $meta['signatures']);
         }
+    }
+
+    /**
+     * Guards against shipping a special form that `phel doc` and the API
+     * reference cannot see (the gap that left `load` undocumented). Every
+     * special form registered in the analyzer must have a catalog entry or
+     * be listed in {@see self::INTERNAL_SPECIAL_FORMS}.
+     */
+    public function test_every_registered_special_form_is_documented(): void
+    {
+        $documented = NativeSymbolCatalog::definitions();
+
+        foreach ($this->registeredSpecialFormNames() as $name) {
+            if (in_array($name, self::INTERNAL_SPECIAL_FORMS, true)) {
+                continue;
+            }
+
+            self::assertArrayHasKey(
+                $name,
+                $documented,
+                sprintf(
+                    'Special form "%s" is registered in the analyzer but missing from NativeSymbolCatalog. '
+                    . 'Add a catalog entry (so it shows in `phel doc`) or list it in INTERNAL_SPECIAL_FORMS.',
+                    $name,
+                ),
+            );
+        }
+    }
+
+    /**
+     * Reads the special-form symbol names from the analyzer's central
+     * `match ($symbolName)` registration, resolving each `Symbol::NAME_*`
+     * constant to its string value.
+     *
+     * @return list<string>
+     */
+    private function registeredSpecialFormNames(): array
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__, 5)
+            . '/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php',
+        );
+
+        $start = strpos($source, 'match ($symbolName)');
+        $end = strpos($source, 'default =>', $start === false ? 0 : $start);
+        self::assertIsInt($start, 'Could not locate the special-form match block');
+        self::assertIsInt($end, 'Could not locate the end of the special-form match block');
+
+        $block = substr($source, $start, $end - $start);
+        preg_match_all('/Symbol::(NAME_[A-Z_]+)/', $block, $matches);
+
+        $reflection = new ReflectionClass(Symbol::class);
+        $names = [];
+        foreach (array_unique($matches[1]) as $constant) {
+            /** @var string $value */
+            $value = $reflection->getConstant($constant);
+            $names[] = $value;
+        }
+
+        return $names;
     }
 }


### PR DESCRIPTION
## 🤔 Background

Following the `load` fix (#2335), an audit of registered special forms against `NativeSymbolCatalog` found three more compiler special forms with no `.phel` source and no catalog entry, so they were invisible to `phel doc` and the phel-lang.org API reference:

- `in-ns` — switch to an existing namespace (REPL navigation)
- `use` — register PHP class aliases in the current namespace
- `var` — resolve a symbol to its first-class `Var` handle (reader shorthand `#'sym`)

A separate scan for public stdlib symbols with no docs at all found two internal holders leaking into the public surface: `repl/build-facade` and `schema` coercer/`invalid-marker`.

## 💡 Goal

Close the special-form documentation gaps and prevent the class of bug from recurring.

## 🔖 Changes

- Add `NativeSymbolCatalog` entries (doc, signature, desc, example) for `in-ns`, `use`, `var`.
- Add a regression test `test_every_registered_special_form_is_documented`: it parses the analyzer's central `match ($symbolName)` registration and asserts every special form has a catalog entry, unless allowlisted as internal (`new`, `defenum*`, `reify*` — whose user-facing forms `php/new`/`defenum`/`reify` are documented). This fails the build if a future special form ships undocumented.
- Privatize `repl/build-facade` (`def` → `def-`; only used inside `phel.repl`).
- Document `coercer/invalid-marker` (it is re-exported as `phel.schema/invalid-marker`, so it stays public).

`phel doc in-ns|use|var` now render entries. `composer test` is green (5897 core + 4186 compiler); cs-fixer + phpstan clean.
