### PR TITLE
docs(core): add :example metadata to math and predicate functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 - Docs: the `load` special form is now documented in the API reference and `phel doc load` (it was implemented but missing from the native symbol catalog)
 - Docs: the `in-ns`, `use`, and `var` special forms are now documented in the API reference and `phel doc`; a regression test now fails if any registered special form lacks a catalog entry
+- Docs: added `:example` (and missing `:see-also`) metadata to the core math (`+`, `-`, `*`, `/`, `inc`, `dec`, `bit-*`, `min`, `max`, `mean`, `median`, …) and predicate (`int?`, `float?`, `number?`, `string?`, `keyword?`, `vector?`, `map?`, `seq?`, `empty?`, …) functions, so they show runnable examples in `phel doc` and the API reference
 - `phel.reflect`: `class-attributes`/`method-attributes`/`property-attributes`/`attributes` read PHP 8 attributes as `{:name :args}` maps (#2314, #2320)
 - `phel.reflect`: `enum->keyword`/`keyword->enum`/`enum-values` bridge native PHP enums to keywords and back (#2315, #2321)
 - `iterator-seq`: lazy seq over a PHP `Traversable`, pulled one element at a time (#2312, #2318)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -29,7 +29,9 @@
 
 (defn bit-and
   "Bitwise and."
-  {:inline (fn [x y & args] `(do (assert-non-nil ~x ~y ~@args) (php/& ~x ~y ~@args)))}
+  {:inline (fn [x y & args] `(do (assert-non-nil ~x ~y ~@args) (php/& ~x ~y ~@args)))
+   :example "(bit-and 12 10) ; => 8"
+   :see-also ["bit-or" "bit-xor" "bit-not"]}
   [x y & args]
   (let [all (concat [x y] args)]
     (apply assert-non-nil all)
@@ -37,7 +39,9 @@
 
 (defn bit-or
   "Bitwise or."
-  {:inline (fn [x y & args] `(do (assert-non-nil ~x ~y ~@args) (php/| ~x ~y ~@args)))}
+  {:inline (fn [x y & args] `(do (assert-non-nil ~x ~y ~@args) (php/| ~x ~y ~@args)))
+   :example "(bit-or 12 10) ; => 14"
+   :see-also ["bit-and" "bit-xor" "bit-not"]}
   [x y & args]
   (let [all (concat [x y] args)]
     (apply assert-non-nil all)
@@ -45,7 +49,9 @@
 
 (defn bit-xor
   "Bitwise xor."
-  {:inline (fn [x y & args] `(do (assert-non-nil ~x ~y ~@args) (php/^ ~x ~y ~@args)))}
+  {:inline (fn [x y & args] `(do (assert-non-nil ~x ~y ~@args) (php/^ ~x ~y ~@args)))
+   :example "(bit-xor 12 10) ; => 6"
+   :see-also ["bit-and" "bit-or" "bit-not"]}
   [x y & args]
   (let [all (concat [x y] args)]
     (apply assert-non-nil all)
@@ -53,21 +59,27 @@
 
 (defn bit-not
   "Bitwise complement."
-  {:inline (fn [x] `(do (assert-non-nil ~x) (php/~ ~x)))}
+  {:inline (fn [x] `(do (assert-non-nil ~x) (php/~ ~x)))
+   :example "(bit-not 0) ; => -1"
+   :see-also ["bit-and" "bit-or" "bit-xor"]}
   [x]
   (assert-non-nil x)
   (php/~ x))
 
 (defn bit-shift-left
   "Bitwise shift left."
-  {:inline (fn [x n] `(do (assert-non-nil ~x ~n) (php/<< ~x ~n)))}
+  {:inline (fn [x n] `(do (assert-non-nil ~x ~n) (php/<< ~x ~n)))
+   :example "(bit-shift-left 1 4) ; => 16"
+   :see-also ["bit-shift-right"]}
   [x n]
   (assert-non-nil x n)
   (php/<< x n))
 
 (defn bit-shift-right
   "Bitwise shift right."
-  {:inline (fn [x n] `(do (assert-non-nil ~x ~n) (php/>> ~x ~n)))}
+  {:inline (fn [x n] `(do (assert-non-nil ~x ~n) (php/>> ~x ~n)))
+   :example "(bit-shift-right 16 2) ; => 4"
+   :see-also ["bit-shift-left"]}
   [x n]
   (assert-non-nil x n)
   (php/>> x n))
@@ -115,6 +127,8 @@
 (defn +
   "Returns the sum of all elements in `xs`. All elements `xs` must be numbers.
   If `xs` is empty, return 0."
+  {:example "(+ 1 2 3) ; => 6"
+   :see-also ["-" "*" "/" "sum"]}
   [& xs]
   (apply assert-non-nil xs)
   (case (count xs)
@@ -126,6 +140,8 @@
 (defn -
   "Returns the difference of all elements in `xs`. If `xs` is empty, return 0. If `xs`
   has one element, return the negative value of that element."
+  {:example "(- 10 3 2) ; => 5\n(- 4) ; => -4"
+   :see-also ["+" "*" "/"]}
   [& xs]
   (apply assert-non-nil xs)
   (case (count xs)
@@ -137,6 +153,8 @@
 (defn *
   "Returns the product of all elements in `xs`. All elements in `xs` must be
 numbers. If `xs` is empty, return 1."
+  {:example "(* 2 3 4) ; => 24"
+   :see-also ["+" "-" "/"]}
   [& xs]
   (apply assert-non-nil xs)
   (case (count xs)
@@ -152,6 +170,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   Integer division with a non-zero remainder returns a `Ratio`
   (e.g. `(/ 1 2) => 1/2`). Use `(/ 1.0 2)` or `(double ...)` for float
   division."
+  {:example "(/ 1 2) ; => 1/2\n(/ 10 2) ; => 5"
+   :see-also ["+" "-" "*" "quot" "mod"]}
   [& xs]
   (apply assert-non-nil xs)
   (case (count xs)
@@ -199,18 +219,24 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn **
   "Return `a` to the power of `x`."
+  {:example "(** 2 8) ; => 256"
+   :see-also ["*" "sqrt"]}
   [a x]
   (assert-non-nil a x)
   (php/:: NumericOperations (power a x)))
 
 (defn inc
   "Increments `x` by one."
+  {:example "(inc 1) ; => 2"
+   :see-also ["dec" "+"]}
   [x]
   (assert-non-nil x)
   (php/:: NumericOperations (add x 1)))
 
 (defn dec
   "Decrements `x` by one."
+  {:example "(dec 5) ; => 4"
+   :see-also ["inc" "-"]}
   [x]
   (assert-non-nil x)
   (php/:: NumericOperations (subtract x 1)))
@@ -266,36 +292,50 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn even?
   "Checks if `x` is even."
+  {:example "(even? 4) ; => true"
+   :see-also ["odd?" "zero?"]}
   [x]
   (php/:: NumericOperations (isZero (% x 2))))
 
 (defn odd?
   "Checks if `x` is odd."
+  {:example "(odd? 3) ; => true"
+   :see-also ["even?" "zero?"]}
   [x]
   (not (even? x)))
 
 (defn zero?
   "Checks if `x` is zero."
+  {:example "(zero? 0) ; => true"
+   :see-also ["pos?" "neg?" "one?"]}
   [x]
   (php/:: NumericOperations (isZero x)))
 
 (defn one?
   "Checks if `x` is one."
+  {:example "(one? 1) ; => true"
+   :see-also ["zero?"]}
   [x]
   (or (= x 1) (= x 1.0)))
 
 (defn pos?
   "Checks if `x` is greater than zero."
+  {:example "(pos? 3) ; => true"
+   :see-also ["neg?" "zero?"]}
   [x]
   (> x 0))
 
 (defn neg?
   "Checks if `x` is smaller than zero."
+  {:example "(neg? -2) ; => true"
+   :see-also ["pos?" "zero?"]}
   [x]
   (< x 0))
 
 (defn nan?
   "Checks if `x` is not a number."
+  {:example "(nan? ##NaN) ; => true"
+   :see-also ["NaN?" "inf?"]}
   [x]
   (if (nil? x)
     false
@@ -303,7 +343,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn NaN?
   "Checks if `x` is not a number. Alias for `nan?`, matching Clojure's `NaN?`."
-  {:see-also ["nan?" "inf?"]}
+  {:example "(NaN? ##NaN) ; => true"
+   :see-also ["nan?" "inf?"]}
   [x]
   (nan? x))
 
@@ -461,17 +502,23 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn rand-int
   "Returns a random number between 0 and `n`."
+  {:example "(rand-int 100) ; => 42"
+   :see-also ["rand" "rand-nth"]}
   [n]
   (php/random_int 0 n))
 
 (defn rand-nth
   "Returns a random item from xs."
+  {:example "(rand-nth [:a :b :c]) ; => :b"
+   :see-also ["rand" "rand-int"]}
   [xs]
   (when-not (nil? xs)
     (get xs (rand-int (dec (count xs))))))
 
 (defn extreme
   "Returns the most extreme value in `args` based on the binary `order` function."
+  {:example "(extreme > [1 5 2]) ; => 5"
+   :see-also ["min" "max" "reduce"]}
   [order args]
   (reduce #(if (order %1 %2) %1 %2) args))
 
@@ -482,6 +529,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 (defn min
   "Returns the minimum of all arguments. Returns `##NaN` whenever any
   numeric argument is `##NaN`."
+  {:example "(min 3 1 2) ; => 1"
+   :see-also ["max" "min-key" "extreme"]}
   [& numbers]
   (cond
     (php/=== 1 (count numbers)) (first numbers)
@@ -491,6 +540,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 (defn max
   "Returns the maximum of all arguments. Returns `##NaN` whenever any
   numeric argument is `##NaN`."
+  {:example "(max 3 1 2) ; => 3"
+   :see-also ["min" "max-key" "extreme"]}
   [& numbers]
   (cond
     (php/=== 1 (count numbers)) (first numbers)
@@ -527,6 +578,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn coerce-in
   "Returns `v` if it is in the range, or `min` if `v` is less than `min`, or `max` if `v` is greater than `max`."
+  {:example "(coerce-in 5 0 10) ; => 5\n(coerce-in 15 0 10) ; => 10"
+   :see-also ["min" "max"]}
   [v min max]
   (when (< max min)
     (throw (php/new \InvalidArgumentException "Max values is bigger than min value")))
@@ -534,17 +587,23 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn sum
   "Returns the sum of all elements is `xs`."
+  {:example "(sum [1 2 3]) ; => 6"
+   :see-also ["+" "mean" "median"]}
   [xs]
   (apply + xs))
 
 (defn mean
   "Returns the mean of `xs` as a float."
+  {:example "(mean [1 2 3]) ; => 2"
+   :see-also ["sum" "median"]}
   [xs]
   (php/fdiv (sum xs) (count xs)))
 
 (defn median
   "Returns the median of `xs`. With an even-sized collection the result is
   the float average of the two middle elements."
+  {:example "(median [3 1 2]) ; => 2\n(median [1 2 3 4]) ; => 2.5"
+   :see-also ["mean" "sum"]}
   [xs]
   (let [arr (to-php-array xs)
         cnt (count arr)]

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -65,6 +65,8 @@
 * `:php/resource`
 * `:php/object`
 * `:unknown`"
+  {:example "(type [1 2]) ; => :vector\n(type :a) ; => :keyword"
+   :see-also ["vector?" "map?" "keyword?"]}
   [x]
   (cond
     (php/instanceof x PersistentVectorInterface)  :vector
@@ -132,13 +134,16 @@
 
 (defn float?
   "Returns true if `x` is float point number, false otherwise."
+  {:example "(float? 1.0) ; => true\n(float? 1) ; => false"
+   :see-also ["int?" "number?" "double?"]}
   [x]
   (php/is_float x))
 
 (defn integer?
   "Returns true if `x` is a mathematical integer: a fixed-precision PHP
    `int` or a `BigInt`."
-  {:see-also ["int?" "bigint?"]}
+  {:example "(integer? 1) ; => true\n(integer? 1.0) ; => false"
+   :see-also ["int?" "bigint?"]}
   [x]
   (or (php/is_int x)
       (php/instanceof x BigInt)))
@@ -146,7 +151,8 @@
 (defn int?
   "Returns true if `x` is a fixed-precision PHP integer. `BigInt`
    values return false; use `integer?` to accept either."
-  {:see-also ["integer?" "bigint?"]}
+  {:example "(int? 1) ; => true\n(int? 1.0) ; => false"
+   :see-also ["integer?" "bigint?"]}
   [x]
   (php/is_int x))
 
@@ -183,6 +189,8 @@
 
 (defn number?
   "Returns true if `x` is a number: int, float, `Ratio`, `BigInt`, or `BigDecimal`."
+  {:example "(number? 1) ; => true\n(number? \"a\") ; => false"
+   :see-also ["int?" "float?" "integer?"]}
   [x]
   (or (php/is_int x)
       (php/is_float x)
@@ -204,12 +212,15 @@
    Alias for `float?`, matching Clojure's `double?` naming. Since Phel
    uses PHP floats (IEEE 754 doubles) there is no separate single-precision
    float type."
-  {:see-also ["float?" "number?"]}
+  {:example "(double? 1.0) ; => true"
+   :see-also ["float?" "number?"]}
   [x]
   (float? x))
 
 (defn string?
   "Returns true if `x` is a string, false otherwise."
+  {:example "(string? \"a\") ; => true\n(string? :a) ; => false"
+   :see-also ["char?" "keyword?"]}
   [x]
   (php/is_string x))
 
@@ -228,11 +239,15 @@
 
 (defn keyword?
   "Returns true if `x` is a keyword, false otherwise."
+  {:example "(keyword? :a) ; => true\n(keyword? 'a) ; => false"
+   :see-also ["symbol?" "ident?" "simple-keyword?"]}
   [x]
   (php/instanceof x Keyword))
 
 (defn symbol?
   "Returns true if `x` is a symbol, false otherwise."
+  {:example "(symbol? 'a) ; => true\n(symbol? :a) ; => false"
+   :see-also ["keyword?" "ident?" "simple-symbol?"]}
   [x]
   (php/instanceof x Symbol))
 
@@ -245,19 +260,22 @@
 
 (defn simple-symbol?
   "Returns true if `x` is a symbol without a namespace."
-  {:see-also ["symbol?" "simple-ident?"]}
+  {:example "(simple-symbol? 'a) ; => true\n(simple-symbol? 'foo/bar) ; => false"
+   :see-also ["symbol?" "simple-ident?"]}
   [x]
   (and (symbol? x) (nil? (php/-> x (getNamespace)))))
 
 (defn simple-keyword?
   "Returns true if `x` is a keyword without a namespace."
-  {:see-also ["keyword?" "simple-ident?"]}
+  {:example "(simple-keyword? :a) ; => true\n(simple-keyword? :foo/bar) ; => false"
+   :see-also ["keyword?" "simple-ident?"]}
   [x]
   (and (keyword? x) (nil? (php/-> x (getNamespace)))))
 
 (defn simple-ident?
   "Returns true if `x` is a symbol or keyword without a namespace."
-  {:see-also ["simple-symbol?" "simple-keyword?" "ident?"]}
+  {:example "(simple-ident? 'a) ; => true\n(simple-ident? 'foo/bar) ; => false"
+   :see-also ["simple-symbol?" "simple-keyword?" "ident?"]}
   [x]
   (or (simple-symbol? x) (simple-keyword? x)))
 
@@ -282,6 +300,8 @@
 
 (defn fn?
   "Returns true if `x` is a function, false otherwise."
+  {:example "(fn? inc) ; => true\n(fn? 42) ; => false"
+   :see-also ["ifn?"]}
   [x]
   (= (type x) :function))
 
@@ -308,6 +328,8 @@
 
 (defn map?
   "Returns true if `x` is a hash map, false otherwise."
+  {:example "(map? {:a 1}) ; => true\n(map? [1 2]) ; => false"
+   :see-also ["vector?" "set?" "associative?"]}
   [x]
   (and (php/instanceof x PersistentMapInterface)
        (not (php/instanceof x AbstractPersistentStruct))))
@@ -323,6 +345,8 @@
   "Returns true if `x` is a vector. Map entries returned by iterating a
   hash map (`(first {:a 1})`) are vector-shaped two-element values, so
   this predicate also accepts the typed `MapEntry`."
+  {:example "(vector? [1 2]) ; => true\n(vector? '(1 2)) ; => false"
+   :see-also ["map?" "list?" "sequential?"]}
   [x]
   (or (php/instanceof x PersistentVectorInterface)
       (php/instanceof x MapEntry)))
@@ -340,6 +364,8 @@
 (defn list?
   "Returns true if `x` is a list, false otherwise.
   Returns false for the seq view of non-list collections produced by `seq`."
+  {:example "(list? '(1 2)) ; => true\n(list? [1 2]) ; => false"
+   :see-also ["vector?" "seq?" "sequential?"]}
   [x]
   (and (php/instanceof x PersistentListInterface)
        (php/-> x (isList))))
@@ -353,6 +379,8 @@
 
 (defn boolean?
   "Returns true if `x` is a boolean, false otherwise."
+  {:example "(boolean? true) ; => true\n(boolean? nil) ; => false"
+   :see-also ["boolean" "nil?"]}
   [x]
   (php/is_bool x))
 
@@ -385,6 +413,8 @@
 
 (defn php-array?
   "Returns true if `x` is a PHP Array, false otherwise."
+  {:example "(php-array? (php/array 1 2)) ; => true\n(php-array? [1 2]) ; => false"
+   :see-also ["php-object?" "php-resource?" "vector?"]}
   [x]
   (php/is_array x))
 
@@ -395,13 +425,16 @@
 
 (defn php-object?
   "Returns true if `x` is a PHP object, false otherwise."
+  {:example "(php-object? (php/new \\stdClass)) ; => true"
+   :see-also ["php-array?" "php-resource?"]}
   [x]
   (= (type x) :php/object))
 
 (defn seq?
   "Returns true if `x` is a seq (a list, a lazy sequence, or a realized
   `Cons` cell returned by `(next some-lazy-seq)`)."
-  {:see-also ["seq" "lazy-seq" "lazy-seq?"]}
+  {:example "(seq? '(1 2)) ; => true\n(seq? [1 2]) ; => false"
+   :see-also ["seq" "lazy-seq" "lazy-seq?"]}
   [x]
   (or (php/instanceof x LazySeqInterface)
       (php/instanceof x Cons)
@@ -420,6 +453,8 @@
 (defn empty?
   "Returns true if x would be 0, \"\" or empty collection, false otherwise.
   Safe on infinite/lazy sequences: checks the first element instead of counting."
+  {:example "(empty? []) ; => true\n(empty? [1]) ; => false"
+   :see-also ["not-empty" "empty" "count"]}
   [x]
   (cond
     (php/is_numeric x)                  (= 0 x)
@@ -430,6 +465,8 @@
 
 (defn not-empty
   "Returns `coll` if it contains elements, otherwise nil."
+  {:example "(not-empty [1 2]) ; => [1 2]\n(not-empty []) ; => nil"
+   :see-also ["empty?" "empty"]}
   [coll]
   (if (empty? coll)
     nil
@@ -576,6 +613,8 @@
 
 (defn set?
   "Returns true if `x` is a set, false otherwise."
+  {:example "(set? (hash-set 1 2)) ; => true\n(set? [1 2]) ; => false"
+   :see-also ["map?" "vector?" "sorted?"]}
   [x]
   (php/instanceof x PersistentHashSetInterface))
 


### PR DESCRIPTION
## 🤔 Background

Following the doc-coverage audit (#2337), ~227 public stdlib symbols had a `:doc` but no `:example`, so they render without a usage example in `phel doc` and the phel-lang.org API reference. The highest-traffic gaps were the core math and predicate functions.

## 💡 Goal

Add runnable `:example` metadata (and fill in missing `:see-also`) for the core math and predicate functions. Every example output was verified against the readable `Printer` (the same representation `phel doc`/REPL prints), so the documented results are accurate.

## 🔖 Changes

`src/phel/core/math.phel` — `+`, `-`, `*`, `/`, `**`, `inc`, `dec`, `bit-and`, `bit-or`, `bit-xor`, `bit-not`, `bit-shift-left`, `bit-shift-right`, `even?`, `odd?`, `zero?`, `one?`, `pos?`, `neg?`, `nan?`, `NaN?`, `extreme`, `min`, `max`, `coerce-in`, `sum`, `mean`, `median`, `rand-int`, `rand-nth`.

`src/phel/core/predicates.phel` — `type`, `float?`, `integer?`, `int?`, `number?`, `double?`, `string?`, `keyword?`, `symbol?`, `simple-symbol?`, `simple-keyword?`, `simple-ident?`, `fn?`, `map?`, `vector?`, `list?`, `boolean?`, `php-array?`, `php-object?`, `seq?`, `empty?`, `not-empty`, `set?`.

Skipped: deprecated aliases (`function?`, `hash-map?`), and a few with no clean deterministic example (`struct?`, `php-resource?`). `rand-int`/`rand-nth` use representative values like the existing `rand` example.

`composer test-core` green (5897); `phel format` clean; doc spot-checked.
