### PR TITLE
feat(formatter): align ns/indentation with cljfmt best practices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `phel format`: collapses runs of consecutive blank lines to a single blank line (cljfmt's `:remove-consecutive-blank-lines?`)
-- `phel format`: cljfmt-aligned indentation for more forms — `defstruct`, `defrecord`, `definterface`, `defexception`, `defenum`, `defprotocol`, `defmulti`, `defmethod`, `defonce`, `reify` (inner), and `when-first`, `doseq`, `dotimes`, `letfn`, `with-redefs`, `with-bindings`, `extend-type`, `extend-protocol`, `with-output-buffer`, `delay`, `lazy-seq` (block); previously these fell back to call-style alignment
+- `phel format`: collapses consecutive blank lines to one, and indents more definition/body forms (`defstruct`, `defprotocol`, `defmethod`, `reify`, `doseq`, `letfn`, …) the cljfmt way instead of call-style alignment
 - Docs: `load`, `in-ns`, `use`, and `var` special forms now documented in the API reference and `phel doc`; a regression test fails if any registered special form lacks a catalog entry
 - Docs: `:example` (and missing `:see-also`) metadata on the core math (`+`, `-`, `*`, `/`, `bit-*`, `min`, `max`, `mean`, `median`, …) and predicate (`int?`, `float?`, `string?`, `keyword?`, `vector?`, `map?`, `seq?`, `empty?`, …) functions
 - `phel.reflect`: `class-attributes`/`method-attributes`/`property-attributes`/`attributes` read PHP 8 attributes as `{:name :args}` maps (#2314, #2320)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Docs: function `:example` outputs now match REPL output, so `phel doc` and the API reference are accurate
 - `phel->php`: integer/string map keys now convert instead of throwing `getName() on int` (#2298)
 - Structs: `$struct['field']` array access now accepts a plain PHP string offset (was keyword-only) (#2313, #2319)
+- Dependencies: constrain `gacela-project/gacela` to `^1.14 <1.15`; 1.15.0 breaks the `run`/`build`/`export` console commands. Lift once Phel supports it
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `phel format`: collapses runs of consecutive blank lines to a single blank line (cljfmt's `:remove-consecutive-blank-lines?`)
+- `phel format`: cljfmt-aligned indentation for more forms — `defstruct`, `defrecord`, `definterface`, `defexception`, `defenum`, `defprotocol`, `defmulti`, `defmethod`, `defonce`, `reify` (inner), and `when-first`, `doseq`, `dotimes`, `letfn`, `with-redefs`, `with-bindings`, `extend-type`, `extend-protocol`, `with-output-buffer`, `delay`, `lazy-seq` (block); previously these fell back to call-style alignment
 - Docs: `load`, `in-ns`, `use`, and `var` special forms now documented in the API reference and `phel doc`; a regression test fails if any registered special form lacks a catalog entry
 - Docs: `:example` (and missing `:see-also`) metadata on the core math (`+`, `-`, `*`, `/`, `bit-*`, `min`, `max`, `mean`, `median`, …) and predicate (`int?`, `float?`, `string?`, `keyword?`, `vector?`, `map?`, `seq?`, `empty?`, …) functions
 - `phel.reflect`: `class-attributes`/`method-attributes`/`property-attributes`/`attributes` read PHP 8 attributes as `{:name :args}` maps (#2314, #2320)

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=8.4",
         "amphp/amp": "^3.1",
-        "gacela-project/gacela": "^1.14",
+        "gacela-project/gacela": "^1.14 <1.15",
         "symfony/console": "^6.0|^7.0|^8.0",
         "symfony/routing": "^7.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf3f895c66e75351eb2a45d85f0f6b60",
+    "content-hash": "752d0e1cbe299e924e7d5e812899e3e3",
     "packages": [
         {
             "name": "amphp/amp",
@@ -89,16 +89,16 @@
         },
         {
             "name": "gacela-project/container",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/container.git",
-                "reference": "62a409c918fe0e301b909da1c54aea189bd6e76a"
+                "reference": "6251aaf6973ab7ddc41f596a18a8ea9334582a1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/container/zipball/62a409c918fe0e301b909da1c54aea189bd6e76a",
-                "reference": "62a409c918fe0e301b909da1c54aea189bd6e76a",
+                "url": "https://api.github.com/repos/gacela-project/container/zipball/6251aaf6973ab7ddc41f596a18a8ea9334582a1b",
+                "reference": "6251aaf6973ab7ddc41f596a18a8ea9334582a1b",
                 "shasum": ""
             },
             "require": {
@@ -145,7 +145,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/resolver/issues",
-                "source": "https://github.com/gacela-project/container/tree/0.8.0"
+                "source": "https://github.com/gacela-project/container/tree/0.8.1"
             },
             "funding": [
                 {
@@ -153,7 +153,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-11-08T22:36:48+00:00"
+            "time": "2026-06-05T11:50:32+00:00"
         },
         {
             "name": "gacela-project/gacela",

--- a/src/phel/core/lazy.phel
+++ b/src/phel/core/lazy.phel
@@ -48,10 +48,10 @@
    :see-also ["iterate" "repeatedly" "lazy-seq"]}
   [step opts]
   (lazy-seq
-   (let [kf     (get opts :kf identity)
-         vf     (get opts :vf identity)
-         initk  (get opts :initk)
-         result (step initk)]
-     (when (not (nil? result))
-       (cons (vf result)
-             (iteration step (assoc opts :initk (kf result))))))))
+    (let [kf     (get opts :kf identity)
+          vf     (get opts :vf identity)
+          initk  (get opts :initk)
+          result (step initk)]
+      (when (not (nil? result))
+        (cons (vf result)
+              (iteration step (assoc opts :initk (kf result))))))))

--- a/src/phel/core/loops.phel
+++ b/src/phel/core/loops.phel
@@ -5,7 +5,6 @@
 
 ;; --- Side-effect loops ---
 
-
 (defn run!
   "Calls `(f x)` for each element in `coll` for side effects. Returns nil."
   {:example "(run! println [1 2 3])"
@@ -22,4 +21,4 @@
   (let [n-sym (gensym)]
     `(let [~n-sym ~n]
        (doseq [~binding :range [0 ~n-sym]]
-              ~@body))))
+         ~@body))))

--- a/src/phel/core/parsing.phel
+++ b/src/phel/core/parsing.phel
@@ -44,4 +44,3 @@
     (cond
       (= s "true")  true
       (= s "false") false)))
-

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -650,7 +650,6 @@
             (copy-meta coll result))))
     (throw (php/new InvalidArgumentException "distinct expects 0 or 1 arguments"))))
 
-
 (defn reverse
   "Reverses the order of the elements in the given sequence."
   {:example "(reverse [1 2 3 4]) ; => [4 3 2 1]"
@@ -781,7 +780,6 @@
     (foreach [k v arr]
       (php/-> res (put k v)))
     (persistent res)))
-
 
 (defn- phel->php-key
   "Converts a Phel map key into a valid PHP array key: named keys

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -49,7 +49,6 @@
         nil
         (php/aget coll (php/- n 1))))))
 
-
 (defn push
   "Inserts `x` at the end of the sequence `coll`."
   {:deprecated "0.25.0"

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -8,30 +8,30 @@
 ;; ---
 
 (defstruct uri [scheme userinfo host port path query fragment]
-           Stringable
-           (__toString [this]
-                       (let [authority (str host)
-                             authority (if (and userinfo (not= userinfo ""))
-                                         (str userinfo "@" authority)
-                                         authority)
-                             authority (if port
-                                         (str authority ":" port)
-                                         authority)
-                             res       ""
-                             res       (if (and scheme (not= scheme ""))
-                                         (str res scheme ":")
-                                         res)
-                             res       (if (or (not= authority "") (= scheme "file"))
-                                         (str res "//" authority)
-                                         res)
-                             res       (str res path)
-                             res       (if (and query (not= query ""))
-                                         (str res "?" query)
-                                         res)
-                             res       (if (and fragment (not= fragment ""))
-                                         (str res "#" fragment)
-                                         res)]
-                         res)))
+  Stringable
+  (__toString [this]
+              (let [authority (str host)
+                    authority (if (and userinfo (not= userinfo ""))
+                                (str userinfo "@" authority)
+                                authority)
+                    authority (if port
+                                (str authority ":" port)
+                                authority)
+                    res       ""
+                    res       (if (and scheme (not= scheme ""))
+                                (str res scheme ":")
+                                res)
+                    res       (if (or (not= authority "") (= scheme "file"))
+                                (str res "//" authority)
+                                res)
+                    res       (str res path)
+                    res       (if (and query (not= query ""))
+                                (str res "?" query)
+                                res)
+                    res       (if (and fragment (not= fragment ""))
+                                (str res "#" fragment)
+                                res)]
+                res)))
 
 (def- uri-host-port-regex "/^(.+)\:(\d+)$/")
 
@@ -449,7 +449,6 @@
         (if reason (str " " reason) ""))
        true
        status))))
-
 
 (defn- assert-no-crlf [value]
   (when (and (string? value)

--- a/src/phel/match.phel
+++ b/src/phel/match.phel
@@ -130,9 +130,9 @@
                       "match :or pattern requires at least one alternative")))
     (let [compiled (for [a :in alts] (compile-pattern target a))]
       (doseq [c :in compiled]
-             (when-not (empty? (get c :bindings))
-               (throw (php/new \InvalidArgumentException
-                               "match :or alternatives must not introduce bindings"))))
+        (when-not (empty? (get c :bindings))
+          (throw (php/new \InvalidArgumentException
+                          "match :or alternatives must not introduce bindings"))))
       (let [checks (for [c :in compiled] (get c :check))]
         {:check `(or ~@checks), :bindings []}))))
 

--- a/src/phel/mock.phel
+++ b/src/phel/mock.phel
@@ -210,10 +210,10 @@
         mock-syms (map (fn [_] (gensym "mock")) values)]
     `(let [~@(interleave mock-syms values)]
        (with-redefs [~@(interleave symbols mock-syms)]
-                    (try
-                      (do ~@body)
-                      (finally
-                        ~@(map (fn [m] `(reset-mock! ~m)) mock-syms)))))))
+         (try
+           (do ~@body)
+           (finally
+             ~@(map (fn [m] `(reset-mock! ~m)) mock-syms)))))))
 
 (defmacro with-mock-wrapper
   "Like with-mocks but for wrapped mocks (interop scenarios).
@@ -243,7 +243,7 @@
     `(let [~@(interleave mock-syms mocks)
            ~@(interleave wrapper-syms wrappers)]
        (with-redefs [~@(interleave symbols wrapper-syms)]
-                    (try
-                      (do ~@body)
-                      (finally
-                        ~@reset-forms))))))
+         (try
+           (do ~@body)
+           (finally
+             ~@reset-forms))))))

--- a/src/phel/router.phel
+++ b/src/phel/router.phel
@@ -116,10 +116,10 @@
   (constantly (h/response-from-map {:status status, :body body})))
 
 (definterface Router
-              (routes [this] "Returns all registered routes as a vector of [path data] tuples.")
-              (match-by-path [this path] "Matches a route given a path. Returns nil if path doesn't match.")
-              (match-by-name [this route-name] "Matches a route given a route name. Returns nil if route can't be found.")
-              (generate [this route-name parameter] "Generate a url for a route"))
+  (routes [this] "Returns all registered routes as a vector of [path data] tuples.")
+  (match-by-path [this path] "Matches a route given a path. Returns nil if path doesn't match.")
+  (match-by-name [this route-name] "Matches a route given a route name. Returns nil if route can't be found.")
+  (generate [this route-name parameter] "Generate a url for a route"))
 
 (defn- build-route-collection [normalized-routes]
   (for [route :in normalized-routes
@@ -177,20 +177,20 @@
     {:template template, :data data}))
 
 (defstruct SymfonyRouter [normalized-routes route-collection matcher generator]
-           Router
-           (routes [this] normalized-routes)
-           (match-by-path [this path]
-                          (match-with matcher path
-                                      (fn [route-name]
-                                        (let [route (php/-> route-collection (get route-name))]
-                                          [(php/-> route (getOption "template"))
-                                           (php/-> route (getOption "data"))]))))
-           (match-by-name [this route-name]
-                          (when-let [route (php/-> route-collection (get (full-name route-name)))]
-                            {:template (php/-> route (getOption "template"))
-                             :data     (php/-> route (getOption "data"))}))
-           (generate [this route-name parameters]
-                     (generate-with generator route-name parameters)))
+  Router
+  (routes [this] normalized-routes)
+  (match-by-path [this path]
+                 (match-with matcher path
+                             (fn [route-name]
+                               (let [route (php/-> route-collection (get route-name))]
+                                 [(php/-> route (getOption "template"))
+                                  (php/-> route (getOption "data"))]))))
+  (match-by-name [this route-name]
+                 (when-let [route (php/-> route-collection (get (full-name route-name)))]
+                   {:template (php/-> route (getOption "template"))
+                    :data     (php/-> route (getOption "data"))}))
+  (generate [this route-name parameters]
+            (generate-with generator route-name parameters)))
 
 (defn router
   "Builds a dynamic `Router` from a nested route tree.
@@ -219,14 +219,14 @@
                    (php/new UrlGenerator coll ctx))))
 
 (defstruct CompiledSymfonyRouter [normalized-routes matcher generator indexed-routes]
-           Router
-           (routes [this] normalized-routes)
-           (match-by-path [this path]
-                          (match-with matcher path |(get indexed-routes $)))
-           (match-by-name [this route-name]
-                          (indexed-route->match (get indexed-routes (full-name route-name))))
-           (generate [this route-name parameters]
-                     (generate-with generator route-name parameters)))
+  Router
+  (routes [this] normalized-routes)
+  (match-by-path [this path]
+                 (match-with matcher path |(get indexed-routes $)))
+  (match-by-name [this route-name]
+                 (indexed-route->match (get indexed-routes (full-name route-name))))
+  (generate [this route-name parameters]
+            (generate-with generator route-name parameters)))
 
 (defmacro compiled-router
   "Like `router` but performs Symfony's route compilation at macro-expansion
@@ -243,9 +243,9 @@
   (let [{:path path, :data data, :or {path "", data {}}} (or (eval options) {})
         flattened-routes                                 (vec (flatten-routes (eval raw-routes) path data))
         indexed-routes                                   (persistent
-                                                       (for [route :in flattened-routes
-                                                             :reduce [acc (transient {})]]
-                                                         (assoc! acc (route-name-of route) route)))
+                                                          (for [route :in flattened-routes
+                                                                :reduce [acc (transient {})]]
+                                                            (assoc! acc (route-name-of route) route)))
         route-collection                                 (build-route-collection flattened-routes)
         compiled-matcher-routes                          (php/-> (php/new CompiledUrlMatcherDumper route-collection) (getCompiledRoutes))
         compiled-generator-routes                        (php/-> (php/new CompiledUrlGeneratorDumper route-collection) (getCompiledRoutes))

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -126,7 +126,7 @@
 ;;   (defmethod report :custom-type [event] ...)
 ;; or by registering a function through `set-reporters!`/`add-reporter!`.
 (defmulti report
-          "Records a test-framework event and dispatches it to the active
+  "Records a test-framework event and dispatches it to the active
   reporters. `data` must contain a `:type` key (`:pass`, `:failed`,
   `:error`, `:begin-test-ns`, `:end-test-ns`, `:begin-test-run`,
   `:summary`, or a user-defined event). The default methods for
@@ -134,7 +134,7 @@
   registered reporter. Other event types flow straight through to the
   reporter set. Extend by registering
   `(defmethod report :custom-type [event] ...)`."
-          (fn [data] (:type data)))
+  (fn [data] (:type data)))
 
 (defn- report-assertion! [data]
   (let [decorated (decorate-event data)]
@@ -142,13 +142,13 @@
     (fan-out! decorated)))
 
 (defmethod report :pass [data]
-           (report-assertion! (assoc data :state :pass)))
+  (report-assertion! (assoc data :state :pass)))
 
 (defmethod report :failed [data]
-           (report-assertion! (assoc data :state :failed)))
+  (report-assertion! (assoc data :state :failed)))
 
 (defmethod report :error [data]
-           (report-assertion! (assoc data :state :error)))
+  (report-assertion! (assoc data :state :error)))
 
 ;; `:predicate`, `:binary`, `:any`, `:thrown`, `:thrown-with-msg` — the
 ;; legacy assertion-level types emitted by the built-in `is` macro. Each
@@ -180,11 +180,11 @@
   (swap! report-methods assoc event-type fan-out!))
 
 (defmethod report :skipped [data]
-           (record-skip! data)
-           (fan-out! data))
+  (record-skip! data)
+  (fan-out! data))
 
 (defmethod report :default [data]
-           (fan-out! (decorate-event data)))
+  (fan-out! (decorate-event data)))
 
 (defn do-report
   "Add file and line information to a test result and call report.
@@ -194,7 +194,6 @@
    :example "(do-report {:state :pass :type :any :message \"ok\"})"}
   [m]
   (report m))
-
 
 ;; ---------------------------
 ;; `is` macro and its asserts
@@ -326,28 +325,28 @@
 ;; returning a quoted form to be evaluated by `is`. Methods must be
 ;; loaded before any `is` form using their dispatch value is expanded.
 (defmulti assert-expr
-          (fn [_ form]
-            (if (and (list? form) (symbol? (first form)))
-              (first form)
-              :default)))
+  (fn [_ form]
+    (if (and (list? form) (symbol? (first form)))
+      (first form)
+      :default)))
 
 (defmethod assert-expr 'not [message form]
-           (let [inner (second form)]
-             (cond
-               (and (list? inner) (= 3 (count inner)))
-               (assert-binary inner message true)
-               (and (list? inner) (= 2 (count inner)))
-               (assert-predicate inner message true)
-               (assert-any form message))))
+  (let [inner (second form)]
+    (cond
+      (and (list? inner) (= 3 (count inner)))
+      (assert-binary inner message true)
+      (and (list? inner) (= 2 (count inner)))
+      (assert-predicate inner message true)
+      (assert-any form message))))
 
 (defmethod assert-expr 'thrown? [message form]
-           (assert-thrown form message))
+  (assert-thrown form message))
 
 (defmethod assert-expr 'thrown-with-msg? [message form]
-           (assert-thrown-with-msg form message))
+  (assert-thrown-with-msg form message))
 
 (defmethod assert-expr 'output? [message form]
-           (assert-output form message))
+  (assert-output form message))
 
 (def- assert-expr-special-forms
   ;; Special forms and structured-syntax macros that must not be treated as
@@ -358,15 +357,15 @@
             'cond 'case 'binding 'for 'dofor 'doseq))
 
 (defmethod assert-expr :default [message form]
-           (let [head    (when (list? form) (first form))
-                 fn-call (and (symbol? head)
-                              (not (contains? assert-expr-special-forms head)))]
-             (cond
-               (and fn-call (= 3 (count form)))
-               (assert-binary form message false)
-               (and fn-call (= 2 (count form)))
-               (assert-predicate form message false)
-               (assert-any form message))))
+  (let [head    (when (list? form) (first form))
+        fn-call (and (symbol? head)
+                     (not (contains? assert-expr-special-forms head)))]
+    (cond
+      (and fn-call (= 3 (count form)))
+      (assert-binary form message false)
+      (and fn-call (= 2 (count form)))
+      (assert-predicate form message false)
+      (assert-any form message))))
 
 (defmacro is
   "Asserts that an expression is true."

--- a/src/phel/test/rose.phel
+++ b/src/phel/test/rose.phel
@@ -23,26 +23,26 @@
   which is incompatible with the self-recursive rose-tree structure."
   [f coll]
   (lazy-seq
-   (when-let [s (seq coll)]
-     (cons (f (first s)) (lazy-map f (rest s))))))
+    (when-let [s (seq coll)]
+      (cons (f (first s)) (lazy-map f (rest s))))))
 
 (defn- lazy-filter
   "One-element-at-a-time `filter`."
   [pred coll]
   (lazy-seq
-   (when-let [s (seq coll)]
-     (let [x (first s)]
-       (if (pred x)
-         (cons x (lazy-filter pred (rest s)))
-         (lazy-filter pred (rest s)))))))
+    (when-let [s (seq coll)]
+      (let [x (first s)]
+        (if (pred x)
+          (cons x (lazy-filter pred (rest s)))
+          (lazy-filter pred (rest s)))))))
 
 (defn- lazy-concat
   "One-element-at-a-time concatenation of two lazy seqs."
   [a b]
   (lazy-seq
-   (if-let [s (seq a)]
-     (cons (first s) (lazy-concat (rest s) b))
-     b)))
+    (if-let [s (seq a)]
+      (cons (first s) (lazy-concat (rest s) b))
+      b)))
 
 ;; ----------------
 ;; Constructors
@@ -156,9 +156,9 @@
   "Helper: lazily iterates each position in turn."
   [trees i n]
   (lazy-seq
-   (when (< i n)
-     (lazy-concat (positional-shrinks trees i)
-                  (shrinks-of-many* trees (+ i 1) n)))))
+    (when (< i n)
+      (lazy-concat (positional-shrinks trees i)
+                   (shrinks-of-many* trees (+ i 1) n)))))
 
 (defn- shrinks-of-many
   "Given a vector of rose trees, returns a lazy sequence of rose-tree

--- a/src/php/Formatter/CLAUDE.md
+++ b/src/php/Formatter/CLAUDE.md
@@ -18,11 +18,12 @@ Parses Phel source into AST, applies formatting rules, writes back.
 
 1. `RemoveSurroundingWhitespaceRule`
 2. `UnindentRule`
-3. `IndentRule` with indenters:
-   - `InnerIndenter`: `def`, `def-`, `defn`, `defn-`, `defmacro`, `defmacro-`, `deftest`, `fn`
-   - `BlockIndenter`: `catch`, `do`, `if`, `if-not`, `foreach`, `for`, `dofor`, `let`, `ns`, `loop`, `case`, `cond`, `condp`, `try`, `finally`, `when`, `when-not`, `when-let`, `when-some`, `if-let`, `if-some`, `binding`
-4. `AlignPairsRule`
-5. `RemoveTrailingWhitespaceRule`
+3. `RemoveConsecutiveBlankLinesRule` (collapses 2+ blank lines to one; cljfmt parity)
+4. `IndentRule` with indenters:
+   - `InnerIndenter`: `def`, `def-`, `defn`, `defn-`, `defmacro`, `defmacro-`, `deftest`, `fn`, `defstruct`, `defrecord`, `definterface`, `defexception`, `defenum`, `defprotocol`, `defmulti`, `defmethod`, `defonce`, `reify`
+   - `BlockIndenter`: `catch`, `do`, `if`, `if-not`, `foreach`, `for`, `dofor`, `let`, `ns`, `loop`, `case`, `cond`, `condp`, `try`, `finally`, `when`, `when-not`, `when-let`, `when-some`, `if-let`, `if-some`, `binding`, `when-first`, `doseq`, `dotimes`, `letfn`, `with-redefs`, `with-bindings`, `extend-type`, `extend-protocol`, `with-output-buffer`, `delay`, `lazy-seq`
+5. `AlignPairsRule`
+6. `RemoveTrailingWhitespaceRule`
 
 ## Dependencies
 

--- a/src/php/Formatter/Domain/Rules/RemoveConsecutiveBlankLinesRule.php
+++ b/src/php/Formatter/Domain/Rules/RemoveConsecutiveBlankLinesRule.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Formatter\Domain\Rules;
+
+use Phel\Formatter\Domain\Rules\Zipper\ParseTreeZipper;
+use Phel\Formatter\Domain\Rules\Zipper\ZipperException;
+use Phel\Shared\Parser\Node\NodeInterface;
+
+/**
+ * Collapses runs of consecutive blank lines into a single blank line, matching
+ * cljfmt's `:remove-consecutive-blank-lines?` (on by default).
+ *
+ * The lexer emits one {@see \Phel\Shared\Parser\Node\NewlineNode} per `\n`, so a
+ * blank line is two adjacent newline nodes. Anything beyond the second
+ * consecutive newline is removed, leaving at most one empty line between forms.
+ * Runs after {@see UnindentRule}, which strips the indentation whitespace that
+ * would otherwise sit between the newlines of an "empty" line.
+ */
+final readonly class RemoveConsecutiveBlankLinesRule implements RuleInterface
+{
+    /** One newline ends a line; a second produces a single blank line. */
+    private const int MAX_CONSECUTIVE_NEWLINES = 2;
+
+    /**
+     * @throws ZipperException
+     */
+    public function transform(NodeInterface $node): NodeInterface
+    {
+        return $this->removeConsecutiveBlankLines(ParseTreeZipper::createRoot($node));
+    }
+
+    /**
+     * @throws ZipperException
+     */
+    private function removeConsecutiveBlankLines(ParseTreeZipper $loc): NodeInterface
+    {
+        $node = $loc;
+        while (!$node->isEnd()) {
+            /** @var ParseTreeZipper $node */
+            $node = $node->next();
+            if ($this->isExtraBlankLine($node)) {
+                /** @var ParseTreeZipper $node */
+                $node = $node->remove();
+            }
+        }
+
+        return $node->root();
+    }
+
+    private function isExtraBlankLine(ParseTreeZipper $loc): bool
+    {
+        return $loc->isNewline()
+            && $this->precedingLineBreakCount($loc) >= self::MAX_CONSECUTIVE_NEWLINES;
+    }
+
+    /**
+     * Counts consecutive line breaks immediately to the left of $loc. A comment
+     * node carries its own trailing newline, so it counts as one line break and
+     * ends the run (a comment is content, not blank space).
+     */
+    private function precedingLineBreakCount(ParseTreeZipper $loc): int
+    {
+        $count = 0;
+        $cursor = $loc;
+        while (!$cursor->isFirst()) {
+            $cursor = $cursor->left();
+            if ($cursor->isNewline()) {
+                ++$count;
+                continue;
+            }
+
+            if ($cursor->isComment()) {
+                ++$count;
+            }
+
+            break;
+        }
+
+        return $count;
+    }
+}

--- a/src/php/Formatter/FormatterFactory.php
+++ b/src/php/Formatter/FormatterFactory.php
@@ -16,6 +16,7 @@ use Phel\Formatter\Domain\Rules\AlignPairsRule;
 use Phel\Formatter\Domain\Rules\Indenter\BlockIndenter;
 use Phel\Formatter\Domain\Rules\Indenter\InnerIndenter;
 use Phel\Formatter\Domain\Rules\IndentRule;
+use Phel\Formatter\Domain\Rules\RemoveConsecutiveBlankLinesRule;
 use Phel\Formatter\Domain\Rules\RemoveSurroundingWhitespaceRule;
 use Phel\Formatter\Domain\Rules\RemoveTrailingWhitespaceRule;
 use Phel\Formatter\Domain\Rules\UnindentRule;
@@ -44,6 +45,7 @@ final class FormatterFactory extends AbstractFactory
             [
                 $this->createRemoveSurroundingWhitespaceRule(),
                 $this->createUnindentRule(),
+                $this->createRemoveConsecutiveBlankLinesRule(),
                 $this->createIndentRule(),
                 $this->createAlignPairsRule(),
                 $this->createRemoveTrailingWhitespaceRule(),
@@ -61,6 +63,11 @@ final class FormatterFactory extends AbstractFactory
         return new UnindentRule();
     }
 
+    private function createRemoveConsecutiveBlankLinesRule(): RemoveConsecutiveBlankLinesRule
+    {
+        return new RemoveConsecutiveBlankLinesRule();
+    }
+
     private function createIndentRule(): IndentRule
     {
         return new IndentRule([
@@ -72,6 +79,16 @@ final class FormatterFactory extends AbstractFactory
             new InnerIndenter('defmacro-', 0),
             new InnerIndenter('deftest', 0),
             new InnerIndenter('fn', 0),
+            new InnerIndenter('defstruct', 0),
+            new InnerIndenter('defrecord', 0),
+            new InnerIndenter('definterface', 0),
+            new InnerIndenter('defexception', 0),
+            new InnerIndenter('defenum', 0),
+            new InnerIndenter('defprotocol', 0),
+            new InnerIndenter('defmulti', 0),
+            new InnerIndenter('defmethod', 0),
+            new InnerIndenter('defonce', 0),
+            new InnerIndenter('reify', 0),
 
             new BlockIndenter('catch', 2),
             new BlockIndenter('do', 0),
@@ -95,6 +112,17 @@ final class FormatterFactory extends AbstractFactory
             new BlockIndenter('if-let', 1),
             new BlockIndenter('if-some', 1),
             new BlockIndenter('binding', 1),
+            new BlockIndenter('when-first', 1),
+            new BlockIndenter('doseq', 1),
+            new BlockIndenter('dotimes', 1),
+            new BlockIndenter('letfn', 1),
+            new BlockIndenter('with-redefs', 1),
+            new BlockIndenter('with-bindings', 1),
+            new BlockIndenter('extend-type', 1),
+            new BlockIndenter('extend-protocol', 1),
+            new BlockIndenter('with-output-buffer', 0),
+            new BlockIndenter('delay', 0),
+            new BlockIndenter('lazy-seq', 0),
         ]);
     }
 

--- a/src/php/Formatter/FormatterFactory.php
+++ b/src/php/Formatter/FormatterFactory.php
@@ -28,6 +28,35 @@ use Phel\Shared\Facade\CommandFacadeInterface;
  */
 final class FormatterFactory extends AbstractFactory
 {
+    /**
+     * Definition forms whose body is indented two spaces under the head line.
+     *
+     * @var list<string>
+     */
+    private const array INNER_INDENT_SYMBOLS = [
+        'def', 'def-', 'defn', 'defn-', 'defmacro', 'defmacro-', 'deftest', 'fn',
+        'defstruct', 'defrecord', 'definterface', 'defexception', 'defenum',
+        'defprotocol', 'defmulti', 'defmethod', 'defonce', 'reify',
+    ];
+
+    /**
+     * Block forms mapped to the number of leading arguments before the body
+     * (the body switches to a two-space indent once it starts a line).
+     *
+     * @var array<string, int>
+     */
+    private const array BLOCK_INDENT_SYMBOLS = [
+        'do' => 0, 'cond' => 0, 'try' => 0, 'finally' => 0,
+        'with-output-buffer' => 0, 'delay' => 0, 'lazy-seq' => 0,
+        'if' => 1, 'if-not' => 1, 'foreach' => 1, 'for' => 1, 'dofor' => 1,
+        'let' => 1, 'ns' => 1, 'loop' => 1, 'case' => 1, 'when' => 1,
+        'when-not' => 1, 'when-let' => 1, 'when-some' => 1, 'if-let' => 1,
+        'if-some' => 1, 'binding' => 1, 'when-first' => 1, 'doseq' => 1,
+        'dotimes' => 1, 'letfn' => 1, 'with-redefs' => 1, 'with-bindings' => 1,
+        'extend-type' => 1, 'extend-protocol' => 1,
+        'catch' => 2, 'condp' => 2,
+    ];
+
     public function createPathsFormatter(): PathsFormatter
     {
         return new PathsFormatter(
@@ -70,60 +99,17 @@ final class FormatterFactory extends AbstractFactory
 
     private function createIndentRule(): IndentRule
     {
-        return new IndentRule([
-            new InnerIndenter('def', 0),
-            new InnerIndenter('def-', 0),
-            new InnerIndenter('defn', 0),
-            new InnerIndenter('defn-', 0),
-            new InnerIndenter('defmacro', 0),
-            new InnerIndenter('defmacro-', 0),
-            new InnerIndenter('deftest', 0),
-            new InnerIndenter('fn', 0),
-            new InnerIndenter('defstruct', 0),
-            new InnerIndenter('defrecord', 0),
-            new InnerIndenter('definterface', 0),
-            new InnerIndenter('defexception', 0),
-            new InnerIndenter('defenum', 0),
-            new InnerIndenter('defprotocol', 0),
-            new InnerIndenter('defmulti', 0),
-            new InnerIndenter('defmethod', 0),
-            new InnerIndenter('defonce', 0),
-            new InnerIndenter('reify', 0),
+        $inner = array_map(
+            static fn(string $symbol): InnerIndenter => new InnerIndenter($symbol, 0),
+            self::INNER_INDENT_SYMBOLS,
+        );
 
-            new BlockIndenter('catch', 2),
-            new BlockIndenter('do', 0),
-            new BlockIndenter('if', 1),
-            new BlockIndenter('if-not', 1),
-            new BlockIndenter('foreach', 1),
-            new BlockIndenter('for', 1),
-            new BlockIndenter('dofor', 1),
-            new BlockIndenter('let', 1),
-            new BlockIndenter('ns', 1),
-            new BlockIndenter('loop', 1),
-            new BlockIndenter('case', 1),
-            new BlockIndenter('cond', 0),
-            new BlockIndenter('condp', 2),
-            new BlockIndenter('try', 0),
-            new BlockIndenter('finally', 0),
-            new BlockIndenter('when', 1),
-            new BlockIndenter('when-not', 1),
-            new BlockIndenter('when-let', 1),
-            new BlockIndenter('when-some', 1),
-            new BlockIndenter('if-let', 1),
-            new BlockIndenter('if-some', 1),
-            new BlockIndenter('binding', 1),
-            new BlockIndenter('when-first', 1),
-            new BlockIndenter('doseq', 1),
-            new BlockIndenter('dotimes', 1),
-            new BlockIndenter('letfn', 1),
-            new BlockIndenter('with-redefs', 1),
-            new BlockIndenter('with-bindings', 1),
-            new BlockIndenter('extend-type', 1),
-            new BlockIndenter('extend-protocol', 1),
-            new BlockIndenter('with-output-buffer', 0),
-            new BlockIndenter('delay', 0),
-            new BlockIndenter('lazy-seq', 0),
-        ]);
+        $block = [];
+        foreach (self::BLOCK_INDENT_SYMBOLS as $symbol => $index) {
+            $block[] = new BlockIndenter($symbol, $index);
+        }
+
+        return new IndentRule([...$inner, ...$block]);
     }
 
     private function createAlignPairsRule(): AlignPairsRule

--- a/tests/phel/are.phel
+++ b/tests/phel/are.phel
@@ -62,11 +62,11 @@
   (let [saved  (get-stats)
         _      (reset-stats)
         _      (with-output-buffer
-                (are [x y] (= x y)
-                     1 1
-                     2 3
-                     4 4
-                     5 6))
+                 (are [x y] (= x y)
+                      1 1
+                      2 3
+                      4 4
+                      5 6))
         counts (get (get-stats) :counts)]
     (restore-stats saved)
     (is (= 2 (:pass counts)) "two groups pass")
@@ -80,10 +80,10 @@
   (let [saved  (get-stats)
         _      (reset-stats)
         _      (with-output-buffer
-                (are [x y] (= x y)
-                     1 1
-                     2 2
-                     3))
+                 (are [x y] (= x y)
+                      1 1
+                      2 2
+                      3))
         counts (get (get-stats) :counts)]
     (restore-stats saved)
     (is (= 2 (:pass counts)) "only complete groups are asserted")
@@ -116,7 +116,7 @@
   (let [saved  (get-stats)
         _      (reset-stats)
         _      (with-output-buffer
-                (are [x y] (= x y)))
+                 (are [x y] (= x y)))
         counts (get (get-stats) :counts)]
     (restore-stats saved)
     (is (= 0 (:total counts)) "no assertions generated")))

--- a/tests/phel/assert-expr-extensibility.phel
+++ b/tests/phel/assert-expr-extensibility.phel
@@ -21,10 +21,10 @@
 ;; ---------------------------------------------------------------------------
 
 (defmethod phel.test/assert-expr 'approx= [message form]
-           (let [a       (second form)
-                 b       (second (next form))
-                 epsilon 0.001]
-             `(is (< (php/abs (- ~a ~b)) ~epsilon) ~message)))
+  (let [a       (second form)
+        b       (second (next form))
+        epsilon 0.001]
+    `(is (< (php/abs (- ~a ~b)) ~epsilon) ~message)))
 
 (deftest test-approx-equal-passes-within-epsilon
   (is (approx= 1.0 1.0001) "approx= passes when difference < epsilon")
@@ -43,9 +43,9 @@
 ;; ---------------------------------------------------------------------------
 
 (defmethod phel.test/assert-expr 'divisible? [message form]
-           (let [n (second form)
-                 d (second (next form))]
-             `(is (zero? (php/% ~n ~d)) ~message)))
+  (let [n (second form)
+        d (second (next form))]
+    `(is (zero? (php/% ~n ~d)) ~message)))
 
 (deftest test-divisible-passes-when-divisible
   (is (divisible? 10 5) "10 is divisible by 5")
@@ -65,8 +65,8 @@
 ;; ---------------------------------------------------------------------------
 
 (defmethod phel.test/assert-expr 'even-positive? [message form]
-           (let [n (second form)]
-             `(is (and (pos? ~n) (even? ~n)) ~message)))
+  (let [n (second form)]
+    `(is (and (pos? ~n) (even? ~n)) ~message)))
 
 (deftest test-even-positive-passes-for-positive-evens
   (is (even-positive? 2) "2 is positive and even")
@@ -89,7 +89,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defmethod phel.test/assert-expr 'always-throws [_message _form]
-           `(throw (php/new \RuntimeException "boom from custom assertion")))
+  `(throw (php/new \RuntimeException "boom from custom assertion")))
 
 (deftest test-custom-method-exception-is-reported-as-error
   (let [saved  (get-stats)
@@ -122,26 +122,26 @@
 ;; ---------------------------------------------------------------------------
 
 (defmethod phel.test/assert-expr 'tagged= [message form]
-           `(is (= ~(second form) ~(second (next form))) ~message))
+  `(is (= ~(second form) ~(second (next form))) ~message))
 
 (deftest test-custom-dispatch-routes-through-new-method
   (is (tagged= 1 1) "tagged= dispatches through registered method")
   (is (tagged= "x" "x") "tagged= works for strings"))
 
 (defmethod t/assert-expr 'p/thrown? [message form]
-           (let [body (rest form)]
-             `(try
-                (let [result# (do ~@body)]
-                  (t/do-report {:type :fail
-                                :message ~message
-                                :expected '~form
-                                :actual result#}))
-                (catch ~'Throwable e#
-                  (t/do-report {:type :pass
-                                :message ~message
-                                :expected '~form
-                                :actual e#})
-                  e#))))
+  (let [body (rest form)]
+    `(try
+       (let [result# (do ~@body)]
+         (t/do-report {:type :fail
+                       :message ~message
+                       :expected '~form
+                       :actual result#}))
+       (catch ~'Throwable e#
+         (t/do-report {:type :pass
+                       :message ~message
+                       :expected '~form
+                       :actual e#})
+         e#))))
 
 (deftest test-custom-clojure-style-thrown-symbol-dispatches-through-new-method
   (let [saved  (get-stats)

--- a/tests/phel/auto-refer.phel
+++ b/tests/phel/auto-refer.phel
@@ -38,4 +38,3 @@
   (is (php/instanceof (atom 1) Atom))
   (is (php/instanceof (delay 1) Delay))
   (is (php/instanceof (volatile! 1) Volatile)))
-

--- a/tests/phel/core/binding-conveyance.phel
+++ b/tests/phel/core/binding-conveyance.phel
@@ -58,7 +58,7 @@
 
 (deftest test-with-redefs-on-non-dynamic-var
   (with-redefs [*not-dynamic* :rebound]
-               (is (= :rebound *not-dynamic*) "with-redefs mutates the root in-place"))
+    (is (= :rebound *not-dynamic*) "with-redefs mutates the root in-place"))
   (is (= :root *not-dynamic*) "with-redefs restores the root on exit"))
 
 (deftest test-binding-on-non-dynamic-var-throws

--- a/tests/phel/core/binding.phel
+++ b/tests/phel/core/binding.phel
@@ -24,13 +24,13 @@
 
 (deftest test-with-redefs-on-any-var
   (with-redefs [*my-redef-target* 99]
-               (is (= 99 *my-redef-target*) "with-redefs swaps the root for any var"))
+    (is (= 99 *my-redef-target*) "with-redefs swaps the root for any var"))
   (is (= 10 *my-redef-target*) "with-redefs restores the root on exit"))
 
 (deftest test-with-redefs-restores-on-throw
   (let [threw? (try
                  (with-redefs [*my-redef-target* 42]
-                              (throw (php/new \RuntimeException "boom")))
+                   (throw (php/new \RuntimeException "boom")))
                  false
                  (catch \Throwable _ true))]
     (is threw? "with-redefs lets the body's exception propagate")

--- a/tests/phel/core/doseq.phel
+++ b/tests/phel/core/doseq.phel
@@ -4,7 +4,7 @@
 (deftest test-doseq-range-side-effects
   (let [sum    (atom 0)
         result (doseq [x :range [0 3]]
-                      (swap! sum + x))]
+                 (swap! sum + x))]
     (is (nil? result) "doseq returns nil")
     (is (= 3 (deref sum)) "doseq executes body for side effects")))
 
@@ -13,64 +13,64 @@
     (doseq [x :in [1 2 3 4]
             :when (even? x)
             :let [y (* x 2)]]
-           (swap! captured (fn [xs] (push xs y))))
+      (swap! captured (fn [xs] (push xs y))))
     (is (= [4 8] (deref captured)) "doseq honors modifiers from for")))
 
 (deftest test-doseq-clojure-style-bindings
   (let [captured (atom [])]
     (doseq [x [1 2 3]]
-           (swap! captured (fn [xs] (push xs x))))
+      (swap! captured (fn [xs] (push xs x))))
     (is (= [1 2 3] (deref captured)) "doseq accepts Clojure-style binding pairs")))
 
 (deftest test-doseq-clojure-style-nested
   (let [captured (atom [])]
     (doseq [x [1 2]
             y [3 4]]
-           (swap! captured (fn [xs] (push xs [x y]))))
+      (swap! captured (fn [xs] (push xs [x y]))))
     (is (= [[1 3] [1 4] [2 3] [2 4]] (deref captured)) "doseq nested Clojure-style")))
 
 (deftest test-doseq-clojure-style-with-when
   (let [captured (atom [])]
     (doseq [x [1 2 3 4 5]
             :when (odd? x)]
-           (swap! captured (fn [xs] (push xs x))))
+      (swap! captured (fn [xs] (push xs x))))
     (is (= [1 3 5] (deref captured)) "doseq Clojure-style with :when modifier")))
 
 (deftest test-doseq-map-destructuring
   (let [captured (atom {})]
     (doseq [[k v] {:a 0 :b 1}]
-           (swap! captured put k v))
+      (swap! captured put k v))
     (is (= {:a 0 :b 1} (deref captured))
         "doseq binds [k v] from map entries, Clojure-aligned"))
   (let [captured (atom [])]
     (doseq [entry {:a 0 :b 1}]
-           (swap! captured (fn [xs] (push xs entry))))
+      (swap! captured (fn [xs] (push xs entry))))
     (is (= [[:a 0] [:b 1]] (deref captured))
         "doseq yields [k v] pair vectors when iterating a map"))
   (let [acc (atom {})]
     (doseq [[k v] {:a 0 :b 1}]
-           (swap! acc assoc k v))
+      (swap! acc assoc k v))
     (is (= {:a 0 :b 1} @acc)
         "doseq [k v] destructuring over a map with (swap! acc assoc k v)")))
 
 (deftest test-doseq-vector-of-vectors-destructuring
   (let [captured (atom [])]
     (doseq [[a b] [[1 2] [3 4]]]
-           (swap! captured (fn [xs] (push xs (+ a b)))))
+      (swap! captured (fn [xs] (push xs (+ a b)))))
     (is (= [3 7] (deref captured))
         "doseq destructuring over vector of vectors still iterates elements")))
 
 (deftest test-doseq-map-empty
   (let [captured (atom 0)]
     (doseq [[_ _] {}]
-           (swap! captured inc))
+      (swap! captured inc))
     (is (= 0 (deref captured)) "doseq over empty map does not execute body")))
 
 (deftest test-doseq-map-with-when
   (let [captured (atom {})]
     (doseq [[k v] {:a 1 :b 2 :c 3}
             :when (odd? v)]
-           (swap! captured put k v))
+      (swap! captured put k v))
     (is (= {:a 1 :c 3} (deref captured))
         "doseq over map honors :when modifier after destructuring")))
 
@@ -78,14 +78,14 @@
   (let [captured (atom {})]
     (doseq [[k v] {:a 1 :b 2}
             :let [v2 (* v 10)]]
-           (swap! captured put k v2))
+      (swap! captured put k v2))
     (is (= {:a 10 :b 20} (deref captured))
         "doseq over map supports :let over destructured bindings")))
 
 (deftest test-doseq-set-iterates-values
   (let [captured (atom #{})]
     (doseq [x #{:a :b :c}]
-           (swap! captured (fn [s] (conj s x))))
+      (swap! captured (fn [s] (conj s x))))
     (is (= #{:a :b :c} (deref captured))
         "doseq over a set still iterates values (not treated as pairs)")))
 
@@ -93,7 +93,7 @@
   (let [captured (atom [])]
     (doseq [[k v] {:a 1 :b 2}
             i [10 20]]
-           (swap! captured (fn [xs] (push xs [k (+ v i)]))))
+      (swap! captured (fn [xs] (push xs [k (+ v i)]))))
     (is (= [[:a 11] [:a 21] [:b 12] [:b 22]] (deref captured))
         "doseq supports Clojure-style map destructuring nested with a vector iteration")))
 

--- a/tests/phel/core/interface-param-attributes.phel
+++ b/tests/phel/core/interface-param-attributes.phel
@@ -8,9 +8,9 @@
   (map |(php/-> $ (getName)) attrs))
 
 (deftest method-and-param-attributes-are-emitted
-  (let [rm     (php/new \ReflectionMethod "phel_test\\core\\interface_param_attributes\\Ctrl" "act")
-        p0     (php/aget (php/-> rm (getParameters)) 0)
-        margs  (attr-names (php/-> rm (getAttributes)))
-        pargs  (attr-names (php/-> p0 (getAttributes)))]
+  (let [rm    (php/new \ReflectionMethod "phel_test\\core\\interface_param_attributes\\Ctrl" "act")
+        p0    (php/aget (php/-> rm (getParameters)) 0)
+        margs (attr-names (php/-> rm (getAttributes)))
+        pargs (attr-names (php/-> p0 (getAttributes)))]
     (is (= ["Route"] margs) "method carries its #[Route] attribute")
     (is (= ["Autowire"] pargs) "parameter carries its #[Autowire] attribute")))

--- a/tests/phel/core/iterator-seq.phel
+++ b/tests/phel/core/iterator-seq.phel
@@ -15,9 +15,9 @@
 
 (deftest iterator-seq-is-composable-with-lazy-ops
   (is (= [2 3 4] (vec (->> (array-iterator 1 2 3 4 5)
-                              (iterator-seq)
-                              (map inc)
-                              (take 3))))
+                           (iterator-seq)
+                           (map inc)
+                           (take 3))))
       "map/take compose over an iterator-seq"))
 
 (deftest iterator-seq-empty-traversable

--- a/tests/phel/core/letfn.phel
+++ b/tests/phel/core/letfn.phel
@@ -4,54 +4,54 @@
 (deftest test-letfn-mutual-recursion
   (is (true? (letfn [(my-even? [n] (if (zero? n) true (my-odd? (dec n))))
                      (my-odd? [n] (if (zero? n) false (my-even? (dec n))))]
-                    (my-even? 10)))
+               (my-even? 10)))
       "mutual recursion: 10 is even")
   (is (false? (letfn [(my-even? [n] (if (zero? n) true (my-odd? (dec n))))
                       (my-odd? [n] (if (zero? n) false (my-even? (dec n))))]
-                     (my-even? 7)))
+                (my-even? 7)))
       "mutual recursion: 7 is not even"))
 
 (deftest test-letfn-single-recursive
   (is (= 120 (letfn [(factorial [n] (if (<= n 1) 1 (* n (factorial (dec n)))))]
-                    (factorial 5)))
+               (factorial 5)))
       "single recursive function"))
 
 (deftest test-letfn-multiple-params
   (letfn [(add [a b] (+ a b))
           (mul [a b] (* a b))]
-         (is (= 5 (add 2 3)) "multi-param function")
-         (is (= 6 (mul 2 3)) "another multi-param function")))
+    (is (= 5 (add 2 3)) "multi-param function")
+    (is (= 6 (mul 2 3)) "another multi-param function")))
 
 (deftest test-letfn-captures-outer-bindings
   (let [offset 100]
     (letfn [(add-offset [x] (+ x offset))]
-           (is (= 142 (add-offset 42)) "letfn captures outer let binding"))))
+      (is (= 142 (add-offset 42)) "letfn captures outer let binding"))))
 
 (deftest test-letfn-fn-as-value
   (is (= [2 4 6]
          (letfn [(dbl [x] (* 2 x))]
-                (map dbl [1 2 3])))
+           (map dbl [1 2 3])))
       "letfn function passed as value to map"))
 
 (deftest test-letfn-three-way-recursion
   (letfn [(a [n] (if (zero? n) :done (b (dec n))))
           (b [n] (if (zero? n) :done (c (dec n))))
           (c [n] (if (zero? n) :done (a (dec n))))]
-         (is (= :done (a 9)) "three-way mutual recursion")))
+    (is (= :done (a 9)) "three-way mutual recursion")))
 
 (deftest test-letfn-nested
   (is (= 10
          (letfn [(outer [x]
                         (letfn [(inner [y] (* y 2))]
-                               (inner x)))]
-                (outer 5)))
+                          (inner x)))]
+           (outer 5)))
       "nested letfn"))
 
 (deftest test-letfn-body-uses-all-fns
   (letfn [(double [x] (* 2 x))
           (triple [x] (* 3 x))]
-         (is (= 6 (double 3)) "double works")
-         (is (= 9 (triple 3)) "triple works")))
+    (is (= 6 (double 3)) "double works")
+    (is (= 9 (triple 3)) "triple works")))
 
 (deftest test-letfn-empty-bindings
   (is (= 42 (letfn [] 42)) "empty bindings returns body value"))

--- a/tests/phel/core/math-operation.phel
+++ b/tests/phel/core/math-operation.phel
@@ -520,7 +520,6 @@
   (is (= 1.5M (bigdec "1.5")) "literal equals constructor")
   (is (= "1500" (str 1.5e3M)) "(str 1.5e3M)"))
 
-
 (deftest test-bigdec-coercions
   (is (= 0 (int 0M)) "(int 0M)")
   (is (= -1 (int -1M)) "(int -1M)")

--- a/tests/phel/core/multimethods.phel
+++ b/tests/phel/core/multimethods.phel
@@ -28,13 +28,13 @@
 (defmulti area (fn [shape] (get shape :type)))
 
 (defmethod area :circle [shape]
-           (let [r (get shape :radius)]
-             (* r r)))
+  (let [r (get shape :radius)]
+    (* r r)))
 
 (defmethod area :rectangle [shape]
-           (let [w (get shape :width)
-                 h (get shape :height)]
-             (* w h)))
+  (let [w (get shape :width)
+        h (get shape :height)]
+    (* w h)))
 
 (deftest test-area-dispatch
   (is (= 9 (area {:type :circle :radius 3})) "circle area (r squared)")
@@ -75,8 +75,8 @@
 ;; --------------------------------
 
 (defmulti documented-area
-          "Area of a shape dispatched by :type."
-          (fn [shape] (get shape :type)))
+  "Area of a shape dispatched by :type."
+  (fn [shape] (get shape :type)))
 
 (defmethod documented-area :square [{:side s}] (* s s))
 

--- a/tests/phel/core/phpdoc-emission.phel
+++ b/tests/phel/core/phpdoc-emission.phel
@@ -5,7 +5,7 @@
   [^{:php/doc "@var list<int>"} items])
 
 (deftest class-and-property-docblocks-are-emitted
-  (let [rc       (php/new \ReflectionClass "phel_test\\core\\phpdoc_emission\\bag")
+  (let [rc        (php/new \ReflectionClass "phel_test\\core\\phpdoc_emission\\bag")
         class-doc (php/-> rc (getDocComment))
         prop-doc  (php/-> (php/-> rc (getProperty "items")) (getDocComment))]
     (is (php/str_contains class-doc "@implements \\IteratorAggregate<int, string>")

--- a/tests/phel/core/protocols.phel
+++ b/tests/phel/core/protocols.phel
@@ -4,19 +4,19 @@
 ;; --- Protocol definition and basic dispatch ---
 
 (defprotocol Describable
-             (describe [this]))
+  (describe [this]))
 
 (extend-type :string
-             Describable
-             (describe [s] (str "string: " s)))
+  Describable
+  (describe [s] (str "string: " s)))
 
 (extend-type :int
-             Describable
-             (describe [n] (str "int: " n)))
+  Describable
+  (describe [n] (str "int: " n)))
 
 (extend-type :keyword
-             Describable
-             (describe [k] (str "keyword: " k)))
+  Describable
+  (describe [k] (str "keyword: " k)))
 
 (deftest test-protocol-dispatch-string
   (is (= "string: hello" (describe "hello")) "dispatches on string"))
@@ -34,31 +34,31 @@
 ;; --- Additional primitive types ---
 
 (defprotocol TypeLabeler
-             (type-label [this]))
+  (type-label [this]))
 
 (extend-type :boolean
-             TypeLabeler
-             (type-label [b] (if b "true" "false")))
+  TypeLabeler
+  (type-label [b] (if b "true" "false")))
 
 (extend-type :float
-             TypeLabeler
-             (type-label [f] (str "float:" f)))
+  TypeLabeler
+  (type-label [f] (str "float:" f)))
 
 (extend-type :vector
-             TypeLabeler
-             (type-label [v] (str "vec:" (count v))))
+  TypeLabeler
+  (type-label [v] (str "vec:" (count v))))
 
 (extend-type :list
-             TypeLabeler
-             (type-label [l] (str "list:" (count l))))
+  TypeLabeler
+  (type-label [l] (str "list:" (count l))))
 
 (extend-type :hash-map
-             TypeLabeler
-             (type-label [m] (str "map:" (count m))))
+  TypeLabeler
+  (type-label [m] (str "map:" (count m))))
 
 (extend-type :set
-             TypeLabeler
-             (type-label [s] (str "set:" (count s))))
+  TypeLabeler
+  (type-label [s] (str "set:" (count s))))
 
 (deftest test-protocol-dispatch-boolean
   (is (= "true" (type-label true)) "dispatches on boolean true")
@@ -82,15 +82,15 @@
 ;; --- nil dispatch ---
 
 (defprotocol Nullable
-             (nil-safe [this]))
+  (nil-safe [this]))
 
 (extend-type nil
-             Nullable
-             (nil-safe [_] "was nil"))
+  Nullable
+  (nil-safe [_] "was nil"))
 
 (extend-type :string
-             Nullable
-             (nil-safe [s] s))
+  Nullable
+  (nil-safe [s] s))
 
 (deftest test-protocol-nil-dispatch
   (is (= "was nil" (nil-safe nil)) "dispatches on nil")
@@ -99,11 +99,11 @@
 ;; --- Multi-arg methods ---
 
 (defprotocol Greetable
-             (greet [this name]))
+  (greet [this name]))
 
 (extend-type :string
-             Greetable
-             (greet [title name] (str "Hello " name ", " title)))
+  Greetable
+  (greet [title name] (str "Hello " name ", " title)))
 
 (deftest test-protocol-multi-arg
   (is (= "Hello World, Sir" (greet "Sir" "World")) "multi-arg dispatch"))
@@ -127,11 +127,11 @@
 (defstruct ProtoPoint [x y])
 
 (defprotocol Printable
-             (to-label [this]))
+  (to-label [this]))
 
 (extend-type ProtoPoint
-             Printable
-             (to-label [p] (str "(" (get p :x) ", " (get p :y) ")")))
+  Printable
+  (to-label [p] (str "(" (get p :x) ", " (get p :y) ")")))
 
 (deftest test-protocol-struct-dispatch
   (is (= "(1, 2)" (to-label (ProtoPoint 1 2))) "dispatches on struct"))
@@ -142,11 +142,11 @@
 ;; --- Multiple protocols on same type ---
 
 (defprotocol Measurable
-             (measure [this]))
+  (measure [this]))
 
 (extend-type :string
-             Measurable
-             (measure [s] (php/strlen s)))
+  Measurable
+  (measure [s] (php/strlen s)))
 
 (deftest test-multiple-protocols-on-type
   (is (= "string: hello" (describe "hello")) "Describable still works")
@@ -155,15 +155,15 @@
 ;; --- Overwrite semantics ---
 
 (defprotocol Versioned
-             (version [this]))
+  (version [this]))
 
 (extend-type :string
-             Versioned
-             (version [_] "v1"))
+  Versioned
+  (version [_] "v1"))
 
 (extend-type :string
-             Versioned
-             (version [_] "v2"))
+  Versioned
+  (version [_] "v2"))
 
 (deftest test-extend-type-overwrites
   (is (= "v2" (version "hi")) "second extend-type overwrites first"))
@@ -171,13 +171,13 @@
 ;; --- Multi-method protocol with satisfies? checking all methods ---
 
 (defprotocol TwoMethods
-             (method-a [this])
-             (method-b [this]))
+  (method-a [this])
+  (method-b [this]))
 
 (extend-type :string
-             TwoMethods
-             (method-a [s] (str "a:" s))
-             (method-b [s] (str "b:" s)))
+  TwoMethods
+  (method-a [s] (str "a:" s))
+  (method-b [s] (str "b:" s)))
 
 (deftest test-multi-method-protocol
   (is (= "a:hi" (method-a "hi")) "method-a dispatches")
@@ -190,15 +190,15 @@
 ;; --- Default fallback ---
 
 (defprotocol Showable
-             (show [this]))
+  (show [this]))
 
 (extend-type :default
-             Showable
-             (show [x] (str "default:" (type x))))
+  Showable
+  (show [x] (str "default:" (type x))))
 
 (extend-type :string
-             Showable
-             (show [s] (str "string:" s)))
+  Showable
+  (show [s] (str "string:" s)))
 
 (deftest test-protocol-default-fallback
   (is (= "string:hi" (show "hi")) "exact match preferred over default")
@@ -209,12 +209,12 @@
 ;; --- extend-protocol convenience ---
 
 (defprotocol Sizeable
-             (size [this]))
+  (size [this]))
 
 (extend-protocol Sizeable
-                 :string (size [s] (php/strlen s))
-                 :vector (size [v] (count v))
-                 :hash-map (size [m] (count m)))
+  :string (size [s] (php/strlen s))
+  :vector (size [v] (count v))
+  :hash-map (size [m] (count m)))
 
 (deftest test-extend-protocol
   (is (= 5 (size "hello")) "extend-protocol string")
@@ -224,16 +224,16 @@
 ;; --- extend-type with multiple protocols at once ---
 
 (defprotocol Nameable
-             (get-name [this]))
+  (get-name [this]))
 
 (defprotocol Ageable
-             (get-age [this]))
+  (get-age [this]))
 
 (extend-type :hash-map
-             Nameable
-             (get-name [m] (get m :name))
-             Ageable
-             (get-age [m] (get m :age)))
+  Nameable
+  (get-name [m] (get m :name))
+  Ageable
+  (get-age [m] (get m :age)))
 
 (deftest test-extend-type-multiple-protocols
   (let [person {:name "Alice" :age 30}]
@@ -243,14 +243,14 @@
 ;; --- Protocol with multi-expression body ---
 
 (defprotocol Summarizable
-             (summarize [this]))
+  (summarize [this]))
 
 (extend-type :vector
-             Summarizable
-             (summarize [v]
-                        (let [n          (count v)
-                              first-item (first v)]
-                          (str n " items, first: " first-item))))
+  Summarizable
+  (summarize [v]
+             (let [n          (count v)
+                   first-item (first v)]
+               (str n " items, first: " first-item))))
 
 (deftest test-protocol-multi-expression-body
   (is (= "3 items, first: :a" (summarize [:a :b :c]))

--- a/tests/phel/core/records.phel
+++ b/tests/phel/core/records.phel
@@ -40,26 +40,26 @@
 ;; --- defrecord with inline protocol methods ---
 
 (defprotocol Drawable
-             (draw [this canvas]))
+  (draw [this canvas]))
 
 (defrecord Shape [label]
-           Drawable
-           (draw [this canvas] (str canvas ":" (get this :label))))
+  Drawable
+  (draw [this canvas] (str canvas ":" (get this :label))))
 
 (deftest test-defrecord-with-protocol
   (is (= "svg:hex" (draw (Shape "hex") "svg")) "inline protocol method dispatches"))
 
 (defprotocol Labellable
-             (label-of [this]))
+  (label-of [this]))
 
 (defprotocol Sized
-             (size-of [this]))
+  (size-of [this]))
 
 (defrecord Box [label w h]
-           Labellable
-           (label-of [this] (get this :label))
-           Sized
-           (size-of [this] (* (get this :w) (get this :h))))
+  Labellable
+  (label-of [this] (get this :label))
+  Sized
+  (size-of [this] (* (get this :w) (get this :h))))
 
 (deftest test-defrecord-multi-protocol
   (let [b (Box "crate" 3 4)]
@@ -95,7 +95,7 @@
 ;; --- deftype with inline protocol methods ---
 
 (defprotocol TypeDescribable
-             (describe-type [this]))
+  (describe-type [this]))
 
 (deftype TypeThing [name]
          TypeDescribable

--- a/tests/phel/core/reify.phel
+++ b/tests/phel/core/reify.phel
@@ -4,10 +4,10 @@
 ;; --- Protocol definitions ---
 
 (defprotocol Speakable
-             (speak [this]))
+  (speak [this]))
 
 (defprotocol Nameable
-             (get-name [this]))
+  (get-name [this]))
 
 ;; --- Single protocol, single method ---
 
@@ -19,8 +19,8 @@
 
 (deftest test-reify-multiple-protocols
   (let [obj (reify
-             Speakable (speak [this] "hi")
-             Nameable (get-name [this] "Bob"))]
+              Speakable (speak [this] "hi")
+              Nameable (get-name [this] "Bob"))]
     (is (= "hi" (speak obj)) "first protocol")
     (is (= "Bob" (get-name obj)) "second protocol")))
 
@@ -41,7 +41,7 @@
 ;; --- Multi-arg methods ---
 
 (defprotocol Greeter
-             (greet [this name]))
+  (greet [this name]))
 
 (deftest test-reify-multi-arg
   (let [obj (reify Greeter (greet [this name] (str "Hello, " name "!")))]
@@ -60,22 +60,22 @@
 
 (deftest test-reify-multi-expression-body
   (let [obj (reify Speakable
-                   (speak [this]
-                          (let [a "hello"
-                                b " world"]
-                            (str a b))))]
+              (speak [this]
+                     (let [a "hello"
+                           b " world"]
+                       (str a b))))]
     (is (= "hello world" (speak obj)) "multi-expression body")))
 
 ;; --- Multiple methods on same protocol ---
 
 (defprotocol Describable
-             (label [this])
-             (detail [this]))
+  (label [this])
+  (detail [this]))
 
 (deftest test-reify-multi-method-protocol
   (let [obj (reify Describable
-                   (label [this] "my-label")
-                   (detail [this] "my-detail"))]
+              (label [this] "my-label")
+              (detail [this] "my-detail"))]
     (is (= "my-label" (label obj)) "first method")
     (is (= "my-detail" (detail obj)) "second method")
     (is (true? (satisfies? Describable obj)) "satisfies multi-method protocol")))
@@ -85,8 +85,8 @@
 (deftest test-reify-shared-closure-var
   (let [prefix ">"
         obj    (reify
-                Speakable (speak [this] (str prefix "speak"))
-                Nameable (get-name [this] (str prefix "name")))]
+                 Speakable (speak [this] (str prefix "speak"))
+                 Nameable (get-name [this] (str prefix "name")))]
     (is (= ">speak" (speak obj)) "first method captures shared var")
     (is (= ">name" (get-name obj)) "second method captures shared var")))
 
@@ -101,13 +101,13 @@
 ;; --- Method using this reference ---
 
 (defprotocol HasTag
-             (tag [this])
-             (tagged-message [this msg]))
+  (tag [this])
+  (tagged-message [this msg]))
 
 (deftest test-reify-method-calls-sibling-method
   (let [obj (reify HasTag
-                   (tag [this] "INFO")
-                   (tagged-message [this msg] (str "[" (tag this) "] " msg)))]
+              (tag [this] "INFO")
+              (tagged-message [this msg] (str "[" (tag this) "] " msg)))]
     (is (= "INFO" (tag obj)) "tag method")
     (is (= "[INFO] hello" (tagged-message obj "hello"))
         "method dispatches through protocol on this")))

--- a/tests/phel/core/transducers.phel
+++ b/tests/phel/core/transducers.phel
@@ -229,7 +229,7 @@
 (deftest test-eduction-doseq
   (let [seen (atom [])]
     (doseq [x (eduction (map inc) [10 20 30])]
-           (swap! seen conj x))
+      (swap! seen conj x))
     (is (= [11 21 31] @seen) "doseq iterates eduction")))
 
 (deftest test-eduction-reiterates-without-cache

--- a/tests/phel/core/var-introspection.phel
+++ b/tests/phel/core/var-introspection.phel
@@ -69,8 +69,8 @@
 
 (deftest test-with-bindings-rebinds-from-map
   (with-bindings {#'*intro-dyn* :wb-a #'*intro-dyn-2* :wb-b}
-                 (is (= :wb-a *intro-dyn*) "first var rebound")
-                 (is (= :wb-b *intro-dyn-2*) "second var rebound"))
+    (is (= :wb-a *intro-dyn*) "first var rebound")
+    (is (= :wb-b *intro-dyn-2*) "second var rebound"))
   (is (= :root *intro-dyn*) "first var restored")
   (is (= :root-2 *intro-dyn-2*) "second var restored"))
 
@@ -89,7 +89,7 @@
 
 (deftest test-with-redefs-rebinds-any-var
   (with-redefs [*intro-static* :swapped *intro-dyn* :also-swapped]
-               (is (= :swapped *intro-static*) "with-redefs accepts non-dynamic vars")
-               (is (= :also-swapped *intro-dyn*) "with-redefs accepts dynamic vars too"))
+    (is (= :swapped *intro-static*) "with-redefs accepts non-dynamic vars")
+    (is (= :also-swapped *intro-dyn*) "with-redefs accepts dynamic vars too"))
   (is (= :static-root *intro-static*) "static restored on exit")
   (is (= :root *intro-dyn*) "dynamic restored on exit"))

--- a/tests/phel/core/watches-validators.phel
+++ b/tests/phel/core/watches-validators.phel
@@ -134,6 +134,3 @@
       "alter-var-root rejects atoms")
   (is (thrown? \InvalidArgumentException (alter-var-root nil inc))
       "alter-var-root rejects nil"))
-
-
-

--- a/tests/phel/http.phel
+++ b/tests/phel/http.phel
@@ -376,7 +376,7 @@
   ;; output buffer so it doesn't leak into the test runner's progress output.
   (let [result (atom :unset)]
     (with-output-buffer
-     (reset! result (h/emit-response (h/response-from-string "anything"))))
+      (reset! result (h/emit-response (h/response-from-string "anything"))))
     (is (nil? @result) "emit-response returns nil")))
 
 (deftest test-emit-response-echoes-body-with-multiple-headers

--- a/tests/phel/mock.phel
+++ b/tests/phel/mock.phel
@@ -169,9 +169,9 @@
 (deftest test-mocking-with-redefs
   (let [mock-http (mock {:id 1 :name "Alice"})]
     (with-redefs [fetch-user (fn [_ id] (mock-http id))]
-                 (let [result (fetch-user nil 123)]
-                   (is (= {:id 1 :name "Alice"} result) "uses mocked response")
-                   (is (called-with? mock-http 123) "verifies call arguments")))))
+      (let [result (fetch-user nil 123)]
+        (is (= {:id 1 :name "Alice"} result) "uses mocked response")
+        (is (called-with? mock-http 123) "verifies call arguments")))))
 
 (deftest test-with-mocks-macro
   (let [mock-http (mock {:status 200})
@@ -286,10 +286,10 @@
 (deftest test-email-sending-mock
   (let [mock-email (mock :sent)]
     (with-redefs [send-email (fn [_ to subject body] (mock-email to subject body))]
-                 (register-user nil {:email "user@example.com"})
-                 (is (called-once? mock-email) "sends exactly one email")
-                 (is (called-with? mock-email "user@example.com" "Welcome!" "Thanks for signing up")
-                     "sends correct email"))))
+      (register-user nil {:email "user@example.com"})
+      (is (called-once? mock-email) "sends exactly one email")
+      (is (called-with? mock-email "user@example.com" "Welcome!" "Thanks for signing up")
+          "sends correct email"))))
 
 (defn fetch-from-api [url]
   "Simulates API call"
@@ -298,9 +298,9 @@
 (deftest test-api-failure-with-mock-throwing
   (let [mock-api (mock-throwing (php/new \RuntimeException "API unavailable"))]
     (with-redefs [fetch-from-api (fn [url] (mock-api url))]
-                 (is (thrown? \RuntimeException (fetch-from-api "http://api.example.com"))
-                     "throws when API fails")
-                 (is (called-with? mock-api "http://api.example.com") "attempted call with URL"))))
+      (is (thrown? \RuntimeException (fetch-from-api "http://api.example.com"))
+          "throws when API fails")
+      (is (called-with? mock-api "http://api.example.com") "attempted call with URL"))))
 
 (defn retry-fetch [fetch-fn url max-retries]
   "Simulates retry logic"
@@ -318,9 +318,9 @@
                                      (when (nil? result)
                                        (throw (php/new \Exception "Failed")))
                                      result))]
-                 (is (= {:status 200} (retry-fetch fetch-from-api "http://api.example.com" 3))
-                     "succeeds after retries")
-                 (is (= 3 (call-count mock-api)) "retries correct number of times"))))
+      (is (= {:status 200} (retry-fetch fetch-from-api "http://api.example.com" 3))
+          "succeeds after retries")
+      (is (= 3 (call-count mock-api)) "retries correct number of times"))))
 
 ;; -----------
 ;; Interop/External Function Mocking Tests
@@ -334,6 +334,6 @@
   (let [mock-external (mock {:success true :data "mocked response"})]
     ;; Mock an external/foreign function by wrapping it
     (with-redefs [call-external-service (fn [_ endpoint] (mock-external endpoint))]
-                 (let [result (call-external-service nil "/api/data")]
-                   (is (= {:success true :data "mocked response"} result) "returns mocked response")
-                   (is (called-with? mock-external "/api/data") "verifies external call was made")))))
+      (let [result (call-external-service nil "/api/data")]
+        (is (= {:success true :data "mocked response"} result) "returns mocked response")
+        (is (called-with? mock-external "/api/data") "verifies external call was made")))))

--- a/tests/phel/repeat-seed.phel
+++ b/tests/phel/repeat-seed.phel
@@ -22,7 +22,7 @@
                                (conj (vec (:reporters options)) capture))]
     (t/reset-stats)
     (with-output-buffer
-     (t/run-tests run-options fixture-ns))
+      (t/run-tests run-options fixture-ns))
     (let [snapshot (t/get-stats)]
       (t/set-reporters! saved-reporters)
       (t/restore-stats saved-stats)
@@ -61,7 +61,7 @@
         saved-stats     (t/get-stats)]
     (t/reset-stats)
     (with-output-buffer
-     (t/run-tests {:reporters [bump-reporter] :repeat 4} fixture-ns))
+      (t/run-tests {:reporters [bump-reporter] :repeat 4} fixture-ns))
     (t/set-reporters! saved-reporters)
     (t/restore-stats saved-stats)
     ;; 3 fixtures × 4 iterations = 12 pass events.
@@ -81,10 +81,10 @@
         saved-stats     (t/get-stats)]
     (t/reset-stats)
     (with-output-buffer
-     (t/run-tests {:reporters [capture]
-                   :random-order true
-                   :seed seed}
-                  fixture-ns))
+      (t/run-tests {:reporters [capture]
+                    :random-order true
+                    :seed seed}
+                   fixture-ns))
     (t/set-reporters! saved-reporters)
     (t/restore-stats saved-stats)
     (deref order)))

--- a/tests/phel/reporter-diff.phel
+++ b/tests/phel/reporter-diff.phel
@@ -25,10 +25,10 @@
   [expected actual]
   (let [rep (t/resolve-reporter :default)]
     (with-output-buffer
-     (rep {:type :begin-test-run})
-     (rep (failure-event expected actual))
-     (rep {:type :summary :total 1 :pass 0 :failed 1 :error 0
-           :failures [(failure-event expected actual)]}))))
+      (rep {:type :begin-test-run})
+      (rep (failure-event expected actual))
+      (rep {:type :summary :total 1 :pass 0 :failed 1 :error 0
+            :failures [(failure-event expected actual)]}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Threshold: small primitive failures keep the legacy single-line summary
@@ -119,14 +119,14 @@
   (let [rep   (t/resolve-reporter :default)
         equal (vec (range 5))
         out   (with-output-buffer
-               (rep {:type :begin-test-run})
-               (rep {:type :binary :state :failed
-                     :pred 'not= :expected equal :actual 'actual-form
-                     :result equal
-                     :form '(not= expected actual)
-                     :location {:file "diff.phel" :line 1}})
-               (rep {:type :summary :total 1 :pass 0 :failed 1 :error 0
-                     :failures []}))]
+                (rep {:type :begin-test-run})
+                (rep {:type :binary :state :failed
+                      :pred 'not= :expected equal :actual 'actual-form
+                      :result equal
+                      :form '(not= expected actual)
+                      :location {:file "diff.phel" :line 1}})
+                (rep {:type :summary :total 1 :pass 0 :failed 1 :error 0
+                      :failures []}))]
     (is (= 0 (php/preg_match "/Diff:/" out))
         "no diff block for not= failures: the values are equal")))
 

--- a/tests/phel/reporters.phel
+++ b/tests/phel/reporters.phel
@@ -85,11 +85,11 @@
 (deftest test-dot-reporter-emits-marker-per-assertion
   (let [rep (t/resolve-reporter :dot)
         out (with-output-buffer
-             (rep {:type :begin-test-run})
-             (rep {:type :pass :state :pass})
-             (rep {:type :failed :state :failed})
-             (rep {:type :error :state :error})
-             (rep {:type :summary :total 3 :pass 1 :failed 1 :error 1}))]
+              (rep {:type :begin-test-run})
+              (rep {:type :pass :state :pass})
+              (rep {:type :failed :state :failed})
+              (rep {:type :error :state :error})
+              (rep {:type :summary :total 3 :pass 1 :failed 1 :error 1}))]
     (is (= ".FE\nTests: 3, Passed: 1, Failed: 1, Errors: 1\n" out)
         "dot reporter prints markers plus one-line summary")))
 
@@ -100,10 +100,10 @@
 (deftest test-tap-reporter-emits-version-and-plan
   (let [rep (t/resolve-reporter :tap)
         out (with-output-buffer
-             (rep {:type :begin-test-run})
-             (rep {:type :pass :state :pass :test-name "a" :message "ok"})
-             (rep {:type :failed :state :failed :test-name "b" :message "bad"})
-             (rep {:type :summary :total 2}))]
+              (rep {:type :begin-test-run})
+              (rep {:type :pass :state :pass :test-name "a" :message "ok"})
+              (rep {:type :failed :state :failed :test-name "b" :message "bad"})
+              (rep {:type :summary :total 2}))]
     (is (php/preg_match "/^TAP version 13\\n/" out)
         "starts with TAP version header")
     (is (php/preg_match "/^ok 1 - a: ok$/m" out)
@@ -171,14 +171,14 @@
 (deftest test-default-reporter-matches-legacy-output
   (let [rep (t/resolve-reporter :default)
         out (with-output-buffer
-             (rep {:type :begin-test-run})
-             (rep {:type :pass :state :pass})
-             (rep {:type :pass :state :pass})
-             (rep {:type :failed :state :failed :form "(= 1 2)"
-                   :type :binary :pred '= :expected 1 :actual 2 :result 2
-                   :message "boom"})
-             (rep {:type :summary :total 3 :pass 2 :failed 1 :error 0
-                   :failures []}))]
+              (rep {:type :begin-test-run})
+              (rep {:type :pass :state :pass})
+              (rep {:type :pass :state :pass})
+              (rep {:type :failed :state :failed :form "(= 1 2)"
+                    :type :binary :pred '= :expected 1 :actual 2 :result 2
+                    :message "boom"})
+              (rep {:type :summary :total 3 :pass 2 :failed 1 :error 0
+                    :failures []}))]
     (is (php/preg_match "/\\.\\.F/" out) "emits marker sequence")
     (is (php/preg_match "/Passed: 2/" out) "prints Passed count")
     (is (php/preg_match "/Failed: 1/" out) "prints Failed count")
@@ -191,9 +191,9 @@
         _     (t/set-reporters! [rep])
         _     (t/reset-stats)
         out   (with-output-buffer
-               (rep {:type :begin-test-run})
-               (is (= 0 (apply + "")))
-               (t/print-summary))
+                (rep {:type :begin-test-run})
+                (is (= 0 (apply + "")))
+                (t/print-summary))
         _     (t/set-reporters! prev)
         _     (t/restore-stats saved)]
     (is (php/preg_match "/Test: \\(= 0 \\(apply \\+ \"\"\\)\\)/" out)
@@ -206,18 +206,18 @@
 (deftest test-default-reporter-thrown-with-msg-prints-when-exception-not-thrown
   (let [rep (t/resolve-reporter :default)
         out (with-output-buffer
-             (rep {:type :begin-test-run})
-             (rep {:type :thrown-with-msg :state :failed
-                   :form "(throw (new E 'x'))" :message "should throw"
-                   :exception-symbol "\\Exception"
-                   :expected-message "expected"
-                   :actual-message nil})
-             (rep {:type :summary :total 1 :pass 0 :failed 1 :error 0
-                   :failures [{:type :thrown-with-msg :state :failed
-                               :form "(throw (new E 'x'))" :message "should throw"
-                               :exception-symbol "\\Exception"
-                               :expected-message "expected"
-                               :actual-message nil}]}))]
+              (rep {:type :begin-test-run})
+              (rep {:type :thrown-with-msg :state :failed
+                    :form "(throw (new E 'x'))" :message "should throw"
+                    :exception-symbol "\\Exception"
+                    :expected-message "expected"
+                    :actual-message nil})
+              (rep {:type :summary :total 1 :pass 0 :failed 1 :error 0
+                    :failures [{:type :thrown-with-msg :state :failed
+                                :form "(throw (new E 'x'))" :message "should throw"
+                                :exception-symbol "\\Exception"
+                                :expected-message "expected"
+                                :actual-message nil}]}))]
     (is (php/preg_match "/to throw a: \\\\Exception \\(it didn't\\)/" out)
         "when no exception thrown, prints 'didn't throw' diagnostic")
     (is (= 0 (php/preg_match "/with message:/" out))
@@ -226,18 +226,18 @@
 (deftest test-default-reporter-thrown-with-msg-prints-when-message-differs
   (let [rep (t/resolve-reporter :default)
         out (with-output-buffer
-             (rep {:type :begin-test-run})
-             (rep {:type :thrown-with-msg :state :failed
-                   :form "(throw (new E 'actual'))" :message "msg mismatch"
-                   :exception-symbol "\\Exception"
-                   :expected-message "expected"
-                   :actual-message "actual"})
-             (rep {:type :summary :total 1 :pass 0 :failed 1 :error 0
-                   :failures [{:type :thrown-with-msg :state :failed
-                               :form "(throw (new E 'actual'))" :message "msg mismatch"
-                               :exception-symbol "\\Exception"
-                               :expected-message "expected"
-                               :actual-message "actual"}]}))]
+              (rep {:type :begin-test-run})
+              (rep {:type :thrown-with-msg :state :failed
+                    :form "(throw (new E 'actual'))" :message "msg mismatch"
+                    :exception-symbol "\\Exception"
+                    :expected-message "expected"
+                    :actual-message "actual"})
+              (rep {:type :summary :total 1 :pass 0 :failed 1 :error 0
+                    :failures [{:type :thrown-with-msg :state :failed
+                                :form "(throw (new E 'actual'))" :message "msg mismatch"
+                                :exception-symbol "\\Exception"
+                                :expected-message "expected"
+                                :actual-message "actual"}]}))]
     (is (php/preg_match "/to throw a: \\\\Exception/" out)
         "exception class is printed")
     (is (php/preg_match "/with message: expected/" out)
@@ -252,16 +252,16 @@
 (deftest test-dot-reporter-tolerates-missing-summary-fields
   (let [rep (t/resolve-reporter :dot)
         out (with-output-buffer
-             (rep {:type :begin-test-run})
-             (rep {:type :summary}))]
+              (rep {:type :begin-test-run})
+              (rep {:type :summary}))]
     (is (php/preg_match "/Tests: /" out)
         "dot reporter renders a summary line even when counts are absent")))
 
 (deftest test-default-reporter-tolerates-summary-without-failures
   (let [rep (t/resolve-reporter :default)
         out (with-output-buffer
-             (rep {:type :begin-test-run})
-             (rep {:type :summary :total 0 :pass 0 :failed 0 :error 0}))]
+              (rep {:type :begin-test-run})
+              (rep {:type :summary :total 0 :pass 0 :failed 0 :error 0}))]
     (is (php/preg_match "/Total: 0/" out)
         "summary renders cleanly when :failures key is absent")))
 
@@ -326,27 +326,27 @@
 (deftest test-tap-reporter-falls-back-to-assertion-description
   (let [rep (t/resolve-reporter :tap)
         out (with-output-buffer
-             (rep {:type :begin-test-run})
-             (rep {:type :pass :state :pass})
-             (rep {:type :summary :total 1}))]
+              (rep {:type :begin-test-run})
+              (rep {:type :pass :state :pass})
+              (rep {:type :summary :total 1}))]
     (is (php/preg_match "/^ok 1 - assertion$/m" out)
         "events without :test-name or :message fall back to 'assertion'")))
 
 (deftest test-tap-reporter-description-uses-message-only-when-name-missing
   (let [rep (t/resolve-reporter :tap)
         out (with-output-buffer
-             (rep {:type :begin-test-run})
-             (rep {:type :pass :state :pass :message "only-message"})
-             (rep {:type :summary :total 1}))]
+              (rep {:type :begin-test-run})
+              (rep {:type :pass :state :pass :message "only-message"})
+              (rep {:type :summary :total 1}))]
     (is (php/preg_match "/^ok 1 - only-message$/m" out)
         "events with :message only use it verbatim")))
 
 (deftest test-tap-reporter-description-uses-test-name-only-when-message-missing
   (let [rep (t/resolve-reporter :tap)
         out (with-output-buffer
-             (rep {:type :begin-test-run})
-             (rep {:type :pass :state :pass :test-name "only-test"})
-             (rep {:type :summary :total 1}))]
+              (rep {:type :begin-test-run})
+              (rep {:type :pass :state :pass :test-name "only-test"})
+              (rep {:type :summary :total 1}))]
     (is (php/preg_match "/^ok 1 - only-test$/m" out)
         "events with :test-name only use it verbatim")))
 
@@ -436,9 +436,9 @@
 (deftest test-testdox-reporter-uses-marker-per-outcome
   (let [rep (t/resolve-reporter :testdox)
         out (with-output-buffer
-             (rep {:type :pass :state :pass :test-name "t1" :message "ok"})
-             (rep {:type :failed :state :failed :test-name "t2" :message "bad"})
-             (rep {:type :error :state :error :test-name "t3" :message "boom"}))]
+              (rep {:type :pass :state :pass :test-name "t1" :message "ok"})
+              (rep {:type :failed :state :failed :test-name "t2" :message "bad"})
+              (rep {:type :error :state :error :test-name "t3" :message "boom"}))]
     (is (php/preg_match "/^✔ t1: ok$/m" out)
         "pass marker prints with test name and message")
     (is (php/preg_match "/^✘ t2: bad$/m" out)
@@ -449,14 +449,14 @@
 (deftest test-testdox-reporter-emits-skipped-marker
   (let [rep (t/resolve-reporter :testdox)
         out (with-output-buffer
-             (rep {:type :skipped :test-name "ignored-case"}))]
+              (rep {:type :skipped :test-name "ignored-case"}))]
     (is (php/preg_match "/↷ ignored-case \\(skipped\\)/" out)
         "skip marker and parenthesised tag appear for skipped tests")))
 
 (deftest test-testdox-reporter-handles-missing-message-with-default
   (let [rep (t/resolve-reporter :testdox)
         out (with-output-buffer
-             (rep {:type :pass :state :pass :test-name "no-msg"}))]
+              (rep {:type :pass :state :pass :test-name "no-msg"}))]
     (is (php/preg_match "/no test message found/" out)
         "falls back to descriptive placeholder when :message absent")))
 
@@ -502,7 +502,7 @@
         prev   (t/get-reporters)]
     (t/reset-stats)
     (with-output-buffer
-     (t/run-tests {:reporters [(fn [e] (swap! events conj (:type e)))]}))
+      (t/run-tests {:reporters [(fn [e] (swap! events conj (:type e)))]}))
     (t/set-reporters! prev)
     (t/restore-stats saved)
     (is (contains? (into (hash-set) (deref events)) :begin-test-run)

--- a/tests/phel/selectors-runtime.phel
+++ b/tests/phel/selectors-runtime.phel
@@ -21,7 +21,7 @@
                                (conj (vec (:reporters options)) capture))]
     (t/reset-stats)
     (with-output-buffer
-     (t/run-tests run-options fixture-ns))
+      (t/run-tests run-options fixture-ns))
     (let [snapshot (t/get-stats)]
       (t/set-reporters! saved-reporters)
       (t/restore-stats saved-stats)
@@ -59,8 +59,8 @@
         capture         (fn [e] (swap! events conj e))]
     (t/reset-stats)
     (with-output-buffer
-     (t/run-tests {:reporters [capture]} fixture-ns)
-     (t/run-tests {:reporters [capture]} fixture-ns))
+      (t/run-tests {:reporters [capture]} fixture-ns)
+      (t/run-tests {:reporters [capture]} fixture-ns))
     (let [summaries (events-of (deref events) :summary)]
       (t/set-reporters! saved-reporters)
       (t/restore-stats saved-stats)

--- a/tests/phel/string.phel
+++ b/tests/phel/string.phel
@@ -54,7 +54,6 @@
   (is (= "OObarfoo" (s/replace-first "foobarfoo" "/f(o+)/" (fn [m g1] (s/upper-case g1)))))
   (is (= "baz\\bangslash" (s/replace-first "bazslashbangslash" "/slash/" (fn [m] "\\")))))
 
-
 (deftest test-join
   (is (= "" (s/join nil)))
   (is (= "" (s/join [])))

--- a/tests/phel/test-framework.phel
+++ b/tests/phel/test-framework.phel
@@ -67,7 +67,7 @@
   (let [saved  (get-stats)
         _      (reset-stats)
         _      (with-output-buffer
-                (is (thrown? \InvalidArgumentException (+ 1 1))))
+                 (is (thrown? \InvalidArgumentException (+ 1 1))))
         counts (get (get-stats) :counts)]
     (restore-stats saved)
     (is (= 1 (:failed counts)) "thrown? without throw records a failure")))
@@ -91,7 +91,7 @@
   (let [saved  (get-stats)
         _      (reset-stats)
         _      (with-output-buffer
-                (is (thrown? (+ 1 2))))
+                 (is (thrown? (+ 1 2))))
         counts (get (get-stats) :counts)]
     (restore-stats saved)
     (is (= 1 (:failed counts))
@@ -117,7 +117,7 @@
   (let [saved  (get-stats)
         _      (reset-stats)
         _      (with-output-buffer
-                (is (thrown-with-msg? \InvalidArgumentException "boom" (+ 1 1))))
+                 (is (thrown-with-msg? \InvalidArgumentException "boom" (+ 1 1))))
         counts (get (get-stats) :counts)]
     (restore-stats saved)
     (is (= 1 (:failed counts)) "thrown-with-msg? without throw records a failure")))
@@ -126,8 +126,8 @@
   (let [saved  (get-stats)
         _      (reset-stats)
         _      (with-output-buffer
-                (is (thrown-with-msg? \InvalidArgumentException "expected"
-                                      (throw (php/new \InvalidArgumentException "different")))))
+                 (is (thrown-with-msg? \InvalidArgumentException "expected"
+                                       (throw (php/new \InvalidArgumentException "different")))))
         counts (get (get-stats) :counts)]
     (restore-stats saved)
     (is (= 1 (:failed counts)) "thrown-with-msg? with wrong message records a failure")))
@@ -143,7 +143,7 @@
   (let [saved  (get-stats)
         _      (reset-stats)
         _      (with-output-buffer
-                (is (output? "expected" (print "actual"))))
+                 (is (output? "expected" (print "actual"))))
         counts (get (get-stats) :counts)]
     (restore-stats saved)
     (is (= 1 (:failed counts)) "output? mismatch records a failure")))
@@ -241,7 +241,7 @@
   (let [saved  (get-stats)
         _      (reset-stats)
         _      (with-output-buffer
-                (is (= 1 (throw (php/new \RuntimeException "boom inside is")))))
+                 (is (= 1 (throw (php/new \RuntimeException "boom inside is")))))
         counts (get (get-stats) :counts)]
     (restore-stats saved)
     (is (= 1 (:error counts)) "uncaught exception in assertion is reported as :error")
@@ -294,8 +294,8 @@
   (let [saved    (get-stats)
         _        (reset-stats)
         _        (with-output-buffer
-                  (testing "math basics"
-                           (is (= 1 2) "addition")))
+                   (testing "math basics"
+                            (is (= 1 2) "addition")))
         snapshot (get-stats)]
     (restore-stats saved)
     (let [failure (first (get snapshot :failed))]

--- a/tests/php/Integration/Formatter/FormatterFacadeTest.php
+++ b/tests/php/Integration/Formatter/FormatterFacadeTest.php
@@ -25,6 +25,8 @@ final class FormatterFacadeTest extends TestCase
     #[DataProvider('providerIndent')]
     #[DataProvider('providerReformatted')]
     #[DataProvider('providerRemoveTrailingWhitespaceRule')]
+    #[DataProvider('providerRemoveConsecutiveBlankLines')]
+    #[DataProvider('providerExtendedIndents')]
     public function test_format(array $actualLines, array $expectedLines): void
     {
         $formatted = $this->formatterFactory
@@ -472,6 +474,148 @@ final class FormatterFacadeTest extends TestCase
                 '  )',
             ],
             ['(foo)'],
+        ];
+    }
+
+    public static function providerRemoveConsecutiveBlankLines(): Generator
+    {
+        yield 'Collapse multiple blank lines between top-level forms' => [
+            [
+                '(def a 1)',
+                '',
+                '',
+                '',
+                '(def b 2)',
+            ],
+            [
+                '(def a 1)',
+                '',
+                '(def b 2)',
+            ],
+        ];
+
+        yield 'Keep a single blank line between top-level forms' => [
+            [
+                '(def a 1)',
+                '',
+                '(def b 2)',
+            ],
+            [
+                '(def a 1)',
+                '',
+                '(def b 2)',
+            ],
+        ];
+
+        yield 'Collapse blank lines inside a body' => [
+            [
+                '(defn foo []',
+                '  (println 1)',
+                '',
+                '',
+                '  (println 2))',
+            ],
+            [
+                '(defn foo []',
+                '  (println 1)',
+                '',
+                '  (println 2))',
+            ],
+        ];
+
+        yield 'Collapse blank lines after a comment' => [
+            [
+                ';; a comment',
+                '',
+                '',
+                '',
+                '(def a 1)',
+            ],
+            [
+                ';; a comment',
+                '',
+                '(def a 1)',
+            ],
+        ];
+    }
+
+    public static function providerExtendedIndents(): Generator
+    {
+        yield 'doseq body is block-indented' => [
+            [
+                '(doseq [x coll]',
+                '(println x))',
+            ],
+            [
+                '(doseq [x coll]',
+                '  (println x))',
+            ],
+        ];
+
+        yield 'dotimes body is block-indented' => [
+            [
+                '(dotimes [i 3]',
+                '(println i))',
+            ],
+            [
+                '(dotimes [i 3]',
+                '  (println i))',
+            ],
+        ];
+
+        yield 'defprotocol methods are inner-indented' => [
+            [
+                '(defprotocol Speakable',
+                '(speak [this]))',
+            ],
+            [
+                '(defprotocol Speakable',
+                '  (speak [this]))',
+            ],
+        ];
+
+        yield 'reify body is inner-indented' => [
+            [
+                '(reify Speakable',
+                '(speak [this] "hi"))',
+            ],
+            [
+                '(reify Speakable',
+                '  (speak [this] "hi"))',
+            ],
+        ];
+
+        yield 'lazy-seq body is block-indented' => [
+            [
+                '(lazy-seq',
+                '(cons 1 nil))',
+            ],
+            [
+                '(lazy-seq',
+                '  (cons 1 nil))',
+            ],
+        ];
+
+        yield 'with-output-buffer body is block-indented' => [
+            [
+                '(with-output-buffer',
+                '(print 1))',
+            ],
+            [
+                '(with-output-buffer',
+                '  (print 1))',
+            ],
+        ];
+
+        yield 'defstruct body is inner-indented' => [
+            [
+                '(defstruct point',
+                '[x y])',
+            ],
+            [
+                '(defstruct point',
+                '  [x y])',
+            ],
         ];
     }
 


### PR DESCRIPTION
## 🤔 Background

`phel format` lagged behind cljfmt (the de-facto Clojure formatter) in two areas that affect everyday namespace and body formatting:

1. **Consecutive blank lines** were never collapsed — three blank lines between two top-level forms stayed as three. cljfmt's `:remove-consecutive-blank-lines?` (on by default) collapses them to one.
2. **Indentation coverage was incomplete.** Only a subset of forms had block/inner indent rules; common definition and body forms (`defstruct`, `defprotocol`, `defmulti`/`defmethod`, `reify`, `doseq`, `dotimes`, `letfn`, `with-redefs`, …) fell back to call-style alignment, producing deeply indented bodies aligned under the form name instead of a clean 2-space body.

cljfmt's `:sort-ns-references?` (sorting `:require`/`:import` libspecs) was evaluated and intentionally left out — it is **off by default in cljfmt**, and reordering a user's requires is a separate, opt-in concern.

## 💡 Goal

Bring `phel format` in line with cljfmt's default formatting behaviour for blank lines and form indentation, so Phel code is laid out the way Clojure developers expect.

## 🔖 Changes

- **New rule `RemoveConsecutiveBlankLinesRule`** — collapses runs of 2+ blank lines to a single blank line (cljfmt parity). A preceding line comment is treated as a line break, so a comment line keeps exactly one blank line after it. Runs after `UnindentRule`, so blank lines are bare newline nodes.
- **Expanded indent registry** in `FormatterFactory`:
  - *Inner* (2-space body): `defstruct`, `defrecord`, `definterface`, `defexception`, `defenum`, `defprotocol`, `defmulti`, `defmethod`, `defonce`, `reify`.
  - *Block*: `when-first`, `doseq`, `dotimes`, `letfn`, `with-redefs`, `with-bindings`, `extend-type`, `extend-protocol` (index 1); `with-output-buffer`, `delay`, `lazy-seq` (index 0).
- **Tests**: added data-provider cases to `FormatterFacadeTest` for blank-line collapsing (incl. inside bodies and after comments) and for each new indent rule.
- **Repo reformat**: applied the updated formatter to `src/phel/` and `tests/phel/` (whitespace-only; all 5897 core tests still pass). Output is idempotent.
- Updated `src/php/Formatter/CLAUDE.md` and `CHANGELOG.md`.