### PR TITLE
docs(core): collapse needlessly multiline docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Richer PHP interop for bridging Phel to typed PHP / framework code (all opt-in, 
 - Internals: split seven oversized god-classes into focused collaborators across compiler/runtime/build/api (pure refactors): `CallSpecialization`, `CallEmitter` (#2273), `CompiledCodeCache` (#2274), `BigInt` (#2275), `NumericOperations` (#2276), `PhelFnLoader` (#2277), `Parser` (#2278); centralized bare-expression capture into `OutputEmitter::captureNodeAsExpression()`
 - Tests: `RegistryTest`/`PhelVarTest` snapshot and restore the global `Registry`, fixing order-dependent `phel.core` failures (#2256)
 - Docs: condensed every `docs/` guide (~17% smaller), verified against the runtime, cross-linked to phel-lang.org
+- Docs: collapsed needlessly multiline `:doc`/docstrings across `src/phel/` (418 strings, 57 files) so prose renders on one line in `phel doc` and the API reference instead of with stray line-break spacing; structured docs (code blocks, aligned key tables, multi-paragraph, indented examples) are preserved (#2340)
 - Quality: repo-wide maintainability pass — docblocks and `:doc`/`:see-also`/`:example` metadata, dead-code/type/naming cleanups, helper extractions, ~40 new unit tests (no behavior change)
 - `agent-install`: simplified to copying skill files and the `.agents/` docs tree; dropped version stamping, `--check`, `--list`
 - `phel.ai`: default chat model is now `claude-sonnet-4-6`; `nearest` computes the query magnitude once instead of per item

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -22,8 +22,7 @@
   (atom default-config))
 
 (def ^:dynamic *http-post*
-  {:doc "HTTP POST seam. Rebind with `binding` in tests to inject a fake transport.
-  Tagged `^:dynamic` so concurrent tests rebinding it stay isolated per fiber."
+  {:doc "HTTP POST seam. Rebind with `binding` in tests to inject a fake transport. Tagged `^:dynamic` so concurrent tests rebinding it stay isolated per fiber."
    :example "(binding [*http-post* (fn [url opts] {:status 200 :body \"...\"})] ...)"}
   hc/post)
 
@@ -44,9 +43,7 @@
   (swap! config merge opts))
 
 (defmacro with-config
-  "Temporarily merges `opts` into the global config for the duration of `body`,
-  then restores the previous config. Safer than `configure` for embedded use,
-  since it won't leave global state mutated when `body` throws."
+  "Temporarily merges `opts` into the global config for the duration of `body`, then restores the previous config. Safer than `configure` for embedded use, since it won't leave global state mutated when `body` throws."
   {:example "(with-config {:provider :openai :model \"gpt-4o\"} (complete \"hi\"))"
    :see-also ["configure" "config"]}
   [opts & body]
@@ -70,8 +67,7 @@
     "ANTHROPIC_API_KEY"))
 
 (defn- resolve-api-key
-  "Resolves the API key from config or environment variables.
-  Supports :anthropic, :openai, and :voyageai providers."
+  "Resolves the API key from config or environment variables. Supports :anthropic, :openai, and :voyageai providers."
   [cfg]
   (let [provider (get cfg :provider)
         env-var  (provider-env-var provider)]
@@ -95,8 +91,7 @@
     "https://api.anthropic.com"))
 
 (defn- resolve-base-url
-  "Resolves the base URL: explicit `:base-url` from config, otherwise the
-  provider default."
+  "Resolves the base URL: explicit `:base-url` from config, otherwise the provider default."
   [cfg provider]
   (or (get cfg :base-url) (provider-base-url provider)))
 
@@ -112,8 +107,7 @@
    :content-type "application/json"})
 
 (defn- anthropic-request
-  "Builds an HTTP request for the Anthropic Messages API.
-  Optionally includes tool definitions."
+  "Builds an HTTP request for the Anthropic Messages API. Optionally includes tool definitions."
   [cfg messages system-prompt & [tools]]
   (let [api-key (resolve-api-key cfg)
         base    (resolve-base-url cfg :anthropic)
@@ -274,9 +268,7 @@
 (def- carry-keys [:model :max-tokens :provider :timeout :base-url :api-key :max-retries])
 
 (defn- apply-opts
-  "Merges per-call opts into cfg. Copies over keys whose value is non-nil so
-  numeric zero and `false` propagate (e.g. `:max-tokens 0`), while an
-  explicit `nil` is treated as 'leave the config alone'."
+  "Merges per-call opts into cfg. Copies over keys whose value is non-nil so numeric zero and `false` propagate (e.g. `:max-tokens 0`), while an explicit `nil` is treated as 'leave the config alone'."
   [cfg opts]
   (let [opts (or opts {})]
     (reduce (fn [acc k]
@@ -320,18 +312,16 @@
 (defn complete
   "Sends a simple text completion request.
 
-  Takes a prompt string and returns the assistant's text response.
-  This is a convenience wrapper around `chat` for single-turn interactions."
+Takes a prompt string and returns the assistant's text response. This is a convenience wrapper around `chat` for single-turn interactions."
   {:example "(complete \"Explain monads in one sentence\")"
    :see-also ["chat" "configure"]}
   [prompt & [opts]]
   (chat [{:role "user", :content prompt}] opts))
 
 (defn chat-with-history
-  "Appends a new user message to an existing conversation history,
-  sends it, and returns the updated history with the assistant's response.
+  "Appends a new user message to an existing conversation history, sends it, and returns the updated history with the assistant's response.
 
-  Useful for building multi-turn conversations."
+Useful for building multi-turn conversations."
   {:example "(chat-with-history [{:role \"user\" :content \"Hi\"}
                               {:role \"assistant\" :content \"Hello!\"}]
                              \"How are you?\")"
@@ -346,8 +336,7 @@
 ;; -----------
 
 (defn- schema->json-description
-  "Converts a field schema map to a human-readable JSON description
-  for the AI prompt."
+  "Converts a field schema map to a human-readable JSON description for the AI prompt."
   [schema]
   (let [lines (for [[k v] :pairs schema]
                 (str "  \"" (name k) "\": " (if (string? v) v (str v))))]
@@ -383,8 +372,7 @@
 ;; -----------
 
 (defn- truncate-for-error
-  "Truncates a string for inclusion in an error message so we don't echo the
-  full model response (which may contain prompt content) into logs."
+  "Truncates a string for inclusion in an error message so we don't echo the full model response (which may contain prompt content) into logs."
   [s]
   (let [limit 120
         len   (php/strlen s)]
@@ -420,8 +408,7 @@
   "You are a precise data extraction assistant. Return only valid JSON.")
 
 (defn- extract-json-array-from-response
-  "Extracts a JSON array from a model response, slicing between the first
-  '[' and the last ']' when the array isn't already at the start."
+  "Extracts a JSON array from a model response, slicing between the first '[' and the last ']' when the array isn't already at the start."
   [response]
   (let [trimmed (php/trim response)]
     (if (php/str_starts_with trimmed "[")
@@ -459,8 +446,7 @@
 (defn extract-many
   "Extracts a list of structured items from text.
 
-  Similar to `extract`, but returns a vector of maps when the text
-  contains multiple items matching the schema."
+Similar to `extract`, but returns a vector of maps when the text contains multiple items matching the schema."
   {:example "(extract-many {:name \"string\" :role \"string\"} \"Alice is CEO, Bob is CTO\")"
    :see-also ["extract" "complete"]}
   [schema text & [opts]]
@@ -501,8 +487,7 @@
     :raw        - The full provider response body
 
   Options map accepts the same keys as `chat`."
-  {:example "(chat-with-tools [{:role \"user\" :content \"What's the weather?\"}]
-                             [(tool \"get-weather\" \"Gets weather\" {:city {:type \"string\"}})])"
+  {:example "(chat-with-tools [{:role \"user\" :content \"What's the weather?\"}] [(tool \"get-weather\" \"Gets weather\" {:city {:type \"string\"}})])"
    :see-also ["tool" "tool-calls" "tool-result" "extract" "run-tools"]}
   [messages tools & [{:keys [system], :as opts}]]
   (let [cfg         (apply-opts @config opts)
@@ -557,8 +542,7 @@
                   :content result-str}]})))
 
 (defn- assistant-message
-  "Builds an assistant message preserving the model's tool_use blocks so the
-  next turn can carry the conversation forward. Anthropic-only for now."
+  "Builds an assistant message preserving the model's tool_use blocks so the next turn can carry the conversation forward. Anthropic-only for now."
   [raw-response]
   {:role "assistant"
    :content (or (get raw-response :content) [])})
@@ -577,9 +561,7 @@
   Returns the assistant's final text. Throws if a tool name has no handler
   or if `:max-turns` is reached without a final response. Anthropic-only;
   OpenAI tool loops require a different message shape and are not handled."
-  {:example "(run-tools [{:role \"user\" :content \"weather?\"}]
-                       [(tool \"get-weather\" \"...\" {:city \"string\"})]
-                       {\"get-weather\" (fn [args] \"72F\")})"
+  {:example "(run-tools [{:role \"user\" :content \"weather?\"}] [(tool \"get-weather\" \"...\" {:city \"string\"})] {\"get-weather\" (fn [args] \"72F\")})"
    :see-also ["chat-with-tools" "tool" "tool-result"]}
   [messages tools handlers & [opts]]
   (let [max-turns (or (get opts :max-turns) 5)]
@@ -625,16 +607,14 @@
   (php/sqrt (apply + (map #(* % %) v))))
 
 (defn- similarity-with-mags
-  "Cosine similarity given each vector's precomputed L2 magnitude. Returns 0.0
-  when either magnitude is zero (and skips the dot product in that case)."
+  "Cosine similarity given each vector's precomputed L2 magnitude. Returns 0.0 when either magnitude is zero (and skips the dot product in that case)."
   [a mag-a b mag-b]
   (if (or (zero? mag-a) (zero? mag-b))
     0.0
     (/ (dot-product a b) (* mag-a mag-b))))
 
 (defn cosine-similarity
-  "Computes the cosine similarity between two numeric vectors.
-  Returns a float between -1.0 and 1.0, where 1.0 means identical direction."
+  "Computes the cosine similarity between two numeric vectors. Returns a float between -1.0 and 1.0, where 1.0 means identical direction."
   {:example "(cosine-similarity [1 0] [0 1]) ; => 0"
    :see-also ["dot-product" "magnitude" "nearest"]}
   [a b]
@@ -680,8 +660,7 @@
   (embed-request provider texts model))
 
 (defn embed-one
-  "Generates an embedding for a single text string.
-  Returns a single embedding vector."
+  "Generates an embedding for a single text string. Returns a single embedding vector."
   {:example "(embed-one \"hello world\") ; => [0.123 -0.456 ...]"
    :see-also ["embed" "cosine-similarity"]}
   [text & [opts]]
@@ -712,10 +691,9 @@
 (defn build-index
   "Builds a searchable index from a collection of text strings.
 
-  Embeds all texts and returns a vector of {:text, :embedding} maps
-  suitable for use with `nearest`.
+Embeds all texts and returns a vector of {:text, :embedding} maps suitable for use with `nearest`.
 
-  Options are passed through to `embed`."
+Options are passed through to `embed`."
   {:example "(build-index [\"hello\" \"world\"])"
    :see-also ["nearest" "embed" "search"]}
   [texts & [opts]]
@@ -725,10 +703,9 @@
          texts embeddings)))
 
 (defn search
-  "Semantic search: embeds a query and finds the k nearest matches
-  in a pre-built index.
+  "Semantic search: embeds a query and finds the k nearest matches in a pre-built index.
 
-  Returns a vector of {:text, :embedding, :similarity} maps."
+Returns a vector of {:text, :embedding, :similarity} maps."
   {:example "(search \"greeting\" my-index 3)"
    :see-also ["nearest" "build-index" "embed-one"]}
   [query index & [{:keys [k model provider], :or {k 5}}]]

--- a/src/phel/base64.phel
+++ b/src/phel/base64.phel
@@ -8,9 +8,7 @@
   (php/base64_encode s))
 
 (defn decode
-  "Decodes a Base64 string. When `strict?` is true, validates that the
-  input contains only characters from the Base64 alphabet and returns
-  false on invalid input (defaults to false)."
+  "Decodes a Base64 string. When `strict?` is true, validates that the input contains only characters from the Base64 alphabet and returns false on invalid input (defaults to false)."
   {:example "(decode \"SGVsbG8=\") ; => \"Hello\""}
   [s & [strict?]]
   (php/base64_decode s (or strict? false)))

--- a/src/phel/cli.phel
+++ b/src/phel/cli.phel
@@ -252,8 +252,7 @@
 (defn progress-finish   "Finish + newline."     [bar] (php/-> bar (finish)) (println))
 
 (defn run-with-progress
-  "Iterate `coll` and invoke `(step-fn item bar)` for each, handling
-  start / advance / finish automatically."
+  "Iterate `coll` and invoke `(step-fn item bar)` for each, handling start / advance / finish automatically."
   {:example "(run-with-progress ctx files (fn [f _] (process f)))"}
   [ctx coll step-fn & [opts]]
   (let [bar (progress-bar ctx (assoc (or opts {}) :max (or (get opts :max) (count coll))))]
@@ -465,16 +464,14 @@
 ;; =============================================================================
 
 (defn argv
-  "Build an `ArgvInput` from a vector of string tokens. Positional args
-  and `--flag=value` are parsed just like a real shell command line."
+  "Build an `ArgvInput` from a vector of string tokens. Positional args and `--flag=value` are parsed just like a real shell command line."
   {:see-also ["argv-with-stdin" "buffered-output"]
    :example  "(argv [\"greet\" \"--loud\" \"alice\"])"}
   [args]
   (php/new ArgvInput (apply php/array (cons "_" args))))
 
 (defn argv-with-stdin
-  "Like `argv` but also wires a STDIN stream so `ask`/`confirm`/`choice`
-  prompts can be tested with canned answers."
+  "Like `argv` but also wires a STDIN stream so `ask`/`confirm`/`choice` prompts can be tested with canned answers."
   {:example "(argv-with-stdin [\"greet\"] \"alice\\n\")"}
   [args stdin-string]
   (let [input  (argv args)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -19,11 +19,7 @@
   "")
 
 (def *assert*
-  {:doc "Controls whether `assert` expands to a runtime check. When logical
-  false at macroexpansion time, `assert` expands to nil and performs no
-  runtime check, matching Clojure's compile-time `*assert*` semantics.
-  Defaults to `true`. To disable globally, set the core binding before
-  compilation via PHP: `\\Phel::addDefinition(\"phel\\\\core\", \"*assert*\", false)`."}
+  {:doc "Controls whether `assert` expands to a runtime check. When logical false at macroexpansion time, `assert` expands to nil and performs no runtime check, matching Clojure's compile-time `*assert*` semantics. Defaults to `true`. To disable globally, set the core binding before compilation via PHP: `\\Phel::addDefinition(\"phel\\\\core\", \"*assert*\", false)`."}
   true)
 
 ;; --------------------------------------------
@@ -43,9 +39,7 @@
     (php/:: Phel (vector (apply php/array xs)))))
 
 (def queue
-  {:doc "Creates a persistent FIFO queue. With no arguments returns an empty
-  queue; with arguments returns a queue with the values pushed in order so
-  that the first argument is at the front."
+  {:doc "Creates a persistent FIFO queue. With no arguments returns an empty queue; with arguments returns a queue with the values pushed in order so that the first argument is at the front."
    :example "(queue 1 2 3) ; => first 1, then 2, then 3"}
   (fn [& xs]
     (php/:: Phel (queue (apply php/array xs)))))
@@ -57,11 +51,7 @@
     (php/:: Phel (map (apply php/array xs)))))
 
 (def array-map
-  {:doc "Constructs a map from the given key/value pairs. If any keys are
-  equal, later values replace earlier ones, as if by repeated `assoc`.
-  Phel has no distinct array-map type, so the result is the same
-  persistent map as `hash-map` — `array-map` exists for `.cljc` interop
-  with Clojure sources."
+  {:doc "Constructs a map from the given key/value pairs. If any keys are equal, later values replace earlier ones, as if by repeated `assoc`. Phel has no distinct array-map type, so the result is the same persistent map as `hash-map` — `array-map` exists for `.cljc` interop with Clojure sources."
    :example "(array-map :a 1 :b 2) ; => {:a 1 :b 2}"
    :see-also ["hash-map"]}
   (fn [& xs]
@@ -146,9 +136,7 @@
 (def first
   {:doc "Returns the first element of a sequence, or nil if empty.
 
-  Maps are treated as a sequence of entries: `(first {:a 1})` returns a
-  typed `MapEntry` equal by value to `[:a 1]`. Strings are treated as
-  sequences of multibyte characters."
+Maps are treated as a sequence of entries: `(first {:a 1})` returns a typed `MapEntry` equal by value to `[:a 1]`. Strings are treated as sequences of multibyte characters."
    :example "(first [1 2 3]) ; => 1"}
   (fn [xs]
     (if (php/instanceof xs FirstInterface)         (php/-> xs (first))
@@ -202,8 +190,7 @@
     (if (php/=== prog nil) "" prog)))
 
 (def argv
-  "Vector of user arguments passed to the script (excludes program name).
-  Use *program* to get the script path or namespace."
+  "Vector of user arguments passed to the script (excludes program name). Use *program* to get the script path or namespace."
   (let [argv-raw (php/aget php/$GLOBALS "__phel_argv")]
     (if (php/=== argv-raw nil)
       []

--- a/src/phel/core/arrays.phel
+++ b/src/phel/core/arrays.phel
@@ -57,10 +57,7 @@
     (to-php-array size-or-seq)))
 
 (defn to-array
-  "Returns a PHP array containing the elements of `coll`. Accepts any
-  collection (vector, list, set, map, PHP array) or `nil`, which yields
-  an empty PHP array. Matches Clojure's `to-array` for `.cljc` interop —
-  in Phel the result is a plain PHP array since PHP has no `Object[]`."
+  "Returns a PHP array containing the elements of `coll`. Accepts any collection (vector, list, set, map, PHP array) or `nil`, which yields an empty PHP array. Matches Clojure's `to-array` for `.cljc` interop — in Phel the result is a plain PHP array since PHP has no `Object[]`."
   {:example "(to-array [1 2 3]) ; => <PHP-Array [1, 2, 3]>\n(to-array nil) ; => <PHP-Array []>"
    :see-also ["to-php-array" "object-array"]}
   [coll]
@@ -90,12 +87,7 @@
     (throw (php/new InvalidArgumentException (str op-name " expects a PHP array")))))
 
 (defn aclone
-  "Returns a shallow copy of a PHP array. The returned array is a
-  distinct value — mutating the copy via `php/aset` does not affect the
-  original, and vice versa. Matches Clojure's `aclone` for `.cljc`
-  interop; raises `InvalidArgumentException` on non-array inputs since
-  Phel's persistent collections are already immutable and don't need
-  cloning."
+  "Returns a shallow copy of a PHP array. The returned array is a distinct value — mutating the copy via `php/aset` does not affect the original, and vice versa. Matches Clojure's `aclone` for `.cljc` interop; raises `InvalidArgumentException` on non-array inputs since Phel's persistent collections are already immutable and don't need cloning."
   {:example "(aclone (object-array 3)) ; => <PHP-Array [nil, nil, nil]>"
    :see-also ["object-array" "to-array"]}
   [arr]
@@ -167,41 +159,35 @@
   ([size init-val-or-seq] (typed-array php/intval 0 size init-val-or-seq)))
 
 (defn long-array
-  "Creates a PHP array of longs (same as int-array in PHP). Accepts the same
-  arities and semantics as `int-array`."
+  "Creates a PHP array of longs (same as int-array in PHP). Accepts the same arities and semantics as `int-array`."
   {:example "(long-array 3) ; => <PHP-Array [0, 0, 0]>\n(long-array 4 7) ; => <PHP-Array [7, 7, 7, 7]>"
    :see-also ["int-array" "float-array" "double-array" "short-array"]}
   ([size-or-seq] (typed-array php/intval 0 size-or-seq))
   ([size init-val-or-seq] (typed-array php/intval 0 size init-val-or-seq)))
 
 (defn float-array
-  "Creates a PHP array of floats. Accepts the same arities as `int-array`;
-  coerces elements to float via `floatval` and zero-pads with `0.0`."
+  "Creates a PHP array of floats. Accepts the same arities as `int-array`; coerces elements to float via `floatval` and zero-pads with `0.0`."
   {:example "(float-array 3) ; => <PHP-Array [0, 0, 0]>\n(float-array 4 1.5) ; => <PHP-Array [1.5, 1.5, 1.5, 1.5]>"
    :see-also ["double-array" "int-array" "long-array" "short-array"]}
   ([size-or-seq] (typed-array php/floatval 0.0 size-or-seq))
   ([size init-val-or-seq] (typed-array php/floatval 0.0 size init-val-or-seq)))
 
 (defn double-array
-  "Creates a PHP array of doubles (same as float-array in PHP). Accepts the same
-  arities and semantics as `float-array`."
+  "Creates a PHP array of doubles (same as float-array in PHP). Accepts the same arities and semantics as `float-array`."
   {:example "(double-array 3) ; => <PHP-Array [0, 0, 0]>\n(double-array 4 1.5) ; => <PHP-Array [1.5, 1.5, 1.5, 1.5]>"
    :see-also ["float-array" "int-array" "long-array" "short-array"]}
   ([size-or-seq] (typed-array php/floatval 0.0 size-or-seq))
   ([size init-val-or-seq] (typed-array php/floatval 0.0 size init-val-or-seq)))
 
 (defn short-array
-  "Creates a PHP array of shorts (16-bit integers). Accepts the same arities
-  and semantics as `int-array`."
+  "Creates a PHP array of shorts (16-bit integers). Accepts the same arities and semantics as `int-array`."
   {:example "(short-array 3) ; => <PHP-Array [0, 0, 0]>\n(short-array 4 7) ; => <PHP-Array [7, 7, 7, 7]>"
    :see-also ["int-array" "long-array" "float-array" "double-array"]}
   ([size-or-seq] (typed-array php/intval 0 size-or-seq))
   ([size init-val-or-seq] (typed-array php/intval 0 size init-val-or-seq)))
 
 (defn aget
-  "Returns the value at `index` in a PHP array. With multiple indices,
-   accesses nested arrays: `(aget arr i j)` is `(aget (aget arr i) j)`.
-   Matches Clojure's `aget` for `.cljc` interop."
+  "Returns the value at `index` in a PHP array. With multiple indices, accesses nested arrays: `(aget arr i j)` is `(aget (aget arr i) j)`. Matches Clojure's `aget` for `.cljc` interop."
   {:example "(aget (php/array 10 20 30) 1) ; => 20"
    :see-also ["aset" "aclone" "object-array"]}
   [arr & indices]

--- a/src/phel/core/async.phel
+++ b/src/phel/core/async.phel
@@ -17,9 +17,7 @@
   (php/new \Phel\Fiber\FiberFacade))
 
 (defn ->closure
-  "Converts a Phel function to a PHP Closure.
-  Many PHP libraries (AMPHP, ReactPHP) type-hint `\\Closure` and reject
-  Phel's `AbstractFn` even though it is callable. This bridges the gap."
+  "Converts a Phel function to a PHP Closure. Many PHP libraries (AMPHP, ReactPHP) type-hint `\\Closure` and reject Phel's `AbstractFn` even though it is callable. This bridges the gap."
   {:example "(->closure (fn [x] (* x 2)))"}
   [f]
   (php/:: \Closure (fromCallable f)))
@@ -39,24 +37,21 @@
         (php/:: \Phel (withDynamicBindings frame# (fn [] ~@body)))))))
 
 (defn- unwrap-future
-  "Returns the raw Amp\\Future for either a `Future` wrapper or
-  a bare `Amp\\Future`."
+  "Returns the raw Amp\\Future for either a `Future` wrapper or a bare `Amp\\Future`."
   [future]
   (if (php/instanceof future \Phel\Lang\Future)
     (php/-> future (unwrap))
     future))
 
 (defn await
-  "Blocks the current fiber until the Future resolves and returns its value.
-  Accepts either a raw `Amp\\Future` or a `Future` wrapper."
+  "Blocks the current fiber until the Future resolves and returns its value. Accepts either a raw `Amp\\Future` or a `Future` wrapper."
   {:example "(await (async (+ 1 2)))"
    :see-also ["async" "await-all" "await-any"]}
   [future]
   (php/-> (unwrap-future future) (await)))
 
 (defn await-all
-  "Awaits all Futures in the given collection. Returns a vector of results.
-  Accepts a mix of raw `Amp\\Future` and `Future` wrappers."
+  "Awaits all Futures in the given collection. Returns a vector of results. Accepts a mix of raw `Amp\\Future` and `Future` wrappers."
   {:example "(await-all [(async 1) (async 2)])"
    :see-also ["await" "await-any" "pmap"]}
   [futures]
@@ -65,8 +60,7 @@
       v)))
 
 (defn await-any
-  "Awaits the first Future to resolve. Returns its value.
-  Accepts a mix of raw `Amp\\Future` and `Future` wrappers."
+  "Awaits the first Future to resolve. Returns its value. Accepts a mix of raw `Amp\\Future` and `Future` wrappers."
   {:example "(await-any [(async 1) (async 2)])"
    :see-also ["await" "await-all"]}
   [futures]
@@ -76,15 +70,9 @@
 (defn pmap
   "Like `map`, but applies `f` to elements concurrently via fibers.
 
-  Returns a vector of results in the original order. With multiple
-  collections, applies `f` to corresponding elements from each collection,
-  stopping when the shortest collection is exhausted.
+Returns a vector of results in the original order. With multiple collections, applies `f` to corresponding elements from each collection, stopping when the shortest collection is exhausted.
 
-  PHP fibers are cooperative on a single thread, so `pmap` overlaps
-  IO-bound work (HTTP, DB, file IO) but does not parallelize CPU-bound
-  computations across cores — unlike `clojure.core/pmap`, which uses a
-  thread pool. ClojureScript and Basilisp follow the same single-threaded
-  model."
+PHP fibers are cooperative on a single thread, so `pmap` overlaps IO-bound work (HTTP, DB, file IO) but does not parallelize CPU-bound computations across cores — unlike `clojure.core/pmap`, which uses a thread pool. ClojureScript and Basilisp follow the same single-threaded model."
   {:example "(pmap inc [1 2 3]) ; => [2 3 4]"
    :see-also ["map" "async" "await-all"]}
   [f & colls]
@@ -94,12 +82,7 @@
     (await-all (apply map (fn [& args] (async (apply f args))) colls))))
 
 (defn future-cancel
-  "Signals the future's internal cancellation token, causing any pending
-  or subsequent `deref` call to raise `CancelledException` (or return the
-  timeout value for the 3-arg form). Due to AMPHP's cooperative fibers,
-  the body keeps running until its next cancellation checkpoint; from
-  the caller's perspective the future behaves as cancelled after this
-  returns."
+  "Signals the future's internal cancellation token, causing any pending or subsequent `deref` call to raise `CancelledException` (or return the timeout value for the 3-arg form). Due to AMPHP's cooperative fibers, the body keeps running until its next cancellation checkpoint; from the caller's perspective the future behaves as cancelled after this returns."
   {:example "(future-cancel (future (expensive-call)))"
    :see-also ["future" "future-cancelled?" "future-done?" "deref"]}
   [f]
@@ -113,13 +96,9 @@
   (php/-> f (isCancelled)))
 
 (defn future-done?
-  "Returns `true` if the future is in a final state (completed, failed,
-  or cancelled).
+  "Returns `true` if the future is in a final state (completed, failed, or cancelled).
 
-  Dispatches on type: for a `\\Phel\\Fiber\\Domain\\Future` (fiber-backed)
-  it calls `isDone`; for any other value it falls back to `realized?`.
-  This lets the same predicate serve both the AMPHP `Future` wrapper
-  and the cooperative fiber future."
+Dispatches on type: for a `\\Phel\\Fiber\\Domain\\Future` (fiber-backed) it calls `isDone`; for any other value it falls back to `realized?`. This lets the same predicate serve both the AMPHP `Future` wrapper and the cooperative fiber future."
   {:example "(future-done? f)"
    :see-also ["realized?" "future-cancel" "future" "future-fiber"]}
   [f]
@@ -136,21 +115,16 @@
 ;; -----------------------------------------------------------------
 
 (defn promise
-  "Returns a new unrealized promise. Deliver a value with `(deliver p v)`
-  and read it back with `@p` (or `(deref p)`).
+  "Returns a new unrealized promise. Deliver a value with `(deliver p v)` and read it back with `@p` (or `(deref p)`).
 
-  Once delivered the value is frozen; subsequent `deliver` calls are
-  no-ops. `deref` on an unrealized promise blocks: from inside a fiber
-  it suspends cooperatively, from the top level it drains the scheduler
-  ready queue and sleeps briefly between checks."
+Once delivered the value is frozen; subsequent `deliver` calls are no-ops. `deref` on an unrealized promise blocks: from inside a fiber it suspends cooperatively, from the top level it drains the scheduler ready queue and sleeps briefly between checks."
   {:example "(let [p (promise)] (deliver p 42) @p) ; => 42"
    :see-also ["deliver" "deref" "realized?" "future-call" "future-fiber"]}
   []
   (php/-> (fiber-facade) (createPromise)))
 
 (defn deliver
-  "Delivers `value` to `p` if it is still unrealized. Returns `p` on
-  first delivery, `nil` if `p` was already delivered."
+  "Delivers `value` to `p` if it is still unrealized. Returns `p` on first delivery, `nil` if `p` was already delivered."
   {:example "(deliver (promise) 7)"
    :see-also ["promise" "deref" "realized?"]}
   [p value]
@@ -184,8 +158,7 @@
   `(future-call (fn [] ~@body)))
 
 (defn future?
-  "Returns true if `x` is a fiber-future (from `future-call`/`future-fiber`)
-  or a `Future` (from the AMPHP-backed `future` macro)."
+  "Returns true if `x` is a fiber-future (from `future-call`/`future-fiber`) or a `Future` (from the AMPHP-backed `future` macro)."
   {:example "(future? (future-call (fn [] 1))) ; => true"
    :see-also ["future" "future-call" "future-fiber"]}
   [x]

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -22,11 +22,9 @@
 (defn atom
   "Creates a new atom with the given value.
 
-  Atoms provide a way to manage mutable state. Use `reset!` to set a new value
-  and `swap!` to update based on the current value.
+Atoms provide a way to manage mutable state. Use `reset!` to set a new value and `swap!` to update based on the current value.
 
-  Optional `:meta` and `:validator` keyword arguments may follow the value in
-  any order. The validator is applied to the initial value when set."
+Optional `:meta` and `:validator` keyword arguments may follow the value in any order. The validator is applied to the initial value when set."
   {:example "(def counter (atom 0))\n(atom 0 :meta {:tag :counter} :validator number?)"
    :see-also ["reset!" "deref" "swap!" "set-validator!"]}
   [value & opts]
@@ -43,8 +41,7 @@
   (php/instanceof x Atom))
 
 (defn var?
-  "Returns true if the given value is a `Var`, the first-class handle to a
-  global definition produced by `(var sym)` and `#'sym`."
+  "Returns true if the given value is a `Var`, the first-class handle to a global definition produced by `(var sym)` and `#'sym`."
   {:see-also ["var-get" "find-var" "alter-var-root"]}
   [x]
   (php/instanceof x PhelVar))
@@ -65,12 +62,9 @@
 (defn deref
   "Returns the current value inside an atom or var.
 
-  For atoms returns the current cell value; for `Var` instances returns the
-  current root binding from the namespace registry.
+For atoms returns the current cell value; for `Var` instances returns the current root binding from the namespace registry.
 
-  With three arguments, and when `variable` is a future or promise, blocks
-  for at most `timeout-ms` milliseconds waiting for it to resolve. If the
-  awaitable has not completed within the timeout, returns `timeout-val`."
+With three arguments, and when `variable` is a future or promise, blocks for at most `timeout-ms` milliseconds waiting for it to resolve. If the awaitable has not completed within the timeout, returns `timeout-val`."
   {:example "(deref (atom 42)) ; => 42\n(deref #'phel.core/map) ; => <function:map>"
    :see-also ["atom" "reset!" "swap!" "future" "var-get"]}
   [variable & args]
@@ -92,7 +86,7 @@
 (defn swap!
   "Atomically swaps the value of the atom to `(apply f current-value args)`.
 
-  Returns the new value after the swap."
+Returns the new value after the swap."
   {:example "(def counter (atom 0))"
    :see-also ["atom" "reset!" "deref"]}
   [variable f & args]
@@ -105,8 +99,7 @@
     (reset! variable next)))
 
 (defn add-watch
-  "Adds a watch function to a variable. The watch fn is called when the variable
-  changes with four arguments: key, ref, old-value, new-value."
+  "Adds a watch function to a variable. The watch fn is called when the variable changes with four arguments: key, ref, old-value, new-value."
   {:example "(add-watch my-var :logger (fn [key ref old new] (println old \"->\" new)))"
    :see-also ["remove-watch" "atom" "swap!"]}
   [variable key f]
@@ -114,9 +107,7 @@
   variable)
 
 (defn alter-var-root
-  "Replaces the root binding of `v` with `(apply f current-root args)`.
-  Returns the new root value. `v` must be a `Var`; pass an atom and you get a
-  clear error pointing at `swap!` instead."
+  "Replaces the root binding of `v` with `(apply f current-root args)`. Returns the new root value. `v` must be a `Var`; pass an atom and you get a clear error pointing at `swap!` instead."
   {:example "(def counter 0)\n(alter-var-root #'counter inc) ; => 1"
    :see-also ["var" "var?" "swap!"]}
   [v f & args]
@@ -124,8 +115,7 @@
   (php/-> v (alterRoot (fn [current] (apply f current args)))))
 
 (defn bound?
-  "Returns true when `v` has a current root binding in the namespace
-  registry. `v` must be a `Var`."
+  "Returns true when `v` has a current root binding in the namespace registry. `v` must be a `Var`."
   {:example "(bound? #'phel.core/map) ; => true"
    :see-also ["thread-bound?" "var-get" "find-var"]}
   [v]
@@ -134,8 +124,7 @@
                           (php/-> v (getName)))))
 
 (defn thread-bound?
-  "Returns true when a fiber-local `binding` (or `with-bindings`) frame
-  currently overrides the value of `v` on the calling fiber."
+  "Returns true when a fiber-local `binding` (or `with-bindings`) frame currently overrides the value of `v` on the calling fiber."
   {:example "(binding [*foo* 1] (thread-bound? #'*foo*)) ; => true"
    :see-also ["bound?" "binding" "var-set"]}
   [v]
@@ -173,8 +162,7 @@
                               "alter-meta! expects a Var or atom as first argument"))))
 
 (defn reset-meta!
-  "Installs `meta-map` as the metadata on `r`, replacing any prior metadata.
-  Works on `Var` handles and on atoms. Returns the installed map."
+  "Installs `meta-map` as the metadata on `r`, replacing any prior metadata. Works on `Var` handles and on atoms. Returns the installed map."
   {:example "(reset-meta! #'my-var {:tag :int})"
    :see-also ["alter-meta!" "meta" "with-meta"]}
   [r meta-map]
@@ -192,9 +180,7 @@
   variable)
 
 (defn set-validator!
-  "Sets a validator function on a variable. The validator is called before any
-  state change with the proposed new value. If it returns a falsy value, an
-  exception is thrown and the state is not changed. Pass nil to remove."
+  "Sets a validator function on a variable. The validator is called before any state change with the proposed new value. If it returns a falsy value, an exception is thrown and the state is not changed. Pass nil to remove."
   {:example "(set-validator! my-var pos?)"
    :see-also ["get-validator" "atom"]}
   [variable f]
@@ -212,8 +198,7 @@
 ;; --------
 
 (defn- lazy-seq-from-generator
-  "Wraps a PHP Generator in a ChunkedSeq for efficient lazy evaluation.
-  ChunkedSeq realizes elements in batches for better performance."
+  "Wraps a PHP Generator in a ChunkedSeq for efficient lazy evaluation. ChunkedSeq realizes elements in batches for better performance."
   [generator]
   (php/:: ChunkedSeq (fromGenerator
                       (php/new Hasher)
@@ -221,9 +206,7 @@
                       generator)))
 
 (defn range
-  "Creates a lazy sequence of numbers. With no arguments returns an infinite
-  sequence starting at 0. With one argument returns (0..n). With two (start..end).
-  With three (start..end step). Note: the infinite sequence is bounded by PHP_INT_MAX."
+  "Creates a lazy sequence of numbers. With no arguments returns an infinite sequence starting at 0. With one argument returns (0..n). With two (start..end). With three (start..end step). Note: the infinite sequence is bounded by PHP_INT_MAX."
   {:example "(range 5) ; => @[0 1 2 3 4]"
    :see-also ["iterate" "repeat"]}
   [& args]
@@ -324,8 +307,7 @@
        (deref ~res-sym))))
 
 (defmacro dofor
-  "Repeatedly executes body for side effects with bindings and modifiers as
-  provided by for. Returns nil."
+  "Repeatedly executes body for side effects with bindings and modifiers as provided by for. Returns nil."
   [head & body]
   (for-builder `(do ~@body) head 0))
 
@@ -352,11 +334,7 @@
   (conj (conj (conj head binding) verb) coll-expr))
 
 (defn- doseq-normalize
-  "Transforms Clojure-style doseq bindings into Phel dofor format.
-  Pairs `[x coll]` become triples `[x :in (doseq-iterable coll)]` so maps
-  iterate as entry pairs. Already-present verb triples `[x :in coll]` pass
-  through unchanged. Modifier keywords like `:when`, `:while`, `:let` pass
-  through unchanged."
+  "Transforms Clojure-style doseq bindings into Phel dofor format. Pairs `[x coll]` become triples `[x :in (doseq-iterable coll)]` so maps iterate as entry pairs. Already-present verb triples `[x :in coll]` pass through unchanged. Modifier keywords like `:when`, `:while`, `:let` pass through unchanged."
   [head]
   (loop [i      0
          result []]
@@ -394,8 +372,7 @@
   x)
 
 (defn- xf-step
-  "Creates a transducer reducing function that delegates 0/1 arity to rf
-  and calls step-fn for the 2-arity step. Eliminates repeated boilerplate."
+  "Creates a transducer reducing function that delegates 0/1 arity to rf and calls step-fn for the 2-arity step. Eliminates repeated boilerplate."
   [rf step-fn]
   (fn [& args]
     (case (count args)

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -164,10 +164,7 @@
       (php/instanceof x BigDecimal)))
 
 (defn- assert-non-nil
-  "Rejects `nil` operands so ordered comparisons fail loudly instead of
-  silently coercing `nil` to 0. Mirrors the arithmetic functions, which
-  already reject `nil`, and matches Clojure/JVM (which throws). Defined
-  locally because `booleans` loads before the arithmetic module."
+  "Rejects `nil` operands so ordered comparisons fail loudly instead of silently coercing `nil` to 0. Mirrors the arithmetic functions, which already reject `nil`, and matches Clojure/JVM (which throws). Defined locally because `booleans` loads before the arithmetic module."
   [a b]
   (when (or (php/=== nil a) (php/=== nil b))
     (throw (php/new InvalidArgumentException "Comparison functions do not accept nil values"))))
@@ -239,9 +236,7 @@
       false)))
 
 (defn <=>
-  "Alias for the spaceship PHP operator in ascending order. Returns an int.
-  Dispatches on `Ratio` and `BigInt` so numeric ordering stays correct
-  for those types."
+  "Alias for the spaceship PHP operator in ascending order. Returns an int. Dispatches on `Ratio` and `BigInt` so numeric ordering stays correct for those types."
   [a b]
   (if (or (numeric-object? a) (numeric-object? b))
     (php/:: NumericOperations (compare a b))
@@ -266,16 +261,14 @@
     false))
 
 (defn every?
-  "Returns true if predicate is true for every element in collection, false otherwise.
-  Alias for `all?`."
+  "Returns true if predicate is true for every element in collection, false otherwise. Alias for `all?`."
   {:example "(every? even? [2 4 6 8]) ; => true"
    :see-also ["all?" "not-every?"]}
   [pred coll]
   (all? pred coll))
 
 (defn not-every?
-  "Returns false if `(pred x)` is logical true for every `x` in collection `coll`
-   or if `coll` is empty. Otherwise returns true."
+  "Returns false if `(pred x)` is logical true for every `x` in collection `coll` or if `coll` is empty. Otherwise returns true."
   {:example "(not-every? even? [2 3 4]) ; => true"
    :see-also ["every?" "all?" "not-any?"]}
   [pred coll]
@@ -285,8 +278,7 @@
 (declare name)
 
 (defn some?
-  "With 1 arg, returns true if `x` is not nil (Clojure semantics).
-   With 2 args, returns true if `pred` is true for at least one element in `coll`."
+  "With 1 arg, returns true if `x` is not nil (Clojure semantics). With 2 args, returns true if `pred` is true for at least one element in `coll`."
   {:example "(some? 1) ; => true\n(some? even? [1 3 5 6 7]) ; => true"}
   ([x] (not (nil? x)))
   ([pred coll]
@@ -296,8 +288,7 @@
      :else                         (recur pred (next coll)))))
 
 (defn not-any?
-  "Returns true if `(pred x)` is logical false for every `x` in `coll`
-   or if `coll` is empty. Otherwise returns false."
+  "Returns true if `(pred x)` is logical false for every `x` in `coll` or if `coll` is empty. Otherwise returns false."
   {:example "(not-any? even? [1 3 5]) ; => true"
    :see-also ["some?" "some" "not-every?"]}
   [pred coll]
@@ -375,9 +366,7 @@
   (or (= category :keyword) (= category :symbol)))
 
 (defn- compare-category
-  "Returns a coarse category for `compare`'s type compatibility check. `nil` is
-  its own category so it can be treated as less than anything. Numbers share a
-  category so `(compare 1 1.5)` works."
+  "Returns a coarse category for `compare`'s type compatibility check. `nil` is its own category so it can be treated as less than anything. Numbers share a category so `(compare 1 1.5)` works."
   [x]
   (cond
     (php/=== x nil)                               :nil

--- a/src/phel/core/collections.phel
+++ b/src/phel/core/collections.phel
@@ -19,17 +19,14 @@
   (php/:: Phel (set (apply php/array xs))))
 
 (defn sorted-map
-  "Creates a new sorted map. Keys are in natural sorted order.
-  The number of parameters must be even."
+  "Creates a new sorted map. Keys are in natural sorted order. The number of parameters must be even."
   {:example "(sorted-map :c 3 :a 1 :b 2) ; keys iterate as :a :b :c"
    :see-also ["sorted-map-by" "hash-map"]}
   [& xs]
   (php/:: Phel (sortedMap (apply php/array xs))))
 
 (defn sorted-map-by
-  "Creates a new sorted map using the given comparator for key ordering.
-  The comparator takes two arguments and returns a negative integer,
-  zero, or a positive integer."
+  "Creates a new sorted map using the given comparator for key ordering. The comparator takes two arguments and returns a negative integer, zero, or a positive integer."
   {:example "(sorted-map-by (fn [a b] (compare b a)) :a 1 :b 2) ; keys iterate as :b :a"
    :see-also ["sorted-map" "compare"]}
   [comp & xs]

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -80,8 +80,7 @@
 ;; ------------------
 
 (defn apply
-  "Applies function `f` to the argument list formed by prepending any
-  intervening arguments to the final collection argument."
+  "Applies function `f` to the argument list formed by prepending any intervening arguments to the final collection argument."
   {:example "(apply + [1 2 3]) ; => 6\n((identity apply) + 1 [2 3]) ; => 6"
    :see-also ["partial" "comp"]}
   ([f args] (apply f args))
@@ -101,14 +100,7 @@
   #(not (apply f %&)))
 
 (defn some-fn
-  "Takes a variadic set of predicates and returns a function `f` that,
-   when called with any number of arguments, returns the first logical
-   true value produced by applying any of the composing predicates to
-   any of its arguments, and `false` when none match. The returned
-   function short-circuits on the first truthy result: arguments after
-   it are not inspected, and predicates after it are not tried.
-   Predicates are consulted in the order supplied; for a given
-   predicate, arguments are consulted left-to-right."
+  "Takes a variadic set of predicates and returns a function `f` that, when called with any number of arguments, returns the first logical true value produced by applying any of the composing predicates to any of its arguments, and `false` when none match. The returned function short-circuits on the first truthy result: arguments after it are not inspected, and predicates after it are not tried. Predicates are consulted in the order supplied; for a given predicate, arguments are consulted left-to-right."
   {:example "((some-fn even? nil?) 1 2) ; => true\n((some-fn pos? even?) -3 -1) ; => false"
    :see-also ["some" "complement" "every?" "not-any?"]}
   ([]
@@ -129,19 +121,14 @@
      fs)))
 
 (defn partial
-  "Takes a function `f` and fewer than the normal number of arguments to `f`,
-  and returns a function that takes a variable number of additional arguments.
-  When called, `f` will be invoked with the bound `args` prepended to the
-  additional arguments."
+  "Takes a function `f` and fewer than the normal number of arguments to `f`, and returns a function that takes a variable number of additional arguments. When called, `f` will be invoked with the bound `args` prepended to the additional arguments."
   {:example "((partial + 10) 1 2) ; => 13"
    :see-also ["comp" "apply"]}
   [f & args]
   #(apply f (concat args %&)))
 
 (defn fnil
-  "Returns a function that replaces nil arguments with the provided defaults
-  before calling f. The number of defaults determines how many leading arguments
-  are nil-checked."
+  "Returns a function that replaces nil arguments with the provided defaults before calling f. The number of defaults determines how many leading arguments are nil-checked."
   {:example "(let [safe-inc (fnil inc 0)] (safe-inc nil)) ; => 1"
    :see-also ["partial" "comp"]}
   [f & defaults]
@@ -158,8 +145,7 @@
         (apply f patched)))))
 
 (defn memoize
-  "Returns a memoized version of the function `f`. The memoized function
-  caches the return value for each set of arguments."
+  "Returns a memoized version of the function `f`. The memoized function caches the return value for each set of arguments."
   {:example (str
              "(defn fact [n]" php/PHP_EOL
              "  (if (zero? n)" php/PHP_EOL
@@ -181,12 +167,9 @@
             res))))))
 
 (defn memoize-lru
-  "Returns a memoized version of the function `f` with an LRU (Least Recently Used)
-  cache limited to `max-size` entries. When the cache exceeds `max-size`, the
-  least recently used entry is evicted. This prevents unbounded memory growth
-  in long-running processes.
+  "Returns a memoized version of the function `f` with an LRU (Least Recently Used) cache limited to `max-size` entries. When the cache exceeds `max-size`, the least recently used entry is evicted. This prevents unbounded memory growth in long-running processes.
 
-  Without arguments, uses a default cache size of 128 entries."
+Without arguments, uses a default cache size of 128 entries."
   {:example (str
              "(defn fact [n]" php/PHP_EOL
              "  (if (zero? n)" php/PHP_EOL
@@ -230,11 +213,7 @@
 ;; -----------------------
 
 (defn tree-seq
-  "Returns a vector of the nodes in the tree, via a depth-first walk.
-  branch? is a function with one argument that returns true if the given node
-  has children.
-  children must be a function with one argument that returns the children of the node.
-  root the root node of the tree."
+  "Returns a vector of the nodes in the tree, via a depth-first walk. branch? is a function with one argument that returns true if the given node has children. children must be a function with one argument that returns the children of the node. root the root node of the tree."
   [branch? children root]
   (let [ret (transient [])]
     (loop [stack (php/array root)]
@@ -264,8 +243,7 @@
        (assoc! acc k v)))))
 
 (defn merge-with
-  "Merges multiple maps into one new map. If a key appears in more than one
-   collection, the result of `(f current-val next-val)` is used."
+  "Merges multiple maps into one new map. If a key appears in more than one collection, the result of `(f current-val next-val)` is used."
   [f & hash-maps]
   (case (count hash-maps)
     0 {}

--- a/src/phel/core/futures.phel
+++ b/src/phel/core/futures.phel
@@ -7,17 +7,11 @@
 ;; Clojure-parity async surface live alongside in `core/async.phel`.
 
 (defmacro future
-  "Starts evaluating `body` asynchronously and returns a `Future`
-  that can be `deref`ed (blocks the current fiber until the value is
-  available) or checked with `realized?`.
+  "Starts evaluating `body` asynchronously and returns a `Future` that can be `deref`ed (blocks the current fiber until the value is available) or checked with `realized?`.
 
-  Supports the 3-arg `(deref f timeout-ms timeout-val)` form for
-  time-bounded blocking, as well as `future-cancel`, `future-cancelled?`
-  and `future-done?` for lifecycle management.
+Supports the 3-arg `(deref f timeout-ms timeout-val)` form for time-bounded blocking, as well as `future-cancel`, `future-cancelled?` and `future-done?` for lifecycle management.
 
-  Must be called from inside a fiber context (e.g. the AMPHP event
-  loop or an enclosing `async` block), because `deref` resolves via
-  AMPHP's fiber-based `await`."
+Must be called from inside a fiber context (e.g. the AMPHP event loop or an enclosing `async` block), because `deref` resolves via AMPHP's fiber-based `await`."
   {:example "(let [f (future (expensive-computation))] @f)"
    :see-also ["realized?" "deref"]}
   [& body]

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -16,8 +16,7 @@
 ;; ---------------
 
 (defmacro with-output-buffer
-  "Everything that is printed inside the body will be stored in a buffer.
-   The result of the buffer is returned."
+  "Everything that is printed inside the body will be stored in a buffer. The result of the buffer is returned."
   [& body]
   (let [res (gensym)]
     `(do
@@ -70,8 +69,7 @@
 ;; ---------------
 
 (defn- file-get-contents-silenced
-  "Wrapper around file_get_contents that suppresses PHP warnings.
-  We handle errors by checking the return value."
+  "Wrapper around file_get_contents that suppresses PHP warnings. We handle errors by checking the return value."
   [path use-include-path context offset length]
   (let [old-error-level (php/error_reporting 0)
         content         (php/file_get_contents path use-include-path context offset length)]
@@ -107,11 +105,9 @@
       content)))
 
 (defn spit
-  "Writes data to file, returning number of bytes that were written or `nil`
-  on failure. Accepts `opts` map for overriding default PHP file_put_contents
-  arguments, as example to append to file use `{:flags php/FILE_APPEND}`.
+  "Writes data to file, returning number of bytes that were written or `nil` on failure. Accepts `opts` map for overriding default PHP file_put_contents arguments, as example to append to file use `{:flags php/FILE_APPEND}`.
 
-  See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-contents.php) for more information."
+See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-contents.php) for more information."
   [filename data & [opts]]
   (when (php/is_dir filename)
     (throw (php/new \InvalidArgumentException
@@ -182,10 +178,7 @@
 ;; ----------------
 
 (defmacro ->
-  "Threads the expr through the forms. Inserts `x` as the second item
-  in the first form, making a list of it if it is not a list already.
-  If there are more forms, insert the first form as the second item in
-  the second form, etc."
+  "Threads the expr through the forms. Inserts `x` as the second item in the first form, making a list of it if it is not a list already. If there are more forms, insert the first form as the second item in the second form, etc."
   [x & forms]
   (loop [x     x
          forms (if (empty? forms) nil forms)]
@@ -198,10 +191,7 @@
       x)))
 
 (defmacro ->>
-  "Threads the expr through the forms. Inserts `x` as the
-  last item in the first form, making a list of it if it is not a
-  list already. If there are more forms, insert the first form as the
-  last item in the second form, etc."
+  "Threads the expr through the forms. Inserts `x` as the last item in the first form, making a list of it if it is not a list already. If there are more forms, insert the first form as the last item in the second form, etc."
   [x & forms]
   (loop [x     x
          forms (if (empty? forms) nil forms)]
@@ -262,18 +252,14 @@
       x)))
 
 (defmacro as->
-  "Binds `name` to `expr`, evaluates the first form in the lexical context
-  of that binding, then binds name to that result, repeating for each
-  successive form, returning the result of the last form."
+  "Binds `name` to `expr`, evaluates the first form in the lexical context of that binding, then binds name to that result, repeating for each successive form, returning the result of the last form."
   [expr name & forms]
   `(let [~name ~expr
          ~@(interleave (repeat (count forms) name) forms)]
      ~name))
 
 (defmacro doto
-  "Evaluates x then calls all of the methods and functions with the
-  value of x supplied at the front of the given arguments. The forms
-  are evaluated in order. Returns x."
+  "Evaluates x then calls all of the methods and functions with the value of x supplied at the front of the given arguments. The forms are evaluated in order. Returns x."
   [x & forms]
   (let [gx (gensym)]
     `(let [~gx ~x]
@@ -285,10 +271,7 @@
        ~gx)))
 
 (defmacro cond->
-  "Takes an expression and a set of test/form pairs. Threads `expr` (via `->`)
-  through each form for which the corresponding test expression is true.
-  Note that, unlike `cond` branching, `cond->` threading does not short-circuit
-  after the first true test expression."
+  "Takes an expression and a set of test/form pairs. Threads `expr` (via `->`) through each form for which the corresponding test expression is true. Note that, unlike `cond` branching, `cond->` threading does not short-circuit after the first true test expression."
   {:example "(cond-> 1 true inc false (* 42) true (* 3)) ; => 6"}
   [expr & clauses]
   (let [g     (gensym)
@@ -302,10 +285,7 @@
        ~g)))
 
 (defmacro cond->>
-  "Takes an expression and a set of test/form pairs. Threads `expr` (via `->>`)
-  through each form for which the corresponding test expression is true.
-  Note that, unlike `cond` branching, `cond->>` threading does not short-circuit
-  after the first true test expression."
+  "Takes an expression and a set of test/form pairs. Threads `expr` (via `->>`) through each form for which the corresponding test expression is true. Note that, unlike `cond` branching, `cond->>` threading does not short-circuit after the first true test expression."
   {:example "(cond->> [1 2 3] true (map inc) false (filter odd?)) ; => @[2 3 4]"}
   [expr & clauses]
   (let [g     (gensym)
@@ -323,8 +303,7 @@
 ;; ---------------
 
 (defn re-pattern
-  "Returns a PCRE pattern string from `s`. If `s` is already delimited,
-  returns it as-is. Otherwise wraps in `/` delimiters."
+  "Returns a PCRE pattern string from `s`. If `s` is already delimited, returns it as-is. Otherwise wraps in `/` delimiters."
   {:example "(re-pattern \"\\\\d+\") ; => \"/\\\\d+/\""
    :see-also ["re-find" "re-matches" "re-seq"]}
   [s]
@@ -348,8 +327,7 @@
       (doall (apply map vector matches)))))
 
 (defn re-find
-  "Returns the first match of pattern in string, or nil if no match.
-  If the pattern has groups, returns a vector of [full-match group1 group2 ...]."
+  "Returns the first match of pattern in string, or nil if no match. If the pattern has groups, returns a vector of [full-match group1 group2 ...]."
   {:example "(re-find #\"\\d+\" \"abc123def\") ; => \"123\""
    :see-also ["re-seq" "re-matches"]}
   [re s]
@@ -362,9 +340,7 @@
           (into [] matches))))))
 
 (defn re-matches
-  "Returns the match, if any, of string to pattern. If the pattern has groups,
-  returns a vector of [full-match group1 group2 ...]. Returns nil if no match.
-  Unlike re-find, the entire string must match."
+  "Returns the match, if any, of string to pattern. If the pattern has groups, returns a vector of [full-match group1 group2 ...]. Returns nil if no match. Unlike re-find, the entire string must match."
   {:example "(re-matches #\"(\\d+)-(\\d+)\" \"12-34\") ; => [\"12-34\" \"12\" \"34\"]"
    :see-also ["re-find" "re-seq"]}
   [re s]
@@ -429,9 +405,7 @@
   (emit-binding-form 'openRedefsFrame bindings body))
 
 (defmacro with-bindings
-  "Like `binding` but takes a map of `Var -> value` instead of a binding
-  vector. Same dynamic-only enforcement: throws when any key resolves
-  to a non-dynamic var."
+  "Like `binding` but takes a map of `Var -> value` instead of a binding vector. Same dynamic-only enforcement: throws when any key resolves to a non-dynamic var."
   [m & body]
   (let [m-sym (gensym "m__")
         v-sym (gensym "v__")

--- a/src/phel/core/lazy.phel
+++ b/src/phel/core/lazy.phel
@@ -10,8 +10,7 @@
 ;; --- Delay / Force ---
 
 (defmacro delay
-  "Takes a body of expressions and yields a Delay object that will invoke the
-  body only the first time it is forced (via force or deref/@), caching the result."
+  "Takes a body of expressions and yields a Delay object that will invoke the body only the first time it is forced (via force or deref/@), caching the result."
   {:example "(def d (delay (println \"computing\") 42))"
    :see-also ["force" "delay?" "realized?"]}
   [& body]

--- a/src/phel/core/loops.phel
+++ b/src/phel/core/loops.phel
@@ -14,8 +14,7 @@
   nil)
 
 (defmacro dotimes
-  "Evaluates body `n` times with `binding` bound to integers from 0 to n-1.
-  Returns nil."
+  "Evaluates body `n` times with `binding` bound to integers from 0 to n-1. Returns nil."
   {:example "(dotimes [i 5] (println i))"}
   [[binding n] & body]
   (let [n-sym (gensym)]

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -85,32 +85,28 @@
   (php/>> x n))
 
 (defn bit-set
-  "Returns the integer `x` with the bit at index `n` (0-based, least
-  significant first) set to 1."
+  "Returns the integer `x` with the bit at index `n` (0-based, least significant first) set to 1."
   {:example "(bit-set 0 2) ; => 4"
    :see-also ["bit-clear" "bit-flip" "bit-test"]}
   [x n]
   (bit-or x (bit-shift-left 1 n)))
 
 (defn bit-clear
-  "Returns the integer `x` with the bit at index `n` (0-based, least
-  significant first) cleared to 0."
+  "Returns the integer `x` with the bit at index `n` (0-based, least significant first) cleared to 0."
   {:example "(bit-clear 7 1) ; => 5"
    :see-also ["bit-set" "bit-flip" "bit-test"]}
   [x n]
   (bit-and x (bit-not (bit-shift-left 1 n))))
 
 (defn bit-flip
-  "Returns the integer `x` with the bit at index `n` (0-based, least
-  significant first) toggled."
+  "Returns the integer `x` with the bit at index `n` (0-based, least significant first) toggled."
   {:example "(bit-flip 5 1) ; => 7"
    :see-also ["bit-set" "bit-clear" "bit-test"]}
   [x n]
   (bit-xor x (bit-shift-left 1 n)))
 
 (defn bit-test
-  "Returns `true` if the bit at index `n` (0-based, least significant
-  first) of the integer `x` is set, `false` otherwise."
+  "Returns `true` if the bit at index `n` (0-based, least significant first) of the integer `x` is set, `false` otherwise."
   {:example "(bit-test 5 0) ; => true"
    :see-also ["bit-set" "bit-clear" "bit-flip"]}
   [x n]
@@ -125,8 +121,7 @@
   php/NAN)
 
 (defn +
-  "Returns the sum of all elements in `xs`. All elements `xs` must be numbers.
-  If `xs` is empty, return 0."
+  "Returns the sum of all elements in `xs`. All elements `xs` must be numbers. If `xs` is empty, return 0."
   {:example "(+ 1 2 3) ; => 6"
    :see-also ["-" "*" "/" "sum"]}
   [& xs]
@@ -138,8 +133,7 @@
     (reduce #(php/:: NumericOperations (add %1 %2)) xs)))
 
 (defn -
-  "Returns the difference of all elements in `xs`. If `xs` is empty, return 0. If `xs`
-  has one element, return the negative value of that element."
+  "Returns the difference of all elements in `xs`. If `xs` is empty, return 0. If `xs` has one element, return the negative value of that element."
   {:example "(- 10 3 2) ; => 5\n(- 4) ; => -4"
    :see-also ["+" "*" "/"]}
   [& xs]
@@ -151,8 +145,7 @@
     (reduce #(php/:: NumericOperations (subtract %1 %2)) xs)))
 
 (defn *
-  "Returns the product of all elements in `xs`. All elements in `xs` must be
-numbers. If `xs` is empty, return 1."
+  "Returns the product of all elements in `xs`. All elements in `xs` must be numbers. If `xs` is empty, return 1."
   {:example "(* 2 3 4) ; => 24"
    :see-also ["+" "-" "/"]}
   [& xs]
@@ -181,9 +174,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
     (reduce #(php/:: NumericOperations (divide %1 %2)) xs)))
 
 (defn quot
-  "Returns the truncated integer quotient of `dividend` / `divisor`.
-  Truncates toward zero. Throws `\\DivisionByZeroError` when `divisor`
-  is zero."
+  "Returns the truncated integer quotient of `dividend` / `divisor`. Truncates toward zero. Throws `\\DivisionByZeroError` when `divisor` is zero."
   {:example "(quot 7 3) ; => 2\n(quot -7 3) ; => -2"
    :see-also ["rem" "mod" "/"]}
   [dividend divisor]
@@ -191,8 +182,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   (php/:: NumericOperations (quot dividend divisor)))
 
 (defn rem
-  "Returns the truncated remainder of `dividend` / `divisor`. The result
-  has the same sign as `dividend` (matches PHP's `%`)."
+  "Returns the truncated remainder of `dividend` / `divisor`. The result has the same sign as `dividend` (matches PHP's `%`)."
   {:example "(rem 7 3) ; => 1\n(rem -7 3) ; => -1"
    :see-also ["quot" "mod" "%"]}
   [dividend divisor]
@@ -407,16 +397,14 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
     :else                         (php/floatval x)))
 
 (defn double
-  "Coerces `x` to a double. In PHP there is no distinction between float and
-   double; both map to the same native PHP float type. Alias for `float`."
+  "Coerces `x` to a double. In PHP there is no distinction between float and double; both map to the same native PHP float type. Alias for `float`."
   {:example "(double 1) ; => 1"
    :see-also ["float" "int?" "number?"]}
   [x]
   (float x))
 
 (defn long
-  "Coerces `x` to a long integer. In PHP there is no distinction between int
-   and long; both map to the same native PHP int type. Alias for `int`."
+  "Coerces `x` to a long integer. In PHP there is no distinction between int and long; both map to the same native PHP int type. Alias for `int`."
   {:example "(long 1.9) ; => 1"
    :see-also ["int" "float" "double"]}
   [x]
@@ -436,36 +424,21 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
     (throw (php/new InvalidArgumentException (php/. label " expects a numeric value")))))
 
 (defn short
-  "Coerces `x` to a signed 16-bit integer in the range `-32768..32767`.
-   Decimal values are truncated toward zero. `Ratio` and `BigInt`
-   values are accepted (truncate toward zero, then range-check). Values
-   outside the range or non-numeric inputs raise `InvalidArgumentException`.
-   Phel has no dedicated short type, so the result is a plain PHP int."
+  "Coerces `x` to a signed 16-bit integer in the range `-32768..32767`. Decimal values are truncated toward zero. `Ratio` and `BigInt` values are accepted (truncate toward zero, then range-check). Values outside the range or non-numeric inputs raise `InvalidArgumentException`. Phel has no dedicated short type, so the result is a plain PHP int."
   {:example "(short 32767) ; => 32767\n(short 1.9) ; => 1\n(short -32768) ; => -32768"
    :see-also ["int" "byte" "long"]}
   [x]
   (clamp-int x -32768 32767 "short"))
 
 (defn byte
-  "Coerces `x` to a signed 8-bit integer in the range `-128..127`.
-   Decimal values are truncated toward zero. `Ratio` and `BigInt`
-   values are accepted (truncate toward zero, then range-check). Values
-   outside the range or non-numeric inputs raise `InvalidArgumentException`.
-   Phel has no dedicated byte type, so the result is a plain PHP int."
+  "Coerces `x` to a signed 8-bit integer in the range `-128..127`. Decimal values are truncated toward zero. `Ratio` and `BigInt` values are accepted (truncate toward zero, then range-check). Values outside the range or non-numeric inputs raise `InvalidArgumentException`. Phel has no dedicated byte type, so the result is a plain PHP int."
   {:example "(byte 127) ; => 127\n(byte 1.9) ; => 1\n(byte -128) ; => -128"
    :see-also ["int?" "float" "double"]}
   [x]
   (clamp-int x -128 127 "byte"))
 
 (defn char
-  "Coerces `x` to a single-character string representing the given
-   Unicode code point. Accepts a non-negative integer (the code point,
-   converted via `mb_chr`) or a single-character string, which is
-   returned as-is. Phel has no dedicated char type — character literals
-   such as `\\A` are already single-character strings — so the result
-   is always a plain string. Matches Clojure's `char` for `.cljc`
-   interop; raises `InvalidArgumentException` on negative ints,
-   non-single-character strings, and all other inputs."
+  "Coerces `x` to a single-character string representing the given Unicode code point. Accepts a non-negative integer (the code point, converted via `mb_chr`) or a single-character string, which is returned as-is. Phel has no dedicated char type — character literals such as `\\A` are already single-character strings — so the result is always a plain string. Matches Clojure's `char` for `.cljc` interop; raises `InvalidArgumentException` on negative ints, non-single-character strings, and all other inputs."
   {:example "(char 65) ; => \"A\"\n(char 32) ; => \" \"\n(char \\A) ; => \"A\""
    :see-also ["byte" "int?" "string?"]}
   [x]
@@ -491,8 +464,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
                     "char expects a non-negative integer or a single-character string"))))
 
 (defn rand
-  "Without arguments, returns a random number in `[0, 1)`. With one
-  argument `n`, returns a random number in `[0, n)`."
+  "Without arguments, returns a random number in `[0, 1)`. With one argument `n`, returns a random number in `[0, n)`."
   {:example "(rand) ; => 0.42\n(rand 100) ; => 73.2"
    :see-also ["rand-int" "rand-nth"]}
   ([]
@@ -527,8 +499,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   (and (php/is_float x) (php/is_nan x)))
 
 (defn min
-  "Returns the minimum of all arguments. Returns `##NaN` whenever any
-  numeric argument is `##NaN`."
+  "Returns the minimum of all arguments. Returns `##NaN` whenever any numeric argument is `##NaN`."
   {:example "(min 3 1 2) ; => 1"
    :see-also ["max" "min-key" "extreme"]}
   [& numbers]
@@ -538,8 +509,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
     :else                       (extreme < numbers)))
 
 (defn max
-  "Returns the maximum of all arguments. Returns `##NaN` whenever any
-  numeric argument is `##NaN`."
+  "Returns the maximum of all arguments. Returns `##NaN` whenever any numeric argument is `##NaN`."
   {:example "(max 3 1 2) ; => 3"
    :see-also ["min" "max-key" "extreme"]}
   [& numbers]
@@ -600,8 +570,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   (php/fdiv (sum xs) (count xs)))
 
 (defn median
-  "Returns the median of `xs`. With an even-sized collection the result is
-  the float average of the two middle elements."
+  "Returns the median of `xs`. With an even-sized collection the result is the float average of the two middle elements."
   {:example "(median [3 1 2]) ; => 2\n(median [1 2 3 4]) ; => 2.5"
    :see-also ["mean" "sum"]}
   [xs]
@@ -641,11 +610,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   (bigdec? x))
 
 (defn bigdec
-  "Coerces `x` to a `Phel\\Lang\\BigDecimal`. Accepts `BigDecimal` (returned
-  as-is), ints, floats (via the shortest round-trip decimal of the
-  float), `BigInt`, `Ratio` (computed via exact decimal division;
-  throws `ArithmeticError` when the expansion does not terminate,
-  matching `(bigdec 1/3)`), and numeric strings."
+  "Coerces `x` to a `Phel\\Lang\\BigDecimal`. Accepts `BigDecimal` (returned as-is), ints, floats (via the shortest round-trip decimal of the float), `BigInt`, `Ratio` (computed via exact decimal division; throws `ArithmeticError` when the expansion does not terminate, matching `(bigdec 1/3)`), and numeric strings."
   {:example "(bigdec 1.5) ; => 1.5M\n(bigdec 1/2) ; => 0.5M\n(bigdec \"3.14\") ; => 3.14M"
    :see-also ["bigdec?" "decimal?" "rationalize"]}
   [x]
@@ -663,9 +628,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
                            (php/get_debug_type x))))))
 
 (defn numerator
-  "Returns the numerator of `r`. For rationals the numerator collapses to a
-  PHP int when it fits; for plain ints and `BigInt` values `r` is returned
-  unchanged."
+  "Returns the numerator of `r`. For rationals the numerator collapses to a PHP int when it fits; for plain ints and `BigInt` values `r` is returned unchanged."
   {:example "(numerator 1/2) ; => 1\n(numerator 5) ; => 5"
    :see-also ["denominator" "rationalize" "ratio?"]}
   [r]
@@ -685,8 +648,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
                          (type r))))))
 
 (defn denominator
-  "Returns the denominator of `r`. For rationals the denominator collapses
-  to a PHP int when it fits; integers and `BigInt` values report `1`."
+  "Returns the denominator of `r`. For rationals the denominator collapses to a PHP int when it fits; integers and `BigInt` values report `1`."
   {:example "(denominator 1/2) ; => 2\n(denominator 5) ; => 1"
    :see-also ["numerator" "rationalize" "ratio?"]}
   [r]
@@ -706,8 +668,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
                          (type r))))))
 
 (defn- float-shortest-decimal
-  "Shortest %g-formatted decimal that round-trips back to `x`. Tries
-  increasing precision so 0.1 becomes \"0.1\", not \"0.10000000000000001\"."
+  "Shortest %g-formatted decimal that round-trips back to `x`. Tries increasing precision so 0.1 becomes \"0.1\", not \"0.10000000000000001\"."
   [x]
   (loop [p 1]
     (let [s (php/sprintf (str "%." p "g") x)]
@@ -744,8 +705,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
         (php/:: Ratio (create num denom))))))
 
 (defn- float->rational
-  "Converts a finite float to a Ratio using its shortest round-trip
-  decimal expansion. Non-finite floats are rejected."
+  "Converts a finite float to a Ratio using its shortest round-trip decimal expansion. Non-finite floats are rejected."
   [x]
   (when (or (php/is_infinite x) (php/is_nan x))
     (throw (php/new InvalidArgumentException
@@ -753,12 +713,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   (decimal-string->rational (float-shortest-decimal x)))
 
 (defn rationalize
-  "Converts `x` to a `Ratio`. Floats use the shortest decimal expansion
-  that round-trips back to the same float, so `(rationalize 0.1)` is `1/10`
-  rather than the float-noise denominator. Ints, `BigInt`, and
-  integer-valued `BigDecimal` values become `n/1` and auto-collapse, so
-  they are returned as the integer value. `BigDecimal` with a fractional
-  part rationalizes through its canonical decimal form."
+  "Converts `x` to a `Ratio`. Floats use the shortest decimal expansion that round-trips back to the same float, so `(rationalize 0.1)` is `1/10` rather than the float-noise denominator. Ints, `BigInt`, and integer-valued `BigDecimal` values become `n/1` and auto-collapse, so they are returned as the integer value. `BigDecimal` with a fractional part rationalizes through its canonical decimal form."
   {:example "(rationalize 0.5) ; => 1/2\n(rationalize 3) ; => 3\n(rationalize 1M) ; => 1"
    :see-also ["numerator" "denominator" "ratio?"]}
   [x]
@@ -814,9 +769,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
     (quot (- n (mod n d)) d)))
 
 (defn floor
-  "Returns the largest integer not greater than `x`. Ints and `BigInt`
-  values are returned unchanged. Ratios collapse via floor division.
-  Floats route through PHP's `floor`."
+  "Returns the largest integer not greater than `x`. Ints and `BigInt` values are returned unchanged. Ratios collapse via floor division. Floats route through PHP's `floor`."
   {:example "(floor 1.7) ; => 1\n(floor -1.2) ; => -2\n(floor 7/3) ; => 2"
    :see-also ["ceil" "round" "quot"]}
   [x]
@@ -831,9 +784,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
                     (str "floor expects a number, got " (type x))))))
 
 (defn ceil
-  "Returns the smallest integer not less than `x`. Ints and `BigInt`
-  values are returned unchanged. Ratios collapse via ceiling division.
-  Floats route through PHP's `ceil`."
+  "Returns the smallest integer not less than `x`. Ints and `BigInt` values are returned unchanged. Ratios collapse via ceiling division. Floats route through PHP's `ceil`."
   {:example "(ceil 1.2) ; => 2\n(ceil -1.7) ; => -1\n(ceil 7/3) ; => 3"
    :see-also ["floor" "round" "quot"]}
   [x]
@@ -848,9 +799,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
                     (str "ceil expects a number, got " (type x))))))
 
 (defn round
-  "Rounds `x` to the nearest integer using PHP's `round` (half away from
-  zero). Ints and `BigInt` values are returned unchanged. Ratios
-  and floats return floats."
+  "Rounds `x` to the nearest integer using PHP's `round` (half away from zero). Ints and `BigInt` values are returned unchanged. Ratios and floats return floats."
   {:example "(round 1.5) ; => 2\n(round -1.5) ; => -2\n(round 5) ; => 5"
    :see-also ["floor" "ceil"]}
   [x]

--- a/src/phel/core/meta.phel
+++ b/src/phel/core/meta.phel
@@ -22,9 +22,7 @@
 
 (def meta
   {:macro true
-   :doc "Gets the metadata attached to a value.
-  For a quoted symbol (`(meta 'foo)`) the definition metadata registered via `def` is returned.
-  For any other expression the value is looked up at runtime and its `MetaInterface` metadata returned."}
+   :doc "Gets the metadata attached to a value. For a quoted symbol (`(meta 'foo)`) the definition metadata registered via `def` is returned. For any other expression the value is looked up at runtime and its `MetaInterface` metadata returned."}
   (fn [obj]
     ;; Only the quoted-symbol form routes to definition metadata. A bare symbol
     ;; could refer to a local binding (let / fn parameter), so we must resolve it

--- a/src/phel/core/ns.phel
+++ b/src/phel/core/ns.phel
@@ -15,18 +15,14 @@
   (php/new Munge))
 
 (defn canonical-ns
-  "Returns the canonical (dot-separated) form of a namespace string.
-  Pass user-supplied namespace strings through this before any registry
-  lookup or write."
+  "Returns the canonical (dot-separated) form of a namespace string. Pass user-supplied namespace strings through this before any registry lookup or write."
   {:example "(canonical-ns \"phel\\core\") ; => \"phel.core\""
    :see-also ["display-ns" "find-ns" "create-ns" "intern"]}
   [ns-str]
   (php/:: Munge (canonicalNs ns-str)))
 
 (defn display-ns
-  "Returns the display (dot-separated) form of a namespace string.
-  Equivalent to `canonical-ns`; kept as a separate name so call sites
-  read intent (display vs. canonicalize)."
+  "Returns the display (dot-separated) form of a namespace string. Equivalent to `canonical-ns`; kept as a separate name so call sites read intent (display vs. canonicalize)."
   {:example "(display-ns \"phel\\core\") ; => \"phel.core\""
    :see-also ["canonical-ns" "find-ns" "loaded-namespaces"]}
   [ns-str]
@@ -53,8 +49,7 @@
   (php/-> munge-instance (encode name-str)))
 
 (defn find-ns
-  "Returns the namespace name in display form if it is loaded, or nil if no
-  namespace of that name exists. Accepts dot or backslash separators on input."
+  "Returns the namespace name in display form if it is loaded, or nil if no namespace of that name exists. Accepts dot or backslash separators on input."
   {:example "(find-ns \"phel.core\") ; => \"phel.core\""
    :see-also ["create-ns" "remove-ns" "loaded-namespaces"]}
   [ns-str]
@@ -63,8 +58,7 @@
       (display-ns canonical))))
 
 (defn create-ns
-  "Creates the given namespace if it does not already exist. Returns the
-  namespace name in display form. Existing namespaces are left untouched."
+  "Creates the given namespace if it does not already exist. Returns the namespace name in display form. Existing namespaces are left untouched."
   {:example "(create-ns \"my-app.tmp\") ; => \"my-app.tmp\""
    :see-also ["find-ns" "remove-ns" "intern"]}
   [ns-str]
@@ -73,8 +67,7 @@
     (display-ns canonical)))
 
 (defn remove-ns
-  "Removes the namespace and all of its definitions from the registry.
-  Use with caution. Returns nil."
+  "Removes the namespace and all of its definitions from the registry. Use with caution. Returns nil."
   {:example "(remove-ns \"my-app\\tmp\")"
    :see-also ["find-ns" "create-ns"]}
   [ns-str]
@@ -102,14 +95,7 @@
   (defs->map (core-munge-ns ns-str) (constantly true)))
 
 (defn intern
-  "Finds or creates a definition named by name-str in namespace ns-str.
-  When a value is supplied, sets the root value to val (overwriting any
-  existing value). When no value is supplied, returns the existing
-  definition unchanged, or creates a new one with nil if none exists.
-  Auto-registers the namespace when creating a new definition; the
-  arity-2 form is a no-op when the definition already exists.
-  Returns the fully qualified symbol naming the definition (with the
-  namespace in display form)."
+  "Finds or creates a definition named by name-str in namespace ns-str. When a value is supplied, sets the root value to val (overwriting any existing value). When no value is supplied, returns the existing definition unchanged, or creates a new one with nil if none exists. Auto-registers the namespace when creating a new definition; the arity-2 form is a no-op when the definition already exists. Returns the fully qualified symbol naming the definition (with the namespace in display form)."
   {:example "(intern \"user\" \"x\" 42) ; => user/x"
    :see-also ["var-get" "find-ns" "create-ns" "ns-interns"]}
   [ns-str name-str & rest]
@@ -159,10 +145,7 @@
      true                            not-found)))
 
 (defn find-var
-  "Returns the `Var` named by the fully-qualified symbol, or nil if no
-  matching definition exists. Tries the symbol name verbatim first (matching
-  how `def` stores entries), then falls back to the encoded form (matching
-  how `intern` stores entries)."
+  "Returns the `Var` named by the fully-qualified symbol, or nil if no matching definition exists. Tries the symbol name verbatim first (matching how `def` stores entries), then falls back to the encoded form (matching how `intern` stores entries)."
   {:example "(find-var 'phel.core/map) ; => #'phel.core/map"
    :see-also ["var-get" "intern" "find-ns"]}
   [sym]
@@ -216,9 +199,7 @@
     (persistent result)))
 
 (defn load-file
-  "Loads and evaluates a Phel source file. Reads the file content and
-  evaluates it using the compiler. Returns the result of the last
-  expression, or nil if the file cannot be read."
+  "Loads and evaluates a Phel source file. Reads the file content and evaluates it using the compiler. Returns the result of the last expression, or nil if the file cannot be read."
   {:example "(load-file \"src/my-module.phel\")"
    :see-also ["loaded-namespaces"]}
   [path]

--- a/src/phel/core/parsing.phel
+++ b/src/phel/core/parsing.phel
@@ -18,9 +18,7 @@
         (php/intval trimmed)))))
 
 (defn parse-double
-  "Parses a string as a float. Returns `nil` for non-numeric input or for
-  inputs that are not strings. Accepts `Infinity`, `-Infinity`, and `NaN`
-  alongside regular decimal and scientific notation."
+  "Parses a string as a float. Returns `nil` for non-numeric input or for inputs that are not strings. Accepts `Infinity`, `-Infinity`, and `NaN` alongside regular decimal and scientific notation."
   {:example "(parse-double \"3.14\") ; => 3.14\n(parse-double \"Infinity\") ; => INF"
    :see-also ["parse-long"]}
   [s]

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -109,10 +109,7 @@
   (php/instanceof x PhpClass))
 
 (defn class
-  "Returns a `Phel\\Lang\\PhpClass` for `x`. With an object argument
-  returns the class of the object. With a string argument resolves the
-  named class or interface FQN. Throws `InvalidArgumentException` for
-  any other input."
+  "Returns a `Phel\\Lang\\PhpClass` for `x`. With an object argument returns the class of the object. With a string argument resolves the named class or interface FQN. Throws `InvalidArgumentException` for any other input."
   {:example "(class (php/new \\stdClass)) ; => stdClass"
    :see-also ["class?" "class-name" "type"]}
   [x]
@@ -123,8 +120,7 @@
     :else                       (throw-class-type-error "class" "an object or class-name string" x)))
 
 (defn class-name
-  "Returns the FQN string of `c` (a `Phel\\Lang\\PhpClass`). Leading
-  backslashes are not preserved (e.g. `\\stdClass` becomes `stdClass`)."
+  "Returns the FQN string of `c` (a `Phel\\Lang\\PhpClass`). Leading backslashes are not preserved (e.g. `\\stdClass` becomes `stdClass`)."
   {:example "(class-name (class \"stdClass\")) ; => \"stdClass\""
    :see-also ["class" "class?"]}
   [c]
@@ -149,8 +145,7 @@
       (php/instanceof x BigInt)))
 
 (defn int?
-  "Returns true if `x` is a fixed-precision PHP integer. `BigInt`
-   values return false; use `integer?` to accept either."
+  "Returns true if `x` is a fixed-precision PHP integer. `BigInt` values return false; use `integer?` to accept either."
   {:example "(int? 1) ; => true\n(int? 1.0) ; => false"
    :see-also ["integer?" "bigint?"]}
   [x]
@@ -164,24 +159,21 @@
   (php/:: NumericOperations (compare x 0)))
 
 (defn neg-int?
-  "Returns true if `x` is a negative integer. Accepts both fixed-precision
-  PHP `int` and arbitrary-precision `BigInt` values."
+  "Returns true if `x` is a negative integer. Accepts both fixed-precision PHP `int` and arbitrary-precision `BigInt` values."
   {:example "(neg-int? -1) ; => true\n(neg-int? 0) ; => false\n(neg-int? (bigint -5)) ; => true"
    :see-also ["int?" "integer?" "pos-int?" "nat-int?"]}
   [x]
   (and (integer? x) (php/< (compare-to-zero x) 0)))
 
 (defn pos-int?
-  "Returns true if `x` is a positive integer (greater than zero). Accepts both
-  fixed-precision PHP `int` and arbitrary-precision `BigInt` values."
+  "Returns true if `x` is a positive integer (greater than zero). Accepts both fixed-precision PHP `int` and arbitrary-precision `BigInt` values."
   {:example "(pos-int? 1) ; => true\n(pos-int? 0) ; => false\n(pos-int? (bigint 5)) ; => true"
    :see-also ["int?" "integer?" "neg-int?" "nat-int?"]}
   [x]
   (and (integer? x) (php/> (compare-to-zero x) 0)))
 
 (defn nat-int?
-  "Returns true if `x` is a non-negative integer (zero or positive). Accepts
-  both fixed-precision PHP `int` and arbitrary-precision `BigInt` values."
+  "Returns true if `x` is a non-negative integer (zero or positive). Accepts both fixed-precision PHP `int` and arbitrary-precision `BigInt` values."
   {:example "(nat-int? 0) ; => true\n(nat-int? 1) ; => true\n(nat-int? (bigint 5)) ; => true"
    :see-also ["int?" "integer?" "pos-int?" "neg-int?"]}
   [x]
@@ -199,19 +191,14 @@
       (php/instanceof x BigDecimal)))
 
 (defn ratio?
-  "Returns true if `x` is a `Ratio` value. Integer-valued rationals
-  auto-collapse to `int`/`BigInt` at construction time, so `(ratio? 2/2)`
-  is `false`."
+  "Returns true if `x` is a `Ratio` value. Integer-valued rationals auto-collapse to `int`/`BigInt` at construction time, so `(ratio? 2/2)` is `false`."
   {:example "(ratio? 1/2) ; => true\n(ratio? 0.5) ; => false"
    :see-also ["number?" "numerator" "denominator" "rationalize"]}
   [x]
   (php/instanceof x Ratio))
 
 (defn double?
-  "Returns true if `x` is a floating-point number, false otherwise.
-   Alias for `float?`, matching Clojure's `double?` naming. Since Phel
-   uses PHP floats (IEEE 754 doubles) there is no separate single-precision
-   float type."
+  "Returns true if `x` is a floating-point number, false otherwise. Alias for `float?`, matching Clojure's `double?` naming. Since Phel uses PHP floats (IEEE 754 doubles) there is no separate single-precision float type."
   {:example "(double? 1.0) ; => true"
    :see-also ["float?" "number?"]}
   [x]
@@ -306,8 +293,7 @@
   (= (type x) :function))
 
 (defn ifn?
-  "Returns true if `x` can be invoked as a function.
-   This includes functions, keywords, maps, vectors, sets, and lists."
+  "Returns true if `x` can be invoked as a function. This includes functions, keywords, maps, vectors, sets, and lists."
   {:example "(ifn? inc) ; => true\n(ifn? :a) ; => true\n(ifn? {}) ; => true\n(ifn? 42) ; => false"
    :see-also ["fn?"]}
   [x]
@@ -342,9 +328,7 @@
   (map? x))
 
 (defn vector?
-  "Returns true if `x` is a vector. Map entries returned by iterating a
-  hash map (`(first {:a 1})`) are vector-shaped two-element values, so
-  this predicate also accepts the typed `MapEntry`."
+  "Returns true if `x` is a vector. Map entries returned by iterating a hash map (`(first {:a 1})`) are vector-shaped two-element values, so this predicate also accepts the typed `MapEntry`."
   {:example "(vector? [1 2]) ; => true\n(vector? '(1 2)) ; => false"
    :see-also ["map?" "list?" "sequential?"]}
   [x]
@@ -362,8 +346,7 @@
       (and (vector? x) (php/=== 2 (php/count x)))))
 
 (defn list?
-  "Returns true if `x` is a list, false otherwise.
-  Returns false for the seq view of non-list collections produced by `seq`."
+  "Returns true if `x` is a list, false otherwise. Returns false for the seq view of non-list collections produced by `seq`."
   {:example "(list? '(1 2)) ; => true\n(list? [1 2]) ; => false"
    :see-also ["vector?" "seq?" "sequential?"]}
   [x]
@@ -392,9 +375,7 @@
   (if x true false))
 
 (defn any?
-  "Returns true given any argument, including `nil` and `false`. Mirrors
-  Clojure's `clojure.core/any?` — useful as a default predicate in spec
-  / validation contexts where every value should be accepted."
+  "Returns true given any argument, including `nil` and `false`. Mirrors Clojure's `clojure.core/any?` — useful as a default predicate in spec / validation contexts where every value should be accepted."
   {:example "(any? nil) ; => true\n(any? 0) ; => true"
    :see-also ["some?" "every?" "ifn?"]}
   [_]
@@ -443,16 +424,14 @@
 (defn lazy-seq?
   "Returns true if `x` is a lazy sequence, false otherwise.
 
-  Unlike `seq?`, this predicate is true only for lazy sequences, not for
-  realized lists. Use `seq?` if you want to accept either."
+Unlike `seq?`, this predicate is true only for lazy sequences, not for realized lists. Use `seq?` if you want to accept either."
   {:example "(lazy-seq? (map inc [1 2 3])) ; => true\n(lazy-seq? '(1 2 3))         ; => false\n(lazy-seq? [1 2 3])          ; => false"
    :see-also ["seq?" "realized?" "lazy-seq"]}
   [x]
   (php/instanceof x LazySeqInterface))
 
 (defn empty?
-  "Returns true if x would be 0, \"\" or empty collection, false otherwise.
-  Safe on infinite/lazy sequences: checks the first element instead of counting."
+  "Returns true if x would be 0, \"\" or empty collection, false otherwise. Safe on infinite/lazy sequences: checks the first element instead of counting."
   {:example "(empty? []) ; => true\n(empty? [1]) ; => false"
    :see-also ["not-empty" "empty" "count"]}
   [x]
@@ -473,8 +452,7 @@
     coll))
 
 (defn empty
-  "Returns an empty collection of the same category as `coll`, preserving
-  the original metadata, or nil if `coll` has no empty equivalent."
+  "Returns an empty collection of the same category as `coll`, preserving the original metadata, or nil if `coll` has no empty equivalent."
   {:example "(empty [1 2 3]) ; => []\n(empty {:a 1}) ; => {}\n(empty (range 10)) ; => ()"
    :see-also ["empty?" "not-empty"]}
   [coll]
@@ -500,12 +478,9 @@
   (php/:: Phel (seqList values)))
 
 (defn seq
-  "Returns a seq on the collection. Strings are converted to a vector of characters.
-  Other non-empty collections (vectors, sets, sorted-maps, sorted-sets, PHP arrays)
-  are converted to a non-list seq. Returns nil if `coll` is empty or nil.
+  "Returns a seq on the collection. Strings are converted to a vector of characters. Other non-empty collections (vectors, sets, sorted-maps, sorted-sets, PHP arrays) are converted to a non-list seq. Returns nil if `coll` is empty or nil.
 
-  This function is useful for explicitly converting strings to sequences of characters,
-  enabling sequence operations like map, filter, and frequencies."
+This function is useful for explicitly converting strings to sequences of characters, enabling sequence operations like map, filter, and frequencies."
   {:example "(seq \"hello\") ; => [\"h\" \"e\" \"l\" \"l\" \"o\"]\n(seq [1 2 3]) ; => (1 2 3)"
    :see-also ["count"]}
   [coll]
@@ -538,7 +513,7 @@
 (defn indexed?
   "Returns true if `x` is an indexed sequence, false otherwise.
 
-  Indexed sequences include lists, vectors, and indexed PHP arrays."
+Indexed sequences include lists, vectors, and indexed PHP arrays."
   {:example "(indexed? [1 2 3]) ; => true"}
   [x]
   (or (php/instanceof x PersistentVectorInterface)
@@ -558,10 +533,7 @@
       (php/is_array x)))
 
 (defn sequential?
-  "Returns true if `x` is a sequential collection (vector, list, or lazy
-   sequence), false otherwise. Sequential collections maintain insertion
-   order and support indexed or linear access. Maps, sets, and structs
-   are not sequential, matching Clojure's `Sequential` marker."
+  "Returns true if `x` is a sequential collection (vector, list, or lazy sequence), false otherwise. Sequential collections maintain insertion order and support indexed or linear access. Maps, sets, and structs are not sequential, matching Clojure's `Sequential` marker."
   {:example "(sequential? [1 2 3]) ; => true\n(sequential? {:a 1}) ; => false"
    :see-also ["coll?" "vector?" "list?" "seq?"]}
   [x]
@@ -585,9 +557,7 @@
       (php/instanceof x LazySeqInterface)))
 
 (defn seqable?
-  "Returns true if `(seq x)` is supported: collections (vectors, lists,
-   maps, sets, structs), lazy sequences, strings, PHP arrays, and nil.
-   Returns false for numbers, booleans, keywords, symbols, and other types."
+  "Returns true if `(seq x)` is supported: collections (vectors, lists, maps, sets, structs), lazy sequences, strings, PHP arrays, and nil. Returns false for numbers, booleans, keywords, symbols, and other types."
   {:example "(seqable? [1 2]) ; => true\n(seqable? 42) ; => false"
    :see-also ["seq" "coll?" "seq?"]}
   [x]

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -51,9 +51,7 @@
 (defn make-hierarchy
   "Creates a fresh, empty hierarchy.
 
-  Returns a map with `:parents`, `:descendants`, and `:ancestors` keys, each
-  holding an empty map. Matches Clojure's hierarchy shape so consumers can
-  destructure any of the three relationship views."
+Returns a map with `:parents`, `:descendants`, and `:ancestors` keys, each holding an empty map. Matches Clojure's hierarchy shape so consumers can destructure any of the three relationship views."
   {:see-also ["derive" "isa?" "parents" "ancestors" "descendants"]}
   []
   {:parents {}, :descendants {}, :ancestors {}})
@@ -84,9 +82,7 @@
 (def ^:private *protocol-type-relations*
   "Maps PHP class tags to the set of protocol values they implement.
 
-  Maintained in parallel with `derive`'s class -> proto-class-string entry
-  so hierarchy queries surface the protocol value itself (the map produced
-  by `defprotocol`) and not just its FQN string."
+Maintained in parallel with `derive`'s class -> proto-class-string entry so hierarchy queries surface the protocol value itself (the map produced by `defprotocol`) and not just its FQN string."
   (atom {}))
 
 (defn- hierarchy-tag
@@ -120,9 +116,7 @@
                     (str "derive parent must be a namespaced symbol/keyword, got: " parent)))))
 
 (defn- protocol-relations
-  "Returns the set of protocol values registered for a PHP class tag.
-  Hierarchy-independent: surfaced by every `parents`/`ancestors`/`descendants`
-  call, mirroring PHP class inheritance."
+  "Returns the set of protocol values registered for a PHP class tag. Hierarchy-independent: surfaced by every `parents`/`ancestors`/`descendants` call, mirroring PHP class inheritance."
   [tag]
   (get @*protocol-type-relations* tag (hash-set)))
 
@@ -141,9 +135,7 @@
   nil)
 
 (defn- derive-only-parents
-  "Returns parents recorded by `derive` for tag, ignoring PHP class
-  inheritance and protocol relations. Used by `descendants` to match
-  Clojure's contract that type inheritance is not surfaced."
+  "Returns parents recorded by `derive` for tag, ignoring PHP class inheritance and protocol relations. Used by `descendants` to match Clojure's contract that type inheritance is not surfaced."
   [parents-map tag]
   (let [resolved-tag (hierarchy-tag tag)]
     (union (get parents-map tag (hash-set))
@@ -187,8 +179,7 @@
        direct))))
 
 (defn- isa-in?
-  "Checks if child is (transitively) a descendant of parent in parents-map.
-  Walks up the parent chain without building the full ancestor set."
+  "Checks if child is (transitively) a descendant of parent in parents-map. Walks up the parent chain without building the full ancestor set."
   [parents-map child parent]
   (let [direct (direct-parents parents-map child)]
     (if (empty? direct)
@@ -212,8 +203,7 @@
    (keys parents-map)))
 
 (defn- compute-descendants-map
-  "Builds the full {tag #{descendants}} map from a parents map.
-  Walks only `derive`-recorded edges, mirroring `descendants`'s contract."
+  "Builds the full {tag #{descendants}} map from a parents map. Walks only `derive`-recorded edges, mirroring `descendants`'s contract."
   [parents-map]
   (reduce
    (fn [acc child]
@@ -250,9 +240,7 @@
   h)
 
 (defn isa?
-  "Returns true if child equals parent, or child is a descendant of parent.
-  When a hierarchy is provided, the check is performed against it; otherwise
-  the global hierarchy is used."
+  "Returns true if child equals parent, or child is a descendant of parent. When a hierarchy is provided, the check is performed against it; otherwise the global hierarchy is used."
   {:example "(do (derive ::square ::shape) (isa? ::square ::shape)) ; => true"
    :see-also ["derive" "parents" "ancestors" "descendants"]}
   ([child parent]
@@ -262,10 +250,7 @@
        (isa-in? (get h :parents) child parent))))
 
 (defn derive
-  "Establishes a parent/child relationship between child and parent keywords.
-  With two arguments, mutates the global hierarchy and returns nil.
-  With a hierarchy `h`, returns a new hierarchy with the relationship added;
-  the original hierarchy is not modified. Throws on cyclic derivation."
+  "Establishes a parent/child relationship between child and parent keywords. With two arguments, mutates the global hierarchy and returns nil. With a hierarchy `h`, returns a new hierarchy with the relationship added; the original hierarchy is not modified. Throws on cyclic derivation."
   {:example "(derive ::square ::shape)"
    :see-also ["underive" "isa?" "parents" "ancestors" "descendants"]}
   ([child parent]
@@ -292,10 +277,7 @@
      (rebuild-hierarchy (assoc h :parents new-pm)))))
 
 (defn underive
-  "Removes a parent/child relationship.
-  With two arguments, mutates the global hierarchy and returns nil.
-  With a hierarchy `h`, returns a new hierarchy without the relationship;
-  the original is unchanged."
+  "Removes a parent/child relationship. With two arguments, mutates the global hierarchy and returns nil. With a hierarchy `h`, returns a new hierarchy without the relationship; the original is unchanged."
   {:example "(underive :square :shape)"
    :see-also ["derive" "isa?" "parents" "ancestors" "descendants"]}
   ([child parent]
@@ -320,8 +302,7 @@
      (rebuild-hierarchy (assoc h :parents new-pm)))))
 
 (defn parents
-  "Returns the set of immediate parents of tag, or nil.
-  When a hierarchy is provided, consults it; otherwise uses the global hierarchy."
+  "Returns the set of immediate parents of tag, or nil. When a hierarchy is provided, consults it; otherwise uses the global hierarchy."
   {:see-also ["ancestors" "descendants" "derive" "isa?"]}
   ([tag]
    (parents @*hierarchy* tag))
@@ -332,8 +313,7 @@
          (when (and p (not (empty? p))) p))))))
 
 (defn ancestors
-  "Returns the set of all transitive ancestors of tag, or nil.
-  When a hierarchy is provided, consults it; otherwise uses the global hierarchy."
+  "Returns the set of all transitive ancestors of tag, or nil. When a hierarchy is provided, consults it; otherwise uses the global hierarchy."
   {:see-also ["parents" "descendants" "derive" "isa?"]}
   ([tag]
    (ancestors @*hierarchy* tag))
@@ -365,9 +345,7 @@
          (when (not (empty? result)) result))))))
 
 (defn prefers?
-  "Returns true if dispatch value `x` is preferred over `y` in `prefers-map`,
-  considering transitive preferences. Used by multimethod dispatch when
-  multiple methods match and the hierarchy does not pick a unique winner."
+  "Returns true if dispatch value `x` is preferred over `y` in `prefers-map`, considering transitive preferences. Used by multimethod dispatch when multiple methods match and the hierarchy does not pick a unique winner."
   {:see-also ["prefer-method" "prefers"]}
   [prefers-map x y]
   (let [direct (get prefers-map x #{})]
@@ -379,9 +357,7 @@
                                   direct)))))
 
 (defn- dominates?
-  "Returns true when candidate `x` is more specific than `y` for multimethod
-  dispatch: either `x` derives from `y` in the hierarchy, or `x` is preferred
-  over `y` via `prefer-method`."
+  "Returns true when candidate `x` is more specific than `y` for multimethod dispatch: either `x` derives from `y` in the hierarchy, or `x` is preferred over `y` via `prefer-method`."
   [prefers-map parents-map x y]
   (or (isa-in? parents-map x y)
       (prefers? prefers-map x y)))
@@ -449,14 +425,11 @@
     :unknown))
 
 (defmacro defprotocol
-  "Defines a protocol with the given method signatures. Each method signature
-  is a list of (method-name [args]).
+  "Defines a protocol with the given method signatures. Each method signature is a list of (method-name [args]).
 
-  Creates a dispatching function for each method that dispatches on the type
-  of the first argument. Use `extend-type` to add implementations.
+Creates a dispatching function for each method that dispatches on the type of the first argument. Use `extend-type` to add implementations.
 
-  A `:default` type can be registered via `extend-type` as a fallback when
-  no specific type implementation is found."
+A `:default` type can be registered via `extend-type` as a fallback when no specific type implementation is found."
   {:example "(defprotocol Stringable (to-string [this]))"
    :see-also ["extend-type" "satisfies?" "extends?" "protocol-type-key"]}
   [protocol-name & method-specs]
@@ -581,8 +554,7 @@
       (every? (fn [dv] (not (nil? (get (deref dv) key)))) dvars))))
 
 (defn extends?
-  "Returns true if the given type-key has implementations for all methods
-  of the protocol. type-key should match what protocol-type-key returns."
+  "Returns true if the given type-key has implementations for all methods of the protocol. type-key should match what protocol-type-key returns."
   {:example "(extends? Stringable :string)"
    :see-also ["satisfies?" "defprotocol" "extend-type"]}
   [protocol type-key]
@@ -592,10 +564,9 @@
       (every? (fn [dv] (not (nil? (get (deref dv) type-key)))) dvars))))
 
 (defmacro extend-protocol
-  "Convenience macro that extends a single protocol to multiple types.
-  Alternates type-specs and method implementations.
+  "Convenience macro that extends a single protocol to multiple types. Alternates type-specs and method implementations.
 
-  Equivalent to multiple `extend-type` calls."
+Equivalent to multiple `extend-type` calls."
   {:example "(extend-protocol Describable
   :string (describe [s] s)
   :int (describe [n] (str n)))"
@@ -826,9 +797,7 @@
        nil)))
 
 (defmacro prefers
-  "Returns the preference map for a multimethod (built by `prefer-method`).
-  Keys are dispatch values; values are sets of dispatch values they are
-  preferred over (directly; preference is transitive when consulted)."
+  "Returns the preference map for a multimethod (built by `prefer-method`). Keys are dispatch values; values are sets of dispatch values they are preferred over (directly; preference is transitive when consulted)."
   {:example "(prefers draw)"
    :see-also ["prefer-method" "defmulti"]}
   [multi-name]
@@ -839,8 +808,7 @@
     `(deref ~prefers-name)))
 
 (defmacro if-let
-  "If test is true, evaluates then with binding-form bound to the value of test,
-  if not, yields else"
+  "If test is true, evaluates then with binding-form bound to the value of test, if not, yields else"
   [bindings then & [else]]
   (let [err #(throw (php/new \InvalidArgumentException %))]
     (when-not
@@ -879,9 +847,7 @@
            ~@body)))))
 
 (defmacro if-some
-  "Binds name to the value of test. If test is not nil, evaluates then with binding-form
-  bound to the value of test, if not, yields else. Unlike if-let, false and 0 are not
-  treated as falsy — only nil triggers the else branch."
+  "Binds name to the value of test. If test is not nil, evaluates then with binding-form bound to the value of test, if not, yields else. Unlike if-let, false and 0 are not treated as falsy — only nil triggers the else branch."
   {:see-also ["if-let" "when-some"]}
   [bindings then & [else]]
   (let [err #(throw (php/new \InvalidArgumentException %))]
@@ -902,9 +868,7 @@
          ~else))))
 
 (defmacro when-some
-  "Binds name to the value of test. When test is not nil, evaluates body with
-  binding-form bound to the value of test. Unlike when-let, false and 0 are not
-  treated as falsy — only nil causes the body to be skipped."
+  "Binds name to the value of test. When test is not nil, evaluates body with binding-form bound to the value of test. Unlike when-let, false and 0 are not treated as falsy — only nil causes the body to be skipped."
   {:see-also ["when-let" "if-some"]}
   [bindings & body]
   `(if-some ~bindings (do ~@body) nil))
@@ -933,9 +897,7 @@
 (defmacro letfn
   "Defines mutually recursive local functions.
 
-  bindings is a vector of function specs: (letfn [(f [params] body) (g [params] body)] expr)
-  All function names are in scope within all function bodies and the body expression,
-  enabling mutual recursion."
+bindings is a vector of function specs: (letfn [(f [params] body) (g [params] body)] expr) All function names are in scope within all function bodies and the body expression, enabling mutual recursion."
   {:example "(letfn [(my-even? [n] (if (zero? n) true (my-odd? (dec n))))
         (my-odd? [n] (if (zero? n) false (my-even? (dec n))))]
   (my-even? 10))"}
@@ -969,10 +931,7 @@
      ret#))
 
 (defmacro assert
-  "Throws an exception if expr is falsy. Optional message string.
-  Used for precondition checking in application code. When `*assert*`
-  is logical false at macroexpansion time, `assert` expands to nil and
-  performs no runtime check."
+  "Throws an exception if expr is falsy. Optional message string. Used for precondition checking in application code. When `*assert*` is logical false at macroexpansion time, `assert` expands to nil and performs no runtime check."
   {:see-also ["when" "throw" "*assert*"]}
   [expr & [message]]
   (when *assert*

--- a/src/phel/core/seq-basics.phel
+++ b/src/phel/core/seq-basics.phel
@@ -121,8 +121,7 @@
 (defn count
   "Counts the number of elements in a sequence. Can be used on everything that implements the PHP Countable interface.
 
-  Works with lists, vectors, hash-maps, sets, strings, and PHP arrays.
-  Returns 0 for nil."
+Works with lists, vectors, hash-maps, sets, strings, and PHP arrays. Returns 0 for nil."
   {:example "(count [1 2 3]) ; => 3"
    :see-also ["empty?" "seq"]}
   [coll]

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -128,8 +128,7 @@
 (defn into
   "Returns `to` with all elements of `from` added.
 
-  When `from` is associative, it is treated as a sequence of key-value pairs.
-  Supports persistent and transient collections."
+When `from` is associative, it is treated as a sequence of key-value pairs. Supports persistent and transient collections."
   {:example "(into [] '(1 2 3)) ; => [1 2 3]"
    :see-also ["conj" "concat" "transduce"]}
   [to & rest]
@@ -232,8 +231,7 @@
                     (str "Cannot disj on type " (type coll))))))
 
 (defn disj
-  "Returns a new set that does not contain the given key(s). Works on hash-sets and sorted-sets.
-  Removing a non-existent key is a no-op. Returns `nil` when called on `nil`."
+  "Returns a new set that does not contain the given key(s). Works on hash-sets and sorted-sets. Removing a non-existent key is a no-op. Returns `nil` when called on `nil`."
   {:example "(disj #{1 2 3} 2) ; => #{1 3}"
    :see-also ["conj" "hash-set" "sorted-set"]}
   ([set] set)
@@ -252,8 +250,7 @@
     (throw (php/new InvalidArgumentException "Cannot slice"))))
 
 (defn set
-  "Coerces a collection to a set. Returns a set containing the distinct elements of `coll`.
-  For creating sets from arguments, use `hash-set`."
+  "Coerces a collection to a set. Returns a set containing the distinct elements of `coll`. For creating sets from arguments, use `hash-set`."
   {:example "(set [1 2 3 2 1]) ; => #{1 2 3}"
    :see-also ["hash-set" "vec" "into"]}
   [coll]
@@ -264,8 +261,7 @@
        (conj! acc x)))))
 
 (defn vec
-  "Coerces a collection to a vector. For hash-maps and structs, entries
-  are returned as 2-element `[key value]` vectors, matching Clojure."
+  "Coerces a collection to a vector. For hash-maps and structs, entries are returned as 2-element `[key value]` vectors, matching Clojure."
   {:example "(vec {:a 1 :b 2}) ; => [[:a 1] [:b 2]]"
    :see-also ["vector" "set" "into"]}
   [coll]
@@ -287,8 +283,7 @@
 (defn get-in
   "Accesses a value in a nested data structure via a sequence of keys.
 
-  Returns `opt` (default nil) when a key is missing mid-traversal.
-  When the path is nil or empty, returns `ds` as-is (which may be nil)."
+Returns `opt` (default nil) when a key is missing mid-traversal. When the path is nil or empty, returns `ds` as-is (which may be nil)."
   {:example "(get-in {:a {:b {:c 42}}} [:a :b :c]) ; => 42"
    :see-also ["assoc-in" "update-in"]}
   [ds ks & [opt]]
@@ -310,7 +305,7 @@
 (defn assoc-in
   "Associates a value in a nested data structure at the given path.
 
-  Creates intermediate maps if they don't exist."
+Creates intermediate maps if they don't exist."
   {:example "(assoc-in {:a {:b 1}} [:a :c] 2) ; => {:a {:b 1, :c 2}}"
    :see-also ["get-in" "update-in" "dissoc-in"]}
   [ds [k & ks] v]
@@ -362,8 +357,7 @@
   (dissoc-in ds ks))
 
 (defn drop
-  "Drops the first `n` elements of `coll`. Returns a lazy sequence.
-  When called with n only, returns a transducer."
+  "Drops the first `n` elements of `coll`. Returns a lazy sequence. When called with n only, returns a transducer."
   {:example "(drop 2 [1 2 3 4 5]) ; => @[3 4 5]"
    :see-also ["take" "drop-last" "transduce"]}
   [n & args]
@@ -385,10 +379,7 @@
     (throw (php/new InvalidArgumentException "drop expects 1 or 2 arguments"))))
 
 (defn drop-last
-  "Drops the last `n` elements of `coll`. `n` defaults to `1` when omitted,
-   matching Clojure's `(drop-last coll)` single-arity form. Returns an empty
-   sequence when `coll` is `nil`. Works with any seqable collection including
-   lazy sequences and ranges."
+  "Drops the last `n` elements of `coll`. `n` defaults to `1` when omitted, matching Clojure's `(drop-last coll)` single-arity form. Returns an empty sequence when `coll` is `nil`. Works with any seqable collection including lazy sequences and ranges."
   {:example "(drop-last [1 2 3 4 5]) ; => @[1 2 3 4]\n(drop-last 2 [1 2 3 4 5]) ; => @[1 2 3]\n(drop-last 5 nil) ; => @[]"
    :see-also ["drop" "butlast"]}
   ([coll] (drop-last 1 coll))
@@ -419,8 +410,7 @@
     (drop-last 1 coll)))
 
 (defn drop-while
-  "Drops all elements at the front of `coll` where `(pred x)` is true. Returns a lazy sequence.
-  When called with pred only, returns a transducer."
+  "Drops all elements at the front of `coll` where `(pred x)` is true. Returns a lazy sequence. When called with pred only, returns a transducer."
   {:example "(drop-while #(< % 5) [1 2 3 4 5 6 3 2 1]) ; => @[5 6 3 2 1]"
    :see-also ["take-while" "drop" "transduce"]}
   [pred & args]
@@ -439,8 +429,7 @@
     (throw (php/new InvalidArgumentException "drop-while expects 1 or 2 arguments"))))
 
 (defn take
-  "Takes the first `n` elements of `coll`.
-  When called with n only, returns a transducer."
+  "Takes the first `n` elements of `coll`. When called with n only, returns a transducer."
   [n & args]
   (case (count args)
     0 (fn [rf]
@@ -484,8 +473,7 @@
     :else (take-last-buffered n coll)))
 
 (defn take-while
-  "Takes all elements at the front of `coll` where `(pred x)` is true. Returns a lazy sequence.
-  When called with pred only, returns a transducer."
+  "Takes all elements at the front of `coll` where `(pred x)` is true. Returns a lazy sequence. When called with pred only, returns a transducer."
   {:example "(take-while #(< % 5) [1 2 3 4 5 6 3 2 1]) ; => @[1 2 3 4]"
    :see-also ["drop-while" "take" "transduce"]}
   [pred & args]
@@ -501,8 +489,7 @@
     (throw (php/new InvalidArgumentException "take-while expects 1 or 2 arguments"))))
 
 (defn take-nth
-  "Returns every nth item in `coll`. Returns a lazy sequence.
-  When called with n only, returns a transducer."
+  "Returns every nth item in `coll`. Returns a lazy sequence. When called with n only, returns a transducer."
   {:example "(take-nth 2 [0 1 2 3 4 5 6 7 8]) ; => @[0 2 4 6 8]"
    :see-also ["take" "filter" "transduce"]}
   [n & args]
@@ -523,8 +510,7 @@
     (throw (php/new InvalidArgumentException "take-nth expects 1 or 2 arguments"))))
 
 (defn filter
-  "Returns a lazy sequence of elements where predicate returns true.
-  When called with pred only, returns a transducer."
+  "Returns a lazy sequence of elements where predicate returns true. When called with pred only, returns a transducer."
   {:example "(filter even? [1 2 3 4 5 6]) ; => @[2 4 6]"
    :see-also ["remove" "keep" "transduce"]}
   [pred & args]
@@ -543,8 +529,7 @@
     (throw (php/new InvalidArgumentException "filter expects 1 or 2 arguments"))))
 
 (defn remove
-  "Returns a lazy sequence of elements where predicate returns false.
-   Opposite of filter. When called with pred only, returns a transducer."
+  "Returns a lazy sequence of elements where predicate returns false. Opposite of filter. When called with pred only, returns a transducer."
   {:example "(remove even? [1 2 3 4 5 6]) ; => @[1 3 5]"
    :see-also ["filter" "transduce"]}
   [pred & args]
@@ -554,8 +539,7 @@
     (throw (php/new InvalidArgumentException "remove expects 1 or 2 arguments"))))
 
 (defn keep
-  "Returns a lazy sequence of non-nil results of applying function to elements.
-  When called with f only, returns a transducer."
+  "Returns a lazy sequence of non-nil results of applying function to elements. When called with f only, returns a transducer."
   {:example "(keep #(when (even? %) (* % %)) [1 2 3 4 5]) ; => @[4 16]"
    :see-also ["keep-indexed" "filter" "transduce"]}
   [pred & args]
@@ -572,8 +556,7 @@
     (throw (php/new InvalidArgumentException "keep expects 1 or 2 arguments"))))
 
 (defn keep-indexed
-  "Returns a lazy sequence of non-nil results of `(pred i x)`.
-  When called with f only, returns a transducer."
+  "Returns a lazy sequence of non-nil results of `(pred i x)`. When called with f only, returns a transducer."
   {:example "(keep-indexed #(when (even? %1) %2) [\"a\" \"b\" \"c\" \"d\"]) ; => @[\"a\" \"c\"]"
    :see-also ["keep" "map-indexed" "transduce"]}
   [pred & args]
@@ -604,8 +587,7 @@
         (if (pred x) x (recur (next s)))))))
 
 (defn find
-  "When called with a collection first, returns `[key value]` when `key` is present.
-  Otherwise returns the first item in `coll` where `(pred item)` evaluates to true."
+  "When called with a collection first, returns `[key value]` when `key` is present. Otherwise returns the first item in `coll` where `(pred item)` evaluates to true."
   {:example "(find {:a 1} :a) ; => [:a 1]\n(find #(> % 5) [1 2 3 6 7 8]) ; => 6"
    :see-also ["find-index" "filter" "some?"]}
   [pred-or-coll coll-or-key]
@@ -626,8 +608,7 @@
       :else            (recur (next s) (php/+ i 1)))))
 
 (defn distinct
-  "Returns a lazy sequence with duplicated values removed in `coll`.
-  When called with no args, returns a transducer."
+  "Returns a lazy sequence with duplicated values removed in `coll`. When called with no args, returns a transducer."
   {:example "(distinct [1 2 1 3 2 4 3]) ; => @[1 2 3 4]"
    :see-also ["frequencies" "set" "dedupe" "transduce"]}
   [& args]
@@ -662,8 +643,7 @@
     (copy-meta coll result)))
 
 (defn reversible?
-  "Returns true if `coll` can be reverse-iterated in constant time.
-  Currently this is true for vectors, sorted-maps, and sorted-sets."
+  "Returns true if `coll` can be reverse-iterated in constant time. Currently this is true for vectors, sorted-maps, and sorted-sets."
   {:example "(reversible? [1 2 3]) ; => true"
    :see-also ["rseq" "reverse"]}
   [coll]
@@ -671,10 +651,7 @@
       (sorted? coll)))
 
 (defn rseq
-  "Returns, in constant time, a sequence of the items in `rev` in reverse
-  order. `rev` must be reversible (a vector, sorted-map, or sorted-set);
-  otherwise an exception is thrown. For sorted-maps, returns reversed `[key value]` pairs.
-  Returns nil if `rev` is empty."
+  "Returns, in constant time, a sequence of the items in `rev` in reverse order. `rev` must be reversible (a vector, sorted-map, or sorted-set); otherwise an exception is thrown. For sorted-maps, returns reversed `[key value]` pairs. Returns nil if `rev` is empty."
   {:example "(rseq [1 2 3]) ; => (3 2 1)"
    :see-also ["reversible?" "reverse"]}
   [rev]
@@ -687,7 +664,7 @@
 (defn frequencies
   "Returns a map from distinct items in `coll` to the number of times they appear.
 
-  Works with vectors, lists, sets, and strings."
+Works with vectors, lists, sets, and strings."
   {:example "(frequencies [:a :b :a :c :b :a]) ; => {:a 3, :b 2, :c 1}"}
   [coll]
   (let [result (persistent
@@ -698,25 +675,21 @@
     (copy-meta coll result)))
 
 (defn keys
-  "Returns a sequence of all keys in a map, or `nil` when the map is `nil`
-  or empty."
+  "Returns a sequence of all keys in a map, or `nil` when the map is `nil` or empty."
   {:example "(keys {:a 1 :b 2}) ; => [:a :b]\n(keys nil) ; => nil"}
   [coll]
   (when-not (empty? coll)
     (copy-meta coll (for [k :keys coll] k))))
 
 (defn vals
-  "Returns a sequence of all values in a map, or `nil` when the map is `nil`
-  or empty."
+  "Returns a sequence of all values in a map, or `nil` when the map is `nil` or empty."
   {:example "(vals {:a 1 :b 2}) ; => [1 2]\n(vals nil) ; => nil"}
   [coll]
   (when-not (empty? coll)
     (copy-meta coll (for [x :in coll] x))))
 
 (defn map-entry
-  "Returns a typed `Phel\\Lang\\Collections\\Map\\MapEntry` for `k`/`v`.
-  Equal to the two-element vector `[k v]` so existing code that
-  destructures `[k v]` keeps working."
+  "Returns a typed `Phel\\Lang\\Collections\\Map\\MapEntry` for `k`/`v`. Equal to the two-element vector `[k v]` so existing code that destructures `[k v]` keeps working."
   {:example "(map-entry :a 1) ; => [:a 1]"
    :see-also ["map-entry?" "key" "val"]}
   [k v]
@@ -826,7 +799,7 @@
 (defn php->phel
   "Recursively converts a PHP array to Phel data structures.
 
-  Indexed PHP arrays become vectors, associative PHP arrays become maps."
+Indexed PHP arrays become vectors, associative PHP arrays become maps."
   {:example "(php->phel (php-associative-array \"a\" 1 \"b\" 2)) ; => {\"a\" 1, \"b\" 2}"
    :see-also ["phel->php"]}
   [x]
@@ -846,8 +819,7 @@
     true                   x))
 
 (defn bean
-  "Returns a Phel map of the public properties of PHP object `obj`, with
-  keyword keys. Inverse of `hydrate` for public-property objects."
+  "Returns a Phel map of the public properties of PHP object `obj`, with keyword keys. Inverse of `hydrate` for public-property objects."
   {:example "(bean (hydrate \"My\\\\Dto\" {:id 1})) ; => {:id 1}"
    :see-also ["hydrate" "php-array-to-map" "php->phel"]}
   [obj]
@@ -857,10 +829,7 @@
     (persistent res)))
 
 (defn hydrate
-  "Creates an instance of PHP class `class-name` (a class-string) without
-  invoking its constructor, then sets each declared property named by the
-  keyword keys of map `m`. Mirrors how ORMs/serializers rebuild entities from
-  raw data; pairs with `bean` for the reverse direction."
+  "Creates an instance of PHP class `class-name` (a class-string) without invoking its constructor, then sets each declared property named by the keyword keys of map `m`. Mirrors how ORMs/serializers rebuild entities from raw data; pairs with `bean` for the reverse direction."
   {:example "(hydrate \"My\\\\Dto\" {:id 1 :name \"x\"})"
    :see-also ["bean"]}
   [class-name m]
@@ -878,12 +847,7 @@
   (some? #(= % val) (vals coll)))
 
 (defn- sort-comparator
-  "Wraps the user-supplied comparator (or `compare` when absent) so its
-  result is always an integer. A predicate-style comparator that
-  returns a boolean follows Clojure semantics: a truthy result means
-  the first argument should sort earlier (`-1`), the reverse-truthy
-  case means it should sort later (`+1`), otherwise the items are
-  considered equal."
+  "Wraps the user-supplied comparator (or `compare` when absent) so its result is always an integer. A predicate-style comparator that returns a boolean follows Clojure semantics: a truthy result means the first argument should sort earlier (`-1`), the reverse-truthy case means it should sort later (`+1`), otherwise the items are considered equal."
   [comp]
   (let [cmp (or comp compare)]
     (fn [a b]
@@ -923,7 +887,7 @@
 (defn sort-by
   "Returns a sorted vector where the sort order is determined by comparing `(keyfn item)`.
 
-  If no comparator is supplied compare is used."
+If no comparator is supplied compare is used."
   {:example "(sort-by count [\"aaa\" \"c\" \"bb\"]) ; => [\"c\" \"bb\" \"aaa\"]\n(sort-by count compare [\"aaa\" \"c\" \"bb\"]) ; => [\"c\" \"bb\" \"aaa\"]"
    :see-also ["sort" "compare"]}
   ([keyfn coll]
@@ -944,7 +908,7 @@
 (defn repeat
   "Returns a vector of length n where every element is x.
 
-  With one argument returns an infinite lazy sequence of x."
+With one argument returns an infinite lazy sequence of x."
   {:example "(repeat 3 :a) ; => [:a :a :a]"
    :see-also ["repeatedly" "cycle"]}
   [a & rest]
@@ -956,7 +920,7 @@
 (defn repeatedly
   "Returns a vector of length n with values produced by repeatedly calling f.
 
-  With one argument returns an infinite lazy sequence of calls to f."
+With one argument returns an infinite lazy sequence of calls to f."
   {:example "(repeatedly 3 rand) ; => [0.234 0.892 0.456] (random values)"
    :see-also ["repeat" "iterate"]}
   [a & rest]
@@ -996,19 +960,14 @@
   (lazy-seq-from-generator (php/:: Seq (iterate f x))))
 
 (defn iterator-seq
-  "Returns a lazy sequence over a PHP `Traversable` (Iterator, Generator,
-  IteratorAggregate, ...), pulling one element at a time. Unlike the eager
-  coercion that materialises a `Traversable` via `iterator_to_array`, this
-  streams a large or infinite source (DB cursor, stream reader, paginated
-  API), so `take`/`map`/`filter` only pull what they consume."
+  "Returns a lazy sequence over a PHP `Traversable` (Iterator, Generator, IteratorAggregate, ...), pulling one element at a time. Unlike the eager coercion that materialises a `Traversable` via `iterator_to_array`, this streams a large or infinite source (DB cursor, stream reader, paginated API), so `take`/`map`/`filter` only pull what they consume."
   {:example "(take 3 (iterator-seq (php/new \\ArrayIterator (php/array 1 2 3 4 5)))) ; => @[1 2 3]"
    :see-also ["lazy-seq" "map" "take"]}
   [traversable]
   (php/:: LazySeq (fromTraversable (php/new Hasher) (php/new Equalizer) traversable)))
 
 (defn cycle
-  "Returns an infinite lazy sequence that cycles through the elements of
-  collection. Maps are iterated as `[key value]` pairs."
+  "Returns an infinite lazy sequence that cycles through the elements of collection. Maps are iterated as `[key value]` pairs."
   {:example "(take 7 (cycle [1 2 3])) ; => @[1 2 3 1 2 3 1]"
    :see-also ["iterate" "repeat"]}
   [coll]
@@ -1063,8 +1022,7 @@
     (apply concat (apply map f args))))
 
 (defn interpose
-  "Returns elements separated by a separator. Returns a lazy sequence.
-  When called with sep only, returns a transducer."
+  "Returns elements separated by a separator. Returns a lazy sequence. When called with sep only, returns a transducer."
   {:example "(interpose 0 [1 2 3]) ; => @[1 0 2 0 3]"
    :see-also ["transduce"]}
   [sep & args]
@@ -1096,9 +1054,7 @@
 (defn map-indexed
   "Maps a function over a collection with index. Returns a lazy sequence.
 
-  Applies `f` to each element in `xs`. `f` is a two-argument function where
-  the first argument is the index (0-based) and the second is the element itself.
-  Works with infinite sequences."
+Applies `f` to each element in `xs`. `f` is a two-argument function where the first argument is the index (0-based) and the second is the element itself. Works with infinite sequences."
   {:example "(map-indexed vector [:a :b :c]) ; => @[[0 :a] [1 :b] [2 :c]]"}
   [f coll]
   (if (php/=== nil coll)
@@ -1110,12 +1066,7 @@
         (copy-meta coll result)))))
 
 (defn interleave
-  "Returns a lazy sequence of the first item in each `colls`, then the
-  second item in each, until any one of the collections is exhausted.
-  Any remaining items in the other collections are ignored. Returns an
-  empty sequence when no collections are supplied or when any
-  collection is empty or `nil`. Maps are iterated as `[key value]`
-  pairs."
+  "Returns a lazy sequence of the first item in each `colls`, then the second item in each, until any one of the collections is exhausted. Any remaining items in the other collections are ignored. Returns an empty sequence when no collections are supplied or when any collection is empty or `nil`. Maps are iterated as `[key value]` pairs."
   {:example "(interleave [1 2 3] [:a :b :c]) ; => @[1 :a 2 :b 3 :c]\n(interleave [1 2 3] [:a :b]) ; => @[1 :a 2 :b]"}
   [& colls]
   (cond
@@ -1184,8 +1135,7 @@
 (defn zipmap
   "Returns a new map with the keys mapped to the corresponding values.
 
-  Stops when the shorter of `keys` or `vals` is exhausted.
-  Works safely with infinite lazy sequences."
+Stops when the shorter of `keys` or `vals` is exhausted. Works safely with infinite lazy sequences."
   {:example "(zipmap [:a :b :c] [1 2 3]) ; => {:a 1, :b 2, :c 3}"
    :see-also ["zipcoll"]}
   [keys vals]
@@ -1213,7 +1163,7 @@
 (defn merge
   "Merges multiple maps into one new map.
 
-  If a key appears in more than one collection, later values replace previous ones."
+If a key appears in more than one collection, later values replace previous ones."
   {:example "(merge {:a 1 :b 2} {:b 3 :c 4}) ; => {:a 1, :b 3, :c 4}"}
   ([] nil)
   ([map] map)
@@ -1234,8 +1184,7 @@
       (copy-meta m result))))
 
 (defn rename-keys
-  "Returns the map with keys renamed according to kmap.
-  Keys not present in kmap are left unchanged."
+  "Returns the map with keys renamed according to kmap. Keys not present in kmap are left unchanged."
   {:example "(rename-keys {:a 1 :b 2 :c 3} {:a :x :b :y}) ; => {:x 1, :y 2, :c 3}"
    :see-also ["select-keys" "keys" "vals"]}
   [m kmap]
@@ -1247,7 +1196,7 @@
 (defn invert
   "Returns a new map where the keys and values are swapped.
 
-  If map has duplicated values, some keys will be ignored."
+If map has duplicated values, some keys will be ignored."
   {:example "(invert {:a 1 :b 2 :c 3}) ; => {1 :a, 2 :b, 3 :c}"}
   [map]
   (persistent
@@ -1280,8 +1229,7 @@
     true                                     (lazy-seq-from-generator (php/:: Seq (partitionBy f coll)))))
 
 (defn dedupe
-  "Returns a lazy sequence with consecutive duplicate values removed in `coll`.
-  When called with no args, returns a transducer."
+  "Returns a lazy sequence with consecutive duplicate values removed in `coll`. When called with no args, returns a transducer."
   {:example "(dedupe [1 1 2 2 2 3 1 1]) ; => @[1 2 3 1]"
    :see-also ["distinct" "transduce"]}
   [& args]
@@ -1322,8 +1270,7 @@
     (php/new Eduction xform coll)))
 
 (defn compact
-  "Returns a lazy sequence with specified values removed from `coll`.
-  If no values are specified, removes nil values by default."
+  "Returns a lazy sequence with specified values removed from `coll`. If no values are specified, removes nil values by default."
   {:example "(compact [1 nil 2 nil 3]) ; => @[1 2 3]"}
   [coll & values]
   (cond

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -25,9 +25,7 @@
 ;; ------------------
 
 (defn peek
-  "Returns the head of a vector / PHP array (the last element) or the
-  head of a list / lazy sequence / queue (the first element). Returns nil
-  if `coll` is empty or nil."
+  "Returns the head of a vector / PHP array (the last element) or the head of a list / lazy sequence / queue (the first element). Returns nil if `coll` is empty or nil."
   {:example "(peek [1 2 3]) ; => 3\n(peek '(:a :b :c)) ; => :a"}
   [coll]
   (cond
@@ -194,8 +192,7 @@
          :else         (recur (php/- i 1) (next s)))))))
 
 (defn nthrest
-  "Returns the nth rest of `coll`, `coll` when `n` is less than 1. Returns
-  an empty list once the collection is exhausted."
+  "Returns the nth rest of `coll`, `coll` when `n` is less than 1. Returns an empty list once the collection is exhausted."
   {:example "(nthrest [1 2 3 4 5] 2) ; => [3 4 5]\n(nthrest [1 2] 5) ; => ()\n(nthrest nil 0) ; => nil\n(nthrest nil 3) ; => ()"
    :see-also ["nth" "nthnext" "drop"]}
   [coll n]
@@ -208,8 +205,7 @@
         (if (nil? s) '() s)))))
 
 (defn nthnext
-  "Returns the nth next of `coll`, `(seq coll)` when `n` is 0.
-   Returns nil if there are fewer than `n` elements remaining."
+  "Returns the nth next of `coll`, `(seq coll)` when `n` is 0. Returns nil if there are fewer than `n` elements remaining."
   {:example "(nthnext [1 2 3 4 5] 2) ; => (3 4 5)\n(nthnext [1 2] 5) ; => nil"
    :see-also ["nth" "nthrest" "drop"]}
   [coll n]
@@ -242,9 +238,7 @@
   (or (php/instanceof coll PersistentMapInterface) (php/instanceof coll TransientMapInterface)))
 
 (defn- vector-assoc
-  "Updates a vector at an integer index. Vectors index by int only; a
-   non-integer key raises a clean `InvalidArgumentException` instead of
-   leaking PHP's `update(): Argument #1 ($i) must be of type int` TypeError."
+  "Updates a vector at an integer index. Vectors index by int only; a non-integer key raises a clean `InvalidArgumentException` instead of leaking PHP's `update(): Argument #1 ($i) must be of type int` TypeError."
   [v key value]
   (if (integer? key)
     (php/-> v (update key value))
@@ -282,9 +276,7 @@
                     (str "assoc expects a map, vector, struct, or nil; got " (type ds))))))
 
 (defn assoc
-  "Associates one or more key-value pairs with a collection.
-  Additional key-value pairs beyond the first are applied in order.
-  Throws if an odd number of extra arguments is provided."
+  "Associates one or more key-value pairs with a collection. Additional key-value pairs beyond the first are applied in order. Throws if an odd number of extra arguments is provided."
   {:example "(assoc {:a 1} :b 2) ; => {:a 1, :b 2}\n(assoc {:a 1} :b 2 :c 3) ; => {:a 1, :b 2, :c 3}"}
   [ds key value & more]
   (when (php/!== 0 (php/& (count more) 1))

--- a/src/phel/core/strings.phel
+++ b/src/phel/core/strings.phel
@@ -19,8 +19,7 @@
 ;;     keeping the trailing `.0`.
 
 (defn- to-symbol-part
-  "Extracts the underlying string from `x` for use as a symbol or
-  namespace component. Keywords and symbols pass through their `name`."
+  "Extracts the underlying string from `x` for use as a symbol or namespace component. Keywords and symbols pass through their `name`."
   [x]
   (if (php/=== nil x)
     nil
@@ -47,14 +46,9 @@
 (defn symbol
   "Returns a new symbol for the given name with an optional namespace.
 
-  With one argument, creates a symbol without namespace. Accepts a
-  string, a keyword, another symbol, or a `Var` (in which case the
-  result is a fully qualified symbol naming the var). With two
-  arguments, creates a symbol in the given namespace; a `nil`
-  namespace yields a symbol without a namespace.
+With one argument, creates a symbol without namespace. Accepts a string, a keyword, another symbol, or a `Var` (in which case the result is a fully qualified symbol naming the var). With two arguments, creates a symbol in the given namespace; a `nil` namespace yields a symbol without a namespace.
 
-  Throws `InvalidArgumentException` for any other input (including
-  functions, numbers, and collections)."
+Throws `InvalidArgumentException` for any other input (including functions, numbers, and collections)."
   {:example "(symbol \"foo\") ; => foo\n(symbol :abc) ; => abc\n(symbol nil \"foo\") ; => foo\n(symbol #'phel.core/+) ; => phel.core/+"}
   [name-or-ns & [name]]
   (if name
@@ -83,8 +77,7 @@
   (php/:: Symbol (gen)))
 
 (defn- float-to-str
-  "Renders a float so integer-valued floats keep the trailing `.0`, while `NaN`
-  and ±Infinity stringify readably."
+  "Renders a float so integer-valued floats keep the trailing `.0`, while `NaN` and ±Infinity stringify readably."
   [x]
   (if (php/is_nan x)
     "NaN"
@@ -96,10 +89,7 @@
           (php/. s ".0"))))))
 
 (defn- val-to-str
-  "Converts a value to its string representation. Booleans become \"true\" or
-\"false\". Nil becomes an empty string. Integer-valued floats keep their `.0`
-suffix (so `(str 0.0)` is `\"0.0\"`, not `\"0\"`). All other values use PHP
-string cast."
+  "Converts a value to its string representation. Booleans become \"true\" or \"false\". Nil becomes an empty string. Integer-valued floats keep their `.0` suffix (so `(str 0.0)` is `\"0.0\"`, not `\"0\"`). All other values use PHP string cast."
   [x]
   (if (php/=== x true)      "true"
       (if (php/=== x false)   "false"
@@ -108,10 +98,7 @@ string cast."
                   (php/. "" x))))))
 
 (defn str
-  "Creates a string by concatenating values together. If no arguments are
-provided an empty string is returned. Nil is represented as an empty string.
-Booleans are represented as \"true\" or \"false\" (matching Clojure semantics).
-Otherwise, it tries to call `__toString`."
+  "Creates a string by concatenating values together. If no arguments are provided an empty string is returned. Nil is represented as an empty string. Booleans are represented as \"true\" or \"false\" (matching Clojure semantics). Otherwise, it tries to call `__toString`."
   [& args]
   (let [cnt (php/count args)]
     (if (php/=== cnt 0)

--- a/src/phel/core/tap.phel
+++ b/src/phel/core/tap.phel
@@ -13,8 +13,7 @@
 (def- *taps* (atom #{}))
 
 (defn add-tap
-  "Registers `f` as a tap. Every call to `tap>` invokes each registered tap
-  with the tapped value. Returns nil."
+  "Registers `f` as a tap. Every call to `tap>` invokes each registered tap with the tapped value. Returns nil."
   {:example "(add-tap println)\n(tap> 42) ; prints 42"
    :see-also ["remove-tap" "tap>"]}
   [f]
@@ -29,8 +28,7 @@
   nil)
 
 (defn tap>
-  "Sends `x` to every registered tap. Exceptions thrown by individual taps are
-  swallowed so one misbehaving tap does not affect the others. Returns true."
+  "Sends `x` to every registered tap. Exceptions thrown by individual taps are swallowed so one misbehaving tap does not affect the others. Returns true."
   {:example "(add-tap println)\n(tap> {:event :login :user \"alice\"})"
    :see-also ["add-tap" "remove-tap"]}
   [x]

--- a/src/phel/core/transducers.phel
+++ b/src/phel/core/transducers.phel
@@ -48,8 +48,7 @@
       (if (reduced? ret) (reduced ret) ret))))
 
 (defn reduce
-  "Reduces collection to a single value by repeatedly applying function to accumulator and elements.
-  Respects early termination via `(reduced val)`."
+  "Reduces collection to a single value by repeatedly applying function to accumulator and elements. Respects early termination via `(reduced val)`."
   {:example "(reduce + [1 2 3 4]) ; => 10"
    :see-also ["transduce" "into" "reduced"]}
   [f & args]
@@ -72,8 +71,7 @@
     (throw (php/new InvalidArgumentException "expected 2 or 3 arguments in reduce"))))
 
 (defn completing
-  "Takes a reducing function `f` of 2 args and returns a fn suitable for transduce
-  by adding a 1-arity (completion) that calls `cf` (default: identity)."
+  "Takes a reducing function `f` of 2 args and returns a fn suitable for transduce by adding a 1-arity (completion) that calls `cf` (default: identity)."
   {:see-also ["transduce"]}
   [f & args]
   (let [cf (if (empty? args) identity (first args))]
@@ -101,8 +99,7 @@
     (throw (php/new InvalidArgumentException "transduce expects 3 or 4 arguments"))))
 
 (defn volatile!
-  "Creates a volatile mutable reference with initial value `val`.
-  Use for transducer state that needs fast mutation without watches."
+  "Creates a volatile mutable reference with initial value `val`. Use for transducer state that needs fast mutation without watches."
   {:see-also ["vreset!" "vswap!" "var"]}
   [val]
   (php/new Volatile val))
@@ -114,8 +111,7 @@
   (php/-> vol (reset val)))
 
 (defn vswap!
-  "Applies `f` to the current value of volatile `vol` plus `args`,
-  and sets the new value. Returns the new value."
+  "Applies `f` to the current value of volatile `vol` plus `args`, and sets the new value. Returns the new value."
   {:see-also ["volatile!" "vreset!"]}
   [vol f & args]
   (vreset! vol (apply f @vol args)))

--- a/src/phel/core/transients.phel
+++ b/src/phel/core/transients.phel
@@ -18,8 +18,7 @@
 (defn transient
   "Converts a persistent collection to a transient collection for efficient updates.
 
-  Transient collections provide faster performance for multiple sequential updates.
-  Use `persistent` to convert back."
+Transient collections provide faster performance for multiple sequential updates. Use `persistent` to convert back."
   {:example "(def t (transient []))"
    :see-also ["persistent"]}
   [coll]
@@ -33,8 +32,7 @@
   (php/-> coll (persistent)))
 
 (defn persistent!
-  "Converts a transient collection back to a persistent collection.
-   Alias for `persistent`, matching Clojure's `persistent!` naming."
+  "Converts a transient collection back to a persistent collection. Alias for `persistent`, matching Clojure's `persistent!` naming."
   {:example "(persistent! (conj! (transient []) 1 2 3)) ; => [1 2 3]"
    :see-also ["persistent" "transient"]}
   [coll]
@@ -80,16 +78,7 @@
                     (str "conj! expects a transient collection, got " (type tcoll))))))
 
 (defn conj!
-  "Adds `value` to the transient collection `tcoll`, mutating it in place,
-   and returns `tcoll`. The 'addition' may happen at different 'places'
-   depending on the concrete transient type: transient vectors append at
-   the tail, transient hash-sets add the element (no-op if already
-   present), and transient hash-maps treat `value` as a `[key value]`
-   pair (or an associative collection of entries).
-   With zero arguments returns a new empty transient vector. With one
-   argument returns `tcoll` unchanged. Variadic forms reduce `conj!` over
-   the remaining values. Raises `InvalidArgumentException` when `tcoll`
-   is not a transient collection. Matches Clojure's `conj!` semantics."
+  "Adds `value` to the transient collection `tcoll`, mutating it in place, and returns `tcoll`. The 'addition' may happen at different 'places' depending on the concrete transient type: transient vectors append at the tail, transient hash-sets add the element (no-op if already present), and transient hash-maps treat `value` as a `[key value]` pair (or an associative collection of entries). With zero arguments returns a new empty transient vector. With one argument returns `tcoll` unchanged. Variadic forms reduce `conj!` over the remaining values. Raises `InvalidArgumentException` when `tcoll` is not a transient collection. Matches Clojure's `conj!` semantics."
   {:example "(persistent (conj! (transient [1 2]) 3)) ; => [1 2 3]"
    :see-also ["conj" "transient" "persistent"]}
   ([] (transient []))
@@ -143,9 +132,7 @@
                     (str "dissoc! expects a transient map, got " (type tcoll))))))
 
 (defn dissoc!
-  "Dissociates one or more keys from a transient map, mutating it in place.
-   Raises `InvalidArgumentException` when `tcoll` is not a transient map.
-   Matches Clojure's `dissoc!` semantics."
+  "Dissociates one or more keys from a transient map, mutating it in place. Raises `InvalidArgumentException` when `tcoll` is not a transient map. Matches Clojure's `dissoc!` semantics."
   {:example "(persistent! (dissoc! (transient {:a 1 :b 2}) :a)) ; => {:b 2}"
    :see-also ["dissoc" "assoc!" "transient" "persistent!"]}
   ([tcoll] tcoll)
@@ -164,9 +151,7 @@
                     (str "disj! expects a transient set, got " (type tcoll))))))
 
 (defn disj!
-  "Removes one or more elements from a transient set, mutating it in place.
-   Raises `InvalidArgumentException` when `tcoll` is not a transient set.
-   Matches Clojure's `disj!` semantics."
+  "Removes one or more elements from a transient set, mutating it in place. Raises `InvalidArgumentException` when `tcoll` is not a transient set. Matches Clojure's `disj!` semantics."
   {:example "(persistent! (disj! (transient #{1 2 3}) 2)) ; => #{1 3}"
    :see-also ["disj" "conj!" "transient" "persistent!"]}
   ([tcoll] tcoll)
@@ -175,9 +160,7 @@
    (reduce disj-bang-single (disj-bang-single tcoll value) more)))
 
 (defn pop!
-  "Removes the last element from a transient vector, mutating it in place.
-   Raises `InvalidArgumentException` when `tcoll` is not a transient vector.
-   Matches Clojure's `pop!` semantics."
+  "Removes the last element from a transient vector, mutating it in place. Raises `InvalidArgumentException` when `tcoll` is not a transient vector. Matches Clojure's `pop!` semantics."
   {:example "(persistent! (pop! (transient [1 2 3]))) ; => [1 2]"
    :see-also ["pop" "conj!" "transient" "persistent!"]}
   [tcoll]

--- a/src/phel/core/uuid.phel
+++ b/src/phel/core/uuid.phel
@@ -11,9 +11,7 @@
 ;; --- UUID ---
 
 (defn uuid?
-  "Returns true if `x` is a `Phel\\Lang\\UUID` value, false otherwise.
-  Canonical UUID strings are rejected — wrap them with `parse-uuid` (or
-  the `#uuid \"...\"` literal) to obtain a typed value."
+  "Returns true if `x` is a `Phel\\Lang\\UUID` value, false otherwise. Canonical UUID strings are rejected — wrap them with `parse-uuid` (or the `#uuid \"...\"` literal) to obtain a typed value."
   {:example "(uuid? #uuid \"550e8400-e29b-41d4-a716-446655440000\") ; => true"
    :see-also ["random-uuid" "parse-uuid"]}
   [x]
@@ -42,9 +40,7 @@
     :else                   nil))
 
 (defn uuid=
-  "Returns true if `a` and `b` are `Phel\\Lang\\UUID` values with the
-  same canonical form. Strings (or anything else) are rejected even if
-  their textual content would match — coerce with `parse-uuid` first."
+  "Returns true if `a` and `b` are `Phel\\Lang\\UUID` values with the same canonical form. Strings (or anything else) are rejected even if their textual content would match — coerce with `parse-uuid` first."
   {:example "(uuid= #uuid \"550e8400-e29b-41d4-a716-446655440000\"
          #uuid \"550E8400-E29B-41D4-A716-446655440000\") ; => true"
    :see-also ["uuid?" "parse-uuid"]}
@@ -60,8 +56,7 @@
        (php/-> x (isNil))))
 
 (defn uuid-version
-  "Returns the version digit (1-5) encoded in UUID `x`, or nil if `x` is
-  not a `UUID` value."
+  "Returns the version digit (1-5) encoded in UUID `x`, or nil if `x` is not a `UUID` value."
   {:example "(uuid-version #uuid \"550e8400-e29b-41d4-a716-446655440000\") ; => 4"
    :see-also ["uuid?" "uuid-variant"]}
   [x]

--- a/src/phel/edn.phel
+++ b/src/phel/edn.phel
@@ -32,8 +32,7 @@
   (php/:: TagRegistry (getInstance)))
 
 (defn- tag-key
-  "Normalises a tag from a symbol, keyword, or string to the string key
-  used by the global `TagRegistry`."
+  "Normalises a tag from a symbol, keyword, or string to the string key used by the global `TagRegistry`."
   [tag]
   (cond
     (string? tag)  tag
@@ -44,8 +43,7 @@
                                         (php/gettype tag))))))
 
 (defn- snapshot-tags
-  "Captures the existing handler for each tag key so it can be restored
-  after the call. Returns a map `{tag-key handler-or-nil}`."
+  "Captures the existing handler for each tag key so it can be restored after the call. Returns a map `{tag-key handler-or-nil}`."
   [reg tag-keys]
   (let [acc (transient {})]
     (foreach [k tag-keys]
@@ -59,9 +57,7 @@
     (php/-> reg (register (tag-key tag) handler))))
 
 (defn- restore-tags
-  "Reinstates the original handlers captured by `snapshot-tags`. When a
-  tag had no prior handler, it is unregistered so the registry returns to
-  its earlier shape."
+  "Reinstates the original handlers captured by `snapshot-tags`. When a tag had no prior handler, it is unregistered so the registry returns to its earlier shape."
   [reg snapshot]
   (foreach [k handler snapshot]
     (if (php/=== handler nil)
@@ -69,8 +65,7 @@
       (php/-> reg (register k handler)))))
 
 (defn- with-readers*
-  "Runs `thunk` with `readers` temporarily installed on the tag registry.
-  Restores prior state in a `finally` so exceptions still clean up."
+  "Runs `thunk` with `readers` temporarily installed on the tag registry. Restores prior state in a `finally` so exceptions still clean up."
   [readers thunk]
   (if (empty? readers)
     (thunk)
@@ -84,9 +79,7 @@
           (restore-tags reg snapshot))))))
 
 (defn- read-next
-  "Reads the next form from the open `token-stream` using `cf`. Skips
-  whitespace, comments, and other trivia parser nodes that precede the
-  next data form. Returns nil when the stream is exhausted."
+  "Reads the next form from the open `token-stream` using `cf`. Skips whitespace, comments, and other trivia parser nodes that precede the next data form. Returns nil when the stream is exhausted."
   [cf token-stream]
   (loop []
     (let [node (php/-> cf (parseNext token-stream))]
@@ -142,19 +135,14 @@
 (def- readable-printer (php/:: Printer (readable)))
 
 (defn write-string
-  "Serialises `value` to its EDN string representation. Uses Phel's
-  readable printer so the output round-trips through `read-string` for
-  all EDN-compatible values (nil, booleans, numbers, strings, keywords,
-  symbols, lists, vectors, maps, sets, and built-in tagged literals
-  such as `#uuid`)."
+  "Serialises `value` to its EDN string representation. Uses Phel's readable printer so the output round-trips through `read-string` for all EDN-compatible values (nil, booleans, numbers, strings, keywords, symbols, lists, vectors, maps, sets, and built-in tagged literals such as `#uuid`)."
   {:example "(write-string {:a 1}) ; => \"{:a 1}\""
    :see-also ["read-string" "write-string-all"]}
   [value]
   (php/-> readable-printer (print value)))
 
 (defn write-string-all
-  "Serialises a sequence of values to EDN, separating top-level forms
-  with a single space. Inverse of `read-string-all`."
+  "Serialises a sequence of values to EDN, separating top-level forms with a single space. Inverse of `read-string-all`."
   {:example "(write-string-all [1 2 3]) ; => \"1 2 3\"\n(write-string-all [1 \"hi\" :kw]) ; => \"1 \\\"hi\\\" :kw\""
    :see-also ["read-string-all" "write-string"]}
   [xs]

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -80,9 +80,7 @@
    url))
 
 (defn uri-from-string
-  "Parses a URI string into a uri struct. Handles UTF-8 URLs and IPv6
-  addresses in brackets. Throws `InvalidArgumentException` on a malformed
-  string."
+  "Parses a URI string into a uri struct. Handles UTF-8 URLs and IPv6 addresses in brackets. Throws `InvalidArgumentException` on a malformed string."
   {:example "(uri-from-string \"https://example.com/path?foo=bar\") ; => (uri \"https\" nil \"example.com\" nil \"/path\" \"foo=bar\" nil)"
    :see-also ["uri-from-globals" "request-from-map"]}
   [url]
@@ -151,9 +149,7 @@
     (persistent res)))
 
 (defn files-from-globals
-  "Extracts uploaded files from `$_FILES` and normalizes them to uploaded-file
-  structs. Handles both flat and nested file specs from multipart uploads.
-  Returns a map of field name to uploaded-file(s)."
+  "Extracts uploaded files from `$_FILES` and normalizes them to uploaded-file structs. Handles both flat and nested file specs from multipart uploads. Returns a map of field name to uploaded-file(s)."
   {:example "(files-from-globals) ; => {:avatar (uploaded-file \"/tmp/phpYzdqkD\" 1024 0 \"photo.jpg\" \"image/jpeg\")}"
    :see-also ["request-from-globals"]}
   [& [files]]
@@ -164,9 +160,7 @@
 ;; -------
 
 (defn headers-from-server
-  "Extracts all HTTP headers from the `$_SERVER` variable. Strips the `HTTP_`
-  prefix, normalizes underscores to hyphens, handles `CONTENT_*` keys, and
-  resolves `REDIRECT_*` keys. Returns a map with keyword keys."
+  "Extracts all HTTP headers from the `$_SERVER` variable. Strips the `HTTP_` prefix, normalizes underscores to hyphens, handles `CONTENT_*` keys, and resolves `REDIRECT_*` keys. Returns a map with keyword keys."
   {:example "(headers-from-server) ; => {:host \"example.com\" :content-type \"application/json\"}"
    :see-also ["request-from-globals"]}
   [& [server]]
@@ -226,15 +220,13 @@
                 (php/array "application/x-www-form-urlencoded" "multipart/form-data")))
 
 (defn- decode-json-body
-  "Decodes a JSON request body. Returns nil for an empty or malformed body so
-  handlers can distinguish 'no usable body' from a real value."
+  "Decodes a JSON request body. Returns nil for an empty or malformed body so handlers can distinguish 'no usable body' from a real value."
   [raw-body]
   (when (and (string? raw-body) (not= raw-body ""))
     (try (json/decode raw-body) (catch \Throwable _ nil))))
 
 (defn- resolve-parsed-body
-  "Resolves `:parsed-body`: form data from `$_POST`, a decoded JSON body, or nil.
-  The `:content-type` header is parsed once and matched against both cases."
+  "Resolves `:parsed-body`: form data from `$_POST`, a decoded JSON body, or nil. The `:content-type` header is parsed once and matched against both cases."
   [method headers post-parameter raw-body]
   (let [content-type (content-type-base headers)]
     (cond
@@ -269,8 +261,7 @@
      {})))
 
 (defn- json-request-body
-  "Reads the raw request body from `php://input`, but only when the request
-  declares a JSON content type. Other requests never touch the input stream."
+  "Reads the raw request body from `php://input`, but only when the request declares a JSON content type. Other requests never touch the input stream."
   [server]
   (let [content-type (php/strtolower (str (or (get server "CONTENT_TYPE")
                                               (get server "HTTP_CONTENT_TYPE")
@@ -279,10 +270,7 @@
       (php/file_get_contents "php://input"))))
 
 (defn request-from-globals
-  "Extracts a request from `$_SERVER`, `$_GET`, `$_POST`, `$_COOKIE`, `$_FILES`
-  and, for JSON requests, the raw request body (`php://input`). Requires a web
-  request context (PHP-FPM, mod_php, or `php -S`); it cannot be used from the
-  REPL or a CLI script - use `request-from-map` for testing."
+  "Extracts a request from `$_SERVER`, `$_GET`, `$_POST`, `$_COOKIE`, `$_FILES` and, for JSON requests, the raw request body (`php://input`). Requires a web request context (PHP-FPM, mod_php, or `php -S`); it cannot be used from the REPL or a CLI script - use `request-from-map` for testing."
   {:example "(request-from-globals) ; => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"
    :see-also ["request-from-globals-args" "request-from-map"]}
   []

--- a/src/phel/match.phel
+++ b/src/phel/match.phel
@@ -80,9 +80,7 @@
       `(and ~@effective))))
 
 (defn- shape-gated-check
-  "Wraps an inner and-combined check behind a shape predicate. When the
-  target fails the shape check the expression short-circuits to `false`
-  so the inner accessors never see a mismatched value."
+  "Wraps an inner and-combined check behind a shape predicate. When the target fails the shape check the expression short-circuits to `false` so the inner accessors never see a mismatched value."
   [shape inner-checks]
   `(if ~shape ~(and-checks inner-checks) false))
 
@@ -105,9 +103,7 @@
      :bindings (vec (concat [name target] (get sub :bindings)))}))
 
 (defn- compile-guard
-  "(inner :guard pred): compile inner, and-combine with (pred target)
-  evaluated in the context of the inner bindings so the guard can see
-  bound symbols."
+  "(inner :guard pred): compile inner, and-combine with (pred target) evaluated in the context of the inner bindings so the guard can see bound symbols."
   [target pattern]
   (let [inner     (first pattern)
         pred      (get pattern 2)
@@ -121,8 +117,7 @@
     {:check combined, :bindings bindings}))
 
 (defn- compile-or
-  "(:or p1 p2 ...): succeeds if any alternative matches. Alternatives
-  may not introduce bindings (keeps v1 simple and predictable)."
+  "(:or p1 p2 ...): succeeds if any alternative matches. Alternatives may not introduce bindings (keeps v1 simple and predictable)."
   [target pattern]
   (let [alts (vec (next pattern))]
     (when (empty? alts)
@@ -137,9 +132,7 @@
         {:check `(or ~@checks), :bindings []}))))
 
 (defn- index-of-rest
-  "Linear scan for `&` inside a vector, comparing with `=` so that
-  freshly-read symbols match the `'&` literal. Returns the index or
-  nil."
+  "Linear scan for `&` inside a vector, comparing with `=` so that freshly-read symbols match the `'&` literal. Returns the index or nil."
   [pattern]
   (loop [i 0]
     (if (>= i (count pattern))
@@ -149,8 +142,7 @@
         (recur (+ i 1))))))
 
 (defn- split-vector-pattern
-  "Splits a vector pattern around `&`. Returns `[head tail-sym-or-nil]`.
-  Errors if `&` is not followed by exactly one symbol."
+  "Splits a vector pattern around `&`. Returns `[head tail-sym-or-nil]`. Errors if `&` is not followed by exactly one symbol."
   [pattern]
   (let [n   (count pattern)
         idx (index-of-rest pattern)]
@@ -168,8 +160,7 @@
           [(vec (take idx pattern)) tail])))))
 
 (defn- compile-vector
-  "Vector pattern: shape + length check, recursively compile each
-  element, optionally bind the rest of the slice."
+  "Vector pattern: shape + length check, recursively compile each element, optionally bind the rest of the slice."
   [target pattern]
   (let [[head tail-sym] (split-vector-pattern pattern)
         fixed-len       (count head)
@@ -222,8 +213,7 @@
     {:check outer-check, :bindings all-bindings}))
 
 (defn- compile-pattern
-  "Dispatches on pattern shape and delegates to the kind-specific
-  compiler. Returns `{:check expr :bindings [sym val ...]}`."
+  "Dispatches on pattern shape and delegates to the kind-specific compiler. Returns `{:check expr :bindings [sym val ...]}`."
   [target pattern]
   (cond
     (= pattern wildcard-symbol) (compile-wildcard target pattern)
@@ -256,9 +246,7 @@
     [(and-checks checks) bindings]))
 
 (defn- parse-clauses
-  "Walks the body splitting it into `[clauses default]`. `clauses` is a
-  vector of `[pattern-vec expr]`, `default` is the `:else` expression
-  or `nil`."
+  "Walks the body splitting it into `[clauses default]`. `clauses` is a vector of `[pattern-vec expr]`, `default` is the `:else` expression or `nil`."
   [body]
   (loop [remaining body
          clauses   []

--- a/src/phel/mock.phel
+++ b/src/phel/mock.phel
@@ -50,16 +50,14 @@
      call-history)))
 
 (defn spy
-  "Wraps an existing function to track calls while preserving original behavior.
-  Alias for `mock-fn`."
+  "Wraps an existing function to track calls while preserving original behavior. Alias for `mock-fn`."
   {:example "(def original-fn (fn [x] (* x 2)))"
    :see-also ["mock-fn"]}
   [f]
   (mock-fn f))
 
 (defn mock-returning
-  "Creates a mock that returns different values for consecutive calls.
-  After exhausting values, returns the last value."
+  "Creates a mock that returns different values for consecutive calls. After exhausting values, returns the last value."
   {:example "(def my-mock (mock-returning [1 2 3]))"}
   [values]
   (let [call-history (atom [])
@@ -156,8 +154,7 @@
   (first (calls mock-fn)))
 
 (defn reset-mock!
-  "Resets the call history of a mock without removing it from the registry.
-  The mock can continue to be used and track new calls."
+  "Resets the call history of a mock without removing it from the registry. The mock can continue to be used and track new calls."
   {:example "(def my-mock (mock :result))"}
   [mock-fn]
   (let [mock-data (get (deref mock-registry) mock-fn)]
@@ -169,8 +166,7 @@
           (reset-fn))))))
 
 (defn clear-all-mocks!
-  "Clears the entire mock registry.
-  Useful for cleanup between test suites in long-running processes."
+  "Clears the entire mock registry. Useful for cleanup between test suites in long-running processes."
   {:example "(clear-all-mocks!) ; All mocks removed from registry"}
   []
   (reset! mock-registry {}))

--- a/src/phel/reader.phel
+++ b/src/phel/reader.phel
@@ -17,12 +17,9 @@
   (php/:: TagRegistry (getInstance)))
 
 (defn register-tag
-  "Registers a handler for reader tag `tag-name` (a string without the
-  leading `#`). The handler `f` is a 1-arg function receiving the
-  already-read form value and returning the value that should replace
-  the tagged literal.
+  "Registers a handler for reader tag `tag-name` (a string without the leading `#`). The handler `f` is a 1-arg function receiving the already-read form value and returning the value that should replace the tagged literal.
 
-  Re-registering an existing tag overwrites the previous handler."
+Re-registering an existing tag overwrites the previous handler."
   {:example "(register-tag \"date\" my-ns/parse-date)
   ; later: #date \"2026-04-20\" => (my-ns/parse-date \"2026-04-20\")"
    :see-also ["tag-registered?" "unregister-tag" "registered-tags"]}
@@ -38,9 +35,7 @@
   (php/-> (registry) (has tag-name)))
 
 (defn unregister-tag
-  "Removes any handler registered for reader tag `tag-name`. Built-in
-  tags can be unregistered but are re-installed on the next reader
-  bootstrap."
+  "Removes any handler registered for reader tag `tag-name`. Built-in tags can be unregistered but are re-installed on the next reader bootstrap."
   {:example "(unregister-tag \"date\")"
    :see-also ["register-tag" "tag-registered?" "registered-tags"]}
   [tag-name]
@@ -48,8 +43,7 @@
   nil)
 
 (defn registered-tags
-  "Returns a sorted vector of the currently registered reader tag
-  names."
+  "Returns a sorted vector of the currently registered reader tag names."
   {:example "(registered-tags) ; => [\"inst\" \"regex\" \"uuid\"]"
    :see-also ["register-tag" "tag-registered?" "unregister-tag"]}
   []

--- a/src/phel/reflect.phel
+++ b/src/phel/reflect.phel
@@ -12,8 +12,7 @@
   (php/new ReflectionClass class-or-name))
 
 (defn- type-string
-  "Renders a ReflectionType (named, union, or intersection) as a string.
-  Returns nil when the reflection type itself is nil (no declaration)."
+  "Renders a ReflectionType (named, union, or intersection) as a string. Returns nil when the reflection type itself is nil (no declaration)."
   [rt]
   (when rt (php/-> rt (__toString))))
 
@@ -63,8 +62,7 @@
            (property->map p)))))
 
 (defn supers
-  "Returns a set of fully qualified parent classes and implemented
-  interfaces for `class-or-name`."
+  "Returns a set of fully qualified parent classes and implemented interfaces for `class-or-name`."
   {:example "(supers \\RuntimeException)"}
   [class-or-name]
   (let [rc    (reflection-class class-or-name)
@@ -80,8 +78,7 @@
     (persistent! names)))
 
 (defn- attribute-args
-  "Builds the `:args` map for a `ReflectionAttribute`: named arguments become
-  keyword keys, positional arguments keep their integer index."
+  "Builds the `:args` map for a `ReflectionAttribute`: named arguments become keyword keys, positional arguments keep their integer index."
   [a]
   (let [res (transient {})]
     (foreach [k v (php/-> a (getArguments))]
@@ -97,9 +94,7 @@
          (attribute->map a))))
 
 (defn class-attributes
-  "Returns a vector of attribute maps for the class `class-or-name` (string FQN
-  or object). Each map is `{:name <attribute-fqcn> :args {...}}`, where `:args`
-  keys named arguments as keywords and positional arguments by index."
+  "Returns a vector of attribute maps for the class `class-or-name` (string FQN or object). Each map is `{:name <attribute-fqcn> :args {...}}`, where `:args` keys named arguments as keywords and positional arguments by index."
   {:example "(class-attributes \\App\\Controller\\ProductController)"
    :see-also ["method-attributes" "property-attributes" "attributes"]}
   [class-or-name]
@@ -120,8 +115,7 @@
   (attributes-of (php/-> (reflection-class class-or-name) (getProperty property-name))))
 
 (defn attributes
-  "Returns the class-level attribute maps for `obj-or-class`; an instance uses
-  its class. Convenience alias of `class-attributes`."
+  "Returns the class-level attribute maps for `obj-or-class`; an instance uses its class. Convenience alias of `class-attributes`."
   {:example "(attributes my-controller)"
    :see-also ["class-attributes" "method-attributes" "property-attributes"]}
   [obj-or-class]
@@ -159,8 +153,7 @@
   (keyword (php/-> enum-case name)))
 
 (defn keyword->enum
-  "Returns the case of the native PHP enum `enum-class` (string FQN) whose name
-  matches keyword `kw`, or nil when no case matches. Inverse of `enum->keyword`."
+  "Returns the case of the native PHP enum `enum-class` (string FQN) whose name matches keyword `kw`, or nil when no case matches. Inverse of `enum->keyword`."
   {:example "(keyword->enum \\App\\Status :Active)"
    :see-also ["enum->keyword" "enum-values"]}
   [enum-class kw]

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -26,8 +26,7 @@
   (php/:: GlobalEnvironmentSingleton (getInstance)))
 
 (defn loaded-namespaces
-  "Returns all namespaces currently loaded in the REPL, in dot-separated
-  display form."
+  "Returns all namespaces currently loaded in the REPL, in dot-separated display form."
   {:example "(loaded-namespaces) ; => [\"phel.core\" \"phel.repl\"]"}
   []
   (let [raw    (php/:: Phel (getNamespaces))
@@ -48,8 +47,7 @@
   (php/-> build-facade (evalFile file)))
 
 (defn- get-src-dirs
-  "Returns source directories for namespace resolution. Falls back to
-  CommandFacade when src-dirs has not been initialized (e.g. outside vanilla REPL)."
+  "Returns source directories for namespace resolution. Falls back to CommandFacade when src-dirs has not been initialized (e.g. outside vanilla REPL)."
   []
   (if (not (php/empty src-dirs))
     src-dirs
@@ -210,8 +208,7 @@
     (php/-> res (getCode))))
 
 (defn eval-str
-  "Evaluates a string of Phel code and returns the result.
-  If the string contains multiple expressions, returns the result of the last one."
+  "Evaluates a string of Phel code and returns the result. If the string contains multiple expressions, returns the result of the last one."
   {:example "(eval-str \"(+ 1 2)\") ; => 3"
    :see-also ["compile-str" "load-file"]}
   [s]
@@ -220,9 +217,7 @@
     (php/-> cf (eval s opts))))
 
 (defn load-file
-  "Loads and evaluates a Phel source file in the current REPL session.
-  Reads the file content and evaluates it using the compiler, preserving
-  the current REPL namespace context. Returns the result of the last expression."
+  "Loads and evaluates a Phel source file in the current REPL session. Reads the file content and evaluates it using the compiler, preserving the current REPL namespace context. Returns the result of the last expression."
   {:example "(load-file \"src/my-module.phel\")"}
   [path]
   (let [content (php/file_get_contents path)]
@@ -283,7 +278,7 @@
 (defn- dir-fn
   "Prints all public definitions in the given namespace symbol or string.
 
-  Returns nil. Prints one name per line, sorted alphabetically."
+Returns nil. Prints one name per line, sorted alphabetically."
   [ns]
   (let [ns-str  (name ns)
         encoded (munge-ns ns-str)
@@ -300,7 +295,7 @@
 (defmacro dir
   "Prints all public definitions in the given namespace symbol or string.
 
-  Returns nil. Prints one name per line, sorted alphabetically."
+Returns nil. Prints one name per line, sorted alphabetically."
   {:example "(dir phel\\string)"}
   [ns]
   (if (string? ns)
@@ -308,8 +303,7 @@
     `(dir-fn '~ns)))
 
 (defn apropos
-  "Returns a vector of symbols whose name contains the given search string.
-  Searches across all loaded namespaces."
+  "Returns a vector of symbols whose name contains the given search string. Searches across all loaded namespaces."
   {:example "(apropos \"map\") ; => [phel.core/flat-map phel.core/map ...]"}
   [search]
   (let [munge   munge-instance
@@ -327,8 +321,7 @@
     (sort (persistent results))))
 
 (defn find-fn
-  "Searches for functions whose name or docstring contains the search string.
-  Returns a vector of maps with :ns, :name, :doc, :private, :min-arity, :max-arity, :is-variadic."
+  "Searches for functions whose name or docstring contains the search string. Returns a vector of maps with :ns, :name, :doc, :private, :min-arity, :max-arity, :is-variadic."
   {:example "(find-fn \"map\") ; => [{:ns \"phel.core\" :name \"map\" ...} ...]"
    :see-also ["apropos" "search-doc" "get-symbol-info"]}
   [search]
@@ -359,8 +352,7 @@
     (persistent results)))
 
 (defn get-source-code
-  "Returns the source code of the definition identified by namespace and name
-  strings, or nil if the source file cannot be found or metadata is missing."
+  "Returns the source code of the definition identified by namespace and name strings, or nil if the source file cannot be found or metadata is missing."
   {:example "(get-source-code \"phel\\core\" \"map\")"
    :see-also ["source" "get-symbol-info"]}
   [ns-str name-str]
@@ -385,8 +377,7 @@
       `(get-source-code ~(namespace resolved-sym) ~(name resolved-sym)))))
 
 (defn find-ns
-  "Returns the namespace name in display form if it is loaded, or nil if no
-  namespace of that name exists. Accepts dot or backslash separators on input."
+  "Returns the namespace name in display form if it is loaded, or nil if no namespace of that name exists. Accepts dot or backslash separators on input."
   {:example "(find-ns \"phel.core\") ; => \"phel.core\""
    :see-also ["create-ns" "remove-ns" "loaded-namespaces"]}
   [ns-str]
@@ -395,8 +386,7 @@
       (php/:: Munge (displayNs canonical)))))
 
 (defn create-ns
-  "Creates the given namespace if it does not already exist. Returns the
-  namespace name in display form. Existing namespaces are left untouched."
+  "Creates the given namespace if it does not already exist. Returns the namespace name in display form. Existing namespaces are left untouched."
   {:example "(create-ns \"my-app.tmp\") ; => \"my-app.tmp\""
    :see-also ["find-ns" "remove-ns" "intern"]}
   [ns-str]
@@ -405,8 +395,7 @@
     (php/:: Munge (displayNs canonical))))
 
 (defn remove-ns
-  "Removes the namespace and all of its definitions from the registry.
-  Use with caution. Returns nil."
+  "Removes the namespace and all of its definitions from the registry. Use with caution. Returns nil."
   {:example "(remove-ns \"my-app.tmp\")"
    :see-also ["find-ns" "create-ns"]}
   [ns-str]
@@ -414,10 +403,7 @@
   nil)
 
 (defn intern
-  "Finds or creates a definition named by name-str in namespace ns-str,
-  setting its root value to val when supplied (defaults to nil). The
-  namespace is auto-registered by the underlying `addDefinition` call.
-  Returns the fully qualified symbol (with the namespace in display form)."
+  "Finds or creates a definition named by name-str in namespace ns-str, setting its root value to val when supplied (defaults to nil). The namespace is auto-registered by the underlying `addDefinition` call. Returns the fully qualified symbol (with the namespace in display form)."
   {:example "(intern \"user\" \"x\" 42) ; => user/x"
    :see-also ["find-ns" "create-ns" "ns-interns"]}
   [ns-str name-str & rest]
@@ -485,8 +471,7 @@
     (persistent result)))
 
 (defn search-doc
-  "Searches docstrings across all loaded namespaces for the given string.
-  Prints matching function names and their documentation."
+  "Searches docstrings across all loaded namespaces for the given string. Prints matching function names and their documentation."
   {:example "(search-doc \"reduce\")"}
   [search]
   (let [munge        munge-instance
@@ -536,10 +521,7 @@
          :error (php/-> e (getMessage))}))))
 
 (defn test-ns
-  "Runs all tests in a given namespace from the REPL.
-  Requires the namespace if not already loaded, finds all deftest definitions,
-  runs them, prints results, and returns a hash-map with :pass, :fail, and :error counts.
-  Preserves outer test state so it can be safely called during a test run."
+  "Runs all tests in a given namespace from the REPL. Requires the namespace if not already loaded, finds all deftest definitions, runs them, prints results, and returns a hash-map with :pass, :fail, and :error counts. Preserves outer test state so it can be safely called during a test run."
   {:example "(test-ns \"phel-test\\test\\core\")"
    :see-also ["dir" "loaded-namespaces"]}
   [ns-str]
@@ -556,10 +538,7 @@
         result))))
 
 (defn macroexpand-1-form
-  "Expands the given form once if it is a macro call.
-  Takes a quoted form and returns the expanded form, or the original
-  form unchanged if it is not a macro call. Uses the CompilerFacade
-  to perform the expansion without going through analyze+emit."
+  "Expands the given form once if it is a macro call. Takes a quoted form and returns the expanded form, or the original form unchanged if it is not a macro call. Uses the CompilerFacade to perform the expansion without going through analyze+emit."
   {:example "(macroexpand-1-form '(defn foo [x] x))"
    :see-also ["macroexpand-form" "macroexpand-1" "macroexpand"]}
   [form]
@@ -567,9 +546,7 @@
     (php/-> cf (macroexpand1 form))))
 
 (defn macroexpand-form
-  "Recursively expands the given form until it is no longer a macro call.
-  Takes a quoted form and returns the fully expanded form. Uses the
-  CompilerFacade to perform the expansion without going through analyze+emit."
+  "Recursively expands the given form until it is no longer a macro call. Takes a quoted form and returns the fully expanded form. Uses the CompilerFacade to perform the expansion without going through analyze+emit."
   {:example "(macroexpand-form '(defn foo [x] x))"
    :see-also ["macroexpand-1-form" "macroexpand-1" "macroexpand"]}
   [form]
@@ -577,16 +554,14 @@
     (php/-> cf (macroexpand form))))
 
 (defn macroexpand-1
-  "Expands the given form once if it is a macro call. The form must be
-  quoted to prevent evaluation, matching Clojure semantics."
+  "Expands the given form once if it is a macro call. The form must be quoted to prevent evaluation, matching Clojure semantics."
   {:example "(macroexpand-1 '(when true 1 2))"
    :see-also ["macroexpand" "macroexpand-1-form" "macroexpand-form"]}
   [form]
   (macroexpand-1-form form))
 
 (defn macroexpand
-  "Recursively expands the given form until it is no longer a macro call.
-  The form must be quoted to prevent evaluation, matching Clojure semantics."
+  "Recursively expands the given form until it is no longer a macro call. The form must be quoted to prevent evaluation, matching Clojure semantics."
   {:example "(macroexpand '(when true 1 2))"
    :see-also ["macroexpand-1" "macroexpand-1-form" "macroexpand-form"]}
   [form]
@@ -597,8 +572,7 @@
 ;; -----------
 
 (defn- build-namespace-context
-  "Builds a summary of available functions in the current namespace
-  and its aliases for AI context."
+  "Builds a summary of available functions in the current namespace and its aliases for AI context."
   []
   (let [ns           *ns*
         aliases      (ns-aliases ns)
@@ -630,8 +604,7 @@
 (defn explain
   "Sends a Phel code string to the AI for explanation.
 
-  Includes compilation output and namespace context to provide
-  a thorough, grounded explanation."
+Includes compilation output and namespace context to provide a thorough, grounded explanation."
   {:doc "Explains a Phel expression using AI and REPL introspection."
    :example "(explain \"(map inc [1 2 3])\")"
    :see-also ["suggest" "fix" "explain-sym"]}
@@ -662,8 +635,7 @@
           {:system "You are a Phel language assistant. Explain functions clearly, covering purpose, parameters, return value, and typical usage. Keep it concise."})))))
 
 (defn suggest
-  "Describes what you want to accomplish in natural language and
-  receives Phel code suggestions grounded in available functions."
+  "Describes what you want to accomplish in natural language and receives Phel code suggestions grounded in available functions."
   {:doc "Get AI-suggested Phel code for a natural language description."
    :example "(suggest \"filter even numbers from a vector\")"
    :see-also ["explain" "fix"]}
@@ -677,8 +649,7 @@
     (ai/complete prompt {:system "You are a Phel language assistant. Write idiomatic Phel code. Use existing core functions when possible. Be concise."})))
 
 (defn fix
-  "Given Phel code that produced an error, sends both to the AI
-  along with namespace context to suggest a fix."
+  "Given Phel code that produced an error, sends both to the AI along with namespace context to suggest a fix."
   {:doc "Suggests a fix for Phel code that produced an error."
    :example "(fix \"(+ 1 \\\"a\\\")\" \"Cannot add string to integer\")"
    :see-also ["explain" "suggest"]}
@@ -693,8 +664,7 @@
     (ai/complete prompt {:system "You are a Phel language assistant. Diagnose errors precisely and provide minimal, correct fixes."})))
 
 (defn review
-  "Sends Phel code to the AI for a code review, including namespace
-  context for awareness of available functions and conventions."
+  "Sends Phel code to the AI for a code review, including namespace context for awareness of available functions and conventions."
   {:doc "Gets an AI code review for Phel code."
    :example "(review \"(defn add [a b] (+ a b))\")"
    :see-also ["explain" "suggest" "fix"]}
@@ -710,10 +680,9 @@
 (defn embed-ns
   "Builds a searchable index of all public functions in a namespace.
 
-  Each entry contains the function name, docstring, and embedding
-  of the combined name+doc text. Useful for semantic code search.
+Each entry contains the function name, docstring, and embedding of the combined name+doc text. Useful for semantic code search.
 
-  Options are passed through to `ai/embed`."
+Options are passed through to `ai/embed`."
   {:doc "Builds a searchable index of public functions in a namespace."
    :example "(embed-ns \"phel\\core\")"
    :see-also ["search-ns" "ai/embed" "ai/nearest"]}
@@ -735,7 +704,7 @@
 (defn search-ns
   "Semantic search over a namespace index built by `embed-ns`.
 
-  Returns the k most relevant functions for the query."
+Returns the k most relevant functions for the query."
   {:doc "Searches a namespace index for functions matching a query."
    :example "(search-ns \"transform collections\" my-ns-index 5)"
    :see-also ["embed-ns" "ai/nearest" "ai/search"]}

--- a/src/phel/router.phel
+++ b/src/phel/router.phel
@@ -62,8 +62,7 @@
   (partial (compose-middleware middlewares) handler))
 
 (defn- route-name-of
-  "Returns the Symfony route name for a `[path data]` tuple, falling back to
-   the path when `:name` isn't provided."
+  "Returns the Symfony route name for a `[path data]` tuple, falling back to the path when `:name` isn't provided."
   [route]
   (let [[path data] route]
     (if-let [name (get data :name)]
@@ -170,8 +169,7 @@
   (php/-> generator (generate (full-name route-name) (params->php-array parameters))))
 
 (defn- indexed-route->match
-  "Converts an `[path data]` tuple from the compiled router's index into a
-   by-name match response. Returns nil when the tuple is nil."
+  "Converts an `[path data]` tuple from the compiled router's index into a by-name match response. Returns nil when the tuple is nil."
   [route]
   (when-let [[template data] route]
     {:template template, :data data}))
@@ -229,14 +227,9 @@
             (generate-with generator route-name parameters)))
 
 (defmacro compiled-router
-  "Like `router` but performs Symfony's route compilation at macro-expansion
-  time. The resulting router uses Symfony's `CompiledUrlMatcher`/`Generator`
-  which are ~3x faster than their dynamic counterparts for large route
-  tables.
+  "Like `router` but performs Symfony's route compilation at macro-expansion time. The resulting router uses Symfony's `CompiledUrlMatcher`/`Generator` which are ~3x faster than their dynamic counterparts for large route tables.
 
-  Because compilation runs during macro expansion, `raw-routes` must be a
-  literal vector at the call site — it cannot be built from runtime values.
-  Use `router` if your routes are dynamic."
+Because compilation runs during macro expansion, `raw-routes` must be a literal vector at the call site — it cannot be built from runtime values. Use `router` if your routes are dynamic."
   {:example "(compiled-router [[\"/ping\" {:get {:handler pong}}]])"
    :see-also ["router" "handler"]}
   [raw-routes & [options]]

--- a/src/phel/schema.phel
+++ b/src/phel/schema.phel
@@ -40,8 +40,7 @@
   (v/schema-head schema))
 
 (defn schema-args
-  "Returns the positional arguments of `schema` (children past the head
-  and optional options map)."
+  "Returns the positional arguments of `schema` (children past the head and optional options map)."
   {:example "(schema-args [:vector :int]) ; => [:int]"}
   [schema]
   (v/schema-args schema))
@@ -81,25 +80,21 @@
   (e/human-readable-explain result))
 
 (defn coerce
-  "Walks `schema` and coerces string-shaped input into schema-required
-  types. Idempotent for already-typed values."
+  "Walks `schema` and coerces string-shaped input into schema-required types. Idempotent for already-typed values."
   {:example "(coerce :int \"42\") ; => 42"
    :see-also ["conform" "validate"]}
   [schema value]
   (c/coerce schema value))
 
 (defn conform
-  "Coerces `value` against `schema`. Returns the coerced value on
-  success, otherwise `:phel.schema/invalid`."
+  "Coerces `value` against `schema`. Returns the coerced value on success, otherwise `:phel.schema/invalid`."
   {:example "(conform :int \"42\") ; => 42"
    :see-also ["coerce" "validate"]}
   [schema value]
   (c/conform schema value))
 
 (def invalid-marker
-  "Sentinel value (`:phel.schema/invalid`) returned by `conform` when a
-  value cannot be coerced to fit a schema. `conform` returns this marker
-  instead of throwing, so compare against it to detect failure."
+  "Sentinel value (`:phel.schema/invalid`) returned by `conform` when a value cannot be coerced to fit a schema. `conform` returns this marker instead of throwing, so compare against it to detect failure."
   c/invalid-marker)
 
 (defn generate
@@ -152,16 +147,14 @@
 ;; ------
 
 (defn schema-check?
-  "Returns `true` when runtime validation performed by the instrument
-  helpers is currently enabled."
+  "Returns `true` when runtime validation performed by the instrument helpers is currently enabled."
   {:example "(schema-check?) ; => true"
    :see-also ["set-schema-check!" "with-schema-check"]}
   []
   (i/schema-check?))
 
 (defn set-schema-check!
-  "Enables (`true`) or disables (`false`) runtime validation. Returns
-  the new value."
+  "Enables (`true`) or disables (`false`) runtime validation. Returns the new value."
   {:example "(set-schema-check! false)"
    :see-also ["schema-check?"]}
   [enabled?]
@@ -176,8 +169,7 @@
   (i/with-schema-check enabled? f))
 
 (defn wrap-with-schema
-  "Wraps `f` so calls validate arguments and return values against the
-  supplied schemas."
+  "Wraps `f` so calls validate arguments and return values against the supplied schemas."
   {:example "(wrap-with-schema add [:int :int] :int)"
    :see-also ["instrument!"]}
   [f arg-schema return-schema]
@@ -191,16 +183,14 @@
   (i/wrap-with-function-schema f schema))
 
 (defn instrument!
-  "Registers `f` wrapped with `schema` under `name`. Returns the wrapped
-  function. The original is preserved so `unstrument!` can restore it."
+  "Registers `f` wrapped with `schema` under `name`. Returns the wrapped function. The original is preserved so `unstrument!` can restore it."
   {:example "(instrument! :add add [:=> [:int :int] :int])"
    :see-also ["unstrument!"]}
   [name f schema]
   (i/instrument! name f schema))
 
 (defn unstrument!
-  "Removes the instrumentation registered under `name` and returns the
-  original, unwrapped function (or `nil` if no entry)."
+  "Removes the instrumentation registered under `name` and returns the original, unwrapped function (or `nil` if no entry)."
   {:example "(unstrument! :add)"}
   [name]
   (i/unstrument! name))

--- a/src/phel/schema/coercer.phel
+++ b/src/phel/schema/coercer.phel
@@ -13,8 +13,7 @@
 (declare coerce)
 
 (def invalid-marker
-  "Sentinel keyword returned by coercion when a value cannot be coerced to
-  the target schema. Re-exported as `phel.schema/invalid-marker`."
+  "Sentinel keyword returned by coercion when a value cannot be coerced to the target schema. Re-exported as `phel.schema/invalid-marker`."
   :phel.schema/invalid)
 
 ;; Coerces to int: parses integer-shaped strings, accepts floats only when
@@ -220,10 +219,7 @@
                             value))))
 
 (defn coerce
-  "Walks `schema` and returns `value` with string-typed inputs coerced
-  into their schema-required types. Already-typed values pass through.
-  Unknown or untranslatable values are returned unchanged so validation
-  can report the real failure."
+  "Walks `schema` and returns `value` with string-typed inputs coerced into their schema-required types. Already-typed values pass through. Unknown or untranslatable values are returned unchanged so validation can report the real failure."
   {:example "(coerce :int \"42\") ; => 42"
    :see-also ["phel\\schema/conform" "phel\\schema/validate"]}
   [schema value]
@@ -233,8 +229,7 @@
     :else             value))
 
 (defn conform
-  "Coerces `value` against `schema`. Returns the coerced value if it
-  then validates, otherwise the invalid marker `:phel.schema/invalid`."
+  "Coerces `value` against `schema`. Returns the coerced value if it then validates, otherwise the invalid marker `:phel.schema/invalid`."
   {:example "(conform :int \"42\") ; => 42"
    :see-also ["coerce" "phel\\schema/validate"]}
   [schema value]

--- a/src/phel/schema/explainer.phel
+++ b/src/phel/schema/explainer.phel
@@ -232,8 +232,7 @@
     [(make-error path in schema value :mismatch)]))
 
 (defn explain
-  "Returns `nil` if `value` conforms to `schema`, otherwise a map
-  describing the violations."
+  "Returns `nil` if `value` conforms to `schema`, otherwise a map describing the violations."
   {:example "(explain :int :oops)"
    :see-also ["phel\\schema/validate" "phel\\schema/human-readable-explain"]}
   [schema value]
@@ -253,8 +252,7 @@
        (print-str (get err :value))))
 
 (defn human-readable-explain
-  "Renders an explain result as a multi-line human string suitable for
-  REPL or CI output. Returns `nil` for a `nil` result."
+  "Renders an explain result as a multi-line human string suitable for REPL or CI output. Returns `nil` for a `nil` result."
   {:example "(human-readable-explain (explain :int :oops))"
    :see-also ["explain"]}
   [result]

--- a/src/phel/schema/instrument.phel
+++ b/src/phel/schema/instrument.phel
@@ -35,8 +35,7 @@
   (reset! schema-check?-atom (boolean enabled?)))
 
 (defn with-schema-check
-  "Runs thunk `f` with runtime validation set to `enabled?`, restoring
-  the previous value even if `f` throws."
+  "Runs thunk `f` with runtime validation set to `enabled?`, restoring the previous value even if `f` throws."
   [enabled? f]
   (let [prev @schema-check?-atom]
     (reset! schema-check?-atom (boolean enabled?))
@@ -127,9 +126,7 @@
   (wrap-with-schema f (get schema 1) (get schema 2)))
 
 (defn instrument!
-  "Registers `f` under `name` (any key) wrapped with `schema`. Returns
-  the wrapped fn. Subsequent calls to `unstrument!` with the same name
-  can restore the original via `(instrumented-original name)`."
+  "Registers `f` under `name` (any key) wrapped with `schema`. Returns the wrapped fn. Subsequent calls to `unstrument!` with the same name can restore the original via `(instrumented-original name)`."
   {:example "(def add* (instrument! :add add [:=> [:int :int] :int]))"
    :see-also ["unstrument!" "*schema-check*"]}
   [name f schema]
@@ -138,8 +135,7 @@
     wrapped))
 
 (defn unstrument!
-  "Unregisters the instrumentation bound to `name` and returns the
-  original (unwrapped) function if present, otherwise `nil`."
+  "Unregisters the instrumentation bound to `name` and returns the original (unwrapped) function if present, otherwise `nil`."
   {:example "(unstrument! :add)"
    :see-also ["instrument!"]}
   [name]

--- a/src/phel/schema/registry.phel
+++ b/src/phel/schema/registry.phel
@@ -11,8 +11,7 @@
 (def- registry (atom {}))
 
 (defn register!
-  "Registers `schema` under `name` (usually a keyword). Overwrites any
-  previous entry. Returns the registered schema."
+  "Registers `schema` under `name` (usually a keyword). Overwrites any previous entry. Returns the registered schema."
   {:example "(register! :email [:and :string [:re #\"@\"]])"
    :see-also ["deref-ref" "registered?"]}
   [name schema]
@@ -28,8 +27,7 @@
   nil)
 
 (defn deref-ref
-  "Returns the schema registered under `name`, or `nil` if no schema is
-  registered with that name."
+  "Returns the schema registered under `name`, or `nil` if no schema is registered with that name."
   {:example "(deref-ref :email)"
    :see-also ["register!"]}
   [name]
@@ -43,8 +41,7 @@
   (contains? @registry name))
 
 (defn registry-snapshot
-  "Returns the current registry as a plain map. Intended for inspection
-  and testing."
+  "Returns the current registry as a plain map. Intended for inspection and testing."
   []
   @registry)
 

--- a/src/phel/schema/validator.phel
+++ b/src/phel/schema/validator.phel
@@ -36,10 +36,7 @@
                     (str label ": " head)))))
 
 (defn resolve-or-default
-  "Like `resolve-or-throw`, but returns `default` when `head` is not
-  registered instead of throwing. Used by `coerce` where unknown heads
-  are intentionally passed through unchanged for downstream validation
-  to flag."
+  "Like `resolve-or-throw`, but returns `default` when `head` is not registered instead of throwing. Used by `coerce` where unknown heads are intentionally passed through unchanged for downstream validation to flag."
   [head f default]
   (if (reg/registered? head)
     (f (reg/deref-ref head))
@@ -50,8 +47,7 @@
 ;; ----------------
 
 (defn schema-head
-  "Returns the head (kind keyword) of `schema`. Keyword schemas are
-  their own head; vector schemas use their first element."
+  "Returns the head (kind keyword) of `schema`. Keyword schemas are their own head; vector schemas use their first element."
   [schema]
   (cond
     (keyword? schema)                            schema
@@ -59,10 +55,7 @@
     :else                                        nil))
 
 (defn- extract-options
-  "Returns `[options remaining]` where `options` is a map (possibly
-  empty) of trailing options pulled from the second position of a
-  parametric schema, and `remaining` is the rest of the args after
-  the options map."
+  "Returns `[options remaining]` where `options` is a map (possibly empty) of trailing options pulled from the second position of a parametric schema, and `remaining` is the rest of the args after the options map."
   [args]
   (if (and (not (empty? args))
            (map? (first args)))
@@ -70,8 +63,7 @@
     [{} args]))
 
 (defn schema-args
-  "Returns the positional arguments of `schema` (children past the
-  head and optional options map)."
+  "Returns the positional arguments of `schema` (children past the head and optional options map)."
   [schema]
   (if (vector? schema)
     (let [tail         (apply vector (next schema))
@@ -169,16 +161,14 @@
        (every? true? (map-indexed (fn [i s] (valid? s (get value i))) elem-schemas))))
 
 (defn map-entry-options
-  "Options map for a `[:map ...]` entry `[key opts? schema]`. Returns an
-  empty map when the entry has no options position."
+  "Options map for a `[:map ...]` entry `[key opts? schema]`. Returns an empty map when the entry has no options position."
   [entry]
   (if (and (>= (count entry) 3) (map? (get entry 1)))
     (get entry 1)
     {}))
 
 (defn map-entry-schema
-  "Inner schema of a `[:map ...]` entry, skipping the options map when
-  present."
+  "Inner schema of a `[:map ...]` entry, skipping the options map when present."
   [entry]
   (if (and (>= (count entry) 3) (map? (get entry 1)))
     (get entry 2)
@@ -243,8 +233,7 @@
       :else                          (recur (next schemas)))))
 
 (defn- pattern-source
-  "Returns the raw regex string for a `:re` schema. Accepts either a
-  string pattern (used verbatim) or a compiled PHP regex handle."
+  "Returns the raw regex string for a `:re` schema. Accepts either a string pattern (used verbatim) or a compiled PHP regex handle."
   [pattern]
   (cond
     (string? pattern) pattern

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -21,8 +21,7 @@
 (defn chars
   "Returns a vector of characters from string s.
 
-  This is a convenience function for converting strings to character sequences.
-  Properly handles multibyte UTF-8 characters."
+This is a convenience function for converting strings to character sequences. Properly handles multibyte UTF-8 characters."
   {:example "(chars \"hello\") ; => [\"h\" \"e\" \"l\" \"l\" \"o\"]"
    :see-also ["seq"]}
   [s]
@@ -154,8 +153,7 @@
   (php/preg_replace "/[\s]+$/u" "" s))
 
 (defn blank?
-  "True if s is nil, empty, or contains only whitespace. Non-breaking
-  separators (`U+00A0`, `U+2007`, `U+202F`) are not treated as whitespace."
+  "True if s is nil, empty, or contains only whitespace. Non-breaking separators (`U+00A0`, `U+2007`, `U+202F`) are not treated as whitespace."
   {:example "(blank? \"   \") ; => true"}
   [s]
   (cond
@@ -214,9 +212,7 @@
     (php/implode "" mapped)))
 
 (defn index-of
-  "Returns the index of the first occurrence of value in s, or nil if not
-  found. The optional from-index sets where the search begins; a negative
-  from-index counts back from the end of s."
+  "Returns the index of the first occurrence of value in s, or nil if not found. The optional from-index sets where the search begins; a negative from-index counts back from the end of s."
   {:example "(index-of \"hello world\" \"world\") ; => 6"
    :see-also ["last-index-of" "contains?"]}
   [s value & [from-index]]
@@ -235,9 +231,7 @@
       result)))
 
 (defn last-index-of
-  "Returns the index of the last occurrence of value in s, or nil if not
-  found. The optional from-index sets the upper bound for the match; a
-  negative from-index counts back from the end of s."
+  "Returns the index of the last occurrence of value in s, or nil if not found. The optional from-index sets the upper bound for the match; a negative from-index counts back from the end of s."
   {:example "(last-index-of \"hello world world\" \"world\") ; => 12"
    :see-also ["index-of" "contains?"]}
   [s value & [from-index]]

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -43,16 +43,14 @@
 (def- *reporters* (atom []))
 
 (defn set-reporters!
-  "Replaces the active reporter set with `reporters` (a sequence of
-  single-argument functions). Returns the new reporter list."
+  "Replaces the active reporter set with `reporters` (a sequence of single-argument functions). Returns the new reporter list."
   {:example "(set-reporters! [my-reporter-fn])"
    :see-also ["add-reporter!" "clear-reporters!" "report"]}
   [reporters]
   (reset! *reporters* (vec reporters)))
 
 (defn add-reporter!
-  "Appends `reporter-fn` to the active reporter set. Returns the updated
-  reporter list."
+  "Appends `reporter-fn` to the active reporter set. Returns the updated reporter list."
   {:example "(add-reporter! tap-reporter)"
    :see-also ["set-reporters!" "clear-reporters!" "report"]}
   [reporter-fn]
@@ -83,8 +81,7 @@
     (str (s/join " > " *testing-contexts*) " - ")))
 
 (defn- decorate-event
-  "Prepends testing-context information to the event message and injects
-  the current test name."
+  "Prepends testing-context information to the event message and injects the current test name."
   [data]
   (let [ctx  (testing-contexts-str)
         data (cond
@@ -187,9 +184,7 @@
   (fan-out! (decorate-event data)))
 
 (defn do-report
-  "Add file and line information to a test result and call report.
-  If you are writing a custom assert-expr method, call this function
-  to pass test results to report."
+  "Add file and line information to a test result and call report. If you are writing a custom assert-expr method, call this function to pass test results to report."
   {:see-also ["report" "assert-expr"]
    :example "(do-report {:state :pass :type :any :message \"ok\"})"}
   [m]
@@ -388,10 +383,7 @@
 (defmacro deftest
   "Defines a test function.
 
-  Metadata attached to `test-name` is forwarded to the defined function
-  so selectors can inspect it at runtime. `^:integration` (shorthand
-  for `{:integration true}`) and `^{:tags [:integration :slow]}`
-  multi-tag maps are both honoured."
+Metadata attached to `test-name` is forwarded to the defined function so selectors can inspect it at runtime. `^:integration` (shorthand for `{:integration true}`) and `^{:tags [:integration :slow]}` multi-tag maps are both honoured."
   {:example "(deftest test-add)"}
   [test-name & body]
   (when-not (symbol? test-name)
@@ -406,29 +398,21 @@
          ~@body))))
 
 (defmacro testing
-  "Adds a testing context string. Used inside deftest to describe a group of assertions.
-  The context string is prepended to failure messages for better diagnostics."
+  "Adds a testing context string. Used inside deftest to describe a group of assertions. The context string is prepended to failure messages for better diagnostics."
   {:example "(deftest test-math\n  (testing \"addition\"\n    (is (= 2 (+ 1 1)))))"}
   [context & body]
   `(binding [*testing-contexts* (conj *testing-contexts* ~context)]
      ~@body))
 
 (defn- quote-if-empty-list
-  "Wraps an empty-list cell in `(quote ())` so it survives compilation as
-  literal data. Phel's evaluator cannot apply an empty list as a call, so a
-  bare `()` placed in value position (e.g. as an `are` template cell) must be
-  quoted for the generated code to compile. Non-empty lists and other values
-  are returned unchanged — the caller can quote explicitly if needed."
+  "Wraps an empty-list cell in `(quote ())` so it survives compilation as literal data. Phel's evaluator cannot apply an empty list as a call, so a bare `()` placed in value position (e.g. as an `are` template cell) must be quoted for the generated code to compile. Non-empty lists and other values are returned unchanged — the caller can quote explicitly if needed."
   [value]
   (if (and (list? value) (empty? value))
     `(quote ~value)
     value))
 
 (defn- substitute-symbols
-  "Recursively replaces every occurrence of a key in `smap` within `form` with
-  its corresponding value, walking lists, vectors, hash-maps, and hash-sets.
-  Used by `are` to expand template cells at macro-expansion time rather than
-  let-binding them at runtime."
+  "Recursively replaces every occurrence of a key in `smap` within `form` with its corresponding value, walking lists, vectors, hash-maps, and hash-sets. Used by `are` to expand template cells at macro-expansion time rather than let-binding them at runtime."
   [smap form]
   (cond
     (contains? smap form) (quote-if-empty-list (get smap form))
@@ -481,15 +465,12 @@
   (php/-> readable-printer (print value)))
 
 (defn- print-label
-  "Prints `label:`, the readable form of `value`, then any extra
-  trailing words on a single line. Used by the built-in failure
-  printers to keep the right-aligned two-column layout consistent."
+  "Prints `label:`, the readable form of `value`, then any extra trailing words on a single line. Used by the built-in failure printers to keep the right-aligned two-column layout consistent."
   [label value & extras]
   (apply println (str label ":") (readable-str value) extras))
 
 (defn- print-form-evaluated
-  "Prints the `Form: ... / evaluated to: ...` pair shared by every
-  failure printer that reports a single value and its computed result."
+  "Prints the `Form: ... / evaluated to: ...` pair shared by every failure printer that reports a single value and its computed result."
   [label-form form label-eval result]
   (print-label label-form form)
   (print-label label-eval result))
@@ -509,23 +490,19 @@
   80)
 
 (defn- sequential?
-  "Returns true when `v` is a vector or a list: the two ordered shapes
-  the diff renderer aligns by index."
+  "Returns true when `v` is a vector or a list: the two ordered shapes the diff renderer aligns by index."
   [v]
   (or (vector? v) (list? v)))
 
 (defn- same-shape?
-  "Returns true when `a` and `b` are both maps, both sets, or both
-  sequential. Mixed-shape pairs fall back to the summary printer."
+  "Returns true when `a` and `b` are both maps, both sets, or both sequential. Mixed-shape pairs fall back to the summary printer."
   [a b]
   (or (and (map? a) (map? b))
       (and (set? a) (set? b))
       (and (sequential? a) (sequential? b))))
 
 (defn- diff-worth-rendering?
-  "Decides whether `expected` and `actual` are large enough to justify a
-  block-style diff. Below the thresholds the existing summary line is
-  more readable than the diff."
+  "Decides whether `expected` and `actual` are large enough to justify a block-style diff. Below the thresholds the existing summary line is more readable than the diff."
   [expected actual]
   (or (> (count expected) diff-min-count)
       (> (count actual) diff-min-count)
@@ -536,9 +513,7 @@
   (println (str "    " marker " " text)))
 
 (defn- sort-by-readable
-  "Sorts `coll` by the readable representation of each entry. Used to
-  give the diff a deterministic order even when keys or values mix
-  types that Phel's default comparator rejects."
+  "Sorts `coll` by the readable representation of each entry. Used to give the diff a deterministic order even when keys or values mix types that Phel's default comparator rejects."
   [coll]
   (sort-by readable-str coll))
 
@@ -610,8 +585,7 @@
     (print-sequential-diff expected actual)))
 
 (defn- collection-diff-applicable?
-  "Returns true when a `=`/`not=` failure carries two same-shape
-  collections big enough to benefit from a stacked diff."
+  "Returns true when a `=`/`not=` failure carries two same-shape collections big enough to benefit from a stacked diff."
   [expected actual]
   (and (same-shape? expected actual)
        (diff-worth-rendering? expected actual)))
@@ -727,9 +701,7 @@
   (case state :failed "F" :error "E" "."))
 
 (defn- default-reporter
-  "Human-readable dot output. Preserves the legacy behavior: `.` for
-  pass, `F` for fail, `E` for error, plus periodic newlines so long
-  runs wrap at 80 columns. `S` marks a skipped test."
+  "Human-readable dot output. Preserves the legacy behavior: `.` for pass, `F` for fail, `E` for error, plus periodic newlines so long runs wrap at 80 columns. `S` marks a skipped test."
   [event]
   ;; Dot/wrap branches are skipped when an outer `with-output-buffer`
   ;; silences this reporter: counting invisible dots and resetting the
@@ -752,8 +724,7 @@
       (emit-marker! "S"))))
 
 (defn- testdox-reporter
-  "Per-assertion single-line description used by the `--reporter=testdox`
-  flag."
+  "Per-assertion single-line description used by the `--reporter=testdox` flag."
   [event]
   (let [type (:type event)]
     (cond
@@ -835,9 +806,7 @@
     (s/join "\n" (filter some? output))))
 
 (defn- tap-reporter
-  "TAP v13 output. Emits `TAP version 13`, `1..N` plan, `ok`/`not ok`
-  lines per assertion, and a YAML block per failure. `N` is the total
-  number of assertions observed during the run."
+  "TAP v13 output. Emits `TAP version 13`, `1..N` plan, `ok`/`not ok` lines per assertion, and a YAML block per failure. `N` is the total number of assertions observed during the run."
   [event]
   (let [type (:type event)]
     (cond
@@ -972,8 +941,7 @@
             (= :error state)  (update :errors inc))))
 
 (defn- junit-ensure-current
-  "Ensures `state` has a `:current` suite; lazily initialised from the
-  event's `:ns` when a testcase arrives outside a `begin-test-ns`."
+  "Ensures `state` has a `:current` suite; lazily initialised from the event's `:ns` when a testcase arrives outside a `begin-test-ns`."
   [state event]
   (or (:current state)
       (assoc empty-junit-suite :name (or (:ns event) ""))))
@@ -1020,8 +988,7 @@
         (junit-write-output state)))))
 
 (defn set-junit-output!
-  "Configures the output path the JUnit reporter writes to. When `nil`,
-  the XML is printed to stdout."
+  "Configures the output path the JUnit reporter writes to. When `nil`, the XML is printed to stdout."
   {:example "(set-junit-output! \"build/junit.xml\")"}
   [path]
   (swap! junit-state assoc :output-path path))
@@ -1046,9 +1013,7 @@
     :else           nil))
 
 (defn resolve-reporter
-  "Returns the reporter function registered for `name` (keyword or
-  string). Checks user-registered reporters before the built-in set.
-  Returns `nil` if the name is unknown."
+  "Returns the reporter function registered for `name` (keyword or string). Checks user-registered reporters before the built-in set. Returns `nil` if the name is unknown."
   {:see-also ["set-reporters!" "register-reporter!"]
    :example "(resolve-reporter :junit-xml)"}
   [name]
@@ -1057,8 +1022,7 @@
         (get built-in-reporters kw))))
 
 (defn register-reporter!
-  "Registers a custom reporter function under `name` (keyword or
-  keyword-castable string). Returns `name`."
+  "Registers a custom reporter function under `name` (keyword or keyword-castable string). Returns `name`."
   {:example "(register-reporter! :my-reporter (fn [event] ...))"
    :see-also ["resolve-reporter"]}
   [name reporter-fn]
@@ -1090,9 +1054,7 @@
      :total total}))
 
 (defn print-summary
-  "Emits the `:summary` event to the active reporter set.
-  Kept for backwards compatibility; prefer letting `run-tests` emit the
-  event at the end of the run."
+  "Emits the `:summary` event to the active reporter set. Kept for backwards compatibility; prefer letting `run-tests` emit the event at the end of the run."
   {:example "(print-summary)"}
   []
   (fan-out! (summary-event (deref stats))))
@@ -1155,17 +1117,13 @@
 ;; -------------
 
 (defn- legacy-filter-matches?
-  "Back-compat: the original `--filter` option accepted a single
-  substring matched against the test name. When selectors are also
-  active, this check still applies so existing callers keep behaving."
+  "Back-compat: the original `--filter` option accepted a single substring matched against the test name. When selectors are also active, this check still applies so existing callers keep behaving."
   [filter-value test-name]
   (or (nil? filter-value)
       (s/contains? (or test-name "") filter-value)))
 
 (defn- find-test-vars
-  "Discovers every `deftest`-defined function in `ns` and returns a
-  vector of `{:fn <callable> :meta <map>}` entries. The caller is
-  responsible for applying selectors."
+  "Discovers every `deftest`-defined function in `ns` and returns a vector of `{:fn <callable> :meta <map>}` entries. The caller is responsible for applying selectors."
   [ns]
   (let [munge    (php/new Munge)
         munge-ns (php/-> munge (encodeRegistryKey ns))]
@@ -1176,9 +1134,7 @@
             :meta meta}))))
 
 (defn- selector-options
-  "Extracts the tag/namespace selector subset from the full options map.
-  Name-based filters (`:filter` / `:filters`) are handled separately as
-  discovery filters and are intentionally excluded here."
+  "Extracts the tag/namespace selector subset from the full options map. Name-based filters (`:filter` / `:filters`) are handled separately as discovery filters and are intentionally excluded here."
   [options]
   {:include     (:include options)
    :exclude     (:exclude options)
@@ -1225,8 +1181,7 @@
       (some (fn [t] (= t (str ns "/" test-name))) only-tests)))
 
 (defn- visible-test-pred
-  "Returns the predicate that decides whether a discovered test passes
-  the discovery filters (`:filter`, `:filters`, `:only-tests`)."
+  "Returns the predicate that decides whether a discovered test passes the discovery filters (`:filter`, `:filters`, `:only-tests`)."
   [options ns]
   (let [filter-value    (:filter options)
         filter-patterns (:filters options)
@@ -1245,10 +1200,7 @@
   (swap! timings conj {:ns ns, :test-name test-name, :duration-ms duration-ms}))
 
 (defn- maybe-shuffle-tests
-  "Returns `tests` shuffled when `:random-order` is set in `options` (or
-  an explicit `:seed` is supplied), or unchanged otherwise. The active
-  seed (`:seed-resolved`) reseeds PHP's Mersenne Twister so the resulting
-  order is reproducible."
+  "Returns `tests` shuffled when `:random-order` is set in `options` (or an explicit `:seed` is supplied), or unchanged otherwise. The active seed (`:seed-resolved`) reseeds PHP's Mersenne Twister so the resulting order is reproducible."
   [options tests]
   (if (or (:random-order options) (:seed options))
     (do
@@ -1301,8 +1253,7 @@
              (run-one-test! options ns each-wrap test))))))))
 
 (defn- coerce-reporter
-  "Turns a single `:reporters` entry (function, keyword, or string) into
-  a reporter function. Throws on unknown names or invalid values."
+  "Turns a single `:reporters` entry (function, keyword, or string) into a reporter function. Throws on unknown names or invalid values."
   [r]
   (cond
     (fn? r)
@@ -1326,9 +1277,7 @@
       [:default]))
 
 (defn- resolve-reporters-option
-  "Resolves the `:reporters` option into a vector of reporter functions.
-  Accepts a sequence of keywords or strings (built-in names), or a
-  sequence of functions, or a mix. Defaults to `[:default]`."
+  "Resolves the `:reporters` option into a vector of reporter functions. Accepts a sequence of keywords or strings (built-in names), or a sequence of functions, or a mix. Defaults to `[:default]`."
   [options]
   (vec (map coerce-reporter (requested-reporters options))))
 
@@ -1338,9 +1287,7 @@
   (php/random_int 0 php/PHP_INT_MAX))
 
 (defn- resolve-seed
-  "Returns the seed `run-tests` should use, or `nil` when ordering is
-  deterministic and no seed was requested. An explicit `:seed` always
-  wins; `:random-order` without a seed gets a freshly generated one."
+  "Returns the seed `run-tests` should use, or `nil` when ordering is deterministic and no seed was requested. An explicit `:seed` always wins; `:random-order` without a seed gets a freshly generated one."
   [options]
   (cond
     (:seed options)         (:seed options)
@@ -1416,8 +1363,7 @@
   (reset! failed-tests []))
 
 (defn- announce-seed!
-  "Prints `Seed: <n>` once at the start of a randomized run so failures
-  can be reproduced with `--seed=<n>`."
+  "Prints `Seed: <n>` once at the start of a randomized run so failures can be reproduced with `--seed=<n>`."
   [options]
   (when-let [seed (:seed-resolved options)]
     (println (str "Seed: " seed))))
@@ -1453,8 +1399,7 @@
       (execute-run! options namespaces))))
 
 (defn reset-stats
-  "Resets the test statistics to their initial state.
-  Call this before running a new batch of tests to get fresh results."
+  "Resets the test statistics to their initial state. Call this before running a new batch of tests to get fresh results."
   {:example "(reset-stats)"}
   []
   (reset! stats initial-stats))
@@ -1479,9 +1424,7 @@
   (reset! stats saved))
 
 (defn get-failed-tests
-  "Returns the names (`ns/test-name`) of tests that failed or errored
-  in the last run. Used by `--parallel` orchestration to aggregate
-  last-failed lists across worker processes."
+  "Returns the names (`ns/test-name`) of tests that failed or errored in the last run. Used by `--parallel` orchestration to aggregate last-failed lists across worker processes."
   {:example "(get-failed-tests) ; => [\"my-app/foo-test\"]"}
   []
   (deref failed-tests))

--- a/src/phel/test/gen.phel
+++ b/src/phel/test/gen.phel
@@ -198,9 +198,7 @@
          (if (pred v) v (recur (inc i))))))))
 
 (defn sized
-  "Builds a generator from a function `f` of `size`. The returned generator
-  forwards its `size` into `f`, which must yield another generator that is
-  then invoked with the same size."
+  "Builds a generator from a function `f` of `size`. The returned generator forwards its `size` into `f`, which must yield another generator that is then invoked with the same size."
   {:example "(sized (fn [n] (return n)))"}
   [f]
   (fn [size] ((f size) size)))
@@ -232,8 +230,7 @@
     (fn [size] ((rand-elem v) size))))
 
 (defn frequency
-  "Generator that picks one of the `[weight gen]` pairs with probability
-  proportional to weight."
+  "Generator that picks one of the `[weight gen]` pairs with probability proportional to weight."
   {:example "((frequency [[9 (return :a)] [1 (return :b)]]) 100)"}
   [pairs]
   (let [v     (into [] pairs)
@@ -252,9 +249,7 @@
             (recur (inc i) next-remaining)))))))
 
 (defn tuple
-  "Generator of a fixed-length vector produced by running each of the given
-  generators in order. Accepts either a vector of generators or variadic
-  generator arguments."
+  "Generator of a fixed-length vector produced by running each of the given generators in order. Accepts either a vector of generators or variadic generator arguments."
   {:example "((tuple int boolean) 10) ; => [3 true]"}
   [& gens]
   (let [v (if (and (= 1 (count gens)) (vector? (first gens)))
@@ -288,8 +283,7 @@
     (apply list (for [_ :range [0 (rand-int* 0 (non-negative size))]] (g size)))))
 
 (defn map-of
-  "Generator of hash-maps with keys from `kg` and values from `vg`. Number of
-  entries is in `[0, size]`."
+  "Generator of hash-maps with keys from `kg` and values from `vg`. Number of entries is in `[0, size]`."
   {:example "((map-of keyword int) 2) ; => {:a 1 :b -3}"}
   [kg vg]
   (fn [size]
@@ -321,8 +315,7 @@
    (g (or size default-size))))
 
 (defn sample
-  "Runs `g` `num-samples` times (default 10) and returns a vector of values.
-  Accepts `:size` and `:seed`."
+  "Runs `g` `num-samples` times (default 10) and returns a vector of values. Accepts `:size` and `:seed`."
   {:example "(sample int 5) ; => [3 -7 0 1 -2]"}
   ([g] (sample g 10 {}))
   ([g num-samples] (sample g num-samples {}))
@@ -355,10 +348,7 @@
           {:result :failed, :num-tests (inc i), :args args})))))
 
 (defn- shrink-outcome
-  "Given a failing trial `outcome`, runs the shrink driver on its args
-  and returns an outcome augmented with `:original-args`, `:shrunk-args`
-  and `:shrink-steps`. If `shrink?` is falsy, returns `outcome`
-  unchanged."
+  "Given a failing trial `outcome`, runs the shrink driver on its args and returns an outcome augmented with `:original-args`, `:shrunk-args` and `:shrink-steps`. If `shrink?` is falsy, returns `outcome` unchanged."
   [outcome property shrink?]
   (let [failing? (or (= :failed (:result outcome))
                      (= :error (:result outcome)))]
@@ -397,9 +387,7 @@
      (assoc outcome :seed effective-seed))))
 
 (defn spec-failure-message
-  "Renders the human-readable failure message for a `defspec` outcome
-  map. Includes the shrink summary when the trial's arguments were
-  shrunk to a smaller counterexample."
+  "Renders the human-readable failure message for a `defspec` outcome map. Includes the shrink summary when the trial's arguments were shrunk to a smaller counterexample."
   {:example "(spec-failure-message \"my-spec\" {:result :failed ...})"
    :see-also ["quick-check" "defspec"]}
   [name-str res]
@@ -423,9 +411,7 @@
     (apply str (conj parts ")"))))
 
 (defn- emit-spec-failure-event!
-  "Fans out a `:defspec-failed` event carrying the rich outcome map so
-  reporters can surface the shrunk counterexample, seed, and shrink
-  step count."
+  "Fans out a `:defspec-failed` event carrying the rich outcome map so reporters can surface the shrunk counterexample, seed, and shrink step count."
   [name-str res]
   (t/do-report
    (merge

--- a/src/phel/test/rose.phel
+++ b/src/phel/test/rose.phel
@@ -18,9 +18,7 @@
 ;; ----------------
 
 (defn- lazy-map
-  "Element-wise `(map f coll)` that realises one element at a time.
-  Necessary because the built-in `map` realises a full chunk at once,
-  which is incompatible with the self-recursive rose-tree structure."
+  "Element-wise `(map f coll)` that realises one element at a time. Necessary because the built-in `map` realises a full chunk at once, which is incompatible with the self-recursive rose-tree structure."
   [f coll]
   (lazy-seq
     (when-let [s (seq coll)]
@@ -56,8 +54,7 @@
   {:root x, :children (lazy-seq nil)})
 
 (defn rose-tree
-  "Rose tree constructor. `children` should be a lazy sequence of rose
-  trees (or any seqable value)."
+  "Rose tree constructor. `children` should be a lazy sequence of rose trees (or any seqable value)."
   {:example "(rose-tree 1 (list (rose-pure 0)))"
    :see-also ["rose-pure" "rose-fmap"]}
   [root children]
@@ -78,8 +75,7 @@
   (or (get t :children) (lazy-seq nil)))
 
 (defn rose-shrinks
-  "Alias for `rose-children`: the lazy sequence of immediate smaller
-  variants of the current root."
+  "Alias for `rose-children`: the lazy sequence of immediate smaller variants of the current root."
   {:example "(rose-shrinks (rose-pure 1)) ; => @[]"
    :see-also ["rose-children"]}
   [t]
@@ -96,8 +92,7 @@
 ;; ----------------
 
 (defn rose-fmap
-  "Applies `f` to every value in rose tree `t` (the root and, lazily,
-  every descendant)."
+  "Applies `f` to every value in rose tree `t` (the root and, lazily, every descendant)."
   {:example "(rose-fmap inc (rose-pure 1)) ; root = 2"
    :see-also ["rose-bind" "rose-filter"]}
   [f t]
@@ -106,9 +101,7 @@
                        (rose-children t))})
 
 (defn rose-bind
-  "Monadic bind. `f` takes a value and returns a rose tree; the resulting
-  tree combines the shrinks of `t` (each fed through `f`) with the
-  shrinks produced by `f` on the root."
+  "Monadic bind. `f` takes a value and returns a rose tree; the resulting tree combines the shrinks of `t` (each fed through `f`) with the shrinks produced by `f` on the root."
   {:example "(rose-bind (rose-pure 1) (fn [n] (rose-pure (inc n))))"
    :see-also ["rose-fmap" "rose-pure"]}
   [t f]
@@ -146,8 +139,7 @@
 ;; ----------------
 
 (defn- positional-shrinks
-  "For index `i`, emits a lazy seq of variants of `trees` where only
-  position `i` has been replaced with each of its shrinks."
+  "For index `i`, emits a lazy seq of variants of `trees` where only position `i` has been replaced with each of its shrinks."
   [trees i]
   (lazy-map (fn [shrunk-i] (assoc trees i shrunk-i))
             (rose-children (get trees i))))
@@ -161,14 +153,12 @@
                    (shrinks-of-many* trees (+ i 1) n)))))
 
 (defn- shrinks-of-many
-  "Given a vector of rose trees, returns a lazy sequence of rose-tree
-  vectors where each vector shrinks exactly one of the inputs in turn."
+  "Given a vector of rose trees, returns a lazy sequence of rose-tree vectors where each vector shrinks exactly one of the inputs in turn."
   [trees]
   (shrinks-of-many* trees 0 (count trees)))
 
 (defn rose-zip
-  "Takes a vector of rose trees and returns a rose tree whose root is
-  the vector of roots and whose children shrink one position at a time."
+  "Takes a vector of rose trees and returns a rose tree whose root is the vector of roots and whose children shrink one position at a time."
   {:example "(rose-zip [(rose-pure 1) (rose-pure 2)])"
    :see-also ["rose-bind"]}
   [trees]
@@ -208,8 +198,7 @@
                      raw))))))
 
 (defn shrink-int
-  "Shrink strategy toward zero: halving steps (`n/2`, `n/4`, …) and then
-  decrement toward zero."
+  "Shrink strategy toward zero: halving steps (`n/2`, `n/4`, …) and then decrement toward zero."
   {:example "(shrink-int 8)"
    :see-also ["shrink-int-towards"]}
   [n]
@@ -246,8 +235,7 @@
   (into [] (concat (take i v) (drop (+ i 1) v))))
 
 (defn- shrink-vector-by-removal
-  "Candidates formed by dropping a leading block of halving sizes, then
-  single-element drops."
+  "Candidates formed by dropping a leading block of halving sizes, then single-element drops."
   [trees]
   (let [n (count trees)]
     (if (= 0 n)
@@ -263,9 +251,7 @@
                (remove-at trees i)))))))
 
 (defn rose-vector
-  "Rose tree for a vector whose children are built from the rose trees
-  of its elements. Shrinks by removing elements and by shrinking each
-  element in place."
+  "Rose tree for a vector whose children are built from the rose trees of its elements. Shrinks by removing elements and by shrinking each element in place."
   {:example "(rose-vector [(int-rose-tree 3) (int-rose-tree 5)])"
    :see-also ["rose-zip"]}
   [element-trees]
@@ -278,8 +264,7 @@
                 (lazy-map rose-vector (shrinks-of-many trees)))}))
 
 (defn rose-vector-lax
-  "Like `rose-vector` but preserves original length; only shrinks each
-  element in place (no removal)."
+  "Like `rose-vector` but preserves original length; only shrinks each element in place (no removal)."
   [element-trees]
   (let [trees (into [] element-trees)]
     {:root     (into [] (map rose-root trees))

--- a/src/phel/test/selector.phel
+++ b/src/phel/test/selector.phel
@@ -29,15 +29,13 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- non-empty-vec?
-  "Returns `true` when `xs` is a non-nil, non-empty vector/seq. Used to
-  check whether a selector option was supplied by the caller."
+  "Returns `true` when `xs` is a non-nil, non-empty vector/seq. Used to check whether a selector option was supplied by the caller."
   [xs]
   (and (not (nil? xs))
        (not (empty? xs))))
 
 (defn- tag-key
-  "Coerces a selector tag (keyword or string) into the keyword form used
-  to look up metadata. Returns `nil` for other inputs."
+  "Coerces a selector tag (keyword or string) into the keyword form used to look up metadata. Returns `nil` for other inputs."
   [tag]
   (cond
     (keyword? tag) tag
@@ -45,8 +43,7 @@
     :else          nil))
 
 (defn- truthy-tag?
-  "True when `meta` contains a truthy value at `kw`. Also accepts
-  vector-valued `:tags` metadata, checking membership by keyword."
+  "True when `meta` contains a truthy value at `kw`. Also accepts vector-valued `:tags` metadata, checking membership by keyword."
   [meta kw]
   (let [direct (get meta kw)
         tags   (get meta :tags)]
@@ -55,10 +52,7 @@
              (truthy? (some (fn [t] (= kw (tag-key t))) tags))))))
 
 (defn has-tag?
-  "Returns `true` when `meta` carries `tag` (a keyword or a string
-  treated as a keyword). Single-keyword metadata (`^:integration`) and
-  map-based multi-tag metadata (`^{:tags [:integration :slow]}`) both
-  match."
+  "Returns `true` when `meta` carries `tag` (a keyword or a string treated as a keyword). Single-keyword metadata (`^:integration`) and map-based multi-tag metadata (`^{:tags [:integration :slow]}`) both match."
   {:example "(has-tag? {:integration true} :integration)"
    :see-also ["matches-include?" "matches-exclude?"]}
   [meta tag]
@@ -74,8 +68,7 @@
   (truthy? (some (fn [tag] (has-tag? meta tag)) tags)))
 
 (defn matches-include?
-  "Returns `true` when `includes` is empty (no restriction) or when any
-  tag in `includes` is truthy on `meta`."
+  "Returns `true` when `includes` is empty (no restriction) or when any tag in `includes` is truthy on `meta`."
   {:example "(matches-include? [:integration] {:integration true})"
    :see-also ["matches-exclude?" "keep-test?"]}
   [includes meta]
@@ -83,9 +76,7 @@
       (any-tag-matches? includes meta)))
 
 (defn matches-exclude?
-  "Returns `true` when any tag in `excludes` is truthy on `meta`. An
-  empty or nil `excludes` vector always returns `false` (nothing
-  excluded)."
+  "Returns `true` when any tag in `excludes` is truthy on `meta`. An empty or nil `excludes` vector always returns `false` (nothing excluded)."
   {:example "(matches-exclude? [:slow] {:slow true})"
    :see-also ["matches-include?" "keep-test?"]}
   [excludes meta]
@@ -97,9 +88,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- glob->regex
-  "Converts a namespace glob (`phel.http.*`) into an anchored PCRE
-  pattern. `.` is treated literally, `*` matches any run of non-`.`
-  characters, `**` matches anything. The glob is case-sensitive."
+  "Converts a namespace glob (`phel.http.*`) into an anchored PCRE pattern. `.` is treated literally, `*` matches any run of non-`.` characters, `**` matches anything. The glob is case-sensitive."
   [pattern]
   (let [len (php/strlen pattern)
         out (atom "")
@@ -154,8 +143,7 @@
                             (normalize-ns ns-name)))))
 
 (defn matches-ns?
-  "Returns `true` when `patterns` is empty (no restriction) or when any
-  glob in `patterns` matches `ns-name`."
+  "Returns `true` when `patterns` is empty (no restriction) or when any glob in `patterns` matches `ns-name`."
   {:example "(matches-ns? [\"phel.http.*\"] \"phel.http.client\")"
    :see-also ["ns-matches?" "keep-test?"]}
   [patterns ns-name]
@@ -167,9 +155,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- compile-filter-regex
-  "Wraps a user-supplied regex body in PCRE delimiters when it is not
-  already a `/.../` pattern. Treats bare fragments as substring
-  matchers."
+  "Wraps a user-supplied regex body in PCRE delimiters when it is not already a `/.../` pattern. Treats bare fragments as substring matchers."
   [pattern]
   (if (and (string? pattern)
            (> (php/strlen pattern) 1)
@@ -179,8 +165,7 @@
     (str "/" (php/preg_quote pattern "/") "/")))
 
 (defn name-matches?
-  "Returns `true` when `pattern` (a PCRE `/.../` string or a plain
-  substring) matches `test-name`."
+  "Returns `true` when `pattern` (a PCRE `/.../` string or a plain substring) matches `test-name`."
   {:example "(name-matches? \"add-\" \"test-add-one\")"
    :see-also ["matches-filter?"]}
   [pattern test-name]
@@ -189,8 +174,7 @@
        (= 1 (php/preg_match (compile-filter-regex pattern) test-name))))
 
 (defn matches-filter?
-  "Returns `true` when `patterns` is empty (no restriction) or when any
-  entry in `patterns` matches `test-name`."
+  "Returns `true` when `patterns` is empty (no restriction) or when any entry in `patterns` matches `test-name`."
   {:example "(matches-filter? [\"add-\"] \"test-add-one\")"
    :see-also ["name-matches?" "keep-test?"]}
   [patterns test-name]
@@ -202,11 +186,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn keep-test?
-  "Returns `true` when the test described by `meta` and `ns-name`
-  should be run under `options`. `options` is a map that may carry any
-  of `:include`, `:exclude`, `:ns-patterns`, `:filters`. Selectors that
-  are absent or empty impose no restriction; specified selectors are
-  AND'd together."
+  "Returns `true` when the test described by `meta` and `ns-name` should be run under `options`. `options` is a map that may carry any of `:include`, `:exclude`, `:ns-patterns`, `:filters`. Selectors that are absent or empty impose no restriction; specified selectors are AND'd together."
   {:example "(keep-test? {:include [:integration]} \"my.ns\" {:integration true :test-name \"t\"})"
    :see-also ["matches-include?" "matches-exclude?" "matches-ns?" "matches-filter?"]}
   [options ns-name meta]
@@ -223,8 +203,7 @@
 (def- selector-keys [:include :exclude :ns-patterns :filters])
 
 (defn has-selectors?
-  "Returns `true` when `options` contains at least one non-empty
-  selector key."
+  "Returns `true` when `options` contains at least one non-empty selector key."
   {:example "(has-selectors? {:include [:integration]})"
    :see-also ["keep-test?"]}
   [options]

--- a/src/phel/test/shrink.phel
+++ b/src/phel/test/shrink.phel
@@ -46,10 +46,7 @@
                  (shrink-vector-tree v))))
 
 (defn value->rose
-  "Builds a rose tree for `v` using the built-in shrink strategy that
-  matches its runtime type. Integers shrink toward zero; strings,
-  vectors, lists, hash-maps and sets shrink by element removal plus
-  recursive element shrinks; everything else is a leaf."
+  "Builds a rose tree for `v` using the built-in shrink strategy that matches its runtime type. Integers shrink toward zero; strings, vectors, lists, hash-maps and sets shrink by element removal plus recursive element shrinks; everything else is a leaf."
   {:example "(value->rose 10)"
    :see-also ["phel\\test\\rose/int-rose-tree"]}
   [v]
@@ -67,8 +64,7 @@
 ;; ----------------
 
 (defn- fails?
-  "Returns `true` when `pred` fails for `value` (either returning a
-  non-truthy result or throwing)."
+  "Returns `true` when `pred` fails for `value` (either returning a non-truthy result or throwing)."
   [pred value]
   (try
     (not (pred value))
@@ -105,10 +101,7 @@
 ;; ----------------
 
 (defn args->rose
-  "Rose tree whose root is `args` and children shrink each positional
-  argument in place using its value-based shrinker. Arguments are
-  never dropped (they are function parameters, not collection
-  elements)."
+  "Rose tree whose root is `args` and children shrink each positional argument in place using its value-based shrinker. Arguments are never dropped (they are function parameters, not collection elements)."
   {:example "(args->rose [10])"
    :see-also ["value->rose"]}
   [args]

--- a/src/phel/transit.phel
+++ b/src/phel/transit.phel
@@ -71,16 +71,14 @@
        (php/=== c (php/substr s 0 1))))
 
 (defn- tag-string
-  "Returns the tag portion of a `~#tag`-encoded array marker, or nil
-  when `s` is not such a marker."
+  "Returns the tag portion of a `~#tag`-encoded array marker, or nil when `s` is not such a marker."
   [s]
   (when (and (php/is_string s)
              (php/=== "~#" (php/substr s 0 2)))
     (php/substr s 2)))
 
 (defn- decode-tagged-scalar
-  "Decodes a `~`-prefixed string. Returns the decoded value, or the
-  original string when the prefix is one of the escape forms."
+  "Decodes a `~`-prefixed string. Returns the decoded value, or the original string when the prefix is one of the escape forms."
   [s opts]
   (let [marker (php/substr s 1 1)
         rep    (php/substr s 2)]
@@ -105,8 +103,7 @@
                           (str "Unknown Transit scalar tag '~" marker "'"))))))))
 
 (defn- decode-cmap
-  "Decodes a `~#cmap` payload — a flat sequence of alternating key/value
-  representations — into a persistent map."
+  "Decodes a `~#cmap` payload — a flat sequence of alternating key/value representations — into a persistent map."
   [pairs opts]
   (let [acc (transient {})]
     (loop [items pairs]
@@ -136,8 +133,7 @@
                         (str "Unknown Transit tag '~#" tag "'")))))))
 
 (defn- decode-array
-  "Decodes a JSON array. Detects `[\"~#tag\", rep]` markers before
-  falling back to a positional vector decode."
+  "Decodes a JSON array. Detects `[\"~#tag\", rep]` markers before falling back to a positional vector decode."
   [arr opts]
   (let [head (php/aget arr 0)
         tag  (tag-string head)]
@@ -149,8 +145,7 @@
         (persistent acc)))))
 
 (defn- decode-object
-  "Decodes a JSON object (as PHP associative array) into a Phel map.
-  String keys may themselves be Transit-encoded (e.g. `\"~:foo\"`)."
+  "Decodes a JSON object (as PHP associative array) into a Phel map. String keys may themselves be Transit-encoded (e.g. `\"~:foo\"`)."
   [obj opts]
   (let [acc (transient {})]
     (foreach [k v obj]
@@ -241,9 +236,7 @@
       (php-indexed-array "~#cmap" pairs))))
 
 (defn- encode-sequential
-  "Encodes each element of `coll` into a PHP array. When `tag` is non-nil the
-  array is wrapped as a Transit tagged array (e.g. \"~#set\"); a nil `tag`
-  yields a bare array."
+  "Encodes each element of `coll` into a PHP array. When `tag` is non-nil the array is wrapped as a Transit tagged array (e.g. \"~#set\"); a nil `tag` yields a bare array."
   [coll tag]
   (let [arr (php/array)]
     (foreach [x coll]

--- a/src/phel/walk.phel
+++ b/src/phel/walk.phel
@@ -1,10 +1,7 @@
 (ns phel.walk)
 
 (defn walk
-  "Traverses `form`, an arbitrary data structure. Applies `inner` to each
-  element of `form`, building up a data structure of the same type, then
-  applies `outer` to the result. Recognizes vectors, lists, hash-maps,
-  and hash-sets. Other types are returned as-is."
+  "Traverses `form`, an arbitrary data structure. Applies `inner` to each element of `form`, building up a data structure of the same type, then applies `outer` to the result. Recognizes vectors, lists, hash-maps, and hash-sets. Other types are returned as-is."
   {:doc "Generic tree walker for nested data structures."
    :see-also ["postwalk" "prewalk"]
    :example "(walk inc identity [1 2 3]) ; => [2 3 4]"}
@@ -26,9 +23,7 @@
      form)))
 
 (defn postwalk
-  "Performs a depth-first, post-order traversal of `form`. Calls `f` on each
-  sub-form, uses `f`'s return value in place of the original. Walks into
-  vectors, lists, hash-maps, and hash-sets."
+  "Performs a depth-first, post-order traversal of `form`. Calls `f` on each sub-form, uses `f`'s return value in place of the original. Walks into vectors, lists, hash-maps, and hash-sets."
   {:doc "Bottom-up tree walk — applies f after recursing into children."
    :see-also ["prewalk" "walk" "postwalk-replace"]
    :example "(postwalk inc [1 [2 3]]) ; => [2 [3 4]]"}
@@ -36,8 +31,7 @@
   (walk #(postwalk f %) f form))
 
 (defn prewalk
-  "Like `postwalk`, but does a pre-order traversal (applies `f` before recursing
-  into children)."
+  "Like `postwalk`, but does a pre-order traversal (applies `f` before recursing into children)."
   {:doc "Top-down tree walk — applies f before recursing into children."
    :see-also ["postwalk" "walk" "prewalk-replace"]
    :example "(prewalk identity [1 [2 3]]) ; => [1 [2 3]]"}

--- a/src/phel/watch.phel
+++ b/src/phel/watch.phel
@@ -5,9 +5,7 @@
 (def- on-reload-hooks (atom {}))
 
 (defn register-on-reload
-  "Registers a zero-arg function to run every time `namespace` is
-  reloaded by the watcher. Replaces any previously registered hook
-  with the same `name`."
+  "Registers a zero-arg function to run every time `namespace` is reloaded by the watcher. Replaces any previously registered hook with the same `name`."
   {:example "(register-on-reload \"my-app\\core\" :refresh (fn [] (println \"reloaded\")))"}
   [namespace name hook-fn]
   (swap! on-reload-hooks
@@ -22,8 +20,7 @@
   (swap! on-reload-hooks (fn [m] (assoc m namespace {}))))
 
 (defn run-on-reload-hooks
-  "Executes every hook registered for `namespace`. Returns the
-  number of hooks that fired."
+  "Executes every hook registered for `namespace`. Returns the number of hooks that fired."
   {:example "(run-on-reload-hooks \"my-app\\core\")"}
   [namespace]
   (let [entry (get (deref on-reload-hooks) namespace {})]
@@ -34,9 +31,7 @@
     (count entry)))
 
 (defn watch!
-  "Starts the file watcher on the given vector of paths. Blocks until
-  the watcher is stopped (e.g. Ctrl+C). Reloads changed namespaces in
-  dependency order and runs any hooks registered with `register-on-reload`."
+  "Starts the file watcher on the given vector of paths. Blocks until the watcher is stopped (e.g. Ctrl+C). Reloads changed namespaces in dependency order and runs any hooks registered with `register-on-reload`."
   {:example "(watch! [\"src/\" \"tests/\"])"}
   [paths & [opts]]
   (let [facade  (php/new WatchFacade)


### PR DESCRIPTION
## 🤔 Background

Many `:doc`/docstrings in `src/phel/` were wrapped across multiple source lines mid-sentence. The embedded newline + indentation leaked into the stored string, so `phel doc` and the phel-lang.org API reference rendered them with stray extra spacing (e.g. `float and  double`, `` `Ratio`,   `BigInt` ``).

## 💡 Goal

Closes #2340 — prose docs render on one clean line; genuinely structured docs stay as-is.

## 🔖 Changes

- Collapsed **418 prose docstrings/`:doc` strings across 57 files** into single logical lines (a vetted, comment-aware transformer; reviewed diff).
- Also collapsed single `:example` calls whose **arguments** were wrapped across lines.
- **Preserved** (left untouched) everything that is genuinely structured:
  - multi-paragraph docs (blank-line separated),
  - aligned key/option tables (e.g. `phel.ai`, `phel.cli`),
  - indented example/clause blocks (e.g. `condp`),
  - code-led / keyword-led / bullet / numbered lines,
  - multi-call `:example` demos (independent calls joined by `\n`, kept multiline per maintainer preference).
- Audited `NativeSymbolCatalog.php`: its multi-line entries are intentional ` ```phel ` code blocks and `PHP_EOL` multi-step examples — no changes needed.

## ✅ Verification

- `composer test-core` green (5897).
- `phel format --dry-run src/phel`: no drift.
- Spot-checked `phel doc` rendering (stray spacing gone).
- Net `-687` lines.