### PR TITLE
fix: support Gacela 1.15 (project-relative cache dir)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 - Docs: function `:example` outputs now match REPL output, so `phel doc` and the API reference are accurate
 - `phel->php`: integer/string map keys now convert instead of throwing `getName() on int` (#2298)
 - Structs: `$struct['field']` array access now accepts a plain PHP string offset (was keyword-only) (#2313, #2319)
-- Tests: isolate Gacela's per-project config cache between tests (a PHPUnit extension + dedicated cache dir), removing cross-test leakage via the shared on-disk cache; `gacela-project/gacela` stays pinned `<1.15` (1.15 changes that cache in a way that also affects the packaged `phel test`, pending a production cache-keying fix)
+- Dependencies: support `gacela-project/gacela` 1.15. Gacela 1.15 persists the merged app config (`gacela-merged-config.php`); Phel now points Gacela's cache at the project-relative `.phel/cache` (was the shared system temp dir) so one project's `srcDirs`/config can't leak into another — fixing the packaged `phel test`/`build` when run against a user project. Tests isolate the cache per run via a PHPUnit extension
 
 ### Added
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=8.4",
         "amphp/amp": "^3.1",
-        "gacela-project/gacela": "^1.14 <1.15",
+        "gacela-project/gacela": "^1.14",
         "symfony/console": "^6.0|^7.0|^8.0",
         "symfony/routing": "^7.3|^8.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b2602cad605e9975085c19be19126a3",
+    "content-hash": "07ae10612a4433c900ae6011acd68e9c",
     "packages": [
         {
             "name": "amphp/amp",
@@ -157,20 +157,20 @@
         },
         {
             "name": "gacela-project/gacela",
-            "version": "1.14.4",
+            "version": "1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/gacela.git",
-                "reference": "d3058fa16b4748adca17d7e5b940c0dc5daa3e61"
+                "reference": "378c69c45446f60c821ea1c3bb4638ca052c7d94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/d3058fa16b4748adca17d7e5b940c0dc5daa3e61",
-                "reference": "d3058fa16b4748adca17d7e5b940c0dc5daa3e61",
+                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/378c69c45446f60c821ea1c3bb4638ca052c7d94",
+                "reference": "378c69c45446f60c821ea1c3bb4638ca052c7d94",
                 "shasum": ""
             },
             "require": {
-                "gacela-project/container": "^0.8",
+                "gacela-project/container": "^0.8.1",
                 "php": ">=8.1"
             },
             "require-dev": {
@@ -210,8 +210,8 @@
             ],
             "authors": [
                 {
-                    "name": "Jose Maria Valera Reales",
-                    "email": "chemaclass@outlook.es",
+                    "name": "Jose M. Valera Reales",
+                    "email": "gacela@chemaclass.com",
                     "homepage": "https://chemaclass.com"
                 },
                 {
@@ -230,7 +230,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/gacela/issues",
-                "source": "https://github.com/gacela-project/gacela/tree/1.14.4"
+                "source": "https://github.com/gacela-project/gacela/tree/1.15.0"
             },
             "funding": [
                 {
@@ -238,7 +238,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-04-20T09:41:26+00:00"
+            "time": "2026-06-05T12:00:26+00:00"
         },
         {
             "name": "psr/container",

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -30,12 +30,20 @@ class Phel
     private const string PHEL_CONFIG_LOCAL_FILE_NAME = 'phel-config-local.php';
 
     /**
-     * Use sys_get_temp_dir() by default.
-     * This can be overridden with the env variable: GACELA_CACHE_DIR=/tmp...
+     * Project-relative cache dir for Gacela's config/class caches.
+     *
+     * Gacela resolves a relative dir against the app root, so each project gets
+     * its own cache. This matters since Gacela >= 1.15 persists the merged app
+     * config (`gacela-merged-config.php`): an empty dir would resolve to the
+     * shared `sys_get_temp_dir()`, leaking one project's `srcDirs`/config into
+     * another (e.g. the PHAR running against a user project). Reuses Phel's
+     * existing `.phel/cache` convention.
+     *
+     * Can be overridden with the env variable: GACELA_CACHE_DIR=/tmp...
      *
      * @see https://github.com/gacela-project/gacela/pull/322
      */
-    private const string FILE_CACHE_DIR = '';
+    private const string FILE_CACHE_DIR = '.phel/cache';
 
     private static ?PhelConfig $autoDetectedConfig = null;
 


### PR DESCRIPTION
## 🤔 Background

Follow-up to #2342, which pinned `gacela-project/gacela` `<1.15`. Gacela 1.15 added persistent caching of the **merged app config** (`gacela-merged-config.php`), keyed only by the cache directory — not by the app root. Phel used the empty default, which resolves to the shared `sys_get_temp_dir()`, so one project's `srcDirs`/config leaked into another. The packaged `phel test`/`build` (PHAR smoke) failed with "Cannot find any tests" because it read the repo's `srcDirs` (`src/phel`) instead of the user project's.

## 💡 Goal

Make Phel compatible with Gacela 1.15 and lift the pin.

## 🔖 Changes

- `Phel::FILE_CACHE_DIR`: `''` → `'.phel/cache'`. Gacela resolves a **relative** cache dir against the app root, so each project gets its own `gacela-merged-config.php` — no cross-project leakage. Reuses Phel's existing `.phel/cache` convention; still overridable via `GACELA_CACHE_DIR`. The PHAR keeps writing cache to the (writable) user project, never `phar://`.
- `composer.json`: `gacela-project/gacela` `^1.14 <1.15` → `^1.14` (resolves to 1.15).

The per-test cache isolation extension from #2342 already keeps the suite clean on 1.15.

## ✅ Verification

- Rebuilt `phel.phar` (Gacela 1.15) and ran the smoke sequence (`init`/`doctor`/`test`) against a scaffold **with a deliberately poisoned shared system-temp cache** (repo `srcDirs`): `phel test` now finds and runs the scaffold's tests.
- `composer test` green: integration 846, core 5897, 0 failures; static analysis clean.