### PR TITLE
feat(compiler): name the [this & _] workaround in __invoke arity error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Richer PHP interop for bridging Phel to typed PHP / framework code (all opt-in, 
 - `agent-install`: simplified to copying skill files and the `.agents/` docs tree; dropped version stamping, `--check`, `--list`
 - `phel.ai`: default chat model is now `claude-sonnet-4-6`; `nearest` computes the query magnitude once instead of per item
 - Dropped redundant `(:require phel.core)` from 14 library namespaces (always preloaded); kept in `phel.string`, which needs the `core/` alias for `core/reverse`
+- `defstruct` `:php` block: the incompatible-`__invoke` arity error now points at the `[this & _]` workaround for callers that want a no-meaningful-argument invoke
 
 ## [0.41.0](https://github.com/phel-lang/phel-lang/compare/v0.40.0...v0.41.0) - 2026-06-01
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpBlockAnalyzer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpBlockAnalyzer.php
@@ -105,7 +105,8 @@ final readonly class PhpBlockAnalyzer
         if (!$compatible) {
             throw AnalyzerException::withLocation(
                 "A struct's '__invoke' must take exactly one call argument or be variadic "
-                . '(e.g. [this x] or [this & xs]), because a struct is already callable as a map. Got '
+                . '(e.g. [this x] or [this & xs]), because a struct is already callable as a map. '
+                . 'To accept a call with no meaningful argument, use a variadic tail and ignore it: [this & _]. Got '
                 . $required . ' required argument(s).',
                 $methodForm,
             );


### PR DESCRIPTION
## 🤔 Background

PR #2346 added inline PHP magic methods on `defstruct` via the `:php` block. A custom `__invoke` must stay compatible with the inherited map-call signature `__invoke(mixed $key)`, so it has to take exactly one call argument or be variadic. A zero-arg `[this]` is rejected at analyze time with a clear Phel error (instead of an uncatchable PHP fatal).

In Slack, a user hit that error while trying to declare a struct callable with no meaningful argument, and the message didn't tell them how to express that intent.

## 💡 Goal

Make the arity error self-documenting: point callers who want a no-argument-style invoke straight at the idiomatic workaround.

## 🔖 Changes

- `PhpBlockAnalyzer::assertCompatibleInvoke`: the error message now names the `[this & _]` variadic-ignore workaround.
- No behavior change — declared arity still equals emitted arity; no silent rewrite. Chosen over auto-allowing `[this]` to keep source and generated PHP signatures in lockstep and avoid silently swallowing call args.
- CHANGELOG `## Unreleased` note.
