### PR TITLE
feat(compiler): php/callable first-class callable interop form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `php/callable`: first-class callable interop form emitting native PHP 8.1 `(...)` syntax for free functions (`(php/callable \strlen)`), static methods (`(php/callable Foo bar)`), and instance methods (`(php/callable obj method)`) — zero-overhead, no `fn` wrapper
+
 ## [0.42.0](https://github.com/phel-lang/phel-lang/compare/v0.41.0...v0.42.0) - 2026-06-06
 
 ### Fixed

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -14,6 +14,7 @@ Call PHP from Phel and Phel from PHP.
 | Array access | `$arr[$key]` | `(php/aget arr key)` |
 | By-reference arg | `$obj->m($out)` (writes back into `$out`) | `(php/-> obj (m (php/ref out)))` |
 | Named arguments | `new Mailer(host: "smtp", port: 25)` | `(php/new \Mailer :& :host "smtp" :port 25)` |
+| First-class callable | `strlen(...)`, `$obj->m(...)`, `Foo::bar(...)` | `(php/callable \strlen)`, `(php/callable obj m)`, `(php/callable Foo bar)` |
 
 ## Calling PHP from Phel
 
@@ -116,6 +117,27 @@ Use the `:&` marker to pass PHP 8 named arguments in `php/new`, `php/->`, and `p
 ```
 
 Without the `:&` marker a keyword is just a positional value, so existing calls are unaffected. `php/ref` may be used as a named-argument value (`:out (php/ref x)`).
+
+### First-class callables
+
+`php/callable` builds a native PHP 8.1 first-class callable `(...)` from a PHP function or method. It is zero-overhead: no wrapping `fn` closure is allocated, and it reads cleaner when passing a method as a value:
+
+```phel
+;; Free function
+(map (php/callable \strtoupper) ["a" "b"])     ; => ["A" "B"]
+;; compiles to \strtoupper(...)
+
+;; Static method
+(php/callable \DateTimeImmutable createFromFormat)
+;; compiles to \DateTimeImmutable::createFromFormat(...)
+
+;; Instance method
+(let [list (php/new \ArrayObject [1 2 3])]
+  (php/callable list getArrayCopy))
+;; compiles to ($list)->getArrayCopy(...)
+```
+
+The first argument decides the target shape: a lone symbol is a free function, a class reference (`\Foo`, or an imported/uppercase class) plus a method name is a static call, and anything else plus a method name is an instance call on the evaluated object. The result is an ordinary callable, so it composes with `map`, `filter`, and friends.
 
 ### Working with PHP Arrays
 

--- a/src/php/Api/Infrastructure/NativeSymbolCatalog.php
+++ b/src/php/Api/Infrastructure/NativeSymbolCatalog.php
@@ -382,6 +382,18 @@ Calls a static method or property from a PHP class. Both method-name and propert
             'desc' => 'Calls a static method or property from a PHP class. Both method-name and property must be symbols and cannot be an evaluated value.',
             'example' => '(php/:: DateTime (createFromFormat "Y-m-d" "2024-01-01"))',
         ],
+        Symbol::NAME_PHP_CALLABLE => [
+            'doc' => '```phel
+(php/callable \function)
+(php/callable Class method)
+(php/callable object method)
+```
+Builds a native PHP 8.1 first-class callable `(...)` from a free function, a static method, or an instance method, without allocating an `fn` wrapper.',
+            'docUrl' => '/documentation/php-interop/#php-first-class-callable',
+            'signatures' => ['(php/callable \function)', '(php/callable Class method)', '(php/callable object method)'],
+            'desc' => 'Builds a native PHP first-class callable from a function or method, without an fn wrapper.',
+            'example' => '(map (php/callable \strtoupper) ["a" "b"])',
+        ],
         Symbol::NAME_PHP_REF => [
             'doc' => '```phel
 (php/-> object (method (php/ref local)))

--- a/src/php/Compiler/Domain/Analyzer/Ast/PhpCallableNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/PhpCallableNode.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Ast;
+
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Lang\SourceLocation;
+
+/**
+ * First-class callable form `(php/callable ...)`, emitting native PHP 8.1
+ * `(...)` syntax. Three target shapes:
+ *
+ * - free function: `targetExpr === null`, `name` is the function reference;
+ * - static method: `targetExpr` is a `PhpClassNameNode`, `isStatic === true`;
+ * - instance method: `targetExpr` is the analyzed object expression.
+ */
+final class PhpCallableNode extends AbstractNode
+{
+    public function __construct(
+        NodeEnvironmentInterface $env,
+        private readonly ?AbstractNode $targetExpr,
+        private readonly string $name,
+        private readonly bool $isStatic,
+        ?SourceLocation $sourceLocation = null,
+    ) {
+        parent::__construct($env, $sourceLocation);
+    }
+
+    public function getTargetExpr(): ?AbstractNode
+    {
+        return $this->targetExpr;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function isStatic(): bool
+    {
+        return $this->isStatic;
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -39,6 +39,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpASetSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpAUnsetInSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpAUnsetSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpBlockAnalyzer;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpCallableSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpNewSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpObjectCallSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpOSetSymbol;
@@ -325,6 +326,7 @@ final class AnalyzePersistentList
             Symbol::NAME_PHP_NEW, Symbol::NAME_NEW => new PhpNewSymbol($this->analyzer),
             Symbol::NAME_PHP_OBJECT_CALL => new PhpObjectCallSymbol($this->analyzer, isStatic: false),
             Symbol::NAME_PHP_OBJECT_STATIC_CALL => new PhpObjectCallSymbol($this->analyzer, isStatic: true),
+            Symbol::NAME_PHP_CALLABLE => new PhpCallableSymbol($this->analyzer),
             Symbol::NAME_PHP_REF => new PhpRefSymbol($this->analyzer),
             Symbol::NAME_PHP_ARRAY_GET => new PhpAGetSymbol($this->analyzer),
             Symbol::NAME_PHP_ARRAY_GET_IN => new PhpAGetInSymbol($this->analyzer),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpCallableSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpCallableSymbol.php
@@ -40,13 +40,11 @@ final readonly class PhpCallableSymbol implements SpecialFormAnalyzerInterface
             );
         }
 
-        $exprEnv = $env->withExpressionContext()->withDisallowRecurFrame();
-
         if ($count === 2) {
             return $this->analyzeFreeFunction($list, $env);
         }
 
-        return $this->analyzeMethod($list, $env, $exprEnv);
+        return $this->analyzeMethod($list, $env);
     }
 
     /**
@@ -79,7 +77,6 @@ final readonly class PhpCallableSymbol implements SpecialFormAnalyzerInterface
     private function analyzeMethod(
         PersistentListInterface $list,
         NodeEnvironmentInterface $env,
-        NodeEnvironmentInterface $exprEnv,
     ): PhpCallableNode {
         $target = $list->get(1);
         $methodSymbol = $list->get(2);
@@ -89,6 +86,8 @@ final readonly class PhpCallableSymbol implements SpecialFormAnalyzerInterface
                 $list,
             );
         }
+
+        $exprEnv = $env->withExpressionContext()->withDisallowRecurFrame();
 
         $classNode = $this->resolveClassReference($target, $env, $exprEnv);
         if ($classNode instanceof PhpClassNameNode) {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpCallableSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpCallableSymbol.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpCallableNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Symbol;
+
+use function count;
+use function get_debug_type;
+use function sprintf;
+
+/**
+ * (php/callable \strlen)        => strlen(...)
+ * (php/callable Foo bar)        => Foo::bar(...)
+ * (php/callable obj process)    => $obj->process(...).
+ *
+ * Emits a native PHP 8.1 first-class callable, avoiding the allocation and
+ * verbosity of wrapping the target in an `fn` closure.
+ */
+final readonly class PhpCallableSymbol implements SpecialFormAnalyzerInterface
+{
+    public function __construct(
+        private AnalyzerInterface $analyzer,
+    ) {}
+
+    public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): PhpCallableNode
+    {
+        $count = count($list);
+        if ($count < 2 || $count > 3) {
+            throw AnalyzerException::withLocation(
+                "One or two arguments are expected for 'php/callable'",
+                $list,
+            );
+        }
+
+        $exprEnv = $env->withExpressionContext()->withDisallowRecurFrame();
+
+        if ($count === 2) {
+            return $this->analyzeFreeFunction($list, $env);
+        }
+
+        return $this->analyzeMethod($list, $env, $exprEnv);
+    }
+
+    /**
+     * @param PersistentListInterface<mixed> $list
+     */
+    private function analyzeFreeFunction(
+        PersistentListInterface $list,
+        NodeEnvironmentInterface $env,
+    ): PhpCallableNode {
+        $fnSymbol = $list->get(1);
+        if (!$fnSymbol instanceof Symbol) {
+            throw AnalyzerException::withLocation(
+                "First argument of 'php/callable' must be a Symbol",
+                $list,
+            );
+        }
+
+        return new PhpCallableNode(
+            $env,
+            null,
+            $fnSymbol->getFullName(),
+            isStatic: false,
+            sourceLocation: $list->getStartLocation(),
+        );
+    }
+
+    /**
+     * @param PersistentListInterface<mixed> $list
+     */
+    private function analyzeMethod(
+        PersistentListInterface $list,
+        NodeEnvironmentInterface $env,
+        NodeEnvironmentInterface $exprEnv,
+    ): PhpCallableNode {
+        $target = $list->get(1);
+        $methodSymbol = $list->get(2);
+        if (!$methodSymbol instanceof Symbol) {
+            throw AnalyzerException::withLocation(
+                sprintf("Method argument of 'php/callable' must be a Symbol, got %s", get_debug_type($methodSymbol)),
+                $list,
+            );
+        }
+
+        $classNode = $this->resolveClassReference($target, $env, $exprEnv);
+        if ($classNode instanceof PhpClassNameNode) {
+            return new PhpCallableNode(
+                $env,
+                $classNode,
+                $methodSymbol->getName(),
+                isStatic: true,
+                sourceLocation: $list->getStartLocation(),
+            );
+        }
+
+        return new PhpCallableNode(
+            $env,
+            $this->analyzer->analyze($target, $exprEnv),
+            $methodSymbol->getName(),
+            isStatic: false,
+            sourceLocation: $list->getStartLocation(),
+        );
+    }
+
+    private function resolveClassReference(
+        mixed $target,
+        NodeEnvironmentInterface $env,
+        NodeEnvironmentInterface $exprEnv,
+    ): ?PhpClassNameNode {
+        if (!$target instanceof Symbol || $env->hasLocal($target)) {
+            return null;
+        }
+
+        $resolved = $this->analyzer->resolve($target, $exprEnv);
+
+        return $resolved instanceof PhpClassNameNode ? $resolved : null;
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpCallableEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpCallableEmitter.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpCallableNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+
+use function assert;
+
+/**
+ * Emits a native PHP 8.1 first-class callable `(...)`:
+ *
+ * - free function:    `\strlen(...)`
+ * - static method:    `\Foo::bar(...)`
+ * - instance method:  `($obj)->process(...)`.
+ */
+final class PhpCallableEmitter implements NodeEmitterInterface
+{
+    use WithOutputEmitterTrait;
+
+    public function emit(AbstractNode $node): void
+    {
+        assert($node instanceof PhpCallableNode);
+
+        $location = $node->getStartSourceLocation();
+        $this->outputEmitter->emitContextPrefix($node->getEnv(), $location);
+        $this->outputEmitter->emitStr('(', $location);
+        $this->emitCallableReference($node);
+        $this->outputEmitter->emitStr('(...))', $location);
+        $this->outputEmitter->emitContextSuffix($node->getEnv(), $location);
+    }
+
+    private function emitCallableReference(PhpCallableNode $node): void
+    {
+        $location = $node->getStartSourceLocation();
+        $targetExpr = $node->getTargetExpr();
+
+        if (!$targetExpr instanceof AbstractNode) {
+            $this->outputEmitter->emitStr($node->getName(), $location);
+            return;
+        }
+
+        if ($node->isStatic() && $targetExpr instanceof PhpClassNameNode) {
+            $this->outputEmitter->emitStr($targetExpr->getAbsolutePhpName() . '::' . $node->getName(), $location);
+            return;
+        }
+
+        $this->outputEmitter->emitStr('(', $location);
+        $this->outputEmitter->emitNode($targetExpr);
+        $this->outputEmitter->emitStr(')->' . $node->getName(), $location);
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -29,6 +29,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayGetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayPushNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArraySetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayUnsetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpCallableNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpNamedArgNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpNewNode;
@@ -74,6 +75,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpArrayGetEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpArrayPushEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpArraySetEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpArrayUnsetEmitter;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpCallableEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpClassNameEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpNamedArgEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpNewEmitter;
@@ -153,6 +155,7 @@ final class NodeEmitterFactory
             PhpNamedArgNode::class => new PhpNamedArgEmitter($outputEmitter),
             PhpVarNode::class => new PhpVarEmitter($outputEmitter),
             PhpObjectCallNode::class => new PhpObjectCallEmitter($outputEmitter),
+            PhpCallableNode::class => new PhpCallableEmitter($outputEmitter),
             PhpRefNode::class => new PhpRefEmitter($outputEmitter),
             RecurNode::class => new RecurEmitter($outputEmitter),
             ThrowNode::class => new ThrowEmitter($outputEmitter),

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -67,6 +67,8 @@ final class Symbol extends AbstractType implements IdenticalInterface, FnInterfa
 
     public const string NAME_PHP_OBJECT_STATIC_CALL = 'php/::';
 
+    public const string NAME_PHP_CALLABLE = 'php/callable';
+
     public const string NAME_QUOTE = 'quote';
 
     public const string NAME_VAR = 'var';

--- a/tests/php/Integration/Fixtures/Call/php-callable-free-function.test
+++ b/tests/php/Integration/Fixtures/Call/php-callable-free-function.test
@@ -1,0 +1,4 @@
+--PHEL--
+(php/callable \strtoupper)
+--PHP--
+(\strtoupper(...));

--- a/tests/php/Integration/Fixtures/Call/php-callable-instance-method.test
+++ b/tests/php/Integration/Fixtures/Call/php-callable-instance-method.test
@@ -1,0 +1,5 @@
+--PHEL--
+(let [o (php/new \ArrayObject)] (php/callable o getArrayCopy))
+--PHP--
+$o_1 = (new \ArrayObject());
+(($o_1)->getArrayCopy(...));

--- a/tests/php/Integration/Fixtures/Call/php-callable-static-method.test
+++ b/tests/php/Integration/Fixtures/Call/php-callable-static-method.test
@@ -1,0 +1,4 @@
+--PHEL--
+(php/callable \DateTimeImmutable createFromFormat)
+--PHP--
+(\DateTimeImmutable::createFromFormat(...));

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/PhpCallableSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/PhpCallableSymbolTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm;
+
+use Phel;
+use Phel\Compiler\Application\Analyzer;
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpCallableNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpCallableSymbol;
+use Phel\Lang\Symbol;
+use Phel\Shared\Exceptions\AbstractLocatedException;
+use PHPUnit\Framework\TestCase;
+
+final class PhpCallableSymbolTest extends TestCase
+{
+    private AnalyzerInterface $analyzer;
+
+    protected function setUp(): void
+    {
+        $this->analyzer = new Analyzer(new GlobalEnvironment());
+    }
+
+    public function test_free_function(): void
+    {
+        $node = $this->analyze([
+            Symbol::create(Symbol::NAME_PHP_CALLABLE),
+            Symbol::create('\strtoupper'),
+        ]);
+
+        self::assertNull($node->getTargetExpr());
+        self::assertFalse($node->isStatic());
+        self::assertSame('\strtoupper', $node->getName());
+    }
+
+    public function test_static_method(): void
+    {
+        $node = $this->analyze([
+            Symbol::create(Symbol::NAME_PHP_CALLABLE),
+            Symbol::create('\DateTimeImmutable'),
+            Symbol::create('createFromFormat'),
+        ]);
+
+        self::assertTrue($node->isStatic());
+        self::assertInstanceOf(PhpClassNameNode::class, $node->getTargetExpr());
+        self::assertSame('createFromFormat', $node->getName());
+    }
+
+    public function test_instance_method(): void
+    {
+        $node = $this->analyze([
+            Symbol::create(Symbol::NAME_PHP_CALLABLE),
+            42,
+            Symbol::create('process'),
+        ]);
+
+        self::assertFalse($node->isStatic());
+        self::assertInstanceOf(LiteralNode::class, $node->getTargetExpr());
+        self::assertSame('process', $node->getName());
+    }
+
+    public function test_too_few_arguments(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage("One or two arguments are expected for 'php/callable'");
+
+        $this->analyze([Symbol::create(Symbol::NAME_PHP_CALLABLE)]);
+    }
+
+    public function test_too_many_arguments(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage("One or two arguments are expected for 'php/callable'");
+
+        $this->analyze([
+            Symbol::create(Symbol::NAME_PHP_CALLABLE),
+            Symbol::create('\Foo'),
+            Symbol::create('bar'),
+            Symbol::create('baz'),
+        ]);
+    }
+
+    public function test_free_function_must_be_symbol(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage("First argument of 'php/callable' must be a Symbol");
+
+        $this->analyze([
+            Symbol::create(Symbol::NAME_PHP_CALLABLE),
+            42,
+        ]);
+    }
+
+    public function test_method_argument_must_be_symbol(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage("Method argument of 'php/callable' must be a Symbol");
+
+        $this->analyze([
+            Symbol::create(Symbol::NAME_PHP_CALLABLE),
+            Symbol::create('\Foo'),
+            42,
+        ]);
+    }
+
+    private function analyze(array $elements): PhpCallableNode
+    {
+        $list = Phel::list($elements);
+
+        return new PhpCallableSymbol($this->analyzer)
+            ->analyze($list, NodeEnvironment::empty());
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Phel is FP-first, so passing PHP functions and methods as values is core. Until now the only way to use a PHP method as a value was wrapping it in a closure, which allocates and reads verbosely:

```phel
(map (fn [x] (php/-> obj (process x))) coll)
```

PHP 8.1 introduced first-class callable syntax (`strlen(...)`, `$obj->m(...)`, `Foo::bar(...)`) which is zero-overhead and concise. Phel had no native form to emit it.

## 💡 Goal

Add a native `php/callable` special form that emits PHP 8.1 `(...)` syntax for free functions, static methods, and instance methods, with no closure wrapper.

```phel
(php/callable \strlen)                              ; => strlen(...)
(php/callable \DateTimeImmutable createFromFormat)  ; => \DateTimeImmutable::createFromFormat(...)
(php/callable obj process)                          ; => ($obj)->process(...)
```

The first argument selects the shape: a lone symbol is a free function; a class reference (`\Foo`, or an imported/uppercase class) plus a method name is a static call; anything else plus a method name is an instance call on the evaluated object.

## 🔖 Changes

- New `Symbol::NAME_PHP_CALLABLE` (`php/callable`), registered as a special form in `AnalyzePersistentList`.
- `PhpCallableSymbol` analyzer + `PhpCallableNode` AST node + `PhpCallableEmitter`, wired into `NodeEmitterFactory`.
- Static-vs-instance disambiguation reuses the existing symbol resolver (target resolving to a `PhpClassNameNode` ⇒ static).
- `NativeSymbolCatalog` entry so `php/callable` shows up in `phel doc`.
- Unit tests (`PhpCallableSymbolTest`) and integration fixtures under `tests/php/Integration/Fixtures/Call/` for all three forms.
- Docs in `docs/php-interop.md` (Quick Reference row + dedicated section).
- `CHANGELOG.md` under `## Unreleased`.

Closes #2348