### PR TITLE
fix(compiler): complete :tag type coverage for never/mixed/nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 - `php/callable`: first-class callable interop form emitting native PHP 8.1 `(...)` syntax for free functions (`(php/callable \strlen)`), static methods (`(php/callable Foo bar)`), and instance methods (`(php/callable obj method)`) — zero-overhead, no `fn` wrapper
 - `defstruct` `^:php/readonly`: emits the struct's typed fields as PHP `readonly` properties (untagged fields default to `readonly mixed`), making the immutability visible to psalm/phpstan; persistent `assoc`/`put` keeps working via a constructor-rebuild override
 
+### Fixed
+
+- `:tag` return-type checking: declaring `never`/`void`/`null` on a function whose body returns a concrete value is now a compile-time type error instead of emitting PHP that fatals at load; `mixed`, `?T` nullable, and union/intersection return tags continue to pass through
+
 ## [0.42.0](https://github.com/phel-lang/phel-lang/compare/v0.41.0...v0.42.0) - 2026-06-06
 
 ### Fixed

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -214,6 +214,35 @@ Phel uses `.` as the namespace separator, matching Clojure. The legacy `\` separ
 (bean obj)                              ; public properties => {:key value}
 ```
 
+## Typed generated PHP (`:tag`)
+
+`^{:tag T}` annotates the PHP type that a generated construct should carry, so a
+mixed PHP codebase and static analysers (psalm/phpstan) see real types. It works
+on `defstruct` fields, `definterface` params and return types, and the return
+type of a typed/exported `defn` (the tag goes on the param vector:
+`(defn f ^{:tag int} [x] ...)`).
+
+Any modern PHP type expression is accepted:
+
+```phel
+^{:tag int}            ; int
+^{:tag ?int}           ; ?int       (nullable: the value or nil)
+^{:tag mixed}          ; mixed      (any value)
+^{:tag never}          ; never      (return type only; the fn must not return)
+^{:tag (int string)}   ; int|string (a list => union)
+^{:tag [Countable Stringable]} ; Countable&Stringable (a vector => intersection)
+^{:tag \DateTimeImmutable}     ; a class FQN, verbatim
+```
+
+A bare symbol or string passes through verbatim, so PHP keywords (`mixed`,
+`never`, `iterable`, `self`, `static`) and pre-formed strings (`"int|null"`)
+also work. A `never` return is only valid when the function genuinely never
+returns (it throws or exits); declaring `never`/`void`/`null` on a function
+whose body returns a concrete value is reported as a type error at compile time.
+
+Nested DNF types like `(A|B)&C` are out of scope: use a flat union (a list) or a
+flat intersection (a vector).
+
 ## PHP magic methods on structs
 
 A `defstruct` compiles to a real PHP class, so it can expose PHP magic methods

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TagCompatibility.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TagCompatibility.php
@@ -148,6 +148,11 @@ final class TagCompatibility
             'bool' => $literalType === 'bool',
             'array' => $literalType === 'vector' || $literalType === 'map',
             'iterable' => in_array($literalType, ['vector', 'map', 'set'], true),
+            // `null`/`void`/`never` cannot be satisfied by a concrete returned
+            // value: `null` only holds nil (handled above), a `void` fn must not
+            // return a value, and a `never` fn must not return at all, so any
+            // non-nil tail literal is incompatible with them.
+            'null', 'void', 'never' => false,
             default => true,
         };
     }

--- a/tests/phel/core/tag-types.phel
+++ b/tests/phel/core/tag-types.phel
@@ -20,3 +20,15 @@
         b (put a :value "two")]
     (is (= 1 (a :value)) "original is unchanged")
     (is (= "two" (b :value)) "put returns an updated copy")))
+
+;; Return type tags: `mixed` accepts any tail, `?T` accepts nil or T.
+(defn mixed-ret ^{:tag mixed} [x] x)
+(defn nullable-ret ^{:tag ?int} [b] (if b 1 nil))
+
+(deftest mixed-return-tag-accepts-any
+  (is (= 5 (mixed-ret 5)) "mixed return accepts an int")
+  (is (= "x" (mixed-ret "x")) "mixed return accepts a string"))
+
+(deftest nullable-return-tag-accepts-nil-and-value
+  (is (= 1 (nullable-ret true)) "nullable return yields the int")
+  (is (nil? (nullable-ret false)) "nullable return yields nil"))

--- a/tests/php/Integration/Fixtures/Def/definterface-never-mixed-nullable.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-never-mixed-nullable.test
@@ -1,0 +1,10 @@
+--PHEL--
+(definterface* Effect (^{:tag never} fail [this]) (^{:tag mixed} unwrap [this]) (^{:tag ?int} maybe [this ^{:tag ?string} id]))
+--PHP--
+if (!interface_exists('user\Effect')) {
+interface Effect {
+  public function fail(): never;
+  public function unwrap(): mixed;
+  public function maybe(?string $id): ?int;
+}
+}

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/TagCompatibilityTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/TagCompatibilityTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\TagCompatibility;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class TagCompatibilityTest extends TestCase
+{
+    #[DataProvider('providerAccepts')]
+    public function test_accepts(string $tag, string $literalType, bool $expected): void
+    {
+        self::assertSame($expected, TagCompatibility::accepts($tag, $literalType));
+    }
+
+    /**
+     * @return iterable<string, array{string, string, bool}>
+     */
+    public static function providerAccepts(): iterable
+    {
+        yield 'mixed accepts a scalar' => ['mixed', 'int', true];
+        yield 'mixed accepts nil' => ['mixed', 'nil', true];
+        yield 'empty tag accepts anything' => ['', 'string', true];
+
+        yield 'nullable accepts nil' => ['?int', 'nil', true];
+        yield 'nullable accepts the inner type' => ['?int', 'int', true];
+        yield 'nullable rejects an unrelated type' => ['?int', 'string', false];
+
+        yield 'union accepts a member' => ['int|string', 'string', true];
+        yield 'union rejects a non-member' => ['int|string', 'bool', false];
+        yield 'union with null accepts nil' => ['int|null', 'nil', true];
+
+        yield 'never rejects a concrete return' => ['never', 'int', false];
+        yield 'never rejects nil' => ['never', 'nil', false];
+        yield 'void rejects a concrete return' => ['void', 'string', false];
+        yield 'void rejects nil' => ['void', 'nil', false];
+
+        yield 'null tag accepts nil' => ['null', 'nil', true];
+        yield 'null tag rejects a value' => ['null', 'int', false];
+
+        yield 'int accepts int' => ['int', 'int', true];
+        yield 'int rejects string' => ['int', 'string', false];
+        yield 'float accepts int' => ['float', 'int', true];
+
+        yield 'unknown class tag is not rejected' => ['\DateTime', 'vector', true];
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`:tag` already handles bare types, `?T` nullable, unions `(a b)`, intersections `[a b]`, and class FQNs verbatim. The reported papercuts were in the *return-type* path: `never`/`void`/`null` tags slipped through the compatibility check even when the function body returns a concrete value, so the compiler emitted PHP that fatals at load (`A never-returning function must not return`, `A void method must not return a value`).

## 💡 Goal

Round out `:tag` so any valid modern PHP return type either emits cleanly or fails fast with a clear Phel error — never produces broken PHP.

## 🔖 Changes

- `TagCompatibility::accepts` now rejects a concrete (non-nil) tail literal for the `never`, `void`, and `null` tags. A `never` fn that genuinely never returns (throws/exits) still compiles, because its tail type is unknown and the check is skipped. `mixed`, `?T` nullable, and union/intersection tags were already correct and stay so.
- Unit test `TagCompatibilityTest` covering `mixed`, `?T`, unions, `never`/`void`/`null`, and scalar matches.
- Integration fixture `definterface-never-mixed-nullable.test` proving `never`/`mixed`/`?int` return types and a `?string` param emit cleanly.
- Phel runtime cases in `tag-types.phel` for `mixed` and `?int` return tags.
- Docs: new "Typed generated PHP (`:tag`)" section in `docs/php-interop.md`, including DNF `(A|B)&C` documented as out of scope.

### 🔍 Refactor pass

Re-reviewed every touched file; the change is a localized two-line hardening of `TagCompatibility`, so no separate refactor commit was warranted.

Closes #2350