### PR TITLE
feat(compiler): ^:php/override sugar for #[\Override]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - `php/callable`: first-class callable interop form emitting native PHP 8.1 `(...)` syntax for free functions (`(php/callable \strlen)`), static methods (`(php/callable Foo bar)`), and instance methods (`(php/callable obj method)`) — zero-overhead, no `fn` wrapper
 - `defstruct` `^:php/readonly`: emits the struct's typed fields as PHP `readonly` properties (untagged fields default to `readonly mixed`), making the immutability visible to psalm/phpstan; persistent `assoc`/`put` keeps working via a constructor-rebuild override
 - `defenum` methods and interfaces: after the cases, a `defenum` can declare implemented interfaces (with their methods) and a `:php` block of plain/magic methods, reusing `defstruct`'s inline-implementation machinery; works for both pure and backed enums
+- `^:php/override` method sugar: emits PHP 8.3 `#[\Override]` on a generated method (defstruct/defenum interface impls and definterface methods), short for `^{:php/attr [[:Override]]}`. Struct/enum inline method impls now also emit method-level `:php/attr` and `:php/doc`
 
 ### Fixed
 

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -288,6 +288,7 @@ When the generated PHP must satisfy a framework's type expectations, opt-in meta
 |---|---|---|
 | `^{:tag T}` | struct field, interface param/return | typed signature; `(a b)` = union `a\|b`, `[a b]` = intersection `a&b` |
 | `^{:php/attr [...]}` | struct/interface name, field, method, param, exported `defn` | PHP 8 `#[Attr]` |
+| `^:php/override` | struct/enum/interface method | `#[\Override]` (PHP 8.3); sugar for `^{:php/attr [[:Override]]}` |
 | `^{:php/doc "..."}` | struct/interface name, field, method | PHPDoc block (phpstan/psalm) |
 | `^{:php/json true}` / `^{:php/stringable true}` | struct name | implements `\JsonSerializable` / `\Stringable` |
 | `^:php/readonly` | struct name | `readonly` typed properties (immutability visible to psalm/phpstan); untagged fields default to `readonly mixed` |

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -87,6 +87,8 @@ The interface + `:php`-block parsing shared by `defstruct` and `defenum` lives i
 
 `^{:php/doc <str|[str...]>}` on any of those names/fields/methods emits a PHPDoc block (one-line string or multi-line list/vector) above the construct, so phpstan/psalm see generated classes as typed.
 
+`^:php/override` on a method (defstruct/defenum interface impls, definterface methods) is sugar for `#[\Override]` (PHP 8.3); `PhpAttributeEmitterTrait::phpAttributeLines` renders it ahead of any explicit `:php/attr` lines. Struct/enum inline method impls now emit method-level `:php/attr`/`:php/doc`/`^:php/override` too (previously only definterface methods did).
+
 All opt-in; untagged forms are byte-identical to before. Export wrappers carry the same `:php/attr` via `Interop`'s `CompiledPhpMethodBuilder` (see `src/php/Interop/CLAUDE.md`).
 
 ## Global Environment

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEnumEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEnumEmitter.php
@@ -131,6 +131,7 @@ final readonly class DefEnumEmitter implements NodeEmitterInterface
         foreach ($node->getInterfaces() as $interface) {
             foreach ($interface->getMethods() as $method) {
                 $this->outputEmitter->emitLine();
+                $this->emitAttributes($method->getName()->getMeta(), $node->getStartSourceLocation());
                 $this->methodEmitter->emit($method->getName()->getName(), $method->getFnNode());
             }
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -356,6 +356,8 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
         foreach ($node->getInterfaces() as $defStruct) {
             foreach ($defStruct->getMethods() as $method) {
                 $this->outputEmitter->emitLine();
+                $this->emitDocBlock($method->getName()->getMeta(), $node->getStartSourceLocation());
+                $this->emitAttributes($method->getName()->getMeta(), $node->getStartSourceLocation());
                 $this->methodEmitter->emit($method->getName()->getName(), $method->getFnNode());
             }
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpAttributeEmitterTrait.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpAttributeEmitterTrait.php
@@ -11,6 +11,7 @@ use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use Phel\Shared\PhpAttributeRenderer;
 
+use function array_unshift;
 use function implode;
 use function is_string;
 
@@ -83,6 +84,8 @@ trait PhpAttributeEmitterTrait
     /**
      * Renders the `:php/attr` specs carried by the symbol meta into PHP
      * attribute lines (`#[...]`), or an empty list when none are present.
+     * The `^:php/override` flag is sugar for `#[\Override]` and is rendered
+     * first, before any explicit `:php/attr` lines.
      *
      * @param PersistentMapInterface<mixed, mixed>|null $meta
      *
@@ -94,7 +97,13 @@ trait PhpAttributeEmitterTrait
             return [];
         }
 
-        return $renderer->render($meta->find(Keyword::create('attr', 'php')));
+        $lines = $renderer->render($meta->find(Keyword::create('attr', 'php')));
+
+        if ($meta->find(Keyword::create('override', 'php')) === true) {
+            array_unshift($lines, '#[\Override]');
+        }
+
+        return $lines;
     }
 
     /**

--- a/tests/phel/core/defstruct-php-override.phel
+++ b/tests/phel/core/defstruct-php-override.phel
@@ -1,0 +1,23 @@
+(ns phel-test.core.defstruct-php-override
+  (:require phel.test :refer [deftest is]))
+
+(definterface Greeter
+  (greet [this]))
+
+(defstruct greeting [name]
+  Greeter
+  (^:php/override greet [this] (php/. "hi " (get this :name))))
+
+(defn- method-has-override? [class-fqn method]
+  (let [rm    (php/new \ReflectionMethod class-fqn method)
+        attrs (php/-> rm (getAttributes "Override"))]
+    (php/< 0 (php/count attrs))))
+
+(deftest override-method-still-runs
+  (is (= "hi sam" (greet (greeting "sam"))) "the overriding method behaves normally"))
+
+(deftest override-attribute-is-emitted
+  (let [present (method-has-override?
+                 "phel_test\\core\\defstruct_php_override\\greeting"
+                 "greet")]
+    (is (true? present) "the method carries the #[\\Override] attribute")))

--- a/tests/php/Integration/Fixtures/Def/defstruct-php-override.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-php-override.test
@@ -1,0 +1,24 @@
+--PHEL--
+(defstruct* Foo [x] \Stringable (^:php/override __toString [this] "foo"))
+--PHP--
+if (!class_exists('user\Foo')) {
+final class Foo extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct implements \Stringable {
+
+  protected const array ALLOWED_KEYS = ['x'];
+
+  protected $x;
+
+  public function __construct($x, $meta = null) {
+    parent::__construct();
+    $this->x = $x;
+    $this->meta = $meta;
+  }
+
+  #[\Override]
+  public function __toString() {
+    $x = $this->x;
+    $this_1 = $this;
+    return "foo";
+  }
+}
+}


### PR DESCRIPTION
## 🤔 Background

PHP 8.3 `#[\Override]` was reachable via `^{:php/attr [[:Override]]}`, but that's verbose for such a common, intent-revealing marker.

## 💡 Goal

One-word sugar that emits `#[\Override]` on the generated method.

```phel
(defstruct greeting [name]
  Greeter
  (^:php/override greet [this] (php/. "hi " (get this :name))))
;; => #[\Override] public function greet() { ... }
```

## 🔖 Changes

- `^:php/override` on a method desugars to `#[\Override]`, rendered first in `PhpAttributeEmitterTrait::phpAttributeLines` — the single `:php/attr` chokepoint — so it works everywhere method attributes are emitted.
- Struct and enum inline method impls now emit method-level attributes (`:php/attr`, `:php/doc`, and `^:php/override`); previously only `definterface` methods did.
- Integration fixture (`defstruct-php-override.test`) and a Phel runtime test (`defstruct-php-override.phel`) asserting via reflection that the `#[\Override]` attribute is present and the method still runs.
- Docs (`framework-integration.md` metadata table) and module `CLAUDE.md`; `CHANGELOG.md` under `## Unreleased`.

### Note

`#[\Override]` is only valid where a parent/interface method exists (PHP enforces this at class-declaration time), so it belongs on interface-implementing methods — exactly the inline-impl sites covered here.

Closes #2352