### PR TITLE
fix(compiler): resolve bare defenum name for EnumName/case access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - `:tag` return-type checking: declaring `never`/`void`/`null` on a function whose body returns a concrete value is now a compile-time type error instead of emitting PHP that fatals at load; `mixed`, `?T` nullable, and union/intersection return tags continue to pass through
+- `defenum`: the bare enum name now resolves to its namespaced PHP class, so the documented `EnumName/case` access form works (previously failed with `Class "EnumName" not found`)
 
 ## [0.42.0](https://github.com/phel-lang/phel-lang/compare/v0.41.0...v0.42.0) - 2026-06-06
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefEnumSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefEnumSymbol.php
@@ -50,6 +50,10 @@ final readonly class DefEnumSymbol implements SpecialFormAnalyzerInterface
             throw AnalyzerException::wrongArgumentType("First argument of 'defenum", 'Symbol', $name, $list);
         }
 
+        // Register the enum's bare name so it resolves to the namespaced PHP
+        // class (like `definterface`), enabling `EnumName/case` access.
+        $this->analyzer->addInterface($this->analyzer->getNamespace(), $name);
+
         $elements = [];
         foreach ($list as $element) {
             $elements[] = $element;

--- a/tests/phel/core/defenum.phel
+++ b/tests/phel/core/defenum.phel
@@ -27,6 +27,13 @@
     (is (= 3 (count cases)) "pure enum exposes all cases")
     (is (true? (Color? (php/aget cases 0))) "pure case satisfies predicate")))
 
+(deftest bare-name-case-access
+  ;; The enum's bare name resolves to the namespaced PHP class, so the
+  ;; documented `EnumName/case` access form works (issue #2358).
+  (is (true? (Status? Status/active)) "Status/active resolves to a case")
+  (is (= "active" (php/-> Status/active value)) "the resolved case carries its value")
+  (is (true? (Color? Color/red)) "pure-enum case access works too"))
+
 ;; Enum with an implemented interface and a `:php` block of plain methods.
 (definterface Describable
   (describe [this]))


### PR DESCRIPTION
## 🤔 Background

`defenum`'s own docstring advertises `(Status? Status/active)`, but `Status/active` failed at compile/run with `Class "Status" not found`. The enum was emitted correctly under its munged namespace (`\demo\Status`), but the bare `Status` symbol was not registered as a resolvable type in the defining namespace (unlike `definterface`), so `EnumName/case` could not resolve.

## 💡 Goal

Make the documented `EnumName/case` access form work.

## 🔖 Changes

- `DefEnumSymbol` now registers the enum's bare name in the namespace's resolvable-type registry (`analyzer->addInterface`, the same mechanism `definterface` uses). The bare name then resolves to the namespaced PHP class, so `Status/active` compiles to `\demo\Status::active`. Using an enum where an interface is expected stays rejected (the struct/enum impl path guards with `ReflectionClass::isInterface()`).
- Regression tests in `tests/phel/core/defenum.phel` covering bare-name case access for both backed and pure enums.
- `CHANGELOG.md` under `## Unreleased`.

The `defenum` docstring example is now accurate as written.

Closes #2358