### PR TITLE
perf(lang): cache Symbol::hash crc32 in readonly property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Performance
 
 - Compiler: `NodeEnvironment` local lookups are now O(1) hash-map indexed instead of linear/nested scans, so symbol resolution no longer degrades with `let`/`fn`/`loop` nesting depth (~1.7× faster at depth 20)
+- `Symbol::hash()` caches its `crc32` in a readonly property (mirroring `Keyword`), so repeated hashing of the same symbol during compilation no longer recomputes (~1.9× faster per repeated hash)
 
 ### Fixed
 

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -119,10 +119,14 @@ final class Symbol extends AbstractType implements IdenticalInterface, FnInterfa
 
     private static int $symGenCounter = 1;
 
+    private readonly int $hash;
+
     public function __construct(
         private readonly ?string $namespace,
         private readonly string $name,
-    ) {}
+    ) {
+        $this->hash = crc32($name);
+    }
 
     #[Override]
     public function __toString(): string
@@ -200,7 +204,7 @@ final class Symbol extends AbstractType implements IdenticalInterface, FnInterfa
 
     public function hash(): int
     {
-        return crc32($this->name);
+        return $this->hash;
     }
 
     public function equals(mixed $other): bool

--- a/tests/php/Benchmark/Lang/SymbolBench.php
+++ b/tests/php/Benchmark/Lang/SymbolBench.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Lang;
+
+use Phel\Lang\Symbol;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+
+/**
+ * `Symbol::hash()` micro-benchmark.
+ *
+ * The compiler hashes the same `Symbol` instance many times while
+ * resolving it against the global, local, and shadowed environments
+ * (each backed by a hash map). This measures repeated hashing of a
+ * single instance, which is exactly that pattern.
+ */
+final class SymbolBench
+{
+    private Symbol $symbol;
+
+    public function setUp(): void
+    {
+        $this->symbol = Symbol::createForNamespace('phel\\core', 'map-indexed');
+    }
+
+    /**
+     * @Revs(100000)
+     *
+     * @Iterations(5)
+     *
+     * @BeforeMethods("setUp")
+     */
+    public function bench_repeated_hash(): void
+    {
+        $symbol = $this->symbol;
+        for ($i = 0; $i < 16; ++$i) {
+            $symbol->hash();
+        }
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`Symbol::hash()` recomputed `crc32($this->name)` on every call. Symbols are the dominant value type during compilation, and the same instance is hashed repeatedly while it is resolved against the global, local, and shadowed environments (all hash-map backed, including the new O(1) `NodeEnvironment` index). `Keyword` already caches its hash in a `readonly` property — `Symbol` did not.

## 💡 Goal

Cache the hash once, mirroring `Keyword`, so repeated hashing of the same symbol is a property read instead of a `crc32` recompute. No behavior change.

## 🔖 Changes

- `Symbol`: add `private readonly int $hash`, computed as `crc32($name)` in the constructor; `hash()` returns it. The hashed string is unchanged (name only, namespace excluded), so `equals`/`hash`/identity semantics are byte-identical to before.
- Add `SymbolBench::bench_repeated_hash` micro-benchmark (16 repeated hashes of one instance).
- CHANGELOG `## Unreleased` → Performance note.

## 📊 Validation

`SymbolBench` (100k revs × 5 its, 16 repeated hashes per rev):

| impl | mode |
|---|---|
| recompute crc32 | 0.330μs |
| cached readonly | 0.173μs |

**~1.9× faster** (−47.6%) on the repeated-hash path. End-to-end `PhelBench::bench_core_file_compilation` is within run-to-run noise (hashing is a small slice of total compile) — this is a no-regression micro-optimization on a hot inner path, consistent with #2367.

Refactor pass: change is two lines mirroring an existing pattern; no duplication or cleanup surfaced. No `ref` commit needed.
