### PR TITLE
perf(compiler): O(n) reference tracking in LetSimplifier drop pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Compiler: `NodeEnvironment` local lookups are now O(1) hash-map indexed instead of linear/nested scans, so symbol resolution no longer degrades with `let`/`fn`/`loop` nesting depth (~1.7× faster at depth 20)
 - `Symbol::hash()` caches its `crc32` in a readonly property (mirroring `Keyword`), so repeated hashing of the same symbol during compilation no longer recomputes (~1.9× faster per repeated hash)
 - Analyzer: static-set membership checks in the type analyzer (`CallTypeExpectationResolver`, `ReturnTypeInferrer`, `ConstantFolder`, `DefSymbol`) now use `isset` keyed-map lookups instead of `in_array` scans (~3.7× faster per check)
+- `LetSimplifier`: the unused-binding drop pass tracks live references in a name-keyed set, turning its O(n²) scan-and-rebuild into O(n) over a `let`'s bindings (matters for `let` blocks with many bindings)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/LetSimplifier.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/LetSimplifier.php
@@ -11,10 +11,10 @@ use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\LocalVarReferences;
 
+use function array_fill_keys;
 use function array_reverse;
 use function array_slice;
 use function count;
-use function in_array;
 
 /**
  * Two-fold rewrite of `let` after analysis:
@@ -75,8 +75,11 @@ final readonly class LetSimplifier
             return $node;
         }
 
-        /** @var list<string> $allRefs */
-        $allRefs = $bodyRefs;
+        // Name-keyed set of live references, so membership is an O(1)
+        // isset and folding an init's refs in is O(1) per ref. A flat
+        // list would make this O(n^2) over the bindings (scan + rebuild).
+        /** @var array<string, true> $refSet */
+        $refSet = array_fill_keys($bodyRefs, true);
         $keepReversed = [];
         $dropped = false;
 
@@ -84,7 +87,7 @@ final readonly class LetSimplifier
             $shadow = $binding->getShadow()->getName();
             $init = $binding->getInitExpr();
 
-            $stillReferenced = in_array($shadow, $allRefs, true);
+            $stillReferenced = isset($refSet[$shadow]);
             $initPure = $this->purity->isPure($init);
 
             if ($stillReferenced || !$initPure) {
@@ -94,7 +97,9 @@ final readonly class LetSimplifier
                     return $node;
                 }
 
-                $allRefs = [...$allRefs, ...$extra];
+                foreach ($extra as $ref) {
+                    $refSet[$ref] = true;
+                }
 
                 continue;
             }

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/LetSimplifierTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/LetSimplifierTest.php
@@ -93,6 +93,26 @@ final class LetSimplifierTest extends TestCase
         self::assertSame($node, $simplified);
     }
 
+    public function test_keeps_binding_referenced_only_via_a_later_init(): void
+    {
+        // (let [a 1 b a] b) — body references only `b`, but `b`'s init
+        // references `a`. `a` must survive the drop pass via the
+        // transitive reference set, otherwise `b`'s init would point at
+        // a missing binding. Nothing is dropped or inlined (b's init is
+        // not a literal), so the node is returned unchanged.
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $aBinding = $this->binding('a', new LiteralNode($env, 1));
+        $bBinding = $this->binding('b', new LocalVarNode($env, $aBinding->getShadow()));
+        $body = new DoNode($env, [], new LocalVarNode($env, $bBinding->getShadow()));
+        $node = new LetNode($env, [$aBinding, $bBinding], $body, false);
+
+        $simplified = new LetSimplifier()->simplify($node);
+
+        self::assertSame($node, $simplified);
+        self::assertInstanceOf(LetNode::class, $simplified);
+        self::assertCount(2, $simplified->getBindings());
+    }
+
     private function binding(string $name, mixed $init): BindingNode
     {
         $env = NodeEnvironment::empty()->withExpressionContext();


### PR DESCRIPTION
## 🤔 Background

`LetSimplifier::dropUnusedBindings()` tracked live references in a flat `list<string>`:

- `in_array($shadow, $allRefs, true)` — O(n) scan per binding.
- `$allRefs = [...$allRefs, ...$extra]` — O(n) spread-rebuild per kept binding.

So the drop pass was O(n²) over a `let`'s bindings. It runs on every non-loop `LetNode` during the simplification pass.

## 💡 Goal

Track references in a name-keyed set (`array<string, true>`): `isset` membership and O(1) incremental insert → O(n) overall. No behavior change.

## 🔖 Changes

- `dropUnusedBindings`: build the reference set with `array_fill_keys($bodyRefs, true)`, test with `isset`, fold each init's refs in with a `foreach` insert instead of a spread rebuild.
- `inlineSingleTailUse` is untouched — it counts occurrences, not just membership.
- Add `LetSimplifierTest::test_keeps_binding_referenced_only_via_a_later_init`: a binding referenced only through a later kept binding's init must survive the drop pass (exercises the transitive reference set).

## 📊 Validation

`O(n²) → O(n)` for a `let` with n bindings; the gain grows with binding count and is within noise for typical small `let` blocks. Full `composer test` green (quality + 5941 tests); drop semantics identical (existing + new `LetSimplifierTest` cases pass).

Symbol shadow names never lex as pure integers (those parse as numbers), so there is no array-key int-cast hazard from using them as keys.

Refactor pass: localized set conversion with an explanatory comment and a consistent imported `array_fill_keys`; no duplication or dead code. No separate `ref` commit needed.

Closes #2371
