### PR TITLE
docs(profile): correct Munge dependency

### DIFF
--- a/src/php/Profile/CLAUDE.md
+++ b/src/php/Profile/CLAUDE.md
@@ -45,7 +45,7 @@ Profile/
 ## Dependencies
 
 - **Run** (`RunFacade`): `runFile`, `runNamespace`, `autoDetectEntryPoint`, `writeLocatedException`, `writeStackTrace`
-- **Compiler** (`Munge`): namespace canonicalization
+- **Shared** (`Munge`): namespace canonicalization
 - **Lang** (`AbstractFn`, `ProfilerHookInterface`, `Registry`): fn proxy and hook installation
 
 ## Key Constraints


### PR DESCRIPTION
## Summary
- correct the Profile module dependency entry for `Munge` to point to `Shared`
- align the doc with `Phel\Shared\Munge`

## Verification
- `rg -n "namespace Phel\\Shared|class Munge" src/php/Shared/Munge.php`
- `git diff --cached --check`

Resolves #2380