### PR TITLE
ref(modules): inject *FacadeInterface in satellite factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to this project will be documented in this file.
 - `LetSimplifier`: the unused-binding drop pass tracks live references in a name-keyed set, turning its O(n²) scan-and-rebuild into O(n) over a `let`'s bindings (matters for `let` blocks with many bindings)
 - Parser: `AtomParser` skips the anchored number-regex gauntlet for atoms that cannot start a number (first char not a digit/sign/dot), so symbol tokens parse straight through (~1.5× faster per symbol atom); `Parser` token-stream dispatch uses an `isset` keyed-map lookup instead of `in_array`
 
+### Changed
+
+- Architecture: the satellite-module factories (`Lsp`, `Lint`, `Watch`, `Nrepl`, `Profile`) now inject the `Phel\Shared\Facade\*FacadeInterface` contracts instead of neighbour modules' concrete facades, matching the core modules and the project's "inject interfaces" rule; `RunFacadeInterface` gains `autoDetectEntryPoint(): ?string` so the contract covers what `Profile` consumes
+
 ### Fixed
 
 - `:tag`: a `never`/`void`/`null` return tag on a value-returning function is now a compile error instead of PHP that fatals at load; `mixed`, `?T`, and union/intersection tags still pass

--- a/src/php/Lint/LintFactory.php
+++ b/src/php/Lint/LintFactory.php
@@ -6,8 +6,6 @@ namespace Phel\Lint;
 
 use Gacela\Framework\AbstractFactory;
 use Phel\Api\ApiFacade;
-use Phel\Command\CommandFacade;
-use Phel\Compiler\CompilerFacade;
 use Phel\Lint\Application\Cache\LintCache;
 use Phel\Lint\Application\Config\ConfigLoader;
 use Phel\Lint\Application\Config\RuleRegistry;
@@ -31,7 +29,9 @@ use Phel\Lint\Application\Rule\UnusedRequireRule;
 use Phel\Lint\Application\RulePipeline;
 use Phel\Lint\Application\SourceReader;
 use Phel\Lint\Domain\LintRuleInterface;
-use Phel\Run\RunFacade;
+use Phel\Shared\Facade\CommandFacadeInterface;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+use Phel\Shared\Facade\RunFacadeInterface;
 
 use function implode;
 use function md5;
@@ -117,17 +117,17 @@ final class LintFactory extends AbstractFactory
         return $this->getProvidedDependency(LintProvider::FACADE_API);
     }
 
-    public function getCompilerFacade(): CompilerFacade
+    public function getCompilerFacade(): CompilerFacadeInterface
     {
         return $this->getProvidedDependency(LintProvider::FACADE_COMPILER);
     }
 
-    public function getCommandFacade(): CommandFacade
+    public function getCommandFacade(): CommandFacadeInterface
     {
         return $this->getProvidedDependency(LintProvider::FACADE_COMMAND);
     }
 
-    public function getRunFacade(): RunFacade
+    public function getRunFacade(): RunFacadeInterface
     {
         return $this->getProvidedDependency(LintProvider::FACADE_RUN);
     }

--- a/src/php/Lsp/LspFactory.php
+++ b/src/php/Lsp/LspFactory.php
@@ -43,7 +43,7 @@ use Phel\Lsp\Application\Rpc\RequestDispatcher;
 use Phel\Lsp\Application\Rpc\ResponseBuilder;
 use Phel\Lsp\Application\Rpc\StreamNotificationSink;
 use Phel\Lsp\Application\Session\Session;
-use Phel\Run\RunFacade;
+use Phel\Shared\Facade\RunFacadeInterface;
 
 /**
  * @extends AbstractFactory<LspConfig>
@@ -211,7 +211,7 @@ final class LspFactory extends AbstractFactory
         return $this->getProvidedDependency(LspProvider::FACADE_FORMATTER);
     }
 
-    public function getRunFacade(): RunFacade
+    public function getRunFacade(): RunFacadeInterface
     {
         return $this->getProvidedDependency(LspProvider::FACADE_RUN);
     }

--- a/src/php/Nrepl/NreplFactory.php
+++ b/src/php/Nrepl/NreplFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phel\Nrepl;
 
 use Gacela\Framework\AbstractFactory;
-use Phel\Api\ApiFacade;
 use Phel\Nrepl\Application\Op\CloneOp;
 use Phel\Nrepl\Application\Op\CloseOp;
 use Phel\Nrepl\Application\Op\CompletionsOp;
@@ -20,7 +19,8 @@ use Phel\Nrepl\Domain\Bencode\BencodeEncoder;
 use Phel\Nrepl\Domain\Op\OpDispatcher;
 use Phel\Nrepl\Domain\Session\SessionRegistry;
 use Phel\Nrepl\Infrastructure\NreplSocketServer;
-use Phel\Run\RunFacade;
+use Phel\Shared\Facade\ApiFacadeInterface;
+use Phel\Shared\Facade\RunFacadeInterface;
 use Phel\Shared\Printer\Printer;
 use Phel\Shared\Printer\PrinterInterface;
 
@@ -86,12 +86,12 @@ final class NreplFactory extends AbstractFactory
         return Printer::readable();
     }
 
-    public function getRunFacade(): RunFacade
+    public function getRunFacade(): RunFacadeInterface
     {
         return $this->getProvidedDependency(NreplProvider::FACADE_RUN);
     }
 
-    public function getApiFacade(): ApiFacade
+    public function getApiFacade(): ApiFacadeInterface
     {
         return $this->getProvidedDependency(NreplProvider::FACADE_API);
     }

--- a/src/php/Profile/ProfileFactory.php
+++ b/src/php/Profile/ProfileFactory.php
@@ -8,7 +8,7 @@ use Gacela\Framework\AbstractFactory;
 use Phel\Profile\Domain\Formatter\JsonFormatter;
 use Phel\Profile\Domain\Formatter\TableFormatter;
 use Phel\Profile\Domain\ProfilerSession;
-use Phel\Run\RunFacade;
+use Phel\Shared\Facade\RunFacadeInterface;
 
 /**
  * @extends AbstractFactory<ProfileConfig>
@@ -30,7 +30,7 @@ final class ProfileFactory extends AbstractFactory
         return new JsonFormatter();
     }
 
-    public function getRunFacade(): RunFacade
+    public function getRunFacade(): RunFacadeInterface
     {
         return $this->getProvidedDependency(ProfileProvider::FACADE_RUN);
     }

--- a/src/php/Shared/Facade/RunFacadeInterface.php
+++ b/src/php/Shared/Facade/RunFacadeInterface.php
@@ -18,6 +18,13 @@ interface RunFacadeInterface
     public function runFile(string $filename): void;
 
     /**
+     * Resolves the project's configured entry-point namespace, or null when
+     * none is detected. Used by tooling that runs a project without an
+     * explicit target.
+     */
+    public function autoDetectEntryPoint(): ?string;
+
+    /**
      * @return mixed The result of the executed code
      */
     public function eval(string $phelCode, CompileOptions $compileOptions): mixed;

--- a/src/php/Watch/WatchFactory.php
+++ b/src/php/Watch/WatchFactory.php
@@ -6,9 +6,9 @@ namespace Phel\Watch;
 
 use Gacela\Framework\AbstractFactory;
 use Phel\Api\ApiFacade;
-use Phel\Build\BuildFacade;
-use Phel\Command\CommandFacade;
-use Phel\Run\RunFacade;
+use Phel\Shared\Facade\BuildFacadeInterface;
+use Phel\Shared\Facade\CommandFacadeInterface;
+use Phel\Shared\Facade\RunFacadeInterface;
 use Phel\Watch\Application\ApiProjectReindexer;
 use Phel\Watch\Application\MtimeFileSystemScanner;
 use Phel\Watch\Application\NamespaceResolver;
@@ -94,12 +94,12 @@ final class WatchFactory extends AbstractFactory
         return new NullReloadEventPublisher();
     }
 
-    public function getRunFacade(): RunFacade
+    public function getRunFacade(): RunFacadeInterface
     {
         return $this->getProvidedDependency(WatchProvider::FACADE_RUN);
     }
 
-    public function getBuildFacade(): BuildFacade
+    public function getBuildFacade(): BuildFacadeInterface
     {
         return $this->getProvidedDependency(WatchProvider::FACADE_BUILD);
     }
@@ -109,7 +109,7 @@ final class WatchFactory extends AbstractFactory
         return $this->getProvidedDependency(WatchProvider::FACADE_API);
     }
 
-    public function getCommandFacade(): CommandFacade
+    public function getCommandFacade(): CommandFacadeInterface
     {
         return $this->getProvidedDependency(WatchProvider::FACADE_COMMAND);
     }

--- a/tests/php/Unit/Architecture/SatelliteFactoryFacadeInjectionTest.php
+++ b/tests/php/Unit/Architecture/SatelliteFactoryFacadeInjectionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Architecture;
+
+use Generator;
+use Phel\Lint\LintFactory;
+use Phel\Lsp\LspFactory;
+use Phel\Nrepl\NreplFactory;
+use Phel\Profile\ProfileFactory;
+use Phel\Shared\Facade\ApiFacadeInterface;
+use Phel\Shared\Facade\BuildFacadeInterface;
+use Phel\Shared\Facade\CommandFacadeInterface;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+use Phel\Shared\Facade\RunFacadeInterface;
+use Phel\Watch\WatchFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionNamedType;
+
+/**
+ * Satellite modules must depend on the Shared facade *contracts*, not on a
+ * neighbour module's concrete facade. The factory getter return type is the
+ * one place that pins this down, so we lock it here against regressions.
+ */
+final class SatelliteFactoryFacadeInjectionTest extends TestCase
+{
+    #[DataProvider('factoryGetterProvider')]
+    public function test_factory_getter_returns_facade_interface(
+        string $factory,
+        string $method,
+        string $expectedInterface,
+    ): void {
+        $returnType = new ReflectionMethod($factory, $method)->getReturnType();
+
+        self::assertInstanceOf(ReflectionNamedType::class, $returnType);
+        self::assertSame($expectedInterface, $returnType->getName());
+    }
+
+    public static function factoryGetterProvider(): Generator
+    {
+        yield 'Lsp run' => [LspFactory::class, 'getRunFacade', RunFacadeInterface::class];
+
+        yield 'Lint run' => [LintFactory::class, 'getRunFacade', RunFacadeInterface::class];
+        yield 'Lint compiler' => [LintFactory::class, 'getCompilerFacade', CompilerFacadeInterface::class];
+        yield 'Lint command' => [LintFactory::class, 'getCommandFacade', CommandFacadeInterface::class];
+
+        yield 'Watch run' => [WatchFactory::class, 'getRunFacade', RunFacadeInterface::class];
+        yield 'Watch command' => [WatchFactory::class, 'getCommandFacade', CommandFacadeInterface::class];
+        yield 'Watch build' => [WatchFactory::class, 'getBuildFacade', BuildFacadeInterface::class];
+
+        yield 'Nrepl run' => [NreplFactory::class, 'getRunFacade', RunFacadeInterface::class];
+        yield 'Nrepl api' => [NreplFactory::class, 'getApiFacade', ApiFacadeInterface::class];
+
+        yield 'Profile run' => [ProfileFactory::class, 'getRunFacade', RunFacadeInterface::class];
+    }
+
+    public function test_run_facade_interface_declares_auto_detect_entry_point(): void
+    {
+        self::assertTrue(
+            method_exists(RunFacadeInterface::class, 'autoDetectEntryPoint'),
+            'Profile consumes RunFacade::autoDetectEntryPoint via the Shared contract.',
+        );
+    }
+}

--- a/tests/php/Unit/Watch/Application/ReloadOrchestratorTest.php
+++ b/tests/php/Unit/Watch/Application/ReloadOrchestratorTest.php
@@ -283,6 +283,11 @@ final class FakeRunFacade implements RunFacadeInterface
 
     public function runFile(string $filename): void {}
 
+    public function autoDetectEntryPoint(): ?string
+    {
+        return null;
+    }
+
     public function eval(string $phelCode, CompileOptions $compileOptions): mixed
     {
         return null;


### PR DESCRIPTION
## 🤔 Background

An architecture review of `src/php/` module boundaries found that the satellite-module factories (`Lsp`, `Lint`, `Watch`, `Nrepl`, `Profile`) inject neighbour modules' **concrete** facades (`ApiFacade`, `RunFacade`, …) rather than the `Phel\Shared\Facade\*FacadeInterface` contracts. This breaks the project's own "inject interfaces" rule, which the core modules (`Api`, `Run`, `Build`, `Interop`, `Formatter`) already follow. The consumers in these modules already type-hint the interfaces; only the factory getters lagged behind.

## 💡 Goal

Make the satellite factories depend on the Shared facade contracts, completing dependency inversion and matching the core modules.

## 🔖 Changes

- **Factory getters now return `*FacadeInterface`** where the interface already covers every call site:
  - `RunFacadeInterface` — all five factories
  - `CompilerFacadeInterface`, `CommandFacadeInterface` — `Lint`
  - `CommandFacadeInterface`, `BuildFacadeInterface` — `Watch`
  - `ApiFacadeInterface` — `Nrepl`
- **`RunFacadeInterface` gains `autoDetectEntryPoint(): ?string`** — `Profile` consumes it via the contract; the concrete `RunFacade` already implements it. The test fake `FakeRunFacade` is updated accordingly.
- **Providers are intentionally untouched**: they still resolve the concrete facade via `getRequired(ConcreteFacade::class)`, exactly like the `Api`/`Run`/`Build` providers. The contract boundary lives at the factory getter (the canonical Gacela pattern here).
- **Deliberately left concrete** (out of scope, documented): `ApiFacade` in `Lsp`/`Lint` and `FormatterFacade` in `Lsp`. Their interfaces do not declare the methods these modules call (`analyzeSource`, `completeAtPoint`, `findReferences`, `indexProject`, `resolveSymbol`, `formatString`). Completing those contracts would force `Api\Domain` types (`ProjectIndex`, `Definition`) into the `Shared` leaf module, which the Shared design explicitly avoids — a separate architectural decision, not a mechanical swap.
- **Test**: new `SatelliteFactoryFacadeInjectionTest` reflection-locks each switched getter's return type and the new contract method against regressions.

### Refactor pass

The change is already minimal (return-type + import swaps, one contract method, one fake update). The mandatory final review surfaced **no** duplication, dead code, or naming drift to fix, so no separate `ref(...)` commit was needed.

### Verification

- `composer test-compiler` green (4273 tests), `phpstan` + `psalm` clean, `composer fix` no-op. Static analysis is the real type gate here: an incompatible interface swap would fail it.

Closes #2377
