### PR TITLE
ref(modules): extract pure VLQ codec from Compiler to Phel\Shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Architecture: the satellite-module factories (`Lsp`, `Lint`, `Watch`, `Nrepl`, `Profile`) now inject the `Phel\Shared\Facade\*FacadeInterface` contracts instead of neighbour modules' concrete facades, matching the core modules and the project's "inject interfaces" rule; `RunFacadeInterface` gains `autoDetectEntryPoint(): ?string` so the contract covers what `Profile` consumes
 - Architecture: the eval-result value objects (`EvalResult`, `EvalError`, `StackFrame`) moved from `Run\Domain\Repl` to the leaf `Phel\Shared\Eval` namespace, so `RunFacadeInterface::structuredEval()` and its Nrepl/Watch consumers no longer reach into another module's `Domain`. The compiler orchestration that produced them (formerly `EvalResult::fromEval`) now lives in `Run\Application\StructuredEvaluator`, keeping the moved VOs logic-free
 - Architecture: version detection consolidated into a new `Phel\Shared\VersionResolver` (git/Composer/official-release gathering on top of `VersionFinder`); both Console and Run resolve their version through it, removing Run's structural dependency on the whole Console module (it previously injected `ConsoleFacade` solely for `getVersion()`)
+- Architecture: the pure Base64-VLQ codec moved from `Compiler\Domain\Emitter\OutputEmitter\SourceMap\VLQ` to the leaf `Phel\Shared\SourceMap\VLQ` (it carries no compiler state and is a stateless utility like `Munge`/`VersionFinder`); the SourceMap producer/consumer keep their emitter behaviour in Compiler
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/SourceMap/SourceMapConsumer.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/SourceMap/SourceMapConsumer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\SourceMap;
 
+use Phel\Shared\SourceMap\VLQ;
+
 final class SourceMapConsumer
 {
     /** @var array<int, list<int>> */

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/SourceMap/SourceMapGenerator.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/SourceMap/SourceMapGenerator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\SourceMap;
 
+use Phel\Shared\SourceMap\VLQ;
+
 use function count;
 
 final readonly class SourceMapGenerator

--- a/src/php/Shared/CLAUDE.md
+++ b/src/php/Shared/CLAUDE.md
@@ -63,6 +63,7 @@ Strategy pattern via `TypePrinter/`: one class per Phel/PHP type; `WithColorTrai
 - `VersionFinder`: pure version-string builder from explicit git inputs (`tagCommitHash`, `currentCommit`, `isOfficialRelease`); no I/O
 - `VersionResolver`: gathers the ambient version inputs (git working copy, Composer `InstalledVersions`, build-time `.phel-release.php`/`OFFICIAL_RELEASE`) and returns `VersionFinder::getVersion()`. Both Console and Run consume it directly, so neither owns version-detection wiring
 - `CompileOptions`: constants for source maps, emit-only mode, optimization levels
+- `SourceMap/VLQ`: pure Base64-VLQ codec (`decode`, `encodeIntegers`, `encodeInteger`); stateless, no module deps. Consumed by Compiler's `SourceMapGenerator`/`SourceMapConsumer`
 - `PhpAttributeRenderer`: renders `^{:php/attr ...}` metadata specs into PHP 8 attribute source lines (`#[\ORM\Column(length: 255)]`); pure, stateless. Accepts a bare keyword (`:ORM/Entity`), a single spec vector (`[:ORM/Column {:length 255}]`, first element is the name keyword), or a vector of specs (`[[:ORM/Id] [:ORM/Column]]`). Consumed by `DefStructEmitter`/`DefInterfaceEmitter` and the Interop export generator
 
 ## Dependencies

--- a/src/php/Shared/SourceMap/VLQ.php
+++ b/src/php/Shared/SourceMap/VLQ.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel\Compiler\Domain\Emitter\OutputEmitter\SourceMap;
+namespace Phel\Shared\SourceMap;
 
 use Exception;
 

--- a/tests/php/Unit/Shared/SourceMap/VLQTest.php
+++ b/tests/php/Unit/Shared/SourceMap/VLQTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\SourceMap;
+namespace PhelTest\Unit\Shared\SourceMap;
 
-use Phel\Compiler\Domain\Emitter\OutputEmitter\SourceMap\VLQ;
+use Phel\Shared\SourceMap\VLQ;
 use PHPUnit\Framework\TestCase;
 
 final class VLQTest extends TestCase


### PR DESCRIPTION
## 🤔 Background

An architecture review of `src/php/` module boundaries flagged that `VLQ` — a pure, dependency-free Base64-VLQ codec (its only imports are PHP's `Exception` + `strlen`) — lived deep inside the compiler at `Compiler\Domain\Emitter\OutputEmitter\SourceMap\VLQ`. It carries no compiler state and is exactly the kind of "pure stateless utility" the `Phel\Shared` leaf already hosts (`Munge`, `ColorStyle`, `VersionFinder`).

## 💡 Goal

Relocate the stateless `VLQ` codec to the `Phel\Shared` leaf, keeping the SourceMap emitter behaviour where it belongs (Compiler). No behavior change; static analysis is the gate.

## 🔖 Changes

- Moved `VLQ` → `Phel\Shared\SourceMap\VLQ` (via `git mv`, history preserved).
- Moved its test → `tests/php/Unit/Shared/SourceMap/VLQTest.php`.
- `SourceMapGenerator` and `SourceMapConsumer` now `use Phel\Shared\SourceMap\VLQ;` (they stay in Compiler — they are emitter behaviour, not pure utilities).
- Updated `src/php/Shared/CLAUDE.md` (new utility) and `CHANGELOG.md` under `## Unreleased`.

**Out of scope:** only `VLQ` is dependency-free; `SourceMapGenerator`/`SourceMapConsumer`/`SourceMapState` stay in Compiler.

**Refactor pass:** the change is a pure namespace move plus two `use` imports; it introduces no new duplication or naming drift (the `new VLQ()` in both consumers is pre-existing), so the mandatory final refactor pass surfaced zero additional changes.

Closes #2385
