### PR TITLE
fix: map built-output runtime errors back to Phel source via sibling .map files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Runtime errors in `phel build` output now map back to the Phel source: the error printer reads the sibling `<file>.php.map` and `<file>.phel` artifacts (previously written but never consumed) and reports `out/foo.phel:42` instead of the generated PHP line
+- Inline source maps in eval temp files are detected again: the extractor now scans past the `<?php` opener (and optional `declare` statements) for the metadata comments instead of only reading the first two lines
+
 ## [0.43.0](https://github.com/phel-lang/phel-lang/compare/v0.42.0...v0.43.0) - 2026-06-09
 
 ### Added

--- a/src/php/Build/Application/FileCompiler.php
+++ b/src/php/Build/Application/FileCompiler.php
@@ -11,6 +11,7 @@ use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\IO\FileIoInterface;
 use Phel\Shared\CompileOptions;
 use Phel\Shared\Facade\CompilerFacadeInterface;
+use Phel\Shared\SourceMap\BuiltFilePreamble;
 use Phel\Shared\SourceMap\SourceMapSiblings;
 
 use function function_exists;
@@ -40,7 +41,7 @@ final readonly class FileCompiler implements FileCompilerInterface
             BuildFacade::disableBuildMode();
         }
 
-        $phpCode = "<?php declare(strict_types=1);\n" . $result->getPhpCode();
+        $phpCode = BuiltFilePreamble::prepend($result->getPhpCode());
 
         $this->fileIo->putContents($dest, $phpCode);
         $this->writeSourceReference($dest, $phelCode);

--- a/src/php/Build/Application/FileCompiler.php
+++ b/src/php/Build/Application/FileCompiler.php
@@ -11,6 +11,7 @@ use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\IO\FileIoInterface;
 use Phel\Shared\CompileOptions;
 use Phel\Shared\Facade\CompilerFacadeInterface;
+use Phel\Shared\SourceMap\SourceMapSiblings;
 
 use function function_exists;
 
@@ -57,13 +58,13 @@ final readonly class FileCompiler implements FileCompilerInterface
 
     private function writeSourceReference(string $dest, string $phelCode): void
     {
-        $sourceFile = str_replace('.php', '.phel', $dest);
+        $sourceFile = SourceMapSiblings::sourceFile($dest);
         $this->fileIo->putContents($sourceFile, $phelCode);
     }
 
     private function writeSourceMap(string $dest, string $sourceMap, bool $enableSourceMaps): void
     {
-        $mapFile = $dest . '.map';
+        $mapFile = SourceMapSiblings::mapFile($dest);
 
         if ($enableSourceMaps) {
             $this->fileIo->putContents($mapFile, $sourceMap);

--- a/src/php/Build/Domain/Compile/SecondaryFileHarvester.php
+++ b/src/php/Build/Domain/Compile/SecondaryFileHarvester.php
@@ -7,6 +7,7 @@ namespace Phel\Build\Domain\Compile;
 use Phel\Build\Domain\Cache\CompiledCodeCacheInterface;
 use Phel\Build\Domain\IO\FileIoInterface;
 use Phel\Shared\NamespaceInformation;
+use Phel\Shared\SourceMap\SourceMapSiblings;
 use RuntimeException;
 
 use function dirname;
@@ -54,7 +55,7 @@ final readonly class SecondaryFileHarvester
         $this->ensureDir(dirname($targetPath));
         $this->fileIo->putContents($targetPath, $this->fileIo->getContents($cachedPath));
         $this->fileIo->putContents(
-            (string) preg_replace('/\.php$/', '.phel', $targetPath),
+            SourceMapSiblings::sourceFile($targetPath),
             $sourceCode,
         );
     }

--- a/src/php/Command/CLAUDE.md
+++ b/src/php/Command/CLAUDE.md
@@ -42,6 +42,6 @@ Infrastructure/  ComposerVendorDirectoriesFinder, ErrorLog, SourceMapExtractor
 ## Key Constraints
 
 - `DirectoryFinder`: resolves paths, handles PHAR archives, caches results
-- `SourceMapExtractor`: maps compiled PHP back to Phel source locations
+- `SourceMapExtractor`: maps compiled PHP back to Phel source locations; reads inline `// `/`// ;;` header comments (eval temp files) or sibling `<file>.map` + `<file>.phel` artifacts (built output)
 - `TextExceptionPrinter`: renders with syntax highlighting and source pointers
 - Config includes stale output recovery hint for corrupted build state

--- a/src/php/Command/Domain/Exceptions/Extractor/FilePositionExtractor.php
+++ b/src/php/Command/Domain/Exceptions/Extractor/FilePositionExtractor.php
@@ -18,32 +18,30 @@ final readonly class FilePositionExtractor implements FilePositionExtractorInter
     {
         $sourceMapInfo = $this->sourceMapExtractor->extractFromFile($filename);
 
+        if (!$sourceMapInfo->hasFilename()) {
+            return new FilePosition($filename, $line);
+        }
+
         return new FilePosition(
-            $this->extractOriginalFilename($sourceMapInfo, $filename),
+            $sourceMapInfo->filename(),
             $this->extractOriginalLine($sourceMapInfo, $line),
         );
     }
 
-    private function extractOriginalFilename(SourceMapInformation $sourceMapInfo, string $filename): string
-    {
-        if (!str_contains($sourceMapInfo->filename(), '// ')) {
-            return $filename;
-        }
-
-        return trim(substr($sourceMapInfo->filename(), 3));
-    }
-
     private function extractOriginalLine(SourceMapInformation $sourceMapInfo, int $line): int
     {
-        if (!str_contains($sourceMapInfo->filename(), '// ')
-            || !str_contains($sourceMapInfo->sourceMap(), '// ')
-        ) {
+        if (!$sourceMapInfo->hasMappings()) {
             return $line;
         }
 
-        $mapping = trim(substr($sourceMapInfo->sourceMap(), 3));
-        $sourceMapConsumer = new SourceMapConsumer($mapping);
-        $originalLine = $sourceMapConsumer->getOriginalLine($line - 1);
+        $generatedLine = $line - ($sourceMapInfo->codeStartLine() - 1);
+
+        if ($generatedLine < 1) {
+            return $line;
+        }
+
+        $sourceMapConsumer = new SourceMapConsumer($sourceMapInfo->mappings());
+        $originalLine = $sourceMapConsumer->getOriginalLine($generatedLine);
 
         if ($originalLine === null || $originalLine === 0) {
             return $line;

--- a/src/php/Command/Domain/Exceptions/Extractor/ReadModel/SourceMapInformation.php
+++ b/src/php/Command/Domain/Exceptions/Extractor/ReadModel/SourceMapInformation.php
@@ -4,20 +4,50 @@ declare(strict_types=1);
 
 namespace Phel\Command\Domain\Exceptions\Extractor\ReadModel;
 
+/**
+ * Normalized source-map data extracted from a compiled PHP file.
+ *
+ * The mappings string is the raw VLQ-encoded source map whose line N maps to
+ * line N of the generated code, i.e. excluding any file prefix lines
+ * (`<?php`, declare statements, metadata comments). `codeStartLine` is the
+ * 1-based line in the compiled file where the generated code begins, so a
+ * trace line translates via `traceLine - (codeStartLine - 1)`.
+ */
 final readonly class SourceMapInformation
 {
     public function __construct(
         private string $filename,
-        private string $sourceMap,
+        private string $mappings,
+        private int $codeStartLine = 1,
     ) {}
+
+    public static function none(): self
+    {
+        return new self('', '');
+    }
 
     public function filename(): string
     {
         return $this->filename;
     }
 
-    public function sourceMap(): string
+    public function mappings(): string
     {
-        return $this->sourceMap;
+        return $this->mappings;
+    }
+
+    public function codeStartLine(): int
+    {
+        return $this->codeStartLine;
+    }
+
+    public function hasFilename(): bool
+    {
+        return $this->filename !== '';
+    }
+
+    public function hasMappings(): bool
+    {
+        return $this->mappings !== '';
     }
 }

--- a/src/php/Command/Infrastructure/SourceMapExtractor.php
+++ b/src/php/Command/Infrastructure/SourceMapExtractor.php
@@ -6,6 +6,8 @@ namespace Phel\Command\Infrastructure;
 
 use Phel\Command\Domain\Exceptions\Extractor\ReadModel\SourceMapInformation;
 use Phel\Command\Domain\Exceptions\Extractor\SourceMapExtractorInterface;
+use Phel\Shared\SourceMap\BuiltFilePreamble;
+use Phel\Shared\SourceMap\InlineSourceMapComments;
 use Phel\Shared\SourceMap\SourceMapSiblings;
 
 use function fclose;
@@ -33,20 +35,11 @@ use function trim;
 final class SourceMapExtractor implements SourceMapExtractorInterface
 {
     /**
-     * Inline metadata sits within the first lines of an eval temp file:
-     * `<?php`, an optional `declare(ticks=1);`, then the two comments.
+     * Inline metadata sits within the first lines of an eval temp file
+     * (written by RequireEvaluator): `<?php`, an optional `declare(ticks=1);`,
+     * then the two comments prepended by EmitterResult.
      */
     private const int MAX_HEADER_LINES = 4;
-
-    private const string FILENAME_COMMENT_PREFIX = '// ';
-
-    private const string MAPPINGS_COMMENT_PREFIX = '// ;;';
-
-    /**
-     * Built files start with a single `<?php declare(strict_types=1);` line
-     * (see FileCompiler), so the generated code begins on line 2.
-     */
-    private const int BUILT_FILE_CODE_START_LINE = 2;
 
     public function extractFromFile(string $filename): SourceMapInformation
     {
@@ -76,23 +69,23 @@ final class SourceMapExtractor implements SourceMapExtractorInterface
                     return null;
                 }
 
-                // The mappings check must come first: FILENAME_COMMENT_PREFIX
-                // is a prefix of MAPPINGS_COMMENT_PREFIX, so reversing the
-                // order would capture the mappings line as a filename.
-                if (str_starts_with($line, self::MAPPINGS_COMMENT_PREFIX)) {
+                // The mappings check must come first: FILENAME_PREFIX is a
+                // prefix of MAPPINGS_PREFIX, so reversing the order would
+                // capture the mappings line as a filename.
+                if (str_starts_with($line, InlineSourceMapComments::MAPPINGS_PREFIX)) {
                     if ($sourceFilename === '') {
                         return null;
                     }
 
                     return new SourceMapInformation(
                         $sourceFilename,
-                        trim(substr($line, strlen(self::MAPPINGS_COMMENT_PREFIX))),
+                        trim(substr($line, strlen(InlineSourceMapComments::MAPPINGS_PREFIX))),
                         $lineNumber + 1,
                     );
                 }
 
-                if (str_starts_with($line, self::FILENAME_COMMENT_PREFIX)) {
-                    $sourceFilename = trim(substr($line, strlen(self::FILENAME_COMMENT_PREFIX)));
+                if (str_starts_with($line, InlineSourceMapComments::FILENAME_PREFIX)) {
+                    $sourceFilename = trim(substr($line, strlen(InlineSourceMapComments::FILENAME_PREFIX)));
                 }
             }
         } finally {
@@ -120,7 +113,7 @@ final class SourceMapExtractor implements SourceMapExtractorInterface
         return new SourceMapInformation(
             $sourceFile,
             trim($mappings),
-            self::BUILT_FILE_CODE_START_LINE,
+            BuiltFilePreamble::codeStartLine(),
         );
     }
 }

--- a/src/php/Command/Infrastructure/SourceMapExtractor.php
+++ b/src/php/Command/Infrastructure/SourceMapExtractor.php
@@ -6,11 +6,11 @@ namespace Phel\Command\Infrastructure;
 
 use Phel\Command\Domain\Exceptions\Extractor\ReadModel\SourceMapInformation;
 use Phel\Command\Domain\Exceptions\Extractor\SourceMapExtractorInterface;
+use Phel\Shared\SourceMap\SourceMapSiblings;
 
 use function fclose;
 use function fgets;
 use function fopen;
-use function sprintf;
 use function str_starts_with;
 use function strlen;
 use function substr;
@@ -101,8 +101,8 @@ final class SourceMapExtractor implements SourceMapExtractorInterface
 
     private function extractFromSiblingFiles(string $filename): SourceMapInformation
     {
-        $mapFile = sprintf('%s.map', $filename);
-        $sourceFile = str_replace('.php', '.phel', $filename);
+        $mapFile = SourceMapSiblings::mapFile($filename);
+        $sourceFile = SourceMapSiblings::sourceFile($filename);
 
         if (!is_file($mapFile) || !is_file($sourceFile)) {
             return SourceMapInformation::none();

--- a/src/php/Command/Infrastructure/SourceMapExtractor.php
+++ b/src/php/Command/Infrastructure/SourceMapExtractor.php
@@ -10,40 +10,114 @@ use Phel\Command\Domain\Exceptions\Extractor\SourceMapExtractorInterface;
 use function fclose;
 use function fgets;
 use function fopen;
+use function sprintf;
+use function str_starts_with;
+use function strlen;
+use function substr;
+use function trim;
 
 /**
- * Reads the first two lines of a generated PHP file, which Phel emits as source
- * map metadata comments (a `// ` filename comment followed by a `// ` source map
- * comment). Both lines are returned verbatim for the caller to parse.
+ * Extracts source-map metadata from a compiled PHP file so runtime stack
+ * traces can be mapped back to the original Phel source.
+ *
+ * Two layouts are supported:
+ *
+ * 1. Inline (eval temp files): the emitter prepends a `// <source>` filename
+ *    comment followed by a `// ;;<mappings>` comment. These may sit below a
+ *    `<?php` opener and optional declare statements, so the first few lines
+ *    are scanned for the comment pair.
+ * 2. Sibling files (built output): `phel build` writes the mappings next to
+ *    the compiled file as `<file>.map` and a copy of the source as
+ *    `<file>.phel` (see FileCompiler), with no inline comments.
  */
 final class SourceMapExtractor implements SourceMapExtractorInterface
 {
     /**
-     * Returns the raw first two lines of the file. Empty strings indicate that no
-     * source map is available, i.e. the file is missing, unreadable, or shorter
-     * than two lines; an empty string is therefore indistinguishable from a truly
-     * blank line, so callers must treat empty as "no source map".
+     * Inline metadata sits within the first lines of an eval temp file:
+     * `<?php`, an optional `declare(ticks=1);`, then the two comments.
      */
+    private const int MAX_HEADER_LINES = 4;
+
+    private const string FILENAME_COMMENT_PREFIX = '// ';
+
+    private const string MAPPINGS_COMMENT_PREFIX = '// ;;';
+
+    /**
+     * Built files start with a single `<?php declare(strict_types=1);` line
+     * (see FileCompiler), so the generated code begins on line 2.
+     */
+    private const int BUILT_FILE_CODE_START_LINE = 2;
+
     public function extractFromFile(string $filename): SourceMapInformation
     {
-        if (!file_exists($filename)) {
-            return new SourceMapInformation('', '');
+        return $this->extractInline($filename)
+            ?? $this->extractFromSiblingFiles($filename);
+    }
+
+    private function extractInline(string $filename): ?SourceMapInformation
+    {
+        if (!is_file($filename)) {
+            return null;
         }
 
         $handle = fopen($filename, 'rb');
 
         if ($handle === false) {
-            return new SourceMapInformation('', '');
+            return null;
         }
 
-        $filenameComment = fgets($handle);
-        $sourceMapComment = fgets($handle);
+        $sourceFilename = '';
 
-        fclose($handle);
+        try {
+            for ($lineNumber = 1; $lineNumber <= self::MAX_HEADER_LINES; ++$lineNumber) {
+                $line = fgets($handle);
+
+                if ($line === false) {
+                    return null;
+                }
+
+                if (str_starts_with($line, self::MAPPINGS_COMMENT_PREFIX)) {
+                    if ($sourceFilename === '') {
+                        return null;
+                    }
+
+                    return new SourceMapInformation(
+                        $sourceFilename,
+                        trim(substr($line, strlen(self::MAPPINGS_COMMENT_PREFIX))),
+                        $lineNumber + 1,
+                    );
+                }
+
+                if (str_starts_with($line, self::FILENAME_COMMENT_PREFIX)) {
+                    $sourceFilename = trim(substr($line, strlen(self::FILENAME_COMMENT_PREFIX)));
+                }
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        return null;
+    }
+
+    private function extractFromSiblingFiles(string $filename): SourceMapInformation
+    {
+        $mapFile = sprintf('%s.map', $filename);
+        $sourceFile = str_replace('.php', '.phel', $filename);
+
+        if (!is_file($mapFile) || !is_file($sourceFile)) {
+            return SourceMapInformation::none();
+        }
+
+        $mappings = file_get_contents($mapFile);
+
+        if ($mappings === false || trim($mappings) === '') {
+            return SourceMapInformation::none();
+        }
 
         return new SourceMapInformation(
-            $filenameComment === false ? '' : $filenameComment,
-            $sourceMapComment === false ? '' : $sourceMapComment,
+            $sourceFile,
+            trim($mappings),
+            self::BUILT_FILE_CODE_START_LINE,
         );
     }
 }

--- a/src/php/Command/Infrastructure/SourceMapExtractor.php
+++ b/src/php/Command/Infrastructure/SourceMapExtractor.php
@@ -76,6 +76,9 @@ final class SourceMapExtractor implements SourceMapExtractorInterface
                     return null;
                 }
 
+                // The mappings check must come first: FILENAME_COMMENT_PREFIX
+                // is a prefix of MAPPINGS_COMMENT_PREFIX, so reversing the
+                // order would capture the mappings line as a filename.
                 if (str_starts_with($line, self::MAPPINGS_COMMENT_PREFIX)) {
                     if ($sourceFilename === '') {
                         return null;

--- a/src/php/Compiler/Domain/Emitter/EmitterResult.php
+++ b/src/php/Compiler/Domain/Emitter/EmitterResult.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Emitter;
 
+use Phel\Shared\SourceMap\InlineSourceMapComments;
+
 final readonly class EmitterResult
 {
     public function __construct(
@@ -27,8 +29,8 @@ final readonly class EmitterResult
     {
         if ($this->enableSourceMaps) {
             return (
-                '// ' . $this->source . "\n"
-                . '// ;;' . $this->sourceMap . "\n"
+                InlineSourceMapComments::FILENAME_PREFIX . $this->source . "\n"
+                . InlineSourceMapComments::MAPPINGS_PREFIX . $this->sourceMap . "\n"
                 . $this->phpCode
             );
         }

--- a/src/php/Compiler/Domain/Evaluator/Exceptions/EvaluatedCodeException.php
+++ b/src/php/Compiler/Domain/Evaluator/Exceptions/EvaluatedCodeException.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Evaluator\Exceptions;
 
 use Phel\Compiler\Domain\Emitter\OutputEmitter\SourceMap\SourceMapConsumer;
+use Phel\Shared\SourceMap\InlineSourceMapComments;
 use RuntimeException;
 use Throwable;
 
 use function explode;
 use function str_starts_with;
+use function strlen;
 use function substr;
 use function trim;
 
@@ -64,20 +66,23 @@ final class EvaluatedCodeException extends RuntimeException
         $filenameComment = $lines[0];
         $sourceMapComment = $lines[1] ?? '';
 
-        $file = str_starts_with($filenameComment, '// ')
-            ? trim(substr($filenameComment, 3))
+        $file = str_starts_with($filenameComment, InlineSourceMapComments::FILENAME_PREFIX)
+            ? trim(substr($filenameComment, strlen(InlineSourceMapComments::FILENAME_PREFIX)))
             : 'string';
 
-        if (!str_starts_with($sourceMapComment, '// ;;')) {
+        if (!str_starts_with($sourceMapComment, InlineSourceMapComments::MAPPINGS_PREFIX)) {
             return [$file, $generatedLine];
         }
 
-        $mapping = trim(substr($sourceMapComment, 3));
-        if ($mapping === '' || $mapping === ';;') {
+        $mappings = trim(substr($sourceMapComment, strlen(InlineSourceMapComments::MAPPINGS_PREFIX)));
+        if ($mappings === '') {
             return [$file, $generatedLine];
         }
 
-        $consumer = new SourceMapConsumer($mapping);
+        // The two metadata comment lines sit above the generated code, so the
+        // `;;` padding shifts the mapping by two lines and lets the consumer
+        // take raw eval line numbers directly.
+        $consumer = new SourceMapConsumer(';;' . $mappings);
         $originalLine = $consumer->getOriginalLine($generatedLine);
 
         return [$file, $originalLine ?? $generatedLine];

--- a/src/php/Shared/CLAUDE.md
+++ b/src/php/Shared/CLAUDE.md
@@ -64,6 +64,9 @@ Strategy pattern via `TypePrinter/`: one class per Phel/PHP type; `WithColorTrai
 - `VersionResolver`: gathers the ambient version inputs (git working copy, Composer `InstalledVersions`, build-time `.phel-release.php`/`OFFICIAL_RELEASE`) and returns `VersionFinder::getVersion()`. Both Console and Run consume it directly, so neither owns version-detection wiring
 - `CompileOptions`: constants for source maps, emit-only mode, optimization levels
 - `SourceMap/VLQ`: pure Base64-VLQ codec (`decode`, `encodeIntegers`, `encodeInteger`); stateless, no module deps. Consumed by Compiler's `SourceMapGenerator`/`SourceMapConsumer`
+- `SourceMap/SourceMapSiblings`: naming convention for the `<file>.php.map` + `<file>.phel` artifacts next to built files. Written by Build (`FileCompiler`, `SecondaryFileHarvester`), read by Command (`SourceMapExtractor`)
+- `SourceMap/BuiltFilePreamble`: the fixed `<?php declare(strict_types=1);` line before generated code in built files; `prepend()` for the writer (`FileCompiler`), `codeStartLine()` for the reader (`SourceMapExtractor`)
+- `SourceMap/InlineSourceMapComments`: `// `/`// ;;` metadata comment prefixes for inline source maps in eval'd code. Written by Compiler's `EmitterResult`, parsed by `SourceMapExtractor` and `EvaluatedCodeException`
 - `PhpAttributeRenderer`: renders `^{:php/attr ...}` metadata specs into PHP 8 attribute source lines (`#[\ORM\Column(length: 255)]`); pure, stateless. Accepts a bare keyword (`:ORM/Entity`), a single spec vector (`[:ORM/Column {:length 255}]`, first element is the name keyword), or a vector of specs (`[[:ORM/Id] [:ORM/Column]]`). Consumed by `DefStructEmitter`/`DefInterfaceEmitter` and the Interop export generator
 
 ## Dependencies

--- a/src/php/Shared/SourceMap/BuiltFilePreamble.php
+++ b/src/php/Shared/SourceMap/BuiltFilePreamble.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared\SourceMap;
+
+use function substr_count;
+
+/**
+ * The fixed first line(s) `phel build` writes before the generated code of
+ * every compiled PHP file. The build prepends it (FileCompiler) and the error
+ * printer subtracts it again to translate runtime trace lines into source-map
+ * lines (SourceMapExtractor), so the layout lives here in Shared: growing the
+ * preamble automatically keeps both sides in sync.
+ */
+final class BuiltFilePreamble
+{
+    private const string CONTENT = "<?php declare(strict_types=1);\n";
+
+    private function __construct() {}
+
+    public static function prepend(string $phpCode): string
+    {
+        return self::CONTENT . $phpCode;
+    }
+
+    /**
+     * 1-based line in a built file where the generated code begins.
+     */
+    public static function codeStartLine(): int
+    {
+        return substr_count(self::CONTENT, "\n") + 1;
+    }
+}

--- a/src/php/Shared/SourceMap/InlineSourceMapComments.php
+++ b/src/php/Shared/SourceMap/InlineSourceMapComments.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared\SourceMap;
+
+/**
+ * Comment prefixes for the inline source-map metadata embedded in eval'd
+ * code: a `// <source>` filename comment followed by a `// ;;<mappings>`
+ * comment. The emitter writes them (EmitterResult) and the error printers
+ * parse them back (SourceMapExtractor, EvaluatedCodeException), so the
+ * convention lives here in Shared.
+ *
+ * Note that FILENAME_PREFIX is a prefix of MAPPINGS_PREFIX, so readers must
+ * check for the mappings prefix first.
+ */
+final class InlineSourceMapComments
+{
+    public const string FILENAME_PREFIX = '// ';
+
+    public const string MAPPINGS_PREFIX = '// ;;';
+
+    private function __construct() {}
+}

--- a/src/php/Shared/SourceMap/SourceMapSiblings.php
+++ b/src/php/Shared/SourceMap/SourceMapSiblings.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Shared\SourceMap;
 
-use function sprintf;
 use function str_ends_with;
 use function strlen;
 use function substr;
@@ -28,7 +27,7 @@ final class SourceMapSiblings
 
     public static function mapFile(string $compiledFile): string
     {
-        return sprintf('%s%s', $compiledFile, self::MAP_SUFFIX);
+        return $compiledFile . self::MAP_SUFFIX;
     }
 
     public static function sourceFile(string $compiledFile): string
@@ -37,6 +36,6 @@ final class SourceMapSiblings
             $compiledFile = substr($compiledFile, 0, -strlen(self::PHP_SUFFIX));
         }
 
-        return sprintf('%s%s', $compiledFile, self::PHEL_SUFFIX);
+        return $compiledFile . self::PHEL_SUFFIX;
     }
 }

--- a/src/php/Shared/SourceMap/SourceMapSiblings.php
+++ b/src/php/Shared/SourceMap/SourceMapSiblings.php
@@ -24,6 +24,8 @@ final class SourceMapSiblings
 
     private const string MAP_SUFFIX = '.map';
 
+    private function __construct() {}
+
     public static function mapFile(string $compiledFile): string
     {
         return sprintf('%s%s', $compiledFile, self::MAP_SUFFIX);

--- a/src/php/Shared/SourceMap/SourceMapSiblings.php
+++ b/src/php/Shared/SourceMap/SourceMapSiblings.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared\SourceMap;
+
+use function sprintf;
+use function str_ends_with;
+use function strlen;
+use function substr;
+
+/**
+ * Naming convention for the artifacts `phel build` writes next to each
+ * compiled PHP file: the VLQ source map (`<file>.php.map`) and a copy of the
+ * Phel source (`<file>.phel`). The build writes them (FileCompiler) and the
+ * error printer reads them back (SourceMapExtractor), so the convention lives
+ * here in Shared.
+ */
+final class SourceMapSiblings
+{
+    private const string PHP_SUFFIX = '.php';
+
+    private const string PHEL_SUFFIX = '.phel';
+
+    private const string MAP_SUFFIX = '.map';
+
+    public static function mapFile(string $compiledFile): string
+    {
+        return sprintf('%s%s', $compiledFile, self::MAP_SUFFIX);
+    }
+
+    public static function sourceFile(string $compiledFile): string
+    {
+        if (str_ends_with($compiledFile, self::PHP_SUFFIX)) {
+            $compiledFile = substr($compiledFile, 0, -strlen(self::PHP_SUFFIX));
+        }
+
+        return sprintf('%s%s', $compiledFile, self::PHEL_SUFFIX);
+    }
+}

--- a/tests/php/Integration/Command/Domain/Extractor/BuiltOutputSourceMapTest.php
+++ b/tests/php/Integration/Command/Domain/Extractor/BuiltOutputSourceMapTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Command\Domain\Extractor;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractor;
+use Phel\Command\Infrastructure\SourceMapExtractor;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+use function file;
+use function mkdir;
+use function sprintf;
+use function str_contains;
+use function sys_get_temp_dir;
+use function uniqid;
+
+/**
+ * End-to-end check that exception positions inside `phel build` output can be
+ * mapped back to the Phel source through the sibling `<file>.php.map` and
+ * `<file>.phel` artifacts the build writes next to each compiled file.
+ */
+final class BuiltOutputSourceMapTest extends TestCase
+{
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function test_built_output_position_maps_back_to_sibling_phel_source(): void
+    {
+        Phel::bootstrap(__DIR__);
+
+        $srcFile = __DIR__ . '/Fixtures/main.phel';
+        $outDir = sys_get_temp_dir() . '/phel-built-source-map-' . uniqid();
+        mkdir($outDir);
+        $dest = $outDir . '/main.php';
+
+        new BuildFacade()->compileFile($srcFile, $dest);
+
+        self::assertFileExists($dest . '.map');
+        self::assertFileExists($outDir . '/main.phel');
+
+        // The compiled `(php/+ a b)` expression is the only generated line
+        // containing a `+` operator; a runtime error there would report this line.
+        $generatedLine = $this->findLineContaining($dest, ' + ');
+        $expectedPhelLine = $this->findLineContaining($srcFile, 'php/+');
+
+        $position = new FilePositionExtractor(new SourceMapExtractor())
+            ->getOriginal($dest, $generatedLine);
+
+        self::assertSame($outDir . '/main.phel', $position->filename());
+        self::assertSame($expectedPhelLine, $position->line());
+    }
+
+    private function findLineContaining(string $file, string $needle): int
+    {
+        foreach ((array) file($file) as $index => $line) {
+            if (str_contains((string) $line, $needle)) {
+                return $index + 1;
+            }
+        }
+
+        self::fail(sprintf("No line containing '%s' in %s", $needle, $file));
+    }
+}

--- a/tests/php/Integration/Command/Domain/Extractor/BuiltOutputSourceMapTest.php
+++ b/tests/php/Integration/Command/Domain/Extractor/BuiltOutputSourceMapTest.php
@@ -12,12 +12,16 @@ use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
+use function array_map;
 use function file;
+use function glob;
 use function mkdir;
+use function rmdir;
 use function sprintf;
 use function str_contains;
 use function sys_get_temp_dir;
 use function uniqid;
+use function unlink;
 
 /**
  * End-to-end check that exception positions inside `phel build` output can be
@@ -26,6 +30,16 @@ use function uniqid;
  */
 final class BuiltOutputSourceMapTest extends TestCase
 {
+    private string $outDir = '';
+
+    protected function tearDown(): void
+    {
+        if ($this->outDir !== '') {
+            array_map(unlink(...), glob($this->outDir . '/*') ?: []);
+            rmdir($this->outDir);
+        }
+    }
+
     #[RunInSeparateProcess]
     #[PreserveGlobalState(false)]
     public function test_built_output_position_maps_back_to_sibling_phel_source(): void
@@ -33,8 +47,9 @@ final class BuiltOutputSourceMapTest extends TestCase
         Phel::bootstrap(__DIR__);
 
         $srcFile = __DIR__ . '/Fixtures/main.phel';
-        $outDir = sys_get_temp_dir() . '/phel-built-source-map-' . uniqid();
-        mkdir($outDir);
+        $this->outDir = sys_get_temp_dir() . '/phel-built-source-map-' . uniqid();
+        mkdir($this->outDir);
+        $outDir = $this->outDir;
         $dest = $outDir . '/main.php';
 
         new BuildFacade()->compileFile($srcFile, $dest);

--- a/tests/php/Integration/Command/Domain/Extractor/Fixtures/main.phel
+++ b/tests/php/Integration/Command/Domain/Extractor/Fixtures/main.phel
@@ -1,0 +1,6 @@
+(ns sourcemap.fixture)
+
+(def a 1)
+(def b 2)
+
+(php/+ a b)

--- a/tests/php/Unit/Command/Domain/Exceptions/Extractor/FilePositionExtractorTest.php
+++ b/tests/php/Unit/Command/Domain/Exceptions/Extractor/FilePositionExtractorTest.php
@@ -12,46 +12,74 @@ use PHPUnit\Framework\TestCase;
 
 final class FilePositionExtractorTest extends TestCase
 {
-    public function test_get_original(): void
+    public function test_returns_input_position_when_no_source_map(): void
     {
         $extractor = new FilePositionExtractor(
-            $this->stubSourceMapExtractor(),
+            $this->stubSourceMapExtractor(SourceMapInformation::none()),
         );
 
-        $filename = '/example-module-name/file-name.phel';
-        $line = 1;
-
         self::assertEquals(
-            new FilePosition($filename, $line),
-            $extractor->getOriginal($filename, $line),
+            new FilePosition('/example-module-name/file-name.php', 1),
+            $extractor->getOriginal('/example-module-name/file-name.php', 1),
         );
     }
 
-    public function test_get_original_with_file_name_comment(): void
+    public function test_replaces_filename_when_no_mappings_available(): void
     {
         $extractor = new FilePositionExtractor(
-            $this->stubSourceMapExtractor(
-                '// file-name/comment',
-            ),
+            $this->stubSourceMapExtractor(new SourceMapInformation('/src/main.phel', '')),
         );
 
-        $filename = '/example-module-name/file-name.phel';
-        $line = 1;
-
         self::assertEquals(
-            new FilePosition('file-name/comment', $line),
-            $extractor->getOriginal($filename, $line),
+            new FilePosition('/src/main.phel', 7),
+            $extractor->getOriginal('/tmp/__phel_abc.php', 7),
         );
     }
 
-    private function stubSourceMapExtractor(
-        string $filename = '',
-        string $sourceMap = '',
-    ): SourceMapExtractorInterface {
-        $sourceMapExtractor = $this->createMock(SourceMapExtractorInterface::class);
+    public function test_maps_line_through_mappings_relative_to_code_start(): void
+    {
+        // 'AACA' maps generated line 1 to original line 2; the generated code
+        // starts at file line 4, so trace line 4 is generated line 1.
+        $extractor = new FilePositionExtractor(
+            $this->stubSourceMapExtractor(new SourceMapInformation('/src/main.phel', 'AACA', 4)),
+        );
+
+        self::assertEquals(
+            new FilePosition('/src/main.phel', 2),
+            $extractor->getOriginal('/tmp/__phel_abc.php', 4),
+        );
+    }
+
+    public function test_keeps_line_when_mappings_have_no_entry_for_it(): void
+    {
+        $extractor = new FilePositionExtractor(
+            $this->stubSourceMapExtractor(new SourceMapInformation('/src/main.phel', 'AACA', 4)),
+        );
+
+        self::assertEquals(
+            new FilePosition('/src/main.phel', 9),
+            $extractor->getOriginal('/tmp/__phel_abc.php', 9),
+        );
+    }
+
+    public function test_keeps_line_when_trace_line_is_before_code_start(): void
+    {
+        $extractor = new FilePositionExtractor(
+            $this->stubSourceMapExtractor(new SourceMapInformation('/src/main.phel', 'AACA', 4)),
+        );
+
+        self::assertEquals(
+            new FilePosition('/src/main.phel', 2),
+            $extractor->getOriginal('/tmp/__phel_abc.php', 2),
+        );
+    }
+
+    private function stubSourceMapExtractor(SourceMapInformation $info): SourceMapExtractorInterface
+    {
+        $sourceMapExtractor = $this->createStub(SourceMapExtractorInterface::class);
         $sourceMapExtractor
             ->method('extractFromFile')
-            ->willReturn(new SourceMapInformation($filename, $sourceMap));
+            ->willReturn($info);
 
         return $sourceMapExtractor;
     }

--- a/tests/php/Unit/Command/Infrastructure/SourceMapExtractorTest.php
+++ b/tests/php/Unit/Command/Infrastructure/SourceMapExtractorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Command\Infrastructure;
+
+use Phel\Command\Domain\Exceptions\Extractor\ReadModel\SourceMapInformation;
+use Phel\Command\Infrastructure\SourceMapExtractor;
+use PHPUnit\Framework\TestCase;
+
+use function file_put_contents;
+use function mkdir;
+use function sys_get_temp_dir;
+use function uniqid;
+
+final class SourceMapExtractorTest extends TestCase
+{
+    private string $dir;
+
+    private SourceMapExtractor $extractor;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/phel-source-map-extractor-' . uniqid();
+        mkdir($this->dir);
+        $this->extractor = new SourceMapExtractor();
+    }
+
+    public function test_extracts_inline_metadata_from_eval_temp_file(): void
+    {
+        $file = $this->dir . '/__phel_abc.php';
+        file_put_contents($file, "<?php\n// /src/main.phel\n// ;;AACA\n\$x = 1;\n");
+
+        $info = $this->extractor->extractFromFile($file);
+
+        self::assertSame('/src/main.phel', $info->filename());
+        self::assertSame('AACA', $info->mappings());
+        self::assertSame(4, $info->codeStartLine());
+    }
+
+    public function test_extracts_inline_metadata_below_declare_statement(): void
+    {
+        $file = $this->dir . '/__phel_ticks.php';
+        file_put_contents($file, "<?php\ndeclare(ticks=1);\n// /src/main.phel\n// ;;AACA\n\$x = 1;\n");
+
+        $info = $this->extractor->extractFromFile($file);
+
+        self::assertSame('/src/main.phel', $info->filename());
+        self::assertSame('AACA', $info->mappings());
+        self::assertSame(5, $info->codeStartLine());
+    }
+
+    public function test_extracts_sibling_map_and_phel_files_from_built_output(): void
+    {
+        $file = $this->dir . '/main.php';
+        file_put_contents($file, "<?php declare(strict_types=1);\n\$x = 1;\n");
+        file_put_contents($file . '.map', ';AACA');
+        file_put_contents($this->dir . '/main.phel', "(ns app\\main)\n(def x 1)\n");
+
+        $info = $this->extractor->extractFromFile($file);
+
+        self::assertSame($this->dir . '/main.phel', $info->filename());
+        self::assertSame(';AACA', $info->mappings());
+        self::assertSame(2, $info->codeStartLine());
+    }
+
+    public function test_returns_none_for_built_output_without_phel_sibling(): void
+    {
+        $file = $this->dir . '/orphan.php';
+        file_put_contents($file, "<?php declare(strict_types=1);\n\$x = 1;\n");
+        file_put_contents($file . '.map', ';AACA');
+
+        self::assertEquals(SourceMapInformation::none(), $this->extractor->extractFromFile($file));
+    }
+
+    public function test_returns_none_for_plain_php_file(): void
+    {
+        $file = $this->dir . '/vendor.php';
+        file_put_contents($file, "<?php\n\$x = 1;\n");
+
+        self::assertEquals(SourceMapInformation::none(), $this->extractor->extractFromFile($file));
+    }
+
+    public function test_returns_none_for_missing_file(): void
+    {
+        self::assertEquals(
+            SourceMapInformation::none(),
+            $this->extractor->extractFromFile($this->dir . '/does-not-exist.php'),
+        );
+    }
+}

--- a/tests/php/Unit/Command/Infrastructure/SourceMapExtractorTest.php
+++ b/tests/php/Unit/Command/Infrastructure/SourceMapExtractorTest.php
@@ -8,10 +8,14 @@ use Phel\Command\Domain\Exceptions\Extractor\ReadModel\SourceMapInformation;
 use Phel\Command\Infrastructure\SourceMapExtractor;
 use PHPUnit\Framework\TestCase;
 
+use function array_map;
 use function file_put_contents;
+use function glob;
 use function mkdir;
+use function rmdir;
 use function sys_get_temp_dir;
 use function uniqid;
+use function unlink;
 
 final class SourceMapExtractorTest extends TestCase
 {
@@ -24,6 +28,12 @@ final class SourceMapExtractorTest extends TestCase
         $this->dir = sys_get_temp_dir() . '/phel-source-map-extractor-' . uniqid();
         mkdir($this->dir);
         $this->extractor = new SourceMapExtractor();
+    }
+
+    protected function tearDown(): void
+    {
+        array_map(unlink(...), glob($this->dir . '/*') ?: []);
+        rmdir($this->dir);
     }
 
     public function test_extracts_inline_metadata_from_eval_temp_file(): void

--- a/tests/php/Unit/Shared/SourceMap/BuiltFilePreambleTest.php
+++ b/tests/php/Unit/Shared/SourceMap/BuiltFilePreambleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared\SourceMap;
+
+use Phel\Shared\SourceMap\BuiltFilePreamble;
+use PHPUnit\Framework\TestCase;
+
+use function explode;
+use function substr_count;
+
+final class BuiltFilePreambleTest extends TestCase
+{
+    public function test_prepend_puts_generated_code_after_php_opener(): void
+    {
+        $built = BuiltFilePreamble::prepend("echo 'hi';\n");
+
+        self::assertStringStartsWith('<?php ', $built);
+        self::assertStringEndsWith("\necho 'hi';\n", $built);
+    }
+
+    public function test_code_start_line_matches_prepended_layout(): void
+    {
+        $built = BuiltFilePreamble::prepend('generated code');
+
+        self::assertSame(
+            'generated code',
+            explode("\n", $built)[BuiltFilePreamble::codeStartLine() - 1],
+        );
+    }
+
+    public function test_preamble_is_a_single_line(): void
+    {
+        self::assertSame(1, substr_count(BuiltFilePreamble::prepend(''), "\n"));
+        self::assertSame(2, BuiltFilePreamble::codeStartLine());
+    }
+}

--- a/tests/php/Unit/Shared/SourceMap/SourceMapSiblingsTest.php
+++ b/tests/php/Unit/Shared/SourceMap/SourceMapSiblingsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared\SourceMap;
+
+use Phel\Shared\SourceMap\SourceMapSiblings;
+use PHPUnit\Framework\TestCase;
+
+final class SourceMapSiblingsTest extends TestCase
+{
+    public function test_map_file_appends_map_suffix(): void
+    {
+        self::assertSame('/out/phel/json.php.map', SourceMapSiblings::mapFile('/out/phel/json.php'));
+    }
+
+    public function test_source_file_replaces_php_suffix(): void
+    {
+        self::assertSame('/out/phel/json.phel', SourceMapSiblings::sourceFile('/out/phel/json.php'));
+    }
+
+    public function test_source_file_only_touches_the_suffix(): void
+    {
+        self::assertSame('/out/x.php-dir/main.phel', SourceMapSiblings::sourceFile('/out/x.php-dir/main.php'));
+    }
+
+    public function test_source_file_appends_suffix_when_file_is_not_php(): void
+    {
+        self::assertSame('/out/main.txt.phel', SourceMapSiblings::sourceFile('/out/main.txt'));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`phel build` writes a `<file>.php.map` (VLQ source map) and a `<file>.phel` (source copy) next to every compiled file, but nothing ever read them: the error printer's `SourceMapExtractor` only looks at the first two lines of the failing PHP file for inline `// ` metadata comments, which built files don't have. So runtime errors in built output always pointed at generated PHP lines, and the `.map` artifacts were dead weight.

On top of that, the inline path was broken too: eval temp files start with `<?php` (and optionally `declare(ticks=1);`), so the metadata comments sit on lines 2-3 (or 3-4), where the two-line reader never found them.

## 💡 Goal

Make the existing source-map artifacts earn their keep: runtime errors in built output report `out/foo.phel:42` instead of the generated PHP line, and inline source maps in eval temp files are detected again.

## 🔖 Changes

- `SourceMapExtractor` now scans the first header lines of the compiled file for the `// <source>` + `// ;;<mappings>` comment pair (skipping the `<?php` opener and declare statements), and falls back to the sibling `<file>.map` + `<file>.phel` artifacts written by `FileCompiler` for built output.
- `SourceMapInformation` is now a normalized read model (original filename, raw VLQ mappings, 1-based code start line) instead of two raw comment lines, so `FilePositionExtractor` does a single well-defined line translation: `traceLine - (codeStartLine - 1)` through `SourceMapConsumer`.
- Unit tests for both extraction layouts plus edge cases (missing file, plain PHP file, orphan `.map` without `.phel` sibling), and an end-to-end integration test that compiles a fixture via `BuildFacade` and asserts the mapped position lands on the right `.phel` line.
- CHANGELOG entry under `## Unreleased`; Command module doc updated.

Follow-up candidate (not in this PR): `phel run` with the compiled-code cache enabled compiles with source maps disabled (`FileEvaluator::compileForCache`), so cache-hit traces remain unmapped.