### PR TITLE
docs(modules): dedupe and tighten module CLAUDE.md files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,5 @@ agnostic-ai.local.yaml
 .claude/
 .codex/
 .agents/
-CLAUDE.md
-AGENTS.md
+/CLAUDE.md
+/AGENTS.md

--- a/src/php/Api/CLAUDE.md
+++ b/src/php/Api/CLAUDE.md
@@ -2,58 +2,24 @@
 
 REPL autocompletion, function introspection, documentation, and user-code semantic analysis (diagnostics, project index, jump-to-def, find-references, completion at point).
 
-## Gacela Pattern
-
-- **Facade**: `ApiFacade` implements `ApiFacadeInterface`
-- **Factory**: `ApiFactory` extends `AbstractFactory<ApiConfig>`
-- **Config**: `ApiConfig.allNamespaces()` lists 24 documented namespaces; `githubRef()` returns latest version
-- **Provider**: `ApiProvider` injects `RunFacade` and `CompilerFacade`
-
 ## Public API (Facade)
 
-| Method | Returns | Purpose |
-|--------|---------|---------|
-| `replComplete(string)` | `list<string>` | Basic REPL autocompletion |
-| `replCompleteWithTypes(string)` | `list<CompletionResultTransfer>` | Completion with type info for nREPL |
-| `getPhelFunctions(list<string> = [])` | `list<PhelFunction>` | All public Phel functions, optionally filtered by namespace |
-| `analyzeSource(string, string)` | `list<Diagnostic>` | Parse and analyze, return diagnostics |
-| `findSymbolMetadata(string, string = 'user')` | `?PhelFunction` | Symbol lookup in registry and static catalog |
-| `indexProject(list<string>)` | `ProjectIndex` | Build project-level symbol index from source dirs |
-| `resolveSymbol(ProjectIndex, string, string)` | `?Definition` | Jump to definition |
-| `findReferences(ProjectIndex, string, string)` | `list<Location>` | Find all reference sites of a symbol |
-| `completeAtPoint(string, int, int, ProjectIndex)` | `list<Completion>` | Context-aware completion (locals, project defs, phel.core) |
-| `createApiDaemon()` | `ApiDaemon` | Long-running JSON-RPC daemon |
+- `replComplete(string)` / `replCompleteWithTypes(string)`: REPL autocompletion, plain or with type info (nREPL)
+- `getPhelFunctions(list<string> = [])`: all public Phel functions, optionally filtered by namespace
+- `analyzeSource(string, string): list<Diagnostic>`: parse and analyze, return diagnostics
+- `findSymbolMetadata(string, string = 'user')`: symbol lookup in registry and static catalog
+- `indexProject`, `resolveSymbol`, `findReferences`, `completeAtPoint`: project-level symbol tooling (`ProjectIndex`, `Definition`, `Location`, `Completion` transfers)
+- `createApiDaemon()`: long-running JSON-RPC daemon
 
 ## Dependencies
 
-- **Run** (RunFacade): namespace resolution, directory listing
-- **Compiler** (CompilerFacade): lex, parse, read, analyze phases
-
-## Structure
-
-```
-Api/
-├── Application/
-│   ├── Analysis/              Pluggable analysis stages (LexAndParseStage, ReadAndAnalyzeStage, etc.)
-│   ├── SourceAnalyzer          Pipeline runner for analysis stages
-│   ├── ReplCompleter, PointCompleter, SymbolMetadataFinder
-│   ├── ProjectIndexer, SymbolResolver, ReferenceFinder, SymbolExtractor
-│   └── PhelFnNormalizer, PhelFnGroupKeyGenerator, PhpSymbolCatalog
-├── Domain/                     Interface contracts and exception types
-├── Infrastructure/
-│   ├── Command/                CLI commands (Doc, Analyze, Index)
-│   ├── Daemon/                 ApiDaemon (JSON-RPC server)
-│   ├── phel/                   Phel-native helpers
-│   ├── PhelFnLoader            Merges runtime + native symbol metadata (thin loader)
-│   └── NativeSymbolCatalog     Static doc table for special forms / built-ins (no .phel source)
-├── Transfer/                   DTO contracts (PhelFunction, Diagnostic, Definition, ProjectIndex, etc.)
-└── Gacela files                ApiFacade, ApiFactory, ApiConfig, ApiProvider
-```
+Run (namespace resolution, directory listing), Compiler (lex, parse, read, analyze phases). `ApiConfig.allNamespaces()` lists the 24 documented namespaces; `githubRef()` returns latest version.
 
 ## Key Constraints
 
-- `SourceAnalyzer` takes `list<AnalysisStageInterface>` (add/remove in `ApiFactory::createSourceAnalyzer()`)
+- `SourceAnalyzer` runs a pipeline of `list<AnalysisStageInterface>` (`Application/Analysis/`); add/remove stages in `ApiFactory::createSourceAnalyzer()`
+- Analysis routes through `CompilerFacade` phases only
+- `Infrastructure/NativeSymbolCatalog`: static doc table for special forms / built-ins with no `.phel` source; special forms (`load`, `in-ns`, `use`) need an entry here to show in `phel doc`. `PhelFnLoader` merges it with runtime metadata
 - `ProjectIndexer` re-indexes from scratch; caching hook at `SymbolExtractor` call-site
 - `ReplCompleter` lazy-loads Phel functions, caches PHP builtin catalog
 - `PhelFnNormalizer` normalizes Phel function metadata with group keys and GitHub ref
-- Analysis routes through `CompilerFacade` phases only

--- a/src/php/Build/CLAUDE.md
+++ b/src/php/Build/CLAUDE.md
@@ -1,56 +1,25 @@
 # Build Module
 
-Core orchestrator for compiling Phel projects to PHP: dependency resolution, caching, namespace extraction.
-
-## Gacela Pattern
-
-- **Facade**: `BuildFacade` (implements `BuildFacadeInterface`)
-- **Factory**: `BuildFactory` (extends `AbstractFactory<BuildConfig>`)
-- **Config**: `BuildConfig` (cache/temp dirs, namespace cache flags, paths to ignore, entry point detection)
-- **Provider**: `BuildProvider` (injects `CompilerFacade`, `CommandFacade`)
+Compiles Phel projects to PHP: dependency resolution, caching, namespace extraction.
 
 ## Public API (Facade)
 
-| Method | Return | Purpose |
-|--------|--------|---------|
-| `getNamespaceFromFile(string $filename)` | `NamespaceInformation` | Extract namespace from single file |
-| `getNamespaceFromDirectories(array $dirs)` | `NamespaceInformation[]` | Extract all namespaces from dirs |
-| `getDependenciesForNamespace(array $dirs, array $ns)` | `NamespaceInformation[]` | Topologically sorted dependencies for namespaces |
-| `compileFile(string $src, string $dest)` | `CompiledFile` | Compile single file to PHP, write to dest |
-| `evalFile(string $src)` | `CompiledFile` | Compile without writing output |
-| `compileProject(BuildOptions $opts)` | `CompiledFile[]` | Compile entire project |
-| `writeLocatedException(OutputInterface, CompilerException)` | `void` | Delegate exception formatting to Command |
-| `writeStackTrace(OutputInterface, Throwable)` | `void` | Delegate stack trace formatting to Command |
-| `clearCache()` | `string[]` | Paths cleared from temp/cache dirs |
-| `getOutputDirectory()` | `string` | Delegate to Command facade |
-| `getHealthCheck()` | `ModuleHealthCheckInterface` | Cache, output, source dir health checks |
-
-> `NamespaceInformation` (the VO returned by the extraction methods above) lives in `Phel\Shared`, not this module. Build produces it; `Domain/Extractor/` imports it from Shared.
+- `getNamespaceFromFile(string)` / `getNamespaceFromDirectories(array)`: extract `NamespaceInformation` (the VO lives in `Phel\Shared`, not here; Build produces it)
+- `getDependenciesForNamespace(array $dirs, array $ns)`: topologically sorted dependencies
+- `compileFile(src, dest)` / `evalFile(src)` / `compileProject(BuildOptions)`: compile to PHP (evalFile skips writing output)
+- `clearCache(): string[]`: paths cleared from temp/cache dirs
+- `getHealthCheck()`: cache, output, source dir checks
+- `writeLocatedException` / `writeStackTrace` / `getOutputDirectory`: delegate to Command facade
 
 ## Dependencies
 
-| Name | Injected as | Purpose |
-|------|-------------|---------|
-| Compiler | `CompilerFacade` (via Provider) | Phel-to-PHP compilation |
-| Command | `CommandFacade` (via Provider) | Output/source dirs, error formatting |
-
-## Structure
-
-```
-Build/
-├── Application/        ProjectCompiler, FileCompiler, FileEvaluator, NamespaceExtractor (cached)
-├── Domain/             Cache/, Compile/, Extractor/, IO/ (interfaces, value objects, sorters)
-├── Infrastructure/     Cache/, IO/ (concrete implementations)
-│                       Cache/ `CompiledCodeCache` is the policy orchestrator; it delegates to
-│                       `CacheDirectory` (layout), `CacheIndexFile` (index load/save/merge),
-│                       `NamespaceEnvironmentStore` (env data), `CachePathResolver`, `AtomicFileWriter`
-└── Gacela files        Facade, Factory, Config, Provider
-```
+Compiler (Phel-to-PHP compilation), Command (output/source dirs, error formatting).
 
 ## Key Constraints
 
 - Two-level caching: namespace extraction (optional) + compiled code (optional)
+- `Infrastructure/Cache/CompiledCodeCache` is the policy orchestrator; delegates to `CacheDirectory` (layout), `CacheIndexFile` (index load/save/merge), `NamespaceEnvironmentStore` (env data), `CachePathResolver`, `AtomicFileWriter`
 - `TopologicalNamespaceSorter` orders compilation to resolve dependencies
 - `FileEvaluator` is singleton; repeated `(load ...)` calls reuse instance to preserve compiled-code index
 - Auto-detect main namespace: scans source dirs for `core.phel` or `main.phel`
-- Excluded paths in extraction: output directory pruned to prevent namespace shadowing
+- Output directory pruned from extraction to prevent namespace shadowing

--- a/src/php/CLAUDE.md
+++ b/src/php/CLAUDE.md
@@ -1,0 +1,42 @@
+# PHP Modules
+
+Each directory under `src/php/` is a module. The conventions here apply to all of them; each module's own CLAUDE.md documents only deviations and knowledge you cannot derive from the code.
+
+## Gacela Convention
+
+Unless a module says "No Gacela Pattern", it follows this wiring:
+
+- `XFacade implements XFacadeInterface`; core interfaces (Compiler, Build, Run, Command, Console, Formatter, Interop, Api) live in `Phel\Shared\Facade` (dependency inversion); Fiber/Filesystem keep theirs in the module root; newer modules (Lint, Lsp, Nrepl, Profile, Watch) extend `AbstractFacade` without an interface.
+- `XFactory extends AbstractFactory<XConfig>`; `XConfig` reads module settings.
+- `XProvider` exposes cross-module facades via `FACADE_*` constants; modules list these under "Dependencies".
+- Layered layout: `Application/` (use cases), `Domain/` (interfaces, value objects, logic), `Infrastructure/` (I/O, CLI commands, adapters), `Transfer/` (DTOs), Gacela files at module root.
+
+Rules:
+
+- Cross-module access goes through facades only; inject `*FacadeInterface`, never a concrete facade.
+- A Factory may only `new` classes from its own module; cross-module instances come via the injected Facade.
+- New modules add their `FacadeInterface` to `Shared/Facade/`.
+
+## Module Map
+
+| Module | Role |
+|--------|------|
+| Api | REPL completion, docs, diagnostics, project index (jump-to-def, references) |
+| Build | Compile Phel projects to PHP: dependency order, caching, namespace extraction |
+| Command | Error reporting, exception formatting, directory discovery |
+| Compiler | Pipeline: lexer → parser → reader → analyzer → simplifier → emitter |
+| Config | `PhelConfig` data model (leaf, no Gacela) |
+| Console | CLI entry point; registers commands from all modules |
+| Fiber | Promises, futures, cooperative scheduler for `phel.core` async |
+| Filesystem | Temp dir management, compiled artifact tracking |
+| Formatter | Code formatter (`phel format`) |
+| HttpClient | Stream transport for `phel.http-client` (leaf, no Gacela) |
+| Interop | PHP wrapper generation for `^{:export true}` fns |
+| Lang | Runtime types, persistent collections (leaf, no Gacela) |
+| Lint | Read-only semantic linter |
+| Lsp | LSP v3.17 server over stdio |
+| Nrepl | nREPL server (bencode over TCP) |
+| Profile | Instrumentation profiler (`phel profile`) |
+| Run | Execution, REPL, test runner, CLI commands |
+| Shared | Facade interfaces, contracts, pure utilities (leaf, no Gacela) |
+| Watch | Hot-reload file watcher |

--- a/src/php/Command/CLAUDE.md
+++ b/src/php/Command/CLAUDE.md
@@ -2,46 +2,19 @@
 
 Error reporting, exception formatting, directory discovery.
 
-## Gacela Pattern
-
-- **Facade**: `CommandFacade` implements `CommandFacadeInterface`
-- **Factory**: `CommandFactory`
-- **Config**: `CommandConfig` with code dirs, vendor dir, error log path, stale output hint
-- **Provider**: `CommandProvider` provides `PHP_CONFIG_READER`
-
 ## Public API (Facade)
 
-| Method | Returns |
-|--------|---------|
-| `writeLocatedException(OutputInterface, AbstractLocatedException, CodeSnippet)` | `void` |
-| `writeStackTrace(OutputInterface, Throwable)` | `void` |
-| `getExceptionString(AbstractLocatedException, CodeSnippet)` | `string` |
-| `getStackTraceString(Throwable)` | `string` |
-| `getExceptionPrinter()` | `ExceptionPrinterInterface` |
-| `getAllPhelDirectories()` | `array` (internal phel + project + vendor) |
-| `getSourceDirectories()` | `array` (project + vendor) |
-| `getProjectSourceDirectories()` | `array` (user-configured only) |
-| `getTestDirectories()` | `array` |
-| `getVendorSourceDirectories()` | `array` |
-| `getOutputDirectory()` | `string` |
-| `readPhelConfig(string)` | `array` |
+- Exceptions: `writeLocatedException`, `writeStackTrace`, `getExceptionString`, `getStackTraceString`, `getExceptionPrinter`
+- Directories: `getAllPhelDirectories()` (internal phel + project + vendor), `getSourceDirectories()` (project + vendor), `getProjectSourceDirectories()` (user-configured only), `getTestDirectories()`, `getVendorSourceDirectories()`, `getOutputDirectory()`
+- `readPhelConfig(string): array`
 
 ## Dependencies
 
-**Shared**: `AbstractLocatedException`, `CodeSnippet`, `Printer`, `ColorStyle`, `Munge`
-**Config**: `PhelConfig`, `PhelBuildConfig`
-
-## Structure
-
-```
-Application/     CommandExceptionWriter, DirectoryFinder, TextExceptionPrinter
-Domain/          CodeDirectories, CommandExceptionWriterInterface, Exceptions/, Finder/
-Infrastructure/  ComposerVendorDirectoriesFinder, ErrorLog, SourceMapExtractor
-```
+No facade dependencies; Provider exposes `PHP_CONFIG_READER`. Uses Shared (`AbstractLocatedException`, `CodeSnippet`, `Printer`, `ColorStyle`, `Munge`) and Config (`PhelConfig`, `PhelBuildConfig`).
 
 ## Key Constraints
 
 - `DirectoryFinder`: resolves paths, handles PHAR archives, caches results
-- `SourceMapExtractor`: maps compiled PHP back to Phel source locations; reads inline `// `/`// ;;` header comments (eval temp files) or sibling `<file>.map` + `<file>.phel` artifacts (built output)
+- `Infrastructure/SourceMapExtractor`: maps compiled PHP back to Phel source locations; reads inline `// `/`// ;;` header comments (eval temp files) or sibling `<file>.map` + `<file>.phel` artifacts (built output)
 - `TextExceptionPrinter`: renders with syntax highlighting and source pointers
 - Config includes stale output recovery hint for corrupted build state

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -2,64 +2,30 @@
 
 Core compilation pipeline: Phel source to tokens to AST to analyzed nodes to PHP code.
 
-## Gacela Pattern
-
-- **Facade**: `CompilerFacade` implements `CompilerFacadeInterface`
-- **Factory**: `CompilerFactory` extends `AbstractFactory<CompilerConfig>`
-- **Config**: `CompilerConfig` exposes `assertsEnabled()`, `warnDeprecationsEnabled()`
-- **Provider**: `CompilerProvider` injects `FilesystemFacade` via `FACADE_FILESYSTEM`
-
 ## Public API (Facade)
 
 | Category | Methods |
 |----------|---------|
-| Compilation | `compile(string, CompileOptions): EmitterResult`, `compileForCache(...)`, `compileForm(mixed, CompileOptions): EmitterResult` |
-| Evaluation | `eval(string, CompileOptions): mixed`, `evalForm(mixed, CompileOptions): mixed` |
-| Pipeline | `lexString(string, ...): TokenStream`, `parseNext(TokenStream): ?NodeInterface`, `parseAll(TokenStream): FileNode`, `read(NodeInterface): ReaderResult`, `analyze(mixed, NodeEnvironmentInterface): AbstractNode` |
-| Macros | `macroexpand1(mixed): mixed`, `macroexpand(mixed): mixed` |
-| Environment | `initializeGlobalEnvironment(): void`, `resetGlobalEnvironment(): void`, `isGlobalEnvironmentInitialized(): bool`, `getGlobalEnvironment(): GlobalEnvironmentInterface`, `initializeNewGlobalEnvironment(): GlobalEnvironmentInterface`, `setGlobalEnvironment(GlobalEnvironmentInterface): void` |
-| Namespace state | `getNamespaceEnvironmentData(string): array`, `restoreNamespaceEnvironmentData(string, array): void` |
-| Debugging | `enableDebugLineTap(?string, string): void`, `disableDebugLineTap(): void` |
-| Utility | `encodeNs(string): string` (PHP-form via `Munge::encodePhpNs`), `hasBalancedParentheses(string): bool` |
+| Compilation | `compile`, `compileForCache`, `compileForm` (return `EmitterResult`) |
+| Evaluation | `eval(string, CompileOptions)`, `evalForm(mixed, CompileOptions)` |
+| Pipeline | `lexString → TokenStream`, `parseNext → ?NodeInterface`, `parseAll → FileNode`, `read → ReaderResult`, `analyze(mixed, NodeEnvironmentInterface) → AbstractNode` |
+| Macros | `macroexpand1`, `macroexpand` |
+| Environment | `initializeGlobalEnvironment`, `resetGlobalEnvironment`, `isGlobalEnvironmentInitialized`, `getGlobalEnvironment`, `initializeNewGlobalEnvironment`, `setGlobalEnvironment` |
+| Namespace state | `getNamespaceEnvironmentData`, `restoreNamespaceEnvironmentData` |
+| Debugging | `enableDebugLineTap`, `disableDebugLineTap` |
+| Utility | `encodeNs` (PHP-form via `Munge::encodePhpNs`), `hasBalancedParentheses` |
 
 ## Dependencies
 
-- **Filesystem**: `FilesystemFacade` for file I/O
-- **Shared**: `Munge`, `Printer`, exceptions
+Filesystem (file I/O); Shared (`Munge`, `Printer`, exceptions). `CompilerConfig` exposes `assertsEnabled()`, `warnDeprecationsEnabled()`.
 
 ## Phase Pipeline
 
-| Phase | Input | Output |
-|-------|-------|--------|
-| Lexer | Phel source string | `TokenStream` |
-| Parser | `TokenStream` | `FileNode` (parse tree) |
-| Reader | `NodeInterface` | `ReaderResult` (Phel data) |
-| Analyzer | Phel data | `AbstractNode` (AST with `NodeEnvironment`) |
-| Simplifier | `AbstractNode` | `AbstractNode` (optimized) |
-| Emitter | `AbstractNode` | `EmitterResult` (PHP code) |
+Lexer (source → `TokenStream`) → Parser (→ `FileNode` parse tree) → Reader (→ `ReaderResult` Phel data) → Analyzer (→ `AbstractNode` AST with `NodeEnvironment`) → Simplifier (→ optimized AST) → Emitter (→ `EmitterResult` PHP code).
 
 **Simplification pass** (runs after `ConstantFolder`): drops pure non-tail expressions from `(do ...)` via `PureExpressionDetector`; inlines calls at opt level >= 2 via `CallInliner` (delegates purity to `ConstantFolder` for known calls, `SymbolicPurityDetector` for structural checks). `^:pure` metadata opts a `defn` into inlining trust (author responsibility for correctness).
 
-## Structure
-
-```
-Compiler/
-├── Application/           Analyzer, CodeCompiler, EvalCompiler, Lexer, Parser, Reader, 
-│                         GlobalEnvironmentManager, MacroExpander, NamespaceEnvironmentSerializer
-├── Domain/
-│   ├── Analyzer/         AST nodes, ConstantFolder, TypeAnalyzer, special form handlers,
-│   │                     GlobalEnvironmentRegistry/Interface, SymbolSuggestionProvider
-│   ├── Compiler/         CodeCompilerInterface, EvalCompilerInterface
-│   ├── Emitter/          OutputEmitter, FileEmitter, StatementEmitter, *Specialization classes,
-│   │                     NodeEmitter/ (per-AST emitters; Specialized/ holds the CallEmitter families)
-│   ├── Evaluator/        InMemoryEvaluator, RequireEvaluator
-│   ├── Lexer/            TokenStream (Token + parse-tree nodes live in Phel\Shared\Parser\Node)
-│   ├── Parser/           ExpressionParserFactory (produces Shared\Parser\Node\* parse tree);
-│   │                     ExpressionParser/ sub-parsers (Atom, String, List, Quote, Meta, ReaderConditional)
-│   └── Reader/           ReaderInterface, QuasiquoteTransformer, ExpressionReaderFactory
-├── Infrastructure/       GlobalEnvironmentSingleton (ABI shim for generated PHP), DebugLineTap
-└── Gacela files          CompilerFacade, CompilerFactory, CompilerConfig, CompilerProvider
-```
+Note: lexer `Token` and parse-tree nodes live in `Phel\Shared\Parser\Node`; `ExpressionParserFactory` produces them (sub-parsers in `Domain/Parser/ExpressionParser/`).
 
 ## Key Constraints
 
@@ -87,7 +53,7 @@ The interface + `:php`-block parsing shared by `defstruct` and `defenum` lives i
 
 `^{:php/doc <str|[str...]>}` on any of those names/fields/methods emits a PHPDoc block (one-line string or multi-line list/vector) above the construct, so phpstan/psalm see generated classes as typed.
 
-`^:php/override` on a method (defstruct/defenum interface impls, definterface methods) is sugar for `#[\Override]` (PHP 8.3); `PhpAttributeEmitterTrait::phpAttributeLines` renders it ahead of any explicit `:php/attr` lines. Struct/enum inline method impls now emit method-level `:php/attr`/`:php/doc`/`^:php/override` too (previously only definterface methods did).
+`^:php/override` on a method (defstruct/defenum interface impls, definterface methods) is sugar for `#[\Override]` (PHP 8.3); `PhpAttributeEmitterTrait::phpAttributeLines` renders it ahead of any explicit `:php/attr` lines. Struct/enum inline method impls emit method-level `:php/attr`/`:php/doc`/`^:php/override` too.
 
 All opt-in; untagged forms are byte-identical to before. Export wrappers carry the same `:php/attr` via `Interop`'s `CompiledPhpMethodBuilder` (see `src/php/Interop/CLAUDE.md`).
 

--- a/src/php/Config/CLAUDE.md
+++ b/src/php/Config/CLAUDE.md
@@ -1,38 +1,18 @@
 # Config Module
 
-Pure data/model layer defining configuration structure for Phel projects.
-
-## No Gacela Pattern
-
-Leaf module; no Facade, Factory, or DependencyProvider. Config classes used directly by other modules' `*Config` classes via Gacela's `AbstractConfig`.
+Pure data/model layer defining configuration structure for Phel projects. No Gacela pattern: leaf module; config classes are used directly by other modules' `*Config` classes via Gacela's `AbstractConfig`.
 
 ## Key Classes
 
 ### PhelConfig
 
-Immutable `final readonly class`. Every mutation returns new instance via `with*()` methods.
+Immutable `final readonly class` (~650 LOC). Every mutation returns a new instance via `with*()` methods (directory, layout, build, export, cache, flag setters); `forProject(ProjectLayout = Flat, string $mainNamespace = '')` convenience constructor; `validate(): list<string>` (empty if valid); `jsonSerialize()`.
 
-**Factory**: `forProject(ProjectLayout $layout = Flat, string $mainNamespace = '')` convenience constructor.
+**Deprecated (since 0.37)**: `setX()` and `useLayout()`/`useNestedLayout()`/`useFlatLayout()` shim to `with*()` counterparts (marked `#[Deprecated]`). Permanent backward-compatibility aliases, not scheduled for removal in a minor release; removal would require a major version bump.
 
-**Public methods**:
-- Directory: `withSrcDirs()`, `withTestDirs()`, `withVendorDir()`, `withFormatDirs()`
-- Layout: `withLayout(ProjectLayout)` (resets src/test/format/export-from dirs per layout)
-- Build: `withMainPhelNamespace()`, `withMainPhpPath()`, `withBuildDestDir()`, `withBuildConfig(PhelBuildConfig)`
-- Export: `withExportNamespacePrefix()`, `withExportTargetDirectory()`, `withExportFromDirectories()`, `withExportConfig(PhelExportConfig)`
-- Cache: `withCacheDir()`, `withTempDir()`, `withEnableNamespaceCache()`, `withEnableCompiledCodeCache()`, `withPhelDir()`
-- Flags: `withIgnoreWhenBuilding()`, `withNoCacheWhenBuilding()`, `withKeepGeneratedTempFiles()`, `withEnableAsserts()`, `withWarnDeprecations()`, `withErrorLogFile()`
-- Validation: `validate(): list<string>` (empty if valid)
-- Serialization: `jsonSerialize(): array<string, mixed>`
+### PhelBuildConfig / PhelExportConfig
 
-**Deprecated (since 0.37)**: `setX()` and `useLayout()`/`useNestedLayout()`/`useFlatLayout()` shim to `with*()` counterparts (marked `#[Deprecated]`). These are permanent backward-compatibility aliases: they are not scheduled for removal in a minor release. Use `with*()` for new code; any eventual removal would require a major version bump.
-
-### PhelBuildConfig
-
-Immutable value object. Public methods: `withMainPhelNamespace()`, `withMainPhpPath()`, `withDestDir()`. Deprecated `setX()` shims retained.
-
-### PhelExportConfig
-
-Immutable value object. Public methods: `withFromDirectories()`, `withNamespacePrefix()`, `withTargetDirectory()`. Deprecated `setX()` shims retained.
+Immutable value objects (`withMainPhelNamespace`/`withMainPhpPath`/`withDestDir`; `withFromDirectories`/`withNamespacePrefix`/`withTargetDirectory`). Deprecated `setX()` shims retained.
 
 ### ProjectLayout (enum)
 
@@ -40,22 +20,7 @@ Immutable value object. Public methods: `withFromDirectories()`, `withNamespaceP
 - `Nested`: `src/phel`, `tests/phel` (PHP under `src/php/`)
 - `Root`: `.`, `.` (single-file or scratch)
 
-## Structure
-
-- `PhelConfig.php` (main config, ~650 LOC)
-- `PhelBuildConfig.php` (build destination metadata)
-- `PhelExportConfig.php` (export namespace/path mapping)
-- `ProjectLayout.php` (enum: src/test directory layout)
-- `PhelConfigValidator.php` (validation helper)
-- `CLAUDE.md` (this file)
-
-## Consumed By
-
-Build, Compiler, Filesystem, Interop, Command, Formatter, Run modules.
-
-## Dependencies
-
-None.
+`withLayout(ProjectLayout)` resets src/test/format/export-from dirs per layout.
 
 ## Key Constraints
 

--- a/src/php/Console/CLAUDE.md
+++ b/src/php/Console/CLAUDE.md
@@ -2,54 +2,22 @@
 
 CLI application entry point: bootstraps Symfony Console, registers commands, detects version.
 
-## Gacela Pattern
-
-- **Facade**: `ConsoleFacade` implements `ConsoleFacadeInterface`
-- **Factory**: `ConsoleFactory` creates `ConsoleBootstrap`, `ArgvInputSanitizer`, `VersionResolver` (from `Phel\Shared`)
-- **Provider**: `ConsoleProvider` injects `COMMANDS`, `FACADE_FILESYSTEM`
-
 ## Public API (Facade)
 
-- `getVersion(): string` : full version (`v0.30.0`) or beta with hash (`v0.30.0-beta#abc1234`)
-- `runConsole(): void` : execute the CLI application
+- `getVersion(): string`: full version (`v0.30.0`) or beta with hash (`v0.30.0-beta#abc1234`)
+- `runConsole(): void`: execute the CLI application
 
 ## CLI Commands
 
-Registered via `ConsoleProvider::COMMANDS` from per-module `ConsoleCommandProviderInterface` impls in `Infrastructure/Command/*Commands.php`:
-
-- **Run**: init, agent-install, ns, repl, eval, compile, run, test, test-worker, doctor
-- **Api**: doc, analyze, index, api-daemon
-- **Build**: build, cache:clear
-- **Formatter**: format
-- **Interop**: export
-- **Lint**: lint
-- **Lsp**: lsp
-- **Nrepl**: nrepl
-- **Profile**: profile
-- **Watch**: watch
-- **Framework**: cache:warm, debug:container, debug:dependencies, debug:modules, list:modules, profile:report, validate:config
+Registered via `ConsoleProvider::COMMANDS` from per-module `ConsoleCommandProviderInterface` impls in `Infrastructure/Command/*Commands.php` (one provider per module: Run, Api, Build, Formatter, Interop, Lint, Lsp, Nrepl, Profile, Watch, plus Framework debug commands). Sibling Command classes are wired via these providers, not via Facade injection.
 
 ## Dependencies
 
-- **Filesystem** (`FilesystemFacade`) : cleanup after execution
-
-Sibling Command classes are wired via per-module `*Commands.php` providers, not via Facade injection.
-
-## Structure
-
-```
-Console/
-├── Application/        ArgvInputSanitizer, WarnDeprecationsFlag
-├── Domain/             ConsoleCommandProviderInterface
-├── Infrastructure/
-│   ├── ConsoleBootstrap (extends Symfony Application)
-│   └── Command/        per-module *Commands providers (Run, Api, Build, Lint, ...)
-└── Gacela files        ConsoleFacade, ConsoleFactory, ConsoleProvider
-```
+Filesystem (cleanup after execution). Version detection via `Phel\Shared\VersionResolver`.
 
 ## Key Constraints
 
 - Default command is `repl` (when no command specified)
-- `ConsoleBootstrap.run()` calls `FilesystemFacade.clearAll()` then exits manually
+- `ConsoleBootstrap` (extends Symfony Application): `run()` calls `FilesystemFacade.clearAll()` then exits manually
 - `ArgvInputSanitizer` normalizes arguments, separating script options from command arguments via `--`
 - `WarnDeprecationsFlag.applyAndStrip()` processes deprecation notices from argv

--- a/src/php/Fiber/CLAUDE.md
+++ b/src/php/Fiber/CLAUDE.md
@@ -1,46 +1,25 @@
 # Fiber Module
 
-Cooperative fiber primitives: promises, futures, and a single-threaded scheduler used by `phel.core` for `promise`/`deliver` and `future-call`/`future-fiber`.
-
-## Gacela Pattern
-
-- **Facade**: `FiberFacade` implements `FiberFacadeInterface`
-- **Factory**: `FiberFactory` creates Promise, Future, and wires the scheduler
-- **Config**: `FiberConfig` with default poll sleep (500 microseconds)
-- **Provider**: `FiberProvider` (no cross-module dependencies)
+Cooperative fiber primitives: promises, futures, and a single-threaded scheduler used by `phel.core` for `promise`/`deliver` and `future-call`/`future-fiber`. No cross-module dependencies; `FiberConfig` holds default poll sleep (500 microseconds).
 
 ## Public API (Facade)
 
-- `createPromise(): Promise` creates a single-delivery promise
-- `future(callable $body): Future` executes callable in a fiber
-- `await(Awaitable, ?int $timeoutMs = null): mixed` blocks until realized
-- `scheduler(): Scheduler` returns process-wide singleton
+- `createPromise(): Promise`: single-delivery promise
+- `future(callable $body): Future`: executes callable in a fiber
+- `await(Awaitable, ?int $timeoutMs = null): mixed`: blocks until realized
+- `scheduler(): Scheduler`: process-wide singleton
 
-## Scheduler Semantics
+## Semantics
 
-- Single-threaded, cooperative. FIFO ready-queue of suspended fibers.
-- `Scheduler::instance()` exposes process-wide singleton; tests inject fresh instance via `Scheduler::setInstance()`.
-- Inside a Fiber: `await()` cooperatively yields via `Fiber::suspend()` until realized.
-- Outside a Fiber: `await()` drains ready queue, sleeping briefly between ticks.
-- CPU-bound work blocks until fiber yields. No preemption.
-
-## Domain
-
-- **Promise**: single-delivery, implements Awaitable and FnInterface. `derefWithTimeout(0, fallback)` returns fallback immediately.
-- **Future**: wraps callable in Fiber; captures return value or exception. Cancellation is cooperative via `isCancelled()` flag and `cancel()` method.
-- **Awaitable**: contract for `isRealized()`, `deref()`, `derefWithTimeout(int, mixed)`. Implemented by Promise and Future.
-
-## Structure
-
-```
-Fiber/
-├── Domain/        Awaitable, Scheduler, Promise, Future
-└── Gacela files   FiberFacade, FiberFacadeInterface, FiberFactory, FiberConfig, FiberProvider
-```
+- Scheduler: single-threaded, cooperative, FIFO ready-queue of suspended fibers. No preemption; CPU-bound work blocks until fiber yields.
+- `await()` inside a Fiber yields via `Fiber::suspend()` until realized; outside a Fiber it drains the ready queue, sleeping briefly between ticks.
+- `Awaitable` contract (`isRealized()`, `deref()`, `derefWithTimeout(int, mixed)`) implemented by Promise and Future.
+- Future cancellation is cooperative: `cancel()` sets `isCancelled()` flag.
 
 ## Key Constraints
 
-- Scheduler is process-wide singleton. Tests must call `Scheduler::setInstance(null)` in tearDown or inject isolated instance.
+- Scheduler is process-wide singleton (`Scheduler::instance()`). Tests must call `Scheduler::setInstance(null)` in tearDown or inject isolated instance.
 - Exceptions inside Future body are captured and rethrown on `deref()`.
 - `Promise::deliver()` is idempotent: first call returns true, subsequent calls return false.
 - `derefWithTimeout(0, fallback)` always returns fallback immediately (Clojure semantics).
+- Promise implements `FnInterface` (callable).

--- a/src/php/Filesystem/CLAUDE.md
+++ b/src/php/Filesystem/CLAUDE.md
@@ -1,39 +1,16 @@
 # Filesystem Module
 
-Temp directory management and compiled artifact tracking.
-
-## Gacela Pattern
-
-- **Facade**: `FilesystemFacade` implements `FilesystemFacadeInterface`
-- **Factory**: `FilesystemFactory` extends `AbstractFactory<FilesystemConfig>`
-- **Config**: `FilesystemConfig` reads `KEEP_GENERATED_TEMP_FILES` (bool) and `TEMP_DIR` (string)
-- **No Provider**: no inter-module dependencies
+Temp directory management and compiled artifact tracking. No Provider (no inter-module dependencies); `FilesystemConfig` reads `KEEP_GENERATED_TEMP_FILES` (bool) and `TEMP_DIR` (string).
 
 ## Public API (Facade)
 
-- `addFile(string $file): void`: register a compiled file for tracking
+- `addFile(string): void`: register a compiled file for tracking
 - `clearAll(): void`: delete all tracked files
 - `getTempDir(): string`: get or create temp directory
-- `getHealthCheck(): ModuleHealthCheckInterface`: health check for temp dir existence and writeability
-
-## Dependencies
-
-- `PhelConfig`: configuration values
-- `Phel\Shared\Exceptions\FileException`: exception type
-
-## Structure
-
-```
-Filesystem/
-├── Application/     FileIo, TempDirFinder, TempDirHealthCheck
-├── Domain/          FilesystemInterface, FileIoInterface, NullFilesystem
-├── Infrastructure/  RealFilesystem
-└── Gacela/          FilesystemFacade, FilesystemFactory, FilesystemConfig
-```
+- `getHealthCheck()`: temp dir existence and writeability
 
 ## Key Constraints
 
-- **Strategy pattern**: `RealFilesystem` (normal) vs `NullFilesystem` (when `KEEP_GENERATED_TEMP_FILES = true`)
+- Strategy pattern: `RealFilesystem` (normal) vs `NullFilesystem` (when `KEEP_GENERATED_TEMP_FILES = true`)
 - `RealFilesystem` tracks files in static array `$files`
-- `TempDirFinder::getOrCreateTempDir()` throws `FileException` on mkdir/chmod failures
-- Caching: once created, temp dir path cached in instance variable
+- `TempDirFinder::getOrCreateTempDir()` throws `FileException` on mkdir/chmod failures; once created, temp dir path cached in instance variable

--- a/src/php/Formatter/CLAUDE.md
+++ b/src/php/Formatter/CLAUDE.md
@@ -2,17 +2,10 @@
 
 Parses Phel source into AST, applies formatting rules, writes back.
 
-## Gacela Pattern
-
-- **Facade**: `FormatterFacade` implements `FormatterFacadeInterface`
-- **Factory**: `FormatterFactory` creates `PathsFormatter`, `Formatter`, rules and indenters
-- **Config**: `FormatterConfig.getFormatDirs()` (default: `['src', 'tests']`)
-- **Provider**: `FormatterProvider` injects `CompilerFacade` (`FACADE_COMPILER`) and `CommandFacade` (`FACADE_COMMAND`)
-
 ## Public API (Facade)
 
-- `format(array $paths, OutputInterface $output, bool $dryRun = false): array` returns paths with changes
-- `formatString(string $source, string $uri = '...'): string` formats code in memory
+- `format(array $paths, OutputInterface $output, bool $dryRun = false): array`: returns paths with changes
+- `formatString(string $source, string $uri = '...'): string`: formats code in memory
 
 ## Formatting Rules (in order)
 
@@ -27,18 +20,7 @@ Parses Phel source into AST, applies formatting rules, writes back.
 
 ## Dependencies
 
-- **Compiler**: `CompilerFacade` for lexing and parsing
-- **Command**: `CommandFacadeInterface` for CLI output
-
-## Structure
-
-```
-Formatter/
-├── Application/         Formatter, PathsFormatter, PhelPathFilter
-├── Domain/              FormatterInterface, PathFilterInterface, RuleInterface, IO/FileIoInterface, rules, indenters
-├── Infrastructure/      Command/FormatCommand, IO/SystemFileIo
-└── Gacela files         FormatterFacade, FormatterFactory, FormatterProvider, FormatterConfig
-```
+Compiler (lexing and parsing), Command (CLI output). `FormatterConfig.getFormatDirs()` defaults to `['src', 'tests']`.
 
 ## Key Constraints
 

--- a/src/php/HttpClient/CLAUDE.md
+++ b/src/php/HttpClient/CLAUDE.md
@@ -1,33 +1,15 @@
 # HttpClient Module
 
-Outbound HTTP support for `phel.http-client`. No Gacela Facade: pure stateless utility classes consumed directly by Phel core via PHP interop.
+Outbound HTTP support for `phel.http-client`. No Gacela pattern: stateless utility classes consumed directly by Phel core via PHP interop.
 
-## No Gacela Pattern
-
-Stateless, no module config, no registry, no cross-module dependencies. Facade would add ceremony without value.
-
-**Public-surface decision (#2261):** kept as-is. No PHP module consumes these classes; the only caller is user-facing Phel interop (`src/phel/http-client.phel` calls `\Phel\HttpClient\StreamTransport` by FQCN), so a Facade would have zero internal callers and renaming for `Shared` would break the public interop class name. `Shared` is also reserved for I/O-free utilities, and `StreamTransport` performs network I/O — so it cannot move there.
+**Public-surface decision (#2261):** kept as-is. No PHP module consumes these classes; the only caller is user-facing Phel interop (`src/phel/http-client.phel` calls `\Phel\HttpClient\StreamTransport` by FQCN), so a Facade would have zero internal callers and renaming for `Shared` would break the public interop class name. `Shared` is also reserved for I/O-free utilities, and `StreamTransport` performs network I/O, so it cannot move there.
 
 ## Public API
 
-**`StreamTransport::send(string $method, string $url, array<string, string> $headers, ?string $body, array<string, mixed> $options): array`**
-
-Performs HTTP request via PHP stream context. Returns `{status: int, headers: array<string, string>, body: string, version: string, reason: string}`. Throws `RuntimeException` on fopen failure.
-
-**`ResponseParser::parse(array<string> $rawHeaders): array`**
-
-Parses PHP `$http_response_header` into `{status: int, version: string, reason: string, headers: array<string, string>}`. Handles redirect chains by resetting on new HTTP status line. Lowercases header names; keeps last value for duplicates.
-
-## Structure
-
-```
-HttpClient/
-├── ResponseParser.php
-└── StreamTransport.php
-```
+- `StreamTransport::send(method, url, headers, ?body, options): array`: HTTP request via PHP stream context. Returns `{status, headers, body, version, reason}`. Honors `:timeout` option; throws `RuntimeException` on failure.
+- `ResponseParser::parse(array $rawHeaders): array`: parses PHP `$http_response_header` into `{status, version, reason, headers}`. Lowercases header names; keeps last value for duplicates.
 
 ## Key Constraints
 
-- Both classes `final`; stable public APIs (addressable from user Phel via interop).
-- `StreamTransport` honors `:timeout` option; throws `RuntimeException` on request failure.
-- `ResponseParser` must handle redirect chains (status line resets on new response).
+- Both classes `final`; stable public APIs (addressable from user Phel via interop)
+- `ResponseParser` must handle redirect chains (status line resets on new response)

--- a/src/php/Interop/CLAUDE.md
+++ b/src/php/Interop/CLAUDE.md
@@ -2,46 +2,19 @@
 
 Generates PHP wrapper classes for Phel functions marked with `^{:export true}`.
 
-## Gacela Pattern
-
-- **Facade**: `InteropFacade` implements `InteropFacadeInterface`
-- **Factory**: `InteropFactory`
-- **Config**: `InteropConfig` exposes export dirs, namespace prefix, target directory
-- **Provider**: injects `CommandFacade` (FACADE_COMMAND), `BuildFacade` (FACADE_BUILD)
-
 ## Public API (Facade)
 
-- `generateExportCode(): list<Wrapper>` orchestrates full pipeline
-- `writeLocatedException(OutputInterface, CompilerException): void`
-- `writeStackTrace(OutputInterface, Throwable): void`
+- `generateExportCode(): list<Wrapper>`: orchestrates full pipeline (`ExportCodeGenerator`)
+- `writeLocatedException` / `writeStackTrace`: delegate to Command
 
 ## Dependencies
 
-| Module | Usage |
-|--------|-------|
-| Command | Error/exception output via CommandFacade |
-| Build | Namespace extraction, compilation, evaluation |
-
-## Structure
-
-```
-Interop/
-├── Application/           ExportCodeGenerator (orchestrator)
-├── Domain/
-│   ├── DirectoryRemover/  Removes stale export dir
-│   ├── ExportFinder/      Scans for :export metadata (FunctionsToExportFinder)
-│   ├── FileCreator/       Writes Wrapper to filesystem
-│   ├── Generator/         WrapperGenerator, CompiledPhpClassBuilder, CompiledPhpMethodBuilder
-│   └── ReadModel/         Wrapper, FunctionToExport
-├── Infrastructure/        ExportCommand (CLI), FileSystemIo
-├── PhelCallerTrait.php    In generated wrappers; callPhel(ns, def, ...args)
-└── Gacela files
-```
+Command (error/exception output), Build (namespace extraction, compilation, evaluation). `InteropConfig` exposes export dirs, namespace prefix, target directory.
 
 ## Key Constraints
 
-- Only functions with `^{:export true}` metadata exported
+- Only functions with `^{:export true}` metadata exported (`Domain/ExportFinder/FunctionsToExportFinder`)
 - Phel namespaces to PHP: hyphens become CamelCase (my-lib -> MyLib)
-- Generated classes use PhelCallerTrait for cached definition resolution
+- Generated classes use `PhelCallerTrait` (`callPhel(ns, def, ...args)`) for cached definition resolution
 - Export directory wiped and regenerated each run
-- `^{:php/attr [...]}` metadata on an exported `defn` is threaded through `FunctionToExport` and rendered (via `Phel\Shared\PhpAttributeRenderer`) as PHP 8 attributes above the wrapper method (e.g. `#[\…\Route('/p')]`)
+- `^{:php/attr [...]}` metadata on an exported `defn` is threaded through `FunctionToExport` and rendered (via `Phel\Shared\PhpAttributeRenderer` in `CompiledPhpMethodBuilder`) as PHP 8 attributes above the wrapper method (e.g. `#[\…\Route('/p')]`)

--- a/src/php/Lang/CLAUDE.md
+++ b/src/php/Lang/CLAUDE.md
@@ -1,116 +1,62 @@
 # Lang Module
 
-Core runtime type system: persistent data structures, language primitives, and collection protocols.
-
-## No Gacela Pattern
-
-Foundational leaf module with no Facade, Factory, or DependencyProvider. All types used directly by other modules.
+Core runtime type system: persistent data structures, language primitives, and collection protocols. No Gacela pattern: foundational leaf module; all types used directly by other modules. Depends only on `Phel\Shared` (`AbstractType::__toString()` uses `Printer::readable()`; `AbstractPersistentStruct` uses `Munge` for key encoding, lockstep with compiler).
 
 ## Core Types
 
 **Symbols, Keywords, Variables**
-- **Symbol**: names with optional namespace; special constants for language forms (`def`, `fn`, `if`, etc.)
-- **Keyword**: interned pool; callable to access map values; implements `FnInterface`
+- **Symbol**: names with optional namespace; special constants for language forms (`def`, `fn`, `if`, ...)
+- **Keyword**: interned pool (identical keywords share instance); callable to access map values (`FnInterface`)
 - **Atom**: mutable box with watches, validators, `deref` (Clojure-aligned; was `Variable`)
-- **PhelVar**: first-class handle to global `def`. Methods: `deref`, `meta`, `alterRoot`, `addWatch`/`removeWatch`, `alterMeta`/`resetMeta`, `isDynamic` (cached). Callable via `__invoke` to current root. Produced by `Registry::addDefinition`/`getVar` and `(var sym)` form
-- **PhelVarStateRegistry**: singleton side table for per-var watches, metadata, dynamic-flag cache keyed by `(ns, name)`; enables `PhelVar` to stay `readonly` while `alter-meta!` and `add-watch` mutate canonical state. The `isDynamic` cache is cleared here via `invalidateDynamicCache(ns, name)` whenever metadata changes (`alter-meta!`/`reset-meta!` or a re-`def`), not in `PhelVar` itself
+- **PhelVar**: first-class handle to global `def` (`deref`, `meta`, `alterRoot`, watches, `alterMeta`/`resetMeta`, cached `isDynamic`); callable via `__invoke` to current root. Produced by `Registry::addDefinition`/`getVar` and `(var sym)` form
+- **PhelVarStateRegistry**: singleton side table for per-var watches, metadata, dynamic-flag cache keyed by `(ns, name)`; lets `PhelVar` stay `readonly` while `alter-meta!`/`add-watch` mutate canonical state. The `isDynamic` cache is cleared here via `invalidateDynamicCache(ns, name)` whenever metadata changes (`alter-meta!`/`reset-meta!` or re-`def`), not in `PhelVar`
 
 **Numeric Types**
-- **BigInt**: arbitrary-precision signed integer (`final readonly`, `TypeInterface`); base-10^9 with sign. Methods: `fromInt`, `fromFloat`, `fromString`, `add`/`subtract`/`multiply`/`divide`/`mod`/`gcd`/`pow`/`negate`/`abs`, `compareTo`, `equals`, `hash`, `toInt`, `fitsInPhpInt`. No I/O or static state. Owns sign + metadata + signed semantics; delegates the sign-agnostic digit-array kernels to **BigIntMagnitude**
-- **BigIntMagnitude**: stateless base-10^9 magnitude arithmetic (`compare`/`add`/`subtract`/`multiply`/`divMod`/`trim`, plus `split`/`fromDecimalDigits`/`toDecimalString` conversions). Pure functions on `list<int>` digit arrays; the unsigned kernel under `BigInt`
-- **Ratio**: exact rational `n/d` (`final readonly`, `TypeInterface`); always normalized (denom > 0, gcd=1). `create($num, $den)` auto-collapses to `int`/`BigInt` if integral. Arithmetic preserves type over reals
-- **BigDecimal**: arbitrary-precision signed decimal (`final readonly`, `TypeInterface`); mantissa * 10^-scale. Constructors: `fromString`, `fromInt`, `fromBigInt`, `fromFloat` (shortest round-trip). Methods: `add`/`subtract`/`multiply`/`divideExact`/`negate`/`abs`/`compareTo`/`isZero`. Equality by value via `compareTo` (1.20M = 1.2M). `divideExact` extends scale to 100 digits. `__toString` outputs scale-respecting form without M suffix; `toPlainString` alias. REPL output appends M suffix for round-trip. Literals: `1.5M`, `1.5e3M`
+- **BigInt**: arbitrary-precision signed integer; base-10^9 with sign. Owns sign + metadata + signed semantics; delegates sign-agnostic digit-array kernels to **BigIntMagnitude** (stateless pure functions on `list<int>` digit arrays)
+- **Ratio**: exact rational `n/d`; always normalized (denom > 0, gcd=1). `create($num, $den)` auto-collapses to `int`/`BigInt` if integral
+- **BigDecimal**: arbitrary-precision signed decimal; mantissa * 10^-scale. Equality by value via `compareTo` (1.20M = 1.2M); `divideExact` extends scale to 100 digits. `__toString` omits the M suffix; REPL output appends M for round-trip. Literals: `1.5M`, `1.5e3M`
 
 **Type Values**
-- **UUID**: canonical 36-char UUID (`final readonly`, `TypeInterface`). Methods: `fromString` (validates, lowercases), `randomV4`, `version`, `variant` (ncs, rfc-4122, microsoft, reserved), `isNil`, value-based `equals`/`hash`. Literal: `#uuid "..."`
-- **PhpClass**: typed wrapper for PHP class/interface FQN (`final readonly`, `TypeInterface`). Methods: `fromName` (validates, strips leading \), `ofValue` (get object class), `isInstance` (runtime `is_a`). Backs `phel.core/class`, `class?`, `class-name`
-
-**Collections (full types listed below)**
-- **PersistentQueue**: persistent FIFO (`final readonly`, `TypeInterface, Countable, IteratorAggregate, FirstInterface, CdrInterface, ConsInterface, PushInterface, PopInterface`). Two-stack banker's queue; O(1) amortized push/peek/pop. Constructor: `empty`, `fromArray`. `cons` alias for `push`. Type: `:queue`
-- **MapEntry**: typed two-element entry (`final readonly`, `TypeInterface, Countable, IteratorAggregate, FirstInterface, CdrInterface`). Equal by value to 2-element vector (both directions). Accessors: `key()`/`value()`; `first()` = key, `cdr()` = 1-vector with value
+- **UUID**: canonical 36-char UUID; `fromString` (validates, lowercases), `randomV4`, `version`, `variant`, value-based equality. Literal: `#uuid "..."`
+- **PhpClass**: typed wrapper for PHP class/interface FQN; backs `phel.core/class`, `class?`, `class-name`
 
 **Lazy and Mutable**
-- **Delay**: single-value lazy computation; `deref()` runs the thunk once and caches the result, `isRealized()` reports whether it has run. Use for single-value laziness (distinct from **LazySeq**, which is for sequences)
+- **Delay**: single-value lazy computation; `deref()` runs the thunk once and caches (distinct from **LazySeq**, which is for sequences)
 - **Volatile**: lightweight mutable container for transducer state (no watches/validators)
 - **Reduced**: signals early termination from reduce/transduce
-- **Future**: Amphp adapter; exposes Phel deref/realized? protocol
-- **Eduction**: transducer composition helper
-- **LazySeq**: lazy sequence implementation with chunking
+- **Future**: Amphp adapter exposing Phel deref/realized? protocol; **Eduction**: transducer composition helper
 
-**Utilities**
-- **NumericOperations**: static dispatch for `+`/`-`/`*`/`/`, comparisons, predicates across PHP numbers, `BigInt`, `Ratio`, `BigDecimal`. Owns only the contagion ladders; delegates type lifting to **NumericCoercion** and native-int overflow detection to **IntegerOverflow**
-- **NumericCoercion**: stateless numeric type lifting/validation (`ensureNumeric`, `toFloat`/`toBigInt`/`toBigDecimal`, `rationalOperand`, `collapseBigInt`, `toIntExponent`, `truncateToInt`) shared by `NumericOperations`
-- **IntegerOverflow**: pure native-int overflow predicates (`onAdd`/`onSubtract`/`onMultiply`); tells `NumericOperations` when to promote an int op to `BigInt`
-- **DynamicScope**: dynamic variable binding context
-- **Truthy**: coercion to boolean
-- **TypeStringifier**: `__toString` rendering
-- **Hasher**, **Equalizer**: collection hashing and equality; `HasherInterface`, `EqualizerInterface`
+**Numeric Utilities**
+- **NumericOperations**: static dispatch for arithmetic/comparisons/predicates across PHP numbers, `BigInt`, `Ratio`, `BigDecimal`. Owns only the contagion ladders; delegates type lifting to **NumericCoercion** and native-int overflow detection to **IntegerOverflow** (promotes int ops to `BigInt` on overflow)
+
+Other utilities: `DynamicScope` (dynamic bindings), `Truthy`, `TypeStringifier`, `Hasher`/`Equalizer` (collection hashing/equality).
 
 ## Runtime Infrastructure
 
-- **Registry**: singleton managing definitions by namespace (values + metadata); `getInstance()`
-- **TypeFactory**: singleton creating persistent collections; provides `Hasher` and `Equalizer` singletons
-- **Seq**: static utility for sequence ops (map, filter, take, drop, partition)
-- **TagRegistry**: reader literal tag handler dispatch
-- **LoadClasspath**: static accessor for the `(load ...)` classpath, stored in `Registry` under `phel.core/*load-classpath*`. Lives here (not Compiler) because its state is a `Registry` slot; `publish()`/`read()` consumed by Run, Build, and the emitted `(load ...)` lookup. FQN baked into generated PHP by `LoadEmitter`; do not rename.
+- **Registry**: singleton managing definitions by namespace (values + metadata)
+- **TypeFactory**: singleton creating persistent collections; provides `Hasher`/`Equalizer` singletons
+- **Seq**: static utility for sequence ops; **TagRegistry**: reader literal tag handler dispatch (`TagHandlers/`: `#inst`, `#uuid`, regex)
+- **LoadClasspath**: static accessor for the `(load ...)` classpath, stored in `Registry` under `phel.core/*load-classpath*`. Lives here (not Compiler) because its state is a `Registry` slot; FQN baked into generated PHP by `LoadEmitter`; do not rename
 - **Phel**: static helper for namespace/definition lookups (used by Api, Interop)
 
-## Interface Hierarchy
+## Interfaces
 
-**Core**
-- `TypeInterface`: extends `MetaInterface`, `SourceLocationInterface`, `EqualsInterface`, `HashableInterface`
-- `NamedInterface`: `getName()`, `getNamespace()`, `getFullName()`
-- `FnInterface`: marker for callable types
-- `IdenticalInterface`: identity-based equality (`===`)
-- `EqualsInterface`, `HashableInterface`: value-based equality and hashing
+- `TypeInterface` extends `MetaInterface`, `SourceLocationInterface`, `EqualsInterface`, `HashableInterface`
+- `NamedInterface` (`getName`/`getNamespace`/`getFullName`); `FnInterface` (callable marker); `IdenticalInterface` (`===` equality)
+- Collection capabilities compose as needed: `PushInterface`, `PopInterface`, `ConsInterface`, `CdrInterface`, `FirstInterface`, `ContainsInterface`, `RestInterface`, `ConcatInterface`, `SliceInterface`, `SeqInterface`, `AsTransientInterface`
 
-**Collection Capabilities** (compose as needed)
-- `PushInterface`, `PopInterface`, `ConsInterface`, `CdrInterface`, `FirstInterface`
-- `ContainsInterface`, `RestInterface`, `ConcatInterface`, `SliceInterface`
-- `SeqInterface`: iterate; `AsTransientInterface`: convert to transient
+## Collections
 
-## Collections Subdirectory Structure
+By subdirectory: `Map/` (PersistentArrayMap, PersistentHashMap, MapEntry), `SortedMap/`, `Vector/`, `LinkedList/` (PersistentList), `Queue/` (PersistentQueue: two-stack banker's queue, O(1) amortized; printed `<-(...)-<`), `HashSet/`, `SortedSet/`, `LazySeq/` (lazy chunking), `Struct/` (AbstractPersistentStruct), `Generators/` (sequence generators).
 
-| Name | Location | Interfaces |
-|------|----------|-----------|
-| **PersistentArrayMap** | `Map/` | `PersistentMapInterface` |
-| **PersistentHashMap** | `Map/` | `PersistentMapInterface` |
-| **PersistentSortedMap** | `SortedMap/` | `PersistentMapInterface` (sorted keys) |
-| **MapEntry** | `Map/` | `TypeInterface, FirstInterface, CdrInterface` |
-| **PersistentVector** | `Vector/` | `PersistentVectorInterface` |
-| **PersistentList** | `LinkedList/` | `PersistentListInterface` |
-| **PersistentQueue** | `Queue/` | `TypeInterface` (FIFO) |
-| **PersistentHashSet** | `HashSet/` | `PersistentHashSetInterface` |
-| **PersistentSortedSet** | `SortedSet/` | `PersistentHashSetInterface` (sorted elements) |
-| **LazySeq** | `LazySeq/` | `LazySeqInterface` (lazy chunking) |
-| **AbstractPersistentStruct** | `Struct/` | struct key encoding via `Phel\Shared\Munge` |
-
-**Transients**: `TransientVector`, `TransientMapWrapper` (array/hash maps, hash-sets), `TransientSortedMap`/`TransientSortedSet` (sorted maps/sets via delegation). All share `TransientStateTrait`: `persistent()` invalidates; mutators call `ensureTransientActive()` to guard reuse after `persistent!`
-
-## Generators
-
-Sequence generators in `Generators/`: `CombineGenerator`, `DedupeGenerator`, `FileGenerator`, `InfiniteGenerator`, `PartitionGenerator`, `SequenceGenerator`, `SliceGenerator`, `TransformGenerator`
-
-## Tag Handlers
-
-Reader literals in `TagHandlers/`: builtin handlers for `#inst`, `#uuid`, regex literals. `AbstractStringTagHandler`, `BuiltinTagHandlers`, `InstTagHandler`, `RegexTagHandler`, `UUIDTagHandler`
-
-## Dependencies
-
-**Leaf module**; depends only on `Phel\Shared` (itself a leaf):
-- `AbstractType::__toString()` calls `Phel\Shared\Printer\Printer::readable()` for collection rendering
-- `AbstractPersistentStruct` uses `Phel\Shared\Munge` for key encoding (lockstep with compiler)
-
-## Used By
-
-Every module: Compiler (AST), Printer, Build (namespace extraction), Api, Interop, Run (evaluation)
+- **MapEntry**: equal by value to a 2-element vector (both directions); `first()` = key, `cdr()` = 1-vector with value
+- **Transients**: `TransientVector`, `TransientMapWrapper`, `TransientSortedMap`/`TransientSortedSet`. All share `TransientStateTrait`: `persistent()` invalidates; mutators call `ensureTransientActive()` to guard reuse after `persistent!`
 
 ## Key Constraints
 
-- All collections are **persistent** (immutable) with transient variants for bulk building
-- `Keyword` intern pool; identical keywords share instance for memory efficiency
+- All collections are persistent (immutable) with transient variants for bulk building
 - `Registry`, `TypeFactory` are singletons; access via `getInstance()`
 - `Registry` keys are dot-separated: `phel.core`, `my-app.lib` (after `-` → `_` munge). Compiler feeds through `Munge::encodeRegistryKey`
 - `Symbol::getFullName` returns dot form; symbols with PHP class FQN namespace (leading `\`) keep backslash for static-method shorthand
 - Source locations preserved via `SourceLocationInterface` for error reporting
-- `PhelVar` implements `FnInterface` so handles are callable
+- Numeric/value types (`BigInt`, `Ratio`, `BigDecimal`, `UUID`, `PhpClass`) are `final readonly` `TypeInterface` implementations with no I/O or static state

--- a/src/php/Lint/CLAUDE.md
+++ b/src/php/Lint/CLAUDE.md
@@ -2,51 +2,28 @@
 
 Read-only semantic linter emitting diagnostics on Phel sources without rewriting.
 
-## Gacela Pattern
-
-- **Facade**: `LintFacade`
-- **Factory**: `LintFactory`
-- **Config**: `LintConfig` (default severities, cache dir, config filename)
-- **Provider**: `LintProvider` (injects `FACADE_API`, `FACADE_COMPILER`, `FACADE_COMMAND`, `FACADE_RUN`)
-
 ## Public API (Facade)
 
-| Method | Signature |
-|--------|-----------|
-| `lint` | `(list<string> $paths, RuleSettings $settings, ?LintCache $cache): LintResult` |
-| `loadSettings` | `(string $configPath, RuleSettings $defaults): RuleSettings` |
-| `defaultSettings` | `(): RuleSettings` |
-| `formatters` | `(): FormatterRegistry` |
-| `createCache` | `(string $baseDir, RuleSettings $settings): LintCache` |
+- `lint(list<string> $paths, RuleSettings $settings, ?LintCache $cache): LintResult`
+- `loadSettings(string $configPath, RuleSettings $defaults): RuleSettings`, `defaultSettings()`
+- `formatters(): FormatterRegistry`, `createCache(string $baseDir, RuleSettings $settings): LintCache`
 
-## CLI Command
+## CLI
 
-```
-./bin/phel lint [paths]... [--format=human|json|github] [--config=path] [--no-cache]
-```
+`./bin/phel lint [paths]... [--format=human|json|github] [--config=path] [--no-cache]`
 
 Exit codes: 0 = clean/warnings only; 1 = errors; 2 = invocation error.
 
 ## Rule Set (v1)
 
-| Code | Default |
-|------|---------|
-| `phel/unresolved-symbol` | error |
-| `phel/arity-mismatch` | error |
-| `phel/invalid-destructuring` | error |
-| `phel/duplicate-key` | error |
-| `phel/unused-binding` | warning |
-| `phel/unused-require` | warning |
-| `phel/unused-import` | warning |
-| `phel/shadowed-binding` | warning |
-| `phel/redundant-do` | warning |
-| `phel/discouraged-var` | warning |
+Errors: `phel/unresolved-symbol`, `phel/arity-mismatch`, `phel/invalid-destructuring`, `phel/duplicate-key`.
+Warnings: `phel/unused-binding`, `phel/unused-require`, `phel/unused-import`, `phel/shadowed-binding`, `phel/redundant-do`, `phel/discouraged-var`.
 
 To add a rule: create `LintRuleInterface` class in `Application/Rule/`, add code constant to `RuleRegistry`, instantiate in `LintFactory::createRules()`. Do not edit existing rules.
 
 ## Config File
 
-File: `phel-lint.phel` (override via `--config`). Phel map parsed by reader:
+`phel-lint.phel` (override via `--config`). Phel map parsed by reader:
 
 ```phel
 {:rules {:phel/unused-binding :off
@@ -56,51 +33,19 @@ File: `phel-lint.phel` (override via `--config`). Phel map parsed by reader:
 
 Severities: `:error`, `:warning`, `:info`, `:hint`, `:off`. Patterns match file path (if contains `/` or `.phel`) or namespace name via `fnmatch`.
 
-## Cache
-
-Optional, enabled by default. Stores per-file diagnostics at `.phel/lint-cache/index.json` keyed by MD5(file hash) + rule fingerprint. Disable with `--no-cache`.
-
 ## Output Formats
 
-| Format | Output |
-|--------|--------|
-| `human` | `file:line:col [severity] code message` plus summary |
-| `json` | JSON array of `Diagnostic` objects (stable) |
-| `github` | `::warning file=X,line=Y,col=Z,title=CODE::message` annotations |
-
-Registered on `FormatterRegistry`, implement `DiagnosticFormatterInterface`.
+`human` (`file:line:col [severity] code message` + summary), `json` (stable array of `Diagnostic`), `github` (workflow annotations). Registered on `FormatterRegistry`; implement `DiagnosticFormatterInterface`.
 
 ## Dependencies
 
-| Module | Via | Purpose |
-|--------|-----|---------|
-| Api | `ApiFacade` | `analyzeSource` (semantic diagnostics), `indexProject` |
-| Compiler | `CompilerFacade` | `lexString`, `parseNext`, `read` |
-| Command | `CommandFacade` | Default source directories |
-| Run | `RunFacade` | `loadPhelNamespaces()` ensures symbols are resolved |
-
-## Structure
-
-```
-Lint/
-|-- Application/
-|   |-- Cache/           LintCache (MD5 hash + rule-fingerprint keyed JSON)
-|   |-- Config/          RuleRegistry, RuleSettings, ConfigLoader
-|   |-- Formatter/       HumanFormatter, JsonFormatter, GithubFormatter, FormatterRegistry
-|   |-- Rule/            10 rule classes; FormWalker, DiagnosticBuilder, utilities
-|   +-- FileCollector, SourceReader, RulePipeline, LintRunner
-|-- Domain/              LintRuleInterface, DiagnosticFormatterInterface, FileAnalysis
-|-- Infrastructure/Command/   LintCommand (Symfony console)
-|-- Transfer/            LintResult
-+-- Gacela              LintFacade, LintFactory, LintConfig, LintProvider
-```
+Api (`analyzeSource` semantic diagnostics, `indexProject`), Compiler (`lexString`, `parseNext`, `read`), Command (default source directories), Run (`loadPhelNamespaces()` ensures symbols resolved).
 
 ## Key Constraints
 
 - Read-only: never rewrites source (fmt owns whitespace/indent)
 - Semantic diagnostics (`unresolved-symbol`, `arity-mismatch`) shared via `FileAnalysis::$semanticDiagnostics` so analyzer runs once per file via `ApiFacade::analyzeSource`
-- Rule pipeline open/closed: `LintFactory::createRules()` only edit point for new rules
-- `FormatterRegistry` open/closed: register new formatters without editing existing ones
-- Cache fingerprint = MD5(all rule codes + severity + exclude patterns); adding/removing rules or editing `phel-lint.phel` invalidates cache
+- Open/closed: `LintFactory::createRules()` and `FormatterRegistry` are the only edit points for new rules/formatters
+- Cache (default on, `.phel/lint-cache/index.json`): keyed by MD5(file hash) + rule fingerprint (all rule codes + severity + exclude patterns); adding/removing rules or editing `phel-lint.phel` invalidates
 - `RulePipeline` isolates failing rules; one bad rule does not kill run
 - `DuplicateKeyRule` scans parse tree (not read forms); reader silently deduplicates map literals

--- a/src/php/Lsp/CLAUDE.md
+++ b/src/php/Lsp/CLAUDE.md
@@ -2,54 +2,27 @@
 
 Language Server Protocol v3.17 over stdio (JSON-RPC 2.0 with `Content-Length` framing). Thin transport on top of Api, Lint, Formatter, and Run facades.
 
-## Gacela Pattern
-
-- **Facade**: `LspFacade` extends `AbstractFacade<LspFactory>`
-- **Factory**: `LspFactory` extends `AbstractFactory<LspConfig>`
-- **Config**: `LspConfig` with methods: `defaultDiagnosticDebounceMs()`, `defaultServerName()`, `defaultServerVersion()`
-- **Provider**: `LspProvider` injects Api, Lint, Formatter, Run facades via `FACADE_API`, `FACADE_LINT`, `FACADE_FORMATTER`, `FACADE_RUN`
-
 ## Public API (Facade)
 
-- `createServer($input, $output): LspServer` - wire streams and return server instance
-- `createDispatcher(): RequestDispatcher` - build dispatcher with all handlers registered (test support)
+- `createServer($input, $output): LspServer`: wire streams and return server instance
+- `createDispatcher(): RequestDispatcher`: build dispatcher with all handlers registered (test support)
 
 ## Supported LSP Methods
 
-| Lifecycle | Text Sync | Language Features | Diagnostics |
-|-----------|-----------|-------------------|-------------|
-| initialize, initialized, shutdown, exit | didOpen, didChange, didClose, didSave | hover, definition, references, completion, documentSymbol, workspace/symbol, rename, formatting | publishDiagnostics (debounced 200ms on change, immediate on save) |
+- Lifecycle: initialize, initialized, shutdown, exit
+- Text sync: didOpen, didChange, didClose, didSave
+- Language features: hover, definition, references, completion, documentSymbol, workspace/symbol, rename, formatting
+- Diagnostics: publishDiagnostics (debounced 200ms on change, immediate on save)
 
-## Dependencies (Provider Constants)
+## Dependencies
 
-- `FACADE_API` - semantic analysis, symbol resolve/references, completion
-- `FACADE_LINT` - rule-based diagnostics
-- `FACADE_FORMATTER` - string formatting
-- `FACADE_RUN` - Phel namespace loading
-
-## Structure
-
-```
-Lsp/
-|-- Application/
-|   |-- Convert/         PositionConverter, UriConverter, DiagnosticConverter, LocationConverter, CompletionConverter, SymbolInformationBuilder, SymbolKindMapper
-|   |-- Diagnostics/     DiagnosticPublisher
-|   |-- Document/        Document, DocumentStore, ContentChangeApplier
-|   |-- Handler/         InitializeHandler, InitializedHandler, ShutdownHandler, ExitHandler, DidOpenHandler, DidChangeHandler, DidCloseHandler, DidSaveHandler, HoverHandler, DefinitionHandler, ReferencesHandler, CompletionHandler, DocumentSymbolHandler, WorkspaceSymbolHandler, RenameHandler, FormattingHandler, CursorContext, SymbolResolver
-|   |-- Rpc/             LspServer, MessageReader, MessageWriter, RequestDispatcher, StreamNotificationSink, ResponseBuilder, ParamsExtractor
-|   +-- Session/         Session
-|-- Domain/              HandlerInterface, NotificationSink
-|-- Infrastructure/
-|   +-- Command/         LspCommand (Symfony console)
-+-- Gacela              LspFacade, LspFactory, LspConfig, LspProvider
-```
+Api (semantic analysis, symbol resolve/references, completion), Lint (rule-based diagnostics), Formatter (string formatting), Run (Phel namespace loading).
 
 ## Key Constraints
 
 - Framing: strict `Content-Length: <n>\r\n\r\n<body>` (LSP spec, not newline-delimited or bencode)
-- New LSP method: add `HandlerInterface` subclass, register in `createDispatcher()`
+- New LSP method: add `HandlerInterface` subclass in `Application/Handler/`, register in `createDispatcher()`
 - Handlers avoid transport directly; return via `RequestDispatcher` or push via `Session::sink()`
 - `DocumentStore` is authoritative for open-file content
 - Diagnostics debounced via `DiagnosticPublisher::shouldPublish()`
-- Converters pure (no Facade state), fully testable
-- Cross-module access through facades only
+- Converters (`Application/Convert/`) are pure (no Facade state), fully testable

--- a/src/php/Nrepl/CLAUDE.md
+++ b/src/php/Nrepl/CLAUDE.md
@@ -1,15 +1,6 @@
 # Nrepl Module
 
-nREPL protocol server; bencode-over-TCP for editor tooling (Cursive, Calva, CIDER, Conjure).
-
-## Gacela Pattern
-
-| Component | Class | Notes |
-|-----------|-------|-------|
-| Facade | `NreplFacade` | extends `AbstractFacade<NreplFactory>` |
-| Factory | `NreplFactory` | extends `AbstractFactory<NreplConfig>` |
-| Config | `NreplConfig` | port 7888, host 127.0.0.1 |
-| Provider | `NreplProvider` | injects Run and Api facades |
+nREPL protocol server; bencode-over-TCP for editor tooling (Cursive, Calva, CIDER, Conjure). `NreplConfig`: port 7888, host 127.0.0.1.
 
 ## Public API (Facade)
 
@@ -19,34 +10,15 @@ nREPL protocol server; bencode-over-TCP for editor tooling (Cursive, Calva, CIDE
 
 ## Supported Ops
 
-| Op | Via |
-|----|-----|
-| `clone`, `close`, `describe`, `eval`, `load-file`, `interrupt` | Core |
-| `completions` | ApiFacade::replCompleteWithTypes |
-| `lookup`, `info`, `eldoc` | ApiFacade::findSymbolMetadata |
+Core: `clone`, `close`, `describe`, `eval`, `load-file`, `interrupt`. Via Api facade: `completions` (replCompleteWithTypes), `lookup`/`info`/`eldoc` (findSymbolMetadata).
 
 ## Dependencies
 
-- **Run** (FACADE_RUN): structuredEval, getVersion, loadPhelNamespaces
-- **Api** (FACADE_API): replCompleteWithTypes, findSymbolMetadata
-
-## Structure
-
-```
-Nrepl/
-|-- Application/Op/      Op handlers + EvalResultResponder (one per nREPL op)
-|-- Domain/
-|   |-- Bencode/         Pure encoder/decoder (Gacela-free)
-|   |-- Op/              Dispatcher, request/response, OpHandlerInterface
-|   |-- Session/         Registry and session state
-|   +-- Transport/       ClientConnection
-|-- Infrastructure/      SocketServer, ClientFiberPool, NreplCommand
-+-- Gacela files
-```
+Run (structuredEval, getVersion, loadPhelNamespaces), Api (completion, symbol metadata).
 
 ## Key Constraints
 
-- Bencode codec has zero dependencies; reusable standalone
+- Bencode codec (`Domain/Bencode/`) has zero dependencies; reusable standalone
 - Each nREPL op implements `OpHandlerInterface`; dispatcher maps name to handler
 - Client loop uses PHP Fibers (one per connection, cooperative suspend)
 - Eval always via RunFacade (no inline compilation)

--- a/src/php/Profile/CLAUDE.md
+++ b/src/php/Profile/CLAUDE.md
@@ -2,13 +2,6 @@
 
 Instrumentation profiler for `phel profile` command. Reports per-fn call counts, self/total/avg/max timings, and compile-time phase costs.
 
-## Gacela Pattern
-
-- **Facade**: `ProfileFacade`
-- **Factory**: `ProfileFactory` (creates `ProfilerSession`, formatters; provides `RunFacade`)
-- **Config**: `ProfileConfig` (default top limit)
-- **Provider**: `ProfileProvider` (injects `RunFacade` via `FACADE_RUN`)
-
 ## Public API (Facade)
 
 - `startSession(): ProfilerSession`
@@ -19,40 +12,14 @@ Instrumentation profiler for `phel profile` command. Reports per-fn call counts,
 
 `Phel\Lang\Registry` carries optional `static ?ProfilerHookInterface $profilerHook`. When set, `Registry::addDefinition` wraps each `AbstractFn` in `ProfilingFn` proxy before storing. `GlobalVarEmitter` routes all global-fn calls through `\Phel::getDefinition(...)`, so no emitter changes needed. Off-state cost: one null-check per `addDefinition`; zero call-site overhead when disabled.
 
-## Structure
-
-```
-Profile/
-├── Domain/
-│   ├── Formatter/
-│   │   ├── JsonFormatter.php
-│   │   └── TableFormatter.php
-│   ├── ProfileReport.php       Immutable: per-fn stats, per-source phase ms, wall-clock ms
-│   ├── ProfilerSession.php     Implements ProfilerHookInterface; stack-based self/total accounting
-│   ├── ProfilingFn.php         AbstractFn proxy; times __invoke via session
-│   ├── ReportFormat.php        Enum: Table, Json, Both (emitsTable/emitsJson predicates)
-│   └── SortOrder.php           Enum: SelfTime, TotalTime, Calls, Avg
-├── Infrastructure/
-│   └── Command/
-│       └── ProfileCommand.php  Symfony CLI command; wraps RunFacade::runFile/runNamespace
-└── Gacela files
-    ├── ProfileFacade
-    ├── ProfileFactory
-    ├── ProfileConfig
-    └── ProfileProvider
-```
-
 ## Dependencies
 
-- **Run** (`RunFacade`): `runFile`, `runNamespace`, `autoDetectEntryPoint`, `writeLocatedException`, `writeStackTrace`
-- **Shared** (`Munge`): namespace canonicalization
-- **Lang** (`AbstractFn`, `ProfilerHookInterface`, `Registry`): fn proxy and hook installation
+Run (`runFile`, `runNamespace`, `autoDetectEntryPoint`, error writers), Shared (`Munge` namespace canonicalization), Lang (`AbstractFn`, `ProfilerHookInterface`, `Registry`).
 
 ## Key Constraints
 
 - Hook wraps fns at definition-time only; non-`AbstractFn` values pass through unchanged
-- `ProfilingFn` extends `AbstractFn` so downstream `instanceof` checks succeed
-- `ProfilingFn::__construct` copies inner meta; `getMeta()` and `withMeta()` work via `MetaTrait`
-- Self time: maintain per-call stack, subtract child inclusive time from parent
+- `ProfilingFn` extends `AbstractFn` so downstream `instanceof` checks succeed; copies inner meta so `getMeta()`/`withMeta()` work via `MetaTrait`
+- Self time: `ProfilerSession` maintains per-call stack, subtracts child inclusive time from parent
 - Self-recursive calls bypass proxy (`$this(...)` vs registry lookup); entry from outside counted, recursion depth not
 - `ProfileCommand` installs hook before run, clears in `finally` block

--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -1,74 +1,32 @@
 # Run Module
 
-Runtime execution: runs Phel namespaces/files, REPL, evaluation, testing, and all CLI commands.
-
-## Gacela Pattern
-
-- **Facade**: `RunFacade` implements `RunFacadeInterface`
-- **Factory**: `RunFactory` extends `AbstractFactory<RunConfig>`
-- **Config**: `RunConfig` : REPL startup file path
-- **Provider**: `RunProvider` : injects 4 facades: `CommandFacade`, `CompilerFacade`, `BuildFacade`, `ApiFacade`
+Runtime execution: runs Phel namespaces/files, REPL, evaluation, testing, and most CLI commands.
 
 ## Public API (Facade)
 
-**Execution**
-- `runNamespace(string): void` : execute a namespace with dependencies
-- `runFile(string): void` : execute a Phel file
-- `getNamespaceFromFile(string): NamespaceInformation`
-- `getDependenciesForNamespace(array, array): array` : topologically sorted
-- `getDependenciesFromPaths(array): array`
-- `evalFile(NamespaceInformation): void`
-- `eval(string, CompileOptions = new CompileOptions()): mixed` : compile + execute a Phel snippet
-- `structuredEval(string, CompileOptions = new CompileOptions()): EvalResult` : eval returning success/incomplete/failure result
-- `loadPhelNamespaces(?string = null): void` : load core + startup
-
-**Query**
-- `getAllPhelDirectories(): array`
-- `getLoadedNamespaces(): array`
-- `getVersion(): string`
-- `autoDetectEntryPoint(): ?string` : prefer `main.phel`, fall back to `core.phel`
-
-**Debugging**
-- `enableDebugLineTap(?string $phelFileFilter = null, string $logPath = './phel-debug.log'): void`
-- `disableDebugLineTap(): void`
-
-**Parallel testing**
-- `createParallelTestOrchestrator(): ParallelTestOrchestrator` : process-pool runner that spawns `phel _test-worker` subprocesses, dispatches one ns per work frame, buffers per-ns output, flushes in input order
-- `createCpuCountDetector(): CpuCountDetector` : honours `PHEL_TEST_WORKERS` env var, falls back to `nproc` / `sysctl` / `/proc/cpuinfo`, caps at 8
-
-**Error Handling**
-- `writeLocatedException(OutputInterface, CompilerException): void`
-- `writeStackTrace(OutputInterface, Throwable): void`
+- Execution: `runNamespace(string)`, `runFile(string)`, `evalFile(NamespaceInformation)`, `eval(string, CompileOptions)`, `structuredEval(string, CompileOptions): EvalResult` (success/incomplete/failure), `loadPhelNamespaces(?string)` (core + startup)
+- Namespaces: `getNamespaceFromFile`, `getDependenciesForNamespace` (topologically sorted), `getDependenciesFromPaths`
+- Query: `getAllPhelDirectories`, `getLoadedNamespaces`, `getVersion`, `autoDetectEntryPoint` (prefers `main.phel`, falls back to `core.phel`)
+- Debugging: `enableDebugLineTap(?string $phelFileFilter, string $logPath)`, `disableDebugLineTap`
+- Parallel testing: `createParallelTestOrchestrator()` (process pool spawning `phel _test-worker` subprocesses, one ns per length-prefixed JSON work frame, per-ns output buffered and flushed in input order), `createCpuCountDetector()` (honours `PHEL_TEST_WORKERS`, falls back to `nproc`/`sysctl`/`/proc/cpuinfo`, caps at 8)
+- Error handling: `writeLocatedException`, `writeStackTrace`
 
 ## Dependencies
 
-- **Build** (`BuildFacade`) : namespace extraction, dependency resolution, file evaluation
-- **Compiler** (`CompilerFacade`) : compilation, evaluation, environment management
-- **Command** (`CommandFacade`) : directories, error formatting
-- **Shared** (`VersionResolver`) : version string (git/Composer/official-release detection); Run resolves this directly, no Console dependency
-- **Api** (`ApiFacade`) : REPL autocompletion
+Most connected module, 4 Provider facades: Build (namespace extraction, dependency resolution, file evaluation), Compiler (compilation, evaluation, environment), Command (directories, error formatting), Api (REPL autocompletion). Version comes from `Shared\VersionResolver` directly, so Run does not depend on Console.
 
-## Structure
+## Structure Notes
 
-```
-Run/
-├── Application/        runners, loaders, REPL infrastructure, Agent/ install helpers, Test/ (parallel runner)
-├── Domain/             Agent/, Init/, Repl/ (+ Hint/), Runner/, Test/, stdin/loader interfaces
-├── Infrastructure/     Command/ (9 Symfony commands; one hidden `_test-worker`), PhpStdinReader
-├── Runtime/            PhelSourceLoader (cached-PHP boot entry)
-└── Gacela files        RunFacade, RunFactory, RunConfig, RunProvider
-```
-
-`Application/Test/`: `ParallelTestOrchestrator` (proc_open pool), `TestWorkerHandle` (one live subprocess), `WorkerFrame` (length-prefixed JSON framing), `CpuCountDetector` (cross-platform CPU autodetect, capped at 8).
+- `Infrastructure/Command/`: 9 Symfony commands, one hidden `_test-worker`
+- `Runtime/PhelSourceLoader`: cached-PHP boot entry
 
 ## Key Constraints
 
-- `StructuredEvaluator` (Application) produces the pure `Phel\Shared\Eval\EvalResult` VO via `success()`/`incomplete()`/`failure()`; it never throws and owns the snapshot/restore orchestration (the VOs themselves carry no logic and live in `Phel\Shared`)
+- `StructuredEvaluator` (Application) produces the pure `Phel\Shared\Eval\EvalResult` VO via `success()`/`incomplete()`/`failure()`; it never throws and owns the snapshot/restore orchestration (the VOs carry no logic and live in `Phel\Shared`)
 - REPL supports environment snapshot/restore on eval failure
 - `ReplCommandSystemIo` requires PHP `readline` extension; falls back to `ReplCommandFallbackIo`
 - `ReplHistoryPathResolver` returns `.phel/repl-history`; transparently migrates legacy `.phel-repl-history`
 - `ReplHistory` registers `*1`/`*2`/`*3`/`*e` in `phel.core` after REPL boot
 - `ReplErrorFormatter` renders eval-time `Throwable`s with short headline, hints, and filtered trace
 - New `ReplHint` implementations register via `RunFactory::createReplHints()`
-- `BundledNamespaces` lists every `phel.*` module; `NamespaceLoader` (REPL startup) uses it as eager seeds. `FileRunner` instead uses `BundledNamespaceDetector` to seed only bundles referenced via fully qualified form (`phel.json/encode`) or matching Clojure-compatible requires (`clojure.test` -> `phel.test`) in the script, avoiding the cold-start penalty for scripts that don't reach into bundled modules
-- Most connected module: 4 Provider dependencies (Build, Compiler, Command, Api); version comes from `Shared\VersionResolver`, so Run no longer depends on Console
+- `BundledNamespaces` lists every `phel.*` module; `NamespaceLoader` (REPL startup) uses it as eager seeds. `FileRunner` instead uses `BundledNamespaceDetector` to seed only bundles referenced via fully qualified form (`phel.json/encode`) or matching Clojure-compatible requires (`clojure.test` -> `phel.test`) in the script, avoiding cold-start penalty for scripts that don't reach into bundled modules

--- a/src/php/Shared/CLAUDE.md
+++ b/src/php/Shared/CLAUDE.md
@@ -1,86 +1,53 @@
 # Shared Module
 
-Contract layer: facade interfaces, constants, and cross-module utilities; pure stateless helpers and exception registry.
+Contract layer: facade interfaces, constants, cross-module value objects, and pure stateless utilities. No Gacela pattern; no outward dependencies (other modules appear only in interface signatures).
 
-## No Gacela Pattern
+## Facade Interfaces
 
-Pure contract module; no Facade, Factory, or DependencyProvider. Defines interfaces other modules implement.
-
-## Facade Interfaces (8)
-
-Located in `Facade/` subdirectory. Each module implements one:
-
-| Interface | Module | Key Methods |
-|-----------|--------|-------------|
-| `CompilerFacadeInterface` | Compiler | `eval()`, `compile()`, `lexString()`, `analyze()`, `macroexpand()` |
-| `BuildFacadeInterface` | Build | `compileFile()`, `compileProject()`, `getNamespaceFromFile()` |
-| `RunFacadeInterface` | Run | `runNamespace()`, `eval()`, `structuredEval()`, `loadPhelNamespaces()` |
-| `CommandFacadeInterface` | Command | `writeLocatedException()`, `getAllPhelDirectories()`, `getSourceDirectories()` |
-| `ConsoleFacadeInterface` | Console | `getVersion()`, `runConsole()` |
-| `FormatterFacadeInterface` | Formatter | `format()` |
-| `InteropFacadeInterface` | Interop | `generateExportCode()` |
-| `ApiFacadeInterface` | Api | `getPhelFunctions()`, `replComplete()`, `replCompleteWithTypes()` |
+`Facade/` holds the cross-module facade contracts: Compiler, Build, Run, Command, Console, Formatter, Interop, Api. Modules import these instead of concrete facades; this enables dependency inversion. A facade interface belongs here once another module consumes it; keep its imports minimal.
 
 ## Constants
 
-- `CompilerConstants.PHEL_CORE_NAMESPACE = 'phel.core'`, `DEFAULT_SOURCE = 'string'` (the `lexString` source label; `CompilerFacadeInterface` defaults to it so it no longer references the `Application\Lexer` concrete)
-- `BuildConstants.BUILD_MODE = '*build-mode*'`
-- `ReplConstants.REPL_MODE = '*repl-mode*'`
-- `CompileOptions.DEFAULT_SOURCE = 'string'`, `DEFAULT_STARTING_LINE = 1`, `DEFAULT_ENABLE_SOURCE_MAPS = true`, `DEFAULT_EMIT_ONLY = false`
+- `CompilerConstants.PHEL_CORE_NAMESPACE = 'phel.core'`, `DEFAULT_SOURCE = 'string'` (the `lexString` source label; `CompilerFacadeInterface` defaults to it so it does not reference the `Application\Lexer` concrete)
+- `BuildConstants.BUILD_MODE = '*build-mode*'`; `ReplConstants.REPL_MODE = '*repl-mode*'`
+- `CompileOptions.DEFAULT_SOURCE`, `DEFAULT_STARTING_LINE`, `DEFAULT_ENABLE_SOURCE_MAPS`, `DEFAULT_EMIT_ONLY`
 
-## Exceptions
-
-Located in `Exceptions/`:
+## Exceptions (`Exceptions/`)
 
 - `CompilerException`: wraps `AbstractLocatedException` with `CodeSnippet`
-- `AbstractLocatedException`: base for located errors with `SourceLocation` and `ErrorCode`
-- `ErrorCode`: enum for PHEL001-PHEL310 error codes (analyzer, parser, reader, lexer)
-- `FileException`: file/directory operations
-- `CompiledCodeIsMalformedException`: wraps PHP `eval()` parse errors
+- `AbstractLocatedException`: base for located errors with `SourceLocation` and `ErrorCode` (enum, PHEL001-PHEL310: analyzer, parser, reader, lexer)
+- `FileException` (file/directory ops), `CompiledCodeIsMalformedException` (wraps PHP `eval()` parse errors)
 
 ## Value Objects
 
-- `NamespaceInformation`: pure `final readonly` DTO (`file`, `namespace`, `dependencies`, `isPrimaryDefinition`) produced by Build, consumed across Build/Run/Interop and returned by the Build/Run facade interfaces. Lives here so the Shared facade contracts no longer back-reference a foreign module's `Domain`.
-- `Eval/`: pure `final readonly` VOs describing an eval outcome — `EvalResult` (`success()`/`incomplete()`/`failure()` named constructors), `EvalError`, `StackFrame`. Returned by `RunFacadeInterface::structuredEval()` and consumed by Nrepl/Watch; the producing orchestration lives in `Run\Application\StructuredEvaluator`, so these stay logic-free. Lives here so the Run facade contract no longer exposes `Run\Domain`.
+- `NamespaceInformation`: pure `final readonly` DTO (`file`, `namespace`, `dependencies`, `isPrimaryDefinition`) produced by Build, consumed across Build/Run/Interop. Lives here so the Shared facade contracts don't back-reference a foreign module's `Domain`.
+- `Eval/`: pure `final readonly` VOs for eval outcomes: `EvalResult` (`success()`/`incomplete()`/`failure()` named constructors), `EvalError`, `StackFrame`. Returned by `RunFacadeInterface::structuredEval()`, consumed by Nrepl/Watch; producing orchestration lives in `Run\Application\StructuredEvaluator`, so these stay logic-free.
 
 ## Parser Model
 
-- `Parser/ReadModel/CodeSnippet`: `SourceLocation` (start/end) and source string; pure data, no dependencies.
-- `Parser/Node/*`: the parse-tree value objects (`FileNode`, `ListNode`, `SymbolNode`, `MetaNode`, trivia nodes, etc.) plus the lexer `Token`. Pure data consumed as a de-facto AST contract by Formatter, Lint, and Api; Compiler still produces them. Living here removes the `CompilerFacadeInterface -> Compiler\Domain` parse-tree references.
+- `Parser/ReadModel/CodeSnippet`: `SourceLocation` (start/end) and source string; pure data.
+- `Parser/Node/*`: parse-tree value objects (`FileNode`, `ListNode`, `SymbolNode`, `MetaNode`, trivia nodes, ...) plus the lexer `Token`. De-facto AST contract consumed by Formatter, Lint, Api; Compiler produces them. Living here removes `CompilerFacadeInterface -> Compiler\Domain` references.
 
 ## Printer
 
-Sub-module in `Printer/`: stateless, no I/O wiring. Entry point: `Printer::readable() | readableWithColor() | nonReadable()` then `print($form): string`. Consumers instantiate directly (no module boundary).
-
-Strategy pattern via `TypePrinter/`: one class per Phel/PHP type; `WithColorTrait` for ANSI support.
+Sub-module in `Printer/` (see `Printer/CLAUDE.md`): stateless strategy-pattern printer; consumers instantiate directly.
 
 ## Utility Classes
 
-- `ColorStyle`: ANSI colors (green, yellow, blue, red); factories: `withStyles()`, `noStyles()`
 - `Munge`: namespace/symbol encoding; `encode()`, `encodePhpNs()`, `encodeRegistryKey()`, `decodeNs()`, `canonicalNs()`, `displayNs()`
-- `ResourceUsageFormatter`: returns "Time: HH:MM:SS.mmm, Memory: X.XX MB" snapshot
+- `ColorStyle`: ANSI colors; factories `withStyles()`, `noStyles()`
+- `ResourceUsageFormatter`: "Time: HH:MM:SS.mmm, Memory: X.XX MB" snapshot
 - `PhelProjectDirectory`: manages `.phel/` directory; respects `PHEL_DIR` env var and `PhelConfig::setPhelDir()`
-- `VersionFinder`: pure version-string builder from explicit git inputs (`tagCommitHash`, `currentCommit`, `isOfficialRelease`); no I/O
-- `VersionResolver`: gathers the ambient version inputs (git working copy, Composer `InstalledVersions`, build-time `.phel-release.php`/`OFFICIAL_RELEASE`) and returns `VersionFinder::getVersion()`. Both Console and Run consume it directly, so neither owns version-detection wiring
-- `CompileOptions`: constants for source maps, emit-only mode, optimization levels
-- `SourceMap/VLQ`: pure Base64-VLQ codec (`decode`, `encodeIntegers`, `encodeInteger`); stateless, no module deps. Consumed by Compiler's `SourceMapGenerator`/`SourceMapConsumer`
+- `VersionFinder`: pure version-string builder from explicit git inputs; no I/O. `VersionResolver`: gathers ambient version inputs (git working copy, Composer `InstalledVersions`, build-time `.phel-release.php`/`OFFICIAL_RELEASE`) and calls `VersionFinder`. Both Console and Run consume it directly, so neither owns version-detection wiring
+- `CompileOptions`: source maps, emit-only mode, optimization levels
+- `SourceMap/VLQ`: pure Base64-VLQ codec (`decode`, `encodeIntegers`, `encodeInteger`); consumed by Compiler's `SourceMapGenerator`/`SourceMapConsumer`
 - `SourceMap/SourceMapSiblings`: naming convention for the `<file>.php.map` + `<file>.phel` artifacts next to built files. Written by Build (`FileCompiler`, `SecondaryFileHarvester`), read by Command (`SourceMapExtractor`)
 - `SourceMap/BuiltFilePreamble`: the fixed `<?php declare(strict_types=1);` line before generated code in built files; `prepend()` for the writer (`FileCompiler`), `codeStartLine()` for the reader (`SourceMapExtractor`)
 - `SourceMap/InlineSourceMapComments`: `// `/`// ;;` metadata comment prefixes for inline source maps in eval'd code. Written by Compiler's `EmitterResult`, parsed by `SourceMapExtractor` and `EvaluatedCodeException`
-- `PhpAttributeRenderer`: renders `^{:php/attr ...}` metadata specs into PHP 8 attribute source lines (`#[\ORM\Column(length: 255)]`); pure, stateless. Accepts a bare keyword (`:ORM/Entity`), a single spec vector (`[:ORM/Column {:length 255}]`, first element is the name keyword), or a vector of specs (`[[:ORM/Id] [:ORM/Column]]`). Consumed by `DefStructEmitter`/`DefInterfaceEmitter` and the Interop export generator
-
-## Dependencies
-
-None outward. Imports from other modules only in interface signatures (Compiler exceptions, Lang types, etc.).
-
-## Used By
-
-Every module imports its facade interface from here. Enables dependency inversion.
+- `PhpAttributeRenderer`: renders `^{:php/attr ...}` metadata specs into PHP 8 attribute source lines (`#[\ORM\Column(length: 255)]`). Accepts a bare keyword (`:ORM/Entity`), a single spec vector (`[:ORM/Column {:length 255}]`), or a vector of specs (`[[:ORM/Id] [:ORM/Column]]`). Consumed by `DefStructEmitter`/`DefInterfaceEmitter` and the Interop export generator
 
 ## Key Constraints
 
 - Leaf dependency: contracts and utilities only, never business logic
-- New modules must add `FacadeInterface` here
-- Facade interfaces keep imports minimal
 - Exceptions are cross-module: thrown and caught everywhere
 - Utilities remain stateless: safe to instantiate without module context

--- a/src/php/Shared/Printer/CLAUDE.md
+++ b/src/php/Shared/Printer/CLAUDE.md
@@ -1,73 +1,21 @@
 # Printer
 
-Converts Phel data structures into readable string representations. Stateless strategy pattern, no I/O wiring, no module boundary; consumers instantiate via factory methods.
-
-## No Gacela Pattern
-
-Entry point: `Printer` class. Stateless, no config, no dependencies from other modules.
+Converts Phel data structures into string representations. Stateless strategy pattern, no I/O wiring, no module boundary; consumers instantiate via factory methods. Depends only on Lang types.
 
 ## Public API
 
-**Printer class factory methods**:
-- `Printer::readable()`: readable text, no ANSI colors
-- `Printer::readableWithColor()`: readable text with ANSI colors
-- `Printer::nonReadable()`: machine-oriented output
-- `Printer::installAsTypeStringifier()`: install as global `TypeStringifier` (used at startup)
+- Factories: `Printer::readable()`, `Printer::readableWithColor()`, `Printer::nonReadable()`, `Printer::installAsTypeStringifier()` (installs as global `TypeStringifier` at startup)
+- Instance: `print(mixed $form): string`
 
-**Instance method**:
-- `print(mixed $form): string`: convert any value to string
+## Type Printers
 
-## Type Printers (26 strategies)
+One class per Phel/PHP type in `TypePrinter/` (26 strategies, each implements `TypePrinterInterface`); runtime dispatch by `gettype()` and `instanceof`. Non-obvious renderings:
 
-Each implements `TypePrinterInterface` and handles one type. Runtime dispatch based on `gettype()` and `instanceof`. Recursive printers receive `PrinterInterface` via constructor.
-
-| Printer | Handles |
-|---------|---------|
-| `StringPrinter` | Strings; handles escape sequences and UTF-8 |
-| `NumberPrinter` | Integers, floats |
-| `BooleanPrinter` | true, false |
-| `NullPrinter` | null |
-| `KeywordPrinter` | Keyword objects |
-| `SymbolPrinter` | Symbol objects |
-| `RatioPrinter` | Ratio numbers (n/d) |
-| `BigDecimalPrinter` | BigDecimal; appends M suffix for reader round-trip |
-| `UUIDPrinter` | UUID objects; rendered as #uuid "..." |
-| `AtomPrinter` | Atom objects; recursive |
-| `VarPrinter` | PhelVar handles; rendered as #'ns/name |
-| `ConsPrinter` | Cons cells (LazySeq head); recursive |
-| `PersistentListPrinter` | Lists; recursive |
-| `PersistentVectorPrinter` | Vectors; recursive |
-| `PersistentMapPrinter` | Maps; recursive |
-| `PersistentHashSetPrinter` | Sets; recursive |
-| `PersistentQueuePrinter` | Queues; recursive; rendered as <-(...)-< to show FIFO direction |
-| `StructPrinter` | Structs; recursive |
-| `LazySeqPrinter` | Lazy sequences; recursive |
-| `ArrayPrinter` | PHP arrays; recursive |
-| `FnPrinter` | Functions; non-readable |
-| `ToStringPrinter` | Objects with __toString() |
-| `ObjectPrinter` | Generic objects; non-readable |
-| `AnonymousClassPrinter` | Anonymous classes |
-| `NonPrintableClassPrinter` | Non-printable objects |
-| `ResourcePrinter` | PHP resources |
-
-## Dependencies
-
-Lang module: Keyword, Symbol, Atom, FnInterface, PhelVar, Ratio, BigDecimal, UUID, all collection interfaces (PersistentListInterface, PersistentVectorInterface, etc.).
-
-## Structure
-
-```
-Printer/
-├── Printer.php
-├── PrinterInterface.php
-└── TypePrinter/
-    ├── TypePrinterInterface.php
-    ├── WithColorTrait.php (constructor: $withColor bool)
-    └── 26 printer classes
-```
+- `BigDecimalPrinter` appends M suffix for reader round-trip; `UUIDPrinter` renders `#uuid "..."`; `VarPrinter` renders `#'ns/name`; `PersistentQueuePrinter` renders `<-(...)-<` to show FIFO direction
+- Fallback chain for plain objects: `ToStringPrinter` (has `__toString`), `ObjectPrinter`, `AnonymousClassPrinter`, `NonPrintableClassPrinter`, `ResourcePrinter`
 
 ## Key Constraints
 
 - Recursive printers construct child `PrinterInterface` at call site (reenters `Printer` dispatch)
-- `WithColorTrait` provides $withColor boolean; each printer controls own color output
+- `WithColorTrait` provides `$withColor` boolean; each printer controls own color output
 - `Printer` is final readonly; extend via new TypePrinter implementations only

--- a/src/php/Watch/CLAUDE.md
+++ b/src/php/Watch/CLAUDE.md
@@ -2,17 +2,11 @@
 
 Hot-reload and file-watch: detects `.phel` changes and re-evaluates affected namespaces in dependency order.
 
-## Gacela Pattern
-
-`WatchFacade` → `WatchFactory` → `WatchConfig`. Provider injects Run, Build, Api, Command facades.
-
 ## Public API (Facade)
 
-- `watch(array $paths, array $options = []): void`: blocking watch loop; options: `backend` (auto|inotify|fswatch|polling), `poll` (ms), `debounce` (ms), `publisher` (optional ReloadEventPublisherInterface)
-- `createFileWatcher(?string $preferred, ?int $pollMs, ?int $debounceMs): FileWatcherInterface`
-- `createFileWatcherBuilder(?int $pollMs, ?int $debounceMs): FileWatcherBuilder`
-- `createReloadOrchestrator(?ReloadEventPublisherInterface $publisher): ReloadOrchestratorInterface`
-- `createNamespaceResolver(): NamespaceResolverInterface`
+- `watch(array $paths, array $options = []): void`: blocking watch loop; options: `backend` (auto|inotify|fswatch|polling), `poll` (ms), `debounce` (ms), `publisher` (optional `ReloadEventPublisherInterface`)
+- `createFileWatcher(?string $preferred, ?int $pollMs, ?int $debounceMs)`, `createFileWatcherBuilder(...)`
+- `createReloadOrchestrator(?ReloadEventPublisherInterface)`, `createNamespaceResolver()`
 
 ## CLI
 
@@ -20,38 +14,12 @@ Hot-reload and file-watch: detects `.phel` changes and re-evaluates affected nam
 
 ## Dependencies
 
-| Module | Constant | Use |
-|--------|----------|-----|
-| Run | `FACADE_RUN` | `evalFile`, `structuredEval`, `loadPhelNamespaces` |
-| Build | `FACADE_BUILD` | `getDependenciesForNamespace` |
-| Api | `FACADE_API` | `indexProject` for incremental re-index |
-| Command | `FACADE_COMMAND` | source directory defaults |
-
-## Structure
-
-```
-Watch/
-|-- Application/
-|   |-- Watcher/
-|   |   +-- InotifyWatcher, FswatchWatcher, PollingWatcher (strategy pattern)
-|   |   +-- FileWatcherBuilder, EventDebouncer, AbstractShellWatcher
-|   |-- NamespaceResolver, ReloadOrchestrator
-|   |-- MtimeFileSystemScanner, ApiProjectReindexer
-|   |-- SystemClock, NullReloadEventPublisher, WatchRunner
-|-- Domain/
-|   +-- FileWatcherInterface, NamespaceResolverInterface, ReloadOrchestratorInterface
-|   +-- ClockInterface, FileSystemScannerInterface, ReloadEventPublisherInterface, ProjectReindexerInterface
-|-- Infrastructure/Command/
-|   +-- WatchCommand (Symfony console entry point)
-|-- Transfer/
-|   +-- WatchEvent
-```
+Run (`evalFile`, `structuredEval`, `loadPhelNamespaces`), Build (`getDependenciesForNamespace`), Api (`indexProject` for incremental re-index), Command (source directory defaults).
 
 ## Key Constraints
 
-- Poll interval default 500ms; debounce default 100ms (ConfigWatch)
-- Debounce coalesces rapid file changes, so editor double-save triggers single reload
-- PollingWatcher exercised in CI; inotify/fswatch probed at runtime but not unit-tested (requires external binaries)
-- ReloadOrchestrator side-effect surface: reload in dep order, run phel.watch/run-on-reload-hooks, re-index, publish event
+- Watcher backends are strategies: `InotifyWatcher`, `FswatchWatcher`, `PollingWatcher`. PollingWatcher exercised in CI; inotify/fswatch probed at runtime but not unit-tested (require external binaries)
+- Poll interval default 500ms; debounce default 100ms; debounce coalesces rapid changes so editor double-save triggers single reload
+- ReloadOrchestrator side-effect surface: reload in dep order, run `phel.watch/run-on-reload-hooks`, re-index, publish event
 - NullReloadEventPublisher is default; swap in nREPL-aware publisher for nREPL context
 - NamespaceResolver uses lightweight regex for performance on every file change; not full parser


### PR DESCRIPTION
## 🤔 Background

Every module under `src/php/` carries a CLAUDE.md for agentic coding context. Over time they accumulated heavy duplication: each file restated the same Gacela wiring boilerplate, mirrored its facade interface line by line, and reproduced directory trees that `ls` already answers. Together they weighed 1271 lines, and the repeated patterns drowned out the genuinely non-derivable knowledge (constraints, ABI gotchas, design decisions).

## 💡 Goal

Cut verbosity and duplication across all module CLAUDE.md files while keeping (and surfacing) the high-value context that agents actually need: key constraints, deviations from convention, and knowledge that cannot be derived from the code.

## 🔖 Changes

- New `src/php/CLAUDE.md`: states the shared Gacela convention once (facade/factory/provider wiring, layered layout, cross-module rules) plus a one-line module map for orientation. Module docs now document only deviations.
- All 20 module CLAUDE.md files rewritten (1271 → 657 lines total):
  - Dropped per-module Gacela boilerplate sections, code-mirroring facade tables, and plain directory trees.
  - Kept all Key Constraints, public-surface decisions (e.g. HttpClient #2261), and dense unique sections (Compiler type-specialized emission and generated-class attributes, Lint rule set/config, Run REPL/test-runner notes, Lang type catalog) in compressed form.
  - Corrected the facade-interface claim: only the 8 cross-module contracts live in `Shared/Facade`; Fiber/Filesystem keep theirs locally, newer modules (Lint, Lsp, Nrepl, Profile, Watch) extend `AbstractFacade` without an interface (verified against the code).
- Anchored the `CLAUDE.md`/`AGENTS.md` gitignore rules to the repo root (`/CLAUDE.md`) so the agnostic-ai ignore for the generated root file no longer catches nested module docs.