### PR TITLE
fix(config): make build withers order-independent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `PhelConfig` build withers are now order-independent: `withMainPhelNamespace(...)` no longer pins the entry point to `out/index.php`, so a following `withBuildDestDir('dist')` correctly yields `dist/index.php` (previously the entry point silently landed outside the dest dir depending on call order)
 - Runtime errors in `phel build` output now map back to the Phel source: the error printer reads the sibling `<file>.php.map` and `<file>.phel` artifacts (previously written but never consumed) and reports `out/foo.phel:42` instead of the generated PHP line
 - Inline source maps in eval temp files are detected again: the extractor now scans past the `<?php` opener (and optional `declare` statements) for the metadata comments instead of only reading the first two lines
 

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -293,20 +293,15 @@ final readonly class PhelConfig implements JsonSerializable
     /**
      * Flattens the build namespace onto PhelConfig.
      *
-     * Defaults the entry-point PHP path to `out/index.php` only when no custom
-     * path has been set yet, i.e. the current value is still empty or already
-     * the default `out/index.php`. Any other (custom) path is preserved, so
-     * calling this repeatedly is idempotent for zero-config projects.
+     * Only the namespace is set here; the entry-point PHP path is left to
+     * PhelBuildConfig's lazy derivation (`<destDir>/index.php`). This keeps the
+     * build withers order-independent: `withMainPhelNamespace()->withBuildDestDir('dist')`
+     * and the reverse both yield `dist/index.php`. Zero-config projects still
+     * derive `out/index.php` from the default dest dir.
      */
     public function withMainPhelNamespace(string $namespace): self
     {
-        $build = $this->buildConfig->withMainPhelNamespace($namespace);
-        $currentPath = $this->buildConfig->getMainPhpPath();
-        if ($currentPath === 'out/index.php' || $currentPath === '') {
-            $build = $build->withMainPhpPath('out/index.php');
-        }
-
-        return $this->with(['buildConfig' => $build]);
+        return $this->with(['buildConfig' => $this->buildConfig->withMainPhelNamespace($namespace)]);
     }
 
     public function withMainPhpPath(string $path): self

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -148,6 +148,22 @@ final class PhelConfigTest extends TestCase
         self::assertSame('build', $serialized[PhelConfig::BUILD_CONFIG][PhelBuildConfig::DEST_DIR]);
     }
 
+    public function test_main_php_path_follows_dest_dir_regardless_of_wither_order(): void
+    {
+        $nsFirst = new PhelConfig()
+            ->withMainPhelNamespace('app\\main')
+            ->withBuildDestDir('dist')
+            ->jsonSerialize();
+
+        $destFirst = new PhelConfig()
+            ->withBuildDestDir('dist')
+            ->withMainPhelNamespace('app\\main')
+            ->jsonSerialize();
+
+        self::assertSame('dist/index.php', $nsFirst[PhelConfig::BUILD_CONFIG][PhelBuildConfig::MAIN_PHP_PATH]);
+        self::assertSame($destFirst, $nsFirst);
+    }
+
     public function test_with_export_proxy_methods(): void
     {
         $config = new PhelConfig()


### PR DESCRIPTION
## 🤔 Background

`PhelConfig::withMainPhelNamespace()` eagerly pinned the literal `out/index.php` into `PhelBuildConfig::mainPhpPath` whenever the path was still default. Because `PhelBuildConfig::getMainPhpPath()` short-circuits and returns the raw stored path as-is when it contains a `/`, a later `withBuildDestDir('dist')` had **no effect** on the entry point.

The two withers were non-commutative:

```php
(new PhelConfig())->withMainPhelNamespace('app\\main')->withBuildDestDir('dist');
// entry point: out/index.php  (wrong — outside dest dir, silent)

(new PhelConfig())->withBuildDestDir('dist')->withMainPhelNamespace('app\\main');
// entry point: dist/index.php (correct)
```

A built project's entry point could land outside its dest dir with no warning.

## 💡 Goal

Make the build withers order-independent so the entry-point PHP path always follows the configured dest dir.

## 🔖 Changes

- Drop the eager `out/index.php` pin in `PhelConfig::withMainPhelNamespace()`; only the namespace is set, and the entry-point path is left to `PhelBuildConfig`'s existing lazy derivation (`<destDir>/index.php`).
- Zero-config output is byte-identical (existing tests unchanged): the default dest dir `out` still derives `out/index.php`.
- Add regression test `test_main_php_path_follows_dest_dir_regardless_of_wither_order` asserting both call orders yield `dist/index.php`.
- Update the method docblock and add a CHANGELOG entry.

All unit + integration tests, PHPStan (full), and Rector pass locally.