### PR TITLE
feat(build): expose optimizationLevel in PhelConfig and the build/run/test pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `PhelConfig::withOptimizationLevel(int)` (`optimization-level` config key, default 0): `phel build`, `phel run`, `phel test`, `phel eval`, and `phel compile` now compile at the configured level, making level 2 (`^:pure` call-site inlining + self-recursive tail-call rewriting) reachable for real projects; REPL and nREPL stay at level 0 (#2387)
+- `phel build -O <level>` (`--optimization-level`) CLI override taking precedence over the configured level; changing the level automatically invalidates both the incremental `phel build` output and the compiled-code cache
+
 ### Fixed
 
 - Runtime errors in `phel build` output now map back to the Phel source: the error printer reads the sibling `<file>.php.map` and `<file>.phel` artifacts (previously written but never consumed) and reports `out/foo.phel:42` instead of the generated PHP line

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -25,6 +25,29 @@ Invalidation is automatic: each run hashes the `.phel` source (`md5`) against th
 
 For hot numeric/string fns, add `:tag` annotations on params and the return slot (`^int`, `^float`, `^string`, `^bool`). The compiler emits matching PHP type declarations and infers the return type from primitive ops in tail position, letting the tracing JIT specialize the call. Tag mismatches surface as Phel diagnostics at compile time. Measure with `composer bench-jit-baseline` and `composer bench-jit-tracing` (see [`internals/benchmarks.md`](internals/benchmarks.md)).
 
+## Optimization levels
+
+`phel-config.php` can opt the compiler into higher optimization levels (default 0):
+
+```php
+return new PhelConfig()
+    ->withOptimizationLevel(2);
+```
+
+| Level | Effect |
+|---|---|
+| 0 | Off (default); output is byte-identical to previous releases |
+| 1 | Reserved for auto-inlining single-expression private `defn-` (not implemented yet) |
+| 2 | `^:pure` call-site inlining + rewrite of self-recursive tail calls into an implicit loop |
+
+The level applies to `phel build`, `phel run`, `phel test`, `phel eval`, and `phel compile`. The REPL and nREPL always compile at level 0 so interactive redefinition stays predictable. `phel build -O2` (long form `--optimization-level=2`) overrides the configured level for a single build.
+
+Level 2 trade-offs:
+
+- `^:pure` is the author's promise that a single-arity `defn` is side-effect free and safe to inline at call sites; the compiler trusts the annotation instead of verifying it.
+- Tail-call rewriting eliminates per-iteration PHP stack frames (deep self-recursion no longer overflows) at the cost of a shorter stack trace inside the loop.
+- Changing the level automatically invalidates the compiled-code cache and the incremental `phel build` output, so the next run recompiles everything once.
+
 ## Memory limit
 
 `./vendor/bin/phel` raises `memory_limit` to `-1` automatically. If you invoke PHP directly (`php ./vendor/bin/phel ...`) or embed Phel, bump the limit yourself. The compiler's `token_get_all` validation can exceed 128M on large projects.

--- a/src/php/Build/Application/FileCompiler.php
+++ b/src/php/Build/Application/FileCompiler.php
@@ -22,15 +22,17 @@ final readonly class FileCompiler implements FileCompilerInterface
         private CompilerFacadeInterface $compilerFacade,
         private NamespaceExtractorInterface $namespaceExtractor,
         private FileIoInterface $fileIo,
+        private int $defaultOptimizationLevel = CompileOptions::DEFAULT_OPTIMIZATION_LEVEL,
     ) {}
 
-    public function compileFile(string $src, string $dest, bool $enableSourceMaps): CompiledFile
+    public function compileFile(string $src, string $dest, bool $enableSourceMaps, ?int $optimizationLevel = null): CompiledFile
     {
         $phelCode = $this->fileIo->getContents($src);
 
         $options = new CompileOptions()
             ->setSource($src)
-            ->setIsEnabledSourceMaps($enableSourceMaps);
+            ->setIsEnabledSourceMaps($enableSourceMaps)
+            ->setOptimizationLevel($optimizationLevel ?? $this->defaultOptimizationLevel);
 
         BuildFacade::enableBuildMode();
         ob_start();

--- a/src/php/Build/Application/FileEvaluator.php
+++ b/src/php/Build/Application/FileEvaluator.php
@@ -38,6 +38,7 @@ final class FileEvaluator
         private readonly ?CompiledCodeCacheInterface $compiledCodeCache = null,
         private readonly FirstFormExtractor $firstFormExtractor = new FirstFormExtractor(),
         private readonly ?DependencyTrackerInterface $dependencyTracker = null,
+        private readonly int $optimizationLevel = CompileOptions::DEFAULT_OPTIMIZATION_LEVEL,
     ) {}
 
     /**
@@ -65,7 +66,7 @@ final class FileEvaluator
         $namespace = $namespaceInfo->getNamespace();
 
         if ($this->compiledCodeCache instanceof CompiledCodeCacheInterface) {
-            $sourceHash = md5($code);
+            $sourceHash = $this->sourceHash($code);
             $cachedPath = $this->compiledCodeCache->get($src, $sourceHash);
 
             if ($cachedPath !== null) {
@@ -113,7 +114,8 @@ final class FileEvaluator
 
             $options = new CompileOptions()
                 ->setSource($src)
-                ->setIsEnabledSourceMaps(false);
+                ->setIsEnabledSourceMaps(false)
+                ->setOptimizationLevel($this->optimizationLevel);
 
             $result = $this->compilerFacade->compileForCache($code, $options);
             $this->compiledCodeCache->put($src, $namespace, $sourceHash, $result->getPhpCode());
@@ -130,11 +132,24 @@ final class FileEvaluator
 
         $options = new CompileOptions()
             ->setSource($src)
-            ->setIsEnabledSourceMaps(true);
+            ->setIsEnabledSourceMaps(true)
+            ->setOptimizationLevel($this->optimizationLevel);
 
         $this->compilerFacade->eval($code, $options);
 
         return new CompiledFile($src, '', $namespace);
+    }
+
+    /**
+     * Cache key for the compiled-code cache. The optimization level is mixed
+     * in so changing it invalidates entries compiled at another level; level 0
+     * keeps the historical plain `md5` so existing caches stay warm.
+     */
+    private function sourceHash(string $code): string
+    {
+        return $this->optimizationLevel > 0
+            ? md5($code . '|O' . $this->optimizationLevel)
+            : md5($code);
     }
 
     private function analyzeNsForm(string $code, string $src): void

--- a/src/php/Build/Application/ProjectCompiler.php
+++ b/src/php/Build/Application/ProjectCompiler.php
@@ -25,6 +25,13 @@ use function sprintf;
 
 final readonly class ProjectCompiler
 {
+    /**
+     * Marker file in the output directory recording the optimization level of
+     * the last build. The incremental cache only compares mtimes, so without
+     * this record a level change would silently reuse stale output.
+     */
+    private const string OPTIMIZATION_LEVEL_FILE = '.phel-optimization-level';
+
     private CompiledTargetPathResolver $targetPathResolver;
 
     public function __construct(
@@ -71,6 +78,9 @@ final readonly class ProjectCompiler
         // sibling files during compile-time statement evaluation.
         LoadClasspath::publish($srcDirectories);
 
+        $optimizationLevel = $buildOptions->getOptimizationLevel() ?? $this->config->getOptimizationLevel();
+        $optimizationLevelChanged = $this->storedOptimizationLevel($dest) !== $optimizationLevel;
+
         $namespaceInformation = $this->namespaceExtractor->getNamespacesFromDirectories($srcDirectories);
         /** @var list<CompiledFile> $result */
         $result = [];
@@ -94,7 +104,7 @@ final readonly class ProjectCompiler
                 throw new RuntimeException(sprintf('Directory "%s" was not created', $targetDir));
             }
 
-            if ($this->canUseCache($buildOptions, $targetFile, $info)) {
+            if (!$optimizationLevelChanged && $this->canUseCache($buildOptions, $targetFile, $info)) {
                 // Load cached file to register definitions and execute top-level expressions
                 BuildFacade::enableBuildMode();
                 ob_start();
@@ -120,11 +130,13 @@ final readonly class ProjectCompiler
                 $info->getFile(),
                 $targetFile,
                 $buildOptions->isSourceMapEnabled(),
+                $optimizationLevel,
             );
 
             touch($targetFile, $this->getFileMtime($info->getFile()));
         }
 
+        $this->storeOptimizationLevel($dest, $optimizationLevel);
         $this->harvestSecondaries($namespaceInformation, $dest, $srcDirectories);
 
         if ($this->config->shouldCreateEntryPointPhpFile()) {
@@ -175,6 +187,33 @@ final readonly class ProjectCompiler
         }
 
         return array_all($this->config->getPathsToAvoidCache(), static fn(string $path): bool => !str_contains($targetFile, $path));
+    }
+
+    private function storedOptimizationLevel(string $dest): int
+    {
+        $file = $dest . '/' . self::OPTIMIZATION_LEVEL_FILE;
+
+        return is_file($file) ? (int) file_get_contents($file) : 0;
+    }
+
+    private function storeOptimizationLevel(string $dest, int $level): void
+    {
+        $file = $dest . '/' . self::OPTIMIZATION_LEVEL_FILE;
+
+        if ($level === 0) {
+            // Level 0 leaves no marker, keeping default builds byte-identical.
+            if (is_file($file)) {
+                @unlink($file);
+            }
+
+            return;
+        }
+
+        if (!is_dir($dest) && !mkdir($dest, 0777, true) && !is_dir($dest)) {
+            throw new RuntimeException(sprintf('Directory "%s" was not created', $dest));
+        }
+
+        file_put_contents($file, (string) $level);
     }
 
     private function getFileMtime(string $file): int

--- a/src/php/Build/BuildConfig.php
+++ b/src/php/Build/BuildConfig.php
@@ -7,6 +7,7 @@ namespace Phel\Build;
 use Gacela\Framework\AbstractConfig;
 use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
+use Phel\Shared\CompileOptions;
 use Phel\Shared\PhelProjectDirectory;
 
 use function is_string;
@@ -47,6 +48,11 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
         }
 
         return $config;
+    }
+
+    public function getOptimizationLevel(): int
+    {
+        return max(0, (int) $this->get(PhelConfig::OPTIMIZATION_LEVEL, CompileOptions::DEFAULT_OPTIMIZATION_LEVEL));
     }
 
     public function isNamespaceCacheEnabled(): bool

--- a/src/php/Build/BuildConfigInterface.php
+++ b/src/php/Build/BuildConfigInterface.php
@@ -17,4 +17,6 @@ interface BuildConfigInterface
     public function getPathsToAvoidCache(): array;
 
     public function shouldCreateEntryPointPhpFile(): bool;
+
+    public function getOptimizationLevel(): int;
 }

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -66,6 +66,7 @@ final class BuildFactory extends AbstractFactory
             $this->getCompilerFacade(),
             $this->createNamespaceExtractor(),
             $this->createFileIo(),
+            $this->getConfig()->getOptimizationLevel(),
         );
     }
 
@@ -83,6 +84,7 @@ final class BuildFactory extends AbstractFactory
                 $this->createCompiledCodeCache(),
                 $this->createFirstFormExtractor(),
                 $this->createDependencyTracker(),
+                $this->getConfig()->getOptimizationLevel(),
             ),
         );
     }

--- a/src/php/Build/CLAUDE.md
+++ b/src/php/Build/CLAUDE.md
@@ -23,3 +23,4 @@ Compiler (Phel-to-PHP compilation), Command (output/source dirs, error formattin
 - `FileEvaluator` is singleton; repeated `(load ...)` calls reuse instance to preserve compiled-code index
 - Auto-detect main namespace: scans source dirs for `core.phel` or `main.phel`
 - Output directory pruned from extraction to prevent namespace shadowing
+- Optimization level: `BuildConfig::getOptimizationLevel()` (key `PhelConfig::OPTIMIZATION_LEVEL`) is injected into `FileCompiler` (constructor default; per-call override wins, used by `phel build -O`) and `FileEvaluator` (also mixed into the compiled-code cache hash when > 0). `ProjectCompiler` records the level in `<out>/.phel-optimization-level` and forces a recompile when it changes, because the incremental cache is mtime-only; level 0 leaves no marker

--- a/src/php/Build/Domain/Compile/BuildOptions.php
+++ b/src/php/Build/Domain/Compile/BuildOptions.php
@@ -9,6 +9,7 @@ final readonly class BuildOptions
     public function __construct(
         private bool $enableCache,
         private bool $enableSourceMap,
+        private ?int $optimizationLevel = null,
     ) {}
 
     public function isCacheEnabled(): bool
@@ -19,5 +20,14 @@ final readonly class BuildOptions
     public function isSourceMapEnabled(): bool
     {
         return $this->enableSourceMap;
+    }
+
+    /**
+     * CLI override for the configured optimization level; `null` means
+     * "use the level from `phel-config.php`".
+     */
+    public function getOptimizationLevel(): ?int
+    {
+        return $this->optimizationLevel;
     }
 }

--- a/src/php/Build/Domain/Compile/FileCompilerInterface.php
+++ b/src/php/Build/Domain/Compile/FileCompilerInterface.php
@@ -6,5 +6,8 @@ namespace Phel\Build\Domain\Compile;
 
 interface FileCompilerInterface
 {
-    public function compileFile(string $src, string $dest, bool $enableSourceMaps): CompiledFile;
+    /**
+     * @param int|null $optimizationLevel `null` falls back to the implementation's configured default
+     */
+    public function compileFile(string $src, string $dest, bool $enableSourceMaps, ?int $optimizationLevel = null): CompiledFile;
 }

--- a/src/php/Build/Infrastructure/Command/BuildCommand.php
+++ b/src/php/Build/Infrastructure/Command/BuildCommand.php
@@ -30,12 +30,20 @@ final class BuildCommand extends Command
 
     private const string OPTION_SOURCE_MAP = 'source-map';
 
+    private const string OPTION_OPTIMIZATION_LEVEL = 'optimization-level';
+
     protected function configure(): void
     {
         $this->setName('build')
             ->setDescription('Build the current project')
             ->addOption(self::OPTION_CACHE, null, InputOption::VALUE_NEGATABLE, 'Enable cache', true)
-            ->addOption(self::OPTION_SOURCE_MAP, null, InputOption::VALUE_NEGATABLE, 'Enable source maps', true);
+            ->addOption(self::OPTION_SOURCE_MAP, null, InputOption::VALUE_NEGATABLE, 'Enable source maps', true)
+            ->addOption(
+                self::OPTION_OPTIMIZATION_LEVEL,
+                'O',
+                InputOption::VALUE_REQUIRED,
+                'Override the configured optimization level (0 = off, 2 = inline + tail-call rewrite)',
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -58,9 +66,12 @@ final class BuildCommand extends Command
 
     private function getBuildOptions(InputInterface $input): BuildOptions
     {
+        $rawLevel = $input->getOption(self::OPTION_OPTIMIZATION_LEVEL);
+
         return new BuildOptions(
             $input->getOption(self::OPTION_CACHE) === true,
             $input->getOption(self::OPTION_SOURCE_MAP) === true,
+            $rawLevel === null ? null : max(0, (int) $rawLevel),
         );
     }
 

--- a/src/php/Config/CLAUDE.md
+++ b/src/php/Config/CLAUDE.md
@@ -6,7 +6,7 @@ Pure data/model layer defining configuration structure for Phel projects. No Gac
 
 ### PhelConfig
 
-Immutable `final readonly class` (~650 LOC). Every mutation returns a new instance via `with*()` methods (directory, layout, build, export, cache, flag setters); `forProject(ProjectLayout = Flat, string $mainNamespace = '')` convenience constructor; `validate(): list<string>` (empty if valid); `jsonSerialize()`.
+Immutable `final readonly class` (~650 LOC). Every mutation returns a new instance via `with*()` methods (directory, layout, build, export, cache, flag setters); `withOptimizationLevel(int)` (key `optimization-level`, clamped >= 0) sets the compiler optimization level consumed by Build/Run (REPL/nREPL ignore it); `forProject(ProjectLayout = Flat, string $mainNamespace = '')` convenience constructor; `validate(): list<string>` (empty if valid); `jsonSerialize()`.
 
 **Deprecated (since 0.37)**: `setX()` and `useLayout()`/`useNestedLayout()`/`useFlatLayout()` shim to `with*()` counterparts (marked `#[Deprecated]`). Permanent backward-compatibility aliases, not scheduled for removal in a minor release; removal would require a major version bump.
 

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -43,6 +43,8 @@ final readonly class PhelConfig implements JsonSerializable
 
     public const string PHEL_DIR = 'phel-dir';
 
+    public const string OPTIMIZATION_LEVEL = 'optimization-level';
+
     /** @var list<string> */
     public const array DEFAULT_SRC_DIRS = ['src'];
 
@@ -77,6 +79,7 @@ final readonly class PhelConfig implements JsonSerializable
         public bool $enableNamespaceCache = true,
         public bool $enableCompiledCodeCache = true,
         public string $phelDir = '',
+        public int $optimizationLevel = 0,
     ) {
         $this->tempDir = $tempDir === null
             ? sys_get_temp_dir() . self::PHEL_TEMP_SUBDIR . '/tmp'
@@ -208,6 +211,16 @@ final readonly class PhelConfig implements JsonSerializable
     public function getPhelDir(): string
     {
         return $this->phelDir;
+    }
+
+    /**
+     * Compiler optimization level: 0 = off (default), 1 = reserved for
+     * auto-inlining, 2 = `^:pure` call-site inlining + self-recursive
+     * tail-call rewriting. See `CompileOptions::DEFAULT_OPTIMIZATION_LEVEL`.
+     */
+    public function getOptimizationLevel(): int
+    {
+        return $this->optimizationLevel;
     }
 
     // ========================================
@@ -406,6 +419,17 @@ final readonly class PhelConfig implements JsonSerializable
     public function withPhelDir(string $dir): self
     {
         return $this->with(['phelDir' => $dir]);
+    }
+
+    /**
+     * Set the compiler optimization level applied by `phel build`, `phel run`,
+     * and `phel test` (REPL and nREPL always stay at 0). Negative values are
+     * clamped to 0. Level 2 enables `^:pure` call-site inlining and
+     * self-recursive tail-call rewriting.
+     */
+    public function withOptimizationLevel(int $level): self
+    {
+        return $this->with(['optimizationLevel' => max(0, $level)]);
     }
 
     // ========================================
@@ -608,6 +632,7 @@ final readonly class PhelConfig implements JsonSerializable
             self::ENABLE_COMPILED_CODE_CACHE => $this->enableCompiledCodeCache,
             self::CACHE_DIR => $this->cacheDir,
             self::PHEL_DIR => $this->phelDir,
+            self::OPTIMIZATION_LEVEL => $this->optimizationLevel,
         ];
     }
 
@@ -638,6 +663,7 @@ final readonly class PhelConfig implements JsonSerializable
             'enableNamespaceCache' => $this->enableNamespaceCache,
             'enableCompiledCodeCache' => $this->enableCompiledCodeCache,
             'phelDir' => $this->phelDir,
+            'optimizationLevel' => $this->optimizationLevel,
         ];
 
         return new self(...[...$base, ...$overrides]);

--- a/src/php/Run/Application/CompileExecutor.php
+++ b/src/php/Run/Application/CompileExecutor.php
@@ -20,6 +20,7 @@ final readonly class CompileExecutor
 {
     public function __construct(
         private CompilerFacadeInterface $compilerFacade,
+        private int $optimizationLevel = CompileOptions::DEFAULT_OPTIMIZATION_LEVEL,
     ) {}
 
     /**
@@ -40,7 +41,9 @@ final readonly class CompileExecutor
         }
 
         try {
-            $options = new CompileOptions()->setEmitOnly(true);
+            $options = new CompileOptions()
+                ->setEmitOnly(true)
+                ->setOptimizationLevel($this->optimizationLevel);
             $result = $this->compilerFacade->compile($source, $options);
             $stdout($result->getPhpCode());
             return true;

--- a/src/php/Run/Application/EvalExecutor.php
+++ b/src/php/Run/Application/EvalExecutor.php
@@ -25,6 +25,7 @@ final readonly class EvalExecutor
         private ColorStyleInterface $style,
         private PrinterInterface $printer,
         private CompilerFacadeInterface $compilerFacade,
+        private int $optimizationLevel = CompileOptions::DEFAULT_OPTIMIZATION_LEVEL,
     ) {}
 
     public function execute(string $input): bool
@@ -39,7 +40,9 @@ final readonly class EvalExecutor
             return false;
         }
 
-        $options = new CompileOptions()->setStartingLine(1);
+        $options = new CompileOptions()
+            ->setStartingLine(1)
+            ->setOptimizationLevel($this->optimizationLevel);
 
         try {
             $result = $this->compilerFacade->eval($input, $options);

--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -22,6 +22,7 @@ Most connected module, 4 Provider facades: Build (namespace extraction, dependen
 
 ## Key Constraints
 
+- `RunConfig::getOptimizationLevel()` (key `PhelConfig::OPTIMIZATION_LEVEL`) is injected into `EvalExecutor` (`phel eval`) and `CompileExecutor` (`phel compile`); `phel run`/`phel test` pick the level up via Build's `FileEvaluator`. The REPL and nREPL always compile at level 0 by design
 - `StructuredEvaluator` (Application) produces the pure `Phel\Shared\Eval\EvalResult` VO via `success()`/`incomplete()`/`failure()`; it never throws and owns the snapshot/restore orchestration (the VOs carry no logic and live in `Phel\Shared`)
 - REPL supports environment snapshot/restore on eval failure
 - `ReplCommandSystemIo` requires PHP `readline` extension; falls back to `ReplCommandFallbackIo`

--- a/src/php/Run/RunConfig.php
+++ b/src/php/Run/RunConfig.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Phel\Run;
 
 use Gacela\Framework\AbstractConfig;
+use Phel\Config\PhelConfig;
+use Phel\Shared\CompileOptions;
 
 final class RunConfig extends AbstractConfig
 {
@@ -14,5 +16,10 @@ final class RunConfig extends AbstractConfig
         // never picks up the bundled REPL bootstrap as a primary
         // `(ns user)` definition for downstream projects dogfooding Phel.
         return __DIR__ . '/../../../resources/repl/startup.phel';
+    }
+
+    public function getOptimizationLevel(): int
+    {
+        return max(0, (int) $this->get(PhelConfig::OPTIMIZATION_LEVEL, CompileOptions::DEFAULT_OPTIMIZATION_LEVEL));
     }
 }

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -189,6 +189,7 @@ class RunFactory extends AbstractFactory
             $this->createColorStyle(),
             $this->createPrinter(),
             $this->getCompilerFacade(),
+            $this->getConfig()->getOptimizationLevel(),
         );
     }
 
@@ -196,6 +197,7 @@ class RunFactory extends AbstractFactory
     {
         return new CompileExecutor(
             $this->getCompilerFacade(),
+            $this->getConfig()->getOptimizationLevel(),
         );
     }
 

--- a/tests/php/Integration/Build/Command/.gitignore
+++ b/tests/php/Integration/Build/Command/.gitignore
@@ -1,1 +1,2 @@
 out-load-e2e/
+out-optimization/

--- a/tests/php/Integration/Build/Command/BuildCommandOptimizationLevelTest.php
+++ b/tests/php/Integration/Build/Command/BuildCommandOptimizationLevelTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Build\Command;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use Phel\Build\Infrastructure\Command\BuildCommand;
+use PhelTest\Integration\Util\DirectoryUtil;
+use PhelTest\Support\PerTestGacelaCache;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function ob_end_clean;
+use function ob_start;
+
+final class BuildCommandOptimizationLevelTest extends TestCase
+{
+    private BuildCommand $command;
+
+    public static function tearDownAfterClass(): void
+    {
+        DirectoryUtil::removeDir(__DIR__ . '/out-optimization');
+    }
+
+    protected function setUp(): void
+    {
+        new PerTestGacelaCache()->isolate();
+        $this->command = new BuildCommand();
+        DirectoryUtil::removeDir(__DIR__ . '/out-optimization');
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_config_level_two_optimizes_build_output(): void
+    {
+        $this->bootstrapGacela();
+
+        $this->runBuild(['--no-source-map' => true, '--no-cache' => true]);
+
+        $php = $this->compiledOutput();
+        // Self-recursive tail call rewritten into an implicit loop.
+        self::assertStringContainsString('while (true)', $php);
+        // `(add2 1 2)` inlined and folded to the literal 3.
+        self::assertMatchesRegularExpression('/"result",\s+3,/', $php);
+        self::assertStringNotContainsString('"add2"))->__invoke(1, 2)', $php);
+
+        self::assertFileExists(__DIR__ . '/out-optimization/.phel-optimization-level');
+        self::assertSame('2', file_get_contents(__DIR__ . '/out-optimization/.phel-optimization-level'));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_cli_override_takes_precedence_over_config(): void
+    {
+        $this->bootstrapGacela();
+
+        $this->runBuild([
+            '--no-source-map' => true,
+            '--no-cache' => true,
+            '--optimization-level' => '0',
+        ]);
+
+        $php = $this->compiledOutput();
+        self::assertStringNotContainsString('while (true)', $php);
+        self::assertStringContainsString('"add2"))->__invoke(1, 2)', $php);
+
+        // Level 0 leaves no marker behind.
+        self::assertFileDoesNotExist(__DIR__ . '/out-optimization/.phel-optimization-level');
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_level_change_invalidates_incremental_cache(): void
+    {
+        $this->bootstrapGacela();
+
+        // First build at level 0 with the incremental cache enabled.
+        $this->runBuild(['--no-source-map' => true, '--optimization-level' => '0']);
+        self::assertStringNotContainsString('while (true)', $this->compiledOutput());
+
+        // Same sources, cache still enabled: only the level changed (config
+        // level 2 applies). The mtime-based cache alone would reuse the stale
+        // level-0 output; the on-disk level marker must force a recompile.
+        $this->runBuild(['--no-source-map' => true]);
+        self::assertStringContainsString('while (true)', $this->compiledOutput());
+    }
+
+    /**
+     * @param array<string, bool|string> $input
+     */
+    private function runBuild(array $input): void
+    {
+        ob_start();
+        try {
+            $this->command->run(
+                new ArrayInput($input),
+                $this->createStub(OutputInterface::class),
+            );
+        } finally {
+            ob_end_clean();
+        }
+    }
+
+    private function compiledOutput(): string
+    {
+        $file = __DIR__ . '/out-optimization/opt_ns/opt.php';
+        self::assertFileExists($file);
+
+        return (string) file_get_contents($file);
+    }
+
+    private function bootstrapGacela(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addAppConfig('phel-config-optimization.php');
+        });
+    }
+}

--- a/tests/php/Integration/Build/Command/phel-config-optimization.php
+++ b/tests/php/Integration/Build/Command/phel-config-optimization.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Phel\Config\PhelConfig;
+
+return new PhelConfig()
+    ->withSrcDirs([__DIR__ . '/src-optimization'])
+    ->withVendorDir('')
+    ->withBuildDestDir('out-optimization')
+    ->withOptimizationLevel(2);

--- a/tests/php/Integration/Build/Command/src-optimization/opt.phel
+++ b/tests/php/Integration/Build/Command/src-optimization/opt.phel
@@ -1,0 +1,8 @@
+(ns opt-ns.opt)
+
+(defn ^:pure add2 [a b] (+ a b))
+
+(defn countdown [n]
+  (if (<= n 0) n (countdown (- n 1))))
+
+(def result (add2 1 2))

--- a/tests/php/Unit/Build/Application/FileCompilerTest.php
+++ b/tests/php/Unit/Build/Application/FileCompilerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Build\Application;
+
+use Phel\Build\Application\FileCompiler;
+use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
+use Phel\Build\Domain\IO\FileIoInterface;
+use Phel\Compiler\Domain\Emitter\EmitterResult;
+use Phel\Shared\CompileOptions;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+use Phel\Shared\NamespaceInformation;
+use PHPUnit\Framework\TestCase;
+
+final class FileCompilerTest extends TestCase
+{
+    private ?CompileOptions $capturedOptions = null;
+
+    public function test_compile_file_defaults_to_optimization_level_zero(): void
+    {
+        $compiler = new FileCompiler(
+            $this->createCapturingCompilerFacade(),
+            $this->createNamespaceExtractor(),
+            $this->createStub(FileIoInterface::class),
+        );
+
+        $compiler->compileFile('/src/test.phel', '/out/test.php', false);
+
+        self::assertNotNull($this->capturedOptions);
+        self::assertSame(0, $this->capturedOptions->getOptimizationLevel());
+    }
+
+    public function test_compile_file_uses_constructor_optimization_level(): void
+    {
+        $compiler = new FileCompiler(
+            $this->createCapturingCompilerFacade(),
+            $this->createNamespaceExtractor(),
+            $this->createStub(FileIoInterface::class),
+            defaultOptimizationLevel: 2,
+        );
+
+        $compiler->compileFile('/src/test.phel', '/out/test.php', false);
+
+        self::assertNotNull($this->capturedOptions);
+        self::assertSame(2, $this->capturedOptions->getOptimizationLevel());
+    }
+
+    public function test_explicit_optimization_level_overrides_constructor_default(): void
+    {
+        $compiler = new FileCompiler(
+            $this->createCapturingCompilerFacade(),
+            $this->createNamespaceExtractor(),
+            $this->createStub(FileIoInterface::class),
+            defaultOptimizationLevel: 2,
+        );
+
+        $compiler->compileFile('/src/test.phel', '/out/test.php', false, 0);
+
+        self::assertNotNull($this->capturedOptions);
+        self::assertSame(0, $this->capturedOptions->getOptimizationLevel());
+    }
+
+    private function createCapturingCompilerFacade(): CompilerFacadeInterface
+    {
+        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade->method('compile')
+            ->willReturnCallback(function (string $code, CompileOptions $options): EmitterResult {
+                $this->capturedOptions = $options;
+
+                return new EmitterResult(false, '$compiled = true;', '', '');
+            });
+
+        return $compilerFacade;
+    }
+
+    private function createNamespaceExtractor(): NamespaceExtractorInterface
+    {
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
+        $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
+            new NamespaceInformation('/src/test.phel', 'test\\ns', ['phel.core']),
+        );
+
+        return $namespaceExtractor;
+    }
+}

--- a/tests/php/Unit/Build/Application/FileEvaluatorTest.php
+++ b/tests/php/Unit/Build/Application/FileEvaluatorTest.php
@@ -10,6 +10,7 @@ use Phel\Build\Domain\Extractor\FirstFormExtractor;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
 use Phel\Compiler\Domain\Emitter\EmitterResult;
+use Phel\Shared\CompileOptions;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use Phel\Shared\NamespaceInformation;
 use PHPUnit\Framework\TestCase;
@@ -488,6 +489,122 @@ final class FileEvaluatorTest extends TestCase
             $tracker,
         );
 
+        $evaluator->evalFile($sourceFile);
+    }
+
+    public function test_eval_file_passes_optimization_level_to_compiler(): void
+    {
+        $sourceFile = $this->tempDir . '/test.phel';
+        file_put_contents($sourceFile, '(ns test\\namespace)');
+        $namespace = 'test\\namespace';
+
+        $capturedOptions = null;
+        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade->method('eval')
+            ->willReturnCallback(static function (string $code, CompileOptions $options) use (&$capturedOptions): mixed {
+                $capturedOptions = $options;
+
+                return null;
+            });
+
+        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
+            new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
+        );
+
+        $evaluator = new FileEvaluator(
+            $compilerFacade,
+            $namespaceExtractor,
+            optimizationLevel: 2,
+        );
+        $evaluator->evalFile($sourceFile);
+
+        self::assertInstanceOf(CompileOptions::class, $capturedOptions);
+        self::assertSame(2, $capturedOptions->getOptimizationLevel());
+    }
+
+    public function test_changing_optimization_level_invalidates_cached_code(): void
+    {
+        $sourceFile = $this->tempDir . '/test.phel';
+        $sourceCode = '(ns test\\namespace)';
+        file_put_contents($sourceFile, $sourceCode);
+        $cacheDir = $this->tempDir . '/cache';
+        $namespace = 'test\\namespace';
+
+        // Entry stored under the plain level-0 hash must not satisfy a level-2 run.
+        $cache = new CompiledCodeCache($cacheDir);
+        $cache->put($sourceFile, $namespace, md5($sourceCode), '$level0 = true;');
+
+        $capturedOptions = null;
+        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade->expects($this->once())
+            ->method('compileForCache')
+            ->willReturnCallback(static function (string $code, CompileOptions $options) use (&$capturedOptions): EmitterResult {
+                $capturedOptions = $options;
+
+                return new EmitterResult(false, '$level2 = true;', '', '');
+            });
+
+        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
+            new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
+        );
+
+        $evaluator = new FileEvaluator(
+            $compilerFacade,
+            $namespaceExtractor,
+            $cache,
+            optimizationLevel: 2,
+        );
+        $evaluator->evalFile($sourceFile);
+
+        self::assertInstanceOf(CompileOptions::class, $capturedOptions);
+        self::assertSame(2, $capturedOptions->getOptimizationLevel());
+
+        // A second level-2 run must hit the freshly stored level-2 entry.
+        FileEvaluator::resetState();
+        $secondFacade = $this->createMock(CompilerFacadeInterface::class);
+        $secondFacade->expects($this->never())->method('compileForCache');
+        $secondFacade->expects($this->never())->method('eval');
+
+        $secondEvaluator = new FileEvaluator(
+            $secondFacade,
+            $namespaceExtractor,
+            $cache,
+            optimizationLevel: 2,
+        );
+        $result = $secondEvaluator->evalFile($sourceFile);
+
+        self::assertSame($namespace, $result->getNamespace());
+    }
+
+    public function test_level_zero_keeps_plain_source_hash(): void
+    {
+        $sourceFile = $this->tempDir . '/test.phel';
+        $sourceCode = '(ns test\\namespace)';
+        file_put_contents($sourceFile, $sourceCode);
+        $cacheDir = $this->tempDir . '/cache';
+        $namespace = 'test\\namespace';
+
+        // Pre-existing level-0 entry stays valid for a level-0 evaluator.
+        $cache = new CompiledCodeCache($cacheDir);
+        $cache->put($sourceFile, $namespace, md5($sourceCode), '$level0 = true;');
+
+        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade->expects($this->never())->method('compileForCache');
+        $compilerFacade->expects($this->never())->method('eval');
+
+        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
+            new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
+        );
+
+        $evaluator = new FileEvaluator(
+            $compilerFacade,
+            $namespaceExtractor,
+            $cache,
+            optimizationLevel: 0,
+        );
         $evaluator->evalFile($sourceFile);
     }
 

--- a/tests/php/Unit/Build/BuildConfigTest.php
+++ b/tests/php/Unit/Build/BuildConfigTest.php
@@ -101,6 +101,34 @@ final class BuildConfigTest extends TestCase
         }
     }
 
+    public function test_optimization_level_defaults_to_zero(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {});
+
+        self::assertSame(0, new BuildConfig()->getOptimizationLevel());
+    }
+
+    public function test_optimization_level_read_from_config(): void
+    {
+        $this->bootstrapWithOptimizationLevel(2);
+
+        self::assertSame(2, new BuildConfig()->getOptimizationLevel());
+    }
+
+    public function test_negative_optimization_level_clamped_to_zero(): void
+    {
+        $this->bootstrapWithOptimizationLevel(-3);
+
+        self::assertSame(0, new BuildConfig()->getOptimizationLevel());
+    }
+
+    private function bootstrapWithOptimizationLevel(int $level): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($level): void {
+            $config->addAppConfigKeyValue(PhelConfig::OPTIMIZATION_LEVEL, $level);
+        });
+    }
+
     private function bootstrapWithCacheDir(string $cacheDir): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {

--- a/tests/php/Unit/Build/Domain/Compile/BuildOptionsTest.php
+++ b/tests/php/Unit/Build/Domain/Compile/BuildOptionsTest.php
@@ -25,6 +25,20 @@ final class BuildOptionsTest extends TestCase
         self::assertFalse($options->isSourceMapEnabled());
     }
 
+    public function test_optimization_level_defaults_to_null(): void
+    {
+        $options = new BuildOptions(enableCache: true, enableSourceMap: true);
+
+        self::assertNull($options->getOptimizationLevel());
+    }
+
+    public function test_optimization_level_override(): void
+    {
+        $options = new BuildOptions(enableCache: true, enableSourceMap: true, optimizationLevel: 2);
+
+        self::assertSame(2, $options->getOptimizationLevel());
+    }
+
     public function test_flags_are_independent(): void
     {
         $cacheOnly = new BuildOptions(enableCache: true, enableSourceMap: false);

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -44,9 +44,35 @@ final class PhelConfigTest extends TestCase
             PhelConfig::ENABLE_COMPILED_CODE_CACHE => true,
             PhelConfig::CACHE_DIR => '.phel/cache',
             PhelConfig::PHEL_DIR => '',
+            PhelConfig::OPTIMIZATION_LEVEL => 0,
         ];
 
         self::assertSame($expected, $config->jsonSerialize());
+    }
+
+    public function test_optimization_level_defaults_to_zero(): void
+    {
+        $config = new PhelConfig();
+
+        self::assertSame(0, $config->getOptimizationLevel());
+    }
+
+    public function test_with_optimization_level(): void
+    {
+        $config = new PhelConfig();
+        $updated = $config->withOptimizationLevel(2);
+
+        self::assertNotSame($config, $updated);
+        self::assertSame(0, $config->getOptimizationLevel());
+        self::assertSame(2, $updated->getOptimizationLevel());
+        self::assertSame(2, $updated->jsonSerialize()[PhelConfig::OPTIMIZATION_LEVEL]);
+    }
+
+    public function test_with_optimization_level_clamps_negative_values(): void
+    {
+        $config = new PhelConfig()->withOptimizationLevel(-1);
+
+        self::assertSame(0, $config->getOptimizationLevel());
     }
 
     public function test_for_project_factory(): void
@@ -181,7 +207,8 @@ final class PhelConfigTest extends TestCase
             ->withFormatDirs(['src', 'tests', 'phel'])
             ->withEnableAsserts(false)
             ->withWarnDeprecations(true)
-            ->withCacheDir('.cache');
+            ->withCacheDir('.cache')
+            ->withOptimizationLevel(2);
 
         $expected = [
             PhelConfig::SRC_DIRS => ['some/directory'],
@@ -210,6 +237,7 @@ final class PhelConfigTest extends TestCase
             PhelConfig::ENABLE_COMPILED_CODE_CACHE => true,
             PhelConfig::CACHE_DIR => '.cache',
             PhelConfig::PHEL_DIR => '',
+            PhelConfig::OPTIMIZATION_LEVEL => 2,
         ];
 
         self::assertSame($expected, $config->jsonSerialize());

--- a/tests/php/Unit/Run/Application/CompileExecutorTest.php
+++ b/tests/php/Unit/Run/Application/CompileExecutorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Application;
+
+use Phel\Compiler\Domain\Emitter\EmitterResult;
+use Phel\Run\Application\CompileExecutor;
+use Phel\Shared\CompileOptions;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class CompileExecutorTest extends TestCase
+{
+    private ?CompileOptions $capturedOptions = null;
+
+    public function test_compile_defaults_to_optimization_level_zero(): void
+    {
+        $executor = new CompileExecutor($this->createCapturingCompilerFacade());
+
+        $executor->execute('(+ 1 2)', static function (string $out): void {}, static function (string $err): void {});
+
+        self::assertNotNull($this->capturedOptions);
+        self::assertSame(0, $this->capturedOptions->getOptimizationLevel());
+        self::assertTrue($this->capturedOptions->isEmitOnly());
+    }
+
+    public function test_compile_uses_configured_optimization_level(): void
+    {
+        $executor = new CompileExecutor($this->createCapturingCompilerFacade(), optimizationLevel: 2);
+
+        $executor->execute('(+ 1 2)', static function (string $out): void {}, static function (string $err): void {});
+
+        self::assertNotNull($this->capturedOptions);
+        self::assertSame(2, $this->capturedOptions->getOptimizationLevel());
+    }
+
+    private function createCapturingCompilerFacade(): CompilerFacadeInterface
+    {
+        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade->method('hasBalancedParentheses')->willReturn(true);
+        $compilerFacade->method('compile')
+            ->willReturnCallback(function (string $code, CompileOptions $options): EmitterResult {
+                $this->capturedOptions = $options;
+
+                return new EmitterResult(false, '3;', '', '');
+            });
+
+        return $compilerFacade;
+    }
+}

--- a/tests/php/Unit/Run/Application/EvalExecutorTest.php
+++ b/tests/php/Unit/Run/Application/EvalExecutorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Application;
+
+use Phel\Run\Application\EvalExecutor;
+use Phel\Run\Domain\Repl\ReplCommandIoInterface;
+use Phel\Shared\ColorStyleInterface;
+use Phel\Shared\CompileOptions;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+use Phel\Shared\Printer\PrinterInterface;
+use PHPUnit\Framework\TestCase;
+
+final class EvalExecutorTest extends TestCase
+{
+    private ?CompileOptions $capturedOptions = null;
+
+    public function test_eval_defaults_to_optimization_level_zero(): void
+    {
+        $executor = $this->createExecutor();
+
+        self::assertTrue($executor->execute('(+ 1 2)'));
+        self::assertNotNull($this->capturedOptions);
+        self::assertSame(0, $this->capturedOptions->getOptimizationLevel());
+    }
+
+    public function test_eval_uses_configured_optimization_level(): void
+    {
+        $executor = $this->createExecutor(optimizationLevel: 2);
+
+        self::assertTrue($executor->execute('(+ 1 2)'));
+        self::assertNotNull($this->capturedOptions);
+        self::assertSame(2, $this->capturedOptions->getOptimizationLevel());
+    }
+
+    private function createExecutor(int $optimizationLevel = 0): EvalExecutor
+    {
+        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade->method('hasBalancedParentheses')->willReturn(true);
+        $compilerFacade->method('eval')
+            ->willReturnCallback(function (string $code, CompileOptions $options): mixed {
+                $this->capturedOptions = $options;
+
+                return 3;
+            });
+
+        $printer = $this->createStub(PrinterInterface::class);
+        $printer->method('print')->willReturn('3');
+
+        return new EvalExecutor(
+            $this->createStub(ReplCommandIoInterface::class),
+            $this->createStub(ColorStyleInterface::class),
+            $printer,
+            $compilerFacade,
+            $optimizationLevel,
+        );
+    }
+}

--- a/tests/php/Unit/Run/RunConfigTest.php
+++ b/tests/php/Unit/Run/RunConfigTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use Phel\Config\PhelConfig;
+use Phel\Run\RunConfig;
+use PHPUnit\Framework\TestCase;
+
+final class RunConfigTest extends TestCase
+{
+    public function test_optimization_level_defaults_to_zero(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {});
+
+        self::assertSame(0, new RunConfig()->getOptimizationLevel());
+    }
+
+    public function test_optimization_level_read_from_config(): void
+    {
+        $this->bootstrapWithOptimizationLevel(2);
+
+        self::assertSame(2, new RunConfig()->getOptimizationLevel());
+    }
+
+    public function test_negative_optimization_level_clamped_to_zero(): void
+    {
+        $this->bootstrapWithOptimizationLevel(-1);
+
+        self::assertSame(0, new RunConfig()->getOptimizationLevel());
+    }
+
+    private function bootstrapWithOptimizationLevel(int $level): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($level): void {
+            $config->addAppConfigKeyValue(PhelConfig::OPTIMIZATION_LEVEL, $level);
+        });
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`CompileOptions::setOptimizationLevel(int)` has existed since 0.41 and gates `CallInliner` (`^:pure` call-site inlining) and `TailCallRewriter` at level 2, but nothing wired it up: `PhelConfig` had no option for it and every `CompileOptions` construction in Build/Run used the default, so `phel build`, `phel run`, and `phel test` always compiled at level 0. The level-2 optimizations were reserved-but-unreachable for real projects.

Closes #2387

## 💡 Goal

Make the optimization level configurable per project (`phel-config.php`) and per build (CLI flag), so level 2 actually reaches `phel build`/`run`/`test`/`eval`/`compile` output, while keeping the level-0 default byte-identical and the REPL/nREPL pinned at level 0.

## 🔖 Changes

- `PhelConfig::withOptimizationLevel(int)` / `getOptimizationLevel()` with new `optimization-level` config key (default 0, negative values clamped), serialized through the config map.
- `BuildConfig::getOptimizationLevel()` (+ `BuildConfigInterface`) and `RunConfig::getOptimizationLevel()` read the key via Gacela.
- Plumbing:
  - `FileCompiler` takes a constructor default level (from config) plus a per-call override; `ProjectCompiler` resolves CLI-override-or-config and passes it down (`phel build`).
  - `FileEvaluator` (used by `phel run`, `phel test`, `(load ...)`) compiles at the configured level.
  - `EvalExecutor` (`phel eval`) and `CompileExecutor` (`phel compile`) honor it too.
  - REPL, nREPL, and the watcher keep constructing default options → level 0 for interactive sessions.
- CLI override: `phel build -O2` / `--optimization-level=2`, taking precedence over the config.
- Stale-cache safety (both caches were level-blind):
  - the compiled-code cache hash mixes in the level when > 0 (level 0 keeps the historical plain `md5`, so existing caches stay warm);
  - `phel build`'s incremental cache is mtime-only, so `ProjectCompiler` records the level in `<out>/.phel-optimization-level` and forces a recompile when it changes (no marker at level 0).
- Docs: `docs/performance.md` section on level semantics (0/1/2) and the `^:pure` contract; module CLAUDE.md notes; CHANGELOG entry.
- Tests: unit coverage for config/options/compiler/evaluator/executors plus an e2e `BuildCommandOptimizationLevelTest` asserting level-2 output (tail-call `while (true)` rewrite + inlined `^:pure` call), CLI override precedence, and level-change invalidation of the incremental cache.

Final refactor review surfaced zero changes: the only candidate was the duplicated one-line config read in `BuildConfig`/`RunConfig`, and extracting a shared helper for one line across module boundaries would be over-engineering.
