### PR TITLE
feat(config): add 'phel config' command to inspect effective config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - `PhelConfig::withOptimizationLevel(int)` (`optimization-level` config key, default 0): `phel build`, `phel run`, `phel test`, `phel eval`, and `phel compile` now compile at the configured level, making level 2 (`^:pure` call-site inlining + self-recursive tail-call rewriting) reachable for real projects; REPL and nREPL stay at level 0 (#2387)
 - `phel build -O <level>` (`--optimization-level`) CLI override taking precedence over the configured level; changing the level automatically invalidates both the incremental `phel build` output and the compiled-code cache
+- `phel config`: new CLI command that prints the effective, merged project configuration (as JSON) together with its provenance — whether `phel-config.php` was found or auto-detected, whether `phel-config-local.php` was applied, and the `PHEL_DIR` env value. Use `phel config --json` for machine-readable output
 
 ### Fixed
 

--- a/src/php/Console/Infrastructure/Command/RunCommands.php
+++ b/src/php/Console/Infrastructure/Command/RunCommands.php
@@ -7,6 +7,7 @@ namespace Phel\Console\Infrastructure\Command;
 use Phel\Console\Domain\ConsoleCommandProviderInterface;
 use Phel\Run\Infrastructure\Command\AgentInstallCommand;
 use Phel\Run\Infrastructure\Command\CompileCommand;
+use Phel\Run\Infrastructure\Command\ConfigCommand;
 use Phel\Run\Infrastructure\Command\DoctorCommand;
 use Phel\Run\Infrastructure\Command\EvalCommand;
 use Phel\Run\Infrastructure\Command\InitCommand;
@@ -31,6 +32,7 @@ final class RunCommands implements ConsoleCommandProviderInterface
             new TestCommand(),
             new TestWorkerCommand(),
             new DoctorCommand(),
+            new ConfigCommand(),
         ];
     }
 }

--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -17,7 +17,7 @@ Most connected module, 4 Provider facades: Build (namespace extraction, dependen
 
 ## Structure Notes
 
-- `Infrastructure/Command/`: 9 Symfony commands, one hidden `_test-worker`
+- `Infrastructure/Command/`: 10 Symfony commands (incl. `config` — dumps effective merged config), one hidden `_test-worker`
 - `Runtime/PhelSourceLoader`: cached-PHP boot entry
 
 ## Key Constraints

--- a/src/php/Run/Domain/Config/EffectiveConfigReader.php
+++ b/src/php/Run/Domain/Config/EffectiveConfigReader.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Config;
+
+use Gacela\Framework\Config\Config;
+use Phel\Config\PhelConfig;
+use Phel\Shared\PhelProjectDirectory;
+
+use function array_key_exists;
+
+use function getenv;
+
+use const DIRECTORY_SEPARATOR;
+
+/**
+ * Reads the effective, merged Phel configuration that the running CLI actually
+ * sees, together with where it came from (config file, local override, env).
+ *
+ * The values come from Gacela's merged config, so they already reflect
+ * `phel-config.php`, the optional `phel-config-local.php` override, and any
+ * auto-detected zero-config defaults.
+ */
+final class EffectiveConfigReader
+{
+    private const string CONFIG_FILE_NAME = 'phel-config.php';
+
+    private const string LOCAL_CONFIG_FILE_NAME = 'phel-config-local.php';
+
+    /**
+     * Canonical key order, mirroring PhelConfig::jsonSerialize().
+     *
+     * @var list<string>
+     */
+    private const array KEY_ORDER = [
+        PhelConfig::SRC_DIRS,
+        PhelConfig::TEST_DIRS,
+        PhelConfig::VENDOR_DIR,
+        PhelConfig::ERROR_LOG_FILE,
+        PhelConfig::BUILD_CONFIG,
+        PhelConfig::EXPORT_CONFIG,
+        PhelConfig::IGNORE_WHEN_BUILDING,
+        PhelConfig::NO_CACHE_WHEN_BUILDING,
+        PhelConfig::KEEP_GENERATED_TEMP_FILES,
+        PhelConfig::TEMP_DIR,
+        PhelConfig::FORMAT_DIRS,
+        PhelConfig::ASSERTS_ENABLED,
+        PhelConfig::WARN_DEPRECATIONS,
+        PhelConfig::ENABLE_NAMESPACE_CACHE,
+        PhelConfig::ENABLE_COMPILED_CODE_CACHE,
+        PhelConfig::CACHE_DIR,
+        PhelConfig::PHEL_DIR,
+        PhelConfig::OPTIMIZATION_LEVEL,
+    ];
+
+    public function read(): EffectiveConfigResult
+    {
+        $config = Config::getInstance();
+        $root = $config->getAppRootDir();
+        $allValues = $config->getAllValues();
+
+        $configPath = $root . DIRECTORY_SEPARATOR . self::CONFIG_FILE_NAME;
+        $localPath = $root . DIRECTORY_SEPARATOR . self::LOCAL_CONFIG_FILE_NAME;
+
+        $phelDirEnv = getenv(PhelProjectDirectory::DIR_ENV);
+
+        return new EffectiveConfigResult(
+            projectRoot: $root,
+            configFilePath: $configPath,
+            configFileExists: file_exists($configPath),
+            localConfigFilePath: $localPath,
+            localConfigFileExists: file_exists($localPath),
+            phelDirEnv: $phelDirEnv === false ? null : $phelDirEnv,
+            values: $this->orderedValues($allValues),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $allValues
+     *
+     * @return array<string, mixed>
+     */
+    private function orderedValues(array $allValues): array
+    {
+        $ordered = [];
+        foreach (self::KEY_ORDER as $key) {
+            if (array_key_exists($key, $allValues)) {
+                $ordered[$key] = $allValues[$key];
+            }
+        }
+
+        return $ordered;
+    }
+}

--- a/src/php/Run/Domain/Config/EffectiveConfigResult.php
+++ b/src/php/Run/Domain/Config/EffectiveConfigResult.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Config;
+
+/**
+ * The resolved configuration the CLI is running with, plus its provenance.
+ */
+final readonly class EffectiveConfigResult
+{
+    /**
+     * @param array<string, mixed> $values the merged config, ordered like PhelConfig::jsonSerialize()
+     */
+    public function __construct(
+        public string $projectRoot,
+        public string $configFilePath,
+        public bool $configFileExists,
+        public string $localConfigFilePath,
+        public bool $localConfigFileExists,
+        public ?string $phelDirEnv,
+        public array $values,
+    ) {}
+}

--- a/src/php/Run/Infrastructure/Command/ConfigCommand.php
+++ b/src/php/Run/Infrastructure/Command/ConfigCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Infrastructure\Command;
+
+use Phel\Run\Domain\Config\EffectiveConfigReader;
+use Phel\Run\Domain\Config\EffectiveConfigResult;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function json_encode;
+use function sprintf;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+
+final class ConfigCommand extends Command
+{
+    private const string OPT_JSON = 'json';
+
+    public function __construct(
+        private readonly EffectiveConfigReader $reader = new EffectiveConfigReader(),
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('config')
+            ->setDescription('Show the effective Phel configuration and where it comes from')
+            ->addOption(
+                self::OPT_JSON,
+                null,
+                InputOption::VALUE_NONE,
+                'Print only the effective config as JSON (machine-readable)',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $effective = $this->reader->read();
+
+        if ($input->getOption(self::OPT_JSON) === true) {
+            $output->writeln($this->toJson($effective->values));
+
+            return Command::SUCCESS;
+        }
+
+        $this->writeSources($output, $effective);
+        $output->writeln('');
+        $output->writeln('<comment>Effective config:</comment>');
+        $output->writeln($this->toJson($effective->values));
+
+        return Command::SUCCESS;
+    }
+
+    private function writeSources(OutputInterface $output, EffectiveConfigResult $effective): void
+    {
+        $output->writeln('<comment>Sources:</comment>');
+        $output->writeln(sprintf(' - project root: %s', $effective->projectRoot));
+
+        if ($effective->configFileExists) {
+            $output->writeln(sprintf(' - phel-config.php: <info>found</info> (%s)', $effective->configFilePath));
+        } else {
+            $output->writeln(' - phel-config.php: <comment>not found</comment> — using auto-detected defaults');
+        }
+
+        if ($effective->localConfigFileExists) {
+            $output->writeln(sprintf(
+                ' - phel-config-local.php: <info>applied</info> (%s)',
+                $effective->localConfigFilePath,
+            ));
+        } else {
+            $output->writeln(' - phel-config-local.php: not present');
+        }
+
+        $output->writeln(sprintf(
+            ' - PHEL_DIR env: %s',
+            $effective->phelDirEnv ?? '(unset)',
+        ));
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private function toJson(array $values): string
+    {
+        return json_encode(
+            $values,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        );
+    }
+}

--- a/tests/php/Integration/Run/Command/Config/ConfigCommandTest.php
+++ b/tests/php/Integration/Run/Command/Config/ConfigCommandTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Run\Command\Config;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use Gacela\Framework\Testing\ContainerFixture;
+use Phel\Config\PhelConfig;
+use Phel\Run\Infrastructure\Command\ConfigCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function json_decode;
+
+use const JSON_THROW_ON_ERROR;
+
+final class ConfigCommandTest extends TestCase
+{
+    use ContainerFixture;
+
+    protected function setUp(): void
+    {
+        $this->resetContainer();
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addAppConfigKeyValue(PhelConfig::SRC_DIRS, ['src/phel']);
+            $config->addAppConfigKeyValue(PhelConfig::VENDOR_DIR, 'vendor');
+            $config->addAppConfigKeyValue(PhelConfig::CACHE_DIR, '.phel/cache');
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanupContainerTempDirs();
+    }
+
+    public function test_default_output_lists_sources_and_effective_config(): void
+    {
+        $tester = new CommandTester(new ConfigCommand());
+
+        $exitCode = $tester->execute([]);
+
+        $display = $tester->getDisplay();
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('Sources:', $display);
+        self::assertStringContainsString('Effective config:', $display);
+        self::assertStringContainsString('src-dirs', $display);
+        self::assertStringContainsString('src/phel', $display);
+        // This fixture dir has no phel-config.php, so it is auto-detected.
+        self::assertStringContainsString('not found', $display);
+    }
+
+    public function test_json_option_emits_only_valid_json(): void
+    {
+        $tester = new CommandTester(new ConfigCommand());
+
+        $exitCode = $tester->execute(['--json' => true]);
+
+        self::assertSame(0, $exitCode);
+
+        $decoded = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+        self::assertSame(['src/phel'], $decoded[PhelConfig::SRC_DIRS]);
+        self::assertSame('vendor', $decoded[PhelConfig::VENDOR_DIR]);
+        self::assertArrayNotHasKey('Sources:', $decoded);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

The configuration the CLI actually runs with is hard to predict: when `phel-config.php` is absent, Phel auto-detects a layout; when present, `phel-config-local.php` is merged on top; and `PHEL_DIR` can override the state directory. None of the existing commands let a user see the resolved result, so debugging "why is my namespace not found" or "where did my cache go" meant reading source.

## 💡 Goal

Give users a first-class way to inspect the effective, merged configuration and understand where each part comes from.

## 🔖 Changes

- New `phel config` command:
  - prints the effective merged config (ordered like `PhelConfig::jsonSerialize()`) as JSON
  - shows provenance: project root, whether `phel-config.php` was found or auto-detected, whether `phel-config-local.php` was applied, and the `PHEL_DIR` env value
  - `phel config --json` prints only the config map (machine-readable)
- `EffectiveConfigReader` (Run/Domain) reads Gacela's merged config + filesystem/env provenance; `EffectiveConfigResult` carries the structured report. The command stays a thin renderer.
- Registered in `RunCommands`; integration test covers default + `--json` output.
- CHANGELOG + Run module CLAUDE.md updated.

Full local gate green: PHPUnit (unit+integration), Psalm, PHPStan, Rector, and the Phel test suite (run by the pre-push hook).

## Example

```
$ phel config
Sources:
 - project root: /path/to/project
 - phel-config.php: found (/path/to/project/phel-config.php)
 - phel-config-local.php: not present
 - PHEL_DIR env: (unset)

Effective config:
{
    "src-dirs": ["src/phel"],
    ...
}
```