### PR TITLE
feat(config): accept configurator closures in withBuildConfig/withExportConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - `PhelConfig::withOptimizationLevel(int)` (`optimization-level` config key, default 0): `phel build`, `phel run`, `phel test`, `phel eval`, and `phel compile` now compile at the configured level, making level 2 (`^:pure` call-site inlining + self-recursive tail-call rewriting) reachable for real projects; REPL and nREPL stay at level 0 (#2387)
 - `phel build -O <level>` (`--optimization-level`) CLI override taking precedence over the configured level; changing the level automatically invalidates both the incremental `phel build` output and the compiled-code cache
 - `phel config`: new CLI command that prints the effective, merged project configuration (as JSON) together with its provenance — whether `phel-config.php` was found or auto-detected, whether `phel-config-local.php` was applied, and the `PHEL_DIR` env value. Use `phel config --json` for machine-readable output
+- `PhelConfig::withBuildConfig()` and `withExportConfig()` now also accept a configurator closure (`fn (PhelBuildConfig $b) => $b->withDestDir('dist')`) that patches the current nested config in place, instead of only a full replacement object — so they compose with the flattened `with*()` setters regardless of call order
 
 ### Fixed
 

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -309,24 +309,46 @@ final readonly class PhelConfig implements JsonSerializable
     }
 
     /**
-     * Replace the whole build value object. Note: this overwrites anything set
-     * via the flattened build withers (`withMainPhelNamespace()`,
-     * `withMainPhpPath()`, `withBuildDestDir()`), so call it before them.
+     * Configure the build value object.
+     *
+     * Pass a `PhelBuildConfig` to replace it wholesale (this overwrites anything
+     * set via the flattened build withers, so call it first). Or pass a
+     * configurator closure to patch the current build config in place, which
+     * composes cleanly with the flattened withers regardless of call order:
+     *
+     *     ->withBuildConfig(fn (PhelBuildConfig $b) => $b->withDestDir('dist'))
+     *
+     * @param callable(PhelBuildConfig):PhelBuildConfig|PhelBuildConfig $buildConfig
      */
-    public function withBuildConfig(PhelBuildConfig $buildConfig): self
+    public function withBuildConfig(PhelBuildConfig|callable $buildConfig): self
     {
-        return $this->with(['buildConfig' => $buildConfig]);
+        $resolved = $buildConfig instanceof PhelBuildConfig
+            ? $buildConfig
+            : $buildConfig($this->buildConfig);
+
+        return $this->with(['buildConfig' => $resolved]);
     }
 
     /**
-     * Replace the whole export value object. Note: this overwrites anything set
-     * via the flattened export withers (`withExportNamespacePrefix()`,
-     * `withExportTargetDirectory()`, `withExportFromDirectories()`) and resets
-     * unspecified fields to their defaults, so call it before them.
+     * Configure the export value object.
+     *
+     * Pass a `PhelExportConfig` to replace it wholesale (this overwrites anything
+     * set via the flattened export withers and resets unspecified fields to their
+     * defaults, so call it first). Or pass a configurator closure to patch the
+     * current export config in place, which composes with the flattened withers
+     * regardless of call order:
+     *
+     *     ->withExportConfig(fn (PhelExportConfig $e) => $e->withNamespacePrefix('App'))
+     *
+     * @param callable(PhelExportConfig):PhelExportConfig|PhelExportConfig $exportConfig
      */
-    public function withExportConfig(PhelExportConfig $exportConfig): self
+    public function withExportConfig(PhelExportConfig|callable $exportConfig): self
     {
-        return $this->with(['exportConfig' => $exportConfig]);
+        $resolved = $exportConfig instanceof PhelExportConfig
+            ? $exportConfig
+            : $exportConfig($this->exportConfig);
+
+        return $this->with(['exportConfig' => $resolved]);
     }
 
     /**

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -283,6 +283,33 @@ final class PhelConfigTest extends TestCase
         self::assertSame('/var/cache/phel', $config->jsonSerialize()[PhelConfig::PHEL_DIR]);
     }
 
+    public function test_with_build_config_closure_patches_in_place(): void
+    {
+        $config = new PhelConfig()
+            ->withMainPhelNamespace('app\\main')
+            ->withBuildConfig(static fn(PhelBuildConfig $b): PhelBuildConfig => $b->withDestDir('dist'));
+
+        $build = $config->jsonSerialize()[PhelConfig::BUILD_CONFIG];
+        // The closure form preserves the previously set namespace ...
+        self::assertSame('app\\main', $build[PhelBuildConfig::MAIN_PHEL_NAMESPACE]);
+        // ... and applies the patch, deriving the entry point under the new dest dir.
+        self::assertSame('dist', $build[PhelBuildConfig::DEST_DIR]);
+        self::assertSame('dist/index.php', $build[PhelBuildConfig::MAIN_PHP_PATH]);
+    }
+
+    public function test_with_export_config_closure_patches_in_place(): void
+    {
+        $config = new PhelConfig()
+            ->withExportTargetDirectory('gen')
+            ->withExportConfig(static fn(PhelExportConfig $e): PhelExportConfig => $e->withNamespacePrefix('App'));
+
+        $export = $config->jsonSerialize()[PhelConfig::EXPORT_CONFIG];
+        // Closure form keeps the earlier target directory ...
+        self::assertSame('gen', $export[PhelExportConfig::TARGET_DIRECTORY]);
+        // ... and patches the prefix.
+        self::assertSame('App', $export[PhelExportConfig::NAMESPACE_PREFIX]);
+    }
+
     public function test_with_methods_return_new_instance(): void
     {
         $original = new PhelConfig();


### PR DESCRIPTION
## 🤔 Background

`withBuildConfig()` / `withExportConfig()` only accepted a full replacement value object. Passing one silently overwrote anything set via the flattened setters (`withMainPhelNamespace()`, `withExportNamespacePrefix()`, ...) and reset unspecified export fields to their defaults, an easy-to-miss footgun that depended on call order.

## 💡 Goal

Let the whole-object setters compose with the flattened setters instead of clobbering them.

## 🔖 Changes

- `withBuildConfig()` and `withExportConfig()` now accept either:
  - a `PhelBuildConfig`/`PhelExportConfig` (replace wholesale, as before), or
  - a configurator closure that patches the current nested config in place:

    ```php
    ->withBuildConfig(fn (PhelBuildConfig $b) => $b->withDestDir('dist'))
    ->withExportConfig(fn (PhelExportConfig $e) => $e->withNamespacePrefix('App'))
    ```

  The closure form preserves values already set via the flattened setters, regardless of order.
- Updated PHPDoc; added unit tests for both closure forms.
- The object-accepting form is unchanged (existing tests pass).

Full local gate green (PHPUnit, Psalm, PHPStan, Rector, Phel suite via pre-push hook).