### PR TITLE
feat(init): scaffold documented phel-config.php and dedupe layout templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 - `phel config`: new CLI command that prints the effective, merged project configuration (as JSON) together with its provenance — whether `phel-config.php` was found or auto-detected, whether `phel-config-local.php` was applied, and the `PHEL_DIR` env value. Use `phel config --json` for machine-readable output
 - `PhelConfig::withBuildConfig()` and `withExportConfig()` now also accept a configurator closure (`fn (PhelBuildConfig $b) => $b->withDestDir('dist')`) that patches the current nested config in place, instead of only a full replacement object — so they compose with the flattened `with*()` setters regardless of call order
 
+### Changed
+
+- `phel init` now scaffolds a `phel-config.php` with a comment header linking to the configuration docs and a few commented-out common tweaks, so newcomers can discover the available options
+
 ### Fixed
 
 - `PhelConfig` build withers are now order-independent: `withMainPhelNamespace(...)` no longer pins the entry point to `out/index.php`, so a following `withBuildDestDir('dist')` correctly yields `dist/index.php` (previously the entry point silently landed outside the dest dir depending on call order)

--- a/src/php/Run/Domain/Init/ProjectTemplateGenerator.php
+++ b/src/php/Run/Domain/Init/ProjectTemplateGenerator.php
@@ -10,38 +10,24 @@ final class ProjectTemplateGenerator
 {
     public function generateConfig(string $namespace, ProjectLayout $layout): string
     {
-        return match ($layout) {
-            ProjectLayout::Flat => <<<PHP
+        $layoutCase = $layout->name;
+
+        return <<<PHP
 <?php
 
 use Phel\\Config\\PhelConfig;
 use Phel\\Config\\ProjectLayout;
 
-return PhelConfig::forProject(ProjectLayout::Flat)
+// See https://github.com/phel-lang/phel-lang/blob/main/docs/configuration.md
+// for every option, caching flags, and precedence. Run `phel config` to print
+// the effective configuration. A few common tweaks:
+//     ->withWarnDeprecations(true)
+//     ->withOptimizationLevel(2)
+//     ->withIgnoreWhenBuilding(['src/scratch.phel'])
+return PhelConfig::forProject(ProjectLayout::{$layoutCase})
     ->withMainPhelNamespace('{$namespace}');
 
-PHP,
-            ProjectLayout::Nested => <<<PHP
-<?php
-
-use Phel\\Config\\PhelConfig;
-use Phel\\Config\\ProjectLayout;
-
-return PhelConfig::forProject(ProjectLayout::Nested)
-    ->withMainPhelNamespace('{$namespace}');
-
-PHP,
-            ProjectLayout::Root => <<<PHP
-<?php
-
-use Phel\\Config\\PhelConfig;
-use Phel\\Config\\ProjectLayout;
-
-return PhelConfig::forProject(ProjectLayout::Root)
-    ->withMainPhelNamespace('{$namespace}');
-
-PHP,
-        };
+PHP;
     }
 
     public function generateMainFile(string $namespace): string


### PR DESCRIPTION
## 🤔 Background

`phel init` generated a bare two-line `phel-config.php` with no hint that ~24 more options exist or where to read about them, so a new user's discovery chain dead-ended right after init. Separately, the three per-layout config templates were byte-identical heredocs differing only in the `ProjectLayout` case name — pure duplication inviting drift.

## 💡 Goal

Make the scaffolded config self-documenting and collapse the duplicated templates.

## 🔖 Changes

- Collapse the three layout heredocs into one template interpolating `$layout->name`.
- Add a comment header to the generated `phel-config.php` linking to `docs/configuration.md`, pointing at `phel config`, and listing a few commented-out common tweaks (`withWarnDeprecations`, `withOptimizationLevel`, `withIgnoreWhenBuilding`).
- Generated output remains valid PHP; existing init tests (substring assertions) pass unchanged.

CHANGELOG updated.