### PR TITLE
fix(config): normalize cacheDir trailing separator in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `PhelConfig` `cacheDir` is now normalized in the constructor (trailing separator stripped), so `new PhelConfig(cacheDir: 'foo/')` and `->withCacheDir('foo/')` produce the same value instead of diverging
 - `PhelConfig` build withers are now order-independent: `withMainPhelNamespace(...)` no longer pins the entry point to `out/index.php`, so a following `withBuildDestDir('dist')` correctly yields `dist/index.php` (previously the entry point silently landed outside the dest dir depending on call order)
 - Runtime errors in `phel build` output now map back to the Phel source: the error printer reads the sibling `<file>.php.map` and `<file>.phel` artifacts (previously written but never consumed) and reports `out/foo.phel:42` instead of the generated PHP line
 - Inline source maps in eval temp files are detected again: the extractor now scans past the `<?php` opener (and optional `declare` statements) for the metadata comments instead of only reading the first two lines

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -54,6 +54,8 @@ final readonly class PhelConfig implements JsonSerializable
 
     public string $tempDir;
 
+    public string $cacheDir;
+
     /**
      * @param list<string> $srcDirs
      * @param list<string> $testDirs
@@ -72,7 +74,7 @@ final readonly class PhelConfig implements JsonSerializable
         public array $noCacheWhenBuilding = [],
         public bool $keepGeneratedTempFiles = false,
         ?string $tempDir = null,
-        public string $cacheDir = self::DEFAULT_CACHE_DIR,
+        string $cacheDir = self::DEFAULT_CACHE_DIR,
         public array $formatDirs = ['src', 'tests'],
         public bool $enableAsserts = true,
         public bool $warnDeprecations = false,
@@ -84,6 +86,7 @@ final readonly class PhelConfig implements JsonSerializable
         $this->tempDir = $tempDir === null
             ? sys_get_temp_dir() . self::PHEL_TEMP_SUBDIR . '/tmp'
             : rtrim($tempDir, DIRECTORY_SEPARATOR);
+        $this->cacheDir = rtrim($cacheDir, DIRECTORY_SEPARATOR);
     }
 
     /**
@@ -463,7 +466,8 @@ final readonly class PhelConfig implements JsonSerializable
      */
     public function withCacheDir(string $dir): self
     {
-        return $this->with(['cacheDir' => rtrim($dir, DIRECTORY_SEPARATOR)]);
+        // Trailing separators are normalized by the constructor.
+        return $this->with(['cacheDir' => $dir]);
     }
 
     /**

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -426,6 +426,15 @@ final class PhelConfigTest extends TestCase
         self::assertSame('.phel/cache', new PhelConfig()->getCacheDir());
     }
 
+    public function test_cache_dir_trailing_separator_normalized_in_constructor(): void
+    {
+        $viaConstructor = new PhelConfig(cacheDir: 'custom/cache/');
+        $viaWither = new PhelConfig()->withCacheDir('custom/cache/');
+
+        self::assertSame('custom/cache', $viaConstructor->getCacheDir());
+        self::assertSame('custom/cache', $viaWither->getCacheDir());
+    }
+
     #[Group('deprecated')]
     public function test_deprecated_setters_still_produce_equivalent_output(): void
     {


### PR DESCRIPTION
## 🤔 Background

`withCacheDir()` strips a trailing directory separator, but the promoted constructor parameter did not. So `new PhelConfig(cacheDir: 'foo/')` kept `'foo/'` while `(new PhelConfig())->withCacheDir('foo/')` produced `'foo'`. The same value therefore serialized differently into Gacela depending on which API the user happened to use, and downstream path concatenations could produce `'foo//...'`.

## 💡 Goal

Make both construction styles equivalent.

## 🔖 Changes

- Normalize `cacheDir` in the constructor (right-trim the separator), mirroring how `tempDir` is already handled. `cacheDir` becomes a non-promoted property assigned in the constructor body.
- Drop the now-redundant `rtrim()` in `withCacheDir()`.
- Regression test: constructor and wither both yield `'custom/cache'` for `'custom/cache/'`.