### PR TITLE
docs(config): add class-level docblocks naming the canonical API

### DIFF
--- a/src/php/Config/PhelBuildConfig.php
+++ b/src/php/Config/PhelBuildConfig.php
@@ -10,6 +10,12 @@ use JsonSerializable;
 use function count;
 use function sprintf;
 
+/**
+ * Immutable build configuration nested under {@see PhelConfig} (`out` key).
+ *
+ * Canonical API: the `with*()` setters. The `set*()` methods are deprecated
+ * since 0.37 and only shim to their `with*()` counterparts.
+ */
 final readonly class PhelBuildConfig implements JsonSerializable
 {
     public const string DEST_DIR = 'dir';

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -7,6 +7,23 @@ namespace Phel\Config;
 use Deprecated;
 use JsonSerializable;
 
+/**
+ * Immutable project configuration returned by `phel-config.php`.
+ *
+ * Canonical API: build an instance with {@see self::forProject()} (or `new`)
+ * and chain the immutable `with*()` setters, each of which returns a new
+ * instance:
+ *
+ *     return PhelConfig::forProject(ProjectLayout::Nested)
+ *         ->withMainPhelNamespace('my-app\main');
+ *
+ * Every option is also readable via a `get*()`/`is*()`/`should*()` accessor.
+ * The `set*()` and `use*Layout()` methods are deprecated since 0.37 and exist
+ * only as backward-compatibility shims for the matching `with*()` methods.
+ *
+ * See docs/configuration.md for the full option reference, and run
+ * `phel config` to inspect the effective merged configuration.
+ */
 final readonly class PhelConfig implements JsonSerializable
 {
     public const string SRC_DIRS = 'src-dirs';

--- a/src/php/Config/PhelExportConfig.php
+++ b/src/php/Config/PhelExportConfig.php
@@ -7,6 +7,12 @@ namespace Phel\Config;
 use Deprecated;
 use JsonSerializable;
 
+/**
+ * Immutable export configuration nested under {@see PhelConfig} (`export` key).
+ *
+ * Canonical API: the `with*()` setters. The `set*()` methods are deprecated
+ * since 0.37 and only shim to their `with*()` counterparts.
+ */
 final readonly class PhelExportConfig implements JsonSerializable
 {
     public const string FROM_DIRECTORIES = 'from-directories';


### PR DESCRIPTION
## 🤔 Background

`PhelConfig` had no class-level docblock, so the canonical entry points (`forProject()` + the `with*()` setters) were not signposted amid ~26 deprecated `set*()`/`use*Layout()` shims and the triple read paths (property, getter, `jsonSerialize`). `PhelBuildConfig` and `PhelExportConfig` had the same gap.

## 💡 Goal

Make the canonical API obvious from the class doc / IDE hover.

## 🔖 Changes

- Add a class-level docblock to `PhelConfig`, `PhelBuildConfig`, and `PhelExportConfig` stating:
  - the canonical API is `forProject()` + chained `with*()` setters
  - `set*()` / `use*Layout()` are 0.37 backward-compatibility shims
  - pointers to `docs/configuration.md` and the `phel config` command

Documentation only; no behaviour change.