### PR TITLE
docs(changelog): summarize the config DX pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+This cycle includes a **project-configuration DX pass**: a new `phel config`
+command to inspect the effective merged configuration, a full
+[configuration reference](docs/configuration.md) (options, caching, precedence,
+`phel-config-local.php`), documented `with*()` semantics, composable
+`withBuildConfig()`/`withExportConfig()` closures, a self-documenting `phel init`
+template, and fixes for order-dependent build withers and `cacheDir`
+normalization.
+
 ### Added
 
 - `PhelConfig::withOptimizationLevel(int)` (`optimization-level` config key, default 0): `phel build`, `phel run`, `phel test`, `phel eval`, and `phel compile` now compile at the configured level, making level 2 (`^:pure` call-site inlining + self-recursive tail-call rewriting) reachable for real projects; REPL and nREPL stay at level 0 (#2387)


### PR DESCRIPTION
## 🤔 Background

The Unreleased section gained several config-related entries across Added/Changed/Fixed from the configuration DX work (#2390, #2392-#2398). Release notes lacked a digestible overview tying them together.

## 💡 Goal

Give readers a one-paragraph summary of the configuration DX pass at the top of Unreleased.

## 🔖 Changes

- Add a short summary note under `## Unreleased` linking the `phel config` command, the configuration reference, documented `with*()` semantics, composable nested-config closures, the `phel init` template, and the build-wither/`cacheDir` fixes. Detailed per-change entries are kept.

Documentation only.