### PR TITLE
chore(phpstan): raise the compiler module to level 8

### DIFF
--- a/phpstan-compiler.neon
+++ b/phpstan-compiler.neon
@@ -2,7 +2,7 @@
 #
 # The whole codebase is checked at `level: 6` (see phpstan.neon). The compiler
 # (lexer/parser/reader/analyzer/emitter) is the correctness-critical core, so it
-# is held to `level: 7` on top of the shared baseline. Raise the level here as the
+# is held to `level: 8` on top of the shared baseline. Raise the level here as the
 # rest of the module is hardened; once the whole tree reaches a level, fold it back
 # into phpstan.neon and drop this file.
 #
@@ -12,7 +12,7 @@ includes:
     - phpstan.neon
 
 parameters:
-    level: 7
+    level: 8
     # The shared baseline declares ignoreErrors for files outside the compiler
     # (Config, Lang, BuildFacade). Those patterns never fire in this scoped run,
     # so silence the "unmatched ignored error" report here.


### PR DESCRIPTION
## 🤔 Background

[#2400](https://github.com/phel-lang/phel-lang/pull/2400) introduced `phpstan-compiler.neon`, a scoped pass holding the compiler pipeline (lexer → parser → reader → analyzer → emitter) to PHPStan level 7 on top of the shared level-6 baseline. Re-measuring the compiler at level 8 turned up **zero** new findings: the level-7 type hardening already satisfies level 8.

## 💡 Goal

Lock in the free ceiling bump so the compiler can't regress below level 8.

## 🔖 Changes

- `phpstan-compiler.neon`: `level: 7` → `level: 8`. No code changes (the module is already clean at 8).

Level 9 is the next target and is tracked separately: it surfaces 33 genuine `mixed`-narrowing findings in the reader/analyzer (catch-type resolution, arity ints, quasiquote forms) that warrant their own reviewable PR.