### PR TITLE
chore(phpstan): raise the compiler module to level 9 (max)

### DIFF
--- a/phpstan-compiler.neon
+++ b/phpstan-compiler.neon
@@ -2,7 +2,7 @@
 #
 # The whole codebase is checked at `level: 6` (see phpstan.neon). The compiler
 # (lexer/parser/reader/analyzer/emitter) is the correctness-critical core, so it
-# is held to `level: 8` on top of the shared baseline. Raise the level here as the
+# is held to `level: 9` on top of the shared baseline. Raise the level here as the
 # rest of the module is hardened; once the whole tree reaches a level, fold it back
 # into phpstan.neon and drop this file.
 #
@@ -12,10 +12,18 @@ includes:
     - phpstan.neon
 
 parameters:
-    level: 8
+    level: 9
     # The shared baseline declares ignoreErrors for files outside the compiler
     # (Config, Lang, BuildFacade). Those patterns never fire in this scoped run,
     # so silence the "unmatched ignored error" report here.
     reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+        # CompilerFacade::encodeNs() delegates through Gacela's cached() helper,
+        # which is typed `mixed`. The gacela.facadeOnlyDelegates rule forbids
+        # narrowing the result inline (a facade method must be a single
+        # delegation), so the mixed return cannot be cast away here.
+        -
+            identifier: return.type
+            path: src/php/Compiler/CompilerFacade.php
     paths!:
         - %currentWorkingDirectory%/src/php/Compiler/

--- a/src/php/Compiler/CompilerFactory.php
+++ b/src/php/Compiler/CompilerFactory.php
@@ -211,7 +211,10 @@ final class CompilerFactory extends AbstractFactory
 
     private function getFilesystemFacade(): FilesystemFacadeInterface
     {
-        return $this->getProvidedDependency(CompilerProvider::FACADE_FILESYSTEM);
+        /** @var FilesystemFacadeInterface $facade */
+        $facade = $this->getProvidedDependency(CompilerProvider::FACADE_FILESYSTEM);
+
+        return $facade;
     }
 
     private function getGlobalEnvironment(): GlobalEnvironmentInterface

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ApplySymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ApplySymbol.php
@@ -34,6 +34,7 @@ final class ApplySymbol implements SpecialFormAnalyzerInterface
 
         /** @var PersistentListInterface<mixed> $data */
         $data = $list->rest();
+        /** @var bool|float|int|string|TypeInterface|null $fnExpr */
         $fnExpr = $data->first();
         /** @var PersistentListInterface<mixed> $args */
         $args = $data->rest();
@@ -67,6 +68,7 @@ final class ApplySymbol implements SpecialFormAnalyzerInterface
         $args = [];
 
         foreach ($argsList as $element) {
+            /** @var bool|float|int|string|TypeInterface|null $element */
             $args[] = $this->fnExpr($element, $env);
         }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor.php
@@ -13,6 +13,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
+use Phel\Lang\TypeInterface;
 
 use function count;
 
@@ -49,6 +50,7 @@ final readonly class Deconstructor implements DeconstructorInterface
     ): void {
         $this->bindingValidator->assertSupportedBinding($binding);
 
+        /** @var bool|float|int|string|TypeInterface|null $value */
         $this->createDeconstructorForBinding($binding)
             ->deconstruct($bindings, $binding, $value);
     }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
@@ -81,6 +81,7 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
         if ($orMap instanceof PersistentMapInterface) {
             foreach ($orMap as $sym => $default) {
                 if ($sym instanceof Symbol) {
+                    /** @var bool|float|int|string|TypeInterface|null $default */
                     $this->orDefaults[$sym->getName()] = $default;
                 }
             }
@@ -122,6 +123,8 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
         }
 
         foreach ($normalBindings as [$key, $bindTo]) {
+            /** @var bool|float|int|string|TypeInterface|null $key */
+            /** @var bool|float|int|string|TypeInterface|null $bindTo */
             $this->bindingIteration($bindings, $binding, $key, $bindTo);
         }
     }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructor.php
@@ -50,6 +50,7 @@ final class VectorBindingDeconstructor implements BindingDeconstructorInterface
         $bindings[] = [$arrSymbol, $value];
         $this->currentListSymbol = $arrSymbol;
 
+        /** @var PersistentVectorInterface<mixed> $binding */
         foreach ($binding as $current) {
             switch ($this->currentState) {
                 case self::STATE_START:

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -81,6 +81,7 @@ final readonly class DefSymbol implements SpecialFormAnalyzerInterface
             $init = $rewriter->injectImplicitParams($init);
         }
 
+        /** @var bool|float|int|string|TypeInterface|null $init */
         $init = $rewriter->injectReturnTypeFromMeta($init, $metaMap);
 
         $initNode = $this->analyzeInit($init, $env, $namespace, $nameSymbol, $metaMap);
@@ -185,7 +186,8 @@ final readonly class DefSymbol implements SpecialFormAnalyzerInterface
         // `^:dynamic`, `^:private`, etc. attach to the name symbol
         // (`(def ^:dynamic *x* 1)`). Merge those flags into the def's
         // metadata map so runtime code can read them off the var.
-        $nameMeta = $list->get(1)->getMeta();
+        $nameForm = $list->get(1);
+        $nameMeta = $nameForm instanceof Symbol ? $nameForm->getMeta() : null;
         if ($nameMeta instanceof PersistentMapInterface) {
             foreach ($nameMeta->getIterator() as $key => $value) {
                 if ($key !== null) {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -216,7 +216,7 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
 
         $arityFn = $meta[Keyword::create('inline-arity')];
 
-        if (!$arityFn) {
+        if (!is_callable($arityFn)) {
             return true;
         }
 
@@ -367,6 +367,7 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
     {
         $result = [];
         foreach ($list->getIterator() as $item) {
+            /** @var array<mixed>|bool|float|int|string|TypeInterface|null $item */
             $result[] = $this->enrichLocation($item, $parent);
         }
 
@@ -421,7 +422,7 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
 
         $minArity = $data->find('min-arity');
 
-        if ($minArity === null) {
+        if (!is_int($minArity)) {
             return;
         }
 
@@ -429,7 +430,8 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
         $rest = $list->rest();
         $gotCount = count($rest);
         $isVariadic = (bool) $data->find('is-variadic');
-        $maxArity = $data->find('max-arity');
+        $maxArityValue = $data->find('max-arity');
+        $maxArity = is_int($maxArityValue) ? $maxArityValue : null;
 
         if ($gotCount < $minArity) {
             throw AnalyzerException::notEnoughArgsProvided($f, $list, $minArity, $isVariadic, $maxArity);

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/RecurSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/RecurSymbol.php
@@ -35,8 +35,9 @@ final class RecurSymbol implements SpecialFormAnalyzerInterface
 
         if (!$currentFrame instanceof RecurFrame) {
             $msg = "Can't call 'recur here. See more: https://phel-lang.org/blog/loop-and-recur";
-            /** @psalm-suppress PossiblyNullArgument */
-            throw AnalyzerException::withLocation($msg, $list->get(0));
+            /** @var Symbol $recurSymbol */
+            $recurSymbol = $list->get(0);
+            throw AnalyzerException::withLocation($msg, $recurSymbol);
         }
 
         if (count($list) - 1 !== count($currentFrame->getParams())) {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
@@ -72,7 +72,7 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
             $form = $forms->first();
 
             if ($this->isCatchForm($form)) {
-                /** @psalm-suppress PossiblyNullArgument -- $form is mixed from first(); null is valid here */
+                /** @var PersistentListInterface<mixed> $form */
                 $state = $this->handleCatchForm($state, $form, $catches, $list);
             } elseif ($this->isFinallyForm($form)) {
                 $state = $this->handleFinallyForm($state, $form, $finally, $list);
@@ -129,6 +129,7 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
             throw AnalyzerException::withLocation("Unexpected form after 'finally", $list);
         }
 
+        /** @var PersistentListInterface<mixed> $form */
         $finally = $form;
         return self::STATE_DONE;
     }
@@ -205,6 +206,8 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
         $name = $catch->get(2);
 
         $this->validateCatchArguments($type, $name, $catch);
+        /** @var Symbol $type */
+        /** @var Symbol $name */
 
         $resolvedType = $this->resolveCatchType($type, $env, $catch);
         $catchBody = $this->analyzeCatchBody($catch, $name, $env, $catchContext);

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -74,7 +74,7 @@ final readonly class LiteralEmitter
         } elseif (is_array($x)) {
             $this->emitArray($x);
         } else {
-            $typeName = $x::class;
+            $typeName = get_debug_type($x);
 
             throw new RuntimeException('literal not supported: ' . $typeName);
         }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/AtomReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/AtomReader.php
@@ -14,6 +14,7 @@ final class AtomReader
      */
     public function read(AbstractAtomNode $node): float|bool|int|string|TypeInterface|null
     {
+        /** @var bool|float|int|string|TypeInterface|null $value */
         $value = $node->getValue();
 
         if ($value instanceof TypeInterface) {

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/QuoasiquoteReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/QuoasiquoteReader.php
@@ -25,6 +25,7 @@ final readonly class QuoasiquoteReader
      */
     public function read(QuoteNode $node, NodeInterface $root): float|bool|int|string|TypeInterface|null
     {
+        /** @var bool|float|int|string|TypeInterface|null $expression */
         $expression = $this->reader->readExpression($node->getExpression(), $root);
         $result = $this->quasiquoteTransformer->transform($expression);
 

--- a/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
+++ b/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
@@ -54,8 +54,12 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
     private function doTransform(TypeInterface|string|float|int|bool|null $form, GensymContext $context): TypeInterface|string|float|int|bool|null
     {
         if ($this->isUnquote($form)) {
-            /** @var PersistentList<mixed> $form */
-            return $form->get(1);
+            /** @var PersistentList<mixed> $unquoteForm */
+            $unquoteForm = $form;
+            /** @var bool|float|int|string|TypeInterface|null $unquoted */
+            $unquoted = $unquoteForm->get(1);
+
+            return $unquoted;
         }
 
         if ($this->isUnquoteSplicing($form)) {
@@ -163,12 +167,15 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
     {
         $xs = [];
         foreach ($seq as $item) {
+            /** @var bool|float|int|string|TypeInterface|null $item */
             if ($this->isUnquote($item)) {
+                /** @var PersistentListInterface<mixed> $item */
                 $xs[] = Phel::list([
                     (Symbol::create(Symbol::NAME_LIST))->copyLocationFrom($item),
                     $item->get(1),
                 ])->copyLocationFrom($item);
             } elseif ($this->isUnquoteSplicing($item)) {
+                /** @var PersistentListInterface<mixed> $item */
                 $xs[] = $item->get(1);
             } else {
                 $xs[] = Phel::list([


### PR DESCRIPTION
## 🤔 Background

[#2400](https://github.com/phel-lang/phel-lang/pull/2400) and [#2401](https://github.com/phel-lang/phel-lang/pull/2401) brought the scoped compiler pass (`phpstan-compiler.neon`) to PHPStan level 8. Level 9 is the strictest level: it bans implicit `mixed` flowing into typed positions. The compiler is the right place to enforce it, since a wrong type flowing through the reader/analyzer is a miscompile.

## 💡 Goal

Hold the compiler pipeline to PHPStan **level 9** and resolve every finding by narrowing types, not weakening signatures.

## 🔖 Changes

`phpstan-compiler.neon`: `level: 8` → `level: 9`, plus 33 finding fixes. The recurring root cause is that a value read off a `PersistentList`/node is `mixed` in the type system even though it is structurally a Phel form.

- **Reader** (`AtomReader`, `QuoasiquoteReader`, `QuasiquoteTransformer`): annotate the Phel-form union on values read off nodes/lists; the unquote narrowing is split so each `@var` matches its assignment target (psalm-safe).
- **Analyzer special forms**: narrow `first()`/`get()`/`foreach` values to the form union or a concrete type (`ApplySymbol`, `DefSymbol`, `RecurSymbol`, `TrySymbol`, the binding deconstructors); guard arity metadata with `is_int` and the inline-arity callback with `is_callable` (`InvokeSymbol`).
- **`LiteralEmitter`**: `get_debug_type()` for the unsupported-literal message (works for non-objects, unlike `$x::class`).
- **`CompilerFactory`**: `@var` the cross-module facade from `getProvidedDependency`.
- **`CompilerFacade::encodeNs`** delegates through Gacela's `mixed`-typed `cached()`; the `facadeOnlyDelegates` rule forbids inline narrowing, so its `return.type` is the single documented `ignoreErrors` entry.

No behavior change. Verified locally: global PHPStan L6, scoped PHPStan L9, Psalm, Rector, php-cs-fixer, 4307 unit/integration tests, 5941 core tests — all green.

This brings the compiler to the maximum PHPStan level. Next: extend the same level toward the rest of `src/` (the larger `Lang/Collections` generics backlog).