### PR TITLE
chore(phpstan): extend level 9 to the Command and Lint modules

### DIFF
--- a/phpstan-strict.neon
+++ b/phpstan-strict.neon
@@ -33,7 +33,14 @@ parameters:
         -
             identifier: argument.type
             path: src/php/Config/PhelConfig.php
+        # CommandFacade's directory getters delegate through Gacela's cached()
+        # helper (mixed return) and the gacela.facadeOnlyDelegates rule forbids
+        # inline narrowing, mirroring CompilerFacade::encodeNs above.
+        -
+            identifier: return.type
+            path: src/php/Command/CommandFacade.php
     paths!:
+        - %currentWorkingDirectory%/src/php/Command/
         - %currentWorkingDirectory%/src/php/Compiler/
         - %currentWorkingDirectory%/src/php/Config/
         - %currentWorkingDirectory%/src/php/Console/
@@ -41,6 +48,7 @@ parameters:
         - %currentWorkingDirectory%/src/php/Formatter/
         - %currentWorkingDirectory%/src/php/HttpClient/
         - %currentWorkingDirectory%/src/php/Interop/
+        - %currentWorkingDirectory%/src/php/Lint/
         - %currentWorkingDirectory%/src/php/Lsp/
         - %currentWorkingDirectory%/src/php/Nrepl/
         - %currentWorkingDirectory%/src/php/Profile/

--- a/src/php/Command/Application/TextExceptionPrinter.php
+++ b/src/php/Command/Application/TextExceptionPrinter.php
@@ -19,6 +19,7 @@ use Phel\Shared\Parser\ReadModel\CodeSnippet;
 use ReflectionClass;
 use Throwable;
 
+use function is_string;
 use function sprintf;
 use function strlen;
 
@@ -150,7 +151,7 @@ final readonly class TextExceptionPrinter implements ExceptionPrinterInterface
                 $rf = new ReflectionClass($class);
                 if ($rf->implementsInterface(FnInterface::class)) {
                     $boundTo = $rf->getConstant('BOUND_TO');
-                    $fnName = $boundTo !== false ? $this->munge->decodeNs($boundTo) : '__invoke';
+                    $fnName = is_string($boundTo) ? $this->munge->decodeNs($boundTo) : '__invoke';
                     $argString = $this->exceptionArgsPrinter->parseArgsAsString($frame['args'] ?? []);
                     $pos = $this->filePositionExtractor->getOriginal($file, $line);
                     $str .= sprintf('#%d %s:%d (gen: %s:%d) : (%s%s)', $i, $pos->filename(), $pos->line(), $file, $line, $fnName, $argString) . PHP_EOL;

--- a/src/php/Command/CommandConfig.php
+++ b/src/php/Command/CommandConfig.php
@@ -9,8 +9,10 @@ use Phel\Command\Domain\CodeDirectories;
 use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
 use Phel\Shared\PhelProjectDirectory;
+use Phel\Shared\ScalarCoercion;
 
 use function dirname;
+use function is_array;
 use function sprintf;
 
 final class CommandConfig extends AbstractConfig
@@ -28,6 +30,7 @@ final class CommandConfig extends AbstractConfig
     public function getCodeDirs(): CodeDirectories
     {
         $buildConfig = $this->get(PhelConfig::BUILD_CONFIG, []);
+        $buildConfig = is_array($buildConfig) ? $buildConfig : [];
 
         // Point at the parent `src` directory (which contains `phel/`) so
         // phel's own core library is discoverable whether phel runs from its
@@ -46,21 +49,21 @@ final class CommandConfig extends AbstractConfig
 
         return new CodeDirectories(
             $phelInternalSrcDir,
-            (array) $this->get(PhelConfig::SRC_DIRS, self::DEFAULT_SRC_DIRS),
-            (array) $this->get(PhelConfig::TEST_DIRS, self::DEFAULT_TEST_DIRS),
-            (string) ($buildConfig[PhelBuildConfig::DEST_DIR] ?? self::DEFAULT_OUTPUT_DIR),
+            ScalarCoercion::toStringList($this->get(PhelConfig::SRC_DIRS, self::DEFAULT_SRC_DIRS), self::DEFAULT_SRC_DIRS),
+            ScalarCoercion::toStringList($this->get(PhelConfig::TEST_DIRS, self::DEFAULT_TEST_DIRS), self::DEFAULT_TEST_DIRS),
+            ScalarCoercion::toString($buildConfig[PhelBuildConfig::DEST_DIR] ?? null, self::DEFAULT_OUTPUT_DIR),
         );
     }
 
     public function getVendorDir(): string
     {
-        return (string) $this->get(PhelConfig::VENDOR_DIR, self::DEFAULT_VENDOR_DIR);
+        return ScalarCoercion::toString($this->get(PhelConfig::VENDOR_DIR, self::DEFAULT_VENDOR_DIR), self::DEFAULT_VENDOR_DIR);
     }
 
     public function getErrorLogFile(): string
     {
-        $path = (string) $this->get(PhelConfig::ERROR_LOG_FILE, self::DEFAULT_ERROR_LOG_FILE);
-        $phelDir = (string) $this->get(PhelConfig::PHEL_DIR, '');
+        $path = ScalarCoercion::toString($this->get(PhelConfig::ERROR_LOG_FILE, self::DEFAULT_ERROR_LOG_FILE), self::DEFAULT_ERROR_LOG_FILE);
+        $phelDir = ScalarCoercion::toString($this->get(PhelConfig::PHEL_DIR, ''));
 
         return PhelProjectDirectory::resolve($this->getAppRootDir(), $path, $phelDir);
     }
@@ -74,10 +77,12 @@ final class CommandConfig extends AbstractConfig
     public function getStaleOutputHint(): string
     {
         $buildConfig = $this->get(PhelConfig::BUILD_CONFIG, []);
-        $outputDir = (string) ($buildConfig[PhelBuildConfig::DEST_DIR] ?? self::DEFAULT_OUTPUT_DIR);
+        $buildConfig = is_array($buildConfig) ? $buildConfig : [];
 
-        $cacheDir = (string) $this->get(PhelConfig::CACHE_DIR, '.phel/cache');
-        $phelDir = (string) $this->get(PhelConfig::PHEL_DIR, '');
+        $outputDir = ScalarCoercion::toString($buildConfig[PhelBuildConfig::DEST_DIR] ?? null, self::DEFAULT_OUTPUT_DIR);
+
+        $cacheDir = ScalarCoercion::toString($this->get(PhelConfig::CACHE_DIR, '.phel/cache'), '.phel/cache');
+        $phelDir = ScalarCoercion::toString($this->get(PhelConfig::PHEL_DIR, ''));
         $resolvedCacheDir = PhelProjectDirectory::resolve($this->getAppRootDir(), $cacheDir, $phelDir);
 
         return sprintf(

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -59,7 +59,10 @@ final class CommandFactory extends AbstractFactory
 
     public function getPhpConfigReader(): PhpConfigReader
     {
-        return $this->getProvidedDependency(CommandProvider::PHP_CONFIG_READER);
+        /** @var PhpConfigReader $reader */
+        $reader = $this->getProvidedDependency(CommandProvider::PHP_CONFIG_READER);
+
+        return $reader;
     }
 
     private function createComposerVendorDirectoriesFinder(): VendorDirectoriesFinderInterface

--- a/src/php/Command/Domain/Exceptions/ExceptionArgsPrinter.php
+++ b/src/php/Command/Domain/Exceptions/ExceptionArgsPrinter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Command\Domain\Exceptions;
 
 use Phel\Shared\Printer\PrinterInterface;
+use Phel\Shared\ScalarCoercion;
 
 use function is_array;
 use function is_bool;
@@ -101,6 +102,6 @@ final readonly class ExceptionArgsPrinter implements ExceptionArgsPrinterInterfa
             return 'Resource id #' . get_resource_id($arg);
         }
 
-        return (string) $arg;
+        return ScalarCoercion::toString($arg);
     }
 }

--- a/src/php/Lint/Application/Cache/LintCache.php
+++ b/src/php/Lint/Application/Cache/LintCache.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Lint\Application\Cache;
 
 use Phel\Api\Transfer\Diagnostic;
+use Phel\Shared\ScalarCoercion;
 
 use Throwable;
 
@@ -65,14 +66,14 @@ final class LintCache
         $diagnostics = [];
         foreach ($entry['diagnostics'] as $data) {
             $diagnostics[] = new Diagnostic(
-                code: (string) ($data['code'] ?? ''),
-                severity: (string) ($data['severity'] ?? Diagnostic::SEVERITY_WARNING),
-                message: (string) ($data['message'] ?? ''),
-                uri: (string) ($data['uri'] ?? $filePath),
-                startLine: (int) ($data['startLine'] ?? 1),
-                startCol: (int) ($data['startCol'] ?? 1),
-                endLine: (int) ($data['endLine'] ?? 1),
-                endCol: (int) ($data['endCol'] ?? 1),
+                code: ScalarCoercion::toString($data['code'] ?? null),
+                severity: ScalarCoercion::toString($data['severity'] ?? null, Diagnostic::SEVERITY_WARNING),
+                message: ScalarCoercion::toString($data['message'] ?? null),
+                uri: ScalarCoercion::toString($data['uri'] ?? null, $filePath),
+                startLine: ScalarCoercion::toInt($data['startLine'] ?? null, 1),
+                startCol: ScalarCoercion::toInt($data['startCol'] ?? null, 1),
+                endLine: ScalarCoercion::toInt($data['endLine'] ?? null, 1),
+                endCol: ScalarCoercion::toInt($data['endCol'] ?? null, 1),
             );
         }
 

--- a/src/php/Lint/Application/FileCollector.php
+++ b/src/php/Lint/Application/FileCollector.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Phel\Lint\Application;
 
+use Phel\Shared\ScalarCoercion;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RegexIterator;
 use UnexpectedValueException;
 
+use function is_array;
 use function is_dir;
 use function is_file;
 use function realpath;
@@ -71,7 +73,9 @@ final class FileCollector
         }
 
         foreach ($regex as $match) {
-            yield $match[0];
+            if (is_array($match) && isset($match[0])) {
+                yield ScalarCoercion::toString($match[0]);
+            }
         }
     }
 }

--- a/src/php/Lint/Application/Rule/UnusedImportRule.php
+++ b/src/php/Lint/Application/Rule/UnusedImportRule.php
@@ -7,6 +7,7 @@ namespace Phel\Lint\Application\Rule;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
+use Phel\Lang\TypeInterface;
 use Phel\Lint\Application\Config\RuleRegistry;
 use Phel\Lint\Domain\FileAnalysis;
 use Phel\Lint\Domain\LintRuleInterface;
@@ -58,7 +59,7 @@ final readonly class UnusedImportRule implements LintRuleInterface
     /**
      * @param PersistentListInterface<mixed> $nsForm
      *
-     * @return list<array{alias:string, display:string, anchor: mixed}>
+     * @return list<array{alias:string, display:string, anchor: bool|float|int|string|TypeInterface|null}>
      */
     private function collectImports(PersistentListInterface $nsForm): array
     {
@@ -75,7 +76,7 @@ final readonly class UnusedImportRule implements LintRuleInterface
     /**
      * @param PersistentListInterface<mixed> $clause
      *
-     * @return list<array{alias:string, display:string, anchor: mixed}>
+     * @return list<array{alias:string, display:string, anchor: bool|float|int|string|TypeInterface|null}>
      */
     private function importsInClause(PersistentListInterface $clause): array
     {

--- a/src/php/Lint/Application/Rule/UnusedRequireRule.php
+++ b/src/php/Lint/Application/Rule/UnusedRequireRule.php
@@ -8,6 +8,7 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
+use Phel\Lang\TypeInterface;
 use Phel\Lint\Application\Config\RuleRegistry;
 use Phel\Lint\Domain\FileAnalysis;
 use Phel\Lint\Domain\LintRuleInterface;
@@ -81,7 +82,7 @@ final readonly class UnusedRequireRule implements LintRuleInterface
     /**
      * @param PersistentListInterface<mixed> $nsForm
      *
-     * @return list<array{alias:string, refers:list<string>, display:string, anchor: mixed}>
+     * @return list<array{alias:string, refers:list<string>, display:string, anchor: bool|float|int|string|TypeInterface|null}>
      */
     private function collectRequires(PersistentListInterface $nsForm): array
     {
@@ -98,7 +99,7 @@ final readonly class UnusedRequireRule implements LintRuleInterface
     /**
      * @param PersistentListInterface<mixed> $clause
      *
-     * @return list<array{alias:string, refers:list<string>, display:string, anchor: mixed}>
+     * @return list<array{alias:string, refers:list<string>, display:string, anchor: bool|float|int|string|TypeInterface|null}>
      */
     private function parseRequireClauseEntries(PersistentListInterface $clause): array
     {
@@ -127,7 +128,7 @@ final readonly class UnusedRequireRule implements LintRuleInterface
     /**
      * @param PersistentVectorInterface<mixed> $vector
      *
-     * @return array{alias:string, refers:list<string>, display:string, anchor: mixed}
+     * @return array{alias:string, refers:list<string>, display:string, anchor: bool|float|int|string|TypeInterface|null}
      */
     private function parseVectorEntry(PersistentVectorInterface $vector): array
     {
@@ -175,11 +176,12 @@ final readonly class UnusedRequireRule implements LintRuleInterface
     /**
      * @param PersistentListInterface<mixed> $clause
      *
-     * @return array{0: array{alias:string, refers:list<string>, display:string, anchor: mixed}, 1: int}
+     * @return array{0: array{alias:string, refers:list<string>, display:string, anchor: bool|float|int|string|TypeInterface|null}, 1: int}
      */
     private function parseFlatEntry(PersistentListInterface $clause, int $startIndex): array
     {
         $size = count($clause);
+        /** @var bool|float|int|string|TypeInterface|null $target */
         $target = $clause->get($startIndex);
         $alias = null;
         $refers = [];

--- a/src/php/Lint/Application/SourceReader.php
+++ b/src/php/Lint/Application/SourceReader.php
@@ -36,6 +36,7 @@ final readonly class SourceReader
      */
     public function read(string $source, string $uri): array
     {
+        /** @var list<bool|float|int|string|TypeInterface|null> $forms */
         $forms = [];
         $namespace = '';
 
@@ -62,6 +63,7 @@ final readonly class SourceReader
                     continue;
                 }
 
+                /** @var bool|float|int|string|TypeInterface|null $form */
                 $form = $readerResult->getAst();
 
                 if ($namespace === '') {

--- a/src/php/Lint/Infrastructure/Command/LintCommand.php
+++ b/src/php/Lint/Infrastructure/Command/LintCommand.php
@@ -13,6 +13,7 @@ use Phel\Lint\LintConfig;
 use Phel\Lint\LintFacade;
 use Phel\Lint\LintFactory;
 use Phel\Shared\PhelProjectDirectory;
+use Phel\Shared\ScalarCoercion;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -103,7 +104,7 @@ final class LintCommand extends Command
             return self::EXIT_INVOCATION_ERROR;
         }
 
-        $format = (string) $input->getOption(self::OPT_FORMAT);
+        $format = ScalarCoercion::toString($input->getOption(self::OPT_FORMAT));
         $formatters = $this->getFacade()->formatters();
         if (!$formatters->has($format)) {
             $output->writeln(sprintf(

--- a/src/php/Lint/LintFactory.php
+++ b/src/php/Lint/LintFactory.php
@@ -114,22 +114,34 @@ final class LintFactory extends AbstractFactory
 
     public function getApiFacade(): ApiFacade
     {
-        return $this->getProvidedDependency(LintProvider::FACADE_API);
+        /** @var ApiFacade $facade */
+        $facade = $this->getProvidedDependency(LintProvider::FACADE_API);
+
+        return $facade;
     }
 
     public function getCompilerFacade(): CompilerFacadeInterface
     {
-        return $this->getProvidedDependency(LintProvider::FACADE_COMPILER);
+        /** @var CompilerFacadeInterface $facade */
+        $facade = $this->getProvidedDependency(LintProvider::FACADE_COMPILER);
+
+        return $facade;
     }
 
     public function getCommandFacade(): CommandFacadeInterface
     {
-        return $this->getProvidedDependency(LintProvider::FACADE_COMMAND);
+        /** @var CommandFacadeInterface $facade */
+        $facade = $this->getProvidedDependency(LintProvider::FACADE_COMMAND);
+
+        return $facade;
     }
 
     public function getRunFacade(): RunFacadeInterface
     {
-        return $this->getProvidedDependency(LintProvider::FACADE_RUN);
+        /** @var RunFacadeInterface $facade */
+        $facade = $this->getProvidedDependency(LintProvider::FACADE_RUN);
+
+        return $facade;
     }
 
     /**

--- a/src/php/Shared/ScalarCoercion.php
+++ b/src/php/Shared/ScalarCoercion.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Phel\Shared;
 
+use function array_map;
+use function array_values;
+use function is_array;
 use function is_numeric;
 use function is_scalar;
 
@@ -28,5 +31,25 @@ final class ScalarCoercion
     public static function toFloat(mixed $value, float $default = 0.0): float
     {
         return is_numeric($value) ? (float) $value : $default;
+    }
+
+    /**
+     * Coerce a config value into a list of strings, falling back to the
+     * default when it is not an array. Each element is coerced via toString().
+     *
+     * @param list<string> $default
+     *
+     * @return list<string>
+     */
+    public static function toStringList(mixed $value, array $default = []): array
+    {
+        if (!is_array($value)) {
+            return $default;
+        }
+
+        return array_values(array_map(
+            static fn(mixed $element): string => self::toString($element),
+            $value,
+        ));
     }
 }

--- a/tests/php/Unit/Shared/ScalarCoercionTest.php
+++ b/tests/php/Unit/Shared/ScalarCoercionTest.php
@@ -49,4 +49,17 @@ final class ScalarCoercionTest extends TestCase
         self::assertSame(0.0, ScalarCoercion::toFloat(null));
         self::assertSame(9.5, ScalarCoercion::toFloat('x', 9.5));
     }
+
+    public function test_to_string_list_coerces_array_elements(): void
+    {
+        self::assertSame(['a', 'b'], ScalarCoercion::toStringList(['a', 'b']));
+        self::assertSame(['1', '2'], ScalarCoercion::toStringList([1, 2]));
+        self::assertSame(['x'], ScalarCoercion::toStringList(['k' => 'x']));
+    }
+
+    public function test_to_string_list_returns_default_for_non_arrays(): void
+    {
+        self::assertSame([], ScalarCoercion::toStringList(null));
+        self::assertSame(['src'], ScalarCoercion::toStringList('nope', ['src']));
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Continues the whole-`src/` PHPStan level-9 rollout ([#2400](https://github.com/phel-lang/phel-lang/pull/2400)–[#2403](https://github.com/phel-lang/phel-lang/pull/2403)). After the compiler and the small leaf modules, this round brings **Command** and **Lint** to level 9. Same mechanical finding mix as the leaf round (factory facade getters, config `mixed` casts, iterator/form narrowing).

## 💡 Goal

Hold Command and Lint to PHPStan level 9, narrowing types rather than weakening signatures.

## 🔖 Changes

- Add `Command` and `Lint` to `phpstan-strict.neon` (now 13 modules at level 9).
- Factory facade getters: `@var` the cross-module facade from `getProvidedDependency()` (`CommandFactory`, `LintFactory`).
- Config/cache/command readers coerce loosely-typed `mixed` via `Phel\Shared\ScalarCoercion`; add `ScalarCoercion::toStringList()` for the recurring `list<string>` config pattern, used by `CommandConfig` (src/test dirs), `LintCache` (diagnostics), `LintCommand` (`--format`).
- Narrow reads to concrete types: `TextExceptionPrinter` `BOUND_TO` (`is_string`), `ExceptionArgsPrinter` scalar fallback, `FileCollector` regex match, `SourceReader` form union, and the Lint rules' require/import `anchor` typed as the Phel-form union instead of `mixed`.

One documented `ignoreErrors` entry added: `CommandFacade`'s directory getters (Gacela `cached()` returns `mixed` and `facadeOnlyDelegates` forbids inline narrowing), mirroring `CompilerFacade::encodeNs`.

No behavior change. Verified locally: PHPStan strict level 9 (13 modules), global level 6, Psalm, Rector, php-cs-fixer, 4315 unit/integration tests, 5941 core tests — all green.

Remaining toward whole-`src/` level 9: `Api`, `Shared`, `Run`, `Build`, then `Lang` last (collection generics + nullability).