### PR TITLE
chore(phpstan): extend level 9 to the Api and Shared modules

### DIFF
--- a/phpstan-strict.neon
+++ b/phpstan-strict.neon
@@ -39,7 +39,15 @@ parameters:
         -
             identifier: return.type
             path: src/php/Command/CommandFacade.php
+        # Printer's dispatchers select a TypePrinterInterface<Concrete> per
+        # runtime-matched type, which is sound by construction but an
+        # existential type: generic invariance cannot relate it to the
+        # declared TypePrinterInterface<mixed> return.
+        -
+            identifier: return.type
+            path: src/php/Shared/Printer/Printer.php
     paths!:
+        - %currentWorkingDirectory%/src/php/Api/
         - %currentWorkingDirectory%/src/php/Command/
         - %currentWorkingDirectory%/src/php/Compiler/
         - %currentWorkingDirectory%/src/php/Config/
@@ -52,4 +60,5 @@ parameters:
         - %currentWorkingDirectory%/src/php/Lsp/
         - %currentWorkingDirectory%/src/php/Nrepl/
         - %currentWorkingDirectory%/src/php/Profile/
+        - %currentWorkingDirectory%/src/php/Shared/
         - %currentWorkingDirectory%/src/php/Watch/

--- a/src/php/Api/Application/Analysis/ReadAndAnalyzeStage.php
+++ b/src/php/Api/Application/Analysis/ReadAndAnalyzeStage.php
@@ -9,9 +9,12 @@ use Phel\Api\Transfer\Diagnostic;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
+use Phel\Lang\TypeInterface;
 use Phel\Shared\Exceptions\ErrorCode;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use Phel\Shared\Parser\Node\NodeInterface;
+
+use function is_array;
 
 /**
  * Second stage: read each parse tree into a Phel value, then analyze
@@ -29,6 +32,9 @@ final readonly class ReadAndAnalyzeStage implements AnalysisStageInterface
     {
         $diagnostics = [];
         $parseTrees = $context['parseTrees'] ?? [];
+        if (!is_array($parseTrees)) {
+            $parseTrees = [];
+        }
 
         foreach ($parseTrees as $parseTree) {
             if (!$parseTree instanceof NodeInterface) {
@@ -37,8 +43,10 @@ final readonly class ReadAndAnalyzeStage implements AnalysisStageInterface
 
             try {
                 $readerResult = $this->compilerFacade->read($parseTree);
+                /** @var bool|float|int|string|TypeInterface|null $ast */
+                $ast = $readerResult->getAst();
                 $this->compilerFacade->analyze(
-                    $readerResult->getAst(),
+                    $ast,
                     NodeEnvironment::empty()->withReturnContext(),
                 );
             } catch (ReaderException $e) {

--- a/src/php/Api/Application/PhelFileIterator.php
+++ b/src/php/Api/Application/PhelFileIterator.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Phel\Api\Application;
 
+use Phel\Shared\ScalarCoercion;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RegexIterator;
 use UnexpectedValueException;
+
+use function is_array;
 
 /**
  * Stateless helper that yields every `.phel` file under a directory tree.
@@ -29,7 +32,9 @@ final class PhelFileIterator
         }
 
         foreach ($regex as $match) {
-            yield $match[0];
+            if (is_array($match) && isset($match[0])) {
+                yield ScalarCoercion::toString($match[0]);
+            }
         }
     }
 }

--- a/src/php/Api/Application/PhelFnNormalizer.php
+++ b/src/php/Api/Application/PhelFnNormalizer.php
@@ -10,6 +10,7 @@ use Phel\Api\Domain\PhelFnNormalizerInterface;
 use Phel\Api\Transfer\PhelFunction;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
+use Phel\Shared\ScalarCoercion;
 
 final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
 {
@@ -57,7 +58,7 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
                 continue;
             }
 
-            $doc = (string) ($meta[Keyword::create('doc')] ?? '');
+            $doc = ScalarCoercion::toString($meta[Keyword::create('doc')] ?? null);
             $parsed = DocstringSignatureParser::parse($doc);
             $signatures = $parsed['signatures'];
             $description = $parsed['description'];
@@ -69,9 +70,9 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
             $line = 0;
             $location = $meta[Keyword::create('start-location')] ?? null;
             if ($location instanceof PersistentMapInterface) {
-                $file = (string) ($location[Keyword::create('file')] ?? '');
+                $file = ScalarCoercion::toString($location[Keyword::create('file')] ?? null);
                 $file = $this->toRelativeFile($file);
-                $line = (int) ($location[Keyword::create('line')] ?? 0);
+                $line = ScalarCoercion::toInt($location[Keyword::create('line')] ?? null);
             }
 
             $normalizedFns[$groupKey][$fnName] = new PhelFunction(
@@ -82,7 +83,7 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
                 description: $description,
                 groupKey: $groupKey,
                 githubUrl: $this->toGithubUrl($file, $line),
-                docUrl: (string) ($meta[Keyword::create('docUrl')] ?? ''),
+                docUrl: ScalarCoercion::toString($meta[Keyword::create('docUrl')] ?? null),
                 file: $file,
                 line: $line,
                 meta: $this->metaToArray($meta),
@@ -116,7 +117,7 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
     {
         $result = [];
         foreach ($meta as $key => $value) {
-            $name = $key instanceof Keyword ? $key->getName() : (string) $key;
+            $name = $key instanceof Keyword ? $key->getName() : ScalarCoercion::toString($key);
             $result[$name] = $value;
         }
 
@@ -153,7 +154,7 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
     }
 
     /**
-     * @param array<string, PhelFunction> $originalNormalizedFns
+     * @param array<array-key, PhelFunction> $originalNormalizedFns
      *
      * @return list<PhelFunction>
      */

--- a/src/php/Api/Application/SymbolMetadataFinder.php
+++ b/src/php/Api/Application/SymbolMetadataFinder.php
@@ -11,6 +11,7 @@ use Phel\Api\Transfer\PhelFunction;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Shared\MungeInterface;
+use Phel\Shared\ScalarCoercion;
 
 use function preg_split;
 use function strrpos;
@@ -156,15 +157,15 @@ final class SymbolMetadataFinder implements SymbolMetadataFinderInterface
      */
     private function toPhelFunction(string $namespace, string $name, PersistentMapInterface $meta): PhelFunction
     {
-        $doc = (string) ($meta[Keyword::create('doc')] ?? '');
+        $doc = ScalarCoercion::toString($meta[Keyword::create('doc')] ?? null);
         $signatures = $this->extractSignatures($meta, $doc, $name);
 
         $file = '';
         $line = 0;
         $location = $meta[Keyword::create('start-location')] ?? null;
         if ($location instanceof PersistentMapInterface) {
-            $file = (string) ($location[Keyword::create('file')] ?? '');
-            $line = (int) ($location[Keyword::create('line')] ?? 0);
+            $file = ScalarCoercion::toString($location[Keyword::create('file')] ?? null);
+            $line = ScalarCoercion::toInt($location[Keyword::create('line')] ?? null);
         }
 
         return new PhelFunction(
@@ -192,7 +193,7 @@ final class SymbolMetadataFinder implements SymbolMetadataFinderInterface
         // docstring fallback.
         $arglists = $meta['arglists'] ?? $meta[Keyword::create('arglists')] ?? null;
         if ($arglists !== null && $arglists !== '') {
-            return $this->splitArglists((string) $arglists, $name);
+            return $this->splitArglists(ScalarCoercion::toString($arglists), $name);
         }
 
         return DocstringSignatureParser::parse($doc)['signatures'];

--- a/src/php/Api/Infrastructure/Command/AnalyzeCommand.php
+++ b/src/php/Api/Infrastructure/Command/AnalyzeCommand.php
@@ -8,6 +8,7 @@ use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Api\ApiFacade;
 use Phel\Api\Transfer\Diagnostic;
+use Phel\Shared\ScalarCoercion;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -35,7 +36,7 @@ final class AnalyzeCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $file = (string) $input->getArgument('file');
+        $file = ScalarCoercion::toString($input->getArgument('file'));
 
         if (!is_file($file)) {
             $output->writeln(sprintf('<error>File not found: %s</error>', $file));

--- a/src/php/Api/Infrastructure/Command/DocCommand.php
+++ b/src/php/Api/Infrastructure/Command/DocCommand.php
@@ -9,6 +9,7 @@ use Gacela\Framework\ServiceResolverAwareTrait;
 use InvalidArgumentException;
 use Phel\Api\ApiFacade;
 use Phel\Api\Transfer\PhelFunction;
+use Phel\Shared\ScalarCoercion;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
@@ -54,13 +55,13 @@ final class DocCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $namespaces = $this->normalizeNamespaces($input->getOption(self::OPTION_NAMESPACES));
+        $namespaces = $this->normalizeNamespaces(ScalarCoercion::toStringList($input->getOption(self::OPTION_NAMESPACES)));
         $phelFunctions = $this->getFacade()->getPhelFunctions($namespaces);
 
-        $search = $input->getArgument('search');
+        $search = ScalarCoercion::toString($input->getArgument('search'));
         $normalized = $this->normalizeGroupedFunctions($phelFunctions, $search);
 
-        $format = strtolower((string) $input->getOption(self::OPTION_FORMAT));
+        $format = strtolower(ScalarCoercion::toString($input->getOption(self::OPTION_FORMAT)));
         if (!in_array($format, self::AVAILABLE_FORMATS, true)) {
             $message = sprintf(
                 'Invalid format "%s". Allowed values: %s',
@@ -209,7 +210,7 @@ final class DocCommand extends Command
                 'signatures' => $phelFunction->signatures,
                 'doc' => $phelFunction->doc,
                 'description' => $description,
-                'example' => (string) ($phelFunction->meta['example'] ?? ''),
+                'example' => ScalarCoercion::toString($phelFunction->meta['example'] ?? null),
                 'githubUrl' => $phelFunction->githubUrl,
                 'docUrl' => $phelFunction->docUrl,
                 'percent' => (int) round($percent),

--- a/src/php/Api/Infrastructure/Daemon/JsonRpcDispatcher.php
+++ b/src/php/Api/Infrastructure/Daemon/JsonRpcDispatcher.php
@@ -9,6 +9,7 @@ use Phel\Api\Transfer\Completion;
 use Phel\Api\Transfer\Diagnostic;
 use Phel\Api\Transfer\Location;
 use Phel\Api\Transfer\ProjectIndex;
+use Phel\Shared\ScalarCoercion;
 use Throwable;
 
 use function is_array;
@@ -80,8 +81,8 @@ final class JsonRpcDispatcher
             'analyzeSource' => array_map(
                 static fn(Diagnostic $d): array => $d->toArray(),
                 $this->facade->analyzeSource(
-                    (string) ($params['source'] ?? ''),
-                    (string) ($params['uri'] ?? ''),
+                    ScalarCoercion::toString($params['source'] ?? null),
+                    ScalarCoercion::toString($params['uri'] ?? null),
                 ),
             ),
             'indexProject' => $this->indexProject($params),
@@ -125,8 +126,8 @@ final class JsonRpcDispatcher
         $index = $this->requireIndex();
         $definition = $this->facade->resolveSymbol(
             $index,
-            (string) ($params['namespace'] ?? ''),
-            (string) ($params['symbol'] ?? ''),
+            ScalarCoercion::toString($params['namespace'] ?? null),
+            ScalarCoercion::toString($params['symbol'] ?? null),
         );
 
         return $definition?->toArray();
@@ -142,8 +143,8 @@ final class JsonRpcDispatcher
         $index = $this->requireIndex();
         $locations = $this->facade->findReferences(
             $index,
-            (string) ($params['namespace'] ?? ''),
-            (string) ($params['symbol'] ?? ''),
+            ScalarCoercion::toString($params['namespace'] ?? null),
+            ScalarCoercion::toString($params['symbol'] ?? null),
         );
 
         return array_map(static fn(Location $loc): array => $loc->toArray(), $locations);
@@ -159,7 +160,7 @@ final class JsonRpcDispatcher
         $index = $this->requireIndex();
 
         $completions = $this->facade->completeAtPoint(
-            (string) ($params['source'] ?? ''),
+            ScalarCoercion::toString($params['source'] ?? null),
             is_int($params['line'] ?? null) ? $params['line'] : 1,
             is_int($params['col'] ?? null) ? $params['col'] : 1,
             $index,

--- a/src/php/Shared/Printer/Printer.php
+++ b/src/php/Shared/Printer/Printer.php
@@ -105,83 +105,37 @@ final readonly class Printer implements PrinterInterface
     }
 
     /**
+     * Each branch builds a printer parameterised for the type it just
+     * matched, so the dispatch is sound even though generic invariance
+     * cannot relate `TypePrinterInterface<Concrete>` to the `<mixed>`
+     * return type (an existential type PHPStan cannot express; see the
+     * documented ignore in phpstan-strict.neon).
+     *
      * @return TypePrinterInterface<mixed>
      */
     private function createObjectTypePrinter(object $form): TypePrinterInterface
     {
-        if ($form instanceof AbstractPersistentStruct) {
-            return new StructPrinter($this);
-        }
-
-        if ($form instanceof PersistentListInterface) {
-            return new PersistentListPrinter($this);
-        }
-
-        if ($form instanceof PersistentVectorInterface) {
-            return new PersistentVectorPrinter($this);
-        }
-
-        if ($form instanceof PersistentMapInterface) {
-            return new PersistentMapPrinter($this);
-        }
-
-        if ($form instanceof PersistentHashSetInterface) {
-            return new PersistentHashSetPrinter($this);
-        }
-
-        if ($form instanceof Cons) {
-            return new ConsPrinter($this);
-        }
-
-        if ($form instanceof LazySeqInterface) {
-            return new LazySeqPrinter($this);
-        }
-
-        if ($form instanceof PersistentQueue) {
-            return new PersistentQueuePrinter($this);
-        }
-
-        if ($form instanceof Keyword) {
-            return new KeywordPrinter($this->withColor);
-        }
-
-        if ($form instanceof Symbol) {
-            return new SymbolPrinter($this->withColor);
-        }
-
-        if ($form instanceof Atom) {
-            return new AtomPrinter($this);
-        }
-
-        if ($form instanceof PhelVar) {
-            return new VarPrinter($this->withColor);
-        }
-
-        if ($form instanceof Ratio) {
-            return new RatioPrinter($this->withColor);
-        }
-
-        if ($form instanceof BigDecimal) {
-            return new BigDecimalPrinter($this->withColor);
-        }
-
-        if ($form instanceof UUID) {
-            return new UUIDPrinter($this->withColor);
-        }
-
-        if ($form instanceof FnInterface) {
-            return new FnPrinter();
-        }
-
-        if (method_exists($form, '__toString')) {
-            return new ToStringPrinter();
-        }
-
-        if (new ReflectionClass($form)->isAnonymous()) {
-            return new AnonymousClassPrinter();
-        }
-
-        return new NonPrintableClassPrinter($this->withColor);
+        return match (true) {
+            $form instanceof AbstractPersistentStruct => new StructPrinter($this),
+            $form instanceof PersistentListInterface => new PersistentListPrinter($this),
+            $form instanceof PersistentVectorInterface => new PersistentVectorPrinter($this),
+            $form instanceof PersistentMapInterface => new PersistentMapPrinter($this),
+            $form instanceof PersistentHashSetInterface => new PersistentHashSetPrinter($this),
+            $form instanceof Cons => new ConsPrinter($this),
+            $form instanceof LazySeqInterface => new LazySeqPrinter($this),
+            $form instanceof PersistentQueue => new PersistentQueuePrinter($this),
+            $form instanceof Keyword => new KeywordPrinter($this->withColor),
+            $form instanceof Symbol => new SymbolPrinter($this->withColor),
+            $form instanceof Atom => new AtomPrinter($this),
+            $form instanceof PhelVar => new VarPrinter($this->withColor),
+            $form instanceof Ratio => new RatioPrinter($this->withColor),
+            $form instanceof BigDecimal => new BigDecimalPrinter($this->withColor),
+            $form instanceof UUID => new UUIDPrinter($this->withColor),
+            $form instanceof FnInterface => new FnPrinter(),
+            method_exists($form, '__toString') => new ToStringPrinter(),
+            new ReflectionClass($form)->isAnonymous() => new AnonymousClassPrinter(),
+            default => new NonPrintableClassPrinter($this->withColor),
+        };
     }
 
     /**

--- a/src/php/Shared/Printer/TypePrinter/FnPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/FnPrinter.php
@@ -6,6 +6,11 @@ namespace Phel\Shared\Printer\TypePrinter;
 
 use ReflectionClass;
 
+use function is_string;
+use function str_replace;
+use function strrpos;
+use function substr;
+
 /**
  * @implements TypePrinterInterface<object>
  */
@@ -29,16 +34,15 @@ final class FnPrinter implements TypePrinterInterface
     {
         $boundTo = new ReflectionClass($form)->getConstant('BOUND_TO');
 
-        if ($boundTo === false || $boundTo === '') {
+        if (!is_string($boundTo) || $boundTo === '') {
             return null;
         }
 
-        $lastSeparator = strrpos((string) $boundTo, '\\');
+        $lastSeparator = strrpos($boundTo, '\\');
         $encodedName = $lastSeparator !== false
-            ? substr((string) $boundTo, $lastSeparator + 1)
+            ? substr($boundTo, $lastSeparator + 1)
             : $boundTo;
 
-        /** @var string */
         return str_replace('_', '-', $encodedName);
     }
 }

--- a/src/php/Shared/Printer/TypePrinter/ToStringPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/ToStringPrinter.php
@@ -4,16 +4,21 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Printer\TypePrinter;
 
+use Stringable;
+
 /**
- * @implements TypePrinterInterface<object>
+ * Selected by the dispatcher only for objects exposing `__toString()`; since
+ * PHP 8 such classes implicitly implement `Stringable`.
+ *
+ * @implements TypePrinterInterface<Stringable>
  */
 final class ToStringPrinter implements TypePrinterInterface
 {
     /**
-     * @param object $form
+     * @param Stringable $form
      */
     public function print(mixed $form): string
     {
-        return $form->__toString();
+        return (string) $form;
     }
 }

--- a/src/php/Shared/ResourceUsageFormatter.php
+++ b/src/php/Shared/ResourceUsageFormatter.php
@@ -27,7 +27,7 @@ final class ResourceUsageFormatter
             );
         }
 
-        $seconds = microtime(true) - $_SERVER['REQUEST_TIME_FLOAT'];
+        $seconds = microtime(true) - ScalarCoercion::toFloat($_SERVER['REQUEST_TIME_FLOAT']);
 
         return sprintf(
             'Time: %s, Memory: %s',

--- a/src/php/Shared/SourceMap/VLQ.php
+++ b/src/php/Shared/SourceMap/VLQ.php
@@ -15,7 +15,12 @@ final class VLQ
     /** @var array<int, string> */
     private array $integerToChar = [];
 
-    /** @var array<string, int> */
+    /**
+     * Keyed by base64 character; PHP coerces the digit characters '0'-'9'
+     * to integer keys, hence the int|string key type.
+     *
+     * @var array<int|string, int>
+     */
     private array $charToInteger = [];
 
     /**


### PR DESCRIPTION
## 🤔 Background / Description (Why?)

Continues the PHPStan strict-config rollout (#2400, #2401, #2402, #2403, #2404). The compiler plus a growing set of modules are held to PHPStan **level 9** (the strictest level) via `phpstan-strict.neon`, while the whole tree stays at level 6. Each round folds another clean module into the strict scope; when the entire tree reaches level 9 the level moves into `phpstan.neon` and the strict file is deleted.

## 🛠 What was done? (How?)

Brings the **Api** and **Shared** modules up to level 9 — 17 modules now pass the maximum level.

**Api**
- Guard mixed reads from the diagnostic/parse-tree context before use.
- Route option/argument coercions through `Phel\Shared\ScalarCoercion`.
- Widen normalizer array keys to `array-key` (`array_merge` renumbers numeric-string keys).

**Shared**
- Convert `Printer` dispatchers to `match (true)` returns.
- Tighten `ToStringPrinter` to `Stringable`.
- Guard `FnPrinter::extractName` against non-string bound names.
- Coerce `REQUEST_TIME_FLOAT` in `ResourceUsageFormatter`.
- Document the `VLQ` digit-key coercion.
- Add a documented ignore for `Printer`'s existential `TypePrinterInterface` return (generic invariance cannot relate `<Concrete>` to `<mixed>`).

## ✅ Checklist

- [x] `composer phpstan-strict` green (level 9 on the strict modules)
- [x] `composer phpstan` green (level 6 whole tree)
- [x] `composer psalm` green
- [x] `composer rector` clean
- [x] PHPUnit unit+integration: 4315 passing
- [x] Phel core: 5941 passing