### PR TITLE
chore(phpstan): extend level 9 to the Run and Build modules

### DIFF
--- a/phpstan-strict.neon
+++ b/phpstan-strict.neon
@@ -48,6 +48,7 @@ parameters:
             path: src/php/Shared/Printer/Printer.php
     paths!:
         - %currentWorkingDirectory%/src/php/Api/
+        - %currentWorkingDirectory%/src/php/Build/
         - %currentWorkingDirectory%/src/php/Command/
         - %currentWorkingDirectory%/src/php/Compiler/
         - %currentWorkingDirectory%/src/php/Config/
@@ -60,5 +61,6 @@ parameters:
         - %currentWorkingDirectory%/src/php/Lsp/
         - %currentWorkingDirectory%/src/php/Nrepl/
         - %currentWorkingDirectory%/src/php/Profile/
+        - %currentWorkingDirectory%/src/php/Run/
         - %currentWorkingDirectory%/src/php/Shared/
         - %currentWorkingDirectory%/src/php/Watch/

--- a/src/php/Build/Application/CacheClearer.php
+++ b/src/php/Build/Application/CacheClearer.php
@@ -6,6 +6,7 @@ namespace Phel\Build\Application;
 
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use SplFileInfo;
 
 use function is_dir;
 
@@ -46,6 +47,10 @@ final readonly class CacheClearer
         );
 
         foreach ($iterator as $file) {
+            if (!$file instanceof SplFileInfo) {
+                continue;
+            }
+
             if ($file->isDir()) {
                 @rmdir($file->getPathname());
             } else {

--- a/src/php/Build/Application/CachedNamespaceExtractor.php
+++ b/src/php/Build/Application/CachedNamespaceExtractor.php
@@ -20,6 +20,8 @@ use RegexIterator;
 use SplFileInfo;
 use UnexpectedValueException;
 
+use function is_array;
+
 final class CachedNamespaceExtractor implements NamespaceExtractorInterface
 {
     private readonly NamespaceFileGrouper $grouper;
@@ -142,6 +144,11 @@ final class CachedNamespaceExtractor implements NamespaceExtractorInterface
 
             try {
                 foreach ($this->phelFileIterator($realpath) as $file) {
+                    if (!is_array($file)) {
+                        continue;
+                    }
+
+                    /** @var array<int, string> $file */
                     if ($this->excludedPaths->contains($file[0], $realpath)) {
                         continue;
                     }
@@ -157,13 +164,17 @@ final class CachedNamespaceExtractor implements NamespaceExtractorInterface
             }
         }
 
-        return array_unique($files);
+        return array_values(array_unique($files));
     }
 
     /**
      * Build the recursive iterator that yields `.phel`/`.cljc` files under
      * `$root`, pruning subtrees flagged by `ExcludedScanPaths` at descent
      * time so vendor/.git/node_modules never get walked.
+     *
+     * `RegexIterator::GET_MATCH` yields each path as a `preg_match` result
+     * array, so the offset-0 capture holds the matched filename (narrowed at
+     * the call site since `RegexIterator`'s generic cannot express it).
      *
      * @return Iterator<mixed, mixed>
      */

--- a/src/php/Build/Application/DependenciesForNamespace.php
+++ b/src/php/Build/Application/DependenciesForNamespace.php
@@ -11,6 +11,7 @@ use SplQueue;
 
 use function array_key_exists;
 use function in_array;
+use function is_string;
 
 final readonly class DependenciesForNamespace
 {
@@ -49,6 +50,9 @@ final readonly class DependenciesForNamespace
         $requiredNamespaces = [];
         while (!$queue->isEmpty()) {
             $currentNs = $queue->dequeue();
+            if (!is_string($currentNs)) {
+                continue;
+            }
 
             if (!array_key_exists($currentNs, $requiredNamespaces)
                 && array_key_exists($currentNs, $index)

--- a/src/php/Build/Application/FileEvaluator.php
+++ b/src/php/Build/Application/FileEvaluator.php
@@ -11,6 +11,7 @@ use Phel\Build\Domain\Compile\CompiledFile;
 use Phel\Build\Domain\Extractor\FirstFormExtractor;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Lang\TypeInterface;
 use Phel\Shared\CompileOptions;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use Phel\Shared\Parser\Node\NodeInterface;
@@ -76,6 +77,7 @@ final class FileEvaluator
                         $envData = $this->compiledCodeCache->getEnvironment($namespace);
 
                         if ($envData !== null) {
+                            /** @var array{refers: array<string, array{ns: ?string, name: string}>, require_aliases: array<string, array{ns: ?string, name: string}>, use_aliases: array<string, array{ns: ?string, name: string}>} $envData */
                             $this->compilerFacade->restoreNamespaceEnvironmentData($namespace, $envData);
                         } else {
                             $this->analyzeNsForm($code, $src);
@@ -170,8 +172,10 @@ final class FileEvaluator
                 }
 
                 $readerResult = $this->compilerFacade->read($parseTree);
+                /** @var bool|float|int|string|TypeInterface|null $ast */
+                $ast = $readerResult->getAst();
                 $this->compilerFacade->analyze(
-                    $readerResult->getAst(),
+                    $ast,
                     NodeEnvironment::empty(),
                 );
 

--- a/src/php/Build/Application/NamespaceExtractor.php
+++ b/src/php/Build/Application/NamespaceExtractor.php
@@ -17,6 +17,7 @@ use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
 use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
 use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
 use Phel\Lang\Symbol;
+use Phel\Lang\TypeInterface;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use Phel\Shared\NamespaceInformation;
 use Phel\Shared\Parser\Node\NodeInterface;
@@ -25,6 +26,9 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RegexIterator;
 use UnexpectedValueException;
+
+use function array_values;
+use function is_array;
 
 final readonly class NamespaceExtractor implements NamespaceExtractorInterface
 {
@@ -60,6 +64,7 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
             }
 
             $readerResult = $this->compilerFacade->read($parseTree);
+            /** @var bool|float|int|string|TypeInterface|null $ast */
             $ast = $readerResult->getAst();
             $node = $this->compilerFacade->analyze($ast, NodeEnvironment::empty());
 
@@ -69,10 +74,10 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
                 return new NamespaceInformation(
                     $realFile !== false ? $realFile : $path,
                     $node->getNamespace(),
-                    array_unique(array_map(
+                    array_values(array_unique(array_map(
                         static fn(Symbol $s): string => $s->getFullName(),
                         $node->getRequireNs(),
-                    )),
+                    ))),
                     isPrimaryDefinition: true,
                 );
             }
@@ -137,6 +142,11 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
 
             $result = [];
             foreach ($phelIterator as $file) {
+                if (!is_array($file)) {
+                    continue;
+                }
+
+                /** @var array<int, string> $file */
                 if ($this->excludedPaths->contains($file[0], $realpath)) {
                     continue;
                 }

--- a/src/php/Build/BuildConfig.php
+++ b/src/php/Build/BuildConfig.php
@@ -9,6 +9,7 @@ use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
 use Phel\Shared\CompileOptions;
 use Phel\Shared\PhelProjectDirectory;
+use Phel\Shared\ScalarCoercion;
 
 use function is_string;
 
@@ -19,7 +20,7 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
      */
     public function getPathsToIgnore(): array
     {
-        return $this->get(PhelConfig::IGNORE_WHEN_BUILDING, []);
+        return ScalarCoercion::toStringList($this->get(PhelConfig::IGNORE_WHEN_BUILDING, []));
     }
 
     /**
@@ -27,7 +28,7 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
      */
     public function getPathsToAvoidCache(): array
     {
-        return $this->get(PhelConfig::NO_CACHE_WHEN_BUILDING, []);
+        return ScalarCoercion::toStringList($this->get(PhelConfig::NO_CACHE_WHEN_BUILDING, []));
     }
 
     public function shouldCreateEntryPointPhpFile(): bool
@@ -37,7 +38,9 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
 
     public function getPhelBuildConfig(): PhelBuildConfig
     {
-        $config = PhelBuildConfig::fromArray((array) $this->get('out', []));
+        /** @var array<string, mixed> $out */
+        $out = (array) $this->get('out', []);
+        $config = PhelBuildConfig::fromArray($out);
 
         // Auto-detect namespace from core.phel if not explicitly configured
         if ($config->getMainPhelNamespace() === '') {
@@ -52,7 +55,7 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
 
     public function getOptimizationLevel(): int
     {
-        return max(0, (int) $this->get(PhelConfig::OPTIMIZATION_LEVEL, CompileOptions::DEFAULT_OPTIMIZATION_LEVEL));
+        return max(0, ScalarCoercion::toInt($this->get(PhelConfig::OPTIMIZATION_LEVEL, CompileOptions::DEFAULT_OPTIMIZATION_LEVEL)));
     }
 
     public function isNamespaceCacheEnabled(): bool
@@ -67,7 +70,7 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
 
     public function getTempDir(): string
     {
-        return (string) $this->get(PhelConfig::TEMP_DIR, sys_get_temp_dir() . '/phel');
+        return ScalarCoercion::toString($this->get(PhelConfig::TEMP_DIR, sys_get_temp_dir() . '/phel'));
     }
 
     public function getCacheDir(): string
@@ -77,8 +80,8 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
             return $envOverride;
         }
 
-        $cacheDir = (string) $this->get(PhelConfig::CACHE_DIR, '.phel/cache');
-        $phelDir = (string) $this->get(PhelConfig::PHEL_DIR, '');
+        $cacheDir = ScalarCoercion::toString($this->get(PhelConfig::CACHE_DIR, '.phel/cache'));
+        $phelDir = ScalarCoercion::toString($this->get(PhelConfig::PHEL_DIR, ''));
 
         return PhelProjectDirectory::resolve($this->getAppRootDir(), $cacheDir, $phelDir);
     }

--- a/src/php/Build/BuildFacade.php
+++ b/src/php/Build/BuildFacade.php
@@ -83,8 +83,8 @@ final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
      * namespaces from all Phel files in the give directories and then return a
      * topological sorted subset of this namespace information.
      *
-     * @param string[] $directories The list of the directories
-     * @param string[] $ns          A list of namespace for which we should find the subset
+     * @param list<string> $directories The list of the directories
+     * @param list<string> $ns          A list of namespace for which we should find the subset
      *
      * @return list<NamespaceInformation>
      */

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -76,7 +76,8 @@ final class BuildFactory extends AbstractFactory
         // evaluator — otherwise each fresh `new BuildFacade()` would
         // rebuild its dependency tree and the on-disk compiled-code
         // index would be re-included per load.
-        return $this->singleton(
+        /** @var FileEvaluator $evaluator */
+        $evaluator = $this->singleton(
             FileEvaluator::class,
             fn(): FileEvaluator => new FileEvaluator(
                 $this->getCompilerFacade(),
@@ -87,11 +88,13 @@ final class BuildFactory extends AbstractFactory
                 $this->getConfig()->getOptimizationLevel(),
             ),
         );
+        return $evaluator;
     }
 
     public function createNamespaceExtractor(): NamespaceExtractorInterface
     {
-        return $this->singleton(
+        /** @var NamespaceExtractorInterface $extractor */
+        $extractor = $this->singleton(
             NamespaceExtractorInterface::class,
             function (): NamespaceExtractorInterface {
                 $excludedPaths = $this->createExcludedScanPaths();
@@ -115,6 +118,7 @@ final class BuildFactory extends AbstractFactory
                 );
             },
         );
+        return $extractor;
     }
 
     public function createCacheClearer(): CacheClearer
@@ -136,12 +140,16 @@ final class BuildFactory extends AbstractFactory
 
     public function getCompilerFacade(): CompilerFacadeInterface
     {
-        return $this->getProvidedDependency(BuildProvider::FACADE_COMPILER);
+        /** @var CompilerFacadeInterface $facade */
+        $facade = $this->getProvidedDependency(BuildProvider::FACADE_COMPILER);
+        return $facade;
     }
 
     public function getCommandFacade(): CommandFacadeInterface
     {
-        return $this->getProvidedDependency(BuildProvider::FACADE_COMMAND);
+        /** @var CommandFacadeInterface $facade */
+        $facade = $this->getProvidedDependency(BuildProvider::FACADE_COMMAND);
+        return $facade;
     }
 
     private function createSecondaryFileHarvester(): ?SecondaryFileHarvester
@@ -160,10 +168,12 @@ final class BuildFactory extends AbstractFactory
 
     private function createCompiledCodeCache(): ?CompiledCodeCache
     {
-        return $this->singleton(
+        /** @var CompiledCodeCache|null $cache */
+        $cache = $this->singleton(
             CompiledCodeCache::class,
             fn(): ?CompiledCodeCache => $this->buildCompiledCodeCache(),
         );
+        return $cache;
     }
 
     private function buildCompiledCodeCache(): ?CompiledCodeCache
@@ -180,12 +190,14 @@ final class BuildFactory extends AbstractFactory
 
     private function createDependencyTracker(): ?DependencyTracker
     {
-        return $this->singleton(
+        /** @var DependencyTracker|null $tracker */
+        $tracker = $this->singleton(
             DependencyTracker::class,
             fn(): ?DependencyTracker => $this->getConfig()->isCompiledCodeCacheEnabled()
                 ? new DependencyTracker($this->getConfig()->getCacheDir())
                 : null,
         );
+        return $tracker;
     }
 
     private function createNamespaceCache(): NamespaceCacheInterface

--- a/src/php/Build/Infrastructure/Cache/CacheIndexFile.php
+++ b/src/php/Build/Infrastructure/Cache/CacheIndexFile.php
@@ -175,9 +175,15 @@ final readonly class CacheIndexFile
             return [];
         }
 
+        $rawEntries = $data['entries'] ?? [];
+        if (!is_array($rawEntries)) {
+            return [];
+        }
+
         $entries = [];
-        foreach ($data['entries'] ?? [] as $sourcePath => $entryData) {
-            if (is_array($entryData)
+        foreach ($rawEntries as $sourcePath => $entryData) {
+            if (is_string($sourcePath)
+                && is_array($entryData)
                 && isset($entryData['namespace'], $entryData['source_hash'], $entryData['compiled_path'])
                 && is_string($entryData['namespace'])
                 && is_string($entryData['source_hash'])

--- a/src/php/Build/Infrastructure/Cache/PhpNamespaceCache.php
+++ b/src/php/Build/Infrastructure/Cache/PhpNamespaceCache.php
@@ -138,14 +138,23 @@ final class PhpNamespaceCache implements NamespaceCacheInterface
             return [];
         }
 
+        $rawEntries = $data['entries'] ?? [];
+        if (!is_array($rawEntries)) {
+            return [];
+        }
+
         $entries = [];
-        foreach ($data['entries'] ?? [] as $file => $entryData) {
+        foreach ($rawEntries as $file => $entryData) {
+            if (!is_string($file)) {
+                continue;
+            }
+
             // Drop entries whose path now lives under an always-excluded
             // segment (vendor/, worktrees/, .agents/, ...). Without this,
             // pre-existing cache entries resurface as primary definitions
             // and trigger duplicate-namespace warnings against real sources
             // every time the exclusion policy gains a new prefix.
-            if (is_string($file) && ExcludedScanPaths::isAlwaysExcluded($file)) {
+            if (ExcludedScanPaths::isAlwaysExcluded($file)) {
                 $this->dirty = true;
                 continue;
             }

--- a/src/php/Build/Infrastructure/Command/BuildCommand.php
+++ b/src/php/Build/Infrastructure/Command/BuildCommand.php
@@ -11,6 +11,7 @@ use Phel\Build\Domain\Compile\BuildOptions;
 use Phel\Build\Domain\Compile\CompiledFile;
 use Phel\Shared\Exceptions\CompilerException;
 use Phel\Shared\ResourceUsageFormatter;
+use Phel\Shared\ScalarCoercion;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -71,7 +72,7 @@ final class BuildCommand extends Command
         return new BuildOptions(
             $input->getOption(self::OPTION_CACHE) === true,
             $input->getOption(self::OPTION_SOURCE_MAP) === true,
-            $rawLevel === null ? null : max(0, (int) $rawLevel),
+            $rawLevel === null ? null : max(0, ScalarCoercion::toInt($rawLevel)),
         );
     }
 

--- a/src/php/Run/Application/Agent/AgentInstaller.php
+++ b/src/php/Run/Application/Agent/AgentInstaller.php
@@ -9,6 +9,7 @@ use Phel\Run\Domain\Agent\AgentPlatform;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
+use SplFileInfo;
 
 use function dirname;
 use function in_array;
@@ -148,6 +149,10 @@ final class AgentInstaller
         );
 
         foreach ($iterator as $item) {
+            if (!$item instanceof SplFileInfo) {
+                continue;
+            }
+
             $sub = $iterator->getSubPathname();
             if (in_array(explode('/', $sub, 2)[0], $skipTopLevel, true)) {
                 continue;
@@ -170,6 +175,10 @@ final class AgentInstaller
         );
 
         foreach ($iterator as $item) {
+            if (!$item instanceof SplFileInfo) {
+                continue;
+            }
+
             if ($item->isDir()) {
                 rmdir($item->getPathname());
             } else {

--- a/src/php/Run/Application/StructuredEvaluator.php
+++ b/src/php/Run/Application/StructuredEvaluator.php
@@ -6,6 +6,7 @@ namespace Phel\Run\Application;
 
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
 use Phel\Compiler\Domain\Parser\Exceptions\UnfinishedParserException;
+use Phel\Lang\Symbol;
 use Phel\Shared\CompileOptions;
 use Phel\Shared\Eval\EvalError;
 use Phel\Shared\Eval\EvalResult;
@@ -142,7 +143,14 @@ final readonly class StructuredEvaluator
     }
 
     /**
-     * @param array<string, mixed>|null $snapshot
+     * @param array{
+     *     ns: string,
+     *     definitions: array<string, array<string, bool>>,
+     *     refers: array<string, array<string, Symbol>>,
+     *     requireAliases: array<string, array<string, Symbol>>,
+     *     useAliases: array<string, array<string, Symbol>>,
+     *     interfaces: array<string, array<string, Symbol>>,
+     * }|null $snapshot
      */
     private function restoreIfNeeded(?GlobalEnvironmentInterface $env, ?array $snapshot): void
     {

--- a/src/php/Run/Application/Test/WorkRequest.php
+++ b/src/php/Run/Application/Test/WorkRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Run\Application\Test;
 
+use Phel\Shared\ScalarCoercion;
+
 /**
  * Decoded parent-to-worker frame. Sibling of {@see WorkerResult}: both
  * value objects encapsulate the JSON wire format so the orchestrator
@@ -25,10 +27,10 @@ final readonly class WorkRequest
     public static function fromFrame(array $frame): self
     {
         return new self(
-            (int) ($frame[FrameKey::INDEX] ?? -1),
-            (string) ($frame[FrameKey::NS] ?? ''),
-            (string) ($frame[FrameKey::FILE] ?? ''),
-            (string) ($frame[FrameKey::OPTIONS] ?? '{}'),
+            ScalarCoercion::toInt($frame[FrameKey::INDEX] ?? null, -1),
+            ScalarCoercion::toString($frame[FrameKey::NS] ?? null),
+            ScalarCoercion::toString($frame[FrameKey::FILE] ?? null),
+            ScalarCoercion::toString($frame[FrameKey::OPTIONS] ?? null, '{}'),
         );
     }
 

--- a/src/php/Run/Application/Test/WorkerFrame.php
+++ b/src/php/Run/Application/Test/WorkerFrame.php
@@ -80,7 +80,9 @@ final class WorkerFrame
         $length = (int) hexdec(substr($header, 0, self::HEADER_HEX_DIGITS));
         $body = '';
         while (strlen($body) < $length) {
-            $chunk = fread($stream, $length - strlen($body));
+            // The loop guard keeps the remainder positive; max() proves the
+            // int<1, max> bound fread() requires for its length argument.
+            $chunk = fread($stream, max(1, $length - strlen($body)));
             if ($chunk === false || $chunk === '') {
                 return null;
             }

--- a/src/php/Run/Application/Test/WorkerResult.php
+++ b/src/php/Run/Application/Test/WorkerResult.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Run\Application\Test;
 
+use Phel\Shared\ScalarCoercion;
+
 use function is_array;
 use function is_string;
 use function sprintf;
@@ -33,14 +35,18 @@ final readonly class WorkerResult
     public static function fromFrame(array $frame): self
     {
         $rawCounts = $frame[FrameKey::COUNTS] ?? [];
+        if (!is_array($rawCounts)) {
+            $rawCounts = [];
+        }
 
+        /** @var array<string, mixed> $rawCounts */
         return new self(
-            (int) ($frame[FrameKey::INDEX] ?? -1),
-            (string) ($frame[FrameKey::NS] ?? ''),
+            ScalarCoercion::toInt($frame[FrameKey::INDEX] ?? null, -1),
+            ScalarCoercion::toString($frame[FrameKey::NS] ?? null),
             (bool) ($frame[FrameKey::OK] ?? false),
-            (string) ($frame[FrameKey::OUTPUT] ?? ''),
+            ScalarCoercion::toString($frame[FrameKey::OUTPUT] ?? null),
             self::extractStringList($frame[FrameKey::FAILED_TESTS] ?? null),
-            is_array($rawCounts) ? Counts::fromArray($rawCounts) : new Counts(),
+            Counts::fromArray($rawCounts),
         );
     }
 

--- a/src/php/Run/Domain/Repl/InputResult.php
+++ b/src/php/Run/Domain/Repl/InputResult.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Run\Domain\Repl;
 
+use Phel\Shared\ScalarCoercion;
+
 use function is_bool;
 use function is_null;
 use function is_string;
@@ -63,6 +65,6 @@ final readonly class InputResult
             return 'nil';
         }
 
-        return (string) $this->lastResult;
+        return ScalarCoercion::toString($this->lastResult);
     }
 }

--- a/src/php/Run/Domain/Repl/ReplCommandSystemIo.php
+++ b/src/php/Run/Domain/Repl/ReplCommandSystemIo.php
@@ -8,6 +8,7 @@ use Phel\Shared\Exceptions\AbstractLocatedException;
 use Phel\Shared\Facade\ApiFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
 use Phel\Shared\Parser\ReadModel\CodeSnippet;
+use Phel\Shared\ScalarCoercion;
 use Throwable;
 
 final readonly class ReplCommandSystemIo implements ReplCommandIoInterface
@@ -91,7 +92,7 @@ final readonly class ReplCommandSystemIo implements ReplCommandIoInterface
 
     public function isBracketedPasteSupported(): bool
     {
-        $haystack = readline_info('library_version') ?? '';
+        $haystack = ScalarCoercion::toString(readline_info('library_version'));
 
         return stripos($haystack, 'editline') === false;
     }

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Run\Domain\Test;
 
 use Phel\Shared\Printer\Printer;
+use Phel\Shared\ScalarCoercion;
 
 use function is_array;
 use function is_int;
@@ -97,12 +98,12 @@ final readonly class TestCommandOptions
             $lastFailedFile = null;
         }
 
-        $slowest = (int) ($options[self::SLOWEST] ?? 0);
+        $slowest = ScalarCoercion::toInt($options[self::SLOWEST] ?? null);
         if ($slowest < 0) {
             $slowest = 0;
         }
 
-        $repeat = (int) ($options[self::REPEAT] ?? 1);
+        $repeat = ScalarCoercion::toInt($options[self::REPEAT] ?? null, 1);
         if ($repeat < 1) {
             $repeat = 1;
         }
@@ -110,8 +111,10 @@ final readonly class TestCommandOptions
         $seedRaw = $options[self::SEED] ?? null;
         $seed = is_int($seedRaw) ? $seedRaw : null;
 
+        $filterRaw = $options[self::FILTER] ?? null;
+
         return new self(
-            $options[self::FILTER] ?? null,
+            is_string($filterRaw) ? $filterRaw : null,
             !empty($options[self::TESTDOX]),
             !empty($options[self::FAIL_FAST]),
             !empty($options[self::STACK_TRACE]),

--- a/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
+++ b/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function implode;
 use function is_file;
+use function is_string;
 use function sprintf;
 
 final class AgentInstallCommand extends Command
@@ -224,7 +225,7 @@ HELP)
         }
 
         $platform = $input->getArgument(self::ARG_PLATFORM);
-        if ($platform === null) {
+        if (!is_string($platform)) {
             $detected = $this->detectAgents();
             if ($detected !== []) {
                 $output->writeln(sprintf('Detected installed agents: <info>%s</info>', implode(', ', $detected)));

--- a/src/php/Run/Infrastructure/Command/CompileCommand.php
+++ b/src/php/Run/Infrastructure/Command/CompileCommand.php
@@ -9,6 +9,7 @@ use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Run\Domain\StdinReaderInterface;
 use Phel\Run\RunFacade;
 use Phel\Run\RunFactory;
+use Phel\Shared\ScalarCoercion;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -66,7 +67,7 @@ final class CompileCommand extends Command
     {
         $stderr = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
 
-        $target = (string) $input->getOption('target');
+        $target = ScalarCoercion::toString($input->getOption('target'));
         if (!in_array($target, self::SUPPORTED_TARGETS, true)) {
             $stderr->writeln(
                 sprintf('Unsupported target "%s". Supported: %s', $target, implode(', ', self::SUPPORTED_TARGETS)),
@@ -76,7 +77,7 @@ final class CompileCommand extends Command
 
         $this->getFacade()->loadPhelNamespaces();
 
-        $source = $this->resolveSource((string) ($input->getArgument('source') ?? ''));
+        $source = $this->resolveSource(ScalarCoercion::toString($input->getArgument('source') ?? null));
 
         $ok = $this->getFactory()
             ->createCompileExecutor()

--- a/src/php/Run/Infrastructure/Command/EvalCommand.php
+++ b/src/php/Run/Infrastructure/Command/EvalCommand.php
@@ -9,6 +9,7 @@ use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Run\Domain\StdinReaderInterface;
 use Phel\Run\RunFacade;
 use Phel\Run\RunFactory;
+use Phel\Shared\ScalarCoercion;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -47,7 +48,7 @@ final class EvalCommand extends Command
     {
         $this->getFacade()->loadPhelNamespaces();
 
-        $expression = (string) ($input->getArgument('expression') ?? '');
+        $expression = ScalarCoercion::toString($input->getArgument('expression') ?? null);
         if ($expression === self::STDIN_MARKER) {
             $expression = ($this->stdinReader ?? $this->getFactory()->createStdinReader())->read();
         }

--- a/src/php/Run/Infrastructure/Command/InitCommand.php
+++ b/src/php/Run/Infrastructure/Command/InitCommand.php
@@ -7,6 +7,7 @@ namespace Phel\Run\Infrastructure\Command;
 use Phel\Config\ProjectLayout;
 use Phel\Run\Domain\Init\NamespaceNormalizer;
 use Phel\Run\Domain\Init\ProjectTemplateGenerator;
+use Phel\Shared\ScalarCoercion;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -90,7 +91,7 @@ final class InitCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $projectName = (string) $input->getArgument(self::ARG_PROJECT_NAME);
+        $projectName = ScalarCoercion::toString($input->getArgument(self::ARG_PROJECT_NAME));
         $layout = $this->resolveLayout($input);
         $force = (bool) $input->getOption(self::OPT_FORCE);
         $dryRun = (bool) $input->getOption(self::OPT_DRY_RUN);

--- a/src/php/Run/Infrastructure/Command/NsCommand.php
+++ b/src/php/Run/Infrastructure/Command/NsCommand.php
@@ -41,13 +41,11 @@ class NsCommand extends Command
         $nsToInspect = $input->getArgument('inspect');
         $isSimple = $input->getOption('simple') === true;
 
-        if ($nsToInspect === null) {
+        if (!is_string($nsToInspect)) {
             return $this->listLoadedNamespaces($output, $isSimple);
         }
 
-        $namespace = is_string($nsToInspect) ? Munge::canonicalNs($nsToInspect) : $nsToInspect;
-
-        return $this->displayNamespaceDependencies($namespace, $output, $isSimple);
+        return $this->displayNamespaceDependencies(Munge::canonicalNs($nsToInspect), $output, $isSimple);
     }
 
     private function listLoadedNamespaces(OutputInterface $output, bool $simple): int

--- a/src/php/Run/Infrastructure/Command/ReplCommand.php
+++ b/src/php/Run/Infrastructure/Command/ReplCommand.php
@@ -114,8 +114,9 @@ final class ReplCommand extends Command
             $this->getFacade()->loadPhelNamespaces($this->replStartupFile);
             Phel::addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, ReplConstants::REPL_MODE, true);
 
-            $this->history = $this->getFactory()->createReplHistory();
-            $this->history->register();
+            $history = $this->getFactory()->createReplHistory();
+            $this->history = $history;
+            $history->register();
 
             $this->loopReadLineAndAnalyze();
 

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Run\Infrastructure\Command;
 
+use ArrayAccess;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Run\Domain\Test\TestCommandOptions;
@@ -13,6 +14,7 @@ use Phel\Shared\CompileOptions;
 use Phel\Shared\Exceptions\CompilerException;
 use Phel\Shared\NamespaceInformation;
 use Phel\Shared\ResourceUsageFormatter;
+use Phel\Shared\ScalarCoercion;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,6 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 use function count;
+use function is_array;
 use function sprintf;
 
 /**
@@ -214,8 +217,14 @@ final class TestCommand extends Command
                 return self::FAILURE;
             }
 
-            $successful = (bool) $result[0];
-            $total = (int) $result[1];
+            // `eval` returns the value of the generated test form, a Phel
+            // vector `[successful? total]` (ArrayAccess), or a plain array.
+            $successful = false;
+            $total = 0;
+            if (is_array($result) || $result instanceof ArrayAccess) {
+                $successful = (bool) ($result[0] ?? false);
+                $total = ScalarCoercion::toInt($result[1] ?? null);
+            }
 
             if ($this->isNoMatchWithSelectors($total, $options)) {
                 $output->writeln('<error>No tests matched the given selectors.</error>');

--- a/src/php/Run/Infrastructure/Command/TestCommandOptionParser.php
+++ b/src/php/Run/Infrastructure/Command/TestCommandOptionParser.php
@@ -10,6 +10,7 @@ use Phel\Lang\Registry;
 use Phel\Run\Application\Test\CpuCountDetector;
 use Phel\Run\Domain\Test\TestCommandOptions;
 use Phel\Shared\PhelProjectDirectory;
+use Phel\Shared\ScalarCoercion;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -93,7 +94,7 @@ final readonly class TestCommandOptionParser
             TestCommandOptions::LIST_ONLY => $listOnly,
             TestCommandOptions::ONLY_TESTS => $lastFailed ? $this->readLastFailed() : [],
             TestCommandOptions::LAST_FAILED_FILE => $listOnly ? null : $lastFailedFile,
-            TestCommandOptions::SLOWEST => (int) $input->getOption(self::OPT_SLOWEST),
+            TestCommandOptions::SLOWEST => ScalarCoercion::toInt($input->getOption(self::OPT_SLOWEST)),
             TestCommandOptions::REPEAT => $this->parseRepeat($input),
             TestCommandOptions::SEED => $this->parseSeed($input),
             TestCommandOptions::RANDOM_ORDER => (bool) $input->getOption(self::OPT_RANDOM_ORDER),
@@ -139,7 +140,7 @@ final readonly class TestCommandOptionParser
         if (!is_numeric($raw)) {
             throw new InvalidArgumentException(sprintf(
                 '--parallel must be an integer >= 1, "auto", or "max", got %s.',
-                is_string($raw) ? $raw : (string) $raw,
+                ScalarCoercion::toString($raw),
             ));
         }
 
@@ -186,7 +187,7 @@ final readonly class TestCommandOptionParser
         if (!is_numeric($raw) || (int) $raw < 1) {
             throw new InvalidArgumentException(sprintf(
                 '--repeat must be a positive integer, got %s.',
-                (string) $raw,
+                ScalarCoercion::toString($raw),
             ));
         }
 
@@ -201,7 +202,7 @@ final readonly class TestCommandOptionParser
         }
 
         if (!is_numeric($raw)) {
-            throw new InvalidArgumentException(sprintf('--seed must be an integer, got %s.', (string) $raw));
+            throw new InvalidArgumentException(sprintf('--seed must be an integer, got %s.', ScalarCoercion::toString($raw)));
         }
 
         return (int) $raw;

--- a/src/php/Run/RunConfig.php
+++ b/src/php/Run/RunConfig.php
@@ -7,6 +7,7 @@ namespace Phel\Run;
 use Gacela\Framework\AbstractConfig;
 use Phel\Config\PhelConfig;
 use Phel\Shared\CompileOptions;
+use Phel\Shared\ScalarCoercion;
 
 final class RunConfig extends AbstractConfig
 {
@@ -20,6 +21,6 @@ final class RunConfig extends AbstractConfig
 
     public function getOptimizationLevel(): int
     {
-        return max(0, (int) $this->get(PhelConfig::OPTIMIZATION_LEVEL, CompileOptions::DEFAULT_OPTIMIZATION_LEVEL));
+        return max(0, ScalarCoercion::toInt($this->get(PhelConfig::OPTIMIZATION_LEVEL, CompileOptions::DEFAULT_OPTIMIZATION_LEVEL)));
     }
 }

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -40,9 +40,11 @@ use Phel\Shared\Facade\CommandFacadeInterface;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use Phel\Shared\Printer\Printer;
 use Phel\Shared\Printer\PrinterInterface;
+use Phel\Shared\ScalarCoercion;
 use Phel\Shared\VersionResolver;
 
 use function extension_loaded;
+use function is_array;
 
 /**
  * @extends AbstractFactory<RunConfig>
@@ -59,17 +61,23 @@ class RunFactory extends AbstractFactory
 
     public function getCommandFacade(): CommandFacadeInterface
     {
-        return $this->getProvidedDependency(RunProvider::FACADE_COMMAND);
+        /** @var CommandFacadeInterface $facade */
+        $facade = $this->getProvidedDependency(RunProvider::FACADE_COMMAND);
+        return $facade;
     }
 
     public function getBuildFacade(): BuildFacadeInterface
     {
-        return $this->getProvidedDependency(RunProvider::FACADE_BUILD);
+        /** @var BuildFacadeInterface $facade */
+        $facade = $this->getProvidedDependency(RunProvider::FACADE_BUILD);
+        return $facade;
     }
 
     public function getCompilerFacade(): CompilerFacadeInterface
     {
-        return $this->getProvidedDependency(RunProvider::FACADE_COMPILER);
+        /** @var CompilerFacadeInterface $facade */
+        $facade = $this->getProvidedDependency(RunProvider::FACADE_COMPILER);
+        return $facade;
     }
 
     public function createNamespaceCollector(): NamespaceCollector
@@ -174,7 +182,9 @@ class RunFactory extends AbstractFactory
 
     public function getApiFacade(): ApiFacadeInterface
     {
-        return $this->getProvidedDependency(RunProvider::FACADE_API);
+        /** @var ApiFacadeInterface $facade */
+        $facade = $this->getProvidedDependency(RunProvider::FACADE_API);
+        return $facade;
     }
 
     public function createVersionResolver(): VersionResolver
@@ -255,9 +265,15 @@ class RunFactory extends AbstractFactory
 
     private function resolvePhelBinaryPath(): string
     {
-        $script = $_SERVER['SCRIPT_FILENAME'] ?? $_SERVER['argv'][0] ?? '';
+        $script = ScalarCoercion::toString($_SERVER['SCRIPT_FILENAME'] ?? null);
         if ($script !== '') {
             return $script;
+        }
+
+        $argv = $_SERVER['argv'] ?? null;
+        $firstArg = is_array($argv) ? ScalarCoercion::toString($argv[0] ?? null) : '';
+        if ($firstArg !== '') {
+            return $firstArg;
         }
 
         return __DIR__ . '/../../../bin/phel';


### PR DESCRIPTION
## 🤔 Background / Description (Why?)

Continues the PHPStan strict-config rollout (#2400, #2401, #2402, #2403, #2404, #2405). A growing set of modules is held to PHPStan **level 9** (the strictest level) via `phpstan-strict.neon`, while the whole tree stays at level 6. Each round folds another clean module into the strict scope; when the entire tree reaches level 9 the level moves into `phpstan.neon` and the strict file is deleted.

## 🛠 What was done? (How?)

Brings the **Run** and **Build** modules up to level 9 — 19 modules now pass the maximum level. Only `src/Phel.php` and the `Lang` collections remain.

**Build**
- Factory facade getters and `singleton()` creators narrow Gacela's `mixed` returns via `@var`.
- `BuildConfig` routes path/option coercions through `Phel\Shared\ScalarCoercion`.
- `CacheClearer` guards recursive-iterator items with `instanceof SplFileInfo`.
- Cache loaders (`CacheIndexFile`, `PhpNamespaceCache`) guard the decoded entries array and its string keys before iterating.
- `NamespaceExtractor`/`CachedNamespaceExtractor` annotate reader ASTs with the honest Phel-form union and narrow `RegexIterator::GET_MATCH` rows at the call site.
- `BuildFacade::getDependenciesForNamespace` tightens its `@param` to `list<string>`.

**Run**
- `RunFactory` facade getters narrow `mixed` via `@var`; `resolvePhelBinaryPath` coerces `$_SERVER` reads through `ScalarCoercion` (satisfying both PHPStan and Psalm).
- `RunConfig` coerces the optimization level.
- Test wire-format VOs (`WorkRequest`, `WorkerResult`, `WorkerFrame`) and CLI option parsing coerce mixed input; `StructuredEvaluator`'s restore snapshot keeps its declared shape.
- `AgentInstaller` guards directory-walk items with `instanceof SplFileInfo`.
- `TestCommand` reads the eval-result tuple via `array|ArrayAccess` (the Phel vector returned by the generated test form).

No new ignores were needed for this round.

## ✅ Checklist

- [x] `composer phpstan-strict` green (level 9 on the strict modules)
- [x] `composer phpstan` green (level 6 whole tree)
- [x] `composer psalm` green
- [x] `composer rector` clean
- [x] PHPUnit unit+integration: 4315 passing
- [x] Phel core: 5941 passing