### PR TITLE
chore(phpstan): extend level 9 to the global Phel facade

### DIFF
--- a/phpstan-strict.neon
+++ b/phpstan-strict.neon
@@ -47,6 +47,7 @@ parameters:
             identifier: return.type
             path: src/php/Shared/Printer/Printer.php
     paths!:
+        - %currentWorkingDirectory%/src/Phel.php
         - %currentWorkingDirectory%/src/php/Api/
         - %currentWorkingDirectory%/src/php/Build/
         - %currentWorkingDirectory%/src/php/Command/

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -287,7 +287,7 @@ final class Phel extends InternalPhel
             $firstArgument = $kvs[0] ?? null;
 
             if (\is_array($firstArgument)) {
-                return $typeFactory->persistentMapFromArray($firstArgument);
+                return $typeFactory->persistentMapFromArray(\array_values($firstArgument));
             }
 
             if ($firstArgument === null) {
@@ -295,7 +295,7 @@ final class Phel extends InternalPhel
             }
         }
 
-        return $typeFactory->persistentMapFromKVs(...$kvs);
+        return $typeFactory->persistentMapFromArray(\array_values($kvs));
     }
 
     /**
@@ -349,10 +349,10 @@ final class Phel extends InternalPhel
     {
         $typeFactory = TypeFactory::getInstance();
         if (\count($kvs) === 1 && \is_array($kvs[0])) {
-            return $typeFactory->persistentSortedMapFromArray($kvs[0]);
+            return $typeFactory->persistentSortedMapFromArray(\array_values($kvs[0]));
         }
 
-        return $typeFactory->persistentSortedMapFromArray($kvs);
+        return $typeFactory->persistentSortedMapFromArray(\array_values($kvs));
     }
 
     /**
@@ -364,10 +364,10 @@ final class Phel extends InternalPhel
     {
         $typeFactory = TypeFactory::getInstance();
         if (\count($kvs) === 1 && \is_array($kvs[0])) {
-            return $typeFactory->persistentSortedMapFromArray($kvs[0], $comparator);
+            return $typeFactory->persistentSortedMapFromArray(\array_values($kvs[0]), $comparator);
         }
 
-        return $typeFactory->persistentSortedMapFromArray($kvs, $comparator);
+        return $typeFactory->persistentSortedMapFromArray(\array_values($kvs), $comparator);
     }
 
     /**


### PR DESCRIPTION
## 🤔 Background / Description (Why?)

Continues the PHPStan strict-config rollout (#2400–#2406). Modules in `phpstan-strict.neon` are held to PHPStan **level 9** (the strictest level) while the whole tree stays at level 6. This round folds in `src/Phel.php`, the global facade. After this, only the `Lang` collections remain outside level 9.

## 🛠 What was done? (How?)

The persistent-map constructors (`map`, `sortedMap`, `sortedMapBy`) feed arbitrary or variadic arrays into `TypeFactory` methods that expect a positional kvs list (`array<int, mixed>`). Each call is wrapped in `array_values` so the list contract is explicit.

Behaviour is unchanged: callers always pass positional key/value pairs (`[k0, v0, k1, v1, ...]`), and `array_values` is the identity on such lists.

## ✅ Checklist

- [x] `composer phpstan-strict` green (level 9 on the strict modules)
- [x] `composer phpstan` green (level 6 whole tree)
- [x] `composer psalm` green
- [x] `composer rector` clean
- [x] PHPUnit unit+integration: 4315 passing
- [x] Phel core: 5941 passing