### PR TITLE
ref(lang): tighten count() and find() collection contracts

### DIFF
--- a/src/php/Lang/Collections/LinkedList/PersistentList.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentList.php
@@ -123,7 +123,7 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
 
     public function count(): int
     {
-        return $this->count;
+        return max(0, $this->count);
     }
 
     /**

--- a/src/php/Lang/Collections/Map/ArrayNode.php
+++ b/src/php/Lang/Collections/Map/ArrayNode.php
@@ -37,7 +37,7 @@ final class ArrayNode implements HashMapNodeInterface, Countable
 
     public function count(): int
     {
-        return $this->count;
+        return max(0, $this->count);
     }
 
     /**

--- a/src/php/Lang/Collections/Map/PersistentArrayMap.php
+++ b/src/php/Lang/Collections/Map/PersistentArrayMap.php
@@ -133,7 +133,7 @@ final class PersistentArrayMap extends AbstractPersistentMap
 
     public function count(): int
     {
-        return (int) (count($this->array) / 2);
+        return intdiv(count($this->array), 2);
     }
 
     /**

--- a/src/php/Lang/Collections/Map/PersistentHashMap.php
+++ b/src/php/Lang/Collections/Map/PersistentHashMap.php
@@ -171,7 +171,7 @@ final class PersistentHashMap extends AbstractPersistentMap
 
     public function count(): int
     {
-        return $this->count;
+        return max(0, $this->count);
     }
 
     /**

--- a/src/php/Lang/Collections/Map/PersistentMapInterface.php
+++ b/src/php/Lang/Collections/Map/PersistentMapInterface.php
@@ -41,7 +41,7 @@ interface PersistentMapInterface extends TypeInterface, Countable, IteratorAggre
     /**
      * @param K $key
      *
-     * @return V
+     * @return V|null Value for $key, or null when the key is absent
      */
     public function find(mixed $key);
 

--- a/src/php/Lang/Collections/Map/TransientArrayMap.php
+++ b/src/php/Lang/Collections/Map/TransientArrayMap.php
@@ -108,7 +108,7 @@ final class TransientArrayMap implements TransientMapInterface
 
     public function count(): int
     {
-        return (int) (count($this->array) / 2);
+        return intdiv(count($this->array), 2);
     }
 
     /**

--- a/src/php/Lang/Collections/Map/TransientHashMap.php
+++ b/src/php/Lang/Collections/Map/TransientHashMap.php
@@ -150,7 +150,7 @@ final class TransientHashMap implements TransientMapInterface
 
     public function count(): int
     {
-        return $this->count;
+        return max(0, $this->count);
     }
 
     /**

--- a/src/php/Lang/Collections/Map/TransientMapInterface.php
+++ b/src/php/Lang/Collections/Map/TransientMapInterface.php
@@ -35,7 +35,7 @@ interface TransientMapInterface extends Countable, ArrayAccess, ContainsInterfac
     /**
      * @param K $key
      *
-     * @return V
+     * @return V|null Value for $key, or null when the key is absent
      */
     public function find(mixed $key);
 

--- a/src/php/Lang/Collections/Queue/PersistentQueue.php
+++ b/src/php/Lang/Collections/Queue/PersistentQueue.php
@@ -183,7 +183,7 @@ final class PersistentQueue extends AbstractType implements TypeInterface, Count
 
     public function count(): int
     {
-        return $this->count;
+        return max(0, $this->count);
     }
 
     /**

--- a/src/php/Lang/Collections/SortedMap/PersistentSortedMap.php
+++ b/src/php/Lang/Collections/SortedMap/PersistentSortedMap.php
@@ -144,7 +144,7 @@ final class PersistentSortedMap extends AbstractPersistentMap
 
     public function count(): int
     {
-        return (int) (count($this->array) / 2);
+        return intdiv(count($this->array), 2);
     }
 
     public function getIterator(): Traversable

--- a/src/php/Lang/Collections/SortedMap/TransientSortedMap.php
+++ b/src/php/Lang/Collections/SortedMap/TransientSortedMap.php
@@ -104,7 +104,7 @@ final class TransientSortedMap implements TransientMapInterface
 
     public function count(): int
     {
-        return (int) (count($this->array) / 2);
+        return intdiv(count($this->array), 2);
     }
 
     /**

--- a/src/php/Lang/Collections/Vector/PersistentVector.php
+++ b/src/php/Lang/Collections/Vector/PersistentVector.php
@@ -104,7 +104,7 @@ final class PersistentVector extends AbstractPersistentVector
      */
     public function count(): int
     {
-        return $this->count;
+        return max(0, $this->count);
     }
 
     /**

--- a/src/php/Lang/Collections/Vector/SubVector.php
+++ b/src/php/Lang/Collections/Vector/SubVector.php
@@ -37,7 +37,7 @@ final class SubVector extends AbstractPersistentVector
 
     public function count(): int
     {
-        return $this->end - $this->start;
+        return max(0, $this->end - $this->start);
     }
 
     /**

--- a/src/php/Lang/Collections/Vector/TransientVector.php
+++ b/src/php/Lang/Collections/Vector/TransientVector.php
@@ -99,7 +99,7 @@ final class TransientVector implements TransientVectorInterface, Stringable
 
     public function count(): int
     {
-        return $this->count;
+        return max(0, $this->count);
     }
 
     /**


### PR DESCRIPTION
## 🤔 Background / Description (Why?)

First of **three** steps bringing the `Lang` module toward PHPStan **level 9**, completing the strict-config rollout (#2400–#2407). `Lang` is the most-depended-on module (public persistent collections + the hot numeric path), so it is split by risk tier rather than landed in one diff:

1. **this PR** — mechanical public-contract tightenings (`count`, `find`)
2. generic `<K, V>` variance on HAMT nodes / transients
3. `NumericOperations` mixed-arithmetic narrowing

`Lang` joins `phpstan-strict.neon` only in step 3, once all three tiers are clean.

## 🛠 What was done? (How?)

Behaviour is unchanged — only the declared types get more honest.

- **`count(): int<0, max>`** (the implicit `Countable` contract). Counter-property implementations return `max(0, ...)`; key/value-array implementations return `intdiv(count(...), 2)` (which also drops the float division + cast).
- **`find(): V|null`** on `PersistentMapInterface` and `TransientMapInterface`. `find()` already returns `null` when the key is absent, so the `@return` now states the honest type. Verified to cause **zero** call-site fallout across the 19 modules already at level 9 (callers already null-check).

## ✅ Checklist

- [x] `composer phpstan-strict` green (no regressions in the 19 modules already at level 9)
- [x] `composer phpstan` green (level 6 whole tree)
- [x] `composer psalm` green
- [x] `composer rector` clean
- [x] PHPUnit unit+integration: 4315 passing
- [x] Phel core: 5941 passing