### PR TITLE
docs: bump PHPStan badge and rule to level 9

### DIFF
--- a/.agnostic-ai/rules/php.md
+++ b/.agnostic-ai/rules/php.md
@@ -8,7 +8,7 @@ globs: src/php/**,tests/php/**
 ## Code Style
 
 - PER 3.0 enforced by php-cs-fixer + rector (auto-formats via PostToolUse hook — no manual run needed)
-- PHPStan level 5, Psalm level 1
+- PHPStan level 9 (max), Psalm level 1
 - Prefer `final` classes unless inheritance is explicitly needed
 - Use `readonly` properties where possible
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <img src="https://github.com/phel-lang/phel-lang/workflows/CI/badge.svg" alt="GitHub Build Status">
   </a>
   <a href="https://github.com/phel-lang/phel-lang/blob/main/phpstan.neon">
-    <img src="https://img.shields.io/badge/PHPStan-level%206-brightgreen" alt="PHPStan level 6">
+    <img src="https://img.shields.io/badge/PHPStan-level%209-brightgreen" alt="PHPStan level 9">
   </a>
   <a href="https://github.com/phel-lang/phel-lang/blob/main/psalm.xml">
     <img src="https://img.shields.io/badge/Psalm-level%201-brightgreen" alt="Psalm level 1">


### PR DESCRIPTION
## 🤔 Background / Description (Why?)

The whole `src/` tree now type-checks at PHPStan **level 9** (#2400–#2410). The README badge and the PHP conventions rule still advertised the old level 5/6.

## 🛠 What was done? (How?)

- `README.md`: PHPStan badge `level 6` → `level 9`.
- `.agnostic-ai/rules/php.md`: `PHPStan level 5, Psalm level 1` → `PHPStan level 9 (max), Psalm level 1`.

Psalm is unchanged (still `errorLevel="1"`).

## ✅ Checklist

- [x] Docs-only; no code changes