### PR TITLE
perf(lang): restore in-place transient vector mutation

### DIFF
--- a/src/php/Lang/Collections/Vector/PersistentVector.php
+++ b/src/php/Lang/Collections/Vector/PersistentVector.php
@@ -40,7 +40,7 @@ final class PersistentVector extends AbstractPersistentVector
     /**
      * @param PersistentMapInterface<mixed, mixed>|null $meta
      * @param int                                       $count The number of elements stored in this vector
-     * @param array<int, array<mixed>>                  $root  The root node of this vector
+     * @param array<int, mixed>                         $root  The root node (holds child nodes or, at the leaf level, values)
      * @param array<int, T>                             $tail  The tail of the vector. This is an optimization
      */
     public function __construct(

--- a/src/php/Lang/Collections/Vector/TransientVector.php
+++ b/src/php/Lang/Collections/Vector/TransientVector.php
@@ -14,7 +14,6 @@ use RuntimeException;
 
 use Stringable;
 
-use function array_values;
 use function count;
 
 /**
@@ -29,10 +28,10 @@ final class TransientVector implements TransientVectorInterface, Stringable
     private int $tailSize;
 
     /**
-     * @param int                      $count The number of elements inside this vector
-     * @param int                      $shift The shift value
-     * @param array<int, array<mixed>> $root  The root node of this vector
-     * @param T[]                      $tail  The tail of the vector. This is an optimization
+     * @param int               $count The number of elements inside this vector
+     * @param int               $shift The shift value
+     * @param array<int, mixed> $root  The root node (holds child nodes or, at the leaf level, values)
+     * @param T[]               $tail  The tail of the vector. This is an optimization
      */
     public function __construct(
         private readonly HasherInterface $hasher,
@@ -165,10 +164,11 @@ final class TransientVector implements TransientVectorInterface, Stringable
             if ($i >= $this->tailOffset()) {
                 $this->tail[$i & self::INDEX_MASK] = $value;
             } else {
-                $root = $this->root;
-                $this->updateInPlace($this->shift, $root, $i, $value);
-                /** @var array<int, array<mixed>> $root */
-                $this->root = $root;
+                // Pass the root array directly into the by-reference parameter
+                // so it is mutated in place. Copying it into a local first
+                // (then writing back) forces a copy-on-write separation of the
+                // whole root node on every update — ~2x slower at depth.
+                $this->updateInPlace($this->shift, $this->root, $i, $value);
             }
 
             return $this;
@@ -333,9 +333,14 @@ final class TransientVector implements TransientVectorInterface, Stringable
         }
 
         $subIndex = ($i >> $level) & self::INDEX_MASK;
-        /** @var array<int, mixed> $childNode */
-        $childNode = &$node[$subIndex];
-        $this->updateInPlace($level - self::SHIFT, $childNode, $i, $value);
+        // Pass the child node array directly into the by-reference parameter so
+        // PHP binds it in place. Binding it through an explicit `&$node[...]`
+        // reference variable first marks the element IS_REF and forces a
+        // copy-on-write separation at every trie level (~2x slower on update).
+        // The element is always a child array here (level > 0); the type is
+        // not expressible without that reference cost.
+        /** @phpstan-ignore argument.type */
+        $this->updateInPlace($level - self::SHIFT, $node[$subIndex], $i, $value);
     }
 
     /**
@@ -377,7 +382,12 @@ final class TransientVector implements TransientVectorInterface, Stringable
     {
         if ($i >= 0 && $i < $this->count) {
             if ($i >= $this->tailOffset()) {
-                return array_values($this->tail);
+                // The tail is built by sequential appends, so it is already a
+                // list; copy-on-write assignment keeps this zero-copy (unlike
+                // array_values, which always allocates a fresh array).
+                /** @var list<T> $tail */
+                $tail = $this->tail;
+                return $tail;
             }
 
             /** @var array<int, mixed> $node */


### PR DESCRIPTION
## 🤔 Background / Description (Why?)

A PHPBench comparison against the pre-campaign baseline (parent of #2400) surfaced two real regressions introduced by the level-9 generic-variance pass (#2409):

| Benchmark | Size | Regression |
|-----------|------|-----------|
| `TransientVectorBench::bench_update` | medium / boundary | **+52% / +95%** |
| `TransientVectorBench::bench_get` | small | **+15%** |

Root cause: #2409 typed both vectors' trie root as `array<int, array<mixed>>`. Because that did not match the by-reference update helper's `array<int, mixed>` parameter, `TransientVector::update` was rewritten to copy the root into a local and write it back, and `updateInPlace` bound the child through an explicit `&$node[...]` reference. Both force a **copy-on-write separation of the trie node on every update**. Separately, `getArrayForIndex` copied the tail via `array_values` on every tail read.

## 🛠 What was done? (How?)

Restores the baseline (in-place) algorithm while keeping level 9:

- Type the root as `array<int, mixed>` on both vectors (the honest type — a trie node holds child nodes, or values at the leaf), so `$this->root` passes straight into the by-reference parameter again: mutated in place, no copy.
- `updateInPlace` recurses on `$node[$subIndex]` directly (one documented `@phpstan-ignore`: the child is always an array at `level > 0`, not expressible without reintroducing the reference cost).
- `getArrayForIndex` returns the tail via a copy-on-write local instead of `array_values`.

**After:** `update` and tail `get` are back to baseline (±1%). Behaviour unchanged.

> Note: `count()` is ~8 ns slower than baseline (the `max(0, …)` guard added for the `int<0, max>` Countable contract in #2408). Left as-is — negligible on an O(1) primitive that is usually compiler-specialised, and removing it would need an 8-class property-type refactor.

## ✅ Checklist

- [x] PHPBench: `update` / tail-`get` restored to baseline (±1%)
- [x] `composer phpstan` green (level 9)
- [x] `composer psalm` green
- [x] `composer rector` clean
- [x] PHPUnit unit+integration: 4315 passing
- [x] Phel core: 5941 passing