### PR TITLE
fix(config): invalidate stale gacela merged-config cache on input change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ template, and several build/cache fixes.
 - `PhelConfig` build withers are order-independent: `withMainPhelNamespace(...)` no longer pins the entry point, so a later `withBuildDestDir('dist')` yields `dist/index.php`
 - `phel build` runtime errors map back to Phel source: the error printer reads the sibling `.php.map`/`.phel` artifacts and reports `out/foo.phel:42` instead of the generated PHP line
 - Inline source maps in eval temp files are detected again: the extractor scans past `<?php` and `declare` statements instead of only the first two lines
+- editing `phel-config.php` takes effect immediately again: Phel fingerprints the merged-config cache inputs and clears Gacela's persisted `gacela-merged-config.php` when they change, instead of replaying a stale cache (Gacela `>= 1.15` auto-warms and reloads it with no freshness check); bumps the requirement to `gacela-project/gacela: ^1.15`
 
 ## [0.43.0](https://github.com/phel-lang/phel-lang/compare/v0.42.0...v0.43.0) - 2026-06-09
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=8.4",
         "amphp/amp": "^3.1",
-        "gacela-project/gacela": "^1.14",
+        "gacela-project/gacela": "^1.15",
         "symfony/console": "^6.0|^7.0|^8.0",
         "symfony/routing": "^7.3|^8.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07ae10612a4433c900ae6011acd68e9c",
+    "content-hash": "3f106ec02b8cf6397bc48e952e8d93f3",
     "packages": [
         {
             "name": "amphp/amp",

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -7,6 +7,7 @@ namespace Phel;
 use Closure;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Config\Config;
+use Gacela\Framework\Config\MergedConfigCache;
 use Gacela\Framework\Gacela;
 use Phar;
 use Phel\Config\PhelConfig;
@@ -21,6 +22,7 @@ use function dirname;
 use function getcwd;
 use function in_array;
 use function is_array;
+use function is_string;
 
 /**
  * @internal use \Phel instead
@@ -101,6 +103,7 @@ class Phel
 
         Gacela::bootstrap($projectRootDir, self::configFn());
 
+        self::refreshStaleMergedConfigCache();
         self::mirrorPhelDirToEnv();
     }
 
@@ -187,6 +190,90 @@ class Phel
     public static function resetAutoDetectedConfig(): void
     {
         self::$autoDetectedConfig = null;
+    }
+
+    /**
+     * Invalidate Gacela's persisted merged-config cache when its inputs change.
+     *
+     * Gacela (>= 1.15) auto-warms the merged app config to
+     * `gacela-merged-config.php` on the first bootstrap and then reloads it
+     * unconditionally, with no freshness check. So editing `phel-config.php`
+     * (or upgrading Phel to a build with new `PhelConfig` keys) would otherwise
+     * be silently ignored until the cache file is deleted by hand.
+     *
+     * We fingerprint the cache inputs (the config files plus the config
+     * data-model classes) and, when the fingerprint changes, clear the merged
+     * cache and re-init so the current values take effect. When nothing changed
+     * this is a handful of stat/hash calls and the cache is reused as intended.
+     */
+    private static function refreshStaleMergedConfigCache(): void
+    {
+        $config = Config::getInstance();
+        $cache = self::mergedConfigCache($config->getCacheDir());
+
+        $fingerprintFile = preg_replace('/\.php$/', '.fingerprint', $cache->filename());
+        if ($fingerprintFile === null) {
+            return;
+        }
+
+        $current = self::configCacheFingerprint($config->getAppRootDir());
+        $stored = is_file($fingerprintFile) ? @file_get_contents($fingerprintFile) : null;
+        if ($stored === $current) {
+            return;
+        }
+
+        $cache->clear();
+        $config->init();
+
+        if (is_dir(dirname($fingerprintFile))) {
+            @file_put_contents($fingerprintFile, $current);
+        }
+    }
+
+    /**
+     * Rebuild Gacela's merged-config cache handle from public API only, so we
+     * can locate and clear it without touching `Config`'s `@internal` cache
+     * helpers. Mirrors how Gacela constructs it: the resolved cache dir plus the
+     * optional `APP_ENV` suffix.
+     */
+    private static function mergedConfigCache(string $cacheDir): MergedConfigCache
+    {
+        $env = getenv('APP_ENV');
+
+        return new MergedConfigCache($cacheDir, is_string($env) ? $env : '');
+    }
+
+    /**
+     * Content hash of everything that determines the merged config: the project
+     * config files plus the config data-model classes (whose keys define the
+     * wire format). Any change flips the hash and invalidates the cache.
+     */
+    private static function configCacheFingerprint(string $projectRootDir): string
+    {
+        $parts = [];
+
+        foreach ([self::PHEL_CONFIG_FILE_NAME, self::PHEL_CONFIG_LOCAL_FILE_NAME] as $name) {
+            $parts[] = $name . ':' . self::fileHash($projectRootDir . '/' . $name);
+        }
+
+        foreach (['PhelConfig.php', 'PhelBuildConfig.php', 'PhelExportConfig.php'] as $model) {
+            $parts[] = $model . ':' . self::fileHash(__DIR__ . '/Config/' . $model);
+        }
+
+        return md5(implode('|', $parts));
+    }
+
+    /**
+     * Stable content hash of a single cache-input file, or a placeholder when
+     * it is absent or unreadable.
+     */
+    private static function fileHash(string $path): string
+    {
+        if (!is_file($path)) {
+            return '-';
+        }
+
+        return md5_file($path) ?: '-';
     }
 
     /**

--- a/tests/php/Integration/Config/MergedConfigCacheInvalidationTest.php
+++ b/tests/php/Integration/Config/MergedConfigCacheInvalidationTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Config;
+
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Testing\ContainerFixture;
+use Phel\Config\PhelConfig;
+use Phel\Phel;
+use PHPUnit\Framework\TestCase;
+
+use function sys_get_temp_dir;
+use function uniqid;
+
+final class MergedConfigCacheInvalidationTest extends TestCase
+{
+    use ContainerFixture;
+
+    private string $projectDir = '';
+
+    protected function setUp(): void
+    {
+        $this->resetContainer();
+        $this->projectDir = sys_get_temp_dir() . '/phel-merged-config-' . uniqid('', true);
+        mkdir($this->projectDir);
+        Phel::resetAutoDetectedConfig();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->projectDir);
+        Phel::resetAutoDetectedConfig();
+        $this->resetContainer();
+    }
+
+    public function test_editing_phel_config_invalidates_the_persisted_merged_cache(): void
+    {
+        $this->writeConfig(['first/dir']);
+        Phel::bootstrap($this->projectDir);
+        self::assertSame(['first/dir'], Config::getInstance()->get(PhelConfig::SRC_DIRS));
+
+        // The merged config is now persisted on disk under the project's
+        // .phel/cache. Re-bootstrapping with a changed config must pick up the
+        // new value instead of replaying the stale cached one.
+        $this->resetContainer();
+        $this->writeConfig(['second/dir']);
+        Phel::bootstrap($this->projectDir);
+
+        self::assertSame(['second/dir'], Config::getInstance()->get(PhelConfig::SRC_DIRS));
+    }
+
+    public function test_unchanged_config_keeps_returning_values_on_cache_hit(): void
+    {
+        $this->writeConfig(['stable/dir']);
+        Phel::bootstrap($this->projectDir);
+        self::assertSame(['stable/dir'], Config::getInstance()->get(PhelConfig::SRC_DIRS));
+
+        // Re-bootstrapping with an unchanged config takes the fast path
+        // (fingerprint matches, the persisted cache is reused) and must still
+        // expose the cached values rather than an empty or broken config.
+        $this->resetContainer();
+        Phel::bootstrap($this->projectDir);
+
+        self::assertSame(['stable/dir'], Config::getInstance()->get(PhelConfig::SRC_DIRS));
+    }
+
+    /**
+     * @param list<string> $srcDirs
+     */
+    private function writeConfig(array $srcDirs): void
+    {
+        $list = "'" . implode("', '", $srcDirs) . "'";
+        file_put_contents(
+            $this->projectDir . '/' . Phel::PHEL_CONFIG_FILE_NAME,
+            <<<PHP
+            <?php
+            use Phel\\Config\\PhelConfig;
+            return (new PhelConfig())->withSrcDirs([{$list}]);
+            PHP,
+        );
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = scandir($dir) ?: [];
+        foreach ($items as $item) {
+            if ($item === '.') {
+                continue;
+            }
+
+            if ($item === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->removeDir($path) : unlink($path);
+        }
+
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Gacela 1.15 auto-warms the merged app config to `gacela-merged-config.php` and then reloads it **unconditionally** on every bootstrap, with no freshness check (`Config::loadMergedConfigValues()` returns `$cache->load()` whenever the file exists). As a result, editing `phel-config.php` — or upgrading Phel to a build with new `PhelConfig` keys — was silently ignored until the cache file was deleted by hand.

## 💡 Goal

Make configuration changes take effect immediately again, without giving up the merged-config cache (which also backs Gacela's class resolution).

## 🔖 Changes

- `Phel::refreshStaleMergedConfigCache()` runs right after `Gacela::bootstrap()`: it fingerprints the cache inputs (the two config files plus the `PhelConfig` / `PhelBuildConfig` / `PhelExportConfig` data-model classes) into a `.fingerprint` sibling of the merged-cache file. On a mismatch it clears Gacela's merged cache and re-inits (re-warming with fresh values); when nothing changed it is a handful of `stat`/hash calls and the cache is reused as intended.
- Uses Gacela's **public** `MergedConfigCache` API only (`Config::getCacheDir()` + `filename()`/`clear()`), never the `@internal` `Config` cache helpers — so it passes Psalm level 1.
- Auto-detected (zero-config) projects are unaffected: their values come from the inline config that overrides the cached merged values on every bootstrap.
- Bumps the requirement to `gacela-project/gacela: ^1.15` (the fix relies on the 1.15 merged-config cache API; `^1.14` would fatal on 1.14).
- Integration tests: editing the config invalidates the persisted cache; an unchanged config keeps serving the cached values (fast path).
- CHANGELOG under `## Unreleased` › Fixed.
