### PR TITLE
ref(config): extract merged-config cache invalidation into a dedicated class

### DIFF
--- a/src/php/MergedConfigCacheInvalidator.php
+++ b/src/php/MergedConfigCacheInvalidator.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel;
+
+use Closure;
+use Gacela\Framework\Config\MergedConfigCache;
+
+use function basename;
+use function dirname;
+use function implode;
+use function is_dir;
+use function is_file;
+use function is_string;
+use function md5;
+use function md5_file;
+use function preg_replace;
+
+/**
+ * Keeps Gacela's persisted merged-config cache (1.15+) in sync with its inputs.
+ *
+ * Gacela auto-warms the merged app config to `gacela-merged-config.php` on the
+ * first bootstrap and then reloads it unconditionally, with no freshness check.
+ * This class fingerprints the files that determine the merged config and, when
+ * the fingerprint changes, clears the cache and triggers a reload so the current
+ * values take effect. When nothing changed it is a handful of stat/hash calls
+ * and the cache is reused as intended.
+ *
+ * It depends only on Gacela's public `MergedConfigCache` API and on an injected
+ * reload callback, so the whole flow is exercisable without a live bootstrap.
+ *
+ * @see Phel::bootstrap()
+ */
+final readonly class MergedConfigCacheInvalidator
+{
+    /**
+     * @param string         $cacheDir          The dir where Gacela persists the merged-config cache
+     * @param list<string>   $fingerprintInputs Absolute paths whose contents determine the merged
+     *                                          config (project config files + config data-model classes)
+     * @param Closure():void $reloadConfig      Reloads Gacela's config from source after a cache clear
+     */
+    public function __construct(
+        private string $cacheDir,
+        private array $fingerprintInputs,
+        private Closure $reloadConfig,
+    ) {}
+
+    public function refreshIfStale(): void
+    {
+        $cache = $this->mergedConfigCache();
+        $fingerprintFile = preg_replace('/\.php$/', '.fingerprint', $cache->filename());
+        if ($fingerprintFile === null) {
+            return;
+        }
+
+        $current = $this->fingerprint();
+        $stored = is_file($fingerprintFile) ? @file_get_contents($fingerprintFile) : null;
+        if ($stored === $current) {
+            return;
+        }
+
+        $cache->clear();
+        ($this->reloadConfig)();
+
+        if (is_dir(dirname($fingerprintFile))) {
+            @file_put_contents($fingerprintFile, $current);
+        }
+    }
+
+    /**
+     * Content hash over every cache input. Any change to a config file or to a
+     * config data-model class (whose keys define the wire format) flips it.
+     */
+    public function fingerprint(): string
+    {
+        $parts = [];
+        foreach ($this->fingerprintInputs as $path) {
+            $parts[] = basename($path) . ':' . $this->fileHash($path);
+        }
+
+        return md5(implode('|', $parts));
+    }
+
+    /**
+     * Rebuild Gacela's merged-config cache handle from public API only, mirroring
+     * how Gacela constructs it: the resolved cache dir plus the optional
+     * `APP_ENV` suffix.
+     */
+    private function mergedConfigCache(): MergedConfigCache
+    {
+        $env = getenv('APP_ENV');
+
+        return new MergedConfigCache($this->cacheDir, is_string($env) ? $env : '');
+    }
+
+    /**
+     * Stable content hash of a single cache-input file, or a placeholder when it
+     * is absent or unreadable.
+     */
+    private function fileHash(string $path): string
+    {
+        if (!is_file($path)) {
+            return '-';
+        }
+
+        return md5_file($path) ?: '-';
+    }
+}

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -7,7 +7,6 @@ namespace Phel;
 use Closure;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Config\Config;
-use Gacela\Framework\Config\MergedConfigCache;
 use Gacela\Framework\Gacela;
 use Phar;
 use Phel\Config\PhelConfig;
@@ -22,7 +21,6 @@ use function dirname;
 use function getcwd;
 use function in_array;
 use function is_array;
-use function is_string;
 
 /**
  * @internal use \Phel instead
@@ -103,7 +101,7 @@ class Phel
 
         Gacela::bootstrap($projectRootDir, self::configFn());
 
-        self::refreshStaleMergedConfigCache();
+        self::mergedConfigCacheInvalidator()->refreshIfStale();
         self::mirrorPhelDirToEnv();
     }
 
@@ -193,87 +191,28 @@ class Phel
     }
 
     /**
-     * Invalidate Gacela's persisted merged-config cache when its inputs change.
-     *
-     * Gacela (>= 1.15) auto-warms the merged app config to
-     * `gacela-merged-config.php` on the first bootstrap and then reloads it
-     * unconditionally, with no freshness check. So editing `phel-config.php`
-     * (or upgrading Phel to a build with new `PhelConfig` keys) would otherwise
-     * be silently ignored until the cache file is deleted by hand.
-     *
-     * We fingerprint the cache inputs (the config files plus the config
-     * data-model classes) and, when the fingerprint changes, clear the merged
-     * cache and re-init so the current values take effect. When nothing changed
-     * this is a handful of stat/hash calls and the cache is reused as intended.
+     * Build the merged-config cache invalidator for the current Gacela config,
+     * wiring it to the project config files and the config data-model classes
+     * whose contents define the cached merged config.
      */
-    private static function refreshStaleMergedConfigCache(): void
+    private static function mergedConfigCacheInvalidator(): MergedConfigCacheInvalidator
     {
         $config = Config::getInstance();
-        $cache = self::mergedConfigCache($config->getCacheDir());
+        $appRootDir = $config->getAppRootDir();
 
-        $fingerprintFile = preg_replace('/\.php$/', '.fingerprint', $cache->filename());
-        if ($fingerprintFile === null) {
-            return;
-        }
-
-        $current = self::configCacheFingerprint($config->getAppRootDir());
-        $stored = is_file($fingerprintFile) ? @file_get_contents($fingerprintFile) : null;
-        if ($stored === $current) {
-            return;
-        }
-
-        $cache->clear();
-        $config->init();
-
-        if (is_dir(dirname($fingerprintFile))) {
-            @file_put_contents($fingerprintFile, $current);
-        }
-    }
-
-    /**
-     * Rebuild Gacela's merged-config cache handle from public API only, so we
-     * can locate and clear it without touching `Config`'s `@internal` cache
-     * helpers. Mirrors how Gacela constructs it: the resolved cache dir plus the
-     * optional `APP_ENV` suffix.
-     */
-    private static function mergedConfigCache(string $cacheDir): MergedConfigCache
-    {
-        $env = getenv('APP_ENV');
-
-        return new MergedConfigCache($cacheDir, is_string($env) ? $env : '');
-    }
-
-    /**
-     * Content hash of everything that determines the merged config: the project
-     * config files plus the config data-model classes (whose keys define the
-     * wire format). Any change flips the hash and invalidates the cache.
-     */
-    private static function configCacheFingerprint(string $projectRootDir): string
-    {
-        $parts = [];
-
-        foreach ([self::PHEL_CONFIG_FILE_NAME, self::PHEL_CONFIG_LOCAL_FILE_NAME] as $name) {
-            $parts[] = $name . ':' . self::fileHash($projectRootDir . '/' . $name);
-        }
-
-        foreach (['PhelConfig.php', 'PhelBuildConfig.php', 'PhelExportConfig.php'] as $model) {
-            $parts[] = $model . ':' . self::fileHash(__DIR__ . '/Config/' . $model);
-        }
-
-        return md5(implode('|', $parts));
-    }
-
-    /**
-     * Stable content hash of a single cache-input file, or a placeholder when
-     * it is absent or unreadable.
-     */
-    private static function fileHash(string $path): string
-    {
-        if (!is_file($path)) {
-            return '-';
-        }
-
-        return md5_file($path) ?: '-';
+        return new MergedConfigCacheInvalidator(
+            $config->getCacheDir(),
+            [
+                $appRootDir . '/' . self::PHEL_CONFIG_FILE_NAME,
+                $appRootDir . '/' . self::PHEL_CONFIG_LOCAL_FILE_NAME,
+                __DIR__ . '/Config/PhelConfig.php',
+                __DIR__ . '/Config/PhelBuildConfig.php',
+                __DIR__ . '/Config/PhelExportConfig.php',
+            ],
+            static function () use ($config): void {
+                $config->init();
+            },
+        );
     }
 
     /**

--- a/tests/php/Unit/MergedConfigCacheInvalidatorTest.php
+++ b/tests/php/Unit/MergedConfigCacheInvalidatorTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit;
+
+use Closure;
+use Phel\MergedConfigCacheInvalidator;
+use PHPUnit\Framework\TestCase;
+
+final class MergedConfigCacheInvalidatorTest extends TestCase
+{
+    private string $dir = '';
+
+    private ?string $previousAppEnv = null;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/phel-mcci-' . uniqid('', true);
+        mkdir($this->dir);
+
+        // Pin the cache filename (no env suffix) so the assertions are stable.
+        $env = getenv('APP_ENV');
+        $this->previousAppEnv = $env === false ? null : $env;
+        putenv('APP_ENV');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->dir);
+        if ($this->previousAppEnv === null) {
+            putenv('APP_ENV');
+        } else {
+            putenv('APP_ENV=' . $this->previousAppEnv);
+        }
+    }
+
+    public function test_fingerprint_changes_when_an_input_file_changes(): void
+    {
+        $input = $this->dir . '/phel-config.php';
+        file_put_contents($input, '<?php return 1;');
+        $invalidator = $this->invalidator([$input]);
+
+        $before = $invalidator->fingerprint();
+        file_put_contents($input, '<?php return 2;');
+
+        self::assertNotSame($before, $invalidator->fingerprint());
+    }
+
+    public function test_fingerprint_is_stable_for_unchanged_inputs(): void
+    {
+        $input = $this->dir . '/phel-config.php';
+        file_put_contents($input, '<?php return 1;');
+        $invalidator = $this->invalidator([$input]);
+
+        self::assertSame($invalidator->fingerprint(), $invalidator->fingerprint());
+    }
+
+    public function test_fingerprint_tolerates_missing_inputs(): void
+    {
+        $invalidator = $this->invalidator([$this->dir . '/absent.php']);
+
+        self::assertNotSame('', $invalidator->fingerprint());
+    }
+
+    public function test_refresh_clears_cache_and_reloads_when_stale(): void
+    {
+        $input = $this->dir . '/phel-config.php';
+        file_put_contents($input, '<?php return 1;');
+        $cacheFile = $this->dir . '/gacela-merged-config.php';
+        file_put_contents($cacheFile, '<?php return [];');
+
+        $reloads = 0;
+        $this->invalidator([$input], static function () use (&$reloads): void {
+            ++$reloads;
+        })->refreshIfStale();
+
+        self::assertSame(1, $reloads);
+        self::assertFileDoesNotExist($cacheFile);
+        self::assertFileExists($this->dir . '/gacela-merged-config.fingerprint');
+    }
+
+    public function test_refresh_skips_when_fingerprint_matches(): void
+    {
+        $input = $this->dir . '/phel-config.php';
+        file_put_contents($input, '<?php return 1;');
+        $cacheFile = $this->dir . '/gacela-merged-config.php';
+        file_put_contents($cacheFile, '<?php return [];');
+
+        $fresh = $this->invalidator([$input]);
+        file_put_contents($this->dir . '/gacela-merged-config.fingerprint', $fresh->fingerprint());
+
+        $reloads = 0;
+        $this->invalidator([$input], static function () use (&$reloads): void {
+            ++$reloads;
+        })->refreshIfStale();
+
+        self::assertSame(0, $reloads);
+        self::assertFileExists($cacheFile);
+    }
+
+    /**
+     * @param list<string> $inputs
+     */
+    private function invalidator(array $inputs, ?Closure $reload = null): MergedConfigCacheInvalidator
+    {
+        return new MergedConfigCacheInvalidator(
+            $this->dir,
+            $inputs,
+            $reload ?? static function (): void {},
+        );
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) ?: [] as $item) {
+            if ($item === '.') {
+                continue;
+            }
+
+            if ($item === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->removeDir($path) : unlink($path);
+        }
+
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

The merged-config cache invalidation shipped in #2413 lived as four private static methods on `Phel`, the static bootstrap entry point. That class is already a catch-all (argv, PHAR resolution, env mirroring, auto-detect), and the cache logic could only be exercised through a full `Phel::bootstrap()` (the integration test), never in isolation.

## 💡 Goal

Give the cache-freshness concern its own home and make it unit-testable — no behavior change.

## 🔖 Changes

- Extract the fingerprint-and-invalidate logic into `Phel\MergedConfigCacheInvalidator` (`final readonly`). It takes the cache dir, the list of fingerprint inputs and a reload callback, so the whole refresh flow runs against a temp dir + a spy in unit tests instead of only through a live Gacela bootstrap.
- `Phel::bootstrap()` now builds the invalidator (wiring the project config files + the `PhelConfig`/`PhelBuildConfig`/`PhelExportConfig` data-model classes) and delegates via `self::mergedConfigCacheInvalidator()->refreshIfStale();`.
- Still uses Gacela's public `MergedConfigCache` API only (unchanged from #2413); `Phel.php` drops the now-unused imports.
- Adds `MergedConfigCacheInvalidatorTest` (fingerprint changes / is stable / tolerates missing inputs; `refreshIfStale` clears + reloads when stale, skips when fresh). The bootstrap-level integration test from #2413 stays.

Follows #2413 (merged).
