### PR TITLE
ref: PHP module quality pass (phase order, leaf purity, DI, PhelConfig trait)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ config, a [configuration reference](docs/configuration.md), composable
 ### Changed
 
 - `phel init` scaffolds a `phel-config.php` with a docs link and commented-out tweaks
+- Docs: a [Deployment guide](docs/deployment.md) covering shared-nothing vs worker runtimes (FrankenPHP/RoadRunner), with a load-once-before-the-loop example
 
 ### Fixed
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ Coming from Clojure? Read [Clojure Migration](clojure-migration.md).
 ## Apps
 
 - [Framework Integration](framework-integration.md): Laravel, Symfony, framework-less
+- [Deployment](deployment.md): worker runtimes (FrankenPHP, RoadRunner), shared-nothing vs persistent state
 - [Examples](examples/README.md): runnable single-file samples
 
 ## Internals

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,67 @@
+# Deployment & Worker Runtimes
+
+By default PHP is **shared-nothing**: every request boots a fresh process, so a
+Phel namespace does not persist between requests. `phel build` compiles your
+namespaces to PHP ahead of time and [opcache](performance.md) caches that
+bytecode, so nothing re-parses per request — but each request still re-runs
+every loaded namespace's top-level forms to register its `def`s.
+
+A **worker runtime** keeps the PHP process alive across requests. Your
+namespaces load **once** at boot and in-memory state survives between requests —
+much closer to the JVM/Clojure model.
+
+## The one rule
+
+Require the built entry point **once, before the request loop**. Everything
+inside the loop should only call your exported functions.
+
+```php
+require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/build/app/main.php'; // loads Phel namespaces ONCE
+```
+
+See [Framework Integration](framework-integration.md) for `phel build` and
+exporting PHP wrappers from Phel.
+
+## FrankenPHP
+
+`worker.php`:
+
+```php
+<?php
+require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/build/app/main.php'; // once, outside the loop
+
+$handler = static function (): void {
+    // call an exported Phel function per request
+    echo \App\Main\handle_request();
+};
+
+while (frankenphp_handle_request($handler)) {
+    gc_collect_cycles();
+}
+```
+
+Run it:
+
+```bash
+frankenphp php-server --root . --worker ./worker.php
+```
+
+> **State is per-worker.** FrankenPHP runs several worker instances, each with
+> its own memory. An in-process value (an `atom`, a cache) is shared between
+> requests handled by the *same* worker, not across all of them. For state that
+> must be global, use Redis/APCu/DB. Append `,1` to the worker path
+> (`--worker ./worker.php,1`) to pin a single worker.
+
+## RoadRunner
+
+Same shape: require the built entry point once, then handle requests in the
+worker loop (via `spiral/roadrunner-http`'s PSR-7 worker), calling your exported
+Phel functions per request.
+
+## When you do not need a worker runtime
+
+Plain PHP-FPM + opcache is fine for most apps. Reach for a worker runtime when
+boot cost or per-request namespace registration shows up in profiling, or when
+you want persistent in-memory state (caches, connection pools) across requests.

--- a/rector.php
+++ b/rector.php
@@ -30,7 +30,7 @@ return RectorConfig::configure()
         // converting to `array_all` with an arrow fn would silently
         // drop the reference because arrow functions capture by value.
         ForeachToArrayAllRector::class => [
-            __DIR__ . '/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/LocalVarReferences.php',
+            __DIR__ . '/src/php/Compiler/Domain/Analyzer/Ast/Reference/LocalVarReferences.php',
         ],
         ReturnTypeFromReturnNewRector::class => [
             __DIR__ . '/tests/php/Unit/Interop/Generator/CompiledPhpMethodBuilderTest.php',

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -17,7 +17,7 @@ Core compilation pipeline: Phel source to tokens to AST to analyzed nodes to PHP
 
 ## Dependencies
 
-Filesystem (file I/O); Shared (`Munge`, `Printer`, exceptions). `CompilerConfig` exposes `assertsEnabled()`, `warnDeprecationsEnabled()`.
+Filesystem (file I/O); Config (`PhelConfig` data model, wrapped by `CompilerConfig`); Shared (`Munge`, `Printer`, exceptions). `CompilerConfig` exposes `assertsEnabled()`, `warnDeprecationsEnabled()`.
 
 ## Phase Pipeline
 

--- a/src/php/Compiler/Domain/Analyzer/Ast/Reference/LocalVarReferences.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/Reference/LocalVarReferences.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel\Compiler\Domain\Emitter\OutputEmitter\Cache;
+namespace Phel\Compiler\Domain\Analyzer\Ast\Reference;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ApplyNode;

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/LetSimplifier.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/LetSimplifier.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
-use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\LocalVarReferences;
+use Phel\Compiler\Domain\Analyzer\Ast\Reference\LocalVarReferences;
 
 use function array_fill_keys;
 use function array_reverse;

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/RecurEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/RecurEmitter.php
@@ -6,7 +6,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\RecurNode;
-use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\LocalVarReferences;
+use Phel\Compiler\Domain\Analyzer\Ast\Reference\LocalVarReferences;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Symbol;
 

--- a/src/php/Config/CLAUDE.md
+++ b/src/php/Config/CLAUDE.md
@@ -6,9 +6,9 @@ Pure data/model layer defining configuration structure for Phel projects. No Gac
 
 ### PhelConfig
 
-Immutable `final readonly class` (~650 LOC). Every mutation returns a new instance via `with*()` methods (directory, layout, build, export, cache, flag setters); `withOptimizationLevel(int)` (key `optimization-level`, clamped >= 0) sets the compiler optimization level consumed by Build/Run (REPL/nREPL ignore it); `forProject(ProjectLayout = Flat, string $mainNamespace = '')` convenience constructor; `validate(): list<string>` (empty if valid); `jsonSerialize()`.
+Immutable `final readonly class` (~620 LOC). Every mutation returns a new instance via `with*()` methods (directory, layout, build, export, cache, flag setters); `withOptimizationLevel(int)` (key `optimization-level`, clamped >= 0) sets the compiler optimization level consumed by Build/Run (REPL/nREPL ignore it); `forProject(ProjectLayout = Flat, string $mainNamespace = '')` convenience constructor; `validate(): list<string>` (empty if valid); `jsonSerialize()`.
 
-**Deprecated (since 0.37)**: `setX()` and `useLayout()`/`useNestedLayout()`/`useFlatLayout()` shim to `with*()` counterparts (marked `#[Deprecated]`). Permanent backward-compatibility aliases, not scheduled for removal in a minor release; removal would require a major version bump.
+**Deprecated (since 0.37)**: `setX()` and `useLayout()`/`useNestedLayout()`/`useFlatLayout()` shim to `with*()` counterparts (marked `#[Deprecated]`), kept in the `PhelConfigDeprecations` trait so they do not clutter the canonical API. Permanent backward-compatibility aliases, not scheduled for removal in a minor release; removal would require a major version bump.
 
 ### PhelBuildConfig / PhelExportConfig
 

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Config;
 
-use Deprecated;
 use JsonSerializable;
 
 /**
@@ -26,6 +25,8 @@ use JsonSerializable;
  */
 final readonly class PhelConfig implements JsonSerializable
 {
+    use PhelConfigDeprecations;
+
     public const string SRC_DIRS = 'src-dirs';
 
     public const string TEST_DIRS = 'test-dirs';
@@ -263,24 +264,6 @@ final readonly class PhelConfig implements JsonSerializable
             'formatDirs' => $layout->getFormatDirs(),
             'exportConfig' => $this->exportConfig->withFromDirectories($layout->getExportFromDirs()),
         ]);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withLayout()')]
-    public function useLayout(ProjectLayout $layout): self
-    {
-        return $this->withLayout($layout);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withLayout(ProjectLayout::Nested)')]
-    public function useNestedLayout(): self
-    {
-        return $this->withLayout(ProjectLayout::Nested);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withLayout(ProjectLayout::Flat)')]
-    public function useFlatLayout(): self
-    {
-        return $this->withLayout(ProjectLayout::Flat);
     }
 
     // ========================================
@@ -557,165 +540,6 @@ final readonly class PhelConfig implements JsonSerializable
     public function withOptimizationLevel(int $level): self
     {
         return $this->with(['optimizationLevel' => max(0, $level)]);
-    }
-
-    // ========================================
-    // Deprecated mutating setters (shim → with*())
-    // ========================================
-    /**
-     * @param list<string> $list
-     */
-    #[Deprecated(message: 'since 0.37, use withSrcDirs()')]
-    public function setSrcDirs(array $list): self
-    {
-        return $this->withSrcDirs($list);
-    }
-
-    /**
-     * @param list<string> $list
-     */
-    #[Deprecated(message: 'since 0.37, use withTestDirs()')]
-    public function setTestDirs(array $list): self
-    {
-        return $this->withTestDirs($list);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withVendorDir()')]
-    public function setVendorDir(string $dir): self
-    {
-        return $this->withVendorDir($dir);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withErrorLogFile()')]
-    public function setErrorLogFile(string $filepath): self
-    {
-        return $this->withErrorLogFile($filepath);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withBuildConfig()')]
-    public function setBuildConfig(PhelBuildConfig $buildConfig): self
-    {
-        return $this->withBuildConfig($buildConfig);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withExportConfig()')]
-    public function setExportConfig(PhelExportConfig $exportConfig): self
-    {
-        return $this->withExportConfig($exportConfig);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withMainPhelNamespace()')]
-    public function setMainPhelNamespace(string $namespace): self
-    {
-        return $this->withMainPhelNamespace($namespace);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withMainPhpPath()')]
-    public function setMainPhpPath(string $path): self
-    {
-        return $this->withMainPhpPath($path);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withBuildDestDir()')]
-    public function setBuildDestDir(string $dir): self
-    {
-        return $this->withBuildDestDir($dir);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withExportNamespacePrefix()')]
-    public function setExportNamespacePrefix(string $prefix): self
-    {
-        return $this->withExportNamespacePrefix($prefix);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withExportTargetDirectory()')]
-    public function setExportTargetDirectory(string $dir): self
-    {
-        return $this->withExportTargetDirectory($dir);
-    }
-
-    /**
-     * @param list<string> $dirs
-     */
-    #[Deprecated(message: 'since 0.37, use withExportFromDirectories()')]
-    public function setExportFromDirectories(array $dirs): self
-    {
-        return $this->withExportFromDirectories($dirs);
-    }
-
-    /**
-     * @param list<string> $list
-     */
-    #[Deprecated(message: 'since 0.37, use withIgnoreWhenBuilding()')]
-    public function setIgnoreWhenBuilding(array $list): self
-    {
-        return $this->withIgnoreWhenBuilding($list);
-    }
-
-    /**
-     * @param list<string> $list
-     */
-    #[Deprecated(message: 'since 0.37, use withNoCacheWhenBuilding()')]
-    public function setNoCacheWhenBuilding(array $list): self
-    {
-        return $this->withNoCacheWhenBuilding($list);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withKeepGeneratedTempFiles()')]
-    public function setKeepGeneratedTempFiles(bool $flag): self
-    {
-        return $this->withKeepGeneratedTempFiles($flag);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withTempDir()')]
-    public function setTempDir(string $dir): self
-    {
-        return $this->withTempDir($dir);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withCacheDir()')]
-    public function setCacheDir(string $dir): self
-    {
-        return $this->withCacheDir($dir);
-    }
-
-    /**
-     * @param list<string> $list
-     */
-    #[Deprecated(message: 'since 0.37, use withFormatDirs()')]
-    public function setFormatDirs(array $list): self
-    {
-        return $this->withFormatDirs($list);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withEnableAsserts()')]
-    public function setEnableAsserts(bool $flag): self
-    {
-        return $this->withEnableAsserts($flag);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withWarnDeprecations()')]
-    public function setWarnDeprecations(bool $flag): self
-    {
-        return $this->withWarnDeprecations($flag);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withEnableNamespaceCache()')]
-    public function setEnableNamespaceCache(bool $flag): self
-    {
-        return $this->withEnableNamespaceCache($flag);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withEnableCompiledCodeCache()')]
-    public function setEnableCompiledCodeCache(bool $flag): self
-    {
-        return $this->withEnableCompiledCodeCache($flag);
-    }
-
-    #[Deprecated(message: 'since 0.37, use withPhelDir()')]
-    public function setPhelDir(string $dir): self
-    {
-        return $this->withPhelDir($dir);
     }
 
     // ========================================

--- a/src/php/Config/PhelConfigDeprecations.php
+++ b/src/php/Config/PhelConfigDeprecations.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Config;
+
+use Deprecated;
+
+/**
+ * Backward-compatibility shims for {@see PhelConfig}.
+ *
+ * Every method here is deprecated since 0.37 and delegates to the matching
+ * immutable `with*()` method on the host class. They are permanent aliases
+ * (removal would require a major version bump); extracted into a trait so they
+ * do not clutter PhelConfig's canonical API.
+ *
+ * @mixin PhelConfig
+ */
+trait PhelConfigDeprecations
+{
+    #[Deprecated(message: 'since 0.37, use withLayout()')]
+    public function useLayout(ProjectLayout $layout): self
+    {
+        return $this->withLayout($layout);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withLayout(ProjectLayout::Nested)')]
+    public function useNestedLayout(): self
+    {
+        return $this->withLayout(ProjectLayout::Nested);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withLayout(ProjectLayout::Flat)')]
+    public function useFlatLayout(): self
+    {
+        return $this->withLayout(ProjectLayout::Flat);
+    }
+
+    /**
+     * @param list<string> $list
+     */
+    #[Deprecated(message: 'since 0.37, use withSrcDirs()')]
+    public function setSrcDirs(array $list): self
+    {
+        return $this->withSrcDirs($list);
+    }
+
+    /**
+     * @param list<string> $list
+     */
+    #[Deprecated(message: 'since 0.37, use withTestDirs()')]
+    public function setTestDirs(array $list): self
+    {
+        return $this->withTestDirs($list);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withVendorDir()')]
+    public function setVendorDir(string $dir): self
+    {
+        return $this->withVendorDir($dir);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withErrorLogFile()')]
+    public function setErrorLogFile(string $filepath): self
+    {
+        return $this->withErrorLogFile($filepath);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withBuildConfig()')]
+    public function setBuildConfig(PhelBuildConfig $buildConfig): self
+    {
+        return $this->withBuildConfig($buildConfig);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withExportConfig()')]
+    public function setExportConfig(PhelExportConfig $exportConfig): self
+    {
+        return $this->withExportConfig($exportConfig);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withMainPhelNamespace()')]
+    public function setMainPhelNamespace(string $namespace): self
+    {
+        return $this->withMainPhelNamespace($namespace);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withMainPhpPath()')]
+    public function setMainPhpPath(string $path): self
+    {
+        return $this->withMainPhpPath($path);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withBuildDestDir()')]
+    public function setBuildDestDir(string $dir): self
+    {
+        return $this->withBuildDestDir($dir);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withExportNamespacePrefix()')]
+    public function setExportNamespacePrefix(string $prefix): self
+    {
+        return $this->withExportNamespacePrefix($prefix);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withExportTargetDirectory()')]
+    public function setExportTargetDirectory(string $dir): self
+    {
+        return $this->withExportTargetDirectory($dir);
+    }
+
+    /**
+     * @param list<string> $dirs
+     */
+    #[Deprecated(message: 'since 0.37, use withExportFromDirectories()')]
+    public function setExportFromDirectories(array $dirs): self
+    {
+        return $this->withExportFromDirectories($dirs);
+    }
+
+    /**
+     * @param list<string> $list
+     */
+    #[Deprecated(message: 'since 0.37, use withIgnoreWhenBuilding()')]
+    public function setIgnoreWhenBuilding(array $list): self
+    {
+        return $this->withIgnoreWhenBuilding($list);
+    }
+
+    /**
+     * @param list<string> $list
+     */
+    #[Deprecated(message: 'since 0.37, use withNoCacheWhenBuilding()')]
+    public function setNoCacheWhenBuilding(array $list): self
+    {
+        return $this->withNoCacheWhenBuilding($list);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withKeepGeneratedTempFiles()')]
+    public function setKeepGeneratedTempFiles(bool $flag): self
+    {
+        return $this->withKeepGeneratedTempFiles($flag);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withTempDir()')]
+    public function setTempDir(string $dir): self
+    {
+        return $this->withTempDir($dir);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withCacheDir()')]
+    public function setCacheDir(string $dir): self
+    {
+        return $this->withCacheDir($dir);
+    }
+
+    /**
+     * @param list<string> $list
+     */
+    #[Deprecated(message: 'since 0.37, use withFormatDirs()')]
+    public function setFormatDirs(array $list): self
+    {
+        return $this->withFormatDirs($list);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withEnableAsserts()')]
+    public function setEnableAsserts(bool $flag): self
+    {
+        return $this->withEnableAsserts($flag);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withWarnDeprecations()')]
+    public function setWarnDeprecations(bool $flag): self
+    {
+        return $this->withWarnDeprecations($flag);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withEnableNamespaceCache()')]
+    public function setEnableNamespaceCache(bool $flag): self
+    {
+        return $this->withEnableNamespaceCache($flag);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withEnableCompiledCodeCache()')]
+    public function setEnableCompiledCodeCache(bool $flag): self
+    {
+        return $this->withEnableCompiledCodeCache($flag);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withPhelDir()')]
+    public function setPhelDir(string $dir): self
+    {
+        return $this->withPhelDir($dir);
+    }
+}

--- a/src/php/Lang/CLAUDE.md
+++ b/src/php/Lang/CLAUDE.md
@@ -37,6 +37,7 @@ Other utilities: `DynamicScope` (dynamic bindings), `Truthy`, `TypeStringifier`,
 - **TypeFactory**: singleton creating persistent collections; provides `Hasher`/`Equalizer` singletons
 - **Seq**: static utility for sequence ops; **TagRegistry**: reader literal tag handler dispatch (`TagHandlers/`: `#inst`, `#uuid`, regex)
 - **LoadClasspath**: static accessor for the `(load ...)` classpath, stored in `Registry` under `phel.core/*load-classpath*`. Lives here (not Compiler) because its state is a `Registry` slot; FQN baked into generated PHP by `LoadEmitter`; do not rename
+- **`\Phel`** (global, `src/Phel.php` — NOT a Lang class): thin root facade that proxies static calls to the `Registry` singleton via `__callStatic`; Api/Interop use it for namespace/definition lookups (`getNamespaces`, `getDefinition`, `getDefinitionMetaData`). Lang's own code must not call it (leaf → root cycle); use `Registry`/`TypeFactory` directly here
 
 ## Interfaces
 

--- a/src/php/Lang/CLAUDE.md
+++ b/src/php/Lang/CLAUDE.md
@@ -37,7 +37,6 @@ Other utilities: `DynamicScope` (dynamic bindings), `Truthy`, `TypeStringifier`,
 - **TypeFactory**: singleton creating persistent collections; provides `Hasher`/`Equalizer` singletons
 - **Seq**: static utility for sequence ops; **TagRegistry**: reader literal tag handler dispatch (`TagHandlers/`: `#inst`, `#uuid`, regex)
 - **LoadClasspath**: static accessor for the `(load ...)` classpath, stored in `Registry` under `phel.core/*load-classpath*`. Lives here (not Compiler) because its state is a `Registry` slot; FQN baked into generated PHP by `LoadEmitter`; do not rename
-- **Phel**: static helper for namespace/definition lookups (used by Api, Interop)
 
 ## Interfaces
 

--- a/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
+++ b/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
@@ -6,7 +6,6 @@ namespace Phel\Lang\Collections\Struct;
 
 use InvalidArgumentException;
 use Override;
-use Phel;
 use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\Collections\Map\AbstractPersistentMap;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -113,7 +112,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     public function getIterator(): Traversable
     {
         foreach (static::ALLOWED_KEYS as $key) {
-            yield Phel::keyword($key) => $this->{$this->keyEncoder->encode($key)};
+            yield Keyword::create($key) => $this->{$this->keyEncoder->encode($key)};
         }
     }
 
@@ -138,7 +137,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     public function getAllowedKeys(): array
     {
         return array_values(array_map(
-            static fn(string $k): Keyword => Phel::keyword($k),
+            static fn(string $k): Keyword => Keyword::create($k),
             static::ALLOWED_KEYS,
         ));
     }
@@ -161,7 +160,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
      */
     private function normalizeOffset(mixed $offset): Keyword
     {
-        return is_string($offset) ? Phel::keyword($offset) : $offset;
+        return is_string($offset) ? Keyword::create($offset) : $offset;
     }
 
     /**
@@ -171,7 +170,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     {
         $kvs = [];
         foreach (static::ALLOWED_KEYS as $allowedKey) {
-            $entryKey = Phel::keyword($allowedKey);
+            $entryKey = Keyword::create($allowedKey);
             if ($this->equalizer->equals($entryKey, $key)) {
                 continue;
             }

--- a/src/php/Lang/Generators/PartitionGenerator.php
+++ b/src/php/Lang/Generators/PartitionGenerator.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phel\Lang\Generators;
 
 use Generator;
-use Phel;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\TypeFactory;
 
@@ -29,7 +28,7 @@ final class PartitionGenerator
             $partition[] = $value;
 
             if (count($partition) === $n) {
-                yield Phel::vector($partition);
+                yield TypeFactory::getInstance()->persistentVectorFromArray($partition);
                 $partition = [];
             }
         }
@@ -51,13 +50,13 @@ final class PartitionGenerator
             $partition[] = $value;
 
             if (count($partition) === $n) {
-                yield Phel::vector($partition);
+                yield TypeFactory::getInstance()->persistentVectorFromArray($partition);
                 $partition = [];
             }
         }
 
         if ($partition !== []) {
-            yield Phel::vector($partition);
+            yield TypeFactory::getInstance()->persistentVectorFromArray($partition);
         }
     }
 
@@ -79,14 +78,14 @@ final class PartitionGenerator
                 $prevKey = $key;
                 $first = false;
             } else {
-                yield Phel::vector($partition);
+                yield TypeFactory::getInstance()->persistentVectorFromArray($partition);
                 $partition = [$value];
                 $prevKey = $key;
             }
         }
 
         if ($partition !== []) {
-            yield Phel::vector($partition);
+            yield TypeFactory::getInstance()->persistentVectorFromArray($partition);
         }
     }
 

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Lang;
 
-use Phel;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use RuntimeException;
 
@@ -167,7 +166,7 @@ final class Registry
         }
 
         /** @var PersistentMapInterface<mixed, mixed>|null $meta */
-        $meta = $this->definitionsMetaData[$ns][$name] ?? Phel::map();
+        $meta = $this->definitionsMetaData[$ns][$name] ?? TypeFactory::getInstance()->persistentMapFromArray([]);
         return $meta;
     }
 

--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -13,7 +13,7 @@ Runtime execution: runs Phel namespaces/files, REPL, evaluation, testing, and mo
 
 ## Dependencies
 
-Most connected module, 4 Provider facades: Build (namespace extraction, dependency resolution, file evaluation), Compiler (compilation, evaluation, environment), Command (directories, error formatting), Api (REPL autocompletion). Version comes from `Shared\VersionResolver` directly, so Run does not depend on Console.
+Most connected module, 5 Provider facades: Build (namespace extraction, dependency resolution, file evaluation), Compiler (compilation, evaluation, environment), Command (directories, error formatting), Api (REPL autocompletion), Filesystem (module health check, surfaced by `phel doctor`). Version comes from `Shared\VersionResolver` directly, so Run does not depend on Console.
 
 ## Structure Notes
 

--- a/src/php/Run/Infrastructure/Command/DoctorCommand.php
+++ b/src/php/Run/Infrastructure/Command/DoctorCommand.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Phel\Run\Infrastructure\Command;
 
-use Gacela\Framework\Gacela;
 use Gacela\Framework\Health\HealthChecker;
 use Gacela\Framework\Health\HealthStatus;
-use Phel\Build\BuildFacade;
-use Phel\Filesystem\FilesystemFacade;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Phel\Run\RunFacade;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -16,8 +16,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function extension_loaded;
 use function sprintf;
 
+/**
+ * @method RunFacade getFacade()
+ */
+#[ServiceMap(method: 'getFacade', className: RunFacade::class)]
 final class DoctorCommand extends Command
 {
+    use ServiceResolverAwareTrait;
+
     protected function configure(): void
     {
         $this->setName('doctor')
@@ -68,10 +74,7 @@ final class DoctorCommand extends Command
         $output->writeln('');
         $output->writeln('Checking module health:');
 
-        $report = new HealthChecker([
-            Gacela::getRequired(FilesystemFacade::class)->getHealthCheck(),
-            Gacela::getRequired(BuildFacade::class)->getHealthCheck(),
-        ])->checkAll();
+        $report = new HealthChecker($this->getFacade()->getModuleHealthChecks())->checkAll();
 
         foreach ($report->getResults() as $moduleName => $status) {
             $output->writeln(sprintf(

--- a/src/php/Run/RunFacade.php
+++ b/src/php/Run/RunFacade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Run;
 
 use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
 use Phel\Run\Application\Test\CpuCountDetector;
 use Phel\Run\Application\Test\ParallelTestOrchestrator;
 use Phel\Shared\CompileOptions;
@@ -161,5 +162,13 @@ final class RunFacade extends AbstractFacade implements RunFacadeInterface
     public function createCpuCountDetector(): CpuCountDetector
     {
         return $this->getFactory()->createCpuCountDetector();
+    }
+
+    /**
+     * @return list<ModuleHealthCheckInterface>
+     */
+    public function getModuleHealthChecks(): array
+    {
+        return $this->getFactory()->getModuleHealthChecks();
     }
 }

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Phel\Run;
 
 use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
+use Phel\Filesystem\FilesystemFacadeInterface;
 use Phel\Run\Application\BundledNamespaceDetector;
 use Phel\Run\Application\BundledNamespaces;
 use Phel\Run\Application\CompileExecutor;
@@ -185,6 +187,24 @@ class RunFactory extends AbstractFactory
         /** @var ApiFacadeInterface $facade */
         $facade = $this->getProvidedDependency(RunProvider::FACADE_API);
         return $facade;
+    }
+
+    public function getFilesystemFacade(): FilesystemFacadeInterface
+    {
+        /** @var FilesystemFacadeInterface $facade */
+        $facade = $this->getProvidedDependency(RunProvider::FACADE_FILESYSTEM);
+        return $facade;
+    }
+
+    /**
+     * @return list<ModuleHealthCheckInterface>
+     */
+    public function getModuleHealthChecks(): array
+    {
+        return [
+            $this->getBuildFacade()->getHealthCheck(),
+            $this->getFilesystemFacade()->getHealthCheck(),
+        ];
     }
 
     public function createVersionResolver(): VersionResolver

--- a/src/php/Run/RunProvider.php
+++ b/src/php/Run/RunProvider.php
@@ -11,6 +11,7 @@ use Phel\Api\ApiFacade;
 use Phel\Build\BuildFacade;
 use Phel\Command\CommandFacade;
 use Phel\Compiler\CompilerFacade;
+use Phel\Filesystem\FilesystemFacade;
 
 final class RunProvider extends AbstractProvider
 {
@@ -21,6 +22,8 @@ final class RunProvider extends AbstractProvider
     public const string FACADE_BUILD = 'FACADE_BUILD';
 
     public const string FACADE_API = 'FACADE_API';
+
+    public const string FACADE_FILESYSTEM = 'FACADE_FILESYSTEM';
 
     #[Provides(self::FACADE_COMMAND)]
     public function commandFacade(Container $container): CommandFacade
@@ -44,5 +47,11 @@ final class RunProvider extends AbstractProvider
     public function apiFacade(Container $container): ApiFacade
     {
         return $container->getLocator()->getRequired(ApiFacade::class);
+    }
+
+    #[Provides(self::FACADE_FILESYSTEM)]
+    public function filesystemFacade(Container $container): FilesystemFacade
+    {
+        return $container->getLocator()->getRequired(FilesystemFacade::class);
     }
 }

--- a/src/php/Shared/Facade/BuildFacadeInterface.php
+++ b/src/php/Shared/Facade/BuildFacadeInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Facade;
 
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
 use Phel\Build\Domain\Compile\CompiledFile;
 use Phel\Shared\NamespaceInformation;
 
@@ -56,4 +57,9 @@ interface BuildFacadeInterface
      * @param string $src The source file
      */
     public function evalFile(string $src): CompiledFile;
+
+    /**
+     * Returns the module's health check for diagnostics (`phel doctor`).
+     */
+    public function getHealthCheck(): ModuleHealthCheckInterface;
 }

--- a/src/php/Shared/Facade/RunFacadeInterface.php
+++ b/src/php/Shared/Facade/RunFacadeInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Facade;
 
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
 use Phel\Shared\CompileOptions;
 use Phel\Shared\Eval\EvalResult;
 use Phel\Shared\Exceptions\CompilerException;
@@ -80,4 +81,11 @@ interface RunFacadeInterface
      * @param string|null $replStartupFile Optional startup file path, defaults to config value if null
      */
     public function loadPhelNamespaces(?string $replStartupFile = null): void;
+
+    /**
+     * Health checks for the modules surfaced by `phel doctor`.
+     *
+     * @return list<ModuleHealthCheckInterface>
+     */
+    public function getModuleHealthChecks(): array;
 }

--- a/tests/php/Unit/Compiler/Domain/Analyzer/Ast/Reference/LocalVarReferencesTest.php
+++ b/tests/php/Unit/Compiler/Domain/Analyzer/Ast/Reference/LocalVarReferencesTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\ConstantHoisting;
+namespace PhelTest\Unit\Compiler\Domain\Analyzer\Ast\Reference;
 
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
@@ -10,8 +10,8 @@ use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MethodCallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\Reference\LocalVarReferences;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
-use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\LocalVarReferences;
 use Phel\Lang\Symbol;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/php/Unit/Watch/Application/ReloadOrchestratorTest.php
+++ b/tests/php/Unit/Watch/Application/ReloadOrchestratorTest.php
@@ -328,6 +328,11 @@ final class FakeRunFacade implements RunFacadeInterface
     }
 
     public function loadPhelNamespaces(?string $replStartupFile = null): void {}
+
+    public function getModuleHealthChecks(): array
+    {
+        return [];
+    }
 }
 
 final class FakeProjectReindexer implements ProjectReindexerInterface


### PR DESCRIPTION
## 🤔 Background

A quality pass over the PHP modules, driven by architecture audits (Compiler, Lang, Run, Build) + a PhelConfig analysis. Boundaries were already clean, so this lands the few genuine issues found.

## 💡 Goal

Improve module quality (phase order, leaf purity, DI, readability) with **no behavior change**. Every commit passes the full CI gate (cs-fixer, psalm L1, phpstan L9, 4332 PHP + 5941 Phel tests).

## 🔖 Changes

- **Compiler phase order** — `LocalVarReferences` (AST walker) was under the emitter but consumed by the analyzer; moved to `Analyzer/Ast/Reference/` so consumers are forward deps.
- **Lang leaf purity** — dropped the top-tier `use Phel;` facade reach-up in `Registry`/`PartitionGenerator`/`AbstractPersistentStruct`; use in-module `TypeFactory`/`Keyword`. Lang now imports only itself + `Shared`.
- **PhelConfig** — moved 26 deprecated `set*()`/`use*Layout()` shims into a `PhelConfigDeprecations` trait (799 → 624 lines); public API unchanged.
- **DoctorCommand** — inject facades via `RunFacade::getModuleHealthChecks()` instead of `Gacela::getRequired()` (the only command using the locator). Verified with `phel doctor`.
- **Docs** — worker-runtime deployment guide (`docs/deployment.md`).

Module `CLAUDE.md` docs updated to match.

## 🧪 Investigated, deliberately not done

- **Build cache dedup** (`CacheIndexFile`/`PhpNamespaceCache`): only ~3 shared lines; the surrounding lock/merge/state logic differs by design. A shared store would add more complexity than it removes, in prod-bug-prone invalidation code.
- **Shared facade → owner-type cycle**: intrinsic to facades exposing typed compiler results (`analyze(): AbstractNode`), and the documented accepted DIP pattern. Full fix would invert the architecture.
