### PR TITLE
docs: simplify, de-duplicate, and correct docs/ guides

### DIFF
--- a/docs/agent-docs.md
+++ b/docs/agent-docs.md
@@ -13,11 +13,18 @@ composer require phel-lang/phel-lang
 ./vendor/bin/phel agent-install --all --with-examples  # also copy runnable example apps
 ```
 
-Platforms: `claude`, `cursor`, `codex`, `gemini`, `copilot`, `aider`. Omit the platform with `--auto` to install only for agents already present (`.claude/`, `.cursor/`, `AGENTS.md`, ...).
+Platforms: `claude`, `cursor`, `codex`, `gemini`, `copilot`, `aider`. `--auto` installs only for agents already present (`.claude/`, `.cursor/`, `AGENTS.md`, ...).
 
-`.agents/` docs (rules, task recipes, quick-syntax) are copied by default; `--no-docs` skips them. Example apps are excluded by default; `--with-examples` includes `.agents/examples/`.
+| Flag | Effect |
+|------|--------|
+| (default) | Copies `.agents/` docs (rules, task recipes, quick-syntax) |
+| `--no-docs` | Skip the `.agents/` docs tree |
+| `--with-examples` | Also copy `.agents/examples/` (excluded by default) |
+| `--force` | Skip the `<path>.pre-phel.bak` backup; overwrite existing skill files and `.agents/` tree |
+| `--dry-run` | Preview without writing |
+| `--uninstall` | Remove skill file(s) (restoring any backup) and the `.agents/` tree |
 
-Existing skill files back up to `<path>.pre-phel.bak`. `--force` skips backup and overwrites an existing `.agents/` tree, `--dry-run` previews, `--uninstall` removes the skill file(s) (restoring any backup) and the `.agents/` tree. Re-run any time to pull the latest docs.
+Re-run any time to pull the latest docs.
 
 ## Destinations
 
@@ -40,9 +47,11 @@ Each installed file routes the agent to `.agents/index.md` for task recipes: sca
 - `http-json-api/`: three JSON endpoints
 - `cli-wordcount/`: stdin + argv, PHP shim binary
 
+`composer test-agents` runs every example's tests against current source; breaking a public API surfaces as a red build on PR.
+
 ## Sync
 
-`resources/agents/VERSION` tracks the targeted phel-lang release. `composer test-agents` runs every example's tests against current source; breaking a public API surfaces as a red build on PR.
+`resources/agents/VERSION` tracks the targeted phel-lang release.
 
 ## Repository maintenance adapters
 

--- a/docs/agent-metrics.md
+++ b/docs/agent-metrics.md
@@ -1,6 +1,6 @@
 # Cold-start metrics
 
-Template for tracking how long each agent takes to build a representative app from a cold session, with and without the Phel agent skill.
+Template for tracking how long each agent takes to build a representative app from a cold session, with and without the Phel agent skill installed.
 
 ## Scenario
 
@@ -38,4 +38,4 @@ Target:
 
 ## Why this matters
 
-Before bundled agent assets, a cold run took ~23 minutes for Claude Code to build a todo app, most of it scraping phel-lang.org. `resources/agents/` aims to drive that well under 5 minutes for any supported agent.
+Before bundled agent assets, a cold Claude Code run took ~23 minutes to build a todo app, most of it scraping phel-lang.org. `resources/agents/` aims to drive that well under 5 minutes for any supported agent.

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -35,9 +35,9 @@
 | `:timeout` | `120` | HTTP timeout (seconds) |
 | `:max-retries` | `2` | Retry 429/5xx with exponential backoff |
 
-Default model evolves with `src/phel/ai.phel`; check there for the current value.
+The default model evolves with `src/phel/ai.phel`; check there for the current value.
 
-Every per-call `opts` map (on `chat`, `complete`, `chat-with-tools`, `extract`, `extract-many`) accepts the same keys for per-request overrides:
+Every per-call `opts` map (`chat`, `complete`, `chat-with-tools`, `extract`, `extract-many`) accepts these keys for per-request overrides:
 
 ```phel
 (ai/complete "Summarize the news" {:provider :openai :model "gpt-4o-mini"})
@@ -97,7 +97,7 @@ Define tools with provider-agnostic `tool`, then either hand off to `run-tools` 
 ;; => "It's 72F and sunny in Paris."
 ```
 
-`run-tools` sends the conversation, resolves tool calls via `handlers` (tool name to fn), feeds results back, and stops when the model returns plain text or `:max-turns` is reached. Anthropic-only.
+`run-tools` sends the conversation, resolves tool calls via `handlers` (tool-name to fn), feeds results back, and stops when the model returns plain text or `:max-turns` is reached. Anthropic-only.
 
 For finer control, use `chat-with-tools` directly:
 
@@ -142,7 +142,7 @@ All failures throw `\RuntimeException`. Messages include HTTP status and provide
 
 ## Testing without a live API
 
-`phel.ai` exposes an HTTP seam `*http-post*` that tests rebind to return canned responses. Combined with `phel.mock`, this removes the dependency on a real provider.
+`phel.ai` exposes an HTTP seam `*http-post*` that tests rebind to return canned responses. Combined with `phel.mock`, this removes the dependency on a live provider.
 
 ```phel
 (ns my-app.test.ai-test

--- a/docs/async-guide.md
+++ b/docs/async-guide.md
@@ -2,9 +2,9 @@
 
 Two concurrency layers over PHP fibers. Most primitives live in `phel.core` (no require). `delay` lives in `phel.async` because Phel's `delay` sleeps, unlike `clojure.core/delay` (a lazy-thunk wrapper).
 
-**AMPHP-backed layer.** Built on `amphp/amp`; an event loop drives fiber-based IO, timers, and combinators. `async`, `await`, `await-all`, `await-any`, `pmap`, `future`, `future-cancel`, `future-cancelled?` in `phel.core`; `delay` in `phel.async`. Use inside an event loop, for timers, IO multiplexing, or fan-out across many Futures.
+**AMPHP-backed layer.** Built on `amphp/amp`; an event loop drives fiber-based IO, timers, and combinators. Functions: `async`, `await`, `await-all`, `await-any`, `pmap`, `future`, `future-cancel`, `future-cancelled?` (in `phel.core`); `delay` (in `phel.async`). Use inside an event loop, for timers, IO multiplexing, or fan-out across many Futures.
 
-**Fiber-backed layer.** Cooperative single-threaded scheduler in `\Phel\Fiber\FiberFacade`, no event loop. `promise`, `deliver`, `future-call`, `future-fiber`, `future?` in `phel.core`. Safe at the top level of a script or REPL. Good for CPU coordination, producer/consumer handoffs, lightweight deref-with-timeout.
+**Fiber-backed layer.** Cooperative single-threaded scheduler in `\Phel\Fiber\FiberFacade`, no event loop. Functions: `promise`, `deliver`, `future-call`, `future-fiber`, `future?` (in `phel.core`). Safe at the top level of a script or REPL. Good for CPU coordination, producer/consumer handoffs, lightweight deref-with-timeout.
 
 ## When to use which
 
@@ -22,7 +22,7 @@ Rule of thumb: fiber layer for plain scripts; AMPHP layer when IO, timers, or AM
 
 ### `async`
 
-`(async body...)` schedules `body` on the AMPHP event loop in a fresh fiber and returns `Amp\Future`. Amp v3 manages the loop automatically; no explicit `Loop::run` needed. Exceptions surface when awaited.
+`(async body...)` schedules `body` on the AMPHP event loop in a fresh fiber and returns `Amp\Future`. Amp v3 manages the loop automatically; no explicit `Loop::run` needed. Exceptions surface when awaited. Captures the caller's dynamic `binding`s and reinstalls them inside the fiber (binding conveyance, as in Clojure's `future`).
 
 ```phel
 (await (async (+ 1 2))) ;; => 3
@@ -45,7 +45,7 @@ Rule of thumb: fiber layer for plain scripts; AMPHP layer when IO, timers, or AM
 
 ### `delay` (in `phel.async`)
 
-`(delay seconds)` suspends for `seconds` (float) via `Amp\delay`. At top level it behaves like `php/sleep`; inside an `async`/`future` body it suspends the *fiber* only and becomes cancellable via `future-cancel`.
+`(delay seconds)` suspends for `seconds` (any number; cast to float) via `Amp\delay`. At top level it behaves like `php/sleep`; inside an `async`/`future` body it suspends the *fiber* only and becomes cancellable via `future-cancel`.
 
 > **Not Clojure's `delay`.** `clojure.core/delay` is a lazy-thunk wrapper, not a sleep. Phel's `delay` lives in `phel.async` (not `phel.core`) to keep the difference visible to `.cljc` portable code.
 
@@ -69,7 +69,7 @@ Rule of thumb: fiber layer for plain scripts; AMPHP layer when IO, timers, or AM
 
 ### `pmap`
 
-`(pmap f coll)` / `(pmap f coll1 coll2 ...)` is concurrent `map` via fibers; results in input order. PHP fibers are cooperative on a single thread: `pmap` overlaps IO-bound work (HTTP, DB, file IO) but does **not** parallelize CPU work across cores. ClojureScript and Basilisp follow the same single-threaded model; `clojure.core/pmap` uses a thread pool.
+`(pmap f coll)` / `(pmap f coll1 coll2 ...)` is concurrent `map` via fibers; results in input order. With multiple collections, stops at the shortest. PHP fibers are cooperative on a single thread: `pmap` overlaps IO-bound work (HTTP, DB, file IO) but does **not** parallelize CPU work across cores. ClojureScript and Basilisp follow the same single-threaded model; `clojure.core/pmap` uses a thread pool.
 
 ### `future`
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1,6 +1,6 @@
 # Building CLIs with `phel.cli`
 
-`phel.cli` is a data-driven wrapper over [`symfony/console`](https://symfony.com/doc/current/components/console.html) (which ships with phel-lang, no extra dependency). Subcommands, arguments, options, prompts, tables, progress bars, shell completion, and signal handling are all plain Phel maps.
+`phel.cli` is a data-driven wrapper over [`symfony/console`](https://symfony.com/doc/current/components/console.html) (bundled with phel-lang, no extra dependency). Subcommands, arguments, options, prompts, tables, progress bars, shell completion, and signal handling are all plain Phel maps.
 
 ## Quickstart
 
@@ -173,10 +173,10 @@ Available `:style` values: `:default`, `:borderless`, `:compact`, `:symfony`, `:
          :complete (fn [_input] ["dev" "staging" "prod"])}]}
 ```
 
-Symfony calls your completion function on `<TAB>` once the shell completion script is installed:
+Symfony calls your completion function on `<TAB>` once the shell completion script is installed. Dump it with the built-in `completion` command (supports `bash`, `zsh`, `fish`):
 
 ```bash
-my-tool _complete --generate-hook=bash > ~/.bash_completion.d/my-tool
+my-tool completion bash > ~/.bash_completion.d/my-tool
 ```
 
 ## Signal handling
@@ -229,7 +229,7 @@ For prompt testing, pipe canned STDIN:
 
 ## Running under `phel run`
 
-Under `./bin/phel run path/to/script.phel arg1 arg2`, Phel's own console occupies `$_SERVER['argv']`; user args arrive through the core var `argv`. Pass them explicitly:
+Under `./bin/phel run path/to/script.phel arg1 arg2`, Phel's own console occupies `$_SERVER['argv']`; user args arrive through the core var `argv`. Pass them explicitly.
 
 ```phel
 ;; Bad: reads the wrapper's argv, so "run" looks like your first command.
@@ -239,7 +239,7 @@ Under `./bin/phel run path/to/script.phel arg1 arg2`, Phel's own console occupie
 (cli/run app (cli/argv argv))
 ```
 
-Only needed under `phel run`. A standalone binary built with `phel build` reads `$_SERVER['argv']` directly, so `(cli/run app)` is fine there.
+This is only needed under `phel run`. A standalone binary built with `phel build` reads `$_SERVER['argv']` directly, so `(cli/run app)` works there.
 
 ## Best practices
 

--- a/docs/clojure-migration.md
+++ b/docs/clojure-migration.md
@@ -6,16 +6,12 @@ Phel is a Lisp compiling to PHP. If you know Clojure, you know most of Phel; thi
 
 | Clojure | Phel | Notes |
 |---------|------|-------|
-| `(ns my.app (:require [clojure.string :as str]))` | `(ns my.app (:require phel.string :as str))` | `.` separator (matches Clojure); `\` accepted for back-compat but deprecated |
-| `(.method obj arg)` | `(php/-> obj (method arg))` | Instance method |
-| `(Class/staticMethod arg)` | `(php/:: Class (method arg))` | Static method |
-| `(ClassName. arg)` | `(ClassName. arg)`, `(new ClassName arg)`, `(php/new ClassName arg)` | All read as `(php/new ClassName ...)` |
-| `(.-field obj)` | `(php/-> obj -field)` | Property access |
-| `(:import [java.util Date])` | `(:use DateTime)` in `ns` | Imports a PHP class by short name; FQNs too: `(:use Phel\Lang\Symbol)` |
-| `(instance? Type x)` | `(instance? Type x)` or `(php/instanceof x Type)` | `instance?` macro wraps `php/instanceof` with Clojure's arg order |
+| `(ns my.app (:require [clojure.string :as str]))` | `(ns my.app (:require phel.string :as str))` | `.` separator (see [Namespace syntax](#namespace-syntax)) |
 | `(class x)` | `(type x)` | Returns a keyword: `:string`, `:int`, `:hash-map` |
 | `(subs s start end)` | `(phel.string/subs s start end)` | Substring |
 | `(clojure.string/upper-case s)` | `(phel.string/upper-case s)` | String utils in `phel.string` |
+
+For the full Java-interop-to-PHP-interop mapping, see [PHP interop (vs Java interop)](#php-interop-vs-java-interop) below.
 
 ## What's the same
 
@@ -34,7 +30,8 @@ Most of Clojure's core library works identically:
 - **Metadata**: `meta`, `with-meta`, `vary-meta`, `^:keyword` reader syntax
 - **Atoms**: `atom`, `deref` / `@`, `swap!`, `reset!`, `add-watch`, `remove-watch`, `set-validator!`
 - **Taps**: `tap>`, `add-tap`, `remove-tap` (synchronous dispatch; no background queue)
-- **Futures**: `future` / `future-fiber` (in `phel.core`). Note: `delay` lives in `phel.async` and is a sleep, not a lazy thunk; `force`/`delay?` do not exist.
+- **Futures**: `future` / `future-fiber` (in `phel.core`).
+- **Delays**: Clojure-compatible `delay` / `force` / `delay?` (lazy thunks, in `phel.core`). A separate suspending-sleep `delay` lives in `phel.async` and shadows the core name when required.
 - **Exceptions**: `ex-info`, `ex-data`, `ex-message`, `ex-cause`, `throw`, `try` / `catch` / `finally`
 - **Transducers**: `transduce`, `into` (3-arg), `sequence`, `completing`, `cat`, plus transducer arities for `map`, `filter`, `take`, `drop`, `keep`, `distinct`, `dedupe`, `mapcat`, `interpose`, and more
 - **Testing**: `deftest`, `is`, `testing`, `are`, `do-report`, extensible `assert-expr` (in `phel.test`)
@@ -69,24 +66,21 @@ Notes:
 
 ## Namespace syntax
 
-Phel uses `.` as the separator, matching Clojure. The legacy `\` separator still parses but is deprecated.
+Phel uses `.` as the separator, matching Clojure. The legacy `\` separator still parses but is deprecated; see [backslash-to-dot migration](migration/backslash-to-dot.md).
 
 ```phel
 ;; Preferred (Clojure-style):
 (ns my.app (:require phel.string :as str))
 
-;; Vector-style :require:
-(ns my.app (:require [phel.string :as str :refer [upper-case]]))
-
 ;; Legacy (deprecated, still parses):
 (ns my\app (:require phel\string :as str))
 ```
 
-See [backslash-to-dot migration](migration/backslash-to-dot.md).
+`:require` accepts both list and vector entries (full `:use`/`:require` reference: [php-interop.md](php-interop.md)).
 
 **Automatic aliasing**: `clojure.*` namespaces in `:require` resolve to `phel.*` when the target exists. `.cljc` files using `(:require [clojure.string :as str])` work unchanged.
 
-**Importing PHP classes**: use `(:use ...)` (Phel's equivalent of `(:import ...)`). PHP class names keep `\` as their native separator:
+**Importing PHP classes**: use `(:use ...)` (Phel's equivalent of Clojure's `(:import ...)`). PHP class names keep `\` as their native separator:
 
 ```phel
 (ns my.app
@@ -117,25 +111,11 @@ See [backslash-to-dot migration](migration/backslash-to-dot.md).
 
 Any PHP function works with the `php/` prefix: `(php/array_map f arr)`, `(php/strtolower "HELLO")`, `(php/json_encode {:a 1})`, `(php/date "Y-m-d")`.
 
+Full interop semantics (by-reference args, named arguments, first-class callables, type conversions): see [php-interop.md](php-interop.md).
+
 ## .cljc cross-compilation
 
-`.cljc` files with reader conditionals share code between Clojure and Phel:
-
-```clojure
-(ns shared.utils
-  (:require #?(:phel phel.string
-               :clj  [clojure.string :as str])))
-
-(defn greet [name]
-  #?(:phel (str "Hello, " name "!")
-     :clj  (str "Hello, " name "!")))
-```
-
-Platform tags: `:phel`, `:clj`, `:cljs`, `:default`. Phel selects `:phel` first, then `:default`. Splice variant embeds multiple forms:
-
-```clojure
-[1 2 #?@(:phel [3 4] :clj [5 6])]   ; In Phel: [1 2 3 4]
-```
+`.cljc` files share code between Clojure and Phel via reader conditionals `#?()`/`#?@()`, selecting the `:phel` branch first, then `:default`. See [reader-conditionals.md](reader-conditionals.md).
 
 ## Clojure-compatible renames
 
@@ -159,13 +139,13 @@ Old Phel-specific names still work but are deprecated (removed in a future major
 |-----------------|------------|-------------|
 | **Refs / STM** | No concurrent transactions in PHP | Use `atom` for mutable state |
 | **Agents** | No background threads | PHP job queues via interop |
-| **core.async** | No goroutines/CSP; fiber primitives (`promise`, `deliver`, `future-fiber`) cover CSP-lite handoffs, all in `phel.core` except `delay` (needs `phel.async`) | See [async-guide.md](async-guide.md) |
+| **core.async** | No goroutines/CSP; fiber primitives (`promise`, `deliver`, `future-fiber`) in `phel.core` cover CSP-lite handoffs | See [async-guide.md](async-guide.md) |
 | **BigInt / BigDecimal / Ratio** | First-class `Phel\Lang\BigInt`, `Phel\Lang\BigDecimal`, `Phel\Lang\Ratio` ship in core | Literals `1N`, `1.5M`, `1/2` or constructors `bigint`, `bigdec`, `rationalize`. See [numeric-tower.md](numeric-tower.md) |
 | **Character type** | PHP has no char type | `\a` literals and `char` / `char?` compile to single-char strings |
 | **Spec** | Not ported | Runtime assertions or PHP validation (also `phel.schema`) |
 | **`alter-var-root`** | Available: `(alter-var-root #'sym f)` re-roots the global binding | `with-redefs` for scoped overrides; `add-watch`/`remove-watch` on vars for tracking |
 
-The async surface lives in `phel.core` (no require): `future`, `future-cancel`, `future-cancelled?`, `future-done?`, `future?`, `pmap`, `promise`, `deliver`, plus fiber combinators `async`, `await`, `await-all`, `await-any`, `future-call`, `future-fiber`, `->closure`. Built on AMPHP fibers. Semantics match `future` where possible (including timeout-bounded `deref`), but cancellation is cooperative and `pmap` is single-threaded (overlaps IO, does not parallelize CPU). Only `delay` needs `(:require phel.async)`, since Phel's `delay` is a sleep primitive. See [async-guide.md](async-guide.md).
+The async surface lives in `phel.core` (no require): `future`, `future-cancel`, `future-cancelled?`, `future-done?`, `future?`, `pmap`, `promise`, `deliver`, plus fiber combinators `async`, `await`, `await-all`, `await-any`, `future-call`, `future-fiber`, `->closure`. Built on AMPHP fibers. Semantics match `future` where possible (including timeout-bounded `deref`), but cancellation is cooperative and `pmap` is single-threaded (overlaps IO, does not parallelize CPU). Phel's `delay` / `force` / `delay?` are Clojure-compatible lazy thunks (in `phel.core`); a separate suspending-sleep `delay` needs `(:require phel.async)` and shadows the core name. See [async-guide.md](async-guide.md).
 
 ## Structural differences
 
@@ -205,13 +185,7 @@ Inline protocol methods work in both (spliced into `extend-type`); `reify` gives
 
 ### No lazy-seq by default
 
-Phel sequences are eager; use `lazy-seq` when needed. `(range)` with 0 args returns an infinite lazy sequence.
-
-```phel
-(defn lazy-fib
-  ([] (lazy-fib 0 1))
-  ([a b] (lazy-seq (cons a (lazy-fib b (+ a b))))))
-```
+Phel sequences are eager; use `lazy-seq` when needed. `(range)` with 0 args returns an infinite lazy sequence. See [lazy-sequences.md](lazy-sequences.md).
 
 ### Test framework
 
@@ -235,10 +209,10 @@ Extend `is` with custom assertions: `(defmethod phel.test/assert-expr 'my-form [
 ## Migration checklist
 
 1. Rename `.clj` files to `.phel` (or `.cljc` for shared code)
-2. Use `.` namespace separators (e.g. `my.app.core`); legacy `\` still parses but is deprecated
+2. Use `.` namespace separators (see [Namespace syntax](#namespace-syntax))
 3. Replace Java interop with PHP interop (`(.method obj)` → `(php/-> obj (method))`)
 4. Rewrite `(:import [java.util Date])` as `(:use DateTime)` in the `ns` form
-5. Replace concurrency primitives (refs, agents, core.async) with `atom` or the AMPHP-backed `phel.core` primitives (`future`, `pmap`, `promise`, `deliver`, ...); add `(:require phel.async :refer [delay])` only for the sleep primitive
+5. Replace concurrency primitives (refs, agents, core.async) with `atom` or the AMPHP-backed `phel.core` primitives (`future`, `pmap`, `promise`, `deliver`, ...); `(:require phel.async :refer [delay])` only for the suspending-sleep `delay` (the lazy-thunk `delay` is already in core)
 6. Run `./bin/phel test` to verify
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,9 +1,8 @@
 # Configuration
 
-A Phel project is configured by a `phel-config.php` file at the project root
-that returns a `Phel\Config\PhelConfig` object. Phel works with **zero config**:
-if the file is absent, the project layout is auto-detected. Add the file when
-you need to change defaults.
+A Phel project is configured by a `phel-config.php` at the project root that
+returns a `Phel\Config\PhelConfig` object. Phel works with **zero config**: if
+the file is absent, the layout is auto-detected. Add the file to change defaults.
 
 ```php
 <?php
@@ -18,7 +17,7 @@ return PhelConfig::forProject(ProjectLayout::Nested)
 ```
 
 Every option has an immutable `with*()` setter that returns a new instance, so
-calls chain. Inspect the effective, merged result at any time with:
+calls chain. Inspect the effective, merged result with:
 
 ```bash
 phel config          # human-readable, with sources
@@ -30,7 +29,7 @@ phel config --json   # just the resolved config map
 `PhelConfig::forProject(ProjectLayout $layout = Flat, string $mainNamespace = '')`
 and `withLayout(ProjectLayout)` set the source/test/format/export directories in
 one step. `withLayout()` resets all four directory groups to the layout's
-defaults (it does not touch build, cache, or flags).
+defaults; it leaves build, cache, and flags untouched.
 
 | Layout   | src dirs     | test dirs      | format dirs              | export-from   |
 | -------- | ------------ | -------------- | ------------------------ | ------------- |
@@ -58,7 +57,7 @@ All directory paths are relative to the project root.
 | `withNoCacheWhenBuilding(array)`| `no-cache-when-building`     | `[]`               | Force recompilation of files during `phel build` (see below). |
 | `withEnableNamespaceCache(bool)`| `enable-namespace-cache`     | `true`             | Cache parsed namespace metadata (see [caching](#caching)). |
 | `withEnableCompiledCodeCache(bool)` | `enable-compiled-code-cache` | `true`         | Cache compiled PHP output (see [caching](#caching)). |
-| `withOptimizationLevel(int)`    | `optimization-level`         | `0`                | Compiler optimization level for `build`/`run`/`test` (REPL/nREPL stay at 0). |
+| `withOptimizationLevel(int)`    | `optimization-level`         | `0`                | Compiler optimization level for `build`/`run`/`test` (see [performance.md](performance.md) for level semantics). |
 | `withTempDir(string)`           | `temp-dir`                   | system temp `/phel/tmp` | Transient compilation artifacts (e.g. `(load ...)`). |
 | `withCacheDir(string)`          | `cache-dir`                  | `'.phel/cache'`    | Persistent cache root (overridden by `PHEL_CACHE_DIR`). |
 | `withPhelDir(string)`           | `phel-dir`                   | `''`               | Relocate the whole `.phel/` state dir (overridden by `PHEL_DIR`). See [Project Layout](project-layout.md). |
@@ -86,10 +85,13 @@ Set via flattened setters, or by passing a `PhelExportConfig` to
 | `withExportNamespacePrefix(string)` | `namespace-prefix` | `'PhelGenerated'`  | PHP namespace prefix for generated wrappers. |
 | `withExportTargetDirectory(string)` | `target-directory` | `'src/PhelGenerated'` | Directory `phel export` writes generated PHP into. |
 
-> **Ordering:** `withBuildConfig()` and `withExportConfig()` replace the whole
-> value object, overwriting anything set via the flattened setters above (and
-> resetting unspecified fields to their defaults). Call them *before* the
-> flattened setters, or just use the flattened setters.
+> **Ordering:** `withBuildConfig()` / `withExportConfig()` accept either form:
+> - A `PhelBuildConfig` / `PhelExportConfig` **replaces the whole value object**,
+>   overwriting anything set via the flattened setters above and resetting
+>   unspecified fields to their defaults, so call it *before* the flattened setters.
+> - A **configurator closure** (`fn ($b) => $b->withDestDir('dist')`) patches the
+>   current value object in place and composes with the flattened setters
+>   regardless of call order.
 
 ## Ignore vs. no-cache when building
 
@@ -116,17 +118,17 @@ Phel keeps two independent caches under the cache dir; both are on by default.
 | `enable-namespace-cache`      | parsed namespace metadata (`(ns ...)` deps) | `<cache-dir>/namespace-cache.php` |
 | `enable-compiled-code-cache`  | compiled PHP output, keyed by content hash | `<cache-dir>/compiled/`        |
 
-The compiled-code cache is also invalidated when the optimization level
-changes. Disable either flag to force re-parsing / recompilation (useful when
-hacking on the compiler itself). See [Performance](performance.md) for cache
-reset tips and [Project Layout](project-layout.md) for the `.phel/` directory.
+Disable either flag to force re-parsing / recompilation (useful when hacking on
+the compiler). See [Performance](performance.md) for cache reset tips, opcache
+interaction, and optimization-level invalidation, and [Project Layout](project-layout.md)
+for relocating the `.phel/` directory.
 
 ## Local overrides: `phel-config-local.php`
 
-A second, optional `phel-config-local.php` at the project root is merged on top
-of `phel-config.php`. Use it for per-developer or per-machine settings you do
-not want to commit (`phel init` adds it to `.gitignore`). It returns a
-`PhelConfig` just like the main file:
+An optional `phel-config-local.php` at the project root is merged on top of
+`phel-config.php`. Use it for per-developer or per-machine settings you do not
+want to commit (`phel init` adds it to `.gitignore`). It returns a `PhelConfig`
+like the main file:
 
 ```php
 <?php
@@ -151,4 +153,6 @@ When the same setting comes from multiple sources, the highest wins:
 4. `PhelConfig` constructor defaults
 5. Auto-detected layout (only when no `phel-config.php` exists)
 
-Run `phel config` to see which files were applied and the resulting values.
+Run `phel config` to see which files were applied and the resulting values. For
+`.phel/` relocation and the `PHEL_DIR` / `PHEL_CACHE_DIR` / `withCacheDir` env-var
+precedence, see [Project Layout](project-layout.md).

--- a/docs/data-formats.md
+++ b/docs/data-formats.md
@@ -1,11 +1,11 @@
 # Data Interchange Formats
 
-Phel ships two eval-free interchange modules for talking to other Clojure-aligned runtimes (or to itself across process boundaries):
+Phel ships two eval-free interchange modules for exchanging data with other Clojure-aligned runtimes (or with itself across process boundaries):
 
-- [`phel.edn`](#phel-edn): [Extensible Data Notation](https://github.com/edn-format/edn), the Clojure-native subset of reader syntax.
-- [`phel.transit`](#phel-transit): [Transit](https://github.com/cognitect/transit-format) layered on top of JSON.
+- [`phel.edn`](#pheledn): [Extensible Data Notation](https://github.com/edn-format/edn), the Clojure-native subset of reader syntax.
+- [`phel.transit`](#pheltransit): [Transit](https://github.com/cognitect/transit-format) layered on top of JSON.
 
-Neither goes through `eval`, so both are safe to point at untrusted input.
+Neither goes through `eval`, so both are safe on untrusted input.
 
 ## `phel.edn`
 
@@ -29,7 +29,7 @@ Neither goes through `eval`, so both are safe to point at untrusted input.
 
 `phel.edn` delegates reading to Phel's own reader and writing to `Printer::readable()`, so every value Phel can print readably round-trips: nil, booleans, integers, floats, strings, characters, keywords, symbols, lists, vectors, maps, sets, the `#_` discard form, `;` comments, and built-in tagged literals (`#uuid`, `#inst`, `#regex`).
 
-The lexer accepts EDN's full tag grammar, so namespaced tags (`#my.app/Person`, `#myapp/double`, `#my.app.module`) lex as a single tag. Unqualified tags (`#uuid`, `#inst`) work unchanged.
+The lexer accepts EDN's full tag grammar: namespaced tags (`#my.app/Person`, `#myapp/double`, `#my.app.module`) lex as a single tag, and unqualified tags (`#uuid`, `#inst`) work unchanged.
 
 ### Examples
 
@@ -65,7 +65,7 @@ The lexer accepts EDN's full tag grammar, so namespaced tags (`#my.app/Person`, 
 | `(read-string s)` / `(read-string s opts)` | Decode one Transit+JSON-Verbose value. |
 | `(write-string v)` | Encode `v` to a Transit+JSON-Verbose string. |
 
-This first iteration implements **JSON-Verbose** only: maps with string keys serialise to ordinary JSON objects (no key caching); any other map serialises as a `~#cmap`.
+This first iteration implements **JSON-Verbose** only (no key caching): maps with string keys serialise to ordinary JSON objects; any other map serialises as a `~#cmap`.
 
 ### Options map
 

--- a/docs/data-structures-guide.md
+++ b/docs/data-structures-guide.md
@@ -1,6 +1,6 @@
 # Data Structures Manipulation Guide
 
-Functions for Phel's immutable, persistent data structures (vectors, maps, sets, lists). Operations return new versions while sharing structure with the original: reads stay O(1) amortized, updates cost log32(n). Names follow Clojure conventions. See the [quick reference](#quick-reference).
+Functions for Phel's immutable, persistent data structures (vectors, maps, sets, lists). Operations return new versions while sharing structure with the original: reads stay O(1) amortized, updates cost log32(n). Names follow Clojure conventions. Jump to the [quick reference](#quick-reference).
 
 ## Strings as Sequences
 
@@ -120,16 +120,16 @@ Returns `true` if the key/index exists. Checks **keys/indices, not values**. **S
 (contains? [10 20 30] 3)    ; => false ; index 3 doesn't
 ```
 
-### `find` : find first match
+### `find` : find entry or first match
 
-Returns the first item where the predicate is true, else `nil`. **Signature:** `[pred coll]`
+Two modes by first arg. Associative (or `nil`) first arg: returns the `[key value]` entry when the key is present, else `nil` (Clojure-aligned). Otherwise treats the first arg as a predicate and returns the first item where it is true, else `nil`. **Signature:** `[pred-or-coll coll-or-key]`
 
 ```phel
-(find #(> % 5) [1 3 7 2 9])  ; => 7
+(find {:a 1 :b 2} :a)        ; => [:a 1]   ; entry lookup
+(find {:a 1} :x)             ; => nil
+(find #(> % 5) [1 3 7 2 9])  ; => 7        ; predicate search
 (find even? [1 3 5 7])       ; => nil
 ```
-
-**Clojure note:** Clojure's `find` returns a `[key value]` entry on associative structures; Phel's `find` is a general search function.
 
 ## Modifying
 
@@ -232,7 +232,7 @@ Remove a key (`dissoc`) or a nested key (`dissoc-in` ⭐). **Signatures:** `[ds 
 
 ## Transient Collections
 
-For hot paths with many sequential updates, use transients: efficient in-place mutation, then convert back to persistent. Mutate with the bang variants `conj!`, `assoc!`, `dissoc!`; finish with `persistent` (or its alias `persistent!`). Do not use a transient after converting it.
+For hot paths with many sequential updates, use transients: in-place mutation, then convert back to persistent. Mutate with the bang variants `conj!`, `assoc!`, `dissoc!`; finish with `persistent` (or its alias `persistent!`). Never use a transient after converting it.
 
 ```phel
 (def t (transient []))

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,14 +1,14 @@
 # Deployment & Worker Runtimes
 
 By default PHP is **shared-nothing**: every request boots a fresh process, so a
-Phel namespace does not persist between requests. `phel build` compiles your
+Phel namespace does not persist between requests. `phel build` compiles
 namespaces to PHP ahead of time and [opcache](performance.md) caches that
 bytecode, so nothing re-parses per request — but each request still re-runs
 every loaded namespace's top-level forms to register its `def`s.
 
-A **worker runtime** keeps the PHP process alive across requests. Your
-namespaces load **once** at boot and in-memory state survives between requests —
-much closer to the JVM/Clojure model.
+A **worker runtime** keeps the PHP process alive across requests: namespaces
+load **once** at boot and in-memory state survives between requests, much closer
+to the JVM/Clojure model.
 
 ## The one rule
 
@@ -33,8 +33,8 @@ require __DIR__ . '/vendor/autoload.php';
 require __DIR__ . '/build/app/main.php'; // once, outside the loop
 
 $handler = static function (): void {
-    // call an exported Phel function per request
-    echo \App\Main\handle_request();
+    // call an exported Phel wrapper per request
+    echo \App\PhelGenerated\App\Main::handleRequest();
 };
 
 while (frankenphp_handle_request($handler)) {
@@ -49,16 +49,16 @@ frankenphp php-server --root . --worker ./worker.php
 ```
 
 > **State is per-worker.** FrankenPHP runs several worker instances, each with
-> its own memory. An in-process value (an `atom`, a cache) is shared between
-> requests handled by the *same* worker, not across all of them. For state that
-> must be global, use Redis/APCu/DB. Append `,1` to the worker path
+> its own memory. An in-process value (an `atom`, a cache) is shared across
+> requests handled by the *same* worker, not across all of them. For global
+> state, use Redis/APCu/DB. Append `,1` to the worker path
 > (`--worker ./worker.php,1`) to pin a single worker.
 
 ## RoadRunner
 
 Same shape: require the built entry point once, then handle requests in the
-worker loop (via `spiral/roadrunner-http`'s PSR-7 worker), calling your exported
-Phel functions per request.
+worker loop (via `spiral/roadrunner-http`'s PSR-7 worker), calling exported Phel
+functions per request.
 
 ## When you do not need a worker runtime
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,10 +1,12 @@
 # Phel single-file showcase
 
-Standalone scripts from primitive literals through concurrency to a full CLI. Run any file with:
+Standalone scripts, from primitive literals through concurrency to a full CLI. Run any file with:
 
 ```bash
 ./bin/phel run docs/examples/<file>.phel
 ```
+
+Copy any file into your project and tweak it.
 
 ## Example overview
 
@@ -25,8 +27,6 @@ Standalone scripts from primitive literals through concurrency to a full CLI. Ru
 | 13 | `13_database-crud.phel` | SQLite products CRUD: rows as immutable maps (not ORM entities), repository boundary, pure service transforms |
 | 14 | `14_doctrine-entity.phel` | Doctrine `#[ORM\Entity]` defined in Phel via `defstruct` + `:php/attr`, verified with `phel.reflect` |
 | extra | `transducers.phel` | Composable transformations: `into`, `transduce`, `sequence` |
-
-Copy any file into your project and tweak it.
 
 ## Snippets
 
@@ -53,7 +53,7 @@ Copy any file into your project and tweak it.
 | `atom`, `swap!`, `reset!` | `snippets/atom.phel` |
 | `phel.string` ops | `snippets/string.phel` |
 
-Each snippet is runnable: `./bin/phel run docs/examples/snippets/<name>.phel`. Use as REPL warm-ups or copy-paste recipes.
+Run any snippet (`./bin/phel run docs/examples/snippets/<name>.phel`) as a REPL warm-up or copy-paste recipe.
 
 ## Run all
 

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -6,7 +6,7 @@ Add Phel to a PHP project without touching `app/` or `src/`.
 
 1. Keep Phel sources under `phel/`.
 2. Mark public functions with `{:export true}`.
-3. Create one main namespace (`app.main`) that `:require`s every feature namespace. Loading it registers all exported functions at once.
+3. Create one main namespace (`app.main`) that `:require`s every feature namespace; loading it registers all exported functions at once.
 4. Export PHP wrappers under your framework's `App\` PSR-4 root via `phel export`.
 5. Prod: `phel build` at deploy, `require 'build/app/main.php'` at boot. Dev: `\Phel::run($root, 'app.main')` compiles on first call.
 
@@ -231,7 +231,7 @@ echo $greet('World') . "\n";
 
 ## Persistence: maps, not entities
 
-Phel models data as immutable values, not mutable identity-tracked objects. An ORM entity (Doctrine, Eloquent) is the opposite: a mutable object the framework hydrates and dirty-tracks. Trying to make a Phel struct *be* an ORM entity fights the language. The functional path keeps rows as plain maps and pushes the database write to the edge.
+Phel models data as immutable values, not mutable identity-tracked objects. An ORM entity (Doctrine, Eloquent) is the opposite: a mutable object the framework hydrates and dirty-tracks. Making a Phel struct *be* an ORM entity fights the language. The functional path keeps rows as plain maps and pushes the database write to the edge.
 
 Two small libraries cover it:
 
@@ -271,14 +271,12 @@ phel-pdo can also wrap an existing PDO handle so its map-returning helpers run o
 
 ### When you really need the object
 
-Some host APIs demand a concrete instance (a typed DTO, a value object a library type-hints). Bridge at the boundary instead of modeling your domain as objects: `hydrate` builds an instance from a map without running its constructor (the ORM/serializer pattern), and `bean` reads a public-property object back into a keyword-keyed map.
+Some host APIs demand a concrete instance (a typed DTO, a value object a library type-hints). Bridge at the boundary instead of modeling your domain as objects: `hydrate` builds an instance from a map without running its constructor (the ORM/serializer pattern), and `bean` reads a public-property object back into a keyword-keyed map. Keep maps as the working representation; reach for them only at the edge where a typed object is unavoidable.
 
 ```phel
 (def dto (hydrate "App\\Dto\\Product" {:id 1 :name "Keyboard" :price 49.9}))
 (bean dto)  ; => {:id 1 :name "Keyboard" :price 49.9}
 ```
-
-Keep maps as the working representation; reach for `hydrate`/`bean` only at the edge where a typed object is unavoidable.
 
 ### Typed PHP from Phel definitions
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -12,6 +12,8 @@ build/        PHAR + release tooling
 
 Compiler is PHP. Stdlib is Phel: `src/phel/core.phel` bootstraps the core namespace by loading sub-files from `src/phel/core/`.
 
+`src/php/` modules use PSR-4 prefix `Phel\`. The global `\Phel` runtime facade lives at `src/Phel.php` (distinct from the `Phel\Phel` bootstrap in `src/php/Phel.php`).
+
 ## Modules
 
 Every directory under `src/php/` is a [Gacela](https://gacela-project.com/) module. `Facade` for public API, `Provider` for cross-module deps, `Factory` for internal wiring.
@@ -103,6 +105,6 @@ Same physical PHP process (REPL, `phel run`) or different (cached files in a fra
 | Core fn in Phel | `src/phel/core/…` |
 | CLI subcommand | new module or `Run/` + `Command/` registration |
 | LSP capability | `Lsp/Domain/` |
-| Lint rule | `Lint/Domain/Analyzer/` |
+| Lint rule | `Lint/Application/Rule/` |
 
 `grep -r "FACADE_" src/php/<Module>/<Module>Provider.php` shows a module's deps.

--- a/docs/internals/benchmarks.md
+++ b/docs/internals/benchmarks.md
@@ -1,8 +1,8 @@
 # Benchmarking Phel
 
-[PHPBench](https://phpbench.readthedocs.io/) is in `require-dev` to measure runtime cost of developer workflows and core data structures. Run the suite to spot regressions before release.
+[PHPBench](https://phpbench.readthedocs.io/) (in `require-dev`) measures the runtime cost of developer workflows and core data structures. Run the suite to spot regressions before release.
 
-Three areas:
+It covers three areas:
 
 - **CLI commands**: `phel run` and `phel test` end-to-end.
 - **Persistent collections**: vectors and hash maps for hot ops like `append`, `update`, `put`.
@@ -14,31 +14,28 @@ Three areas:
 composer phpbench
 ```
 
-Record a baseline and compare the current branch against it:
-
-```bash
-# Create or update baseline (stored under the `baseline` tag)
-composer phpbench-base
-
-# Compare current state with baseline
-composer phpbench-ref
-```
-
-The assertion in [`phpbench.json`](../../phpbench.json) fails the comparison when the measured mode deviates beyond the configured threshold.
-
 Override iterations and revolutions for quick local checks:
 
 ```bash
 composer phpbench -- --iterations=2 --revs=10
 ```
 
-JIT specialization wins on `:tag`-annotated fns can be measured by `TypedSignatureBench`:
+## Comparing against a baseline
+
+```bash
+composer phpbench-base   # record/update baseline (stored under the `baseline` tag)
+composer phpbench-ref    # compare current state with baseline
+```
+
+The assertion in [`phpbench.json`](../../phpbench.json) fails the comparison when the measured mode deviates beyond the configured threshold.
+
+## Measuring JIT gains
+
+`TypedSignatureBench` measures the JIT specialization wins on `:tag`-annotated fns. Compare the two runs to see what typed signatures unlock at runtime:
 
 ```bash
 composer bench-jit-baseline   # opcache off, no JIT
 composer bench-jit-tracing    # opcache on, tracing JIT
 ```
-
-Compare the two runs to see what typed signatures unlock at runtime.
 
 See the [PHPBench docs](https://phpbench.readthedocs.io/) for advanced reporting.

--- a/docs/internals/compiler.md
+++ b/docs/internals/compiler.md
@@ -12,7 +12,7 @@ Seven-stage pipeline. Each stage consumes only the previous stage's output. Sour
 | Emitter | `Domain/Emitter/OutputEmitter.php` | `AbstractNode` | PHP `string` |
 | Evaluator | `Domain/Evaluator/` | PHP `string` | values / side effects |
 
-Paths are relative to `src/php/Compiler/`.
+Paths are relative to `src/php/Compiler/`, except `Shared/Munge.php` (under `src/php/`).
 
 ## Public entry points (`CompilerFacade`)
 

--- a/docs/internals/faq.md
+++ b/docs/internals/faq.md
@@ -8,7 +8,7 @@ Grouped by reader.
 
 **What does emitted PHP look like?** Cached files under `.phel/cache/` after one `phel run`, or the `--PHP--` section of any fixture in `tests/php/Integration/Fixtures/`. Regular PHP calling `\Phel::*` with dot-form registry keys like `"phel.core"`.
 
-**Why `\Phel::addDefinition()` instead of plain functions?** Phel namespaces are runtime values (see [runtime.md](runtime.md)). Single static surface tracks definitions, metadata, reloads. One `require` registers a whole namespace, no per-definition class-loading.
+**Why `\Phel::addDefinition()` instead of plain functions?** Phel namespaces are runtime values (see [runtime.md](runtime.md)). A single static surface tracks definitions, metadata, and reloads; one `require` registers a whole namespace with no per-definition class-loading.
 
 **How does `(my-fn arg)` reach my PHP?** Phel function: compiles to a class with `__invoke`, call site emits `(($lookup))($arg)`. Interop: `(php/-> $obj method arg)` and friends compile to literal `$obj->method($arg)`. See [special-forms.md](special-forms.md).
 
@@ -51,7 +51,7 @@ $emit   = $facade->compile('(print "hi")', new CompileOptions());
 
 **Add a core function.** Pure Phel: `src/phel/core/...` with `:doc`, `:see-also`, `:example`. Run `composer test-core`. Needs PHP: thin wrapper under `src/phel/...` calling a PHP helper, run `composer test-compiler` + `composer test-core`.
 
-**`NodeEnvironment` context.** `Expression`, `Statement`, `Return`. Analyzer picks based on position (function body last form: `Return`; `if` branch in expression position: `Expression`). Wrong PHP output is usually a wrong context, not an emitter bug. Helpers: `withReturnContext()`, `withStatementContext()`, `withExpressionContext()`.
+**`NodeEnvironment` context.** `Expression`, `Statement`, `Return`. Analyzer picks by position (function body's last form: `Return`; `if` branch in expression position: `Expression`). Wrong PHP output is usually a wrong context, not an emitter bug. Helpers: `withReturnContext()`, `withStatementContext()`, `withExpressionContext()`.
 
 **Broken integration fixture.** Update only if new PHP is intentional. Verify by hand first. The `fixture-reviewer` agent (`.claude/agents/`) audits drift.
 

--- a/docs/internals/macros.md
+++ b/docs/internals/macros.md
@@ -25,13 +25,13 @@ REPL `(macroexpand-1 'form)` and nREPL `macroexpand` op route here.
 
 ```phel
 (macroexpand-1 '(when x y z))
-;; => (if x (do y z) nil)
+;; => (if x (do y z))
 
 (macroexpand '(or a b c))
-;; => (let [or__1 a] (if or__1 or__1 (let [or__2 b] (if or__2 or__2 c))))
+;; => (let [__phel_1 a] (if __phel_1 __phel_1 (or b c)))
 ```
 
-Outermost only. No recursion into subforms (analyzer's job).
+Outermost only. No recursion into subforms (analyzer's job): the nested `(or b c)` above stays unexpanded because it is not at the head.
 
 ## Macro arguments
 
@@ -64,10 +64,10 @@ Hard half of hygiene: binding names. Inside a quasiquote, trailing `#` produces 
 
 ```phel
 `(let [x# 1] (+ x# x#))
-;; ≈ (let [x__123__auto__ 1] (+ x__123__auto__ x__123__auto__))
+;; => (let [x__1 1] (+ x__1 x__1))
 ```
 
-`Compiler/Domain/Reader/GensymContext.php`: per-quasiquote map from `"x#"` to a generated `Symbol`. First sight: `Symbol::gen("x")`. Subsequent: reuse. New context per top-level quasiquote.
+`Compiler/Domain/Reader/GensymContext.php`: per-quasiquote map from base `"x__"` (the `#` is stripped and `__` appended) to a generated `Symbol`. First sight: `Symbol::gen("x__")` (→ `x__N`). Subsequent: reuse. New context per top-level quasiquote.
 
 Explicit form: `(gensym)` or `(gensym "prefix")`.
 

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -25,7 +25,7 @@ Three concerns: types, per-namespace `Registry`, value equality + hashing.
 | `Delay` | One-shot lazy value (not a sequence). |
 | `Volatile` | Mutable box for transducer state. |
 | `Reduced` | Early-termination sentinel for `reduce`/`transduce`. |
-| `Future` | Promise/future for `Fiber/`. |
+| `Future` | Amphp-backed future wrapper; `deref` awaits inside a fiber. Used by `async`/`await` (see `src/phel/core/async.phel`). |
 | `SourceLocation` | File + line + column on every readable form. |
 
 All types implement `TypeInterface` (composes `MetaInterface`, `SourceLocationInterface`, `EqualsInterface`, `HashableInterface`).
@@ -69,9 +69,9 @@ Each top-level form compiles + evaluates before the next is analysed, so both st
 
 `src/Phel.php` is the runtime ABI. Cached `.php` files in the wild call into it. Signature changes are breaking.
 
-- `addDefinition($ns, $name, $value, $meta = null)`
+- `addDefinition($ns, $name, $value, $meta = null)` (delegated to `Registry` via `__callStatic`)
 - `keyword($name, $namespace = null)` / `symbol($name)`
-- `vector(...$items)` / `map(...$kvs)` / `set(...$items)`
+- `vector(?array $values = [])` / `set(?array $values = [])` / `map(...$kvs)`
 
 Changing a signature requires auditing `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/*Emitter.php`.
 

--- a/docs/internals/special-forms.md
+++ b/docs/internals/special-forms.md
@@ -1,10 +1,10 @@
 # Special Forms
 
-A list with a recognised head symbol routes to a dedicated analyzer. Anything else (not a special form, not a macro, not a literal collection) is a function call. Macros expand into special forms; special forms are the bottom.
+A list with a recognised head symbol routes to a dedicated analyzer. Anything else (not a special form, macro, or literal collection) is a function call. Macros expand into special forms; special forms are the bottom layer.
 
 ## Dispatch
 
-`Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php` matches the head against `Symbol::NAME_*` constants in `src/php/Lang/Symbol.php`. On match, dispatches to a `SpecialFormAnalyzerInterface` impl in `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`. On miss, falls through to `InvokeSymbol`.
+`Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php` matches the head against `Symbol::NAME_*` constants in `src/php/Lang/Symbol.php`. On match it dispatches to a `SpecialFormAnalyzerInterface` impl in `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`; on miss it falls through to `InvokeSymbol`.
 
 ```php
 match ($symbolName) {
@@ -18,7 +18,7 @@ match ($symbolName) {
 };
 ```
 
-Each handler returns one `AbstractNode`. Emitter has 1:1 mapping to `*Emitter.php` under `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/`.
+Each handler returns one `AbstractNode`. Every node maps 1:1 to an `*Emitter.php` under `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/`.
 
 ## Core
 
@@ -66,7 +66,7 @@ Trailing `*` means not user-facing. Macros `defstruct`, `definterface`, `defexce
 | `php/new` (`new`) | `NAME_PHP_NEW` / `NAME_NEW` | `new Foo(...)` |
 | `php/->` | `NAME_PHP_OBJECT_CALL` | `$obj->method(...)` / `$obj->prop` |
 | `php/::` | `NAME_PHP_OBJECT_STATIC_CALL` | `Foo::method(...)` / `Foo::CONST` |
-| `php/ref` | `NAME_PHP_REF` | by-ref interop arg: captures the local `use(&$x)` so an output parameter writes back |
+| `php/ref` | `NAME_PHP_REF` | by-ref interop arg; captures local via `use(&$x)` so an output parameter writes back |
 | `php/oset` | `NAME_PHP_OBJECT_SET` | `$obj->prop = $v` |
 | `php/aget` | `NAME_PHP_ARRAY_GET` | `$arr[$k]` |
 | `php/aset` | `NAME_PHP_ARRAY_SET` | `$arr[$k] = $v` |
@@ -89,10 +89,10 @@ Run `(macroexpand-1 'form)` to see the truth.
 1. `public const string NAME_FOO = 'foo';` in `src/php/Lang/Symbol.php`
 2. `FooNode extends AbstractNode` in `Compiler/Domain/Analyzer/Ast/`
 3. `FooSymbol implements SpecialFormAnalyzerInterface` in `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`: validate, recurse via `$this->analyzer->analyze(...)`, return `FooNode`
-4. Branch in `AnalyzePersistentList`'s `match`
-5. `FooEmitter` in `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/`, register in `NodeEmitterFactory`. Honor `NodeEnvironment` context
+4. Branch in the `AnalyzePersistentList` `match`
+5. `FooEmitter` in `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/`, registered in `NodeEmitterFactory`; honor `NodeEnvironment` context
 
-Add fixture `tests/php/Integration/Fixtures/Foo/foo-basic.test` + analyzer PHPUnit test.
+Add a fixture `tests/php/Integration/Fixtures/Foo/foo-basic.test` plus an analyzer PHPUnit test.
 
 ## See also
 

--- a/docs/lazy-sequences.md
+++ b/docs/lazy-sequences.md
@@ -4,7 +4,7 @@ Defer computation until values are needed. Two constructs: `lazy-seq` wraps an e
 
 ## `lazy-seq`
 
-Takes a body returning a sequence or nil. Yields a LazySeq that runs the body on first access (`first`, `rest`, `take`, ...) and caches the result. Mechanically: it builds a zero-arg thunk over the body, returns a LazySeq holding it, and evaluates+caches on first access.
+Takes a body returning a sequence or nil. Wraps it in a zero-arg thunk and returns a LazySeq that, on first access (`first`, `rest`, `take`, ...), evaluates the body and caches the result.
 
 ```phel
 (def my-lazy-seq
@@ -125,7 +125,7 @@ These return lazy sequences:
 
 ### Chunking
 
-Lazy sequences realize elements in chunks (lower overhead), so side effects may run for more elements than you consume:
+Lazy sequences may realize more elements than you consume (e.g. `take` forces one extra), so side effects can run for elements you never read:
 
 ```phel
 (take 5 (map (fn [x] (do (println x) x)) (range 100)))
@@ -135,8 +135,8 @@ Lazy sequences realize elements in chunks (lower overhead), so side effects may 
 ### Realizing
 
 ```phel
-(doall lazy-seq)  ; realizes entire sequence, returns it
-(dorun lazy-seq)  ; realizes entire sequence, returns nil
+(doall lazy-seq)  ; realizes entire sequence, returns it as a vector
+(dorun lazy-seq)  ; realizes entire sequence for side effects, returns nil
 ```
 
 ## Gotchas

--- a/docs/lint-guide.md
+++ b/docs/lint-guide.md
@@ -34,7 +34,7 @@
 
 ## Configuration
 
-Drop `phel-lint.phel` at the project root (resolved from the working directory when you run `phel lint`).
+Drop `phel-lint.phel` at the project root (resolved from the working directory). Pass a custom path with `--config=path/to/lint.phel`.
 
 ```phel
 {:rules
@@ -47,11 +47,9 @@ Drop `phel-lint.phel` at the project root (resolved from the working directory w
 
 Severities: `:error`, `:warning`, `:info`, `:hint`, `:off`. Patterns in `:exclude` match file paths (if containing `/` or `.phel`) or namespace names via `fnmatch`.
 
-Pass a custom path with `--config=path/to/lint.phel`.
-
 ## Cache
 
-Results are cached per file by content hash. Subsequent runs only reanalyze changed files. Disable with `--no-cache`.
+Results are cached per file by content hash at `.phel/lint-cache/index.json`. Subsequent runs only reanalyze changed files. Adding/removing rules or editing `phel-lint.phel` invalidates the cache. Disable with `--no-cache`.
 
 ## Editor integration
 

--- a/docs/lsp-guide.md
+++ b/docs/lsp-guide.md
@@ -50,12 +50,12 @@ vim.lsp.start({
 
 ## Diagnostics
 
-Compiler errors, unresolved symbols, arity mismatches, and lint violations. Publication is debounced so typing does not thrash.
+Compiler errors, unresolved symbols, arity mismatches, and lint violations. Publication is debounced (200ms default) so typing does not thrash.
 
 ## Pitfalls
 
 - The server scans files under the project root. Keep `phel-config.php` current for require resolution.
-- LSP runs in its own PHP process. REPL state is not shared with a running `phel nrepl`.
+- LSP runs in its own PHP process; REPL state is not shared with a running `phel nrepl`.
 
 ## See also
 

--- a/docs/match-guide.md
+++ b/docs/match-guide.md
@@ -51,7 +51,7 @@
 - Each pattern vector length must equal the target count
 - `:else` must be the final clause
 - Nested patterns bind left-to-right; a later binding shadows an earlier one with the same name
-- A `:guard` predicate runs against the raw value. Numeric predicates like `pos?` coerce non-numbers in Phel (so `(pos? [1 2])` is truthy), so put literal/structural patterns before an open numeric guard.
+- A `:guard` predicate runs against the raw value. Numeric predicates like `pos?` coerce non-numbers (`(pos? [1 2])` is truthy), so put literal/structural patterns before an open numeric guard.
 
 ## See also
 

--- a/docs/migration/backslash-to-dot.md
+++ b/docs/migration/backslash-to-dot.md
@@ -1,34 +1,34 @@
 # Migration: Backslash Namespace Separator to Dot
 
-Phel historically used the PHP-style backslash (`\`) as the namespace separator in every position: `ns` forms, `:require`/`:use` clauses, fully-qualified call sites, and class FQNs. The dot (`.`) is the target form going forward. The backslash form is **deprecated** and will be removed in a future release.
+Phel historically used the PHP-style backslash (`\`) as the namespace separator everywhere: `ns` forms, `:require`/`:use` clauses, fully-qualified call sites, and class FQNs. The dot (`.`) is the target form going forward. The backslash form is **deprecated** and will be removed in a future release.
 
 Tracking issue: [phel-lang/phel-lang#1567](https://github.com/phel-lang/phel-lang/issues/1567).
 
 ## Opt-in to deprecation warnings
 
-Three equivalent ways. Pick whichever fits your pipeline.
+Three equivalent ways; pick whichever fits your pipeline.
 
-**CLI flag** (recommended for one-off runs and CI configs):
+**CLI flag**, for one-off runs and CI:
 
 ```bash
 vendor/bin/phel run --warn-deprecations src/app.phel
 vendor/bin/phel test --warn-deprecations
 ```
 
-**Environment variable** (recommended for shell-wide sessions):
+**Environment variable**, for shell-wide sessions:
 
 ```bash
 PHEL_WARN_DEPRECATIONS=1 vendor/bin/phel run src/app.phel
 ```
 
-**Project config** (recommended when every local command should opt in):
+**Project config**, when every local command should opt in:
 
 ```php
 return PhelConfig::forProject()
     ->withWarnDeprecations(true);
 ```
 
-When enabled, the compiler emits one `E_USER_DEPRECATED` per unique `(file, symbol)` pair so large projects do not drown in duplicates. `--warn-deprecations` is consumed by the `phel` bootstrap before Symfony's per-command parsers run, so it works with every subcommand.
+When enabled, the compiler emits one `E_USER_DEPRECATED` per unique `(file, symbol)` pair, so large projects do not drown in duplicates. `--warn-deprecations` is consumed by the `phel` bootstrap before Symfony's per-command parsers run, so it works with every subcommand.
 
 ## What is detected today
 
@@ -48,11 +48,11 @@ Tracked as follow-up sub-tasks in #1567:
 - `load` forms (take strings, not symbols)
 - Reader-macro / quoting forms that carry namespace strings as data
 
-Migrate the non-detected positions by hand now. The new dot forms already work at the language level.
+Migrate these positions by hand now; the dot forms already work at the language level.
 
 ## Suppression
 
-Warnings are suppressed automatically for files under phel's bundled stdlib. User projects that use the nested `src/phel` layout still emit warnings normally.
+Warnings are suppressed automatically for files under phel's bundled stdlib. User projects using the nested `src/phel` layout still emit warnings normally.
 
 ## Removal target
 

--- a/docs/mocking-guide.md
+++ b/docs/mocking-guide.md
@@ -1,8 +1,6 @@
 # Mocking in Phel
 
-`phel.mock` ships with phel-lang, no separate install. Require it only in test namespaces.
-
-Replace dependencies with controlled stand-ins for testing.
+Replace dependencies with controlled stand-ins for testing. `phel.mock` ships with phel-lang (no separate install); require it from test namespaces only.
 
 ```phel
 (ns my-app.test.user-test
@@ -46,25 +44,34 @@ Replace dependencies with controlled stand-ins for testing.
 ## Inspecting Mocks
 
 ```phel
-(calls mock)              ; [[1 2] [3]] - all calls
+(calls mock)              ; [[1 2] [3]] - all argument lists
 (call-count mock)         ; 2
-(called? mock)            ; true
+(called? mock)            ; true  - called at least once
+(never-called? mock)      ; false
 (called-once? mock)       ; false
-(called-with? mock 1 2)   ; true
+(called-times? mock 2)    ; true
+(called-with? mock 1 2)   ; true  - exact args
 (first-call mock)         ; [1 2]
 (last-call mock)          ; [3]
+(mock? mock)              ; true
+```
+
+Reset one mock's call history without removing it from the registry:
+```phel
+(reset-mock! mock)
 ```
 
 ## Auto-Reset
 
+`with-mocks` wraps `with-redefs` and resets every mock after the body runs:
 ```phel
 (with-mocks [http-get (mock {:status 200})]
   (fetch-data)
   (is (called-once? http-get)))
-;; Automatically reset here
+;; http-get automatically reset here
 ```
 
-For wrapped mocks (PHP interop):
+For wrapped mocks (PHP interop), use `with-mock-wrapper`; it resets the underlying mock even when it is wrapped in an adapter function:
 ```phel
 (with-mock-wrapper [symfony-service mock-http
                     (fn [args] (mock-http (adapt args)))]
@@ -75,7 +82,7 @@ For wrapped mocks (PHP interop):
 
 ## Cleanup
 
-For long-running processes:
+Clear the entire registry (useful between test suites in long-running processes):
 ```phel
 (clear-all-mocks!)
 ```

--- a/docs/nrepl-guide.md
+++ b/docs/nrepl-guide.md
@@ -5,15 +5,13 @@
 ## Starting the server
 
 ```bash
-./vendor/bin/phel nrepl                    # port 7888, 127.0.0.1
+./vendor/bin/phel nrepl                    # port 7888, host 127.0.0.1 (defaults)
 ./vendor/bin/phel nrepl --port=0           # bind a random free port
-./vendor/bin/phel nrepl -p 7888            # short form of --port
+./vendor/bin/phel nrepl -p 7888            # -p is short for --port
 ./vendor/bin/phel nrepl --host=0.0.0.0 --port=7888
 ```
 
-Short form: `-p`.
-
-The server prints the bound port to stdout for client auto-discovery.
+The server prints the bound `host:port` to stdout for client auto-discovery.
 
 ## Operations
 
@@ -24,7 +22,7 @@ The server prints the bound port to stdout for client auto-discovery.
 | `close` | close a session |
 | `describe` | capability discovery |
 | `load-file` | slurp-and-eval a file's contents |
-| `interrupt` | stop a running `eval` in a session |
+| `interrupt` | acknowledged for editor compatibility (no-op: Phel evals synchronously, nothing to interrupt) |
 | `completions` | return candidate completions for a prefix |
 | `lookup` | return symbol metadata (arglists, doc, file:line) |
 | `info` | equivalent to `lookup` under a different name |
@@ -45,13 +43,13 @@ Run `Calva: Connect to a running REPL`, choose `Generic nREPL`, and point at `12
 
 ### Neovim (vim-iced or Conjure)
 
-Both detect `.nrepl-port` in the repo root. Set it after launching the server.
+Both auto-detect a `.nrepl-port` file in the repo root. Phel does not write it, so create it with the bound port after launching the server.
 
 ## Pitfalls
 
 - Single-user by default. Multiple clients sharing a session see interleaved output.
 - Bind to `127.0.0.1` unless on a trusted network. No auth.
-- `interrupt` stops the eval in that session only, not other sessions or fibers.
+- `interrupt` is a no-op stub: Phel evaluates synchronously, so a running `eval` cannot be cancelled mid-flight. The op is acknowledged only to keep editors happy.
 
 ## See also
 

--- a/docs/numeric-tower.md
+++ b/docs/numeric-tower.md
@@ -10,7 +10,7 @@ Phel has a numeric tower built around five scalar shapes:
 | `Phel\Lang\BigDecimal` | `1.5M` literal, `bigdec` | Arbitrary-precision exact decimal |
 | `float` | Native PHP `float` (IEEE-754 double) | Inexact |
 
-`+`, `-`, `*`, `/`, comparisons, and the predicates dispatch on these types via `Phel\Lang\NumericOperations`. PHP's native operators do not dispatch on objects, so the runtime helper does.
+`+`, `-`, `*`, `/`, comparisons, and the predicates dispatch on these types via `Phel\Lang\NumericOperations`, since PHP's native operators don't dispatch on objects.
 
 ## Notes
 
@@ -35,7 +35,7 @@ Promote with the explicit constructors. A `BigInt` prints as a plain integer (no
 (rationalize 0.1)   ; => 1/10
 ```
 
-The promoting arithmetic ops (`+'`, `-'`, `*'`, `inc'`, `dec'`) auto-promote to `BigInt` on overflow, so use them whenever overflow is possible:
+The promoting arithmetic ops (`+'`, `-'`, `*'`, `inc'`, `dec'`) auto-promote to `BigInt` on overflow. Use them whenever overflow is possible:
 
 ```phel
 (*' 1000000000 1000000000 1000000000)  ; => 1000000000000000000000000000 (BigInt)
@@ -48,7 +48,7 @@ The promoting arithmetic ops (`+'`, `-'`, `*'`, `inc'`, `dec'`) auto-promote to 
 12345678901234567890   ; => float (PHP int range overflow)
 ```
 
-PHP's lexer parses oversize integer literals as `float`, so the same happens in Phel source. Wrap with `bigint` to keep precision:
+PHP's lexer parses oversize integer literals as `float`, and so does Phel's. Wrap with `bigint` to keep precision:
 
 ```phel
 (bigint "12345678901234567890")
@@ -64,7 +64,7 @@ Clojure's `(==)` and `(== x)` return `true` for any single argument. Phel's `==`
 
 ### `rationalize` uses shortest round-trip decimal
 
-`(rationalize 0.1) ; => 1/10`, not `10000000000000001/100000000000000000`. The conversion picks the shortest decimal expansion that round-trips back to the same `float`, so binary-noise digits do not leak into the result. Floats whose exact value has no short decimal representation (e.g. `(/ 1.0 3.0)`) keep that round-trip representation as a `Ratio`.
+`(rationalize 0.1) ; => 1/10`, not `10000000000000001/100000000000000000`. The conversion picks the shortest decimal expansion that round-trips back to the same `float`, so binary-noise digits don't leak in. Floats with no short decimal representation (e.g. `(/ 1.0 3.0)`) keep their round-trip representation as a `Ratio`.
 
 `(rationalize ##Inf)`, `(rationalize ##-Inf)`, and `(rationalize ##NaN)` throw `InvalidArgumentException`.
 

--- a/docs/parallel-tests.md
+++ b/docs/parallel-tests.md
@@ -1,12 +1,13 @@
 # Parallel Test Runner
 
-`phel test --parallel=<N|auto|max>` fans out test namespaces across a pool of subprocess workers, mirroring Clojure's [eftest](https://github.com/eftest/eftest) `:multithread? :namespaces` mode: opt-in, default workers ≈ CPU count, deterministic output, no impact on serial runs.
+`phel test --parallel=<N|auto|max>` fans out test namespaces across a pool of subprocess workers, mirroring Clojure's [eftest](https://github.com/weavejester/eftest) `:multithread? :namespaces` mode: opt-in, default workers ≈ CPU count, deterministic output, no impact on serial runs.
 
 ## When to use it
 
-Use it for suites with non-trivial per-namespace work (DB spin-up, AST benchmarks, heavy property tests), or CI where wall clock dominates worker spawn cost.
-
-Skip it for tiny suites, or when a per-namespace fixture spins up a shared resource (DB, port, fixture file) that can't tolerate N concurrent loaders.
+| Use it | Skip it |
+|---|---|
+| Non-trivial per-namespace work (DB spin-up, AST benchmarks, heavy property tests) | Tiny suites |
+| CI where wall clock dominates worker spawn cost | Per-namespace fixtures sharing a resource (DB, port, fixture file) that can't tolerate N concurrent loaders |
 
 ## Usage
 
@@ -45,9 +46,11 @@ Output is **deterministic in input order**: workers complete in arbitrary order,
 
 `--parallel` silently downgrades to serial when:
 
-- `--reporter=tap`: TAP needs a monotonic test counter.
-- `--list`: discovery only, nothing to fan out.
-- A profiler hook is installed: counts only accrue in the parent.
+| Condition | Reason |
+|---|---|
+| `--reporter=tap` | TAP needs a monotonic test counter |
+| `--list` | Discovery only, nothing to fan out |
+| A profiler hook is installed | Counts only accrue in the parent |
 
 Run with `-v` to see why:
 
@@ -65,7 +68,7 @@ Ignoring --parallel: TAP reporter requires a monotonic test counter.
 4. `/proc/cpuinfo` line count (Linux without `nproc`)
 5. Hardcoded `4`
 
-`auto` clamps to a cap of 8 to stay kind to laptops and shared CI runners; `max` skips the cap.
+`auto` clamps to a cap of 8 (kind to laptops and shared CI runners); `max` skips the cap.
 
 ## Architecture
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -96,7 +96,7 @@
 
 ## Pattern Matching
 
-`phel.match` destructures by shape and binds symbols in one step. Use it when `cond`/`case` would re-query the same value from multiple angles.
+`phel.match` destructures by shape and binds symbols in one step. Use it where `cond`/`case` would re-query the same value from multiple angles.
 
 ```phel
 (ns app.commands
@@ -297,7 +297,7 @@ Without `:else`, `match` throws `RuntimeException` when nothing fits. Add `:else
 (defn valid-age? [age]
   (and (int? age) (>= age 0) (<= age 150)))
 
-;; Collect errors with a transient
+;; Collect errors with a transient (see Transient Collections in data-structures-guide.md)
 (defn validate-user [user]
   (let [errors (transient [])]
     (when-not (valid-email? (get user :email)) (conj! errors "Invalid email"))
@@ -377,7 +377,7 @@ Every `defmacro` body has two implicit symbols:
 
 ### Extending `is` with custom assertions
 
-`phel.test/assert-expr` is an open multimethod. Teach `is` to expand new assertion forms via `defmethod`. The method takes the user-supplied `message` and original `form` (matching `clojure.test/assert-expr`) and returns the code `is` should run:
+`phel.test/assert-expr` is an open multimethod. Teach `is` new assertion forms via `defmethod`. The method takes the user-supplied `message` and original `form` (matching `clojure.test/assert-expr`) and returns the code `is` should run:
 
 ```phel
 (ns my-app.test.helpers
@@ -400,7 +400,7 @@ When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the `:d
 
 ## Build-safe Entry Points
 
-`phel build` evaluates every top-level form at compile time so macros, `def`, `defn`, and `ns` register. Top-level **side effects** (game loops, `stdin` reads, sockets, sleeps) also run and can block the build indefinitely. Guard imperative entry calls with `*build-mode*`:
+`phel build` evaluates every top-level form at compile time so macros, `def`, `defn`, and `ns` register. Top-level **side effects** (game loops, `stdin` reads, sockets, sleeps) also run and can block the build indefinitely. Guard imperative entry points with `*build-mode*`:
 
 ```phel
 (ns app.main)

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -13,15 +13,15 @@ opcache.max_accelerated_files=20000
 opcache.interned_strings_buffer=16
 ```
 
-Create the directory once: `mkdir -p /tmp/php-opcache`. Restart your shell. Repeat runs of `./vendor/bin/phel test` drop from ~12 s to sub-second on warm cache.
+Create the directory once (`mkdir -p /tmp/php-opcache`) and restart your shell. Repeat runs of `./vendor/bin/phel test` then drop from ~12 s to sub-second on a warm cache.
 
 ## Why it is slow without opcache
 
 Every `./vendor/bin/phel` invocation is a fresh PHP process. Without CLI opcache, PHP re-parses every `.php` file each run (`vendor/`, Phel compiler, Symfony console, project classes). `opcache.file_cache` persists compiled bytecode across processes.
 
-Phel adds a compiled-code cache under `.phel/cache/` memoizing Phel-to-PHP compilation per source hash. The two complement each other: Phel's cache skips recompilation; opcache skips re-parsing the resulting PHP.
+Phel adds a compiled-code cache under `.phel/cache/` that memoizes Phel-to-PHP compilation per source hash (the cache flags and their semantics live in [configuration.md](configuration.md#caching)). The two complement each other: Phel's cache skips recompilation; opcache skips re-parsing the resulting PHP.
 
-Invalidation is automatic: each run hashes the `.phel` source (`md5`) against the stored entry, and on mismatch recompiles the file and its transitive dependents. Fresh compiles also `opcache_compile_file()` the generated PHP. Use the reset steps below only if something gets wedged.
+Invalidation is automatic, and changing the optimization level forces a full recompile. Each run hashes the `.phel` source (`md5`) against the stored entry; on mismatch it recompiles the file and its transitive dependents. Fresh compiles also `opcache_compile_file()` the generated PHP. Use the [reset steps](#cache-reset) only if something gets wedged.
 
 For hot numeric/string fns, add `:tag` annotations on params and the return slot (`^int`, `^float`, `^string`, `^bool`). The compiler emits matching PHP type declarations and infers the return type from primitive ops in tail position, letting the tracing JIT specialize the call. Tag mismatches surface as Phel diagnostics at compile time. Measure with `composer bench-jit-baseline` and `composer bench-jit-tracing` (see [`internals/benchmarks.md`](internals/benchmarks.md)).
 
@@ -50,7 +50,7 @@ Level 2 trade-offs:
 
 ## Memory limit
 
-`./vendor/bin/phel` raises `memory_limit` to `-1` automatically. If you invoke PHP directly (`php ./vendor/bin/phel ...`) or embed Phel, bump the limit yourself. The compiler's `token_get_all` validation can exceed 128M on large projects.
+`./vendor/bin/phel` raises `memory_limit` to `-1` automatically. If you invoke PHP directly (`php ./vendor/bin/phel ...`) or embed Phel, bump the limit yourself: the compiler's `token_get_all` validation can exceed 128M on large projects.
 
 ```bash
 php -d memory_limit=-1 ./vendor/bin/phel test
@@ -74,14 +74,12 @@ Prints `bool(true)` when CLI opcache is on.
 
 ## Cache reset
 
-If a run behaves oddly (stale compiled code, missing definitions, cache-hit crashes), wipe both caches and retry:
+If a run behaves oddly (stale compiled code, missing definitions, cache-hit crashes), wipe both caches and retry. The next invocation repopulates cleanly.
 
 ```bash
 rm -rf .phel/cache
 rm -rf /tmp/php-opcache
 ```
-
-Next invocation repopulates cleanly.
 
 ## Benchmarks (reference)
 

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -29,7 +29,7 @@ Prefix any global or namespaced PHP function with `php/`:
 (php/max 1 5 3)                   ; => 5
 ```
 
-The name after `php/` is the full PHP path with case preserved. `\`, `.`, and `/` are interchangeable as namespace separators, so the backslash-free forms work in `.cljc` files or shared snippets without escaping:
+The name after `php/` is the full PHP path with case preserved. `\`, `.`, and `/` are interchangeable separators, so backslash-free forms work in `.cljc` files or shared snippets without escaping:
 
 ```phel
 (php/Amp\trapSignal [php/SIGINT php/SIGTERM])   ; all three compile to
@@ -79,7 +79,7 @@ Capture references with `def` to shorten calls:
 
 ### Output parameters (by reference)
 
-Some PHP methods write into an argument (`PDOStatement::bindColumn`, `bindParam`). Wrap the local in `php/ref` so the result is observable from Phel:
+Some PHP methods write into an argument (`PDOStatement::bindColumn`, `bindParam`). Wrap the local in `php/ref` so the write is observable from Phel:
 
 ```phel
 (let [out "INIT"]
@@ -88,7 +88,7 @@ Some PHP methods write into an argument (`PDOStatement::bindColumn`, `bindParam`
   out)                              ; => the fetched column value
 ```
 
-It works the same way for plain PHP functions with output parameters (`preg_match`, `sort`, `settype`, `array_push`, ...):
+Plain PHP functions with output parameters work the same way (`preg_match`, `sort`, `settype`, `array_push`, ...):
 
 ```phel
 (let [matches nil]
@@ -120,7 +120,7 @@ Without the `:&` marker a keyword is just a positional value, so existing calls 
 
 ### First-class callables
 
-`php/callable` builds a native PHP 8.1 first-class callable `(...)` from a PHP function or method. It is zero-overhead: no wrapping `fn` closure is allocated, and it reads cleaner when passing a method as a value:
+`php/callable` builds a native PHP 8.1 first-class callable `(...)` from a PHP function or method. It is zero-overhead (no wrapping `fn` closure is allocated) and reads cleaner when passing a method as a value:
 
 ```phel
 ;; Free function
@@ -137,7 +137,13 @@ Without the `:&` marker a keyword is just a positional value, so existing calls 
 ;; compiles to ($list)->getArrayCopy(...)
 ```
 
-The first argument decides the target shape: a lone symbol is a free function, a class reference (`\Foo`, or an imported/uppercase class) plus a method name is a static call, and anything else plus a method name is an instance call on the evaluated object. The result is an ordinary callable, so it composes with `map`, `filter`, and friends.
+The first argument decides the target shape:
+
+- a lone symbol → free function;
+- a class reference (`\Foo`, or an imported/uppercase class) plus a method name → static call;
+- anything else plus a method name → instance call on the evaluated object.
+
+The result is an ordinary callable, so it composes with `map`, `filter`, and friends.
 
 ### Working with PHP Arrays
 
@@ -216,10 +222,10 @@ Phel uses `.` as the namespace separator, matching Clojure. The legacy `\` separ
 
 ## Typed generated PHP (`:tag`)
 
-`^{:tag T}` annotates the PHP type that a generated construct should carry, so a
-mixed PHP codebase and static analysers (psalm/phpstan) see real types. It works
-on `defstruct` fields, `definterface` params and return types, and the return
-type of a typed/exported `defn` (the tag goes on the param vector:
+`^{:tag T}` annotates the PHP type a generated construct should carry, so a mixed
+PHP codebase and static analysers (psalm/phpstan) see real types. It works on
+`defstruct` fields, `definterface` params and return types, and the return type
+of a typed/exported `defn` (the tag goes on the param vector:
 `(defn f ^{:tag int} [x] ...)`).
 
 Any modern PHP type expression is accepted:
@@ -246,10 +252,10 @@ flat intersection (a vector).
 ## PHP magic methods on structs
 
 A `defstruct` compiles to a real PHP class, so it can expose PHP magic methods
-(`__invoke`, `__toString`, `__get`, `__set`, `__call`, `__clone`, ...). Most of
-these belong to no PHP interface, so declare them inline through the `:php`
-marker block. Methods after `:php` are emitted directly on the class with no
-backing interface required:
+(`__invoke`, `__toString`, `__get`, `__set`, `__call`, `__clone`, ...). Most
+belong to no PHP interface, so declare them inline through the `:php` marker
+block. Methods after `:php` are emitted directly on the class with no backing
+interface required:
 
 ```phel
 (defstruct multiplier [factor]
@@ -280,9 +286,9 @@ A `:php` block coexists with regular interface implementations:
 
 ### `__invoke` is constrained by the map protocol
 
-A struct is a persistent map, which is already callable as a key lookup
+A struct is a persistent map, already callable as a key lookup
 (`(my-struct :key)` via an inherited `__invoke(mixed $key)`). A custom
-`__invoke` therefore must keep a compatible signature: take **exactly one call
+`__invoke` must therefore keep a compatible signature: take **exactly one call
 argument** or be **variadic**. Phel rejects an incompatible arity at compile
 time with a clear error instead of letting PHP raise an uncatchable fatal.
 
@@ -388,9 +394,9 @@ $response->send();
 ## Performance Tips
 
 ```phel
-;; Transients: mutable during batch build, then freeze
+;; Transients: mutable during batch build, then freeze (see Transient Collections in data-structures-guide.md)
 (persistent!
-  (reduce (fn [acc x] (conj acc (* x 2))) (transient []) large-list))
+  (reduce (fn [acc x] (conj! acc (* x 2))) (transient []) large-list))
 
 ;; Prefer PHP's optimized functions for heavy lifting on PHP arrays
 (php/array_map #(* % 2) php-array)
@@ -467,12 +473,8 @@ $response->send();
 - **Deref**: `@my-atom` shortcuts `(deref my-atom)`.
 - **Import classes**: `:use` in `ns`, not `:import`.
 - **Require vectors**: `(:require [phel.string :as str :refer [upper-case]])` works alongside the list form.
-- **Namespace separators**: Phel uses `.` matching Clojure; legacy `\` is deprecated.
-- **Reader conditionals**: `#?(:phel ...)` and `#?@(:phel ...)` for `.cljc` files.
-- **Unquote**: `~` and `~@` inside syntax-quote (`,` / `,@` deprecated).
-- **Auto-gensym**: `name#` inside syntax-quote produces a unique symbol (`name$` deprecated).
 - **Macro env**: `&form` and `&env` are implicit in every `defmacro`. `&env` is a map of in-scope locals keyed by symbol. `(:ns &env)` is always `nil`, so the `.cljc` `(if (:ns &env) "cljs" ...)` trick lands on the non-cljs branch.
-- **Lambda syntax**: `#(+ %1 %2)` recommended; `|(+ $1 $2)` deprecated.
+- **Reader syntax**: reader macros and their deprecated Phel-specific forms (`#(...)` lambdas, `~`/`~@` unquote, `name#` auto-gensym, `#?(:phel ...)` reader conditionals) live in [Reader Shortcuts](reader-shortcuts.md).
 
 ## See Also
 

--- a/docs/profile-guide.md
+++ b/docs/profile-guide.md
@@ -7,10 +7,8 @@
 ```sh
 ./vendor/bin/phel profile src/phel/main.phel
 ./vendor/bin/phel profile my.namespace
-./vendor/bin/phel profile               # auto-detects entry point
+./vendor/bin/phel profile               # auto-detect: tries main.phel, then core.phel
 ```
-
-Without an argument the command auto-detects the entry point, trying `main.phel` first, then `core.phel`.
 
 ## Sample output
 
@@ -55,7 +53,7 @@ Argv after the path is forwarded to the script:
 
 ## How it works
 
-An **instrumentation** profiler, not a sampler.
+An **instrumentation** profiler, not a sampler:
 
 1. `Registry::$profilerHook` is set before the run. While set, `Registry::addDefinition` wraps every `AbstractFn` in a `ProfilingFn` proxy.
 2. `GlobalVarEmitter` already routes every global-fn call through `\Phel::getDefinition(...)`, so each call hits the proxy's `__invoke`; no emitter or fixture changes.

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -1,8 +1,8 @@
 # Project Layout
 
 Phel writes per-project runtime state under a single `.phel/` directory at the
-project root. The directory is created lazily on first use and is auto-ignored
-by Git via a self-seeded `.phel/.gitignore` (`*`).
+project root. It is created lazily on first use and auto-ignored by Git via a
+self-seeded `.phel/.gitignore` (`*`).
 
 | Path                            | Owner            | Purpose                              |
 | ------------------------------- | ---------------- | ------------------------------------ |
@@ -27,14 +27,14 @@ For the full list of `phel-config.php` options, caching flags, and precedence, s
 
 ## Migration
 
-Existing projects with a top-level `.phel-repl-history` get the file renamed
-into `.phel/repl-history` automatically the next time the REPL boots. No
-action required; the legacy filename will be removed in a future release.
+Existing projects with a top-level `.phel-repl-history` get it renamed into
+`.phel/repl-history` automatically the next time the REPL boots. No action
+required; the legacy filename will be removed in a future release.
 
 ## Read-only filesystems
 
 Directory creation is best-effort. On a read-only filesystem (Lambda, Docker
-`:ro` mounts, sandbox runners), Phel skips `.phel/` creation silently and
-runs without cache, last-failed tracking, or REPL history persistence. Set
+`:ro` mounts, sandbox runners), Phel skips `.phel/` creation silently and runs
+without cache, last-failed tracking, or REPL history persistence. Set
 `PHEL_CACHE_DIR=/some/writable/path` (e.g. `/tmp/phel-cache`) to relocate the
 build cache when you still want caching.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -62,7 +62,7 @@ user:5> (/ 1 0)
 user:6> *e                        ; last exception
 ```
 
-The prompt shows the current namespace; it switches on `(ns ...)` / `(in-ns ...)`. `*1`, `*2`, `*3` hold the last three results; `*e` holds the last exception. Type `exit` or Ctrl-D to quit.
+The prompt shows the current namespace, switching on `(ns ...)` / `(in-ns ...)`. `*1`, `*2`, `*3` hold the last three results; `*e` holds the last exception.
 
 ## Collections
 
@@ -168,7 +168,7 @@ require __DIR__ . '/../vendor/autoload.php';
 echo \Phel::getDefinition('app.greet', 'hello')('World');
 ```
 
-`getDefinition` resolves any Phel function as a PHP callable. Namespace hyphens become underscores in registry keys (`my-app.lib` becomes `my_app.lib`). Full HTTP example: [Framework Integration](framework-integration.md).
+`getDefinition` resolves any Phel function as a PHP callable. Namespace hyphens become underscores in registry keys (`my-app.lib` → `my_app.lib`). Full HTTP example: [Framework Integration](framework-integration.md).
 
 ## Tests
 

--- a/docs/reader-conditionals.md
+++ b/docs/reader-conditionals.md
@@ -1,6 +1,6 @@
 # Reader Conditionals in Phel
 
-Reader conditionals enable platform-specific code in shared source files. They resolve at parse time, before compilation. Phel selects the `:phel` branch, ignores other platforms (`:clj`, `:cljs`, ...), and falls back to `:default` when present. This is what makes `.cljc` files shareable between Phel, Clojure, and other Lisp dialects.
+Reader conditionals enable platform-specific code in shared source files. They resolve at parse time, before compilation. Phel selects the `:phel` branch, ignores other platforms (`:clj`, `:cljs`, ...), and falls back to `:default` when present. This makes `.cljc` files shareable between Phel, Clojure, and other Lisp dialects.
 
 ## Basic usage: `#?()`
 
@@ -37,7 +37,7 @@ Selects one form based on platform:
 
 ## Splicing: `#?@()`
 
-Splices multiple elements from a collection into the surrounding form. The matched branch **must be a sequential collection** (vector or list); its elements are spliced in and the wrapper is removed.
+Splices a collection's elements into the surrounding form. The matched branch **must be a sequential collection** (vector or list); its elements are spliced in and the wrapper removed.
 
 ```phel
 [1 #?@(:phel [2 3]) 4]              ; => [1 2 3 4]
@@ -78,7 +78,7 @@ Phel discovers and compiles `.cljc` files alongside `.phel` files:
      :default "unknown"))
 ```
 
-> **Tip:** `.cljc` files should use `.` as the namespace separator (`shared.utils`) so the file parses cleanly under Clojure too. The legacy `\` separator (`shared\utils`) still resolves but is deprecated.
+> **Tip:** use `.` as the namespace separator (`shared.utils`) so `.cljc` files parse cleanly under Clojure too. The legacy `\` separator (`shared\utils`) still resolves but is deprecated.
 
 ### Platform-specific dependencies
 
@@ -117,15 +117,13 @@ Reader conditionals resolve at parse time, so they work inside any form:
 
 ## How it works
 
-Reader conditionals resolve during the **parsing phase** (Lexer -> **Parser** -> Analyzer -> Emitter). The parser:
+Reader conditionals resolve during the **parsing phase** (Lexer -> **Parser** -> Analyzer -> Emitter), so the analyzer and emitter only ever see the selected form. The parser:
 
 1. Reads keyword-form pairs inside `#?()` or `#?@()`.
 2. Selects `:phel` if present, else `:default`.
 3. `#?()`: replaces the conditional with the selected form.
 4. `#?@()`: splices the selected collection into the parent.
 5. No match: drops the conditional as trivia.
-
-The analyzer and emitter only see the selected form.
 
 ## Summary
 

--- a/docs/reader-shortcuts.md
+++ b/docs/reader-shortcuts.md
@@ -31,7 +31,7 @@ Quasiquote (`` ` ``) is like quote but allows selective evaluation with unquote 
 
 ### Auto-gensym `name#`
 
-Inside a syntax-quote, a symbol ending in `#` expands to a fresh unique name. All occurrences of the same `name#` in one syntax-quote share that name, giving hygienic macros without calling `gensym`:
+Inside a syntax-quote, a symbol ending in `#` expands to a fresh unique name. All occurrences of the same `name#` within one syntax-quote share that name, giving hygienic macros without calling `gensym`:
 
 ```phel
 (defmacro time [expr]
@@ -65,7 +65,7 @@ Resolved at parse time. `#?()` selects one form by platform key; `#?@()` splices
 
 ## Tagged Literals `#<tag> form`
 
-Tagged literals convert a form to a value at read time. Three ship built-in:
+Tagged literals convert a form to a value at read time. Three are built-in:
 
 ```phel
 #inst "2026-01-01T00:00:00Z"                   ; reads as \DateTimeImmutable

--- a/docs/schema-guide.md
+++ b/docs/schema-guide.md
@@ -9,7 +9,7 @@
   (:require phel.schema :as s))
 
 (def User
-  [:map {:closed? true}
+  [:map {:closed true}
    [:id    :int]
    [:email [:re #"^[^@]+@[^@]+$"]]
    [:age   [:maybe :int]]])
@@ -19,7 +19,7 @@
 (s/coerce   User {"id" "1" "email" "a@b.co" "age" nil})
 ```
 
-`[:maybe T]` makes the *value* nilable but the key is still required-present; omit it on a `{:closed? true}` map and validation fails with `:type :missing`.
+`[:maybe T]` makes the *value* nilable but the key is still required-present; omit the key on a `{:closed true}` map and validation fails with `:type :missing`.
 
 ## Schema kinds
 
@@ -29,7 +29,7 @@
 | collection | `[:vector :int]`, `[:set :string]`, `[:map-of :keyword :int]` |
 | map | `[:map [:k :int] [:k2 :string]]` |
 | tuple | `[:tuple :int :string]` |
-| choice | `[:enum :a :b]`, `[:or :int :string]`, `[:and :int pos-int?]`, `[:maybe :int]` |
+| choice | `[:enum :a :b]`, `[:or :int :string]`, `[:and :int [:fn pos-int?]]`, `[:maybe :int]` |
 | regex | `[:re #"pattern"]` |
 | predicate | `[:fn even?]` |
 | reference | `[:ref :my/User]` |
@@ -62,9 +62,10 @@
 
 ## Pitfalls
 
-- `:map` is open by default; add `{:closed? true}` to reject extra keys
-- `[:maybe T]` allows a nil value but does not make the key optional
-- `[:re ...]` expects a `#"regex"` literal, not a string
+- `:map` is open by default; add `{:closed true}` to reject extra keys (note: `:closed`, not `:closed?`; a `?` key is silently ignored)
+- `[:maybe T]` allows a nil value but does not make the key optional; use `{:optional true}` on the entry for that
+- `[:and ...]` children must be schemas; wrap a bare predicate as `[:fn pred]` (e.g. `[:fn pos-int?]`, not `pos-int?`)
+- `[:re ...]` expects a `#"regex"` literal (or a PCRE string *with* delimiters, e.g. `"/^[0-9]+$/"`); a bare pattern string like `"^[0-9]+$"` silently fails
 - `generate` may fail on over-constrained `[:and ...]` or `[:re ...]` schemas; pass `{:gen <gen-fn>}` in schema options to override
 
 ## See also

--- a/docs/transducers.md
+++ b/docs/transducers.md
@@ -1,6 +1,6 @@
 # Transducers in Phel
 
-Transducers are composable pipelines that decouple the transformation (map, filter, take) from the consumer (build a vector, sum, write to a file). They turn one reducing function into another without intermediate collections.
+Transducers are composable pipelines that decouple the transformation (map, filter, take) from the consumer (build a vector, sum, write to a file). They turn one reducing function into another, with no intermediate collections.
 
 A normal pipeline allocates at every step; transducers fuse the steps into a single pass:
 
@@ -33,7 +33,7 @@ Three ways to consume a transducer:
 
 ## Transducer-producing functions
 
-Most sequence functions are dual-purpose. Called **with** a collection they return a lazy sequence; called **without** they return a transducer.
+Most sequence functions are dual-purpose: called **with** a collection they return a lazy sequence; called **without** one they return a transducer.
 
 | Function | Transducer form | Description |
 |---|---|---|
@@ -123,7 +123,7 @@ A transducer takes a reducing function `rf` and returns a new one handling three
 - **1** (completion): return `(rf result)`, optionally flush state
 - **2** (step): the transformation logic
 
-Dispatch on arity with a variadic `[& args]` plus `case (count args)`. This is the shape Phel's own core transducers use internally, and it works correctly when the returned fn closes over `rf` or other state. (A multi-arity `fn` with `([] ...) ([result] ...) ([result input] ...)` clauses reads cleaner but does not currently compile for transducers, so prefer the variadic form.)
+Dispatch on arity with a variadic `[& args]` plus `case (count args)`, the shape Phel's own core transducers use internally. It works correctly when the returned fn closes over `rf` or other state. (A multi-arity `fn` with `([] ...) ([result] ...) ([result input] ...)` clauses reads cleaner but does not currently compile for transducers, so prefer the variadic form.)
 
 ```phel
 ;; A transducer that doubles every element
@@ -207,7 +207,7 @@ Every dual-purpose function has two modes:
 
 **When to use which:**
 
-- **Lazy sequences**: simple linear pipelines. Compose with `->>`.
+- **Lazy sequences**: simple linear pipelines; compose with `->>`.
 - **Transducers**: avoid intermediates in multi-step pipelines, reuse one transformation across sources/destinations, or reduce into something that isn't a sequence (sums, maps, side effects).
 
 ```phel

--- a/docs/watch-guide.md
+++ b/docs/watch-guide.md
@@ -10,7 +10,7 @@
 ./vendor/bin/phel watch -b polling --poll=250   # force polling, 250ms interval
 ```
 
-On each change, `phel watch` reloads the changed namespace and its dependents in topological order.
+On each change, the changed namespace and its dependents reload in topological order.
 
 ## Options
 
@@ -29,7 +29,7 @@ On each change, `phel watch` reloads the changed namespace and its dependents in
 (watch! ["src/" "tests/"])
 ```
 
-Blocks until interrupted (Ctrl+C). Reloads changed namespaces in dependency order. Register per-namespace hooks with `register-on-reload`.
+Blocks until interrupted (Ctrl+C), reloading changed namespaces in dependency order. Register per-namespace reload hooks with `(register-on-reload namespace name hook-fn)`.
 
 ## Pitfalls
 


### PR DESCRIPTION
## 🤔 Background

The `docs/` guides had accumulated verbosity, content duplicated across several files, and a handful of stale examples that no automated check ever exercised. A cross-file audit (verifying every claim against the current compiler, core library, and CLI) surfaced both redundancy and concrete factual drift.

## 💡 Goal

Make the docs tighter, internally consistent, and correct, without losing any technical substance.

## 🔖 Changes

- **Trim verbosity** across all guides; keep every code block, table, and example.
- **De-duplicate** content repeated across files down to one canonical home plus cross-links (interop syntax, namespace-separator policy, reader conditionals, transients, optimization levels, cache/`.phel` relocation).
- **Fix stale/incorrect content**, verified against code:
  - `delay`/`force`/`delay?` exist in core (clojure-migration)
  - `find` signature `[pred-or-coll coll-or-key]` (data-structures)
  - `withBuildConfig`/`withExportConfig` accept configurator closures (configuration)
  - `:map` closed-key is `:closed`, not `:closed?` (schema)
  - `[:re ...]` needs a `#"regex"` literal or a delimiter-wrapped PCRE string (schema)
  - lazy `map`/`filter` realize one element at a time, not in fixed 32-chunks (lazy-sequences)
  - shell completion uses `completion <shell>`, not the removed Symfony-4 `_complete --generate-hook` (cli)
  - FrankenPHP worker export shape `App\PhelGenerated\...::handleRequest` (deployment)
  - fixed broken in-page anchors `#pheledn`/`#pheltransit` (data-formats)
- Restore the user-facing `./vendor/bin/phel` convention and remove introduced em dashes.

Docs-only; no runtime or API change, so no CHANGELOG entry.
