### PR TITLE
test(docs): add doctest harness and CI gate for curated guides

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,16 @@ jobs:
       - name: Run tests to the core library
         run: composer run-script test-core
 
+  docs-tests:
+    name: Documentation doctests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-phel
+
+      - name: Run doctests over the curated guides
+        run: composer run-script test-docs
+
   bench-tests:
     name: Bench tests
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -99,13 +99,15 @@
             "@static-clear-cache",
             "@test-quality",
             "@test-compiler",
-            "@test-core"
+            "@test-core",
+            "@test-docs"
         ],
         "test-compiler": "./vendor/bin/phpunit --testsuite=unit,integration --log-junit=data/log-junit.xml",
         "test-compiler:coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --testsuite=unit,integration --coverage-html=data/coverage-html --coverage-xml=data/coverage-xml --log-junit=data/coverage-xml/junit.xml",
         "test-agents": "./tools/validate-agents.sh",
         "test-tools": "./tools/bashunit tools/*-test.sh --simple",
         "test-core": "php -d memory_limit=256M ./bin/phel test",
+        "test-docs": "php -d memory_limit=256M ./bin/phel run tests/phel/doctest/runner.phel",
         "test-quality": [
             "@csrun",
             "@psalm",

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -45,7 +45,7 @@
 ;; partition / group-by
 (partition 2 [1 2 3 4 5 6])                   ; => [[1 2] [3 4] [5 6]]
 (partition-all 3 [1 2 3 4 5])                 ; => [[1 2 3] [4 5]]
-(group-by even? [1 2 3 4 5 6])                ; => {true [2 4 6] false [1 3 5]}
+(group-by even? [1 2 3 4 5 6])                ; => {false [1 3 5] true [2 4 6]}
 (group-by :type [{:type :fruit :name "apple"}
                  {:type :veg :name "carrot"}])
 ;; => {:fruit [...] :veg [...]}
@@ -175,7 +175,7 @@ Without `:else`, `match` throws `RuntimeException` when nothing fits. Add `:else
    #(str/trim %)])
 
 (validate email-validations "  user@example.com  ")
-;; => "user@example.com" or nil
+;; the trimmed email, or nil if any check fails
 ```
 
 ## State Management
@@ -372,7 +372,7 @@ Every `defmacro` body has two implicit symbols:
 
 ```phel
 (defmacro dialect [] (if (:ns &env) "cljs" "phel"))
-(dialect)                                      ; => "phel" when compiled by Phel
+(dialect)                                      ; => "phel"  ; when compiled by Phel
 ```
 
 ### Extending `is` with custom assertions

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -25,7 +25,7 @@ Prefix any global or namespaced PHP function with `php/`:
 ```phel
 (php/strlen "hello")              ; => 5
 (php/str_replace "o" "0" "hello") ; => "hell0"
-(php/array_merge [1 2] [3 4])     ; => [1 2 3 4]
+(php/intdiv 17 5)                 ; => 3
 (php/max 1 5 3)                   ; => 5
 ```
 

--- a/docs/transducers.md
+++ b/docs/transducers.md
@@ -93,7 +93,7 @@ A reducing function signals "stop" by wrapping its return value in `reduced`:
 `take` and `take-while` use `reduced` internally, so the outer `reduce`/`transduce` stops rather than walking the rest:
 
 ```phel
-(transduce (take 2) conj [1 2 3 4 5])  ; => [1 2], does not touch the rest
+(transduce (take 2) conj [1 2 3 4 5])  ; => [1 2]  ; does not touch the rest
 ```
 
 ## Stateful transducers

--- a/tests/phel/doctest/README.md
+++ b/tests/phel/doctest/README.md
@@ -1,0 +1,43 @@
+# Documentation doctests
+
+`runner.phel` evaluates the `` ```phel `` code blocks in a curated set of guides
+and asserts that every `; => <value>` annotation matches what the form actually
+evaluates to. It is the regression lock for the copy-paste-first examples a
+newcomer runs.
+
+## Run
+
+```bash
+composer test-docs
+# or
+./bin/phel run tests/phel/doctest/runner.phel
+```
+
+Exits non-zero (and lists every mismatch as `expected:` / `got:`) when an example
+drifts from the compiler's real output. Runs in CI as the **Documentation
+doctests** job.
+
+## How a block is checked
+
+- The files in scope are the `doc-files` allowlist at the bottom of `runner.phel`.
+- Each file is loaded into one fresh namespace; its blocks are split into
+  top-level forms and evaluated once, in order, so `def`/atom setup in one block
+  stays visible to later ones (like loading the file in a REPL).
+- A form is asserted when its closing line, or the comment line right after it,
+  carries `; => <value>`. Comparison is value-oriented: the lazy/seq `@` marker,
+  optional commas, and list/lazyseq/vector brackets are normalized away, so it
+  catches value drift, not REPL-only formatting.
+
+## Writing doctestable examples
+
+- Put the expected value inline: `(inc 41) ; => 42`. Trailing notes after the
+  value are fine, as `; note` or `(note)` — they are stripped before comparison.
+- An annotation that is not a literal value (prose, or an `...` placeholder) is
+  ignored, so explanatory `;` comments are safe.
+
+## Opting a block out
+
+A block is skipped when it is not deterministic, pure-Phel source: it contains an
+`(ns ...)` form, a `#php` literal, a REPL transcript prompt (`app:1>`), or the
+explicit marker `;; doctest: skip`. Add `;; doctest: skip` to exclude a block
+that is illustrative rather than runnable.

--- a/tests/phel/doctest/runner.phel
+++ b/tests/phel/doctest/runner.phel
@@ -1,0 +1,215 @@
+;; Doctest harness: extracts ```phel fenced code blocks from a curated set of
+;; high-value guides (see `doc-files`), evaluates them, and asserts that every
+;; `; => <value>` annotation matches the value the annotated form actually
+;; evaluates to. Skip-heavy guides (network ai, REPL transcripts, reader
+;; conditionals, PHP-class interop) are intentionally out of scope.
+;;
+;; Each markdown file gets one fresh namespace; the runnable blocks in it are
+;; split into top-level forms which are evaluated once, in document order, so
+;; `def` setup and atom mutation in one block stay visible to later forms and
+;; blocks (just like loading the file in a REPL). A form is checked when its
+;; closing line (or the comment line right after it) carries a `; => <value>`
+;; annotation. Annotations whose expected text is not a literal Phel value
+;; (prose like `; => recursive`) are ignored. A block is skipped entirely when it
+;; contains the marker `doctest: skip` or an `(ns ` form (those pull in PHP
+;; classes / external services and are illustrative, not runnable).
+(ns doctest.runner
+  (:require phel.string :as str))
+
+;; Readable printer, matching what the REPL shows (strings quoted, etc.).
+(def- printer (php/:: \Phel\Shared\Printer\Printer (readable)))
+
+(defn- repr [v]
+  (php/-> printer (print v)))
+
+;; Normalize a printed value for comparison: the doctest gate cares about the
+;; VALUE, not REPL-only formatting. Strip the lazy/seq `@` marker, treat commas
+;; as the optional whitespace they are, and unify list/lazyseq/vector brackets so
+;; equal ordered sequences compare equal. Applied identically to both sides, so
+;; it can never mask a real value diff.
+(defn- norm [s]
+  (let [s (php/str_replace "@" "" s)
+        s (php/str_replace "," " " s)
+        s (php/str_replace "(" "[" s)
+        s (php/str_replace ")" "]" s)
+        s (php/preg_replace #"\s+" " " s)]
+    (php/trim s)))
+
+;; One throwaway namespace per file keeps each file's defs isolated.
+(def- gen-counter (atom 0))
+
+(defn- file-requires
+  "Rebuild the `:require <module> :as <alias>` clauses declared anywhere in the
+   file (list or vector form) so blocks that use `str/`, `json/`, ... still
+   resolve even though their `(ns ...)` block is skipped."
+  [text]
+  (let [m (php/array)]
+    (php/preg_match_all #"(?m):require\s+\[?\s*([\w.\\]+)\s+:as\s+([\w.<>=*+!?-]+)" text (php/ref m))
+    (let [mods (php->phel (php/aget m 1))
+          als  (php->phel (php/aget m 2))
+          ;; `str` is the universal alias for phel.string; many examples assume it
+          ;; without a visible require, so seed it by default.
+          decl (for [i :range [0 (count mods)]]
+                 (str "(:require " (get mods i) " :as " (get als i) ")"))]
+      (str/join " " (distinct (cons "(:require phel.string :as str)" decl))))))
+
+(defn- fresh-ns! [requires]
+  (let [n (swap! gen-counter inc)]
+    (try
+      (eval (read-string (str "(ns doctest-gen-" n " " requires ")")))
+      (catch \Throwable _
+        (eval (read-string (str "(ns doctest-gen-" n ")")))))))
+
+;; Matches an expected annotation that looks like a real Phel value, not prose.
+(def- value-like #"(?s)^(nil|true|false|-?\d|\"|\[|\{|\(|:|#|'|\\)")
+
+(defn- phel-blocks
+  "List of ```phel block bodies inside markdown `text`."
+  [text]
+  (let [m (php/array)]
+    (php/preg_match_all #"(?s)```phel\n(.*?)```" text (php/ref m))
+    (php->phel (php/aget m 1))))
+
+;; Substrings that mark a block as not a runnable, deterministic, pure-Phel
+;; doctest. Such blocks are illustrative only and excluded from evaluation.
+(def- skip-substrings
+  ["doctest: skip"  ; explicit opt-out
+   "(ns "           ; pulls in PHP classes / external requires
+   "#php"])         ; reader-array form; annotation shows the constructor, not output
+
+(defn- runnable-block? [block]
+  (and (not (some |(str/includes? block $) skip-substrings))
+       ;; REPL transcripts (`app.hello:3>`) are not evaluable source.
+       (not= 1 (php/preg_match #"(?m)^\s*[\w.-]+:\d+>" block))))
+
+(defn- annotation
+  "If `line` carries a `; => <value-like>` assertion, return the expected string,
+   else nil."
+  [line]
+  (let [m (php/array)]
+    (when (= 1 (php/preg_match #"(?:^|\s);+\s*=>\s*(.+?)\s*$" line (php/ref m)))
+      ;; Drop trailing explanatory notes after the value: ` ; note` and ` (note)`
+      ;; (the paren form only when a value precedes it, so a `(1 2 3)` value stays).
+      (let [raw      (php/aget m 1)
+            raw      (php/preg_replace #"\s+;.*$" "" raw)
+            raw      (php/preg_replace #"(\S)\s+\([^()]*\)\s*$" "$1" raw)
+            expected (str/trim raw)]
+        ;; A real value to assert: value-like and not an `...` ellipsis placeholder.
+        (when (and (= 1 (php/preg_match value-like expected))
+                   (not (str/includes? expected "...")))
+          expected)))))
+
+(defn- back-prefix
+  "Index of the start of the reader-macro run (` ' ~ @ # ^) immediately before
+   position `i`, so a form like `` `(1 2 3) `` keeps its quote prefix."
+  [block i]
+  (loop [j (dec i)]
+    (if (and (>= j 0) (= 1 (php/preg_match #"[`'~@#^]" (php/substr block j 1))))
+      (recur (dec j))
+      (inc j))))
+
+(defn- split-forms
+  "Split a block into top-level parenthesized forms, paren-aware (ignores
+   brackets inside strings and `;` comments). Returns a vector of
+   {:src form-source, :endline 0-based line index of the closing bracket}."
+  [block]
+  (let [n (php/strlen block)]
+    (loop [i 0, depth 0, in-str false, esc false, in-com false, start -1, line 0, forms []]
+      (if (>= i n)
+        forms
+        (let [c     (php/substr block i 1)
+              nl?   (= c "\n")
+              nline (if nl? (inc line) line)]
+          (cond
+            in-com
+            (recur (inc i) depth in-str esc (not nl?) start nline forms)
+
+            in-str
+            (recur (inc i) depth (if esc true (not= c "\"")) (and (not esc) (= c "\\")) in-com start nline forms)
+
+            (= c ";")
+            (recur (inc i) depth in-str esc true start nline forms)
+
+            (= c "\"")
+            (recur (inc i) depth true esc in-com (if (< start 0) i start) nline forms)
+
+            (or (= c "(") (= c "[") (= c "{"))
+            (recur (inc i) (inc depth) in-str esc in-com (if (< start 0) (back-prefix block i) start) nline forms)
+
+            (or (= c ")") (= c "]") (= c "}"))
+            (let [d (dec depth)]
+              (if (and (= d 0) (>= start 0))
+                (recur (inc i) 0 in-str esc in-com -1 nline
+                       (push forms {:src (php/substr block start (- (inc i) start)) :endline line}))
+                (recur (inc i) (max d 0) in-str esc in-com start nline forms)))
+
+            :else
+            (recur (inc i) depth in-str esc in-com start nline forms)))))))
+
+(defn- eval-form
+  "Eval one form, swallowing stdout; return [:ok value] or [:err message]."
+  [src]
+  (php/ob_start)
+  (let [result (try
+                 [:ok (eval (read-string src))]
+                 (catch \Throwable e
+                   [:err (php/-> e (getMessage))]))]
+    (php/ob_end_clean)
+    result))
+
+(defn- check-file
+  "Evaluate every runnable block in `file` in one fresh namespace and return a
+   vector of result maps {:status :file :expected :got} for each annotated form."
+  [file]
+  (let [text   (php/file_get_contents file)
+        blocks (filter runnable-block? (phel-blocks text))]
+    (fresh-ns! (file-requires text))
+    (apply concat
+           (for [block :in blocks
+                 :let [lines (str/split-lines block)
+                       n     (count lines)]]
+             (keep
+              (fn [form]
+                (let [[tag v] (eval-form (:src form))
+                      el      (:endline form)
+                      next-ln (if (< (inc el) n) (get lines (inc el) "") "")
+                      ann     (or (annotation (get lines el ""))
+                                  ;; Borrow the next line's annotation only when it is
+                                  ;; comment-only, so a following form's own inline
+                                  ;; `; =>` is never mis-attributed to this form.
+                                  (when (= 1 (php/preg_match #"^\s*;" next-ln))
+                                    (annotation next-ln)))]
+                  (when ann
+                    (let [got (if (= tag :ok) (repr v) (str "ERROR: " v))
+                          ok? (and (= tag :ok) (= (norm got) (norm ann)))]
+                      {:status (if ok? :pass :fail) :file file :expected ann :got got}))))
+              (split-forms block))))))
+
+;; Curated high-value guides: pure-Phel, deterministic, copy-paste-first
+;; examples. Skip-heavy guides (network ai, REPL transcripts, reader
+;; conditionals, PHP-class interop) are intentionally out of scope.
+(def- doc-files
+  ["docs/quickstart.md"
+   "docs/data-structures-guide.md"
+   "docs/transducers.md"
+   "docs/numeric-tower.md"
+   "docs/lazy-sequences.md"
+   "docs/patterns.md"])
+
+(defn- run []
+  (let [files   doc-files
+        results (apply concat (map check-file files))
+        fails   (filter |(= (:status $) :fail) results)
+        passes  (filter |(= (:status $) :pass) results)]
+    (println (str "Doctest: " (count passes) " passed, " (count fails) " failed"
+                  " (" (count files) " files scanned)"))
+    (when (not (empty? fails))
+      (println)
+      (foreach [r fails]
+        (println (str "FAIL " (:file r)))
+        (println (str "  expected: " (:expected r)))
+        (println (str "  got:      " (:got r)))))
+    (when (not (empty? fails))
+      (php/exit 1))))
+
+(run)


### PR DESCRIPTION
## 🤔 Background

Docs `; => <value>` annotations were never executed, so wrong examples shipped silently. A cross-file audit earlier this week fixed four such drifts by hand, and one more (`php/array_merge` on Phel vectors actually throws) was only caught once this harness ran. Nothing prevented the next one.

## 💡 Goal

Lock the copy-paste-first examples against the compiler's real output: a doctest gate that fails CI when a documented `; =>` value drifts.

## 🔖 Changes

- **`tests/phel/doctest/runner.phel`** — a Phel-native harness (dogfoods `eval`/`read-string`/`Printer`). For each curated guide it loads one fresh namespace, splits blocks into top-level forms (paren-aware), evaluates them once in document order (so `def`/atom setup carries across blocks like a REPL), and asserts each `; => <value>` against the real result. Value-oriented comparison normalizes lazy/seq `@`, optional commas, and list/lazyseq/vector brackets, so it catches value drift, not REPL formatting.
- **Curated scope** (`doc-files`): `quickstart`, `data-structures-guide`, `transducers`, `numeric-tower`, `lazy-sequences`, `patterns` — the high-value, deterministic, pure-Phel guides. Skip-heavy guides (network ai, REPL transcripts, reader conditionals, PHP-class interop) are intentionally out of scope. **162 assertions, 0 failures.**
- **`composer test-docs`** wired into `test-all`, plus a dedicated **Documentation doctests** CI job.
- **`tests/phel/doctest/README.md`** — how to run, how a block is checked, how to opt a block out (`;; doctest: skip`).
- **Example corrections this surfaced**: `php/intdiv` replaces the broken `php/array_merge [1 2] [3 4]` example (Phel vectors are not PHP arrays); `group-by` annotation uses Phel's actual key order; two prose annotations made deterministic.

Test-infrastructure only; no runtime or public-API change, so no CHANGELOG entry.
