### PR TITLE
feat(test): show deftest name in failure headlines and diff string mismatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ build/cache fixes.
 - `phel build -O <level>`: per-run override; invalidates the build and compiled-code caches
 - `phel config`: prints the merged config with provenance; `--json` for machine output
 - `withBuildConfig()`/`withExportConfig()` accept a configurator closure, composing with the flattened setters in any order
+- `phel test` failure output: string `=` mismatches print a windowed expected/actual pair with a caret under the first differing character
 
 ### Changed
 
+- `phel test` failure output: `FAIL`/`ERROR` headlines always include the `deftest` name (`FAIL my-test (file.phel:4)`), not only when an assertion message is present
 - `phel init` scaffolds a `phel-config.php` with a docs link and commented-out tweaks
 - New [Deployment guide](docs/deployment.md): shared-nothing vs worker runtimes (FrankenPHP/RoadRunner)
 

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -447,8 +447,10 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
 
 (defn- print-headline [prefix {:test-name test-name, :message message, :location location}]
   (print prefix)
+  (when test-name
+    (print (str " " test-name)))
   (when message
-    (print (str " in (" test-name " '" message "')")))
+    (print (str " '" message "'")))
   (when location
     (print (str " (" (php/basename (get location :file)) ":" (get location :line) ")")))
   (println))
@@ -590,6 +592,62 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
   (and (same-shape? expected actual)
        (diff-worth-rendering? expected actual)))
 
+;; --------------------------
+;; String diff (= failures)
+;; --------------------------
+
+(def- string-diff-context
+  ;; Characters of context shown before the first mismatch when windowing
+  ;; a long string; the window also extends this far after the mismatch.
+  40)
+
+(defn- first-mismatch-index
+  "0-based index of the first differing character between strings `a` and `b`. When one string is a prefix of the other, the mismatch is the length of the shorter one. Returns nil for equal strings."
+  [a b]
+  (let [n (min (php/strlen a) (php/strlen b))]
+    (loop [i 0]
+      (cond
+        (>= i n)
+        (if (= (php/strlen a) (php/strlen b)) nil n)
+
+        (not= (php/substr a i 1) (php/substr b i 1))
+        i
+
+        :else                                        (recur (inc i))))))
+
+(defn- escape-for-string-diff
+  "Escapes backslashes, quotes, and control whitespace so every character renders one-or-more visible columns and the caret stays aligned."
+  [s]
+  (let [s (php/str_replace "\\" "\\\\" s)
+        s (php/str_replace "\n" "\\n" s)
+        s (php/str_replace "\t" "\\t" s)
+        s (php/str_replace "\r" "\\r" s)]
+    (php/str_replace "\"" "\\\"" s)))
+
+(defn- string-diff-window
+  "Renders string `s` windowed from `start` to just past mismatch index `idx` (plus trailing context), quoted and escaped, with `...` markers for clipped ends. Returns [rendered caret-column] where caret-column points at the mismatch within the rendered text."
+  [s start idx]
+  (let [len    (php/strlen s)
+        end    (min len (+ idx string-diff-context))
+        window (php/substr s start (- end start))
+        prefix (php/substr s start (- idx start))
+        lead   (if (pos? start) "..." "")
+        trail  (if (< end len) "..." "")]
+    [(str lead "\"" (escape-for-string-diff window) "\"" trail)
+     (+ (php/strlen lead) 1 (php/strlen (escape-for-string-diff prefix)))]))
+
+(defn- print-string-diff
+  "Prints a windowed expected/actual pair with a caret under the first differing character. Supplements the summary line for `=` failures over two strings."
+  [expected actual]
+  (when-let [idx (first-mismatch-index expected actual)]
+    (let [start            (max 0 (- idx string-diff-context))
+          [exp-line _]     (string-diff-window expected start idx)
+          [act-line caret] (string-diff-window actual start idx)]
+      (println (str "  String diff (first mismatch at index " idx "):"))
+      (println (str "    expected: " exp-line))
+      (println (str "    actual:   " act-line))
+      (println (str (php/str_repeat " " (+ 14 caret)) "^")))))
+
 (defn- print-error [data]
   (print-error-headline data)
   (let [{:exception exception, :form form} data
@@ -616,9 +674,11 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
   (print-form-evaluated "          Form" actual
                         "  evaluated to" result)
   (print-label "    but is not" pred "to" (readable-str expected))
-  (when (and (= pred '=)
-             (collection-diff-applicable? expected result))
-    (print-collection-diff expected result)))
+  (when (= pred '=)
+    (when (collection-diff-applicable? expected result)
+      (print-collection-diff expected result))
+    (when (and (string? expected) (string? result))
+      (print-string-diff expected result))))
 
 (defn- print-binary-not-failure [{:pred pred, :expected expected, :actual actual, :result result}]
   (print-form-evaluated "          Form" actual

--- a/tests/phel/reporter-diff.phel
+++ b/tests/phel/reporter-diff.phel
@@ -155,3 +155,82 @@
         "diff renders for maps with mixed-type keys")
     (is (php/preg_match "/~ \"b\" 2 -> 99/" out)
         "string-keyed change is reported")))
+
+;; ---------------------------------------------------------------------------
+;; Headline: FAIL/ERROR lines carry the deftest name (and optional message)
+;; ---------------------------------------------------------------------------
+
+(defn- named-failure-event [extra]
+  (merge {:type :binary
+          :state :failed
+          :pred '=
+          :expected 1
+          :actual 'actual-form
+          :result 2
+          :form '(= 1 2)
+          :test-name "my-test"
+          :location {:file "diff.phel" :line 7}}
+         extra))
+
+(defn- run-default-reporter-event [event]
+  (let [rep (t/resolve-reporter :default)]
+    (with-output-buffer
+      (rep {:type :begin-test-run})
+      (rep event)
+      (rep {:type :summary :total 1 :pass 0 :failed 1 :error 0
+            :failures [event]}))))
+
+(deftest test-failure-headline-shows-test-name
+  (let [out (run-default-reporter-event (named-failure-event {}))]
+    (is (php/preg_match "/FAIL my-test \\(diff\\.phel:7\\)/" out)
+        "headline carries the deftest name before the location")))
+
+(deftest test-failure-headline-shows-message-after-test-name
+  (let [out (run-default-reporter-event (named-failure-event {:message "boom"}))]
+    (is (php/preg_match "/FAIL my-test 'boom' \\(diff\\.phel:7\\)/" out)
+        "headline carries the name, then the quoted message, then the location")))
+
+(deftest test-error-headline-shows-test-name
+  (let [out (run-default-reporter-event
+             (named-failure-event {:state :error
+                                   :exception (php/new \RuntimeException "kaput")}))]
+    (is (php/preg_match "/ERROR my-test \\(diff\\.phel:7\\)/" out)
+        "error headline carries the deftest name before the location")))
+
+;; ---------------------------------------------------------------------------
+;; String diff: windowed expected/actual pair with a caret at the mismatch
+;; ---------------------------------------------------------------------------
+
+(deftest test-string-diff-marks-first-mismatch
+  (let [out (run-default-reporter "abcdef" "abcXef")]
+    (is (php/preg_match "/String diff \\(first mismatch at index 3\\):/" out)
+        "reports the index of the first differing character")
+    (is (php/preg_match "/expected: \"abcdef\"/" out) "shows the expected string")
+    (is (php/preg_match "/actual:   \"abcXef\"/" out) "shows the actual string")
+    (is (php/preg_match "/(?m)^ {18}\\^$/" out)
+        "caret sits under the mismatch column (14 label cols + quote + 3 chars)")))
+
+(deftest test-string-diff-windows-long-strings
+  (let [prefix (php/str_repeat "x" 100)
+        out    (run-default-reporter (str prefix "abc") (str prefix "abd"))]
+    (is (php/preg_match "/first mismatch at index 102/" out)
+        "index refers to the full string, not the window")
+    (is (php/preg_match "/expected: \\.\\.\\.\"/" out)
+        "clipped leading context is marked with ...")))
+
+(deftest test-string-diff-prefix-case-points-past-shorter-string
+  (let [out (run-default-reporter "abc" "abcdef")]
+    (is (php/preg_match "/first mismatch at index 3/" out)
+        "a strict prefix mismatches at the shorter string's length")))
+
+(deftest test-string-diff-escapes-control-characters
+  (let [out (run-default-reporter "a\nb" "a\nc")]
+    (is (php/preg_match "/expected: \"a\\\\nb\"/" out)
+        "newlines render as the two-column escape \\n")
+    (is (php/preg_match "/first mismatch at index 2/" out)
+        "index counts the raw newline as one character")))
+
+(deftest test-string-diff-not-rendered-for-non-strings
+  (let [out (run-default-reporter 1 2)]
+    (is (= 0 (php/preg_match "/String diff/" out))
+        "no string diff block for non-string values")))


### PR DESCRIPTION
## 🤔 Background

Two `phel test` failure-output gaps hurt scanability:

- A plain `(is ...)` failure printed `FAIL (file.phel:4)` with no test name; the name only appeared when the assertion carried a message. Finding the failing `deftest` meant cross-referencing line numbers.
- A failed `=` over two strings dumped both full strings with no pointer to where they diverge, which is painful for long or near-identical strings. (Maps, vectors, and sets already get a stacked `Diff:` block.)

## 💡 Goal

Make the default reporter's failure output identify the failing test at a glance and pinpoint string mismatches.

## 🔖 Changes

- `print-headline`: always prints the `deftest` name: `FAIL my-test (file.phel:4)`, and with a message `FAIL my-test 'msg' (file.phel:10)`. Applies to `FAIL` and `ERROR` headlines.
- New `String diff` block for failed `=` assertions over two strings:

  ```
    String diff (first mismatch at index 16):
      expected: "the quick brown fox jumps over the lazy dog again and ag"...
      actual:   "the quick brown dog jumps over the lazy dog again and ag"...
                                 ^
  ```

  Windows long strings to 40 chars of context around the mismatch with `...` markers, escapes control characters so the caret stays aligned, and handles the strict-prefix case (mismatch at the shorter string's length).
- 9 new Phel tests in `tests/phel/reporter-diff.phel` covering headline name/message/error variants, caret position, windowing, prefix case, escaping, and the non-string guard.
- CHANGELOG entries under `## Unreleased`.
