### PR TITLE
feat(run): add phel test --watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ build/cache fixes.
 - `phel config`: prints the merged config with provenance; `--json` for machine output
 - `withBuildConfig()`/`withExportConfig()` accept a configurator closure, composing with the flattened setters in any order
 - `phel test` failure output: string `=` mismatches print a windowed expected/actual pair with a caret under the first differing character
+- `phel test --watch`: re-runs the selected tests whenever a `.phel` file (or `phel-config.php`) under the project source/test directories changes
 
 ### Changed
 

--- a/src/php/Run/Application/Test/TestWatchLoop.php
+++ b/src/php/Run/Application/Test/TestWatchLoop.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application\Test;
+
+use Phel\Run\Domain\Test\WatchFileScannerInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * `phel test --watch` driver: runs the test suite once, then re-runs it every
+ * time a watched file changes. The suite itself executes as a subprocess (the
+ * `$runTests` callable), so each run starts from a clean runtime; this loop
+ * only owns change detection and pacing.
+ */
+final readonly class TestWatchLoop
+{
+    public const int POLL_INTERVAL_MS = 500;
+
+    public function __construct(
+        private WatchFileScannerInterface $scanner,
+    ) {}
+
+    /**
+     * Blocks until terminated (Ctrl+C) unless `$maxRuns` is given (used by
+     * tests). Returns the exit code of the most recent test run.
+     *
+     * @param list<string>       $directories
+     * @param callable():int     $runTests
+     * @param callable(int):void $sleep       milliseconds; injectable for tests
+     */
+    public function run(
+        array $directories,
+        callable $runTests,
+        OutputInterface $output,
+        ?callable $sleep = null,
+        ?int $maxRuns = null,
+    ): int {
+        $sleep ??= static function (int $ms): void {
+            usleep($ms * 1000);
+        };
+
+        $exitCode = $runTests();
+        $runs = 1;
+        $snapshot = $this->scanner->snapshot($directories);
+        $this->announceWatching($output);
+
+        while ($maxRuns === null || $runs < $maxRuns) {
+            $sleep(self::POLL_INTERVAL_MS);
+
+            $next = $this->scanner->snapshot($directories);
+            if ($next === $snapshot) {
+                continue;
+            }
+
+            $output->writeln('');
+            $output->writeln('<comment>Change detected, re-running tests...</comment>');
+            $exitCode = $runTests();
+            ++$runs;
+            // Re-scan after the run so changes made while testing trigger
+            // one more run instead of being silently absorbed.
+            $snapshot = $this->scanner->snapshot($directories);
+            $this->announceWatching($output);
+        }
+
+        return $exitCode;
+    }
+
+    private function announceWatching(OutputInterface $output): void
+    {
+        $output->writeln('<info>Watching for file changes... (press Ctrl+C to stop)</info>');
+    }
+}

--- a/src/php/Run/Application/Test/TestWatchRunner.php
+++ b/src/php/Run/Application/Test/TestWatchRunner.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application\Test;
+
+use Phel\Shared\Facade\CommandFacadeInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Resolves which directories `phel test --watch` observes (the project's
+ * source and test directories) and hands them to the watch loop.
+ */
+final readonly class TestWatchRunner
+{
+    public function __construct(
+        private CommandFacadeInterface $commandFacade,
+        private TestWatchLoop $loop,
+    ) {}
+
+    /**
+     * @param callable():int $runTests
+     */
+    public function run(callable $runTests, OutputInterface $output): int
+    {
+        $directories = [
+            ...$this->commandFacade->getProjectSourceDirectories(),
+            ...$this->commandFacade->getTestDirectories(),
+        ];
+
+        return $this->loop->run($directories, $runTests, $output);
+    }
+}

--- a/src/php/Run/Application/Test/WatchFileScanner.php
+++ b/src/php/Run/Application/Test/WatchFileScanner.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application\Test;
+
+use FilesystemIterator;
+use Phel\Run\Domain\Test\WatchFileScannerInterface;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Polling-friendly snapshot of the `.phel` sources (plus `phel-config.php`
+ * files) under a set of directories. Two consecutive snapshots compare equal
+ * exactly when no watched file was added, removed, or modified in between.
+ */
+final class WatchFileScanner implements WatchFileScannerInterface
+{
+    public function snapshot(array $directories): array
+    {
+        $snapshot = [];
+        foreach ($directories as $directory) {
+            if (!is_dir($directory)) {
+                continue;
+            }
+
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+            );
+            /** @var SplFileInfo $file */
+            foreach ($iterator as $file) {
+                if (!$file->isFile()) {
+                    continue;
+                }
+
+                $name = $file->getFilename();
+                if (!str_ends_with($name, '.phel') && $name !== 'phel-config.php') {
+                    continue;
+                }
+
+                $mtime = $file->getMTime();
+                $snapshot[$file->getPathname()] = $mtime;
+            }
+        }
+
+        ksort($snapshot);
+
+        return $snapshot;
+    }
+}

--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -9,6 +9,7 @@ Runtime execution: runs Phel namespaces/files, REPL, evaluation, testing, and mo
 - Query: `getAllPhelDirectories`, `getLoadedNamespaces`, `getVersion`, `autoDetectEntryPoint` (prefers `main.phel`, falls back to `core.phel`)
 - Debugging: `enableDebugLineTap(?string $phelFileFilter, string $logPath)`, `disableDebugLineTap`
 - Parallel testing: `createParallelTestOrchestrator()` (process pool spawning `phel _test-worker` subprocesses, one ns per length-prefixed JSON work frame, per-ns output buffered and flushed in input order), `createCpuCountDetector()` (honours `PHEL_TEST_WORKERS`, falls back to `nproc`/`sysctl`/`/proc/cpuinfo`, caps at 8)
+- Watch testing: `runTestWatchLoop(callable $runTests, OutputInterface)` (`phel test --watch`: polls project src/test dirs for `.phel`/`phel-config.php` mtime changes every 500ms, re-invokes `$runTests` subprocess per change)
 - Error handling: `writeLocatedException`, `writeStackTrace`
 
 ## Dependencies

--- a/src/php/Run/Domain/Test/WatchFileScannerInterface.php
+++ b/src/php/Run/Domain/Test/WatchFileScannerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Test;
+
+interface WatchFileScannerInterface
+{
+    /**
+     * Snapshot of every watched file under the given directories.
+     *
+     * @param list<string> $directories
+     *
+     * @return array<string, int> absolute file path => mtime
+     */
+    public function snapshot(array $directories): array;
+}

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
+use function array_slice;
 use function count;
 use function is_array;
 use function sprintf;
@@ -134,11 +135,20 @@ final class TestCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Run namespaces in parallel using subprocess workers. Accepts an integer worker count, "auto" (CPU detection capped at 8), or "max" (every core the kernel reports, uncapped). Auto-disabled for --reporter=tap, --list, or when a profiler hook is installed.',
+            )->addOption(
+                TestCommandOptionParser::OPT_WATCH,
+                null,
+                InputOption::VALUE_NONE,
+                'Re-run the selected tests whenever a .phel file (or phel-config.php) under the project source/test directories changes. Press Ctrl+C to stop.',
             );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        if ((bool) $input->getOption(TestCommandOptionParser::OPT_WATCH)) {
+            return $this->runWatchMode($output);
+        }
+
         $optionParser = new TestCommandOptionParser();
 
         try {
@@ -240,6 +250,42 @@ final class TestCommand extends Command
         }
 
         return self::FAILURE;
+    }
+
+    /**
+     * Watch mode: re-runs this same invocation (minus --watch) as a subprocess
+     * whenever a watched file changes, so each run starts from a clean runtime.
+     */
+    private function runWatchMode(OutputInterface $output): int
+    {
+        $command = $this->buildWatchRerunShellCommand();
+        $runTests = static function () use ($command): int {
+            $exitCode = 1;
+            passthru($command, $exitCode);
+
+            return $exitCode;
+        };
+
+        return $this->getFacade()->runTestWatchLoop($runTests, $output);
+    }
+
+    private function buildWatchRerunShellCommand(): string
+    {
+        $argv = ScalarCoercion::toStringList($_SERVER['argv'] ?? null);
+        $arguments = [];
+        foreach (array_slice($argv, 1) as $argument) {
+            if ($argument !== '--' . TestCommandOptionParser::OPT_WATCH) {
+                $arguments[] = $argument;
+            }
+        }
+
+        $script = ScalarCoercion::toString($_SERVER['SCRIPT_FILENAME'] ?? null);
+        $parts = [escapeshellarg(PHP_BINARY), escapeshellarg($script)];
+        foreach ($arguments as $argument) {
+            $parts[] = escapeshellarg($argument);
+        }
+
+        return implode(' ', $parts);
     }
 
     /**

--- a/src/php/Run/Infrastructure/Command/TestCommandOptionParser.php
+++ b/src/php/Run/Infrastructure/Command/TestCommandOptionParser.php
@@ -63,6 +63,8 @@ final readonly class TestCommandOptionParser
 
     public const string OPT_PARALLEL = 'parallel';
 
+    public const string OPT_WATCH = 'watch';
+
     private const string LAST_FAILED_FILENAME = 'last-failed.txt';
 
     /**

--- a/src/php/Run/RunFacade.php
+++ b/src/php/Run/RunFacade.php
@@ -165,6 +165,20 @@ final class RunFacade extends AbstractFacade implements RunFacadeInterface
     }
 
     /**
+     * Runs `$runTests` once, then again on every change under the project's
+     * source and test directories. Blocks until terminated; returns the exit
+     * code of the most recent run.
+     *
+     * @param callable():int $runTests
+     */
+    public function runTestWatchLoop(callable $runTests, OutputInterface $output): int
+    {
+        return $this->getFactory()
+            ->createTestWatchRunner()
+            ->run($runTests, $output);
+    }
+
+    /**
      * @return list<ModuleHealthCheckInterface>
      */
     public function getModuleHealthChecks(): array

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -20,6 +20,9 @@ use Phel\Run\Application\ReplHistoryPathResolver;
 use Phel\Run\Application\StructuredEvaluator;
 use Phel\Run\Application\Test\CpuCountDetector;
 use Phel\Run\Application\Test\ParallelTestOrchestrator;
+use Phel\Run\Application\Test\TestWatchLoop;
+use Phel\Run\Application\Test\TestWatchRunner;
+use Phel\Run\Application\Test\WatchFileScanner;
 use Phel\Run\Domain\Repl\Hint\ArgumentCountHint;
 use Phel\Run\Domain\Repl\Hint\NotCallableHint;
 use Phel\Run\Domain\Repl\Hint\ReplHintInterface;
@@ -281,6 +284,14 @@ class RunFactory extends AbstractFactory
     public function createCpuCountDetector(): CpuCountDetector
     {
         return new CpuCountDetector();
+    }
+
+    public function createTestWatchRunner(): TestWatchRunner
+    {
+        return new TestWatchRunner(
+            $this->getCommandFacade(),
+            new TestWatchLoop(new WatchFileScanner()),
+        );
     }
 
     private function resolvePhelBinaryPath(): string

--- a/tests/php/Integration/Run/Command/Test/FixtureProjectHelper.php
+++ b/tests/php/Integration/Run/Command/Test/FixtureProjectHelper.php
@@ -10,6 +10,7 @@ use function dirname;
 use function escapeshellarg;
 use function exec;
 use function implode;
+use function is_resource;
 use function sprintf;
 
 /**
@@ -96,6 +97,57 @@ final readonly class FixtureProjectHelper
         exec($cmd, $output, $exitCode);
 
         return [$exitCode, implode("\n", $output)];
+    }
+
+    /**
+     * Runs `phel test --watch`, waits for the first idle announcement,
+     * touches `$relativeFileToTouch` (with a future mtime so the second-level
+     * granularity scanner is guaranteed to see it), waits for the watcher to
+     * go idle again, then terminates the process. Returns everything written
+     * to stdout/stderr.
+     */
+    public function runPhelTestWatchCycle(string $relativeFileToTouch, int $timeoutSeconds = 60): string
+    {
+        $cmd = 'cd ' . escapeshellarg($this->projectDir)
+            . ' && exec php -d memory_limit=256M ' . escapeshellarg($this->repoRoot . '/bin/phel')
+            . ' test --watch 2>&1';
+
+        $process = proc_open($cmd, [1 => ['pipe', 'w']], $pipes);
+        if (!is_resource($process)) {
+            throw new RuntimeException('Cannot start phel test --watch');
+        }
+
+        stream_set_blocking($pipes[1], false);
+
+        $output = '';
+        $touched = false;
+        $deadline = microtime(true) + $timeoutSeconds;
+        $idleMarker = 'Watching for file changes';
+
+        while (microtime(true) < $deadline) {
+            $chunk = stream_get_contents($pipes[1]);
+            if ($chunk !== false && $chunk !== '') {
+                $output .= $chunk;
+            }
+
+            $idleCount = substr_count($output, $idleMarker);
+            if (!$touched && $idleCount >= 1) {
+                touch($this->projectDir . '/' . $relativeFileToTouch, time() + 2);
+                $touched = true;
+            }
+
+            if ($touched && $idleCount >= 2) {
+                break;
+            }
+
+            usleep(100_000);
+        }
+
+        proc_terminate($process, 9);
+        fclose($pipes[1]);
+        proc_close($process);
+
+        return $output;
     }
 
     private static function copyPhelFiles(string $from, string $to): void

--- a/tests/php/Integration/Run/Command/Test/TestCommandWatch/Fixtures/test1.phel
+++ b/tests/php/Integration/Run/Command/Test/TestCommandWatch/Fixtures/test1.phel
@@ -1,0 +1,5 @@
+(ns test-cmd-watch.test1
+  (:require phel.test :refer [deftest is]))
+
+(deftest my-watch-test
+  (is (= 1 1)))

--- a/tests/php/Integration/Run/Command/Test/TestCommandWatch/TestCommandWatchTest.php
+++ b/tests/php/Integration/Run/Command/Test/TestCommandWatch/TestCommandWatchTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Run\Command\Test\TestCommandWatch;
+
+use Override;
+use PhelTest\Integration\Run\Command\Test\FixtureProjectHelper;
+use PHPUnit\Framework\TestCase;
+
+final class TestCommandWatchTest extends TestCase
+{
+    private FixtureProjectHelper $project;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->project = FixtureProjectHelper::setUpProject(__DIR__);
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->project->tearDownProject();
+    }
+
+    public function test_watch_reruns_tests_when_a_file_changes(): void
+    {
+        $output = $this->project->runPhelTestWatchCycle('Fixtures/test1.phel');
+
+        self::assertSame(
+            2,
+            substr_count($output, 'Watching for file changes'),
+            'watcher announces idle after the initial run and after the rerun: ' . $output,
+        );
+        self::assertStringContainsString('Change detected, re-running tests', $output);
+        self::assertSame(
+            2,
+            substr_count($output, 'Passed: 1'),
+            'the suite runs twice: ' . $output,
+        );
+    }
+}

--- a/tests/php/Unit/Run/Application/Test/TestWatchLoopTest.php
+++ b/tests/php/Unit/Run/Application/Test/TestWatchLoopTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Application\Test;
+
+use Phel\Run\Application\Test\TestWatchLoop;
+use Phel\Run\Domain\Test\WatchFileScannerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+use function count;
+
+final class TestWatchLoopTest extends TestCase
+{
+    public function test_runs_once_and_waits_when_nothing_changes(): void
+    {
+        $loop = new TestWatchLoop($this->scannerReturning([
+            ['a.phel' => 1],
+            ['a.phel' => 1],
+            ['a.phel' => 1],
+        ]));
+
+        $runs = 0;
+        $output = new BufferedOutput();
+
+        $exitCode = $loop->run(
+            ['/src'],
+            static function () use (&$runs): int {
+                ++$runs;
+
+                return 0;
+            },
+            $output,
+            static function (int $ms): void {},
+            maxRuns: 1,
+        );
+
+        self::assertSame(0, $exitCode);
+        self::assertSame(1, $runs);
+        self::assertStringContainsString('Watching for file changes', $output->fetch());
+    }
+
+    public function test_reruns_when_a_snapshot_changes(): void
+    {
+        $loop = new TestWatchLoop($this->scannerReturning([
+            ['a.phel' => 1],  // after initial run
+            ['a.phel' => 2],  // poll detects change
+            ['a.phel' => 2],  // re-scan after second run
+        ]));
+
+        $exitCodes = [1, 0];
+        $runs = 0;
+        $output = new BufferedOutput();
+
+        $exitCode = $loop->run(
+            ['/src'],
+            static function () use (&$runs, $exitCodes): int {
+                return $exitCodes[$runs++];
+            },
+            $output,
+            static function (int $ms): void {},
+            maxRuns: 2,
+        );
+
+        self::assertSame(0, $exitCode, 'returns the exit code of the most recent run');
+        self::assertSame(2, $runs);
+        self::assertStringContainsString('Change detected, re-running tests', $output->fetch());
+    }
+
+    public function test_unchanged_polls_do_not_rerun(): void
+    {
+        $loop = new TestWatchLoop($this->scannerReturning([
+            ['a.phel' => 1],
+            ['a.phel' => 1],
+            ['a.phel' => 1],
+            ['a.phel' => 2],
+            ['a.phel' => 2],
+        ]));
+
+        $runs = 0;
+        $sleeps = 0;
+
+        $loop->run(
+            ['/src'],
+            static function () use (&$runs): int {
+                ++$runs;
+
+                return 0;
+            },
+            new BufferedOutput(),
+            static function (int $ms) use (&$sleeps): void {
+                ++$sleeps;
+            },
+            maxRuns: 2,
+        );
+
+        self::assertSame(2, $runs);
+        self::assertSame(3, $sleeps, 'two idle polls plus the one that detected the change');
+    }
+
+    /**
+     * @param list<array<string, int>> $snapshots consecutive snapshot() return values; the last one repeats
+     */
+    private function scannerReturning(array $snapshots): WatchFileScannerInterface
+    {
+        return new class($snapshots) implements WatchFileScannerInterface {
+            public function __construct(private array $snapshots) {}
+
+            public function snapshot(array $directories): array
+            {
+                /** @var array<string, int> $next */
+                $next = count($this->snapshots) > 1
+                    ? array_shift($this->snapshots)
+                    : $this->snapshots[0];
+
+                return $next;
+            }
+        };
+    }
+}

--- a/tests/php/Unit/Run/Application/Test/WatchFileScannerTest.php
+++ b/tests/php/Unit/Run/Application/Test/WatchFileScannerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Application\Test;
+
+use Phel\Run\Application\Test\WatchFileScanner;
+use PHPUnit\Framework\TestCase;
+
+final class WatchFileScannerTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/phel-watch-scanner-' . bin2hex(random_bytes(6));
+        mkdir($this->dir . '/nested', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        exec('rm -rf ' . escapeshellarg($this->dir));
+    }
+
+    public function test_collects_phel_files_and_config_recursively(): void
+    {
+        touch($this->dir . '/a.phel');
+        touch($this->dir . '/nested/b.phel');
+        touch($this->dir . '/phel-config.php');
+        touch($this->dir . '/ignored.php');
+        touch($this->dir . '/ignored.txt');
+
+        $snapshot = new WatchFileScanner()->snapshot([$this->dir]);
+
+        self::assertSame(
+            [
+                $this->dir . '/a.phel',
+                $this->dir . '/nested/b.phel',
+                $this->dir . '/phel-config.php',
+            ],
+            array_keys($snapshot),
+        );
+    }
+
+    public function test_snapshot_changes_when_a_file_is_touched(): void
+    {
+        $file = $this->dir . '/a.phel';
+        touch($file, time() - 100);
+        $scanner = new WatchFileScanner();
+
+        $before = $scanner->snapshot([$this->dir]);
+        touch($file, time());
+        $after = $scanner->snapshot([$this->dir]);
+
+        self::assertNotSame($before, $after);
+    }
+
+    public function test_missing_directory_is_skipped(): void
+    {
+        self::assertSame([], new WatchFileScanner()->snapshot([$this->dir . '/does-not-exist']));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`phel test` had no rerun-on-change mode; the feedback loop during TDD was manual re-invocation. The Watch module's hot-reload loop is built for in-process namespace reloading and depends on Run, so reusing it from the test command would create a Run <-> Watch facade cycle.

## 💡 Goal

`phel test --watch`: re-run the selected tests automatically whenever a project file changes, with each run starting from a clean runtime.

## 🔖 Changes

- New `--watch` flag on `phel test` (composes with every other flag: `--filter`, `--testdox`, paths, ...). The original invocation minus `--watch` is re-executed as a subprocess on every change; Ctrl+C stops the loop.
- Change detection: a 500ms mtime poll over `.phel` files and `phel-config.php` under the project's source/test directories; the snapshot is retaken after each run so edits made while tests execute still trigger one more run.
- New Run collaborators (no new module dependencies): `WatchFileScanner` (+ `WatchFileScannerInterface`), `TestWatchLoop`, `TestWatchRunner`, exposed via `RunFacade::runTestWatchLoop()`.
- Tests: unit coverage for the scanner (recursive collection, mtime sensitivity, missing dirs) and the loop (initial run, rerun on change, idle polls), plus an end-to-end integration test (`TestCommandWatchTest`) that starts `phel test --watch` in a temp fixture project, touches a file, and asserts the rerun.
- `src/php/Run/CLAUDE.md` and CHANGELOG updated.

Example session:

```
$ phel test --watch
.
Passed: 1 ... Total: 1
Watching for file changes... (press Ctrl+C to stop)

Change detected, re-running tests...
.
Passed: 1 ... Total: 1
Watching for file changes... (press Ctrl+C to stop)
```
