### PR TITLE
ref(run): extract watch rerun command builder and simplify watch loop seams

### DIFF
--- a/src/php/Run/Application/Test/TestWatchLoop.php
+++ b/src/php/Run/Application/Test/TestWatchLoop.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Run\Application\Test;
 
+use Closure;
 use Phel\Run\Domain\Test\WatchFileScannerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -17,36 +18,43 @@ final readonly class TestWatchLoop
 {
     public const int POLL_INTERVAL_MS = 500;
 
+    /** @var Closure(int):void milliseconds */
+    private Closure $sleep;
+
+    /**
+     * @param callable(int):void|null $sleep milliseconds; injectable for tests, defaults to usleep
+     */
     public function __construct(
         private WatchFileScannerInterface $scanner,
-    ) {}
+        ?callable $sleep = null,
+    ) {
+        $this->sleep = $sleep === null
+            ? static function (int $ms): void {
+                usleep($ms * 1000);
+            }
+        : $sleep(...);
+    }
 
     /**
      * Blocks until terminated (Ctrl+C) unless `$maxRuns` is given (used by
      * tests). Returns the exit code of the most recent test run.
      *
-     * @param list<string>       $directories
-     * @param callable():int     $runTests
-     * @param callable(int):void $sleep       milliseconds; injectable for tests
+     * @param list<string>   $directories
+     * @param callable():int $runTests
      */
     public function run(
         array $directories,
         callable $runTests,
         OutputInterface $output,
-        ?callable $sleep = null,
         ?int $maxRuns = null,
     ): int {
-        $sleep ??= static function (int $ms): void {
-            usleep($ms * 1000);
-        };
-
         $exitCode = $runTests();
         $runs = 1;
         $snapshot = $this->scanner->snapshot($directories);
         $this->announceWatching($output);
 
         while ($maxRuns === null || $runs < $maxRuns) {
-            $sleep(self::POLL_INTERVAL_MS);
+            ($this->sleep)(self::POLL_INTERVAL_MS);
 
             $next = $this->scanner->snapshot($directories);
             if ($next === $snapshot) {

--- a/src/php/Run/Application/Test/WatchFileScanner.php
+++ b/src/php/Run/Application/Test/WatchFileScanner.php
@@ -39,8 +39,7 @@ final class WatchFileScanner implements WatchFileScannerInterface
                     continue;
                 }
 
-                $mtime = $file->getMTime();
-                $snapshot[$file->getPathname()] = $mtime;
+                $snapshot[$file->getPathname()] = $file->getMTime();
             }
         }
 

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -22,7 +22,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
-use function array_slice;
 use function count;
 use function is_array;
 use function sprintf;
@@ -258,7 +257,10 @@ final class TestCommand extends Command
      */
     private function runWatchMode(OutputInterface $output): int
     {
-        $command = $this->buildWatchRerunShellCommand();
+        $command = new WatchRerunCommandBuilder()->build(
+            ScalarCoercion::toStringList($_SERVER['argv'] ?? null),
+            ScalarCoercion::toString($_SERVER['SCRIPT_FILENAME'] ?? null),
+        );
         $runTests = static function () use ($command): int {
             $exitCode = 1;
             passthru($command, $exitCode);
@@ -267,25 +269,6 @@ final class TestCommand extends Command
         };
 
         return $this->getFacade()->runTestWatchLoop($runTests, $output);
-    }
-
-    private function buildWatchRerunShellCommand(): string
-    {
-        $argv = ScalarCoercion::toStringList($_SERVER['argv'] ?? null);
-        $arguments = [];
-        foreach (array_slice($argv, 1) as $argument) {
-            if ($argument !== '--' . TestCommandOptionParser::OPT_WATCH) {
-                $arguments[] = $argument;
-            }
-        }
-
-        $script = ScalarCoercion::toString($_SERVER['SCRIPT_FILENAME'] ?? null);
-        $parts = [escapeshellarg(PHP_BINARY), escapeshellarg($script)];
-        foreach ($arguments as $argument) {
-            $parts[] = escapeshellarg($argument);
-        }
-
-        return implode(' ', $parts);
     }
 
     /**

--- a/src/php/Run/Infrastructure/Command/WatchRerunCommandBuilder.php
+++ b/src/php/Run/Infrastructure/Command/WatchRerunCommandBuilder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Infrastructure\Command;
+
+use function array_slice;
+
+/**
+ * Builds the shell command `phel test --watch` re-executes on every change:
+ * the original invocation with the `--watch` flag removed, fully escaped.
+ */
+final readonly class WatchRerunCommandBuilder
+{
+    public function __construct(
+        private string $phpBinary = PHP_BINARY,
+    ) {}
+
+    /**
+     * @param list<string> $argv the original process argv (argv[0] is ignored in favor of `$scriptFilename`)
+     */
+    public function build(array $argv, string $scriptFilename): string
+    {
+        $parts = [escapeshellarg($this->phpBinary), escapeshellarg($scriptFilename)];
+        foreach (array_slice($argv, 1) as $argument) {
+            if ($argument !== '--' . TestCommandOptionParser::OPT_WATCH) {
+                $parts[] = escapeshellarg($argument);
+            }
+        }
+
+        return implode(' ', $parts);
+    }
+}

--- a/tests/php/Unit/Run/Application/Test/TestWatchLoopTest.php
+++ b/tests/php/Unit/Run/Application/Test/TestWatchLoopTest.php
@@ -19,7 +19,7 @@ final class TestWatchLoopTest extends TestCase
             ['a.phel' => 1],
             ['a.phel' => 1],
             ['a.phel' => 1],
-        ]));
+        ]), static function (int $ms): void {});
 
         $runs = 0;
         $output = new BufferedOutput();
@@ -32,7 +32,6 @@ final class TestWatchLoopTest extends TestCase
                 return 0;
             },
             $output,
-            static function (int $ms): void {},
             maxRuns: 1,
         );
 
@@ -47,7 +46,7 @@ final class TestWatchLoopTest extends TestCase
             ['a.phel' => 1],  // after initial run
             ['a.phel' => 2],  // poll detects change
             ['a.phel' => 2],  // re-scan after second run
-        ]));
+        ]), static function (int $ms): void {});
 
         $exitCodes = [1, 0];
         $runs = 0;
@@ -59,7 +58,6 @@ final class TestWatchLoopTest extends TestCase
                 return $exitCodes[$runs++];
             },
             $output,
-            static function (int $ms): void {},
             maxRuns: 2,
         );
 
@@ -70,16 +68,21 @@ final class TestWatchLoopTest extends TestCase
 
     public function test_unchanged_polls_do_not_rerun(): void
     {
-        $loop = new TestWatchLoop($this->scannerReturning([
-            ['a.phel' => 1],
-            ['a.phel' => 1],
-            ['a.phel' => 1],
-            ['a.phel' => 2],
-            ['a.phel' => 2],
-        ]));
+        $sleeps = 0;
+        $loop = new TestWatchLoop(
+            $this->scannerReturning([
+                ['a.phel' => 1],
+                ['a.phel' => 1],
+                ['a.phel' => 1],
+                ['a.phel' => 2],
+                ['a.phel' => 2],
+            ]),
+            static function (int $ms) use (&$sleeps): void {
+                ++$sleeps;
+            },
+        );
 
         $runs = 0;
-        $sleeps = 0;
 
         $loop->run(
             ['/src'],
@@ -89,9 +92,6 @@ final class TestWatchLoopTest extends TestCase
                 return 0;
             },
             new BufferedOutput(),
-            static function (int $ms) use (&$sleeps): void {
-                ++$sleeps;
-            },
             maxRuns: 2,
         );
 

--- a/tests/php/Unit/Run/Infrastructure/Command/WatchRerunCommandBuilderTest.php
+++ b/tests/php/Unit/Run/Infrastructure/Command/WatchRerunCommandBuilderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Infrastructure\Command;
+
+use Phel\Run\Infrastructure\Command\WatchRerunCommandBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class WatchRerunCommandBuilderTest extends TestCase
+{
+    public function test_strips_the_watch_flag_and_keeps_every_other_argument(): void
+    {
+        $command = new WatchRerunCommandBuilder('/usr/bin/php')->build(
+            ['bin/phel', 'test', '--watch', '--filter=my-test', 'tests/foo.phel'],
+            '/project/bin/phel',
+        );
+
+        self::assertSame(
+            "'/usr/bin/php' '/project/bin/phel' 'test' '--filter=my-test' 'tests/foo.phel'",
+            $command,
+        );
+    }
+
+    public function test_uses_script_filename_over_argv_zero(): void
+    {
+        $command = new WatchRerunCommandBuilder('/usr/bin/php')->build(
+            ['relative/phel', 'test'],
+            '/absolute/bin/phel',
+        );
+
+        self::assertStringNotContainsString('relative/phel', $command);
+        self::assertStringContainsString("'/absolute/bin/phel'", $command);
+    }
+
+    public function test_escapes_shell_metacharacters_in_arguments(): void
+    {
+        $command = new WatchRerunCommandBuilder('/usr/bin/php')->build(
+            ['bin/phel', 'test', '--filter=a b; rm -rf /'],
+            '/project/bin/phel',
+        );
+
+        self::assertStringContainsString("'--filter=a b; rm -rf /'", $command);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Post-merge quality pass over #2421 (`phel test --watch`). Three smells: the subprocess command construction (argv filtering, `--watch` stripping, shell escaping) lived untested inside the already-large `TestCommand`; `TestWatchLoop::run()` carried five parameters, two of which (`$sleep`, `$maxRuns`) were test seams; and a single-use temp variable in the scanner.

## 💡 Goal

Same behavior, cleaner seams: pure logic extracted and unit-tested, the loop's public signature reduced to its real inputs.

## 🔖 Changes

- New `WatchRerunCommandBuilder` (Run/Infrastructure): builds the escaped rerun shell command from `(argv, scriptFilename)`; `TestCommand` only feeds it the superglobals. Covered by 3 unit tests (flag stripping, script-filename precedence, shell-metacharacter escaping).
- `TestWatchLoop`: the sleeper becomes a constructor dependency stored as a typed `Closure` (defaults to `usleep`); `run()` drops the nullable `$sleep` parameter.
- `WatchFileScanner`: inline a single-use temp variable.
- No user-facing change; CHANGELOG untouched.
