### PR TITLE
fix(async): await-all and pmap preserve input order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Two themes: project configuration (`phel config`, optimization levels, composabl
 ### Fixed
 
 - `phel test` exit codes: no longer exits 0 when nothing ran, bad paths/selectors fail loudly, and `--list` no longer appends a false `No tests matched`
+- `await-all` (and `pmap`, which builds on it) now return results in input order; `Amp\Future\await` fills its result array in completion order, so concurrent Futures that resolved out of order came back shuffled
 - Editing `phel-config.php` takes effect immediately again: Phel clears Gacela's stale merged-config cache (requires `gacela-project/gacela: ^1.15`)
 - Build config withers are order-independent: `cacheDir` is normalized and `withMainPhelNamespace(...)` no longer pins the entry point
 - Source maps resolve again: `phel build` runtime errors map back to `.phel`, and inline eval maps are scanned past `<?php`/`declare`

--- a/src/phel/core/async.phel
+++ b/src/phel/core/async.phel
@@ -51,13 +51,18 @@
   (php/-> (unwrap-future future) (await)))
 
 (defn await-all
-  "Awaits all Futures in the given collection. Returns a vector of results. Accepts a mix of raw `Amp\\Future` and `Future` wrappers."
+  "Awaits all Futures in the given collection. Returns a vector of results in the same order as the input collection, regardless of which Future resolves first. Accepts a mix of raw `Amp\\Future` and `Future` wrappers."
   {:example "(await-all [(async 1) (async 2)])"
    :see-also ["await" "await-any" "pmap"]}
   [futures]
-  (let [php-futures (to-php-array (map unwrap-future futures))]
-    (for [v :in (php/amp\future\await php-futures)]
-      v)))
+  (let [php-futures (to-php-array (map unwrap-future futures))
+        ;; `Amp\\Future\\await` preserves the original integer keys but
+        ;; fills the result array in *completion* order, so we re-read by
+        ;; index (0..n-1, contiguous from `to-php-array`) to restore the
+        ;; caller's input order — `pmap` and `.cljc` parity rely on it.
+        results     (php/amp\future\await php-futures)]
+    (for [i :in (range (php/count results))]
+      (php/aget results i))))
 
 (defn await-any
   "Awaits the first Future to resolve. Returns its value. Accepts a mix of raw `Amp\\Future` and `Future` wrappers."

--- a/tests/phel/core/async-in-core.phel
+++ b/tests/phel/core/async-in-core.phel
@@ -1,5 +1,6 @@
 (ns phel-test.core.async-in-core
-  (:require phel.test :refer [deftest is]))
+  (:require phel.test :refer [deftest is])
+  (:require phel.async :refer [delay]))
 
 ;; Regression test for https://github.com/phel-lang/phel-lang/issues/1548
 ;; The Clojure-parity async surface (and Phel's fiber combinators that
@@ -25,6 +26,26 @@
 
 (deftest test-pmap-is-available-without-require
   (is (= [2 3 4] (pmap inc [1 2 3])) "pmap is in core"))
+
+;; Regression: `await-all` must return results in *input* order even when
+;; later Futures resolve first. `Amp\Future\await` fills its result array
+;; in completion order, so a naive value-iteration returned them shuffled.
+(deftest test-await-all-preserves-input-order
+  (is (= [:a0 :a1 :a2 :a3]
+         (await-all
+          [(async (do (delay 0.20) :a0))
+           (async (do (delay 0.15) :a1))
+           (async (do (delay 0.10) :a2))
+           (async (do (delay 0.01) :a3))]))
+      "await-all keeps input order despite reverse completion order"))
+
+;; Regression: `pmap` documents "results in the original order"; it builds
+;; on `await-all`, so the same completion-order bug reversed its output.
+(deftest test-pmap-preserves-input-order
+  (is (= [10 20 30 40 50]
+         (pmap (fn [x] (delay (/ (- 10 x) 50.0)) (* x 10))
+               [1 2 3 4 5]))
+      "pmap keeps input order when later elements finish first"))
 
 (deftest test-promise-deliver-deref-are-available-without-require
   (let [p (promise)]


### PR DESCRIPTION
## 🐛 Bug

`await-all` (and `pmap`, built on it) returned results in **completion order**, not input order.

`Amp\Future\await` preserves the original integer keys but fills its result array as each Future resolves. `await-all` iterated the *values*, so concurrent Futures that finished out of order came back shuffled — and `pmap`, whose docstring promises "results in the original order", inherited the bug.

### Reproduce (before)

```phel
(pmap (fn [x] (delay (/ (- 10 x) 50.0)) (* x 10)) [1 2 3 4 5])
;; => [50 40 30 20 10]   ; reversed
```

The existing tests passed only because their Futures completed instantly, so completion order coincidentally matched input order.

## 🛠 Fix

`to-php-array` always yields contiguous `0..n-1` keys, so `await-all` now re-reads the result array by index instead of iterating values. (ksort is unusable here — Phel interop can't pass the array by reference.)

## ✅ Tests

Two regression tests with staggered `delay`s (later elements resolve first) — both fail on `main`, pass with the fix:
- `test-await-all-preserves-input-order`
- `test-pmap-preserves-input-order`

## 📝 Notes

- Docstring for `await-all` now states the order guarantee explicitly.
- Follow-up (separate, on phel-lang.org): the async guide currently hedges on ordering; it can now assert input order.