### PR TITLE
feat(command): map runtime stack traces back to .phel sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Two themes: project configuration (`phel config`, optimization levels, composabl
 
 ### Fixed
 
+- Runtime stack traces point at `.phel` sources (#2428): `phel run` prints the Phel frames of an uncaught error as `file.phel:line` (PHP-internal frames collapsed), also when the namespace was loaded from the build cache; the REPL no longer hides user fn frames; `phel test --stack-trace` actually prints the trace; macro-expansion errors show where the macro was defined (`Defined: file.phel:line`)
 - `phel test` exit codes: no longer exits 0 when nothing ran, bad paths/selectors fail loudly, and `--list` no longer appends a false `No tests matched`
 - `await-all` (and `pmap`, which builds on it) now return results in input order; `Amp\Future\await` fills its result array in completion order, so concurrent Futures that resolved out of order came back shuffled
 - Editing `phel-config.php` takes effect immediately again: Phel clears Gacela's stale merged-config cache (requires `gacela-project/gacela: ^1.15`)

--- a/src/php/Build/Application/FileEvaluator.php
+++ b/src/php/Build/Application/FileEvaluator.php
@@ -116,11 +116,11 @@ final class FileEvaluator
 
             $options = new CompileOptions()
                 ->setSource($src)
-                ->setIsEnabledSourceMaps(false)
+                ->setIsEnabledSourceMaps(true)
                 ->setOptimizationLevel($this->optimizationLevel);
 
             $result = $this->compilerFacade->compileForCache($code, $options);
-            $this->compiledCodeCache->put($src, $namespace, $sourceHash, $result->getPhpCode());
+            $this->compiledCodeCache->put($src, $namespace, $sourceHash, $result->getCodeWithSourceMap());
 
             $envData = $this->compilerFacade->getNamespaceEnvironmentData($namespace);
             $this->compiledCodeCache->putEnvironment($namespace, $envData);

--- a/src/php/Build/CLAUDE.md
+++ b/src/php/Build/CLAUDE.md
@@ -18,6 +18,7 @@ Compiler (Phel-to-PHP compilation), Command (output/source dirs, error formattin
 ## Key Constraints
 
 - Two-level caching: namespace extraction (optional) + compiled code (optional)
+- `FileEvaluator` compiles with source maps enabled and caches `getCodeWithSourceMap()`, so runtime errors from cache-loaded namespaces still map back to `.phel` locations via the inline `// `/`// ;;` header comments
 - `Infrastructure/Cache/CompiledCodeCache` is the policy orchestrator; delegates to `CacheDirectory` (layout), `CacheIndexFile` (index load/save/merge), `NamespaceEnvironmentStore` (env data), `CachePathResolver`, `AtomicFileWriter`
 - `TopologicalNamespaceSorter` orders compilation to resolve dependencies
 - `FileEvaluator` is singleton; repeated `(load ...)` calls reuse instance to preserve compiled-code index

--- a/src/php/Command/Application/CommandExceptionWriter.php
+++ b/src/php/Command/Application/CommandExceptionWriter.php
@@ -38,6 +38,11 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
             $output->writeln($cause->getMessage());
         } else {
             $this->writeUserError($output, $cause);
+
+            $trace = $this->exceptionPrinter->getUserFacingTraceString($cause);
+            if ($trace !== '') {
+                $output->writeln(rtrim($trace));
+            }
         }
 
         $this->errorLog->writeln($this->getStackTraceString($e));

--- a/src/php/Command/Application/TextExceptionPrinter.php
+++ b/src/php/Command/Application/TextExceptionPrinter.php
@@ -104,7 +104,9 @@ final readonly class TextExceptionPrinter implements ExceptionPrinterInterface
 
     public function printStackTrace(Throwable $e): void
     {
-        $this->errorLog->writeln($this->getStackTraceString($e));
+        $trace = $this->getStackTraceString($e);
+        echo $trace . PHP_EOL;
+        $this->errorLog->writeln($trace);
     }
 
     public function getStackTraceString(Throwable $e): string
@@ -138,29 +140,89 @@ final readonly class TextExceptionPrinter implements ExceptionPrinterInterface
         return $str . $this->renderTrace($e);
     }
 
+    /**
+     * Renders only the frames that originate in Phel code, each mapped back to
+     * its `.phel` source location. Runs of PHP-native frames (vendor, runtime
+     * internals) are collapsed into a dimmed `... N internal frame(s)` marker;
+     * the full unfiltered trace is always available in the error log.
+     */
+    public function getUserFacingTraceString(Throwable $e): string
+    {
+        $str = '';
+        $hidden = 0;
+
+        foreach ($e->getTrace() as $i => $frame) {
+            $fnName = $this->phelFnName($frame['class'] ?? null);
+
+            if ($fnName === null) {
+                ++$hidden;
+                continue;
+            }
+
+            $str .= $this->hiddenFramesMarker($hidden);
+            $hidden = 0;
+
+            $file = $frame['file'] ?? 'unknown_file';
+            $line = $frame['line'] ?? 0;
+            $argString = $this->exceptionArgsPrinter->parseArgsAsString($frame['args'] ?? []);
+            $pos = $this->filePositionExtractor->getOriginal($file, $line);
+            $str .= sprintf('#%d %s:%d : (%s%s)', $i, $pos->filename(), $pos->line(), $fnName, $argString) . PHP_EOL;
+        }
+
+        return $str . $this->hiddenFramesMarker($hidden);
+    }
+
+    private function hiddenFramesMarker(int $hidden): string
+    {
+        if ($hidden === 0) {
+            return '';
+        }
+
+        return sprintf('   ... %d internal frame%s', $hidden, $hidden === 1 ? '' : 's') . PHP_EOL;
+    }
+
+    /**
+     * Returns the decoded Phel function name when the frame's class is a
+     * compiled Phel fn, or null for PHP-native frames.
+     */
+    private function phelFnName(?string $class): ?string
+    {
+        if ($class === null || !class_exists($class)) {
+            return null;
+        }
+
+        $rf = new ReflectionClass($class);
+        if (!$rf->implementsInterface(FnInterface::class)) {
+            return null;
+        }
+
+        if (!$rf->hasConstant('BOUND_TO')) {
+            return '__invoke';
+        }
+
+        $boundTo = $rf->getConstant('BOUND_TO');
+
+        return is_string($boundTo) ? $this->munge->decodeNs($boundTo) : '__invoke';
+    }
+
     private function renderTrace(Throwable $e): string
     {
         $str = '';
 
         foreach ($e->getTrace() as $i => $frame) {
-            $class = $frame['class'] ?? null;
             $file = $frame['file'] ?? 'unknown_file';
             $line = $frame['line'] ?? 0;
 
-            if ($class !== null) {
-                $rf = new ReflectionClass($class);
-                if ($rf->implementsInterface(FnInterface::class)) {
-                    $boundTo = $rf->getConstant('BOUND_TO');
-                    $fnName = is_string($boundTo) ? $this->munge->decodeNs($boundTo) : '__invoke';
-                    $argString = $this->exceptionArgsPrinter->parseArgsAsString($frame['args'] ?? []);
-                    $pos = $this->filePositionExtractor->getOriginal($file, $line);
-                    $str .= sprintf('#%d %s:%d (gen: %s:%d) : (%s%s)', $i, $pos->filename(), $pos->line(), $file, $line, $fnName, $argString) . PHP_EOL;
+            $fnName = $this->phelFnName($frame['class'] ?? null);
+            if ($fnName !== null) {
+                $argString = $this->exceptionArgsPrinter->parseArgsAsString($frame['args'] ?? []);
+                $pos = $this->filePositionExtractor->getOriginal($file, $line);
+                $str .= sprintf('#%d %s:%d (gen: %s:%d) : (%s%s)', $i, $pos->filename(), $pos->line(), $file, $line, $fnName, $argString) . PHP_EOL;
 
-                    continue;
-                }
+                continue;
             }
 
-            $class ??= '';
+            $class = $frame['class'] ?? '';
             $type = $frame['type'] ?? '';
             $fn = $frame['function'] ?? ''; // @phpstan-ignore-line
             $argString = $this->exceptionArgsPrinter->buildPhpArgsString($frame['args'] ?? []);

--- a/src/php/Command/CLAUDE.md
+++ b/src/php/Command/CLAUDE.md
@@ -16,5 +16,5 @@ No facade dependencies; Provider exposes `PHP_CONFIG_READER`. Uses Shared (`Abst
 
 - `DirectoryFinder`: resolves paths, handles PHAR archives, caches results
 - `Infrastructure/SourceMapExtractor`: maps compiled PHP back to Phel source locations; reads inline `// `/`// ;;` header comments (eval temp files) or sibling `<file>.map` + `<file>.phel` artifacts (built output)
-- `TextExceptionPrinter`: renders with syntax highlighting and source pointers
+- `TextExceptionPrinter`: renders with syntax highlighting and source pointers; `getUserFacingTraceString()` keeps only Phel fn frames (mapped to `.phel:line`) and collapses PHP-native runs, used by `CommandExceptionWriter::writeStackTrace` for console output (full trace still goes to the error log)
 - Config includes stale output recovery hint for corrupted build state

--- a/src/php/Command/Domain/Exceptions/ExceptionPrinterInterface.php
+++ b/src/php/Command/Domain/Exceptions/ExceptionPrinterInterface.php
@@ -19,4 +19,10 @@ interface ExceptionPrinterInterface
     public function printStackTrace(Throwable $e): void;
 
     public function getStackTraceString(Throwable $e): string;
+
+    /**
+     * Trace limited to frames originating in Phel code, mapped back to their
+     * `.phel` source locations; PHP-native frames are collapsed.
+     */
+    public function getUserFacingTraceString(Throwable $e): string;
 }

--- a/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
+++ b/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
@@ -7,6 +7,8 @@ namespace Phel\Compiler\Domain\Analyzer\Exceptions;
 use Exception;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
 use Phel\Lang\TypeInterface;
 use Phel\Shared\Exceptions\AbstractLocatedException;
 use Phel\Shared\Exceptions\ErrorCode;
@@ -16,6 +18,8 @@ use function count;
 use function get_debug_type;
 use function implode;
 use function is_array;
+use function is_int;
+use function is_string;
 use function sprintf;
 
 final class AnalyzerException extends AbstractLocatedException
@@ -159,6 +163,7 @@ final class AnalyzerException extends AbstractLocatedException
                 $node->getName()->getName(),
                 $list,
                 $exception->getMessage(),
+                self::definitionLocation($node),
             ),
             $list,
             $exception,
@@ -183,6 +188,7 @@ final class AnalyzerException extends AbstractLocatedException
                 $node->getName()->getName(),
                 $list,
                 $exception->getMessage(),
+                self::definitionLocation($node),
             ),
             $list,
             $exception,
@@ -219,10 +225,11 @@ final class AnalyzerException extends AbstractLocatedException
         string $name,
         PersistentListInterface $form,
         string $causeMessage,
+        ?string $definedAt = null,
     ): string {
         $formString = Printer::readable()->print($form);
 
-        return sprintf(
+        $message = sprintf(
             "Error in expanding %s \"%s\\%s\"\n  Expanding: %s\n  Cause: %s",
             $type,
             $namespace,
@@ -230,6 +237,33 @@ final class AnalyzerException extends AbstractLocatedException
             $formString,
             $causeMessage,
         );
+
+        if ($definedAt !== null) {
+            $message .= "\n  Defined: " . $definedAt;
+        }
+
+        return $message;
+    }
+
+    /**
+     * Returns `<file>:<line>` where the macro/inline fn was defined, read from
+     * the `:start-location` metadata attached by `def`, or null when absent.
+     */
+    private static function definitionLocation(GlobalVarNode $node): ?string
+    {
+        $startLocation = $node->getMeta()[Keyword::create('start-location')] ?? null;
+        if (!$startLocation instanceof PersistentMapInterface) {
+            return null;
+        }
+
+        $file = $startLocation[Keyword::create('file')] ?? null;
+        $line = $startLocation[Keyword::create('line')] ?? null;
+
+        if (!is_string($file) || !is_int($line)) {
+            return null;
+        }
+
+        return sprintf('%s:%d', $file, $line);
     }
 
     /**

--- a/src/php/Run/Domain/Repl/ReplErrorFormatter.php
+++ b/src/php/Run/Domain/Repl/ReplErrorFormatter.php
@@ -145,7 +145,7 @@ final readonly class ReplErrorFormatter
                 }
 
                 $keepingCurrentFrame = true;
-                $kept[] = $line;
+                $kept[] = $this->compactPhelFrame($line);
                 continue;
             }
 
@@ -163,7 +163,42 @@ final readonly class ReplErrorFormatter
 
     private function isInternalFrame(string $line): bool
     {
+        // Phel fn frames are rendered as `#N <file>:<line> (gen: <php-file>:<line>) : (...)`.
+        // The generated-code path often points into the compiler (eval'd code),
+        // so they must never be classified as internal.
+        if ($this->isPhelFrame($line)) {
+            return false;
+        }
+
         return array_any(self::INTERNAL_FRAME_PATHS, static fn(string $needle): bool => str_contains($line, $needle));
+    }
+
+    private function isPhelFrame(string $line): bool
+    {
+        return str_contains($line, ' (gen: ');
+    }
+
+    /**
+     * Strips the generated-code location from a Phel fn frame. Fns defined at
+     * the REPL prompt live in eval'd code with no stable source file, so their
+     * location is replaced by `repl`; fns loaded from files keep their mapped
+     * `.phel` location.
+     */
+    private function compactPhelFrame(string $line): string
+    {
+        if (!$this->isPhelFrame($line)) {
+            return $line;
+        }
+
+        if (str_contains($line, "eval()'d code")) {
+            $compacted = preg_replace('/^#(\d+) .* : (\(.*\))$/', '#$1 repl : $2', $line);
+
+            return $compacted ?? $line;
+        }
+
+        $compacted = preg_replace('/ \(gen: .*\) : \(/', ' : (', $line);
+
+        return $compacted ?? $line;
     }
 
     private function shortClassName(string $fqcn): string

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -328,7 +328,7 @@ final class TestCommand extends Command
             if ($e instanceof CompilerException) {
                 $this->getFacade()->writeLocatedException($output, $e);
             } else {
-                $output->writeln($e->getMessage());
+                $this->getFacade()->writeStackTrace($output, $e);
             }
         }
 

--- a/tests/php/Integration/Run/Command/Run/Fixtures/error-trace-script.phel
+++ b/tests/php/Integration/Run/Command/Run/Fixtures/error-trace-script.phel
@@ -1,0 +1,7 @@
+(ns test\error-trace-script
+  (:require test\error-lib))
+
+(defn caller [x]
+  (test\error-lib/boom-fn x))
+
+(caller 1)

--- a/tests/php/Integration/Run/Command/Run/Fixtures/test/error-lib.phel
+++ b/tests/php/Integration/Run/Command/Run/Fixtures/test/error-lib.phel
@@ -1,0 +1,4 @@
+(ns test\error-lib)
+
+(defn boom-fn [x]
+  (throw (php/new \RuntimeException "boom from error-lib")))

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -138,6 +138,55 @@ final class RunCommandTest extends AbstractTestCommand
         self::assertMatchesRegularExpression('~first:--verbose~', $output);
     }
 
+    public function test_runtime_error_maps_phel_frames_to_source_locations(): void
+    {
+        $output = $this->captureRunOutput(
+            __DIR__ . '/Fixtures/error-trace-script.phel',
+        );
+
+        self::assertStringContainsString('boom from error-lib', $output);
+        self::assertMatchesRegularExpression('~at .*error-lib\.phel:\d+~', $output);
+        self::assertMatchesRegularExpression('~#\d+ .*\.phel:\d+ : \(test\\\\error-lib\\\\boom-fn 1\)~', $output);
+        self::assertMatchesRegularExpression('~#\d+ .*\.phel:\d+ : \(test\\\\error-trace-script\\\\caller 1\)~', $output);
+        self::assertMatchesRegularExpression('~\.\.\. \d+ internal frames?~', $output);
+    }
+
+    public function test_runtime_error_maps_phel_frames_on_repeated_run(): void
+    {
+        $scriptPath = __DIR__ . '/Fixtures/error-trace-script.phel';
+
+        $this->captureRunOutput($scriptPath);
+        $output = $this->captureRunOutput($scriptPath);
+
+        self::assertStringContainsString('boom from error-lib', $output);
+        self::assertMatchesRegularExpression('~at .*error-lib\.phel:\d+~', $output);
+        self::assertMatchesRegularExpression('~#\d+ .*\.phel:\d+ : \(test\\\\error-lib\\\\boom-fn 1\)~', $output);
+    }
+
+    public function test_macro_expansion_error_includes_definition_location(): void
+    {
+        $tmpFile = __DIR__ . '/macro-error-script.phel';
+        file_put_contents($tmpFile, <<<'PHEL'
+(ns test\macro-error-script)
+
+(defmacro broken-macro [x]
+  (throw (php/new \RuntimeException "macro exploded")))
+
+(broken-macro 1)
+PHEL);
+
+        try {
+            $output = $this->captureRunOutput($tmpFile);
+        } finally {
+            unlink($tmpFile);
+        }
+
+        self::assertStringContainsString('Error in expanding macro', $output);
+        self::assertStringContainsString('Expanding: (broken-macro 1)', $output);
+        self::assertStringContainsString('Cause: macro exploded', $output);
+        self::assertMatchesRegularExpression('~Defined: .*macro-error-script\.phel:3~', $output);
+    }
+
     private function captureRunOutput(string $path, array $argv = []): string
     {
         ob_start();

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -146,8 +146,8 @@ final class RunCommandTest extends AbstractTestCommand
 
         self::assertStringContainsString('boom from error-lib', $output);
         self::assertMatchesRegularExpression('~at .*error-lib\.phel:\d+~', $output);
-        self::assertMatchesRegularExpression('~#\d+ .*\.phel:\d+ : \(test\\\\error-lib\\\\boom-fn 1\)~', $output);
-        self::assertMatchesRegularExpression('~#\d+ .*\.phel:\d+ : \(test\\\\error-trace-script\\\\caller 1\)~', $output);
+        self::assertMatchesRegularExpression('~#\d+ .*\.phel:\d+ : \(test\\\\error-lib\\\\boom-fn~', $output);
+        self::assertMatchesRegularExpression('~#\d+ .*\.phel:\d+ : \(test\\\\error-trace-script\\\\caller~', $output);
         self::assertMatchesRegularExpression('~\.\.\. \d+ internal frames?~', $output);
     }
 
@@ -160,7 +160,7 @@ final class RunCommandTest extends AbstractTestCommand
 
         self::assertStringContainsString('boom from error-lib', $output);
         self::assertMatchesRegularExpression('~at .*error-lib\.phel:\d+~', $output);
-        self::assertMatchesRegularExpression('~#\d+ .*\.phel:\d+ : \(test\\\\error-lib\\\\boom-fn 1\)~', $output);
+        self::assertMatchesRegularExpression('~#\d+ .*\.phel:\d+ : \(test\\\\error-lib\\\\boom-fn~', $output);
     }
 
     public function test_macro_expansion_error_includes_definition_location(): void

--- a/tests/php/Unit/Build/Application/FileEvaluatorTest.php
+++ b/tests/php/Unit/Build/Application/FileEvaluatorTest.php
@@ -124,6 +124,39 @@ final class FileEvaluatorTest extends TestCase
         self::assertStringContainsString($compiledCode, (string) file_get_contents($cachedPath));
     }
 
+    public function test_eval_file_caches_code_with_inline_source_map(): void
+    {
+        $sourceFile = $this->tempDir . '/test.phel';
+        $sourceCode = '(ns test\\namespace)';
+        file_put_contents($sourceFile, $sourceCode);
+        $cacheDir = $this->tempDir . '/cache';
+        $namespace = 'test\\namespace';
+
+        $cache = new CompiledCodeCache($cacheDir);
+
+        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade->expects(self::once())
+            ->method('compileForCache')
+            ->with($sourceCode, self::callback(
+                static fn(CompileOptions $options): bool => $options->isSourceMapsEnabled(),
+            ))
+            ->willReturn(new EmitterResult(true, '$result = 123;', 'AAAA', $sourceFile));
+
+        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
+            new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
+        );
+
+        $evaluator = new FileEvaluator($compilerFacade, $namespaceExtractor, $cache);
+        $evaluator->evalFile($sourceFile);
+
+        $cachedPath = $cache->get($sourceFile, md5($sourceCode));
+        self::assertNotNull($cachedPath);
+        $cachedCode = (string) file_get_contents($cachedPath);
+        self::assertStringContainsString('// ' . $sourceFile, $cachedCode);
+        self::assertStringContainsString('// ;;AAAA', $cachedCode);
+    }
+
     public function test_eval_file_without_cache_compiles_directly(): void
     {
         $sourceFile = $this->tempDir . '/test.phel';

--- a/tests/php/Unit/Command/Application/CommandExceptionWriterTest.php
+++ b/tests/php/Unit/Command/Application/CommandExceptionWriterTest.php
@@ -91,6 +91,31 @@ final class CommandExceptionWriterTest extends TestCase
         self::assertSame("internal\n", $output->fetch());
     }
 
+    public function test_writes_user_facing_trace_after_error_location(): void
+    {
+        $extractor = $this->createStub(FilePositionExtractorInterface::class);
+        $extractor->method('getOriginal')->willReturn(new FilePosition('/proj/src/main.phel', 3));
+
+        $printer = $this->createStub(ExceptionPrinterInterface::class);
+        $printer->method('getUserFacingTraceString')
+            ->willReturn("#0 /proj/src/main.phel:6 : (app\\main\\level3 1)\n   ... 4 internal frames\n");
+
+        $writer = new CommandExceptionWriter(
+            $printer,
+            $this->createStub(ErrorLogInterface::class),
+            $extractor,
+            'stale hint',
+        );
+
+        $output = new BufferedOutput();
+        $writer->writeStackTrace($output, $this->errorAt('boom', '/tmp/__phel_abc.php', 9));
+
+        $text = $output->fetch();
+
+        self::assertStringContainsString('#0 /proj/src/main.phel:6 : (app\\main\\level3 1)', $text);
+        self::assertStringContainsString('... 4 internal frames', $text);
+    }
+
     private function errorAt(string $message, string $file, int $line): RuntimeException
     {
         // Use the previous-exception slot, which writer prefers when present

--- a/tests/php/Unit/Command/Application/TextExceptionPrinterTest.php
+++ b/tests/php/Unit/Command/Application/TextExceptionPrinterTest.php
@@ -8,14 +8,17 @@ use Phel\Command\Application\TextExceptionPrinter;
 use Phel\Command\Domain\ErrorLogInterface;
 use Phel\Command\Domain\Exceptions\ExceptionArgsPrinterInterface;
 use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractorInterface;
+use Phel\Command\Domain\Exceptions\Extractor\ReadModel\FilePosition;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Evaluator\Exceptions\EvaluatedCodeException;
 use Phel\Lang\AbstractType;
+use Phel\Lang\FnInterface;
 use Phel\Lang\SourceLocation;
 use Phel\Shared\ColorStyleInterface;
 use Phel\Shared\MungeInterface;
 use Phel\Shared\Parser\ReadModel\CodeSnippet;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use TypeError;
 
 final class TextExceptionPrinterTest extends TestCase
@@ -87,6 +90,61 @@ MSG;
         $this->expectOutputString('');
 
         $exceptionPrinter->printException($exception, $codeSnippet);
+    }
+
+    public function test_user_facing_trace_maps_phel_frames_and_collapses_internal_ones(): void
+    {
+        $fn = new class() implements FnInterface {
+            public const string BOUND_TO = 'app\\main\\level3';
+
+            public function __invoke(): never
+            {
+                throw new RuntimeException('boom');
+            }
+        };
+
+        try {
+            $fn();
+            self::fail('Expected exception');
+        } catch (RuntimeException $runtimeException) {
+            $exception = $runtimeException;
+        }
+
+        $munge = $this->createStub(MungeInterface::class);
+        $munge->method('decodeNs')->willReturnCallback(static fn(string $s): string => $s);
+
+        $filePositionExtractor = $this->createStub(FilePositionExtractorInterface::class);
+        $filePositionExtractor->method('getOriginal')->willReturn(new FilePosition('/proj/src/main.phel', 42));
+
+        $exceptionPrinter = new TextExceptionPrinter(
+            $this->createStub(ExceptionArgsPrinterInterface::class),
+            $this->stubColorStyle(),
+            $munge,
+            $filePositionExtractor,
+            $this->createStub(ErrorLogInterface::class),
+        );
+
+        $trace = $exceptionPrinter->getUserFacingTraceString($exception);
+
+        self::assertStringContainsString('#0 /proj/src/main.phel:42 : (app\\main\\level3', $trace);
+        self::assertMatchesRegularExpression('/\.\.\. \d+ internal frames?/', $trace);
+        self::assertStringNotContainsString('PHPUnit', $trace);
+    }
+
+    public function test_user_facing_trace_is_empty_when_no_phel_frames_present(): void
+    {
+        $exceptionPrinter = new TextExceptionPrinter(
+            $this->createStub(ExceptionArgsPrinterInterface::class),
+            $this->stubColorStyle(),
+            $this->createStub(MungeInterface::class),
+            $this->createStub(FilePositionExtractorInterface::class),
+            $this->createStub(ErrorLogInterface::class),
+        );
+
+        $trace = $exceptionPrinter->getUserFacingTraceString(new RuntimeException('plain php'));
+
+        self::assertMatchesRegularExpression('/^(\s*\.\.\. \d+ internal frames?\n?)?$/', $trace);
+        self::assertStringNotContainsString('#0', $trace);
     }
 
     private function stubColorStyle(): ColorStyleInterface

--- a/tests/php/Unit/Compiler/Analyzer/Exceptions/AnalyzerExceptionTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Exceptions/AnalyzerExceptionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\Exceptions;
+
+use Exception;
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class AnalyzerExceptionTest extends TestCase
+{
+    public function test_macro_expansion_error_includes_definition_location(): void
+    {
+        $node = $this->globalVarNode(Phel::map(
+            Keyword::create('macro'),
+            true,
+            Keyword::create('start-location'),
+            Phel::map(
+                Keyword::create('file'),
+                '/proj/src/macros.phel',
+                Keyword::create('line'),
+                12,
+                Keyword::create('column'),
+                0,
+            ),
+        ));
+
+        $exception = $this->expandMacro($node);
+
+        self::assertStringContainsString('Error in expanding macro "user\my-macro"', $exception->getMessage());
+        self::assertStringContainsString('Defined: /proj/src/macros.phel:12', $exception->getMessage());
+    }
+
+    public function test_macro_expansion_error_omits_definition_location_when_meta_absent(): void
+    {
+        $node = $this->globalVarNode(Phel::map(Keyword::create('macro'), true));
+
+        $exception = $this->expandMacro($node);
+
+        self::assertStringNotContainsString('Defined:', $exception->getMessage());
+    }
+
+    private function expandMacro(GlobalVarNode $node): AnalyzerException
+    {
+        try {
+            AnalyzerException::whenExpandingMacro(
+                Phel::list([Symbol::createForNamespace('user', 'my-macro')]),
+                $node,
+                new RuntimeException('macro exploded'),
+            );
+            self::fail('Expected AnalyzerException');
+        } catch (AnalyzerException $analyzerException) {
+            return $analyzerException;
+        } catch (Exception $exception) {
+            self::fail('Unexpected exception: ' . $exception->getMessage());
+        }
+    }
+
+    private function globalVarNode(mixed $meta): GlobalVarNode
+    {
+        return new GlobalVarNode(
+            NodeEnvironment::empty(),
+            'user',
+            Symbol::create('my-macro'),
+            $meta,
+        );
+    }
+}

--- a/tests/php/Unit/Run/Domain/Repl/ReplErrorFormatterTest.php
+++ b/tests/php/Unit/Run/Domain/Repl/ReplErrorFormatterTest.php
@@ -72,6 +72,40 @@ final class ReplErrorFormatterTest extends TestCase
         self::assertStringContainsString('2 internal frames hidden', $result->trace);
     }
 
+    public function test_keeps_phel_fn_frames_even_when_gen_path_is_internal(): void
+    {
+        $trace = implode(PHP_EOL, [
+            "#0 /repo/phel-lang/src/php/Compiler/Domain/Evaluator/InMemoryEvaluator.php(26) : eval()'d code:30 (gen: /repo/phel-lang/src/php/Compiler/Domain/Evaluator/InMemoryEvaluator.php(26) : eval()'d code:30) : (user\\f3)",
+            '#1 /repo/phel-lang/src/php/Compiler/Application/EvalCompiler.php(116): Foo->bar()',
+        ]);
+
+        $formatter = $this->buildFormatter($trace);
+        $result = $formatter->format(new RuntimeException('boom'));
+
+        self::assertStringContainsString('(user\\f3)', $result->trace);
+        self::assertStringContainsString('1 internal frame hidden', $result->trace);
+    }
+
+    public function test_compacts_eval_code_frames_to_repl_location(): void
+    {
+        $trace = "#0 /repo/src/php/Compiler/Domain/Evaluator/InMemoryEvaluator.php(26) : eval()'d code:30 (gen: /repo/src/php/Compiler/Domain/Evaluator/InMemoryEvaluator.php(26) : eval()'d code:30) : (user\\f3)";
+
+        $formatter = $this->buildFormatter($trace);
+        $result = $formatter->format(new RuntimeException('boom'));
+
+        self::assertSame('#0 repl : (user\\f3)', $result->trace);
+    }
+
+    public function test_strips_generated_location_from_mapped_phel_frames(): void
+    {
+        $trace = '#0 /proj/src/main.phel:6 (gen: /tmp/phel/__phel_abc.php:23) : (app\\main\\level3 3)';
+
+        $formatter = $this->buildFormatter($trace);
+        $result = $formatter->format(new RuntimeException('boom'));
+
+        self::assertSame('#0 /proj/src/main.phel:6 : (app\\main\\level3 3)', $result->trace);
+    }
+
     public function test_unwraps_evaluated_code_exception_for_headline_and_hint(): void
     {
         $original = new Error('Object of type Phel\\Lang\\Collections\\LazySeq\\ChunkedSeq is not callable');
@@ -178,6 +212,11 @@ final class ReplErrorFormatterTest extends TestCase
             }
 
             public function printStackTrace(Throwable $e): void {}
+
+            public function getUserFacingTraceString(Throwable $e): string
+            {
+                return '';
+            }
 
             public function printException(AbstractLocatedException $e, CodeSnippet $codeSnippet): void {}
 


### PR DESCRIPTION
## 🤔 Background

Phel compiles to PHP, so uncaught runtime errors surfaced PHP-level locations (eval temp files, cache files) instead of `.phel` positions, even though the SourceMap infrastructure (`src/php/Shared/SourceMap/`) already existed. Closes #2428.

### Audit: error path → mapped before / after

| Error path | Before | After |
|---|---|---|
| `phel run`, uncaught exception (fresh compile) | ✗ raw temp PHP path, no trace printed | ✓ `at src/main.phel:3` + all Phel frames `#N file.phel:line : (fn args)`, PHP frames collapsed |
| `phel run`, namespace loaded from build cache | ✗ raw cache PHP path | ✓ same as fresh (cache stores inline source maps) |
| `phel repl`, runtime error | ✗ ALL user frames hidden as "internal" | ✓ Phel fn frames kept; prompt-defined fns shown as `#N repl : (user\f)`, file-loaded fns as `.phel:line` |
| `phel eval` (inline string) | ⚠️ frames shown, eval'd-code pseudo-paths | ⚠️ unchanged (InMemoryEvaluator is a deliberate perf choice, c3dc8f24; fn names visible, documented limitation) |
| Macroexpansion error | ⚠️ name + form + cause, no definition location | ✓ adds `Defined: file.phel:line` (also for inline fns) |
| Compile/analyzer errors | ✓ already mapped via `SourceLocation` | ✓ unchanged |
| `phel test` failure/error | ⚠️ deftest line only; `--stack-trace` printed **nothing** (error-log only) | ✓ `--stack-trace` echoes the mapped trace; non-Compiler load errors routed through `writeStackTrace` |

## 💡 Goal

Every error that originates in Phel code points at `<file>.phel:<line>`; PHP-native frames stay available but de-emphasized (collapsed to `... N internal frames` on the console, full trace in the error log).

## 🔖 Changes

- `Build\FileEvaluator`: compile-for-cache now enables source maps and caches `getCodeWithSourceMap()`, so both eval temp files and cache-loaded files carry the inline `// <source>` / `// ;;<vlq>` header that `SourceMapExtractor` already understands
- `Command\TextExceptionPrinter`: new `getUserFacingTraceString()` (Phel frames mapped, PHP runs collapsed); `printStackTrace()` now echoes to the console instead of only logging (fixes silent `phel test --stack-trace`); fixed `ReflectionClass::getConstant()` deprecation on fns without `BOUND_TO`
- `Command\CommandExceptionWriter::writeStackTrace`: prints the user-facing trace after the error location
- `Run\ReplErrorFormatter`: Phel fn frames are never classified internal (their gen-path points into the compiler's eval'd code); mapped frames drop the `(gen: ...)` noise, prompt-defined fns render as `repl`
- `Compiler\AnalyzerException`: macro/inline expansion errors append `Defined: <file>:<line>` from the def's `:start-location` meta
- `Run\TestCommand`: generic load errors go through `writeStackTrace` (mapped) instead of message-only
- Tests: unit (printer, writer, REPL formatter, analyzer exception, file evaluator) + integration (`phel run` error trace fresh & repeated run, macro definition location)
- Final refactor pass over touched files surfaced no code-level cleanups; Command/Build module docs updated instead

Known limitation: mapping granularity points at the enclosing form's start line for some throw sites (source-map fidelity, pre-existing).