### PR TITLE
feat(repl): reload changed namespaces and run tests from REPL/nREPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Two themes: project configuration (`phel config`, optimization levels, composabl
 - `phel test --watch`: re-runs the selected tests on every `.phel`/`phel-config.php` change
 - `phel test`: startup progress on stderr, and an expected/actual diff with a caret on failed `=` assertions
 - `withBuildConfig()`/`withExportConfig()` accept a configurator closure
+- REPL-driven workflow (#2429): `(reload!)` re-evaluates project namespaces whose source changed since the last load (plus their dependents) in dependency order; `(reload-all!)` force-reloads every project namespace; `(run-tests 'ns ...)` and `(run-test 'ns/test)` run tests from the REPL. Matching nREPL ops `reload` (`all` param) and `run-tests` (`ns` + optional `var` param) let editors bind "reload changed" and "run test under cursor"
 
 ### Changed
 

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -520,6 +520,163 @@ Returns nil. Prints one name per line, sorted alphabetically."
          :success false
          :error (php/-> e (getMessage))}))))
 
+;; -------------------------------------------------------------------
+;; Namespace reloading
+;; -------------------------------------------------------------------
+
+(def- reload-state
+  ;; ns (display form) -> content hash recorded at last load/reload.
+  (atom {}))
+
+(defn- file-hash [file]
+  (when (php/is_file file)
+    (php/md5_file file)))
+
+(defn- reloadable?
+  "A namespace is reloadable from the REPL when it is a project namespace,
+  i.e. not one of the bundled `phel.*` standard-library modules."
+  [ns-name]
+  (not (php/str_starts_with ns-name "phel.")))
+
+(defn- reloadable-ns-infos
+  "Returns the NamespaceInformation objects for every loaded project
+  namespace, topologically sorted (dependencies first)."
+  []
+  (let [project  (filter reloadable? (loaded-namespaces))
+        ns-array (apply php/array (map canonical-ns project))]
+    (if (php/empty ns-array)
+      (php/array)
+      (filter (fn [info] (reloadable? (php/-> info (getNamespace))))
+              (php/-> build-facade (getDependenciesForNamespace (get-src-dirs) ns-array))))))
+
+(defn- force-eval-file!
+  "Re-evaluates a Phel source file, re-registering its definitions even when
+  the namespace is already loaded. Bypasses the build cache so edits always
+  take effect."
+  [file]
+  (let [content (php/file_get_contents file)]
+    (when content
+      (let [cf   (php/new CompilerFacade)
+            opts (php/-> (php/new CompileOptions) (setSource file))]
+        (php/-> cf (eval content opts))))))
+
+(defn- with-repl-mode
+  "Runs `thunk` with `*repl-mode*` enabled so re-evaluating a definition does
+  not trip the duplicate-definition guard, restoring the previous mode after."
+  [thunk]
+  (let [previous (php/:: Phel (getDefinition "phel.core" "*repl-mode*"))]
+    (php/:: Phel (addDefinition "phel.core" "*repl-mode*" true))
+    (try
+      (thunk)
+      (finally
+        (php/:: Phel (addDefinition "phel.core" "*repl-mode*" previous))))))
+
+(defn- reload-infos!
+  "Reloads the given namespace infos (topologically sorted) when their source
+  changed or a dependency was reloaded in this pass. When `force?` is true,
+  every namespace is reloaded regardless of mtime. Returns a vector of the
+  reloaded namespace names in load order."
+  [infos force?]
+  (let [dirty      (atom {})
+        reloaded   (atom [])
+        current-ns *ns*]
+    (with-repl-mode
+     (fn []
+       (foreach [info infos]
+         (let [ns-name   (canonical-ns (php/-> info (getNamespace)))
+               file      (php/-> info (getFile))
+               deps      (map canonical-ns (php/-> info (getDependencies)))
+               cur-hash  (file-hash file)
+               prev-hash (get (deref reload-state) ns-name)
+               self?     (or force? (not= cur-hash prev-hash))
+               dep?      (some (fn [d] (get (deref dirty) d)) deps)]
+           (when (or self? dep?)
+             (force-eval-file! file)
+             (swap! dirty assoc ns-name true)
+             (swap! reloaded conj ns-name))
+           (swap! reload-state assoc ns-name cur-hash)))))
+    ;; Re-evaluating files switches the current namespace; restore the caller's.
+    (php/-> (get-global-env) (setNs current-ns))
+    (set-ns current-ns)
+    (deref reloaded)))
+
+(defn reload!
+  "Re-evaluates project namespaces whose source files changed since the last
+  load, in dependency order, reloading dependents of changed namespaces too.
+  The first call (no recorded baseline) reloads every loaded project namespace.
+  REPL session state in namespaces without a source file (e.g. `user`) is
+  preserved. A compile error is reported and aborts the offending file without
+  corrupting already-reloaded namespaces. Returns a vector of reloaded
+  namespace names."
+  {:example "(reload!) ; => [\"my-app.lib\" \"my-app.core\"]"
+   :see-also ["reload-all!" "loaded-namespaces"]}
+  []
+  (reload-infos! (reloadable-ns-infos) false))
+
+(defn reload-all!
+  "Force-reloads every loaded project namespace in dependency order, ignoring
+  mtimes. Returns a vector of reloaded namespace names."
+  {:example "(reload-all!) ; => [\"my-app.lib\" \"my-app.core\"]"
+   :see-also ["reload!" "loaded-namespaces"]}
+  []
+  (reload-infos! (reloadable-ns-infos) true))
+
+;; -------------------------------------------------------------------
+;; Running tests from the REPL
+;; -------------------------------------------------------------------
+
+(defn- load-namespace!
+  "Loads a namespace from source if not already loaded, restoring the caller's
+  current namespace afterwards (evaluating a file switches `*ns*`). Namespaces
+  defined directly in the session (no source file) are already loaded and left
+  untouched."
+  [ns-str]
+  (when-not (find-ns ns-str)
+    (let [current *ns*]
+      (eval-namespace ns-str)
+      (php/-> (get-global-env) (setNs current))
+      (set-ns current))))
+
+(defn- run-tests-collecting
+  "Runs `t/run-tests` with the given options and namespace symbols, preserving
+  any outer test state, and returns a {:pass :fail :error} summary."
+  [options namespaces]
+  (let [saved-stats (t/get-stats)]
+    (t/reset-stats)
+    (apply t/run-tests options namespaces)
+    (let [{:counts counts} (t/get-stats)
+          result           {:pass (get counts :pass)
+                            :fail (get counts :failed)
+                            :error (get counts :error)}]
+      (t/restore-stats saved-stats)
+      result)))
+
+(defn run-tests
+  "Runs all tests in the given namespaces from the REPL, loading each namespace
+  first if needed. Each namespace is a symbol, e.g. `'my-app.foo-test`. Prints
+  results through the default reporter and returns a {:pass :fail :error}
+  summary."
+  {:example "(run-tests 'my-app.foo-test 'my-app.bar-test)"
+   :see-also ["run-test" "test-ns" "reload!"]}
+  [& namespaces]
+  (let [ns-syms (map (fn [n] (php/:: Symbol (create (canonical-ns (name n))))) namespaces)]
+    (foreach [n ns-syms]
+      (load-namespace! (name n)))
+    (run-tests-collecting {} ns-syms)))
+
+(defn run-test
+  "Runs a single test from the REPL, identified by a fully qualified symbol
+  `'my-app.foo-test/my-test`. Loads the namespace if needed. Prints results
+  through the default reporter and returns a {:pass :fail :error} summary."
+  {:example "(run-test 'my-app.foo-test/my-test)"
+   :see-also ["run-tests" "test-ns"]}
+  [test-sym]
+  (let [ns-str    (canonical-ns (namespace test-sym))
+        test-name (name test-sym)
+        ns-symbol (php/:: Symbol (create ns-str))]
+    (load-namespace! ns-str)
+    (run-tests-collecting {:only-tests [(str ns-str "/" test-name)]} [ns-symbol])))
+
 (defn test-ns
   "Runs all tests in a given namespace from the REPL. Requires the namespace if not already loaded, finds all deftest definitions, runs them, prints results, and returns a hash-map with :pass, :fail, and :error counts. Preserves outer test state so it can be safely called during a test run."
   {:example "(test-ns \"phel-test\\test\\core\")"

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -549,17 +549,6 @@ Returns nil. Prints one name per line, sorted alphabetically."
       (filter (fn [info] (reloadable? (php/-> info (getNamespace))))
               (php/-> build-facade (getDependenciesForNamespace (get-src-dirs) ns-array))))))
 
-(defn- force-eval-file!
-  "Re-evaluates a Phel source file, re-registering its definitions even when
-  the namespace is already loaded. Bypasses the build cache so edits always
-  take effect."
-  [file]
-  (let [content (php/file_get_contents file)]
-    (when content
-      (let [cf   (php/new CompilerFacade)
-            opts (php/-> (php/new CompileOptions) (setSource file))]
-        (php/-> cf (eval content opts))))))
-
 (defn- with-repl-mode
   "Runs `thunk` with `*repl-mode*` enabled so re-evaluating a definition does
   not trip the duplicate-definition guard, restoring the previous mode after."
@@ -591,7 +580,9 @@ Returns nil. Prints one name per line, sorted alphabetically."
                self?     (or force? (not= cur-hash prev-hash))
                dep?      (some (fn [d] (get (deref dirty) d)) deps)]
            (when (or self? dep?)
-             (force-eval-file! file)
+             ;; load-file re-evaluates the file fresh, bypassing the build
+             ;; cache, so edits always take effect.
+             (load-file file)
              (swap! dirty assoc ns-name true)
              (swap! reloaded conj ns-name))
            (swap! reload-state assoc ns-name cur-hash)))))
@@ -680,19 +671,10 @@ Returns nil. Prints one name per line, sorted alphabetically."
 (defn test-ns
   "Runs all tests in a given namespace from the REPL. Requires the namespace if not already loaded, finds all deftest definitions, runs them, prints results, and returns a hash-map with :pass, :fail, and :error counts. Preserves outer test state so it can be safely called during a test run."
   {:example "(test-ns \"phel-test\\test\\core\")"
-   :see-also ["dir" "loaded-namespaces"]}
+   :see-also ["run-tests" "run-test" "dir" "loaded-namespaces"]}
   [ns-str]
-  (eval-namespace ns-str)
-  (let [saved-stats (t/get-stats)]
-    (t/reset-stats)
-    (let [sym (php/:: Symbol (create ns-str))]
-      (t/run-tests {} sym)
-      (let [{:counts counts} (t/get-stats)
-            result           {:pass (get counts :pass)
-                              :fail (get counts :failed)
-                              :error (get counts :error)}]
-        (t/restore-stats saved-stats)
-        result))))
+  (load-namespace! ns-str)
+  (run-tests-collecting {} [(php/:: Symbol (create (canonical-ns ns-str)))]))
 
 (defn macroexpand-1-form
   "Expands the given form once if it is a macro call. Takes a quoted form and returns the expanded form, or the original form unchanged if it is not a macro call. Uses the CompilerFacade to perform the expansion without going through analyze+emit."

--- a/src/php/Nrepl/Application/Op/ReloadOp.php
+++ b/src/php/Nrepl/Application/Op/ReloadOp.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Application\Op;
+
+use Phel\Nrepl\Domain\Op\OpHandlerInterface;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Shared\CompileOptions;
+use Phel\Shared\Facade\RunFacadeInterface;
+
+/**
+ * Reloads project namespaces whose source files changed since the last load
+ * (or all of them when the `all` param is truthy), delegating to the
+ * `phel\repl/reload!` / `phel\repl/reload-all!` helpers. Editors bind this to
+ * a "reload changed namespaces" shortcut.
+ */
+final readonly class ReloadOp implements OpHandlerInterface
+{
+    public function __construct(
+        private RunFacadeInterface $runFacade,
+        private EvalResultResponder $responder,
+    ) {}
+
+    public function name(): string
+    {
+        return 'reload';
+    }
+
+    public function handle(OpRequest $request): array
+    {
+        $all = $request->stringParam('all');
+        $reloadFn = ($all === '1' || $all === 'true') ? 'reload-all!' : 'reload!';
+
+        $result = $this->runFacade->structuredEval(
+            '(phel\repl/' . $reloadFn . ')',
+            new CompileOptions(),
+        );
+
+        return $this->responder->respond($request, $result, 'reload failed.');
+    }
+}

--- a/src/php/Nrepl/Application/Op/RunTestsOp.php
+++ b/src/php/Nrepl/Application/Op/RunTestsOp.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Application\Op;
+
+use Phel\Nrepl\Domain\Op\OpHandlerInterface;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Nrepl\Domain\Op\OpStatus;
+use Phel\Shared\CompileOptions;
+use Phel\Shared\Facade\RunFacadeInterface;
+
+use function preg_match;
+
+/**
+ * Runs tests from inside the nREPL session, delegating to `phel\repl/run-tests`
+ * (a whole namespace) or `phel\repl/run-test` (a single test when the `var`
+ * param is set). Editors bind this to "run namespace tests" / "run test under
+ * cursor" shortcuts.
+ */
+final readonly class RunTestsOp implements OpHandlerInterface
+{
+    /**
+     * Conservative allow-list for the namespace/test identifiers woven into
+     * the evaluated form. Editors send plain symbols; rejecting anything else
+     * keeps the op from evaluating arbitrary code.
+     */
+    private const string SYMBOL_PATTERN = '/^[A-Za-z0-9._\/*?!<>=+-]+$/';
+
+    public function __construct(
+        private RunFacadeInterface $runFacade,
+        private EvalResultResponder $responder,
+    ) {}
+
+    public function name(): string
+    {
+        return 'run-tests';
+    }
+
+    public function handle(OpRequest $request): array
+    {
+        $ns = $request->stringParam('ns');
+        if ($ns === '') {
+            return [OpResponse::errorDone(
+                $request,
+                'Missing required "ns" param for run-tests op.',
+                [OpStatus::EVAL_ERROR],
+            )];
+        }
+
+        $var = $request->stringParam('var');
+        $identifier = $var === '' ? $ns : $ns . '/' . $var;
+
+        if (preg_match(self::SYMBOL_PATTERN, $identifier) !== 1) {
+            return [OpResponse::errorDone(
+                $request,
+                'Invalid namespace or test name for run-tests op.',
+                [OpStatus::EVAL_ERROR],
+            )];
+        }
+
+        $code = $var === ''
+            ? "(phel\\repl/run-tests '" . $ns . ')'
+            : "(phel\\repl/run-test '" . $identifier . ')';
+
+        $result = $this->runFacade->structuredEval($code, new CompileOptions());
+
+        return $this->responder->respond($request, $result, 'run-tests failed.');
+    }
+}

--- a/src/php/Nrepl/CLAUDE.md
+++ b/src/php/Nrepl/CLAUDE.md
@@ -10,7 +10,7 @@ nREPL protocol server; bencode-over-TCP for editor tooling (Cursive, Calva, CIDE
 
 ## Supported Ops
 
-Core: `clone`, `close`, `describe`, `eval`, `load-file`, `interrupt`. Via Api facade: `completions` (replCompleteWithTypes), `lookup`/`info`/`eldoc` (findSymbolMetadata).
+Core: `clone`, `close`, `describe`, `eval`, `load-file`, `interrupt`. Via Api facade: `completions` (replCompleteWithTypes), `lookup`/`info`/`eldoc` (findSymbolMetadata). REPL-workflow ops delegate to `phel\repl` via `structuredEval`: `reload` (changed project namespaces; `all` param → `reload-all!`), `run-tests` (`ns` param → `phel\repl/run-tests`; add `var` param → `phel\repl/run-test` for a single test).
 
 ## Dependencies
 

--- a/src/php/Nrepl/NreplFactory.php
+++ b/src/php/Nrepl/NreplFactory.php
@@ -14,6 +14,8 @@ use Phel\Nrepl\Application\Op\EvalResultResponder;
 use Phel\Nrepl\Application\Op\InterruptOp;
 use Phel\Nrepl\Application\Op\LoadFileOp;
 use Phel\Nrepl\Application\Op\LookupOp;
+use Phel\Nrepl\Application\Op\ReloadOp;
+use Phel\Nrepl\Application\Op\RunTestsOp;
 use Phel\Nrepl\Domain\Bencode\BencodeDecoder;
 use Phel\Nrepl\Domain\Bencode\BencodeEncoder;
 use Phel\Nrepl\Domain\Op\OpDispatcher;
@@ -52,6 +54,8 @@ final class NreplFactory extends AbstractFactory
         $dispatcher->register(new CloseOp($sessions));
         $dispatcher->register(new EvalOp($this->getRunFacade(), $responder));
         $dispatcher->register(new LoadFileOp($this->getRunFacade(), $responder));
+        $dispatcher->register(new ReloadOp($this->getRunFacade(), $responder));
+        $dispatcher->register(new RunTestsOp($this->getRunFacade(), $responder));
         $dispatcher->register(new InterruptOp());
         $dispatcher->register(new CompletionsOp($this->getApiFacade()));
         $dispatcher->register(new LookupOp($this->getApiFacade(), 'lookup', $sessions));

--- a/tests/phel/repl.phel
+++ b/tests/phel/repl.phel
@@ -1,8 +1,9 @@
 (ns phel-test.repl
-  (:require phel.repl :refer [apropos dir search-doc get-symbol-info get-source-code ns-publics ns-aliases ns-refers ns-interns find-fn test-ns eval-capturing eval-str macroexpand-1-form macroexpand-form macroexpand-1 macroexpand ns-list loaded-namespaces explain suggest fix review embed-ns search-ns find-ns create-ns remove-ns intern])
+  (:require phel.repl :refer [apropos dir search-doc get-symbol-info get-source-code ns-publics ns-aliases ns-refers ns-interns find-fn test-ns run-tests run-test reload! reload-all! eval-capturing eval-str macroexpand-1-form macroexpand-form macroexpand-1 macroexpand ns-list loaded-namespaces explain suggest fix review embed-ns search-ns find-ns create-ns remove-ns intern])
   (:require phel.ai :as ai)
   (:require phel.string :as s)
-  (:require phel.test :refer [deftest is]))
+  (:require phel-test.fixtures.tagged-tests)
+  (:require phel.test :as t :refer [deftest is]))
 
 ;; -------
 ;; apropos
@@ -607,3 +608,46 @@
     (is (nil? (find-ns ns)) "find-ns returns nil after remove-ns")
     (is (= {} (ns-interns ns))
         "ns-interns returns an empty map after remove-ns")))
+
+;; ---------
+;; run-tests / run-test
+;; ---------
+
+(def- fixture-ns 'phel-test.fixtures.tagged-tests)
+
+(defn- quiet-run [thunk]
+  "Runs a REPL test helper while suppressing its reporter output and restoring
+  the outer test stats afterwards. Returns the thunk's value."
+  (let [saved  (t/get-stats)
+        result (atom nil)]
+    (with-output-buffer (reset! result (thunk)))
+    (t/restore-stats saved)
+    (deref result)))
+
+(deftest test-run-tests-returns-summary-map
+  (let [result (quiet-run (fn [] (run-tests fixture-ns)))]
+    (is (= 3 (:pass result)) "run-tests counts every passing fixture test")
+    (is (= 0 (:fail result)) "run-tests reports no failures")
+    (is (= 0 (:error result)) "run-tests reports no errors")))
+
+(deftest test-run-tests-accepts-multiple-namespaces
+  (let [result (quiet-run (fn [] (run-tests fixture-ns fixture-ns)))]
+    (is (= 6 (:pass result))
+        "run-tests runs each named namespace, so passing twice doubles the count")))
+
+(deftest test-run-test-runs-a-single-test
+  (let [result (quiet-run
+                (fn [] (run-test 'phel-test.fixtures.tagged-tests/fixture-unit-passes)))]
+    (is (= 1 (:pass result)) "run-test runs exactly the named test")
+    (is (= 0 (:fail result)) "run-test reports no failures")))
+
+(deftest test-run-test-isolates-the-named-test
+  (let [result (quiet-run
+                (fn [] (run-test 'phel-test.fixtures.tagged-tests/fixture-integration-passes)))]
+    (is (= 1 (:pass result))
+        "run-test selects only the requested test, not its siblings")))
+
+(deftest test-run-tests-preserves-current-namespace
+  (let [before *ns*]
+    (quiet-run (fn [] (run-tests fixture-ns)))
+    (is (= before *ns*) "run-tests restores the caller's namespace")))

--- a/tests/php/Integration/Nrepl/NreplServerTest.php
+++ b/tests/php/Integration/Nrepl/NreplServerTest.php
@@ -177,6 +177,142 @@ final class NreplServerTest extends TestCase
         $server->stop();
     }
 
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function test_it_runs_tests_and_reloads_over_a_live_socket(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Phel::clear();
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+
+        $facade = new NreplFacade();
+        $facade->loadPhelNamespaces();
+
+        $server = $facade->createSocketServer(0, '127.0.0.1');
+        $server->start();
+
+        $client = @stream_socket_client(
+            sprintf('tcp://127.0.0.1:%d', $server->port()),
+            $errno,
+            $errstr,
+            2.0,
+        );
+        if ($client === false) {
+            $server->stop();
+            self::fail(sprintf('Could not connect to server: %s', $errstr));
+        }
+
+        stream_set_blocking($client, false);
+        stream_set_timeout($client, 2);
+
+        $encoder = new BencodeEncoder();
+        $decoder = new BencodeStreamDecoder();
+
+        // describe advertises the new ops
+        $this->writeMessage($client, $encoder->encode(['op' => 'describe', 'id' => 'd1']));
+        $describe = $this->readUntil($client, $decoder, $server, 1);
+        self::assertArrayHasKey('reload', $describe[0]['ops']);
+        self::assertArrayHasKey('run-tests', $describe[0]['ops']);
+
+        $this->writeMessage($client, $encoder->encode(['op' => 'clone', 'id' => 'c1']));
+        $clone = $this->readUntil($client, $decoder, $server, 1);
+        $sessionId = $clone[0]['new-session'];
+
+        // Define a test namespace in the session.
+        $this->writeMessage($client, $encoder->encode([
+            'op' => 'eval',
+            'id' => 'e1',
+            'session' => $sessionId,
+            'code' => '(ns nrepl-sample-test (:require phel\\test :refer [deftest is])) '
+                . '(deftest a-passing-test (is (= 1 1))) '
+                . '(deftest a-failing-test (is (= 1 2)))',
+        ]));
+        $this->readUntil($client, $decoder, $server, 2);
+
+        // run-tests over the whole namespace.
+        $this->writeMessage($client, $encoder->encode([
+            'op' => 'run-tests',
+            'id' => 'r1',
+            'session' => $sessionId,
+            'ns' => 'nrepl-sample-test',
+        ]));
+        $runTests = $this->readUntilDone($client, $decoder, $server);
+        $value = $this->firstWithKey($runTests, 'value');
+        self::assertNotNull($value, 'run-tests should return a summary value');
+        self::assertStringContainsString(':pass 1', (string) $value['value']);
+        self::assertStringContainsString(':fail 1', (string) $value['value']);
+        self::assertNotNull($this->firstWithStatus($runTests, 'done'));
+
+        // run-tests for a single test via the var param.
+        $this->writeMessage($client, $encoder->encode([
+            'op' => 'run-tests',
+            'id' => 'r2',
+            'session' => $sessionId,
+            'ns' => 'nrepl-sample-test',
+            'var' => 'a-passing-test',
+        ]));
+        $runOne = $this->readUntilDone($client, $decoder, $server);
+        $oneValue = $this->firstWithKey($runOne, 'value');
+        self::assertNotNull($oneValue);
+        self::assertStringContainsString(':pass 1', (string) $oneValue['value']);
+        self::assertStringContainsString(':fail 0', (string) $oneValue['value']);
+
+        // reload returns a vector of reloaded namespaces without erroring.
+        $this->writeMessage($client, $encoder->encode([
+            'op' => 'reload',
+            'id' => 'rl1',
+            'session' => $sessionId,
+        ]));
+        $reload = $this->readUntilDone($client, $decoder, $server);
+        self::assertNotNull($this->firstWithStatus($reload, 'done'));
+        self::assertNull(
+            $this->firstWithStatus($reload, 'eval-error'),
+            'reload should not report an eval error',
+        );
+
+        fclose($client);
+        $server->stop();
+    }
+
+    /**
+     * Reads frames until one carries a `done` status, returning everything
+     * collected. Reporter output arrives as several `out` frames before the
+     * value/done pair, so a fixed message count is not reliable here.
+     *
+     * @param resource $client
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function readUntilDone($client, BencodeStreamDecoder $decoder, NreplSocketServer $server, int $timeoutMs = 3000): array
+    {
+        $start = (int) (microtime(true) * 1000);
+        $collected = [];
+
+        while (true) {
+            $this->pump($server);
+            $chunk = @fread($client, 8192);
+            if ($chunk !== false && $chunk !== '') {
+                $decoder->feed($chunk);
+                foreach ($decoder->drain() as $msg) {
+                    if (is_array($msg)) {
+                        $collected[] = $msg;
+                    }
+                }
+            }
+
+            if ($this->firstWithStatus($collected, 'done') !== null) {
+                return $collected;
+            }
+
+            if ((int) (microtime(true) * 1000) - $start > $timeoutMs) {
+                self::fail('Timed out waiting for a done frame.');
+            }
+
+            usleep(2000);
+        }
+    }
+
     /**
      * @param resource $client
      */


### PR DESCRIPTION
## 🤔 Background

Clojure developers expect a REPL-driven workflow: edit a file, reload changed namespaces in place, run tests without restarting the process. Phel already had a REPL, an nREPL server, and a test runner, but no in-session namespace reloading and no way to run tests from the REPL/nREPL. Closes #2429.

## 💡 Goal

Let users keep a long-lived REPL/nREPL session: `(reload!)` after editing picks up changes (and dependents), and tests run from the prompt or an editor shortcut.

## 🔖 Changes

**`phel\repl` (src/phel/repl.phel)**
- `(reload!)` — re-evaluates project namespaces whose source changed since the last load, in dependency order, reloading dependents of changed namespaces too. First call (no baseline) reloads all loaded project namespaces. Runs under a temporary `*repl-mode*` so redefinitions don't trip the duplicate-definition guard, and restores the caller's `*ns*` afterwards. A compile error aborts the offending file without corrupting already-reloaded namespaces.
- `(reload-all!)` — force-reloads every loaded project namespace regardless of mtime.
- `(run-tests 'ns ...)` / `(run-test 'ns/test)` — run tests from the REPL, reusing the `phel\test` runner and the default reporter; return a `{:pass :fail :error}` summary. `test-ns` is reimplemented on top of the shared helpers.
- `phel.*` bundled namespaces are never reloaded; namespaces without a source file (e.g. `user`, session-defined) are left intact, preserving session state.

**nREPL (src/php/Nrepl)**
- `reload` op (`all` param → `reload-all!`) and `run-tests` op (`ns` param, optional `var` for a single test). Both delegate to `phel\repl` via `structuredEval` and reuse `EvalResultResponder`. Editors can bind "reload changed" and "run test under cursor".

**Tests**
- Phel: `run-tests`/`run-test` summaries, multi-namespace, single-test isolation, `*ns*` preservation (tests/phel/repl.phel).
- PHP integration: live-socket nREPL test exercising `describe` (advertises the new ops), `run-tests` (whole ns + single `var`), and `reload` (tests/php/Integration/Nrepl/NreplServerTest.php).

Reload-changes-behavior is additionally verified by hand against a temp project (edit fn → `(reload!)` → new behavior; dependents reload; compile error leaves the session usable).

## Notes
- `reload!` operates on namespaces backed by source files; session-only definitions are untouched.
- nREPL ops documented in `src/php/Nrepl/CLAUDE.md`; CHANGELOG updated under `## Unreleased`.