### PR TITLE
feat(run): scaffold real app templates with phel init --template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Two themes: project configuration (`phel config`, optimization levels, composabl
 ### Added
 
 - `phel config`: prints the merged config with provenance (`--json` for machine output)
+- `phel init --template=<name>` (`-t`): scaffold a runnable project from a bundled example (`http-json-api`, `todo-app`, `cli-wordcount`), with namespaces/composer/entry points renamed to the project name; `--list-templates` (or `-t` with no value) lists them. Composes with `--dry-run`/`--force`. Templates are sourced from `resources/agents/examples/` (now shipped inside `phel.phar`) (#2430)
 - Optimization levels: `PhelConfig::withOptimizationLevel(int)` and `phel build -O <level>`; level 2 enables `^:pure` inlining + self-recursive tail-call rewriting (REPL/nREPL stay at 0) (#2387)
 - `phel test --watch`: re-runs the selected tests on every `.phel`/`phel-config.php` change
 - `phel test`: startup progress on stderr, and an expected/actual diff with a caret on failed `=` assertions

--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -286,6 +286,7 @@ final class PharBuilder
 
             $this->addFiles($phar);
             $this->addReplStartupFile($phar);
+            $this->addExampleTemplates($phar);
             $this->setStub($phar);
             $this->compressPhar($phar);
             $phar->setSignatureAlgorithm(Phar::SHA256);
@@ -559,6 +560,39 @@ final class PharBuilder
         $size = @filesize($startup);
         if ($size !== false) {
             $this->stats['total_size'] += $size;
+        }
+    }
+
+    /**
+     * `resources/` is excluded from the generic walker, but the example app
+     * templates must ship inside the PHAR so `phel init --template` works from
+     * a standalone phar (the rest of `resources/agents/` stays out).
+     */
+    private function addExampleTemplates(Phar $phar): void
+    {
+        $examplesRoot = $this->root . '/resources/agents/examples';
+        if (!is_dir($examplesRoot)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($examplesRoot, FilesystemIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $fileInfo) {
+            if (!$fileInfo->isFile()) {
+                continue;
+            }
+
+            $absolute = $fileInfo->getPathname();
+            $relative = ltrim(str_replace('\\', '/', substr($absolute, \strlen($this->root))), '/');
+            $phar->addFile($absolute, $relative);
+            ++$this->stats['files_added'];
+
+            $size = @filesize($absolute);
+            if ($size !== false) {
+                $this->stats['total_size'] += $size;
+            }
         }
     }
 

--- a/build/phar.sh
+++ b/build/phar.sh
@@ -96,6 +96,10 @@ mkdir -p "$WORK_DIR" "$CACHE_DIR" "$OUTPUT_DIR"
 # Sync Project Files
 # ============================================================================
 rsync -a "$REPO_ROOT/" "$WORK_DIR/" \
+  --include='resources/' \
+  --include='resources/agents/' \
+  --include='resources/agents/examples/***' \
+  --exclude='resources/agents/**' \
   --exclude='.git' \
   --exclude='.github' \
   --exclude='.idea' \
@@ -112,7 +116,6 @@ rsync -a "$REPO_ROOT/" "$WORK_DIR/" \
   --exclude='data' \
   --exclude='vendor' \
   --exclude='build' \
-  --exclude='resources/agents' \
   --exclude='tools' \
   --exclude='examples' \
   --exclude='fixtures' \

--- a/src/php/Run/Application/Agent/AgentInstaller.php
+++ b/src/php/Run/Application/Agent/AgentInstaller.php
@@ -46,7 +46,10 @@ final class AgentInstaller
     {
         foreach ([5, 4, 6] as $levels) {
             $candidate = dirname(__DIR__, $levels) . '/resources/agents';
-            if (is_dir($candidate)) {
+            // The VERSION marker ships only with the full agent docs tree, not
+            // with the examples-only subtree bundled inside phel.phar, so this
+            // keeps reporting the Composer-install hint when run from the PHAR.
+            if (is_file($candidate . '/VERSION')) {
                 return $candidate;
             }
         }

--- a/src/php/Run/Domain/Init/ProjectTemplateScaffolder.php
+++ b/src/php/Run/Domain/Init/ProjectTemplateScaffolder.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Init;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
+use SplFileInfo;
+
+use function dirname;
+use function implode;
+use function is_dir;
+use function ksort;
+use function preg_replace;
+use function sprintf;
+use function str_replace;
+use function strlen;
+use function strtolower;
+use function substr;
+use function trim;
+
+/**
+ * Scaffolds a new project from one of the bundled example apps in
+ * `resources/agents/examples/` (the single source of truth — examples are not
+ * duplicated). Every occurrence of the template's namespace base (its directory
+ * name, e.g. `http-json-api`) is rewritten to the chosen project name across ns
+ * forms, composer.json, entry points, and the README.
+ */
+final class ProjectTemplateScaffolder
+{
+    /** Template name => one-line description, shown by `--list-templates`. */
+    private const array TEMPLATES = [
+        'http-json-api' => 'Minimal HTTP JSON API (phel\http routing, handlers, public/index.php)',
+        'todo-app' => 'HTTP todo app with an in-memory store and route handlers',
+        'cli-wordcount' => 'CLI word-count tool reading stdin or file arguments',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    public function availableTemplates(): array
+    {
+        return self::TEMPLATES;
+    }
+
+    public function hasTemplate(string $name): bool
+    {
+        return isset(self::TEMPLATES[$name]);
+    }
+
+    /**
+     * Builds the file set for a template, keyed by path relative to the project
+     * root, with the namespace base rewritten to the project name.
+     *
+     * @return array<string, string>
+     */
+    public function files(string $templateName, string $projectName): array
+    {
+        if (!$this->hasTemplate($templateName)) {
+            throw new RuntimeException(sprintf(
+                'Unknown template "%s". Available templates: %s',
+                $templateName,
+                implode(', ', array_keys(self::TEMPLATES)),
+            ));
+        }
+
+        $root = $this->locateExamplesRoot() . '/' . $templateName;
+        $base = $this->namespaceBase($projectName);
+
+        $files = [];
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $fileInfo) {
+            if (!$fileInfo instanceof SplFileInfo) {
+                continue;
+            }
+
+            if (!$fileInfo->isFile()) {
+                continue;
+            }
+
+            $absolutePath = $fileInfo->getPathname();
+            $relativePath = substr($absolutePath, strlen($root) + 1);
+            $content = (string) file_get_contents($absolutePath);
+
+            $files[$relativePath] = str_replace($templateName, $base, $content);
+        }
+
+        ksort($files);
+
+        return $files;
+    }
+
+    /**
+     * Locate the bundled `resources/agents/examples/` directory. Levels differ
+     * by install layout: 5 = Composer dependency (vendor/), 4 = this repo's own
+     * checkout, 6 = nested edge cases. The examples subtree is shipped inside
+     * phel.phar even though the rest of `resources/agents/` is not.
+     */
+    public function locateExamplesRoot(): string
+    {
+        foreach ([5, 4, 6] as $levels) {
+            $candidate = dirname(__DIR__, $levels) . '/resources/agents/examples';
+            if (is_dir($candidate)) {
+                return $candidate;
+            }
+        }
+
+        throw new RuntimeException('Cannot locate bundled resources/agents/examples/ directory.');
+    }
+
+    /**
+     * Turns a project name into a kebab-case namespace base (lowercase,
+     * non-alphanumeric runs collapsed to a single hyphen). Hyphens are kept
+     * because Phel namespaces allow them, matching the example layout.
+     */
+    private function namespaceBase(string $projectName): string
+    {
+        $kebab = strtolower((string) preg_replace('/[^a-zA-Z0-9]+/', '-', $projectName));
+        $kebab = trim($kebab, '-');
+
+        return $kebab === '' ? 'app' : $kebab;
+    }
+}

--- a/src/php/Run/Infrastructure/Command/InitCommand.php
+++ b/src/php/Run/Infrastructure/Command/InitCommand.php
@@ -7,6 +7,7 @@ namespace Phel\Run\Infrastructure\Command;
 use Phel\Config\ProjectLayout;
 use Phel\Run\Domain\Init\NamespaceNormalizer;
 use Phel\Run\Domain\Init\ProjectTemplateGenerator;
+use Phel\Run\Domain\Init\ProjectTemplateScaffolder;
 use Phel\Shared\ScalarCoercion;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -14,6 +15,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function dirname;
+use function is_dir;
+use function mkdir;
 use function sprintf;
 
 final class InitCommand extends Command
@@ -32,11 +36,16 @@ final class InitCommand extends Command
 
     private const string OPT_NO_TESTS = 'no-tests';
 
+    private const string OPT_TEMPLATE = 'template';
+
+    private const string OPT_LIST_TEMPLATES = 'list-templates';
+
     private const string DIR_OUT = 'out';
 
     public function __construct(
         private readonly ProjectTemplateGenerator $templateGenerator = new ProjectTemplateGenerator(),
         private readonly NamespaceNormalizer $namespaceNormalizer = new NamespaceNormalizer(),
+        private readonly ProjectTemplateScaffolder $templateScaffolder = new ProjectTemplateScaffolder(),
     ) {
         parent::__construct();
     }
@@ -86,6 +95,19 @@ final class InitCommand extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Skip generating a matching test file',
+            )
+            ->addOption(
+                self::OPT_TEMPLATE,
+                't',
+                InputOption::VALUE_OPTIONAL,
+                'Scaffold from a bundled example template (e.g. http-json-api); omit the value to list templates',
+                false,
+            )
+            ->addOption(
+                self::OPT_LIST_TEMPLATES,
+                null,
+                InputOption::VALUE_NONE,
+                'List the available project templates and exit',
             );
     }
 
@@ -98,6 +120,15 @@ final class InitCommand extends Command
         $noGitignore = (bool) $input->getOption(self::OPT_NO_GITIGNORE);
         $noTests = (bool) $input->getOption(self::OPT_NO_TESTS);
 
+        $template = $input->getOption(self::OPT_TEMPLATE);
+
+        // --list-templates, or -t/--template with no value, prints the catalog.
+        if ((bool) $input->getOption(self::OPT_LIST_TEMPLATES) || $template === null) {
+            $this->printTemplates($output);
+
+            return Command::SUCCESS;
+        }
+
         $cwd = getcwd();
         if ($cwd === false) {
             $output->writeln('<error>Unable to determine current working directory.</error>');
@@ -108,6 +139,17 @@ final class InitCommand extends Command
         if ($dryRun) {
             $output->writeln('<comment>Dry run mode - no files will be created</comment>');
             $output->writeln('');
+        }
+
+        if ($template !== false) {
+            return $this->scaffoldFromTemplate(
+                ScalarCoercion::toString($template),
+                $projectName,
+                $cwd,
+                $output,
+                $force,
+                $dryRun,
+            );
         }
 
         $namespace = $this->namespaceNormalizer->normalize($projectName);
@@ -283,6 +325,79 @@ final class InitCommand extends Command
         $output->writeln(sprintf('<info>%s %s</info>', $action, $displayName));
 
         return true;
+    }
+
+    private function printTemplates(OutputInterface $output): void
+    {
+        $output->writeln('<info>Available templates:</info>');
+        foreach ($this->templateScaffolder->availableTemplates() as $name => $description) {
+            $output->writeln(sprintf('  <comment>%s</comment> - %s', $name, $description));
+        }
+
+        $output->writeln('');
+        $output->writeln('Scaffold one with: <comment>phel init my-app --template=<name></comment>');
+    }
+
+    private function scaffoldFromTemplate(
+        string $template,
+        string $projectName,
+        string $cwd,
+        OutputInterface $output,
+        bool $force,
+        bool $dryRun,
+    ): int {
+        if (!$this->templateScaffolder->hasTemplate($template)) {
+            $output->writeln(sprintf('<error>Unknown template "%s".</error>', $template));
+            $output->writeln('');
+            $this->printTemplates($output);
+
+            return Command::FAILURE;
+        }
+
+        foreach ($this->templateScaffolder->files($template, $projectName) as $relativePath => $content) {
+            $fullPath = $cwd . '/' . $relativePath;
+
+            if (!$dryRun && !$this->ensureParentDir($fullPath, $output)) {
+                return Command::FAILURE;
+            }
+
+            if (!$this->createFile($fullPath, $content, $relativePath, $output, $force, $dryRun)) {
+                return Command::FAILURE;
+            }
+        }
+
+        if (!$dryRun) {
+            $this->printTemplateNextSteps($output, $template);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function ensureParentDir(string $filePath, OutputInterface $output): bool
+    {
+        $dir = dirname($filePath);
+        if (is_dir($dir)) {
+            return true;
+        }
+
+        if (!mkdir($dir, 0755, true) && !is_dir($dir)) {
+            $output->writeln(sprintf('<error>Failed to create directory: %s</error>', $dir));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function printTemplateNextSteps(OutputInterface $output, string $template): void
+    {
+        $output->writeln('');
+        $output->writeln(sprintf('<info>Scaffolded the "%s" template!</info>', $template));
+        $output->writeln('');
+        $output->writeln('Next steps:');
+        $output->writeln('  1. Install dependencies: <comment>composer install</comment>');
+        $output->writeln('  2. Run the tests:        <comment>./vendor/bin/phel test</comment>');
+        $output->writeln('  3. See the README for how to run the app.');
     }
 
     private function printNextSteps(OutputInterface $output, string $mainFilename, bool $noTests): void

--- a/tests/php/Integration/Run/Command/Init/InitCommandTest.php
+++ b/tests/php/Integration/Run/Command/Init/InitCommandTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Run\Command\Init;
 
+use Iterator;
 use Phel\Run\Infrastructure\Command\InitCommand;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -413,6 +415,140 @@ final class InitCommandTest extends TestCase
 
         self::assertFileDoesNotExist($this->testDir . '/.gitignore');
         self::assertFileExists($this->testDir . '/phel-config.php');
+    }
+
+    public function test_lists_templates(): void
+    {
+        $command = new InitCommand();
+        $output = new BufferedOutput();
+
+        chdir($this->testDir);
+        $result = $command->run(new ArrayInput(['--list-templates' => true]), $output);
+
+        self::assertSame(Command::SUCCESS, $result);
+        $text = $output->fetch();
+        self::assertStringContainsString('http-json-api', $text);
+        self::assertStringContainsString('todo-app', $text);
+        self::assertStringContainsString('cli-wordcount', $text);
+        self::assertDirectoryDoesNotExist($this->testDir . '/src');
+    }
+
+    public function test_scaffolds_template_with_renamed_namespaces(): void
+    {
+        $command = new InitCommand();
+        $output = new BufferedOutput();
+
+        chdir($this->testDir);
+        $result = $command->run(new ArrayInput([
+            'project-name' => 'my-api',
+            '--template' => 'http-json-api',
+        ]), $output);
+
+        self::assertSame(Command::SUCCESS, $result);
+        self::assertFileExists($this->testDir . '/src/entry.phel');
+        self::assertFileExists($this->testDir . '/public/index.php');
+        self::assertFileExists($this->testDir . '/composer.json');
+
+        $entry = (string) file_get_contents($this->testDir . '/src/entry.phel');
+        self::assertStringContainsString('(ns my-api\\entry', $entry);
+        self::assertStringNotContainsString('http-json-api', $entry);
+
+        $composer = (string) file_get_contents($this->testDir . '/composer.json');
+        self::assertStringContainsString('my-api', $composer);
+
+        $index = (string) file_get_contents($this->testDir . '/public/index.php');
+        self::assertStringContainsString("'my-api\\\\entry'", $index);
+    }
+
+    /**
+     * @return Iterator<int<0, max>, array{string, string}>
+     */
+    public static function templateProvider(): Iterator
+    {
+        yield ['http-json-api', 'src/entry.phel'];
+        yield ['todo-app', 'src/store.phel'];
+        yield ['cli-wordcount', 'src/counts.phel'];
+    }
+
+    #[DataProvider('templateProvider')]
+    public function test_scaffolds_each_template(string $template, string $markerFile): void
+    {
+        $command = new InitCommand();
+        $output = new BufferedOutput();
+
+        chdir($this->testDir);
+        $result = $command->run(new ArrayInput([
+            'project-name' => 'proj',
+            '--template' => $template,
+        ]), $output);
+
+        self::assertSame(Command::SUCCESS, $result);
+        self::assertFileExists($this->testDir . '/' . $markerFile);
+        self::assertFileExists($this->testDir . '/composer.json');
+    }
+
+    public function test_unknown_template_fails_and_lists_options(): void
+    {
+        $command = new InitCommand();
+        $output = new BufferedOutput();
+
+        chdir($this->testDir);
+        $result = $command->run(new ArrayInput([
+            'project-name' => 'my-api',
+            '--template' => 'does-not-exist',
+        ]), $output);
+
+        self::assertSame(Command::FAILURE, $result);
+        $text = $output->fetch();
+        self::assertStringContainsString('Unknown template', $text);
+        self::assertStringContainsString('http-json-api', $text);
+        self::assertFileDoesNotExist($this->testDir . '/composer.json');
+    }
+
+    public function test_dry_run_template_creates_no_files(): void
+    {
+        $command = new InitCommand();
+        $output = new BufferedOutput();
+
+        chdir($this->testDir);
+        $result = $command->run(new ArrayInput([
+            'project-name' => 'my-api',
+            '--template' => 'cli-wordcount',
+            '--dry-run' => true,
+        ]), $output);
+
+        self::assertSame(Command::SUCCESS, $result);
+        self::assertFileDoesNotExist($this->testDir . '/composer.json');
+        self::assertFileDoesNotExist($this->testDir . '/src/counts.phel');
+        self::assertStringContainsString('[DRY-RUN]', $output->fetch());
+    }
+
+    public function test_force_overwrites_scaffolded_template_files(): void
+    {
+        chdir($this->testDir);
+
+        $first = new InitCommand();
+        $first->run(new ArrayInput([
+            'project-name' => 'my-api',
+            '--template' => 'cli-wordcount',
+        ]), new BufferedOutput());
+
+        file_put_contents($this->testDir . '/composer.json', 'tampered');
+
+        $skipOutput = new BufferedOutput();
+        new InitCommand()->run(new ArrayInput([
+            'project-name' => 'my-api',
+            '--template' => 'cli-wordcount',
+        ]), $skipOutput);
+        self::assertSame('tampered', file_get_contents($this->testDir . '/composer.json'));
+        self::assertStringContainsString('already exists', $skipOutput->fetch());
+
+        new InitCommand()->run(new ArrayInput([
+            'project-name' => 'my-api',
+            '--template' => 'cli-wordcount',
+            '--force' => true,
+        ]), new BufferedOutput());
+        self::assertStringContainsString('phel-examples/my-api', (string) file_get_contents($this->testDir . '/composer.json'));
     }
 
     private function removeDirectory(string $dir): void

--- a/tests/php/Unit/Run/Domain/Init/ProjectTemplateScaffolderTest.php
+++ b/tests/php/Unit/Run/Domain/Init/ProjectTemplateScaffolderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Domain\Init;
+
+use Phel\Run\Domain\Init\ProjectTemplateScaffolder;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class ProjectTemplateScaffolderTest extends TestCase
+{
+    private ProjectTemplateScaffolder $scaffolder;
+
+    protected function setUp(): void
+    {
+        $this->scaffolder = new ProjectTemplateScaffolder();
+    }
+
+    public function test_lists_the_bundled_templates(): void
+    {
+        $templates = $this->scaffolder->availableTemplates();
+
+        self::assertArrayHasKey('http-json-api', $templates);
+        self::assertArrayHasKey('todo-app', $templates);
+        self::assertArrayHasKey('cli-wordcount', $templates);
+    }
+
+    public function test_has_template(): void
+    {
+        self::assertTrue($this->scaffolder->hasTemplate('cli-wordcount'));
+        self::assertFalse($this->scaffolder->hasTemplate('nope'));
+    }
+
+    public function test_files_rewrite_the_namespace_base(): void
+    {
+        $files = $this->scaffolder->files('cli-wordcount', 'my-tool');
+
+        self::assertArrayHasKey('src/main.phel', $files);
+        self::assertArrayHasKey('composer.json', $files);
+
+        $main = $files['src/main.phel'];
+        self::assertStringContainsString('(ns my-tool\\main', $main);
+        self::assertStringNotContainsString('cli-wordcount', $main);
+        self::assertStringContainsString('my-tool', $files['composer.json']);
+    }
+
+    public function test_files_collapse_non_alphanumeric_runs_to_hyphens(): void
+    {
+        $files = $this->scaffolder->files('cli-wordcount', 'My Cool API!');
+
+        self::assertStringContainsString('(ns my-cool-api\\main', $files['src/main.phel']);
+    }
+
+    public function test_files_throws_for_unknown_template(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unknown template "ghost"');
+
+        $this->scaffolder->files('ghost', 'my-app');
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`phel init` only generated a minimal skeleton. Working example apps already live in `resources/agents/examples/` (`todo-app`, `http-json-api`, `cli-wordcount`) but `init` did not use them. New users should get a runnable, tested app in one command. Closes #2430.

## 💡 Goal

`phel init my-api --template=http-json-api` produces a runnable project with namespaces renamed to the project, working out of the box (`composer install && ./vendor/bin/phel test` green).

## 🔖 Changes

- **`phel init --template=<name>` / `-t`** scaffolds from a bundled example. The namespace base (the example's directory name, e.g. `http-json-api`) is rewritten to the project name across ns forms, `composer.json`, entry points (`public/index.php`, `bin/`), and the README.
- **`phel init --list-templates`** (or `-t` with no value) prints the catalog with one-line descriptions.
- `--dry-run` and `--force` compose with `--template`.
- New `ProjectTemplateScaffolder` (Domain/Init) reads the files straight from `resources/agents/examples/` — single source of truth, no duplication — and rewrites the namespace base (kebab-cased project name).
- **PHAR packaging**: `resources/agents/examples/` now ships inside `phel.phar` (rsync re-include + an explicit `addExampleTemplates` step mirroring `addReplStartupFile`, since the generic walker skips `resources/`). The rest of `resources/agents/` stays out; `AgentInstaller::locateSourceRoot` now keys off the `VERSION` marker so its "not in phar, use Composer" hint is unchanged.

## ✅ Acceptance

- [x] `phel init my-api --template=http-json-api` → runnable project, namespaces renamed to `my-api`
- [x] All three examples available as templates (each scaffolds + `phel test` green: 6 / 12 / 9 passing)
- [x] `--dry-run` and `--force` compose with `--template`
- [x] Template files read from `resources/agents/examples/`, **verified shipped in the PHAR** (built phel.phar, scaffolded from it, tests green; agent-docs tree still excluded)
- [x] Integration tests (scaffold + placeholder rewrite per template, list, unknown, dry-run, force) + a `ProjectTemplateScaffolder` unit test
- [x] `phel init --help` documents the options
- [x] CHANGELOG under `## Unreleased`

## 🔍 Notes

- Final refactor pass surfaced no code-level changes: the new command helpers are cohesive and `addExampleTemplates` intentionally mirrors the existing `addReplStartupFile`.
- Website docs page (phel-lang.org) lives in a separate repo and is out of scope for this PR; `--help` text covers the in-CLI documentation.
- Remote/community template registry (`gh:user/repo`) remains out of scope per the issue.