### PR TITLE
feat(lsp): completion + hover + signature help for PHP interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Two themes: project configuration (`phel config`, optimization levels, composabl
 ### Added
 
 - `phel config`: prints the merged config with provenance (`--json` for machine output)
+- LSP PHP interop (#2431): completion for instance methods/properties after `(php/-> receiver ...)`, static methods/constants after `(php/:: Class ...)`, class names in `(php/new ...)` and `\Fully\Qualified` positions, and global functions after `php/`; hover with the reflected signature for PHP methods/functions/classes; signature help for `(php/new ...)` and method calls. Receiver types come from `:tag` metadata, inline `(php/new \Foo)`, or a local `(php/new ...)` binding; an unknown type degrades to no completion with no diagnostics
 - `phel init --template=<name>` (`-t`): scaffold a runnable project from a bundled example (`http-json-api`, `todo-app`, `cli-wordcount`), with namespaces/composer/entry points renamed to the project name; `--list-templates` (or `-t` with no value) lists them. Composes with `--dry-run`/`--force`. Templates are sourced from `resources/agents/examples/` (now shipped inside `phel.phar`) (#2430)
 - Optimization levels: `PhelConfig::withOptimizationLevel(int)` and `phel build -O <level>`; level 2 enables `^:pure` inlining + self-recursive tail-call rewriting (REPL/nREPL stay at 0) (#2387)
 - `phel test --watch`: re-runs the selected tests on every `.phel`/`phel-config.php` change

--- a/src/php/Api/ApiFacade.php
+++ b/src/php/Api/ApiFacade.php
@@ -123,4 +123,28 @@ final class ApiFacade extends AbstractFacade implements ApiFacadeInterface
             ->createSymbolMetadataFinder()
             ->find($symbol, $currentNs);
     }
+
+    /**
+     * Markdown hover for the PHP-interop symbol under the cursor (method,
+     * static member, global function, class), or null when not applicable.
+     */
+    public function phpInteropHoverAt(string $source, int $line, int $col): ?string
+    {
+        return $this->getFactory()
+            ->createPhpInteropDocResolver()
+            ->hoverAt($source, $line, $col);
+    }
+
+    /**
+     * LSP SignatureHelp payload for the PHP-interop call enclosing the cursor,
+     * or null when not applicable.
+     *
+     * @return array{signatures: list<array{label: string}>, activeSignature: int, activeParameter: int}|null
+     */
+    public function phpInteropSignatureAt(string $source, int $line, int $col): ?array
+    {
+        return $this->getFactory()
+            ->createPhpInteropDocResolver()
+            ->signatureAt($source, $line, $col);
+    }
 }

--- a/src/php/Api/ApiFactory.php
+++ b/src/php/Api/ApiFactory.php
@@ -10,6 +10,8 @@ use Phel\Api\Application\Analysis\PreloadDependenciesStage;
 use Phel\Api\Application\Analysis\ReadAndAnalyzeStage;
 use Phel\Api\Application\PhelFnGroupKeyGenerator;
 use Phel\Api\Application\PhelFnNormalizer;
+use Phel\Api\Application\PhpInteropCompleter;
+use Phel\Api\Application\PhpInteropDocResolver;
 use Phel\Api\Application\PointCompleter;
 use Phel\Api\Application\ProjectIndexer;
 use Phel\Api\Application\ReferenceFinder;
@@ -92,7 +94,13 @@ final class ApiFactory extends AbstractFactory
         return new PointCompleter(
             $this->getCompilerFacade(),
             $this->createPhelFnNormalizer(),
+            new PhpInteropCompleter(),
         );
+    }
+
+    public function createPhpInteropDocResolver(): PhpInteropDocResolver
+    {
+        return new PhpInteropDocResolver();
     }
 
     public function createApiDaemon(ApiFacade $facade): ApiDaemon

--- a/src/php/Api/Application/CursorText.php
+++ b/src/php/Api/Application/CursorText.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use function max;
+use function preg_match;
+use function preg_split;
+use function strlen;
+use function substr;
+
+/**
+ * Small text helpers shared by the PHP-interop resolvers for working with a
+ * 1-based (line, col) cursor over a source string.
+ */
+final class CursorText
+{
+    /**
+     * The text on `$line` up to (not including) the cursor column.
+     */
+    public static function before(string $source, int $line, int $col): string
+    {
+        $lines = preg_split('/\r?\n/', $source) ?: [];
+        if (!isset($lines[$line - 1])) {
+            return '';
+        }
+
+        return substr($lines[$line - 1], 0, max(0, $col - 1));
+    }
+
+    /**
+     * The column just past the identifier the cursor sits on, so a resolver
+     * sees the whole word rather than only the part before the caret.
+     */
+    public static function wordEndColumn(string $source, int $line, int $col): int
+    {
+        $lines = preg_split('/\r?\n/', $source) ?: [];
+        $text = $lines[$line - 1] ?? '';
+        $offset = max(0, $col - 1);
+
+        if (preg_match('/[A-Za-z0-9_]+/A', substr($text, $offset), $m) === 1) {
+            return $col + strlen($m[0]);
+        }
+
+        return $col;
+    }
+}

--- a/src/php/Api/Application/PhpInteropCompleter.php
+++ b/src/php/Api/Application/PhpInteropCompleter.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use Phel\Api\Transfer\Completion;
+use Phel\Api\Transfer\PhpInteropContext;
+
+/**
+ * Produces PHP-interop completions at a cursor position by combining the
+ * {@see PhpInteropContextResolver} (what is being typed) with the
+ * {@see PhpInteropReflector} (what the resolved type offers). Returns null when
+ * the cursor is not in a PHP-interop position, so callers fall back to the
+ * normal Phel completion path.
+ */
+final readonly class PhpInteropCompleter
+{
+    public function __construct(
+        private PhpInteropContextResolver $contextResolver = new PhpInteropContextResolver(),
+        private PhpInteropReflector $reflector = new PhpInteropReflector(),
+    ) {}
+
+    /**
+     * @return list<Completion>|null
+     */
+    public function completeAtPoint(string $source, int $line, int $col): ?array
+    {
+        $context = $this->contextResolver->resolve($source, $line, $col);
+
+        return match ($context->kind) {
+            PhpInteropContext::KIND_INSTANCE_MEMBER => $this->reflector->instanceMembers($context->class, $context->prefix),
+            PhpInteropContext::KIND_STATIC_MEMBER => $this->reflector->staticMembers($context->class, $context->prefix),
+            PhpInteropContext::KIND_CLASS_NAME => $this->reflector->classNames($context->prefix),
+            PhpInteropContext::KIND_GLOBAL_FUNCTION => $this->reflector->globalFunctions($context->prefix),
+            default => null,
+        };
+    }
+}

--- a/src/php/Api/Application/PhpInteropContextResolver.php
+++ b/src/php/Api/Application/PhpInteropContextResolver.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use Phel\Api\Transfer\PhpInteropContext;
+
+use function ltrim;
+use function max;
+use function preg_match;
+use function preg_quote;
+use function preg_split;
+use function substr;
+use function trim;
+
+/**
+ * Resolves the PHP-interop completion context at a cursor position by scanning
+ * the source text. Detection is lexical (not analyzer-driven) so it keeps
+ * working while the buffer is mid-edit and unparseable; an unrecognised
+ * position yields {@see PhpInteropContext::none()} so completion degrades to
+ * the normal Phel behaviour.
+ */
+final readonly class PhpInteropContextResolver
+{
+    /**
+     * @param int $line 1-based line number
+     * @param int $col  1-based cursor column
+     */
+    public function resolve(string $source, int $line, int $col): PhpInteropContext
+    {
+        $before = $this->textBeforeCursor($source, $line, $col);
+
+        // (php/-> receiver method|)  or  (php/-> receiver (method|))
+        if (preg_match('/\(\s*php\/->\s+(.+?)\s+\(?([A-Za-z0-9_]*)$/s', $before, $m) === 1) {
+            $class = $this->resolveReceiverClass($m[1], $source);
+            if ($class !== '') {
+                return new PhpInteropContext(PhpInteropContext::KIND_INSTANCE_MEMBER, $m[2], $class);
+            }
+
+            return PhpInteropContext::none();
+        }
+
+        // (php/:: Class method|)  or  (php/:: Class (method|))
+        if (preg_match('/\(\s*php\/::\s+(.+?)\s+\(?([A-Za-z0-9_]*)$/s', $before, $m) === 1) {
+            $class = $this->resolveReceiverClass($m[1], $source);
+            if ($class !== '') {
+                return new PhpInteropContext(PhpInteropContext::KIND_STATIC_MEMBER, $m[2], $class);
+            }
+
+            return PhpInteropContext::none();
+        }
+
+        // (php/new \Foo|
+        if (preg_match('/\(\s*php\/new\s+\\\\?([A-Za-z0-9_\\\\]*)$/', $before, $m) === 1) {
+            return new PhpInteropContext(PhpInteropContext::KIND_CLASS_NAME, $m[1]);
+        }
+
+        // A fully-qualified \Foo\Bar position anywhere.
+        if (preg_match('/\\\\([A-Za-z0-9_\\\\]*)$/', $before, $m) === 1) {
+            return new PhpInteropContext(PhpInteropContext::KIND_CLASS_NAME, $m[1]);
+        }
+
+        // php/<fn> global function (excluding the interop special forms).
+        if (preg_match('/(?:^|[\s(\[{])php\/(\w+)$/', $before, $m) === 1 && $m[1] !== 'new') {
+            return new PhpInteropContext(PhpInteropContext::KIND_GLOBAL_FUNCTION, $m[1]);
+        }
+
+        return PhpInteropContext::none();
+    }
+
+    /**
+     * Resolves a receiver expression to a class name. Handles a class literal
+     * (`\Foo`, `Foo\Bar`), an inline `(php/new \Foo ...)`, or a bare symbol
+     * whose `:tag` / reader-tag / `(php/new ...)` binding is found in the
+     * source. Returns '' when the type is unknown.
+     */
+    private function resolveReceiverClass(string $receiver, string $source): string
+    {
+        $receiver = trim($receiver);
+
+        // Inline construction: (php/-> (php/new \Foo ...) ...)
+        if (preg_match('/\(\s*php\/new\s+\\\\?([A-Za-z0-9_\\\\]+)/', $receiver, $m) === 1) {
+            return ltrim($m[1], '\\');
+        }
+
+        // Class literal: \Foo, \Foo\Bar, or Foo\Bar.
+        if (preg_match('/^\\\\?([A-Za-z_]\w*(?:\\\\[A-Za-z_]\w*)+)$/', $receiver, $m) === 1) {
+            return ltrim($m[1], '\\');
+        }
+
+        if (preg_match('/^\\\\([A-Za-z_]\w*)$/', $receiver, $m) === 1) {
+            return $m[1];
+        }
+
+        // Bare symbol: look up its type from the surrounding source.
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_\-]*$/', $receiver) === 1) {
+            return $this->resolveSymbolTag($receiver, $source);
+        }
+
+        return '';
+    }
+
+    /**
+     * Searches the source for a type annotation of a local binding named
+     * `$symbol`: a `^{:tag \Type}` map, a `^\Type` reader tag, or a
+     * `[symbol (php/new \Type ...)]` binding.
+     */
+    private function resolveSymbolTag(string $symbol, string $source): string
+    {
+        $quoted = preg_quote($symbol, '/');
+
+        // ^{:tag \Type} symbol  /  ^{:tag Type} symbol
+        if (preg_match('/\^\{[^}]*:tag\s+\\\\?([A-Za-z0-9_\\\\]+)[^}]*\}\s+' . $quoted . '\b/', $source, $m) === 1) {
+            return ltrim($m[1], '\\');
+        }
+
+        // ^\Type symbol  /  ^Type symbol
+        if (preg_match('/\^\\\\?([A-Za-z_][A-Za-z0-9_\\\\]*)\s+' . $quoted . '\b/', $source, $m) === 1) {
+            return ltrim($m[1], '\\');
+        }
+
+        // [symbol (php/new \Type ...)]  binding
+        if (preg_match('/\b' . $quoted . '\s+\(\s*php\/new\s+\\\\?([A-Za-z0-9_\\\\]+)/', $source, $m) === 1) {
+            return ltrim($m[1], '\\');
+        }
+
+        return '';
+    }
+
+    private function textBeforeCursor(string $source, int $line, int $col): string
+    {
+        $lines = preg_split('/\r?\n/', $source) ?: [];
+        if (!isset($lines[$line - 1])) {
+            return '';
+        }
+
+        return substr($lines[$line - 1], 0, max(0, $col - 1));
+    }
+}

--- a/src/php/Api/Application/PhpInteropContextResolver.php
+++ b/src/php/Api/Application/PhpInteropContextResolver.php
@@ -7,11 +7,8 @@ namespace Phel\Api\Application;
 use Phel\Api\Transfer\PhpInteropContext;
 
 use function ltrim;
-use function max;
 use function preg_match;
 use function preg_quote;
-use function preg_split;
-use function substr;
 use function trim;
 
 /**
@@ -29,7 +26,7 @@ final readonly class PhpInteropContextResolver
      */
     public function resolve(string $source, int $line, int $col): PhpInteropContext
     {
-        $before = $this->textBeforeCursor($source, $line, $col);
+        $before = CursorText::before($source, $line, $col);
 
         // (php/-> receiver method|)  or  (php/-> receiver (method|))
         if (preg_match('/\(\s*php\/->\s+(.+?)\s+\(?([A-Za-z0-9_]*)$/s', $before, $m) === 1) {
@@ -126,15 +123,5 @@ final readonly class PhpInteropContextResolver
         }
 
         return '';
-    }
-
-    private function textBeforeCursor(string $source, int $line, int $col): string
-    {
-        $lines = preg_split('/\r?\n/', $source) ?: [];
-        if (!isset($lines[$line - 1])) {
-            return '';
-        }
-
-        return substr($lines[$line - 1], 0, max(0, $col - 1));
     }
 }

--- a/src/php/Api/Application/PhpInteropDocResolver.php
+++ b/src/php/Api/Application/PhpInteropDocResolver.php
@@ -7,12 +7,9 @@ namespace Phel\Api\Application;
 use Phel\Api\Transfer\PhpInteropContext;
 
 use function ltrim;
-use function max;
 use function preg_match;
-use function preg_split;
 use function sprintf;
 use function strlen;
-use function substr;
 
 /**
  * Hover and signature-help text for PHP-interop symbols, backed by the same
@@ -35,7 +32,7 @@ final readonly class PhpInteropDocResolver
     {
         // Extend the cursor to the end of the identifier so the resolver sees
         // the whole symbol as the "prefix", then look that exact name up.
-        $wordEndCol = $this->wordEndColumn($source, $line, $col);
+        $wordEndCol = CursorText::wordEndColumn($source, $line, $col);
         $context = $this->contextResolver->resolve($source, $line, $wordEndCol);
 
         return match ($context->kind) {
@@ -56,7 +53,7 @@ final readonly class PhpInteropDocResolver
      */
     public function signatureAt(string $source, int $line, int $col): ?array
     {
-        $before = $this->textBeforeCursor($source, $line, $col);
+        $before = CursorText::before($source, $line, $col);
 
         // (php/new \Class <args>
         if (preg_match('/\(\s*php\/new\s+\\\\?([A-Za-z0-9_\\\\]+)\s/', $before, $m) === 1) {
@@ -148,26 +145,4 @@ final readonly class PhpInteropDocResolver
         ];
     }
 
-    private function wordEndColumn(string $source, int $line, int $col): int
-    {
-        $lines = preg_split('/\r?\n/', $source) ?: [];
-        $text = $lines[$line - 1] ?? '';
-        $offset = max(0, $col - 1);
-
-        if (preg_match('/[A-Za-z0-9_]+/A', substr($text, $offset), $m) === 1) {
-            return $col + strlen($m[0]);
-        }
-
-        return $col;
-    }
-
-    private function textBeforeCursor(string $source, int $line, int $col): string
-    {
-        $lines = preg_split('/\r?\n/', $source) ?: [];
-        if (!isset($lines[$line - 1])) {
-            return '';
-        }
-
-        return substr($lines[$line - 1], 0, max(0, $col - 1));
-    }
 }

--- a/src/php/Api/Application/PhpInteropDocResolver.php
+++ b/src/php/Api/Application/PhpInteropDocResolver.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use Phel\Api\Transfer\PhpInteropContext;
+
+use function ltrim;
+use function max;
+use function preg_match;
+use function preg_split;
+use function sprintf;
+use function strlen;
+use function substr;
+
+/**
+ * Hover and signature-help text for PHP-interop symbols, backed by the same
+ * reflector and context resolver as completion. Both entry points return null
+ * when the cursor is not over a resolvable PHP symbol, so callers fall through
+ * to the Phel behaviour.
+ */
+final readonly class PhpInteropDocResolver
+{
+    public function __construct(
+        private PhpInteropContextResolver $contextResolver = new PhpInteropContextResolver(),
+        private PhpInteropReflector $reflector = new PhpInteropReflector(),
+    ) {}
+
+    /**
+     * Markdown hover for the PHP symbol under the cursor (method, static
+     * member, global function, or class), or null.
+     */
+    public function hoverAt(string $source, int $line, int $col): ?string
+    {
+        // Extend the cursor to the end of the identifier so the resolver sees
+        // the whole symbol as the "prefix", then look that exact name up.
+        $wordEndCol = $this->wordEndColumn($source, $line, $col);
+        $context = $this->contextResolver->resolve($source, $line, $wordEndCol);
+
+        return match ($context->kind) {
+            PhpInteropContext::KIND_INSTANCE_MEMBER,
+            PhpInteropContext::KIND_STATIC_MEMBER => $this->memberHover($context),
+            PhpInteropContext::KIND_GLOBAL_FUNCTION => $this->functionHover($context->prefix),
+            PhpInteropContext::KIND_CLASS_NAME => $this->classHover($context->prefix),
+            default => null,
+        };
+    }
+
+    /**
+     * LSP SignatureHelp payload for the interop call enclosing the cursor, or
+     * null. Covers `(php/new \Class ...)`, `(php/-> recv (method ...))`, and
+     * `(php/:: Class (method ...))`.
+     *
+     * @return array{signatures: list<array{label: string}>, activeSignature: int, activeParameter: int}|null
+     */
+    public function signatureAt(string $source, int $line, int $col): ?array
+    {
+        $before = $this->textBeforeCursor($source, $line, $col);
+
+        // (php/new \Class <args>
+        if (preg_match('/\(\s*php\/new\s+\\\\?([A-Za-z0-9_\\\\]+)\s/', $before, $m) === 1) {
+            $signature = $this->reflector->methodSignature($m[1], '__construct')
+                ?? ($m[1] . '()');
+
+            return $this->signatureResponse(sprintf('new %s', $signature));
+        }
+
+        // (php/:: Class (method <args>
+        if (preg_match('/\(\s*php\/::\s+(.+?)\s+\(([A-Za-z0-9_]+)\s/s', $before, $m) === 1) {
+            return $this->callSignature($m[1], $m[2]);
+        }
+
+        // (php/-> receiver (method <args>
+        if (preg_match('/\(\s*php\/->\s+(.+?)\s+\(([A-Za-z0-9_]+)\s/s', $before, $m) === 1) {
+            return $this->callSignature($m[1], $m[2]);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{signatures: list<array{label: string}>, activeSignature: int, activeParameter: int}|null
+     */
+    private function callSignature(string $receiver, string $method): ?array
+    {
+        $context = $this->contextResolver->resolve(
+            sprintf('(php/-> %s x', $receiver),
+            1,
+            strlen(sprintf('(php/-> %s x', $receiver)) + 1,
+        );
+
+        $class = $context->class;
+        if ($class === '') {
+            return null;
+        }
+
+        $signature = $this->reflector->methodSignature($class, $method);
+
+        return $signature === null ? null : $this->signatureResponse($signature);
+    }
+
+    private function memberHover(PhpInteropContext $context): ?string
+    {
+        if ($context->prefix === '') {
+            return null;
+        }
+
+        $signature = $this->reflector->methodSignature($context->class, $context->prefix);
+        if ($signature === null) {
+            return null;
+        }
+
+        return $this->markdown(sprintf('%s::%s', $context->class, $context->prefix), $signature);
+    }
+
+    private function functionHover(string $function): ?string
+    {
+        $signature = $this->reflector->functionSignature($function);
+
+        return $signature === null ? null : $this->markdown('php/' . $function, $signature);
+    }
+
+    private function classHover(string $class): ?string
+    {
+        $name = ltrim($class, '\\');
+        if ($name === '' || $this->reflector->classNames($name) === []) {
+            return null;
+        }
+
+        return sprintf('**\\%s** _(php class)_', $name);
+    }
+
+    private function markdown(string $title, string $signature): string
+    {
+        return sprintf("**%s** _(php)_\n\n```php\n%s\n```", $title, $signature);
+    }
+
+    /**
+     * @return array{signatures: list<array{label: string}>, activeSignature: int, activeParameter: int}
+     */
+    private function signatureResponse(string $label): array
+    {
+        return [
+            'signatures' => [['label' => $label]],
+            'activeSignature' => 0,
+            'activeParameter' => 0,
+        ];
+    }
+
+    private function wordEndColumn(string $source, int $line, int $col): int
+    {
+        $lines = preg_split('/\r?\n/', $source) ?: [];
+        $text = $lines[$line - 1] ?? '';
+        $offset = max(0, $col - 1);
+
+        if (preg_match('/[A-Za-z0-9_]+/A', substr($text, $offset), $m) === 1) {
+            return $col + strlen($m[0]);
+        }
+
+        return $col;
+    }
+
+    private function textBeforeCursor(string $source, int $line, int $col): string
+    {
+        $lines = preg_split('/\r?\n/', $source) ?: [];
+        if (!isset($lines[$line - 1])) {
+            return '';
+        }
+
+        return substr($lines[$line - 1], 0, max(0, $col - 1));
+    }
+}

--- a/src/php/Api/Application/PhpInteropReflector.php
+++ b/src/php/Api/Application/PhpInteropReflector.php
@@ -1,0 +1,343 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use Phel\Api\Transfer\Completion;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionFunction;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionParameter;
+use ReflectionType;
+use Throwable;
+
+use function array_key_exists;
+use function array_keys;
+use function class_exists;
+use function function_exists;
+use function get_declared_classes;
+use function get_defined_functions;
+use function getcwd;
+use function implode;
+use function interface_exists;
+use function is_array;
+use function is_file;
+use function ltrim;
+use function sprintf;
+use function str_starts_with;
+use function strtolower;
+
+/**
+ * Reflection-backed catalog for PHP interop completion, hover, and signature
+ * help. Every lookup degrades gracefully: an unknown class, an unloadable
+ * symbol, or any reflection failure yields an empty result rather than an
+ * error, so the editor never sees a crash or a bogus diagnostic.
+ */
+final class PhpInteropReflector
+{
+    /** @var list<class-string>|null */
+    private ?array $classmapCache = null;
+
+    public function __construct(
+        private readonly ?string $projectRoot = null,
+    ) {}
+
+    /**
+     * Public instance methods and properties of a class, prefix-filtered.
+     * Used after `(php/-> receiver ...)`.
+     *
+     * @return list<Completion>
+     */
+    public function instanceMembers(string $class, string $prefix = ''): array
+    {
+        $reflection = $this->reflect($class);
+        if (!$reflection instanceof ReflectionClass) {
+            return [];
+        }
+
+        $completions = [];
+
+        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->isStatic()) {
+                continue;
+            }
+
+            if (str_starts_with($method->getName(), '__')) {
+                continue;
+            }
+
+            if ($this->matches($method->getName(), $prefix)) {
+                $completions[] = $this->methodCompletion($method);
+            }
+        }
+
+        foreach ($reflection->getProperties() as $property) {
+            if (!$property->isPublic()) {
+                continue;
+            }
+
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            if ($this->matches($property->getName(), $prefix)) {
+                $completions[] = new Completion(
+                    label: $property->getName(),
+                    kind: Completion::KIND_LOCAL,
+                    detail: $this->renderType($property->getType()) . ' property',
+                );
+            }
+        }
+
+        return $completions;
+    }
+
+    /**
+     * Public static methods and constants of a class, prefix-filtered.
+     * Used after `(php/:: Class ...)`.
+     *
+     * @return list<Completion>
+     */
+    public function staticMembers(string $class, string $prefix = ''): array
+    {
+        $reflection = $this->reflect($class);
+        if (!$reflection instanceof ReflectionClass) {
+            return [];
+        }
+
+        $completions = [];
+
+        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if (!$method->isStatic()) {
+                continue;
+            }
+
+            if (str_starts_with($method->getName(), '__')) {
+                continue;
+            }
+
+            if ($this->matches($method->getName(), $prefix)) {
+                $completions[] = $this->methodCompletion($method);
+            }
+        }
+
+        foreach (array_keys($reflection->getConstants()) as $name) {
+            if ($this->matches($name, $prefix)) {
+                $completions[] = new Completion(
+                    label: $name,
+                    kind: Completion::KIND_KEYWORD,
+                    detail: 'constant',
+                );
+            }
+        }
+
+        return $completions;
+    }
+
+    /**
+     * PHP class names matching a prefix, drawn from the already-declared
+     * classes plus the project's composer classmap when present.
+     *
+     * @return list<Completion>
+     */
+    public function classNames(string $prefix = ''): array
+    {
+        $normalized = ltrim($prefix, '\\');
+        $seen = [];
+        $completions = [];
+
+        foreach ([...get_declared_classes(), ...$this->classmap()] as $class) {
+            if ($this->matches($class, $normalized) && !array_key_exists($class, $seen)) {
+                $seen[$class] = true;
+                $completions[] = new Completion(
+                    label: $class,
+                    kind: Completion::KIND_GLOBAL,
+                    detail: 'class',
+                );
+            }
+        }
+
+        return $completions;
+    }
+
+    /**
+     * PHP global (internal + user) functions matching a prefix. Used after
+     * the `php/` prefix when it is not one of the interop special forms.
+     *
+     * @return list<Completion>
+     */
+    public function globalFunctions(string $prefix = ''): array
+    {
+        $defined = get_defined_functions();
+        $completions = [];
+
+        foreach ([...$defined['internal'], ...$defined['user']] as $function) {
+            if ($this->matches($function, $prefix)) {
+                $completions[] = new Completion(
+                    label: $function,
+                    kind: Completion::KIND_GLOBAL,
+                    detail: $this->functionSignature($function) ?? 'function',
+                );
+            }
+        }
+
+        return $completions;
+    }
+
+    /**
+     * `name(params): return` for a class method, or null when unresolvable.
+     */
+    public function methodSignature(string $class, string $method): ?string
+    {
+        $reflection = $this->reflect($class);
+        if (!$reflection instanceof ReflectionClass) {
+            return null;
+        }
+
+        try {
+            return $this->renderMethod($reflection->getMethod($method));
+        } catch (ReflectionException) {
+            return null;
+        }
+    }
+
+    /**
+     * `name(params): return` for a global function, or null when unresolvable.
+     */
+    public function functionSignature(string $function): ?string
+    {
+        if (!function_exists($function)) {
+            return null;
+        }
+
+        try {
+            $reflection = new ReflectionFunction($function);
+        } catch (ReflectionException) {
+            return null;
+        }
+
+        return sprintf(
+            '%s(%s)%s',
+            $function,
+            $this->renderParameters($reflection->getParameters()),
+            $this->renderReturn($reflection->getReturnType()),
+        );
+    }
+
+    private function methodCompletion(ReflectionMethod $method): Completion
+    {
+        return new Completion(
+            label: $method->getName(),
+            kind: Completion::KIND_MACRO,
+            detail: $this->renderMethod($method),
+        );
+    }
+
+    private function renderMethod(ReflectionMethod $method): string
+    {
+        return sprintf(
+            '%s(%s)%s',
+            $method->getName(),
+            $this->renderParameters($method->getParameters()),
+            $this->renderReturn($method->getReturnType()),
+        );
+    }
+
+    /**
+     * @param list<ReflectionParameter> $parameters
+     */
+    private function renderParameters(array $parameters): string
+    {
+        $rendered = [];
+        foreach ($parameters as $parameter) {
+            $type = $this->renderType($parameter->getType());
+            $name = ($parameter->isVariadic() ? '...$' : '$') . $parameter->getName();
+            $rendered[] = $type === '' ? $name : $type . ' ' . $name;
+        }
+
+        return implode(', ', $rendered);
+    }
+
+    private function renderReturn(?ReflectionType $type): string
+    {
+        $rendered = $this->renderType($type);
+
+        return $rendered === '' ? '' : ': ' . $rendered;
+    }
+
+    private function renderType(?ReflectionType $type): string
+    {
+        if ($type instanceof ReflectionNamedType) {
+            return ($type->allowsNull() && $type->getName() !== 'null' && $type->getName() !== 'mixed' ? '?' : '')
+                . $type->getName();
+        }
+
+        if ($type instanceof ReflectionType) {
+            return (string) $type;
+        }
+
+        return '';
+    }
+
+    /**
+     * @return ReflectionClass<object>|null
+     */
+    private function reflect(string $class): ?ReflectionClass
+    {
+        $name = ltrim($class, '\\');
+        if ($name === '' || (!class_exists($name) && !interface_exists($name))) {
+            return null;
+        }
+
+        return new ReflectionClass($name);
+    }
+
+    private function matches(string $candidate, string $prefix): bool
+    {
+        if ($prefix === '') {
+            return true;
+        }
+
+        return str_starts_with(strtolower($candidate), strtolower($prefix));
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    private function classmap(): array
+    {
+        if ($this->classmapCache !== null) {
+            return $this->classmapCache;
+        }
+
+        $this->classmapCache = [];
+
+        $root = $this->projectRoot ?? (getcwd() ?: null);
+        if ($root === null) {
+            return $this->classmapCache;
+        }
+
+        $classmapFile = $root . '/vendor/composer/autoload_classmap.php';
+        if (!is_file($classmapFile)) {
+            return $this->classmapCache;
+        }
+
+        try {
+            /** @var mixed $map */
+            $map = require $classmapFile;
+        } catch (Throwable) {
+            return $this->classmapCache;
+        }
+
+        if (is_array($map)) {
+            /** @var list<class-string> $keys */
+            $keys = array_keys($map);
+            $this->classmapCache = $keys;
+        }
+
+        return $this->classmapCache;
+    }
+}

--- a/src/php/Api/Application/PointCompleter.php
+++ b/src/php/Api/Application/PointCompleter.php
@@ -40,6 +40,7 @@ final readonly class PointCompleter implements PointCompleterInterface
     public function __construct(
         private CompilerFacadeInterface $compilerFacade,
         private PhelFnNormalizerInterface $phelFnNormalizer,
+        private PhpInteropCompleter $phpInteropCompleter = new PhpInteropCompleter(),
     ) {}
 
     /**
@@ -47,6 +48,13 @@ final readonly class PointCompleter implements PointCompleterInterface
      */
     public function completeAtPoint(string $source, int $line, int $col, ProjectIndex $index): array
     {
+        // PHP-interop positions (php/->, php/::, php/new, \FQN, php/fn) take
+        // precedence; a null result means the cursor is not in such a position.
+        $phpCompletions = $this->phpInteropCompleter->completeAtPoint($source, $line, $col);
+        if ($phpCompletions !== null) {
+            return $phpCompletions;
+        }
+
         $prefix = $this->extractPrefix($source, $line, $col);
 
         $locals = $this->collectLocalsAtPoint($source, $line, $col);

--- a/src/php/Api/CLAUDE.md
+++ b/src/php/Api/CLAUDE.md
@@ -9,6 +9,7 @@ REPL autocompletion, function introspection, documentation, and user-code semant
 - `analyzeSource(string, string): list<Diagnostic>`: parse and analyze, return diagnostics
 - `findSymbolMetadata(string, string = 'user')`: symbol lookup in registry and static catalog
 - `indexProject`, `resolveSymbol`, `findReferences`, `completeAtPoint`: project-level symbol tooling (`ProjectIndex`, `Definition`, `Location`, `Completion` transfers)
+- PHP interop tooling: `completeAtPoint` returns interop completions when the cursor is in a `php/`-interop position (else Phel completions); `phpInteropHoverAt`/`phpInteropSignatureAt` return reflected hover markdown / LSP signature help. Backed by `PhpInteropReflector` (reflection + composer classmap), `PhpInteropContextResolver` (lexical receiver-type resolution from `:tag`/inline `php/new`/binding), `PhpInteropCompleter`, and `PhpInteropDocResolver`. All degrade to empty/null on unknown types or reflection failure
 - `createApiDaemon()`: long-running JSON-RPC daemon
 
 ## Dependencies

--- a/src/php/Api/Transfer/PhpInteropContext.php
+++ b/src/php/Api/Transfer/PhpInteropContext.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Transfer;
+
+/**
+ * The PHP-interop completion context resolved at a cursor position: which kind
+ * of interop is being typed, the receiver class (for member access), and the
+ * partial token already typed.
+ */
+final readonly class PhpInteropContext
+{
+    public const string KIND_NONE = 'none';
+
+    public const string KIND_INSTANCE_MEMBER = 'instance-member';
+
+    public const string KIND_STATIC_MEMBER = 'static-member';
+
+    public const string KIND_CLASS_NAME = 'class-name';
+
+    public const string KIND_GLOBAL_FUNCTION = 'global-function';
+
+    public function __construct(
+        public string $kind,
+        public string $prefix = '',
+        public string $class = '',
+    ) {}
+
+    public static function none(): self
+    {
+        return new self(self::KIND_NONE);
+    }
+
+    public function isNone(): bool
+    {
+        return $this->kind === self::KIND_NONE;
+    }
+}

--- a/src/php/Lsp/Application/Handler/HoverHandler.php
+++ b/src/php/Lsp/Application/Handler/HoverHandler.php
@@ -47,7 +47,11 @@ final readonly class HoverHandler implements HandlerInterface
             return null;
         }
 
-        $markdown = $this->markdownFor($context->word, $session->projectIndex());
+        // PHP-interop symbols (methods, static members, global functions,
+        // classes) resolve via reflection before the Phel symbol lookup.
+        [$line, $col] = $context->document->oneBasedLineCol($context->position);
+        $markdown = $this->apiFacade->phpInteropHoverAt($context->document->text, $line, $col)
+            ?? $this->markdownFor($context->word, $session->projectIndex());
         if ($markdown === null) {
             return null;
         }

--- a/src/php/Lsp/Application/Handler/InitializeHandler.php
+++ b/src/php/Lsp/Application/Handler/InitializeHandler.php
@@ -61,6 +61,9 @@ final readonly class InitializeHandler implements HandlerInterface
                     'triggerCharacters' => ['/', ':', '.'],
                     'resolveProvider' => false,
                 ],
+                'signatureHelpProvider' => [
+                    'triggerCharacters' => [' ', '('],
+                ],
                 'documentSymbolProvider' => true,
                 'workspaceSymbolProvider' => true,
                 'renameProvider' => true,

--- a/src/php/Lsp/Application/Handler/SignatureHelpHandler.php
+++ b/src/php/Lsp/Application/Handler/SignatureHelpHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Api\ApiFacade;
+use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+
+/**
+ * Handles `textDocument/signatureHelp` for PHP-interop calls: shows the
+ * signature of the constructor / method being called inside `(php/new ...)`,
+ * `(php/-> recv (method ...))`, or `(php/:: Class (method ...))`. Returns null
+ * for any other position.
+ */
+final readonly class SignatureHelpHandler implements HandlerInterface
+{
+    public function __construct(
+        private ApiFacade $apiFacade,
+        private ParamsExtractor $params,
+    ) {}
+
+    public function method(): string
+    {
+        return 'textDocument/signatureHelp';
+    }
+
+    public function isNotification(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $uri = $this->params->uri($params);
+        $position = $this->params->position($params);
+        if ($uri === '' || $position === null) {
+            return null;
+        }
+
+        $document = $session->documents()->get($uri);
+        if (!$document instanceof Document) {
+            return null;
+        }
+
+        [$line, $col] = $document->oneBasedLineCol($position);
+
+        return $this->apiFacade->phpInteropSignatureAt($document->text, $line, $col);
+    }
+}

--- a/src/php/Lsp/CLAUDE.md
+++ b/src/php/Lsp/CLAUDE.md
@@ -11,7 +11,8 @@ Language Server Protocol v3.17 over stdio (JSON-RPC 2.0 with `Content-Length` fr
 
 - Lifecycle: initialize, initialized, shutdown, exit
 - Text sync: didOpen, didChange, didClose, didSave
-- Language features: hover, definition, references, completion, documentSymbol, workspace/symbol, rename, formatting
+- Language features: hover, definition, references, completion, signatureHelp, documentSymbol, workspace/symbol, rename, formatting
+- PHP interop (completion/hover/signatureHelp) is resolved by the Api facade (`phpInteropHoverAt`, `phpInteropSignatureAt`; completion via `completeAtPoint`). `CompletionHandler`/`HoverHandler` try the interop path first and fall back to Phel symbols; `SignatureHelpHandler` is interop-only
 - Diagnostics: publishDiagnostics (debounced 200ms on change, immediate on save)
 
 ## Dependencies

--- a/src/php/Lsp/LspFactory.php
+++ b/src/php/Lsp/LspFactory.php
@@ -33,6 +33,7 @@ use Phel\Lsp\Application\Handler\InitializeHandler;
 use Phel\Lsp\Application\Handler\ReferencesHandler;
 use Phel\Lsp\Application\Handler\RenameHandler;
 use Phel\Lsp\Application\Handler\ShutdownHandler;
+use Phel\Lsp\Application\Handler\SignatureHelpHandler;
 use Phel\Lsp\Application\Handler\SymbolResolver;
 use Phel\Lsp\Application\Handler\WorkspaceSymbolHandler;
 use Phel\Lsp\Application\Rpc\LspServer;
@@ -98,6 +99,7 @@ final class LspFactory extends AbstractFactory
         $dispatcher->register(new DefinitionHandler($this->getApiFacade(), $locations, $params, $symbols));
         $dispatcher->register(new ReferencesHandler($this->getApiFacade(), $locations, $params, $symbols));
         $dispatcher->register(new CompletionHandler($this->getApiFacade(), $completions, $params));
+        $dispatcher->register(new SignatureHelpHandler($this->getApiFacade(), $params));
         $dispatcher->register(new DocumentSymbolHandler($this->getApiFacade(), $uris, $symbolBuilder, $params));
         $dispatcher->register(new WorkspaceSymbolHandler($symbolBuilder));
         $dispatcher->register(new RenameHandler($this->getApiFacade(), $positions, $uris, $params, $symbols));

--- a/tests/php/Integration/Lsp/PhpInteropLspTest.php
+++ b/tests/php/Integration/Lsp/PhpInteropLspTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Lsp;
+
+use Phel;
+use Phel\Api\ApiFacade;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Lsp\Application\Convert\CompletionConverter;
+use Phel\Lsp\Application\Document\DocumentStore;
+use Phel\Lsp\Application\Handler\CompletionHandler;
+use Phel\Lsp\Application\Handler\HoverHandler;
+use Phel\Lsp\Application\Handler\SignatureHelpHandler;
+use Phel\Lsp\Application\Handler\SymbolResolver;
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\NotificationSink;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+use function array_column;
+
+final class PhpInteropLspTest extends TestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_completion_lists_instance_methods_for_tagged_receiver(): void
+    {
+        $uri = 'file:///x.phel';
+        $source = "(let [^\\DateTimeImmutable dt (x)]\n  (php/-> dt (get))";
+        // Cursor right after "(get".
+        $session = $this->sessionWith($uri, $source);
+
+        $result = $this->completion()->handle(
+            $this->params($uri, line: 1, character: 13),
+            $session,
+        );
+
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('getTimestamp', $labels);
+        self::assertContains('getOffset', $labels);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_completion_lists_class_names_after_php_new(): void
+    {
+        $uri = 'file:///x.phel';
+        $source = '(php/new \\DateTimeImm)';
+        $session = $this->sessionWith($uri, $source);
+
+        // Cursor right after "DateTimeImm".
+        $result = $this->completion()->handle(
+            $this->params($uri, line: 0, character: 20),
+            $session,
+        );
+
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('DateTimeImmutable', $labels);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_hover_shows_global_function_signature(): void
+    {
+        $uri = 'file:///x.phel';
+        $source = '(php/strlen x)';
+        $session = $this->sessionWith($uri, $source);
+
+        // Cursor on "strlen".
+        $result = $this->hover()->handle(
+            $this->params($uri, line: 0, character: 8),
+            $session,
+        );
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('strlen(', (string) $result['contents']['value']);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_signature_help_for_php_new(): void
+    {
+        $uri = 'file:///x.phel';
+        $source = '(php/new \\DateTimeImmutable )';
+        $session = $this->sessionWith($uri, $source);
+
+        // Cursor inside the argument list.
+        $result = $this->signatureHelp()->handle(
+            $this->params($uri, line: 0, character: 28),
+            $session,
+        );
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('new', (string) $result['signatures'][0]['label']);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_completion_falls_back_to_phel_for_plain_code(): void
+    {
+        $uri = 'file:///x.phel';
+        $source = '(de)';
+        $session = $this->sessionWith($uri, $source);
+
+        // Cursor after "(de".
+        $result = $this->completion()->handle(
+            $this->params($uri, line: 0, character: 3),
+            $session,
+        );
+
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('def', $labels, 'plain Phel completion still works');
+    }
+
+    private function completion(): CompletionHandler
+    {
+        return new CompletionHandler(
+            $this->apiFacade(),
+            new CompletionConverter(),
+            new ParamsExtractor(),
+        );
+    }
+
+    private function hover(): HoverHandler
+    {
+        return new HoverHandler($this->apiFacade(), new ParamsExtractor(), new SymbolResolver());
+    }
+
+    private function signatureHelp(): SignatureHelpHandler
+    {
+        return new SignatureHelpHandler($this->apiFacade(), new ParamsExtractor());
+    }
+
+    private function apiFacade(): ApiFacade
+    {
+        Phel::bootstrap(__DIR__);
+        Phel::clear();
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+
+        return new ApiFacade();
+    }
+
+    private function sessionWith(string $uri, string $source): Session
+    {
+        $session = new Session(new DocumentStore(), new class() implements NotificationSink {
+            public function notify(string $method, array $params): void {}
+        });
+        $session->documents()->open($uri, 'phel', 1, $source);
+
+        return $session;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function params(string $uri, int $line, int $character): array
+    {
+        return [
+            'textDocument' => ['uri' => $uri],
+            'position' => ['line' => $line, 'character' => $character],
+        ];
+    }
+}

--- a/tests/php/Unit/Api/Application/PhpInteropContextResolverTest.php
+++ b/tests/php/Unit/Api/Application/PhpInteropContextResolverTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\PhpInteropContextResolver;
+use Phel\Api\Transfer\PhpInteropContext;
+use PHPUnit\Framework\TestCase;
+
+use function strlen;
+
+final class PhpInteropContextResolverTest extends TestCase
+{
+    private PhpInteropContextResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new PhpInteropContextResolver();
+    }
+
+    public function test_instance_member_after_reader_tag_binding(): void
+    {
+        $source = "(let [^\\DateTimeImmutable dt (make)]\n  (php/-> dt (get";
+        $context = $this->resolveAtEnd($source);
+
+        self::assertSame(PhpInteropContext::KIND_INSTANCE_MEMBER, $context->kind);
+        self::assertSame('DateTimeImmutable', $context->class);
+        self::assertSame('get', $context->prefix);
+    }
+
+    public function test_instance_member_with_tag_map_binding(): void
+    {
+        $source = "(let [^{:tag \\DateTimeImmutable} dt (make)]\n  (php/-> dt get";
+        $context = $this->resolveAtEnd($source);
+
+        self::assertSame(PhpInteropContext::KIND_INSTANCE_MEMBER, $context->kind);
+        self::assertSame('DateTimeImmutable', $context->class);
+        self::assertSame('get', $context->prefix);
+    }
+
+    public function test_instance_member_from_inline_php_new_receiver(): void
+    {
+        $source = '(php/-> (php/new \\DateTimeImmutable) get';
+        $context = $this->resolveAtEnd($source);
+
+        self::assertSame(PhpInteropContext::KIND_INSTANCE_MEMBER, $context->kind);
+        self::assertSame('DateTimeImmutable', $context->class);
+    }
+
+    public function test_instance_member_from_php_new_let_binding(): void
+    {
+        $source = "(let [dt (php/new \\DateTimeImmutable)]\n  (php/-> dt get";
+        $context = $this->resolveAtEnd($source);
+
+        self::assertSame(PhpInteropContext::KIND_INSTANCE_MEMBER, $context->kind);
+        self::assertSame('DateTimeImmutable', $context->class);
+    }
+
+    public function test_static_member_after_class_literal(): void
+    {
+        $source = '(php/:: \\DateTimeImmutable create';
+        $context = $this->resolveAtEnd($source);
+
+        self::assertSame(PhpInteropContext::KIND_STATIC_MEMBER, $context->kind);
+        self::assertSame('DateTimeImmutable', $context->class);
+        self::assertSame('create', $context->prefix);
+    }
+
+    public function test_class_name_after_php_new(): void
+    {
+        $context = $this->resolveAtEnd('(php/new \\DateTimeImm');
+
+        self::assertSame(PhpInteropContext::KIND_CLASS_NAME, $context->kind);
+        self::assertSame('DateTimeImm', $context->prefix);
+    }
+
+    public function test_class_name_for_fully_qualified_position(): void
+    {
+        $context = $this->resolveAtEnd('(def x \\DateTimeImm');
+
+        self::assertSame(PhpInteropContext::KIND_CLASS_NAME, $context->kind);
+        self::assertSame('DateTimeImm', $context->prefix);
+    }
+
+    public function test_global_function_after_php_prefix(): void
+    {
+        $context = $this->resolveAtEnd('(php/strle');
+
+        self::assertSame(PhpInteropContext::KIND_GLOBAL_FUNCTION, $context->kind);
+        self::assertSame('strle', $context->prefix);
+    }
+
+    public function test_unknown_receiver_type_is_none(): void
+    {
+        $source = '(php/-> mystery-thing get';
+        $context = $this->resolveAtEnd($source);
+
+        self::assertTrue($context->isNone());
+    }
+
+    public function test_plain_phel_code_is_none(): void
+    {
+        $context = $this->resolveAtEnd('(defn foo [x] (inc ');
+
+        self::assertTrue($context->isNone());
+    }
+
+    private function resolveAtEnd(string $source): PhpInteropContext
+    {
+        $lastNewline = strrpos($source, "\n");
+        $line = substr_count($source, "\n") + 1;
+        $col = ($lastNewline === false ? strlen($source) : strlen($source) - $lastNewline - 1) + 1;
+
+        return $this->resolver->resolve($source, $line, $col);
+    }
+}

--- a/tests/php/Unit/Api/Application/PhpInteropDocResolverTest.php
+++ b/tests/php/Unit/Api/Application/PhpInteropDocResolverTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\PhpInteropDocResolver;
+use PHPUnit\Framework\TestCase;
+
+use function strlen;
+use function strpos;
+
+final class PhpInteropDocResolverTest extends TestCase
+{
+    private PhpInteropDocResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new PhpInteropDocResolver();
+    }
+
+    public function test_hover_on_instance_method(): void
+    {
+        $source = '(php/-> (php/new \\DateTimeImmutable) getTimestamp)';
+        $cursor = (int) strpos($source, 'getTimestamp') + 3;
+
+        $hover = $this->resolver->hoverAt($source, 1, $cursor);
+
+        self::assertNotNull($hover);
+        self::assertStringContainsString('getTimestamp', $hover);
+        self::assertStringContainsString('```php', $hover);
+    }
+
+    public function test_hover_on_global_function(): void
+    {
+        $source = '(php/strlen x)';
+        $cursor = (int) strpos($source, 'strlen') + 3;
+
+        $hover = $this->resolver->hoverAt($source, 1, $cursor);
+
+        self::assertNotNull($hover);
+        self::assertStringContainsString('php/strlen', $hover);
+        self::assertStringContainsString('strlen(', $hover);
+    }
+
+    public function test_hover_returns_null_for_plain_phel(): void
+    {
+        self::assertNull($this->resolver->hoverAt('(defn foo [x] x)', 1, 8));
+    }
+
+    public function test_signature_help_for_php_new(): void
+    {
+        $source = '(php/new \\DateTimeImmutable ';
+        $help = $this->resolver->signatureAt($source, 1, strlen($source) + 1);
+
+        self::assertNotNull($help);
+        self::assertStringContainsString('new', $help['signatures'][0]['label']);
+        self::assertSame(0, $help['activeSignature']);
+    }
+
+    public function test_signature_help_for_method_call(): void
+    {
+        $source = '(php/-> (php/new \\DateTimeImmutable) (setTimestamp ';
+        $help = $this->resolver->signatureAt($source, 1, strlen($source) + 1);
+
+        self::assertNotNull($help);
+        self::assertStringContainsString('setTimestamp(', $help['signatures'][0]['label']);
+    }
+
+    public function test_signature_help_null_for_plain_phel(): void
+    {
+        self::assertNull($this->resolver->signatureAt('(map inc ', 1, 9));
+    }
+}

--- a/tests/php/Unit/Api/Application/PhpInteropReflectorTest.php
+++ b/tests/php/Unit/Api/Application/PhpInteropReflectorTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\PhpInteropReflector;
+use Phel\Api\Transfer\Completion;
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+
+final class PhpInteropReflectorTest extends TestCase
+{
+    private PhpInteropReflector $reflector;
+
+    protected function setUp(): void
+    {
+        $this->reflector = new PhpInteropReflector();
+    }
+
+    public function test_instance_members_complete_for_known_class(): void
+    {
+        $labels = $this->labels($this->reflector->instanceMembers('\\DateTimeImmutable', 'get'));
+
+        self::assertContains('getTimestamp', $labels);
+        self::assertContains('getOffset', $labels);
+    }
+
+    public function test_instance_members_carry_a_signature_detail(): void
+    {
+        $members = $this->reflector->instanceMembers('\\DateTimeImmutable', 'getTimestamp');
+
+        self::assertNotSame([], $members);
+        self::assertStringContainsString('getTimestamp(', $members[0]->detail);
+    }
+
+    public function test_instance_members_exclude_static_and_magic(): void
+    {
+        $labels = $this->labels($this->reflector->instanceMembers('\\DateTimeImmutable'));
+
+        self::assertNotContains('createFromFormat', $labels, 'static method excluded from instance members');
+        self::assertNotContains('__construct', $labels, 'magic method excluded');
+    }
+
+    public function test_static_members_complete_static_methods(): void
+    {
+        $labels = $this->labels($this->reflector->staticMembers('\\DateTimeImmutable', 'create'));
+
+        self::assertContains('createFromFormat', $labels);
+    }
+
+    public function test_static_members_include_constants(): void
+    {
+        $labels = $this->labels($this->reflector->staticMembers('\\DateTimeImmutable', 'ATOM'));
+
+        self::assertContains('ATOM', $labels);
+    }
+
+    public function test_unknown_class_yields_empty_completions(): void
+    {
+        self::assertSame([], $this->reflector->instanceMembers('\\This\\Does\\Not\\Exist'));
+        self::assertSame([], $this->reflector->staticMembers('\\This\\Does\\Not\\Exist'));
+        self::assertNull($this->reflector->methodSignature('\\Nope', 'foo'));
+    }
+
+    public function test_class_names_complete_from_declared_classes(): void
+    {
+        $labels = $this->labels($this->reflector->classNames('DateTimeImm'));
+
+        self::assertContains('DateTimeImmutable', $labels);
+    }
+
+    public function test_class_names_tolerate_leading_backslash_prefix(): void
+    {
+        $labels = $this->labels($this->reflector->classNames('\\DateTimeImm'));
+
+        self::assertContains('DateTimeImmutable', $labels);
+    }
+
+    public function test_global_functions_complete_and_carry_signature(): void
+    {
+        self::assertContains('str_replace', $this->labels($this->reflector->globalFunctions('str_rep')));
+
+        $completions = $this->reflector->globalFunctions('strrev');
+        self::assertNotSame([], $completions);
+        self::assertStringContainsString('strrev(', $completions[0]->detail);
+    }
+
+    public function test_method_signature_for_known_method(): void
+    {
+        $signature = $this->reflector->methodSignature('\\DateTimeImmutable', 'setTimestamp');
+
+        self::assertNotNull($signature);
+        self::assertStringContainsString('setTimestamp(', $signature);
+    }
+
+    public function test_function_signature_for_known_function(): void
+    {
+        $signature = $this->reflector->functionSignature('strlen');
+
+        self::assertNotNull($signature);
+        self::assertStringContainsString('strlen(', $signature);
+        self::assertStringContainsString(': int', $signature);
+    }
+
+    public function test_function_signature_null_for_unknown(): void
+    {
+        self::assertNull($this->reflector->functionSignature('this_function_does_not_exist_zzz'));
+    }
+
+    /**
+     * @param list<Completion> $completions
+     *
+     * @return list<string>
+     */
+    private function labels(array $completions): array
+    {
+        return array_map(static fn(Completion $c): string => $c->label, $completions);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

PHP interop is core to Phel, but the editor was blind to it: typing `(php/-> $r get...)` or `(php/new \Date...)` gave no completion, hover, or signature help. The LSP already did Phel-symbol work; this makes interop first-class via reflection. Closes #2431.

## 💡 Goal

`(php/-> dt (get|))` with `dt` tagged `\DateTimeImmutable` completes `getTimestamp` etc.; `(php/new \Date|)` completes class names; hover on `php/strlen` shows its signature; unknown types degrade silently.

## 🔖 Changes

New Api services (all degrade to empty/null on unknown types or reflection failure):
- **`PhpInteropReflector`** — reflection-backed catalog: instance methods/properties, static methods/constants, class names (declared + composer classmap), global functions, and method/function signatures.
- **`PhpInteropContextResolver`** — lexical detection of the interop position at the cursor and resolution of the receiver class from `:tag` metadata (`^\Foo` / `^{:tag \Foo}`), an inline `(php/new \Foo)`, or a `[sym (php/new \Foo)]` binding. Lexical (not analyzer-driven) so it survives mid-edit unparseable buffers.
- **`PhpInteropCompleter`** / **`PhpInteropDocResolver`** — completion and hover/signature-help producers; shared `CursorText` helper.

Wiring:
- `ApiFacade::completeAtPoint` returns interop completions when in a `php/` position (else falls back to Phel); new `phpInteropHoverAt` / `phpInteropSignatureAt`.
- LSP: `HoverHandler` tries interop first; new `SignatureHelpHandler`; `signatureHelpProvider` capability advertised.

## ✅ Acceptance

- [x] `(php/-> dt (get|))`, `dt` tagged `\DateTimeImmutable` → `getTimestamp` etc., signature in detail
- [x] `(php/new \Date|)` completes class names from declared classes + project autoloader classmap
- [x] Hover on `php/strlen` shows its signature; hover on methods/classes too
- [x] Signature help for `(php/new ...)` and method calls
- [x] Unknown receiver type → empty completion, no crash, no diagnostics; reflection failures handled
- [x] Unit tests for reflector, context resolver, doc resolver + integration tests for the LSP completion/hover/signatureHelp requests
- [x] CHANGELOG + Api/Lsp module docs

## 🔍 Notes

- Type resolution is scoped per the issue to `:tag`, inline `php/new`, and direct binding flow — no full inference engine.
- Wrong-arity interop diagnostics remain out of scope (follow-up).
- Refactor pass extracted the shared `CursorText` helper (deduped cursor-text logic); no other code-level changes surfaced.