### PR TITLE
ref: replace internal deprecated core fns with superseded-by counterparts

### DIFF
--- a/src/phel/cli.phel
+++ b/src/phel/cli.phel
@@ -276,7 +276,7 @@
     (loop []
       (let [line (php/fgets handle)]
         (when-not (false? line)
-          (push out (php/rtrim line "\r\n"))
+          (conj out (php/rtrim line "\r\n"))
           (recur))))
     (php/fclose handle)
     (persistent out)))

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -309,7 +309,7 @@
   "Checks if value is exactly true (not just truthy)."
   {:example "(true? 1) ; => false"}
   [x]
-  (id x true))
+  (identical? x true))
 
 (defn truthy?
   "Checks if `x` is truthy. Same as `x == true` in PHP."
@@ -320,13 +320,13 @@
   "Checks if value is exactly false (not just falsy)."
   {:example "(false? nil) ; => false"}
   [x]
-  (id x false))
+  (identical? x false))
 
 (defn nil?
   "Returns true if value is nil, false otherwise."
   {:example "(nil? (get {:a 1} :b)) ; => true"}
   [x]
-  (id x nil))
+  (identical? x nil))
 
 (defn str-contains?
   "Returns true if str contains s."

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -167,16 +167,16 @@
   (let [headers (transient {})
         server  (or server php/$_SERVER)]
     (dofor [[k v] :pairs server
-            :let [redirected? (id 0 (php/strpos k "REDIRECT_"))
+            :let [redirected? (identical? 0 (php/strpos k "REDIRECT_"))
                   redirected-key (when redirected? (php/substr k 9))
                   k (if (and redirected? (not (php/array_key_exists redirected-key server)))
                       redirected-key
                       k)]]
       (cond
-        (and v (id 0 (php/strpos k "HTTP_")))
+        (and v (identical? 0 (php/strpos k "HTTP_")))
         (let [name (php/strtr (php/strtolower (php/substr k 5)) "_" "-")]
           (assoc headers (keyword name) v))
-        (and v (id 0 (php/strpos k "CONTENT_")))
+        (and v (identical? 0 (php/strpos k "CONTENT_")))
         (let [name (str "content-" (php/strtolower (php/substr k 8)))]
           (assoc headers (keyword name) v))))
     (persistent headers)))
@@ -453,8 +453,8 @@
   (when-not (php/headers_sent)
     (dofor [[header values] :pairs headers
             :let [normalized-name (normalize-header-name header)
-                  replace (and (id 0 (php/strcasecmp normalized-name "Content-Type"))
-                               (not (id 0 (php/strcasecmp normalized-name "Set-Cookie"))))]]
+                  replace (and (identical? 0 (php/strcasecmp normalized-name "Content-Type"))
+                               (not (identical? 0 (php/strcasecmp normalized-name "Set-Cookie"))))]]
       (cond
         (string? values)
         (php/header (php/sprintf "%s: %s" normalized-name (assert-no-crlf values)) replace status)

--- a/src/phel/test/rose.phel
+++ b/src/phel/test/rose.phel
@@ -85,7 +85,7 @@
   "Returns `true` if `x` looks like a rose tree."
   {:example "(rose? (rose-pure 1)) ; => true"}
   [x]
-  (and (hash-map? x) (contains? x :root) (contains? x :children)))
+  (and (map? x) (contains? x :root) (contains? x :children)))
 
 ;; ----------------
 ;; Structural ops

--- a/src/phel/test/shrink.phel
+++ b/src/phel/test/shrink.phel
@@ -51,13 +51,13 @@
    :see-also ["phel\\test\\rose/int-rose-tree"]}
   [v]
   (cond
-    (int? v)      (r/int-rose-tree v)
-    (string? v)   (shrink-string-tree v)
-    (vector? v)   (shrink-vector-tree v)
-    (list? v)     (shrink-list-tree v)
-    (hash-map? v) (shrink-map-tree v)
-    (set? v)      (shrink-set-tree v)
-    :else         (r/rose-pure v)))
+    (int? v)    (r/int-rose-tree v)
+    (string? v) (shrink-string-tree v)
+    (vector? v) (shrink-vector-tree v)
+    (list? v)   (shrink-list-tree v)
+    (map? v)    (shrink-map-tree v)
+    (set? v)    (shrink-set-tree v)
+    :else       (r/rose-pure v)))
 
 ;; ----------------
 ;; Shrink driver


### PR DESCRIPTION
## 🤔 Background

Phel core ships several deprecated functions (`put`, `push`, `id`, `hash-map?`, …) that still had internal call-sites inside `src/phel/`. While they stay as public API for one more release, keeping them in use internally blocks a clean removal later.

## 💡 Goal

Make every deprecated core function **unused internally**, so they can be safely deleted in the next release without breaking the runtime/library itself. Deprecated `defn`s themselves are untouched (still public for one more release).

## 🔖 Changes

Swapped real phel-fn call-sites for their `:superseded-by` replacement (PHP-interop `php/->` method calls on persistent maps were left alone — those are native `->put()`/`->push()`, not the deprecated phel fns):

- `(id …)` → `(identical? …)` — `core/booleans.phel` (`true?`/`false?`/`nil?`), `http.phel`
- `(hash-map? …)` → `(map? …)` — `test/rose.phel`, `test/shrink.phel`
- `(push …)` → `(conj …)` — `cli.phel`

Remaining deprecated fns (`put`, `unset`, `put-in`, `unset-in`, `values`, `function?`, `set-meta!`, `str-contains?`) already had **zero** internal call-sites.

All 5964 core tests pass.

Closes #2440