### PR TITLE
fix: suppress raw file_get_contents warning on missing file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- `phel test`/`phel run` with a missing file path: no longer leaks a raw `file_get_contents(): Failed to open stream` PHP warning before the clean `Unable to read file "..."` error
+
 ## [0.44.0](https://github.com/phel-lang/phel-lang/compare/v0.43.0...v0.44.0) - 2026-06-13
 
 Two themes: project configuration (`phel config`, optimization levels, composable config setters) and a sharper test runner (`--watch`, startup progress, clearer failures).

--- a/src/php/Build/Infrastructure/IO/SystemFileIo.php
+++ b/src/php/Build/Infrastructure/IO/SystemFileIo.php
@@ -13,7 +13,7 @@ final class SystemFileIo implements FileIoInterface
 {
     public function getContents(string $filename): string
     {
-        $contents = file_get_contents($filename);
+        $contents = @file_get_contents($filename);
 
         if ($contents === false) {
             throw new RuntimeException(sprintf('Unable to read file "%s".', $filename));

--- a/tests/php/Unit/Build/Infrastructure/IO/SystemFileIoTest.php
+++ b/tests/php/Unit/Build/Infrastructure/IO/SystemFileIoTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Build\Infrastructure\IO;
+
+use Phel\Build\Infrastructure\IO\SystemFileIo;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function sprintf;
+use function sys_get_temp_dir;
+use function uniqid;
+
+final class SystemFileIoTest extends TestCase
+{
+    public function test_get_contents_missing_file_throws_without_warning(): void
+    {
+        $io = new SystemFileIo();
+        $missing = sys_get_temp_dir() . '/' . uniqid('phel-missing-', true) . '.phel';
+
+        // Promote any *reported* PHP warning to an exception. The handler honors
+        // error_reporting() (the @-operator masks it out), so a properly suppressed
+        // file_get_contents() warning passes, but removing the @ lets E_WARNING
+        // through the mask and fails this test.
+        // Mimic the production CLI, where E_WARNING is reported; only the
+        // @-operator on file_get_contents() should keep it from leaking.
+        $previousLevel = error_reporting(E_ALL);
+        set_error_handler(static function (int $severity, string $message): bool {
+            if ((error_reporting() & $severity) === 0) {
+                return false;
+            }
+
+            throw new RuntimeException('Unexpected PHP warning leaked: ' . $message);
+        });
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage(sprintf('Unable to read file "%s".', $missing));
+
+            $io->getContents($missing);
+        } finally {
+            restore_error_handler();
+            error_reporting($previousLevel);
+        }
+    }
+
+    public function test_get_contents_reads_existing_file(): void
+    {
+        $io = new SystemFileIo();
+        $path = sys_get_temp_dir() . '/' . uniqid('phel-io-', true) . '.txt';
+        $io->putContents($path, 'hello');
+
+        try {
+            self::assertSame('hello', $io->getContents($path));
+        } finally {
+            $io->removeFile($path);
+        }
+    }
+}


### PR DESCRIPTION
## 🤔 Background

During post-release QA of the v0.44.0 PHAR, running `phel test`/`phel run` against a non-existent file path printed a raw PHP warning:

```
PHP Warning:  file_get_contents(does-not-exist.phel): Failed to open stream: No such file or directory in .../Build/Infrastructure/IO/SystemFileIo.php on line 16
```

...immediately before the clean, intended error:

```
Unable to read file "does-not-exist.phel".
```

Exit code was already correct (1) and the message clear, but the leaked stream-open warning is noise.

## 💡 Goal

Surface only the clean `Unable to read file "..."` error; never leak the underlying `file_get_contents()` warning.

## 🔖 Changes

- `SystemFileIo::getContents()`: `@`-suppress `file_get_contents()`; the `false` check still throws the clean `RuntimeException`.
- New `SystemFileIoTest` covering the missing-file path (asserts the clean exception **and** that no PHP warning leaks, by forcing `error_reporting(E_ALL)` to mimic the production CLI) plus a happy-path read. Verified the test fails if the `@` is removed.
- CHANGELOG: `## Unreleased` → Fixed entry.