### PR TITLE
feat(run): report OPcache CLI caching status in phel doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `phel doctor`: a "Checking performance" section now reports whether OPcache is configured to persist the compiled-code cache across CLI runs (`opcache.enable_cli`, `opcache.file_cache`) and prints actionable tips when it is not, helping warm `phel run`/`phel test` invocations approach native PHP speed (#2444)
+
 ### Fixed
 
 - `phel test`/`phel run` with a missing file path: no longer leaks a raw `file_get_contents(): Failed to open stream` PHP warning before the clean `Unable to read file "..."` error

--- a/docs/internals/benchmarks.md
+++ b/docs/internals/benchmarks.md
@@ -39,3 +39,20 @@ composer bench-jit-tracing    # opcache on, tracing JIT
 ```
 
 See the [PHPBench docs](https://phpbench.readthedocs.io/) for advanced reporting.
+
+## Speeding up CLI runs with OPcache
+
+Phel compiles each `.phel` file to PHP and caches the result under the Phel cache dir (`.phel/cache/compiled/` by default). A warm `phel run` then just `require`s the cached PHP instead of recompiling. The remaining gap versus native PHP comes from PHP re-parsing those cached files on every process, because **OPcache is disabled on the CLI by default** (`opcache.enable_cli=0`).
+
+To let the compiled cache survive across CLI invocations, enable OPcache with its file cache:
+
+```ini
+; php.ini (or a -d flag on the CLI)
+opcache.enable_cli=1
+opcache.file_cache=/tmp/phel-opcache   ; any writable directory
+opcache.file_cache_only=1              ; persist across short-lived CLI processes
+```
+
+`opcache.enable_cli` and `opcache.file_cache` are `PHP_INI_SYSTEM` settings, so they must be set in `php.ini` or via `php -d ...` before the process starts (they cannot be changed at runtime).
+
+Run `phel doctor` to check the current configuration: its "Checking performance" section reports whether OPcache CLI caching is fully configured and prints tips otherwise.

--- a/src/php/Run/Infrastructure/Command/DoctorCommand.php
+++ b/src/php/Run/Infrastructure/Command/DoctorCommand.php
@@ -9,11 +9,13 @@ use Gacela\Framework\Health\HealthStatus;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Run\RunFacade;
+use Phel\Shared\Performance\OpcacheAdvisor;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function extension_loaded;
+use function ini_get;
 use function sprintf;
 
 /**
@@ -34,6 +36,7 @@ final class DoctorCommand extends Command
     {
         $systemOk = $this->checkSystemRequirements($output);
         $modulesOk = $this->checkModuleHealth($output);
+        $this->checkPerformance($output);
 
         if ($systemOk && $modulesOk) {
             $output->writeln('<info>Your system meets all requirements.</info>');
@@ -86,6 +89,28 @@ final class DoctorCommand extends Command
         }
 
         return !$report->hasUnhealthyModules();
+    }
+
+    private function checkPerformance(OutputInterface $output): void
+    {
+        $output->writeln('');
+        $output->writeln('Checking performance:');
+
+        $advice = new OpcacheAdvisor()->advise(
+            opcacheLoaded: extension_loaded('Zend OPcache'),
+            enableCli: (bool) ini_get('opcache.enable_cli'),
+            fileCacheConfigured: (string) ini_get('opcache.file_cache') !== '',
+        );
+
+        if ($advice->optimal) {
+            $output->writeln(sprintf(' - OPcache CLI caching: <info>OK</info> %s', $advice->messages[0]));
+
+            return;
+        }
+
+        foreach ($advice->messages as $message) {
+            $output->writeln(sprintf(' - OPcache CLI caching: <comment>TIP</comment> %s', $message));
+        }
     }
 
     private function formatLevel(HealthStatus $status): string

--- a/src/php/Shared/Performance/OpcacheAdvice.php
+++ b/src/php/Shared/Performance/OpcacheAdvice.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared\Performance;
+
+/**
+ * Result of evaluating the OPcache configuration for CLI usage.
+ */
+final readonly class OpcacheAdvice
+{
+    /**
+     * @param list<string> $messages
+     */
+    public function __construct(
+        public bool $optimal,
+        public array $messages,
+    ) {}
+}

--- a/src/php/Shared/Performance/OpcacheAdvisor.php
+++ b/src/php/Shared/Performance/OpcacheAdvisor.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared\Performance;
+
+/**
+ * Evaluates whether OPcache is configured to persist the compiled-code cache
+ * across CLI invocations, and produces actionable advice when it is not.
+ *
+ * Warm `phel run` reuses the compiled PHP stored under the Phel cache dir, but
+ * without OPcache (and its file cache) every CLI process re-parses those files
+ * from scratch, leaving a gap versus native PHP. This advisor is pure: callers
+ * pass the relevant ini flags so it stays trivially testable.
+ */
+final class OpcacheAdvisor
+{
+    public function advise(
+        bool $opcacheLoaded,
+        bool $enableCli,
+        bool $fileCacheConfigured,
+    ): OpcacheAdvice {
+        if (!$opcacheLoaded) {
+            return new OpcacheAdvice(false, [
+                'OPcache is not available. Enable the Zend OPcache extension to reuse compiled Phel between runs.',
+            ]);
+        }
+
+        $messages = [];
+        if (!$enableCli) {
+            $messages[] = 'opcache.enable_cli is off. Set opcache.enable_cli=1 so the compiled Phel cache survives across CLI runs.';
+        }
+
+        if (!$fileCacheConfigured) {
+            $messages[] = 'opcache.file_cache is not configured. Point it at a writable directory (e.g. opcache.file_cache=/tmp/phel-opcache) to persist the compiled cache across processes.';
+        }
+
+        if ($messages === []) {
+            return new OpcacheAdvice(true, [
+                'OPcache CLI caching is fully configured.',
+            ]);
+        }
+
+        return new OpcacheAdvice(false, $messages);
+    }
+}

--- a/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
+++ b/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
@@ -43,6 +43,20 @@ final class DoctorCommandTest extends TestCase
         self::assertMatchesRegularExpression('/Your system meets all requirements/', $output->fetch());
     }
 
+    public function test_doctor_command_reports_opcache_performance(): void
+    {
+        $output = new BufferedOutput();
+
+        new DoctorCommand()->run(
+            $this->createStub(InputInterface::class),
+            $output,
+        );
+
+        $rendered = $output->fetch();
+        self::assertStringContainsString('Checking performance:', $rendered);
+        self::assertStringContainsString('OPcache CLI caching:', $rendered);
+    }
+
     public function test_doctor_succeeds_when_temp_dir_does_not_exist_yet(): void
     {
         $this->resetContainer();

--- a/tests/php/Unit/Shared/Performance/OpcacheAdvisorTest.php
+++ b/tests/php/Unit/Shared/Performance/OpcacheAdvisorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared\Performance;
+
+use Phel\Shared\Performance\OpcacheAdvisor;
+use PHPUnit\Framework\TestCase;
+
+final class OpcacheAdvisorTest extends TestCase
+{
+    public function test_opcache_not_loaded_is_not_optimal(): void
+    {
+        $advice = new OpcacheAdvisor()->advise(
+            opcacheLoaded: false,
+            enableCli: false,
+            fileCacheConfigured: false,
+        );
+
+        self::assertFalse($advice->optimal);
+        self::assertCount(1, $advice->messages);
+        self::assertStringContainsStringIgnoringCase('opcache', $advice->messages[0]);
+    }
+
+    public function test_loaded_but_disabled_on_cli_warns_about_enable_cli(): void
+    {
+        $advice = new OpcacheAdvisor()->advise(
+            opcacheLoaded: true,
+            enableCli: false,
+            fileCacheConfigured: false,
+        );
+
+        self::assertFalse($advice->optimal);
+        self::assertStringContainsString('opcache.enable_cli', implode("\n", $advice->messages));
+        self::assertStringContainsString('opcache.file_cache', implode("\n", $advice->messages));
+    }
+
+    public function test_enabled_without_file_cache_warns_only_about_file_cache(): void
+    {
+        $advice = new OpcacheAdvisor()->advise(
+            opcacheLoaded: true,
+            enableCli: true,
+            fileCacheConfigured: false,
+        );
+
+        self::assertFalse($advice->optimal);
+        self::assertCount(1, $advice->messages);
+        self::assertStringContainsString('opcache.file_cache', $advice->messages[0]);
+    }
+
+    public function test_fully_configured_is_optimal(): void
+    {
+        $advice = new OpcacheAdvisor()->advise(
+            opcacheLoaded: true,
+            enableCli: true,
+            fileCacheConfigured: true,
+        );
+
+        self::assertTrue($advice->optimal);
+        self::assertCount(1, $advice->messages);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Warm `phel run`/`phel test` already `require` the compiled PHP cached under the Phel cache dir, but PHP CLI OPcache is off by default (`opcache.enable_cli=0`). Every CLI process therefore re-parses those cached files, leaving a 1-2x gap versus native PHP even on warm runs. `opcache.enable_cli`/`opcache.file_cache` are `PHP_INI_SYSTEM`, so they cannot be flipped at runtime; the actionable fix is to surface the gap and tell users how to close it.

## 💡 Goal

Make the OPcache CLI-caching gap visible and actionable, so warm runs can approach native PHP speed.

## 🔖 Changes

- New pure `Phel\Shared\Performance\OpcacheAdvisor` (+ `OpcacheAdvice` VO): evaluates `opcache.enable_cli` and `opcache.file_cache` from primitive inputs and returns actionable tips (fully unit-tested).
- `phel doctor` gains an informational "Checking performance" section reporting whether OPcache CLI caching is fully configured, printing tips otherwise (non-fatal: doctor still succeeds).
- Docs: "Speeding up CLI runs with OPcache" section in `docs/internals/benchmarks.md` with the recommended ini.
- CHANGELOG `## Unreleased` updated.

Closes #2444
