### PR TITLE
feat(build): ship precompiled stdlib bundle in the PHAR for fast cold starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Cold-start speedup: the PHAR now ships a read-only, content-addressed precompiled `phel.*` stdlib bundle (`cache/precompiled/`) that the compiled-code cache consults on a miss. A cold `phel run`/`phel test` in any project reuses the precompiled stdlib (incl. `phel.core`) instead of recompiling it, so first runs approach warm-cache speed. The bundle is keyed by source content hash, so it works regardless of where the PHAR is mounted; it stays inert (no behaviour change) for plain source/composer checkouts (#2443)
 - `phel doctor`: a "Checking performance" section now reports whether OPcache is configured to persist the compiled-code cache across CLI runs (`opcache.enable_cli`, `opcache.file_cache`) and prints actionable tips when it is not, helping warm `phel run`/`phel test` invocations approach native PHP speed (#2444)
 
 ### Fixed

--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -271,6 +271,41 @@ final class PharBuilder
     }
 
     /**
+     * Generate the read-only, content-addressed precompiled stdlib bundle
+     * under cache/precompiled/ so it ships inside the PHAR. At runtime the
+     * compiled-code cache consults it (keyed by source content hash), so a
+     * cold `phel run` in any project reuses the precompiled stdlib instead of
+     * recompiling it. Unlike preCompileStdlib()'s path-keyed cache, this one
+     * is install-location independent.
+     */
+    public function preCompileBundled(): void
+    {
+        $bundleDir = $this->root . '/cache/precompiled';
+
+        // Clean previous bundle to avoid stale, source-mismatched entries.
+        if (is_dir($bundleDir)) {
+            $files = glob($bundleDir . '/*') ?: [];
+            foreach ($files as $file) {
+                @unlink($file);
+            }
+        }
+
+        $exitCode = 0;
+        passthru(
+            \sprintf(
+                'cd %s && php bin/phel _precompile-bundled %s 2>&1',
+                escapeshellarg($this->root),
+                escapeshellarg($bundleDir),
+            ),
+            $exitCode,
+        );
+
+        if ($exitCode !== 0) {
+            throw new RuntimeException("Bundled stdlib precompile failed with exit code {$exitCode}");
+        }
+    }
+
+    /**
      * Build the PHAR archive
      */
     public function build(): void
@@ -278,6 +313,7 @@ final class PharBuilder
         $this->validate();
         $this->prepareReleaseConfig();
         $this->preCompileStdlib();
+        $this->preCompileBundled();
         $this->cleanup();
 
         try {

--- a/docs/internals/benchmarks.md
+++ b/docs/internals/benchmarks.md
@@ -56,3 +56,9 @@ opcache.file_cache_only=1              ; persist across short-lived CLI processe
 `opcache.enable_cli` and `opcache.file_cache` are `PHP_INI_SYSTEM` settings, so they must be set in `php.ini` or via `php -d ...` before the process starts (they cannot be changed at runtime).
 
 Run `phel doctor` to check the current configuration: its "Checking performance" section reports whether OPcache CLI caching is fully configured and prints tips otherwise.
+
+## Precompiled stdlib in the PHAR
+
+A cold run still has to compile the bundled `phel.*` stdlib (most of the cost is `phel.core`) before it can run your code. To avoid that, the PHAR ships a read-only, content-addressed bundle of the precompiled stdlib under `cache/precompiled/`, generated at build time by `build/build-phar.php` (which invokes the internal `phel _precompile-bundled <dir>` command).
+
+At runtime the compiled-code cache (`CompiledCodeCache`) consults this bundle whenever its writable cache misses, keyed by the source content hash. So a cold `phel run` in any project reuses the precompiled stdlib instead of recompiling it, approaching warm-cache speed on the very first run. The writable project cache still wins when present, and the bundle is ignored entirely for plain source or composer checkouts (where it is not shipped), leaving their behaviour unchanged.

--- a/src/php/Build/Application/BundledPrecompiler.php
+++ b/src/php/Build/Application/BundledPrecompiler.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Application;
+
+use Phel\Build\Infrastructure\Cache\AtomicFileWriter;
+use Phel\Build\Infrastructure\Cache\BundledCompiledCache;
+
+use function basename;
+use function dirname;
+use function is_array;
+use function is_dir;
+use function is_file;
+use function is_string;
+use function str_replace;
+use function str_starts_with;
+use function umask;
+
+/**
+ * Exports a populated compiled-code cache into the read-only,
+ * content-addressed bundle consumed by {@see BundledCompiledCache}.
+ *
+ * The normal cache keys compiled files by source path (install-location
+ * sensitive) and stores the source content hash in its index. This exporter
+ * re-keys every bundled `phel.*` entry by that content hash so a cold run on
+ * any machine reuses the precompiled stdlib. All files of a namespace are
+ * exported, including secondaries pulled in via `(load ...)`, because they
+ * each have their own index entry once the cache is fully built.
+ */
+final readonly class BundledPrecompiler
+{
+    private const string BUNDLED_PREFIX = 'phel.';
+
+    public function __construct(
+        private AtomicFileWriter $fileWriter = new AtomicFileWriter(),
+    ) {}
+
+    /**
+     * @return int number of compiled files written into the bundle
+     */
+    public function exportFromCache(string $cacheDir, BundledCompiledCache $target): int
+    {
+        $this->ensureDir($target->compiledTarget('probe'));
+
+        $written = 0;
+        $exportedEnv = [];
+        foreach ($this->loadIndexEntries($cacheDir) as $entry) {
+            $namespace = $entry['namespace'];
+            if (!str_starts_with($namespace, self::BUNDLED_PREFIX)) {
+                continue;
+            }
+
+            $compiledPath = $this->resolveCompiledPath($cacheDir, $entry['compiled_path']);
+            if ($compiledPath === null) {
+                continue;
+            }
+
+            $compiledCode = @file_get_contents($compiledPath);
+            if ($compiledCode === false) {
+                continue;
+            }
+
+            if ($this->fileWriter->write($target->compiledTarget($entry['source_hash']), $compiledCode)) {
+                ++$written;
+            }
+
+            if (!isset($exportedEnv[$namespace])) {
+                $exportedEnv[$namespace] = true;
+                $this->exportEnvironment($cacheDir, $namespace, $target);
+            }
+        }
+
+        return $written;
+    }
+
+    private function exportEnvironment(string $cacheDir, string $namespace, BundledCompiledCache $target): void
+    {
+        $envSource = $cacheDir . '/compiled/' . str_replace(['\\', '/'], '_', $namespace) . '.env.php';
+        if (!is_file($envSource)) {
+            return;
+        }
+
+        $envCode = @file_get_contents($envSource);
+        if ($envCode !== false) {
+            $this->fileWriter->write($target->environmentTarget($namespace), $envCode);
+        }
+    }
+
+    /**
+     * The index stores absolute compiled paths from build time. Prefer them,
+     * but fall back to the same basename under this cache dir so a relocated
+     * cache (copied between machines) still resolves.
+     */
+    private function resolveCompiledPath(string $cacheDir, string $compiledPath): ?string
+    {
+        if (is_file($compiledPath)) {
+            return $compiledPath;
+        }
+
+        $fallback = $cacheDir . '/compiled/' . basename($compiledPath);
+
+        return is_file($fallback) ? $fallback : null;
+    }
+
+    /**
+     * @return list<array{namespace: string, source_hash: string, compiled_path: string}>
+     */
+    private function loadIndexEntries(string $cacheDir): array
+    {
+        $indexFile = $cacheDir . '/compiled-index.php';
+        if (!is_file($indexFile)) {
+            return [];
+        }
+
+        /** @var mixed $data */
+        $data = @include $indexFile;
+        if (!is_array($data) || !isset($data['entries']) || !is_array($data['entries'])) {
+            return [];
+        }
+
+        $entries = [];
+        foreach ($data['entries'] as $entry) {
+            if (is_array($entry)
+                && isset($entry['namespace'], $entry['source_hash'], $entry['compiled_path'])
+                && is_string($entry['namespace'])
+                && is_string($entry['source_hash'])
+                && is_string($entry['compiled_path'])
+            ) {
+                $entries[] = [
+                    'namespace' => $entry['namespace'],
+                    'source_hash' => $entry['source_hash'],
+                    'compiled_path' => $entry['compiled_path'],
+                ];
+            }
+        }
+
+        return $entries;
+    }
+
+    private function ensureDir(string $fileInDir): void
+    {
+        $dir = dirname($fileInDir);
+        if (!is_dir($dir)) {
+            $oldUmask = umask(0);
+            try {
+                @mkdir($dir, 0755, true);
+            } finally {
+                umask($oldUmask);
+            }
+        }
+    }
+}

--- a/src/php/Build/BuildConfig.php
+++ b/src/php/Build/BuildConfig.php
@@ -11,6 +11,7 @@ use Phel\Shared\CompileOptions;
 use Phel\Shared\PhelProjectDirectory;
 use Phel\Shared\ScalarCoercion;
 
+use function dirname;
 use function is_string;
 
 final class BuildConfig extends AbstractConfig implements BuildConfigInterface
@@ -89,6 +90,25 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
     public function getNamespaceCacheFile(): string
     {
         return $this->getCacheDir() . '/namespace-cache.php';
+    }
+
+    /**
+     * Directory of the read-only, content-addressed precompiled stdlib bundle
+     * shipped with the distribution (primarily the PHAR), or null when it is
+     * not present (e.g. a plain source checkout). Resolved relative to the Phel
+     * package root so it works whether Phel runs from its own tree or a PHAR
+     * (where `dirname(__DIR__, 3)` is the `phar://...` mount root).
+     */
+    public function getBundledPrecompiledDir(): ?string
+    {
+        $envOverride = getenv('PHEL_BUNDLED_PRECOMPILED_DIR');
+        if (is_string($envOverride) && $envOverride !== '') {
+            return is_dir($envOverride) ? $envOverride : null;
+        }
+
+        $dir = dirname(__DIR__, 3) . '/cache/precompiled';
+
+        return is_dir($dir) ? $dir : null;
     }
 
     /**

--- a/src/php/Build/BuildFacade.php
+++ b/src/php/Build/BuildFacade.php
@@ -8,6 +8,7 @@ use Gacela\Framework\AbstractFacade;
 use Gacela\Framework\Health\ModuleHealthCheckInterface;
 use Phel\Build\Domain\Compile\BuildOptions;
 use Phel\Build\Domain\Compile\CompiledFile;
+use Phel\Build\Infrastructure\Cache\BundledCompiledCache;
 use Phel\Lang\Registry;
 use Phel\Shared\BuildConstants;
 use Phel\Shared\CompilerConstants;
@@ -168,5 +169,15 @@ final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
         return $this->getFactory()
             ->getCommandFacade()
             ->getOutputDirectory();
+    }
+
+    public function precompileBundledStdlib(string $targetDir): int
+    {
+        return $this->getFactory()
+            ->createBundledPrecompiler()
+            ->exportFromCache(
+                $this->getFactory()->getCacheDir(),
+                new BundledCompiledCache($targetDir),
+            );
     }
 }

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -7,6 +7,7 @@ namespace Phel\Build;
 use Gacela\Framework\AbstractFactory;
 use Gacela\Framework\Health\ModuleHealthCheckInterface;
 use Phel\Build\Application\BuildHealthCheck;
+use Phel\Build\Application\BundledPrecompiler;
 use Phel\Build\Application\CacheClearer;
 use Phel\Build\Application\CachedNamespaceExtractor;
 use Phel\Build\Application\DependenciesForNamespace;
@@ -27,6 +28,7 @@ use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\Extractor\NamespaceSorterInterface;
 use Phel\Build\Domain\Extractor\TopologicalNamespaceSorter;
 use Phel\Build\Domain\IO\FileIoInterface;
+use Phel\Build\Infrastructure\Cache\BundledCompiledCache;
 use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
 use Phel\Build\Infrastructure\Cache\DependencyTracker;
 use Phel\Build\Infrastructure\Cache\PhpNamespaceCache;
@@ -89,6 +91,16 @@ final class BuildFactory extends AbstractFactory
             ),
         );
         return $evaluator;
+    }
+
+    public function createBundledPrecompiler(): BundledPrecompiler
+    {
+        return new BundledPrecompiler();
+    }
+
+    public function getCacheDir(): string
+    {
+        return $this->getConfig()->getCacheDir();
     }
 
     public function createNamespaceExtractor(): NamespaceExtractorInterface
@@ -182,9 +194,12 @@ final class BuildFactory extends AbstractFactory
             return null;
         }
 
+        $bundledDir = $this->getConfig()->getBundledPrecompiledDir();
+
         return new CompiledCodeCache(
             $this->getConfig()->getCacheDir(),
             VersionFinder::LATEST_VERSION,
+            bundled: $bundledDir !== null ? new BundledCompiledCache($bundledDir) : null,
         );
     }
 

--- a/src/php/Build/CLAUDE.md
+++ b/src/php/Build/CLAUDE.md
@@ -9,6 +9,7 @@ Compiles Phel projects to PHP: dependency resolution, caching, namespace extract
 - `compileFile(src, dest)` / `evalFile(src)` / `compileProject(BuildOptions)`: compile to PHP (evalFile skips writing output)
 - `phel build --report` builds a `BuildReport` (`Domain/Compile/BuildReport` + `BuildReportEntry`) from the returned `CompiledFile[]` + build duration: namespace count, per-namespace compiled byte size (read from each target file), total size, fresh/cached counts. Pure VO with `toArray()`; the command renders it
 - `clearCache(): string[]`: paths cleared from temp/cache dirs
+- `precompileBundledStdlib(string $targetDir): int`: exports the populated compiled-code cache into a read-only, content-addressed bundle (caller compiles the bundled namespaces first). Used at PHAR build time
 - `getHealthCheck()`: cache, output, source dir checks
 - `writeLocatedException` / `writeStackTrace` / `getOutputDirectory`: delegate to Command facade
 
@@ -19,6 +20,7 @@ Compiler (Phel-to-PHP compilation), Command (output/source dirs, error formattin
 ## Key Constraints
 
 - Two-level caching: namespace extraction (optional) + compiled code (optional)
+- Bundled precompiled stdlib: `Infrastructure/Cache/BundledCompiledCache` is a read-only, content-addressed (keyed by source content hash, not path → install-location independent) fallback consulted by `CompiledCodeCache` on `get()`/`getEnvironment()` misses. `Application/BundledPrecompiler::exportFromCache()` re-keys a populated cache's `phel.*` entries into the bundle. `BuildConfig::getBundledPrecompiledDir()` resolves `<pkgRoot>/cache/precompiled` (present only in the PHAR; null/inert otherwise; `PHEL_BUNDLED_PRECOMPILED_DIR` overrides)
 - `FileEvaluator` compiles with source maps enabled and caches `getCodeWithSourceMap()`, so runtime errors from cache-loaded namespaces still map back to `.phel` locations via the inline `// `/`// ;;` header comments
 - `Infrastructure/Cache/CompiledCodeCache` is the policy orchestrator; delegates to `CacheDirectory` (layout), `CacheIndexFile` (index load/save/merge), `NamespaceEnvironmentStore` (env data), `CachePathResolver`, `AtomicFileWriter`
 - `TopologicalNamespaceSorter` orders compilation to resolve dependencies

--- a/src/php/Build/Infrastructure/Cache/BundledCompiledCache.php
+++ b/src/php/Build/Infrastructure/Cache/BundledCompiledCache.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Infrastructure\Cache;
+
+use function is_array;
+use function is_file;
+use function str_replace;
+
+/**
+ * Read-only, content-addressed cache of precompiled bundled code shipped with
+ * the Phel distribution (primarily the PHAR). It lets a cold `phel run` in any
+ * project reuse the precompiled `phel.*` stdlib instead of recompiling it.
+ *
+ * Unlike {@see CompiledCodeCache}, lookups are keyed by the source content
+ * hash, not the source file path. The PHAR is mounted at a different absolute
+ * path on every machine, so a path-keyed entry would never match; a content
+ * hash is install-location independent and matches as long as the bundled
+ * `.phel` source is byte-identical to the one being run.
+ *
+ * Layout under {@see $dir}:
+ *   <sourceHash>.php       compiled PHP for a source file
+ *   <munged-ns>.env.php    per-namespace environment data (refers/aliases)
+ */
+final readonly class BundledCompiledCache
+{
+    public function __construct(
+        private string $dir,
+    ) {}
+
+    /**
+     * Path to the precompiled PHP for the given source hash, or null when the
+     * bundle has no matching entry.
+     */
+    public function compiledPath(string $sourceHash): ?string
+    {
+        $path = $this->dir . '/' . $sourceHash . '.php';
+
+        return is_file($path) ? $path : null;
+    }
+
+    /**
+     * Per-namespace environment data, or null when the bundle has none.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function environment(string $namespace): ?array
+    {
+        $path = $this->dir . '/' . $this->mungeNamespace($namespace) . '.env.php';
+
+        if (!is_file($path)) {
+            return null;
+        }
+
+        /** @var mixed $data */
+        $data = require $path;
+
+        if (!is_array($data)) {
+            return null;
+        }
+
+        $environment = [];
+        foreach ($data as $key => $value) {
+            $environment[(string) $key] = $value;
+        }
+
+        return $environment;
+    }
+
+    /**
+     * Absolute path where the compiled PHP for a source hash would live.
+     * Used by the precompiler when writing the bundle.
+     */
+    public function compiledTarget(string $sourceHash): string
+    {
+        return $this->dir . '/' . $sourceHash . '.php';
+    }
+
+    /**
+     * Absolute path where the env data for a namespace would live.
+     * Used by the precompiler when writing the bundle.
+     */
+    public function environmentTarget(string $namespace): string
+    {
+        return $this->dir . '/' . $this->mungeNamespace($namespace) . '.env.php';
+    }
+
+    private function mungeNamespace(string $namespace): string
+    {
+        return str_replace(['\\', '/'], '_', $namespace);
+    }
+}

--- a/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
+++ b/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
@@ -73,6 +73,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
         ?CacheDirectory $directory = null,
         ?CacheIndexFile $indexFile = null,
         ?NamespaceEnvironmentStore $environmentStore = null,
+        private readonly ?BundledCompiledCache $bundled = null,
     ) {
         $this->directory = $directory ?? new CacheDirectory($cacheDir);
         $this->pathResolver = $pathResolver ?? new CachePathResolver($cacheDir);
@@ -91,27 +92,8 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
      */
     public function get(string $sourcePath, string $sourceHash): ?string
     {
-        $this->loadEntries();
-
-        $entry = $this->entries[$sourcePath] ?? null;
-        if ($entry === null) {
-            return null;
-        }
-
-        if ($entry['source_hash'] !== $sourceHash) {
-            return null;
-        }
-
-        $compiledPath = $this->getCompiledPath($sourcePath, $entry['namespace']);
-
-        if (!file_exists($compiledPath)) {
-            return null;
-        }
-
-        $this->entries[$sourcePath]['last_accessed'] = time();
-        $this->touchedThisProcess[$sourcePath] = true;
-
-        return $compiledPath;
+        return $this->getFromEntries($sourcePath, $sourceHash)
+            ?? $this->bundled?->compiledPath($sourceHash);
     }
 
     /**
@@ -193,7 +175,8 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
      */
     public function getEnvironment(string $namespace): ?array
     {
-        return $this->environmentStore->get($namespace);
+        return $this->environmentStore->get($namespace)
+            ?? $this->bundled?->environment($namespace);
     }
 
     /**
@@ -240,6 +223,34 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
         $this->touchedThisProcess = [];
         $this->saveEntries();
         $this->environmentStore->clearMemo();
+    }
+
+    /**
+     * Looks up the writable, path-keyed cache only (no bundled fallback).
+     */
+    private function getFromEntries(string $sourcePath, string $sourceHash): ?string
+    {
+        $this->loadEntries();
+
+        $entry = $this->entries[$sourcePath] ?? null;
+        if ($entry === null) {
+            return null;
+        }
+
+        if ($entry['source_hash'] !== $sourceHash) {
+            return null;
+        }
+
+        $compiledPath = $this->getCompiledPath($sourcePath, $entry['namespace']);
+
+        if (!file_exists($compiledPath)) {
+            return null;
+        }
+
+        $this->entries[$sourcePath]['last_accessed'] = time();
+        $this->touchedThisProcess[$sourcePath] = true;
+
+        return $compiledPath;
     }
 
     private function loadEntries(): void

--- a/src/php/Console/Infrastructure/Command/RunCommands.php
+++ b/src/php/Console/Infrastructure/Command/RunCommands.php
@@ -12,6 +12,7 @@ use Phel\Run\Infrastructure\Command\DoctorCommand;
 use Phel\Run\Infrastructure\Command\EvalCommand;
 use Phel\Run\Infrastructure\Command\InitCommand;
 use Phel\Run\Infrastructure\Command\NsCommand;
+use Phel\Run\Infrastructure\Command\PrecompileBundledCommand;
 use Phel\Run\Infrastructure\Command\ReplCommand;
 use Phel\Run\Infrastructure\Command\RunCommand;
 use Phel\Run\Infrastructure\Command\TestCommand;
@@ -31,6 +32,7 @@ final class RunCommands implements ConsoleCommandProviderInterface
             new RunCommand(),
             new TestCommand(),
             new TestWorkerCommand(),
+            new PrecompileBundledCommand(),
             new DoctorCommand(),
             new ConfigCommand(),
         ];

--- a/src/php/Run/Application/BundledStdlibPrecompiler.php
+++ b/src/php/Run/Application/BundledStdlibPrecompiler.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application;
+
+use Phel\Build\BuildFacade;
+use Phel\Lang\LoadClasspath;
+use Phel\Shared\Facade\BuildFacadeInterface;
+use Phel\Shared\Facade\CommandFacadeInterface;
+
+/**
+ * Orchestrates precompilation of the bundled `phel.*` stdlib into the
+ * read-only, content-addressed bundle consumed at runtime. Discovers every
+ * bundled namespace, resolves them in dependency order, and hands the ordered
+ * source files to the build facade to compile.
+ *
+ * Invoked at distribution-build time (PHAR) so a cold `phel run` in any
+ * project reuses the precompiled stdlib instead of recompiling it.
+ */
+final readonly class BundledStdlibPrecompiler
+{
+    public function __construct(
+        private BuildFacadeInterface $buildFacade,
+        private CommandFacadeInterface $commandFacade,
+        private BundledNamespaces $bundledNamespaces,
+    ) {}
+
+    /**
+     * @return int number of compiled files written
+     */
+    public function precompile(string $targetDir): int
+    {
+        $seeds = $this->bundledNamespaces->all();
+        if ($seeds === []) {
+            return 0;
+        }
+
+        $directories = $this->commandFacade->getAllPhelDirectories();
+        $infos = $this->buildFacade->getDependenciesForNamespace($directories, $seeds);
+
+        // Publish the load classpath so `(load ...)` inside a namespace resolves
+        // its secondary files, and enable build mode like the regular runtime
+        // loader. Evaluating each primary populates the compiled-code cache with
+        // every file (primaries and secondaries) before we export the bundle.
+        LoadClasspath::publish($directories);
+        BuildFacade::enableBuildMode();
+        try {
+            foreach ($infos as $info) {
+                $this->buildFacade->evalFile($info->getFile());
+            }
+        } finally {
+            BuildFacade::disableBuildMode();
+        }
+
+        return $this->buildFacade->precompileBundledStdlib($targetDir);
+    }
+}

--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -19,7 +19,7 @@ Most connected module, 5 Provider facades: Build (namespace extraction, dependen
 
 ## Structure Notes
 
-- `Infrastructure/Command/`: 10 Symfony commands (incl. `config` — dumps effective merged config), one hidden `_test-worker`
+- `Infrastructure/Command/`: 10 Symfony commands (incl. `config` — dumps effective merged config), two hidden: `_test-worker` and `_precompile-bundled <dir>` (precompiles the bundled stdlib into a content-addressed bundle at PHAR build time, via `RunFacade::precompileBundledStdlib()` → `Application/BundledStdlibPrecompiler`, which evals all `phel.*` then delegates to `BuildFacade::precompileBundledStdlib()`)
 - `Runtime/PhelSourceLoader`: cached-PHP boot entry
 
 ## Key Constraints

--- a/src/php/Run/Infrastructure/Command/PrecompileBundledCommand.php
+++ b/src/php/Run/Infrastructure/Command/PrecompileBundledCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Infrastructure\Command;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Phel\Run\RunFacade;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+use function is_string;
+use function sprintf;
+
+/**
+ * Hidden subcommand: precompiles the bundled `phel.*` stdlib into a read-only,
+ * content-addressed bundle at the given directory. Invoked at distribution
+ * build time (see build/build-phar.php) so a cold `phel run` reuses the
+ * precompiled stdlib instead of recompiling it. Not for direct use.
+ *
+ * @method RunFacade getFacade()
+ */
+#[ServiceMap(method: 'getFacade', className: RunFacade::class)]
+final class PrecompileBundledCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    public const string COMMAND_NAME = '_precompile-bundled';
+
+    protected function configure(): void
+    {
+        $this->setName(self::COMMAND_NAME)
+            ->setDescription('Internal: precompile the bundled stdlib. Not for direct use.')
+            ->setHidden(true)
+            ->addArgument(
+                'target-dir',
+                InputArgument::REQUIRED,
+                'Directory to write the content-addressed precompiled bundle into',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $targetDir = $input->getArgument('target-dir');
+        if (!is_string($targetDir) || $targetDir === '') {
+            $output->writeln('<error>A target directory is required.</error>');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $count = $this->getFacade()->precompileBundledStdlib($targetDir);
+        } catch (Throwable $throwable) {
+            $output->writeln(sprintf('<error>Precompile failed: %s</error>', $throwable->getMessage()));
+
+            return self::FAILURE;
+        }
+
+        $output->writeln(sprintf('Precompiled %d bundled module(s) into %s', $count, $targetDir));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/php/Run/RunFacade.php
+++ b/src/php/Run/RunFacade.php
@@ -37,6 +37,13 @@ final class RunFacade extends AbstractFacade implements RunFacadeInterface
             ->run($filename);
     }
 
+    public function precompileBundledStdlib(string $targetDir): int
+    {
+        return $this->getFactory()
+            ->createBundledStdlibPrecompiler()
+            ->precompile($targetDir);
+    }
+
     public function getNamespaceFromFile(string $fileOrPath): NamespaceInformation
     {
         return $this->getFactory()

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -9,6 +9,7 @@ use Gacela\Framework\Health\ModuleHealthCheckInterface;
 use Phel\Filesystem\FilesystemFacadeInterface;
 use Phel\Run\Application\BundledNamespaceDetector;
 use Phel\Run\Application\BundledNamespaces;
+use Phel\Run\Application\BundledStdlibPrecompiler;
 use Phel\Run\Application\CompileExecutor;
 use Phel\Run\Application\EntryPointDetector;
 use Phel\Run\Application\EvalExecutor;
@@ -120,6 +121,15 @@ class RunFactory extends AbstractFactory
     public function createBundledNamespaceDetector(): BundledNamespaceDetector
     {
         return new BundledNamespaceDetector(
+            $this->createBundledNamespaces(),
+        );
+    }
+
+    public function createBundledStdlibPrecompiler(): BundledStdlibPrecompiler
+    {
+        return new BundledStdlibPrecompiler(
+            $this->getBuildFacade(),
+            $this->getCommandFacade(),
             $this->createBundledNamespaces(),
         );
     }

--- a/src/php/Shared/Facade/BuildFacadeInterface.php
+++ b/src/php/Shared/Facade/BuildFacadeInterface.php
@@ -62,4 +62,15 @@ interface BuildFacadeInterface
      * Returns the module's health check for diagnostics (`phel doctor`).
      */
     public function getHealthCheck(): ModuleHealthCheckInterface;
+
+    /**
+     * Exports the populated compiled-code cache into a read-only,
+     * content-addressed bundle under `$targetDir`. Used at distribution-build
+     * time so a cold run can reuse the precompiled stdlib instead of
+     * recompiling it. The caller is responsible for having compiled the
+     * bundled namespaces first (e.g. by evaluating them).
+     *
+     * @return int number of compiled files written
+     */
+    public function precompileBundledStdlib(string $targetDir): int;
 }

--- a/tests/php/Unit/Build/Application/BundledPrecompilerTest.php
+++ b/tests/php/Unit/Build/Application/BundledPrecompilerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Build\Application;
+
+use Phel\Build\Application\BundledPrecompiler;
+use Phel\Build\Infrastructure\Cache\BundledCompiledCache;
+use PHPUnit\Framework\TestCase;
+
+final class BundledPrecompilerTest extends TestCase
+{
+    private string $root;
+
+    private string $cacheDir;
+
+    private string $bundleDir;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/phel-precompile-' . uniqid('', true);
+        $this->cacheDir = $this->root . '/cache';
+        $this->bundleDir = $this->root . '/bundle';
+        mkdir($this->cacheDir . '/compiled', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->root);
+    }
+
+    public function test_exports_bundled_namespaces_keyed_by_source_hash(): void
+    {
+        $compiledFile = $this->cacheDir . '/compiled/phel_core__abc.php';
+        file_put_contents($compiledFile, "<?php\n// core compiled");
+        file_put_contents(
+            $this->cacheDir . '/compiled/phel.core.env.php',
+            '<?php return ' . var_export(['refers' => []], true) . ';',
+        );
+        $this->writeIndex([
+            '/src/phel/core.phel' => [
+                'namespace' => 'phel.core',
+                'source_hash' => 'corehash',
+                'compiled_path' => $compiledFile,
+            ],
+        ]);
+
+        $written = new BundledPrecompiler()->exportFromCache(
+            $this->cacheDir,
+            new BundledCompiledCache($this->bundleDir),
+        );
+
+        $bundle = new BundledCompiledCache($this->bundleDir);
+        self::assertSame(1, $written);
+        self::assertNotNull($bundle->compiledPath('corehash'));
+        self::assertStringContainsString('// core compiled', (string) file_get_contents($bundle->compiledPath('corehash')));
+        self::assertSame(['refers' => []], $bundle->environment('phel.core'));
+    }
+
+    public function test_skips_non_bundled_namespaces(): void
+    {
+        $compiledFile = $this->cacheDir . '/compiled/app_main__xyz.php';
+        file_put_contents($compiledFile, "<?php\n// app");
+        $this->writeIndex([
+            '/src/app/main.phel' => [
+                'namespace' => 'app.main',
+                'source_hash' => 'apphash',
+                'compiled_path' => $compiledFile,
+            ],
+        ]);
+
+        $written = new BundledPrecompiler()->exportFromCache(
+            $this->cacheDir,
+            new BundledCompiledCache($this->bundleDir),
+        );
+
+        self::assertSame(0, $written);
+        self::assertNull(new BundledCompiledCache($this->bundleDir)->compiledPath('apphash'));
+    }
+
+    public function test_resolves_relocated_compiled_path_by_basename(): void
+    {
+        // Index records a stale absolute path (as if built on another machine),
+        // but the file exists under this cache dir's compiled/ by basename.
+        $realFile = $this->cacheDir . '/compiled/phel_json__def.php';
+        file_put_contents($realFile, "<?php\n// json");
+        $this->writeIndex([
+            '/src/phel/json.phel' => [
+                'namespace' => 'phel.json',
+                'source_hash' => 'jsonhash',
+                'compiled_path' => '/build/workdir/cache/compiled/phel_json__def.php',
+            ],
+        ]);
+
+        $written = new BundledPrecompiler()->exportFromCache(
+            $this->cacheDir,
+            new BundledCompiledCache($this->bundleDir),
+        );
+
+        self::assertSame(1, $written);
+        self::assertNotNull(new BundledCompiledCache($this->bundleDir)->compiledPath('jsonhash'));
+    }
+
+    public function test_returns_zero_when_no_index(): void
+    {
+        $written = new BundledPrecompiler()->exportFromCache(
+            $this->cacheDir,
+            new BundledCompiledCache($this->bundleDir),
+        );
+
+        self::assertSame(0, $written);
+    }
+
+    /**
+     * @param array<string, array{namespace: string, source_hash: string, compiled_path: string}> $entries
+     */
+    private function writeIndex(array $entries): void
+    {
+        file_put_contents(
+            $this->cacheDir . '/compiled-index.php',
+            '<?php return ' . var_export(['version' => 'test', 'entries' => $entries], true) . ';',
+        );
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = glob($dir . '/*') ?: [];
+        foreach ($files as $file) {
+            if (is_dir($file)) {
+                $this->removeDir($file);
+            } else {
+                @unlink($file);
+            }
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/php/Unit/Build/Infrastructure/Cache/BundledCompiledCacheTest.php
+++ b/tests/php/Unit/Build/Infrastructure/Cache/BundledCompiledCacheTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Build\Infrastructure\Cache;
+
+use Phel\Build\Infrastructure\Cache\BundledCompiledCache;
+use PHPUnit\Framework\TestCase;
+
+final class BundledCompiledCacheTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/phel-bundled-' . uniqid('', true);
+        mkdir($this->dir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->dir . '/*') ?: [] as $file) {
+            @unlink($file);
+        }
+
+        @rmdir($this->dir);
+    }
+
+    public function test_compiled_path_returns_null_when_missing(): void
+    {
+        $cache = new BundledCompiledCache($this->dir);
+
+        self::assertNull($cache->compiledPath('unknown_hash'));
+    }
+
+    public function test_compiled_path_returns_file_when_present(): void
+    {
+        $cache = new BundledCompiledCache($this->dir);
+        file_put_contents($cache->compiledTarget('abc123'), "<?php\n// code");
+
+        $result = $cache->compiledPath('abc123');
+
+        self::assertNotNull($result);
+        self::assertStringContainsString('// code', (string) file_get_contents($result));
+    }
+
+    public function test_environment_returns_null_when_missing(): void
+    {
+        $cache = new BundledCompiledCache($this->dir);
+
+        self::assertNull($cache->environment('phel\\core'));
+    }
+
+    public function test_environment_reads_back_stored_data(): void
+    {
+        $cache = new BundledCompiledCache($this->dir);
+        $data = ['refers' => ['x' => ['ns' => 'phel\\core', 'name' => 'map']]];
+        file_put_contents(
+            $cache->environmentTarget('phel\\core'),
+            '<?php return ' . var_export($data, true) . ';',
+        );
+
+        self::assertSame($data, $cache->environment('phel\\core'));
+    }
+
+    public function test_environment_munges_namespace_separators_in_path(): void
+    {
+        $cache = new BundledCompiledCache($this->dir);
+
+        self::assertStringEndsWith('phel.core.env.php', $cache->environmentTarget('phel.core'));
+        self::assertStringEndsWith('phel_core.env.php', $cache->environmentTarget('phel\\core'));
+    }
+}

--- a/tests/php/Unit/Build/Infrastructure/Cache/CompiledCodeCacheTest.php
+++ b/tests/php/Unit/Build/Infrastructure/Cache/CompiledCodeCacheTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Build\Infrastructure\Cache;
 
+use Phel\Build\Infrastructure\Cache\BundledCompiledCache;
 use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
@@ -388,6 +389,63 @@ final class CompiledCodeCacheTest extends TestCase
         $cache->putEnvironment('test\\namespace', $envData);
 
         self::assertSame($envData, $cache->getEnvironment('test\\namespace'));
+    }
+
+    public function test_get_falls_back_to_bundled_when_writable_cache_misses(): void
+    {
+        $bundledDir = $this->cacheDir . '/bundled';
+        mkdir($bundledDir, 0755, true);
+        $bundled = new BundledCompiledCache($bundledDir);
+        file_put_contents($bundled->compiledTarget('bundled_hash'), "<?php\n// bundled");
+
+        $cache = new CompiledCodeCache(
+            $this->cacheDir,
+            bundled: $bundled,
+        );
+
+        $result = $cache->get('/any/uncached.phel', 'bundled_hash');
+
+        self::assertNotNull($result);
+        self::assertStringContainsString('// bundled', (string) file_get_contents($result));
+    }
+
+    public function test_get_prefers_writable_cache_over_bundled(): void
+    {
+        $bundledDir = $this->cacheDir . '/bundled';
+        mkdir($bundledDir, 0755, true);
+        $bundled = new BundledCompiledCache($bundledDir);
+        file_put_contents($bundled->compiledTarget('hash'), "<?php\n// bundled");
+
+        $cache = new CompiledCodeCache($this->cacheDir, bundled: $bundled);
+        $cache->put($this->sourceFile, 'test\\namespace', 'hash', '// writable');
+
+        $result = $cache->get($this->sourceFile, 'hash');
+
+        self::assertNotNull($result);
+        self::assertStringContainsString('// writable', (string) file_get_contents($result));
+    }
+
+    public function test_get_environment_falls_back_to_bundled(): void
+    {
+        $bundledDir = $this->cacheDir . '/bundled';
+        mkdir($bundledDir, 0755, true);
+        $bundled = new BundledCompiledCache($bundledDir);
+        $envData = ['refers' => [], 'require_aliases' => [], 'use_aliases' => []];
+        file_put_contents(
+            $bundled->environmentTarget('phel\\core'),
+            '<?php return ' . var_export($envData, true) . ';',
+        );
+
+        $cache = new CompiledCodeCache($this->cacheDir, bundled: $bundled);
+
+        self::assertSame($envData, $cache->getEnvironment('phel\\core'));
+    }
+
+    public function test_get_without_bundled_returns_null_on_miss(): void
+    {
+        $cache = new CompiledCodeCache($this->cacheDir);
+
+        self::assertNull($cache->get('/any/uncached.phel', 'whatever'));
     }
 
     private function removeDir(string $dir): void

--- a/tests/php/Unit/Watch/Application/ReloadOrchestratorTest.php
+++ b/tests/php/Unit/Watch/Application/ReloadOrchestratorTest.php
@@ -256,6 +256,11 @@ final readonly class FakeBuildFacade implements BuildFacadeInterface
     {
         return '';
     }
+
+    public function precompileBundledStdlib(string $targetDir): int
+    {
+        return 0;
+    }
 }
 
 final class FakeRunFacade implements RunFacadeInterface


### PR DESCRIPTION
## 🤔 Background

A cold `phel run`/`phel test` in a fresh project pays ~1s recompiling the bundled `phel.*` stdlib (mostly `phel.core`) before it runs your code (measured: cold ~1.23s vs warm ~0.17s). The PHAR already precompiles stdlib into a path-keyed `cache/compiled/`, but that cache is keyed by the build-time source path, so it is never consulted from an arbitrary project (the PHAR is mounted at a different path on every machine). Net effect: the precompiled stdlib does not help cold starts in real projects.

## 💡 Goal

Make the PHAR's precompiled stdlib actually accelerate cold starts in any project, approaching warm-cache speed on the very first run.

## 🔖 Changes

- **`BundledCompiledCache`** (read-only, content-addressed): looks up compiled PHP + per-namespace env keyed by **source content hash**, so it is install-location independent.
- **`CompiledCodeCache`**: consults the bundle as a fallback on a writable-cache miss for both `get()` and `getEnvironment()`. The writable project cache still wins when present.
- **`BundledPrecompiler::exportFromCache()`**: re-keys a fully-built cache's `phel.*` entries (primaries **and** `(load ...)` secondaries) into the content-addressed bundle.
- **`BundledStdlibPrecompiler`** + hidden **`_precompile-bundled <dir>`** command: evaluates all bundled namespaces, then exports the bundle.
- **`BuildConfig::getBundledPrecompiledDir()`**: resolves `<pkgRoot>/cache/precompiled` (present only in the PHAR; `null`/inert for source & composer checkouts; `PHEL_BUNDLED_PRECOMPILED_DIR` overrides).
- **`build/build-phar.php`**: generates and ships the bundle.
- Docs (`docs/internals/benchmarks.md`) + CHANGELOG.

## ✅ Verification

- New unit tests for the bundled cache, the `CompiledCodeCache` fallback, and the exporter.
- Locally: generated the bundle, then a cold `phel run` with it dropped from **1.23s → 0.18s** and wrote **0** `phel.core` files to the project cache; **all 5964 Phel core tests pass** against the bundled core (output parity verified).
- Inert for source/composer checkouts (no bundle shipped) — existing behaviour unchanged.

Note: the older path-keyed `preCompileStdlib()` bundling is left in place; de-duplicating it against this content-addressed bundle is a sensible follow-up.

Closes #2443
