### PR TITLE
docs(build): document ahead-of-time build artifact performance

### DIFF
--- a/docs/internals/benchmarks.md
+++ b/docs/internals/benchmarks.md
@@ -56,3 +56,23 @@ opcache.file_cache_only=1              ; persist across short-lived CLI processe
 `opcache.enable_cli` and `opcache.file_cache` are `PHP_INI_SYSTEM` settings, so they must be set in `php.ini` or via `php -d ...` before the process starts (they cannot be changed at runtime).
 
 Run `phel doctor` to check the current configuration: its "Checking performance" section reports whether OPcache CLI caching is fully configured and prints tips otherwise.
+
+## Ahead-of-time builds vs runtime compilation
+
+For the fastest, closest-to-native execution, compile the project ahead of time and run the generated PHP directly, so the Phel compiler never runs:
+
+```bash
+composer install --no-dev --optimize-autoloader
+./vendor/bin/phel build          # writes plain PHP to out/
+php out/index.php                 # runs the built entry, zero runtime compilation
+```
+
+The built entry (`out/index.php`) requires the compiled namespace tree, which require-chains the precompiled `phel.core`. No lexer/parser/analyzer/emitter runs on the request path. Indicative CLI process-startup, best-of-5 on a trivial script (your numbers depend on how much stdlib the entry touches and on OPcache):
+
+| Execution mode | Startup |
+|---|---|
+| `php out/index.php` (ahead-of-time build) | ~0.11s |
+| `phel run` (warm cache) | ~0.20s |
+| native PHP equivalent | ~0.05s |
+
+The ahead-of-time artifact roughly halves the gap to native versus a warm `phel run`. See the example deployment guide (`resources/agents/examples/http-json-api/DEPLOYMENT.md`) for the full production flow (Docker, OPcache preload, php-fpm, worker mode).


### PR DESCRIPTION
## 🤔 Background

#2445 asks for an AOT build target that runs as plain PHP with zero runtime compilation, "benchmarked closer to native than `phel run`". Investigation showed this capability already exists (`phel build` → `out/index.php`) and is documented in the example production deployment guide (#2438); the regression fix #2449 made it complete from the PHAR too. The remaining gap was *quantifying* the win.

## 💡 Goal

Document and quantify the ahead-of-time build artifact's startup advantage so users know the deploy path exists and what it buys them.

## 🔖 Changes

- `docs/internals/benchmarks.md`: new "Ahead-of-time builds vs runtime compilation" section — the `composer install --no-dev` + `phel build` + `php out/index.php` flow, an indicative startup comparison (AOT artifact ~0.11s vs warm `phel run` ~0.20s vs native ~0.05s, best-of-5 on a trivial script), and a cross-link to the example deployment guide.

Docs-only; no code changes. Touches only `docs/`, so agent-docs validation is unaffected.

Related to #2445
