### PR TITLE
feat(doc): shell completion for phel doc arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Cold-start speedup: the PHAR now ships `phel.core` precompiled to PHP as `.php` siblings next to its `.phel` sources, so a cold `phel run`/`phel test`/`phel eval` reuses them directly instead of recompiling core on first use (measured ~1.2s -> ~0.2s on an empty project cache). `FileEvaluator` gains a precompiled-sibling fast path: when a `phel build`-style `<name>.php` sits next to a `<name>.phel` source, it is required directly, skipping the lexer/parser/analyzer/emitter pipeline and the compiled-code cache. Inert for plain source/composer checkouts, which ship no siblings (#2443)
 - `phel doctor`: a "Checking performance" section now reports whether OPcache is configured to persist the compiled-code cache across CLI runs (`opcache.enable_cli`, `opcache.file_cache`) and prints actionable tips when it is not, helping warm `phel run`/`phel test` invocations approach native PHP speed (#2444)
+- `phel doc` now offers shell completion for its arguments: `phel doc <TAB>` completes fully qualified function names (`core/map`, ...), `--ns=<TAB>` completes the namespaces that own documented functions, and `--format=<TAB>` completes `table`/`json`. Install the completion script with `phel completion zsh` (or `bash`/`fish`) (#2451)
 
 ### Fixed
 

--- a/src/php/Api/Infrastructure/Command/DocCommand.php
+++ b/src/php/Api/Infrastructure/Command/DocCommand.php
@@ -11,6 +11,7 @@ use Phel\Api\ApiFacade;
 use Phel\Api\Transfer\PhelFunction;
 use Phel\Shared\ScalarCoercion;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -36,13 +37,20 @@ final class DocCommand extends Command
     {
         $this->setName('doc')
             ->setDescription('Display the docs for any/all phel functions')
-            ->addArgument('search', InputArgument::OPTIONAL, 'Search input that look for a similar function name', '')
+            ->addArgument(
+                'search',
+                InputArgument::OPTIONAL,
+                'Search input that look for a similar function name',
+                '',
+                fn(CompletionInput $input): array => $this->completeFunctionNames($input),
+            )
             ->addOption(
                 self::OPTION_NAMESPACES,
                 null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 'Specify which namespaces to load.',
                 [],
+                fn(CompletionInput $input): array => $this->completeNamespaces($input),
             )
             ->addOption(
                 self::OPTION_FORMAT,
@@ -50,6 +58,7 @@ final class DocCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Specify the output format.',
                 'table',
+                self::AVAILABLE_FORMATS,
             );
     }
 
@@ -80,6 +89,54 @@ final class DocCommand extends Command
         $this->printFunctionsAsTable($output, $normalized);
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Suggests fully qualified function names (`namespace/name`) matching the
+     * partial value the user has typed so far. Powers `phel doc <TAB>`.
+     *
+     * @return list<string>
+     */
+    private function completeFunctionNames(CompletionInput $input): array
+    {
+        $typed = $input->getCompletionValue();
+
+        $names = [];
+        /** @var PhelFunction $phelFunction */
+        foreach ($this->getFacade()->getPhelFunctions() as $phelFunction) {
+            $fnName = $phelFunction->namespace . '/' . $phelFunction->name;
+            if ($typed === '' || str_contains($fnName, $typed)) {
+                $names[] = $fnName;
+            }
+        }
+
+        sort($names);
+
+        return $names;
+    }
+
+    /**
+     * Suggests the distinct namespaces that own at least one documented
+     * function. Powers `phel doc --ns=<TAB>`.
+     *
+     * @return list<string>
+     */
+    private function completeNamespaces(CompletionInput $input): array
+    {
+        $typed = $input->getCompletionValue();
+
+        $namespaces = [];
+        /** @var PhelFunction $phelFunction */
+        foreach ($this->getFacade()->getPhelFunctions() as $phelFunction) {
+            $ns = $phelFunction->namespace;
+            if (($typed === '' || str_contains($ns, $typed)) && !in_array($ns, $namespaces, true)) {
+                $namespaces[] = $ns;
+            }
+        }
+
+        sort($namespaces);
+
+        return $namespaces;
     }
 
     /**

--- a/tests/php/Integration/Api/DocCommandTest.php
+++ b/tests/php/Integration/Api/DocCommandTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Api;
+
+use Phel;
+use Phel\Api\Infrastructure\Command\DocCommand;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
+
+final class DocCommandTest extends TestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_search_argument_completes_function_names(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandCompletionTester(new DocCommand());
+        $suggestions = $tester->complete(['map']);
+
+        self::assertContains('core/map', $suggestions);
+        self::assertContains('core/map-indexed', $suggestions);
+        self::assertNotContains('core/reduce', $suggestions, 'Suggestions must be filtered by the typed value');
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_ns_option_completes_namespaces(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandCompletionTester(new DocCommand());
+        $suggestions = $tester->complete(['--ns', '']);
+
+        self::assertContains('core', $suggestions);
+        // Namespaces must be unique.
+        self::assertSame(array_values(array_unique($suggestions)), $suggestions);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_format_option_completes_available_formats(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandCompletionTester(new DocCommand());
+        $suggestions = $tester->complete(['--format', '']);
+
+        self::assertSame(['table', 'json'], $suggestions);
+    }
+
+    private function bootstrap(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Phel::clear();
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Phel ships a Symfony Console `completion` command (`phel completion zsh|bash|fish`), but no command exposed dynamic value suggestions, so tab-completion only ever offered command and option names — never the actual function names you want when reaching for `phel doc`. This is the first concrete item from the DX umbrella issue #2451.

## 💡 Goal

Make `phel doc` self-documenting at the shell: pressing `<TAB>` should surface the function you're looking for, the namespaces worth filtering by, and the valid output formats.

## 🔖 Changes

- `DocCommand` now registers `suggestedValues` on:
  - **`search` argument** → fully qualified function names (`core/map`, `core/map-indexed`, ...), filtered by what you've typed so far.
  - **`--ns` option** → the distinct namespaces that own at least one documented function (deduplicated, sorted).
  - **`--format` option** → `table` / `json`.
- Function/namespace data comes from the existing `ApiFacade::getPhelFunctions()`; no new facade surface.
- Added `tests/php/Integration/Api/DocCommandTest.php` using `CommandCompletionTester` to lock in all three behaviours.
- Documented the feature in `CHANGELOG.md` under `## Unreleased`.

Try it:

```bash
phel completion zsh > "$(brew --prefix)/share/zsh/site-functions/_phel"   # install once
phel doc map<TAB>        # -> core/map, core/map-indexed, ...
phel doc --ns=<TAB>      # -> core, html, json, ...
phel doc --format=<TAB>  # -> table, json
```

Refs #2451
