### PR TITLE
feat(cli): shell completion for known option values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Cold-start speedup: the PHAR now ships `phel.core` precompiled to PHP as `.php` siblings next to its `.phel` sources, so a cold `phel run`/`phel test`/`phel eval` reuses them directly instead of recompiling core on first use (measured ~1.2s -> ~0.2s on an empty project cache). `FileEvaluator` gains a precompiled-sibling fast path: when a `phel build`-style `<name>.php` sits next to a `<name>.phel` source, it is required directly, skipping the lexer/parser/analyzer/emitter pipeline and the compiled-code cache. Inert for plain source/composer checkouts, which ship no siblings (#2443)
 - `phel doctor`: a "Checking performance" section now reports whether OPcache is configured to persist the compiled-code cache across CLI runs (`opcache.enable_cli`, `opcache.file_cache`) and prints actionable tips when it is not, helping warm `phel run`/`phel test` invocations approach native PHP speed (#2444)
 - `phel doc` now offers shell completion for its arguments: `phel doc <TAB>` completes fully qualified function names (`core/map`, ...), `--ns=<TAB>` completes the namespaces that own documented functions, and `--format=<TAB>` completes `table`/`json`. Install the completion script with `phel completion zsh` (or `bash`/`fish`) (#2451)
+- More shell completion for known option values: `phel compile --target=<TAB>` (`php`), plus `phel test --coverage=<TAB>` (`text`/`clover`), `--reporter=<TAB>` (`default`/`testdox`/`dot`/`tap`/`junit-xml`), and `--parallel=<TAB>` (`auto`/`max`) (#2451)
 
 ### Fixed
 

--- a/src/php/Run/Infrastructure/Command/CompileCommand.php
+++ b/src/php/Run/Infrastructure/Command/CompileCommand.php
@@ -60,6 +60,7 @@ final class CompileCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Compilation target. Currently only "php" is supported.',
                 self::TARGET_PHP,
+                self::SUPPORTED_TARGETS,
             );
     }
 

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -84,6 +84,7 @@ final class TestCommand extends Command
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Reporter to emit test events through. Repeatable. Built-ins: default, testdox, dot, tap, junit-xml.',
                 [],
+                ['default', 'testdox', 'dot', 'tap', 'junit-xml'],
             )->addOption(
                 TestCommandOptionParser::OPT_OUTPUT,
                 null,
@@ -144,6 +145,8 @@ final class TestCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Run namespaces in parallel using subprocess workers. Accepts an integer worker count, "auto" (CPU detection capped at 8), or "max" (every core the kernel reports, uncapped). Auto-disabled for --reporter=tap, --list, or when a profiler hook is installed.',
+                null,
+                ['auto', 'max'],
             )->addOption(
                 TestCommandOptionParser::OPT_WATCH,
                 null,
@@ -155,6 +158,7 @@ final class TestCommand extends Command
                 InputOption::VALUE_OPTIONAL,
                 'Collect line coverage (via pcov or xdebug) mapped back to .phel sources. Value is the format: "text" (default) or "clover".',
                 false,
+                ['text', 'clover'],
             )->addOption(
                 self::OPT_COVERAGE_OUTPUT,
                 null,

--- a/tests/php/Integration/Run/Command/Compile/CompileCommandTest.php
+++ b/tests/php/Integration/Run/Command/Compile/CompileCommandTest.php
@@ -8,6 +8,7 @@ use Phel\Phel;
 use Phel\Run\Infrastructure\Command\CompileCommand;
 use Phel\Run\Infrastructure\PhpStdinReader;
 use PhelTest\Integration\Run\Command\AbstractTestCommand;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 
 final class CompileCommandTest extends AbstractTestCommand
@@ -119,6 +120,14 @@ final class CompileCommandTest extends AbstractTestCommand
         $tester->assertCommandIsSuccessful();
         self::assertStringNotContainsString('compile-time-leak', $phpStdout);
         self::assertStringContainsString('"println"', $tester->getDisplay());
+    }
+
+    public function test_target_option_completes_supported_targets(): void
+    {
+        $tester = new CommandCompletionTester(new CompileCommand());
+        $suggestions = $tester->complete(['--target', '']);
+
+        self::assertSame(['php'], $suggestions);
     }
 
     private function stdinReader(string $contents): PhpStdinReader

--- a/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
+++ b/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
@@ -8,6 +8,7 @@ use Phel\Run\Infrastructure\Command\TestCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 
 final class TestCommandOptionsWiringTest extends TestCase
 {
@@ -125,6 +126,30 @@ final class TestCommandOptionsWiringTest extends TestCase
         self::assertStringContainsString('tag', strtolower($include->getDescription()));
         self::assertStringContainsString('skip', strtolower($exclude->getDescription()));
         self::assertStringContainsString('glob', strtolower($ns->getDescription()));
+    }
+
+    public function test_coverage_option_completes_formats(): void
+    {
+        $tester = new CommandCompletionTester(new TestCommand());
+
+        self::assertSame(['text', 'clover'], $tester->complete(['--coverage', '']));
+    }
+
+    public function test_reporter_option_completes_builtins(): void
+    {
+        $tester = new CommandCompletionTester(new TestCommand());
+
+        self::assertSame(
+            ['default', 'testdox', 'dot', 'tap', 'junit-xml'],
+            $tester->complete(['--reporter', '']),
+        );
+    }
+
+    public function test_parallel_option_completes_keywords(): void
+    {
+        $tester = new CommandCompletionTester(new TestCommand());
+
+        self::assertSame(['auto', 'max'], $tester->complete(['--parallel', '']));
     }
 
     private function definition(): InputDefinition


### PR DESCRIPTION
## 🤔 Background

Following #2452 (shell completion for `phel doc`), several other commands expose options whose valid values are a fixed, known set, but offered no tab-completion. Part of the DX umbrella issue #2451.

## 💡 Goal

Let the shell complete the known value sets so users don't have to remember exact spellings.

## 🔖 Changes

- `phel compile --target=<TAB>` → `php` (from `SUPPORTED_TARGETS`).
- `phel test --coverage=<TAB>` → `text` / `clover`.
- `phel test --reporter=<TAB>` → `default` / `testdox` / `dot` / `tap` / `junit-xml`.
- `phel test --parallel=<TAB>` → `auto` / `max`.

All are static `suggestedValues` arrays on the existing option definitions; no runtime work and no behaviour change to the commands themselves.

Tests: `CompileCommandTest::test_target_option_completes_supported_targets` and three new cases in `TestCommandOptionsWiringTest` using `CommandCompletionTester`. CHANGELOG updated under `## Unreleased`.

Refs #2451
