### PR TITLE
ref: resolve PHP 8.5 deprecation warnings in test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 - `phel build` run from the PHAR now compiles and harvests every `(load ...)` secondary of the bundled stdlib into the output tree, instead of short-circuiting to the precompiled siblings — so the deployable artifact (`php out/index.php`) is complete and runs standalone. `(load ...)` resolution and `PhelSourceLoader` now keep build mode active across a whole build so secondaries are recompiled rather than served from the PHAR bundle (regression from the precompiled-stdlib bundle; #2443)
 - `phel test`/`phel run` with a missing file path: no longer leaks a raw `file_get_contents(): Failed to open stream` PHP warning before the clean `Unable to read file "..."` error
+- PHP 8.5: guard `ReflectionClass::getConstant('BOUND_TO')` behind `hasConstant()` in `AbstractFn`, `FnPrinter`, `ProfilingFn`, and the Interop wrapper builder, so rendering/printing/profiling an anonymous function no longer emits the "getConstant() for a non-existent constant is deprecated" warning. The deprecated config setter tests are marked `#[IgnoreDeprecations]`, so `composer test` now runs deprecation-free on PHP 8.5 (#2455)
 
 ## [0.44.0](https://github.com/phel-lang/phel-lang/compare/v0.43.0...v0.44.0) - 2026-06-13
 

--- a/src/php/Interop/Domain/Generator/Builder/CompiledPhpMethodBuilder.php
+++ b/src/php/Interop/Domain/Generator/Builder/CompiledPhpMethodBuilder.php
@@ -33,7 +33,9 @@ final readonly class CompiledPhpMethodBuilder
     public function build(string $phelNs, FunctionToExport $functionToExport): string
     {
         $ref = new ReflectionClass($functionToExport->fn());
-        $boundTo = ScalarCoercion::toString($ref->getConstant('BOUND_TO'));
+        $boundTo = $ref->hasConstant('BOUND_TO')
+            ? ScalarCoercion::toString($ref->getConstant('BOUND_TO'))
+            : '';
         $refInvoke = $ref->getMethod('__invoke');
 
         return str_replace([

--- a/src/php/Lang/AbstractFn.php
+++ b/src/php/Lang/AbstractFn.php
@@ -23,7 +23,10 @@ abstract class AbstractFn implements FnInterface, MetaInterface, Stringable
 
     public function __toString(): string
     {
-        $boundTo = new ReflectionClass($this)->getConstant('BOUND_TO');
+        $reflection = new ReflectionClass($this);
+        $boundTo = $reflection->hasConstant('BOUND_TO')
+            ? $reflection->getConstant('BOUND_TO')
+            : null;
 
         if (!is_string($boundTo) || $boundTo === '') {
             return '<function>';

--- a/src/php/Profile/Domain/ProfilingFn.php
+++ b/src/php/Profile/Domain/ProfilingFn.php
@@ -25,7 +25,10 @@ final class ProfilingFn extends AbstractFn
         private readonly AbstractFn $inner,
         private readonly ProfilerSession $session,
     ) {
-        $constant = new ReflectionClass($inner)->getConstant('BOUND_TO');
+        $reflection = new ReflectionClass($inner);
+        $constant = $reflection->hasConstant('BOUND_TO')
+            ? $reflection->getConstant('BOUND_TO')
+            : null;
         $this->boundTo = is_string($constant) && $constant !== '' ? $constant : '<anonymous>';
         $this->withMeta($inner->getMeta());
     }

--- a/src/php/Shared/Printer/TypePrinter/FnPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/FnPrinter.php
@@ -32,7 +32,10 @@ final class FnPrinter implements TypePrinterInterface
 
     private function extractName(object $form): ?string
     {
-        $boundTo = new ReflectionClass($form)->getConstant('BOUND_TO');
+        $reflection = new ReflectionClass($form);
+        $boundTo = $reflection->hasConstant('BOUND_TO')
+            ? $reflection->getConstant('BOUND_TO')
+            : null;
 
         if (!is_string($boundTo) || $boundTo === '') {
             return null;

--- a/tests/php/Unit/Compiler/Config/PhelBuildConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelBuildConfigTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Unit\Compiler\Config;
 
 use Phel\Config\PhelBuildConfig;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 
 final class PhelBuildConfigTest extends TestCase
@@ -159,6 +160,7 @@ final class PhelBuildConfigTest extends TestCase
     }
 
     #[Group('deprecated')]
+    #[IgnoreDeprecations]
     public function test_deprecated_setters_still_work(): void
     {
         /** @psalm-suppress DeprecatedMethod */

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -9,6 +9,7 @@ use Phel\Config\PhelConfig;
 use Phel\Config\PhelExportConfig;
 use Phel\Config\ProjectLayout;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 
 final class PhelConfigTest extends TestCase
@@ -436,6 +437,7 @@ final class PhelConfigTest extends TestCase
     }
 
     #[Group('deprecated')]
+    #[IgnoreDeprecations]
     public function test_deprecated_setters_still_produce_equivalent_output(): void
     {
         /** @psalm-suppress DeprecatedMethod */
@@ -467,6 +469,7 @@ final class PhelConfigTest extends TestCase
     }
 
     #[Group('deprecated')]
+    #[IgnoreDeprecations]
     public function test_deprecated_layout_shortcuts_match_with_layout(): void
     {
         /** @psalm-suppress DeprecatedMethod */

--- a/tests/php/Unit/Compiler/Config/PhelExportConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelExportConfigTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Unit\Compiler\Config;
 
 use Phel\Config\PhelExportConfig;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 
 final class PhelExportConfigTest extends TestCase
@@ -63,6 +64,7 @@ final class PhelExportConfigTest extends TestCase
     }
 
     #[Group('deprecated')]
+    #[IgnoreDeprecations]
     public function test_deprecated_setters_still_work(): void
     {
         /** @psalm-suppress DeprecatedMethod */

--- a/tests/php/Unit/Lang/AbstractFnTest.php
+++ b/tests/php/Unit/Lang/AbstractFnTest.php
@@ -66,4 +66,32 @@ final class AbstractFnTest extends TestCase
 
         self::assertSame('Hello, <function:name>!', $result);
     }
+
+    public function test_to_string_does_not_deprecate_when_bound_to_is_absent(): void
+    {
+        $fn = new class() extends AbstractFn {
+            public function __invoke(...$args): mixed
+            {
+                return 'test';
+            }
+        };
+
+        $deprecations = [];
+        set_error_handler(
+            static function (int $errno, string $message) use (&$deprecations): bool {
+                $deprecations[] = $message;
+                return true;
+            },
+            E_DEPRECATED,
+        );
+
+        try {
+            $rendered = (string) $fn;
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertSame('<function>', $rendered);
+        self::assertSame([], $deprecations);
+    }
 }

--- a/tests/php/Unit/Printer/TypePrinter/FnPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/FnPrinterTest.php
@@ -21,4 +21,32 @@ final class FnPrinterTest extends TestCase
 
         self::assertSame('<function>', new FnPrinter()->print($class));
     }
+
+    public function test_print_does_not_deprecate_without_bound_to(): void
+    {
+        $class = new class() implements FnInterface {
+            public function __invoke(): string
+            {
+                return 'invoke method';
+            }
+        };
+
+        $deprecations = [];
+        set_error_handler(
+            static function (int $errno, string $message) use (&$deprecations): bool {
+                $deprecations[] = $message;
+                return true;
+            },
+            E_DEPRECATED,
+        );
+
+        try {
+            $rendered = new FnPrinter()->print($class);
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertSame('<function>', $rendered);
+        self::assertSame([], $deprecations);
+    }
 }


### PR DESCRIPTION
## 🤔 Background

On PHP 8.5, `composer test-compiler` surfaced 21 deprecation warnings. Two root causes: `ReflectionClass::getConstant()` called on a class that lacks the constant is now deprecated (hit whenever an anonymous function is rendered/printed/profiled), and the config-setter tests deliberately exercise the `#[Deprecated]` `set*()` shims.

## 💡 Goal

`composer test` runs deprecation-free on PHP 8.5, without losing coverage of the deprecated setters.

## 🔖 Changes

- Guard `ReflectionClass::getConstant('BOUND_TO')` behind `hasConstant()` in `AbstractFn`, `FnPrinter`, `ProfilingFn`, and the Interop wrapper builder (behaviour unchanged: absent constant still yields the anonymous/`<function>` path).
- Mark the dedicated `#[Group('deprecated')]` setter tests `#[IgnoreDeprecations]` — they keep asserting `set*()`/`with*()` equivalence, but no longer surface the intentional deprecation.
- Regression tests asserting no `E_DEPRECATED` is emitted for a `BOUND_TO`-less function (`AbstractFnTest`, `FnPrinterTest`).

Verified locally: `test-quality`, `test-compiler` (4457 tests, 0 deprecations), `test-core` (5964 tests) all green. Refactor pass: considered extracting a shared BOUND_TO reader but kept the guards inline — each call site has distinct downstream handling and the larger `AbstractFn`/`FnPrinter` name-munging duplication is pre-existing and out of scope here.

Closes #2455