### PR TITLE
perf(lang): fast-path native-int arithmetic in NumericOperations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
 - `phel run <TAB>` and `phel test <TAB>` / `phel test --ns=<TAB>` now complete the project's namespaces (source, test, and vendor source dirs); the shell narrows them as you type. Backed by a new `RunFacade::getAllNamespaces()` (#2451)
 - README "Get Started" now documents shell completion: `bash`/`zsh`/`fish` install snippets plus the `#compdef phel` global-binary prerequisite (completion only fires for a binary named `phel` on `$PATH`, so `./vendor/bin/phel` and `./bin/phel` dev checkouts need a global symlink first) (#2451)
 
+### Changed
+
+- Faster native-int arithmetic: `NumericOperations` (`+ - * /`, `compare`, `=`) now fast-paths two native PHP ints ahead of the `is_float`/`instanceof` dispatch ladder, skipping the per-call `ensureNumeric` validation and the type probes that the common case never needs. Micro-benchmarked per 32 ops (`NumericOperationsBench`): `compare` 2.01μs→0.56μs and `=` 2.05μs→0.56μs (~3.7x), `+` 2.49μs→1.00μs (~2.5x), `*` 3.45μs→1.94μs (~1.8x). Behaviour, contagion order, and overflow-to-`BigInt` promotion are unchanged
+
 ### Fixed
 
 - `phel build` run from the PHAR now compiles and harvests every `(load ...)` secondary of the bundled stdlib into the output tree, instead of short-circuiting to the precompiled siblings — so the deployable artifact (`php out/index.php`) is complete and runs standalone. `(load ...)` resolution and `PhelSourceLoader` now keep build mode active across a whole build so secondaries are recompiled rather than served from the PHAR bundle (regression from the precompiled-stdlib bundle; #2443)

--- a/src/php/Lang/NumericOperations.php
+++ b/src/php/Lang/NumericOperations.php
@@ -12,6 +12,7 @@ use function fdiv;
 use function floor;
 use function intdiv;
 use function is_float;
+use function is_int;
 
 /**
  * Runtime numeric dispatch for `+ - * /` and friends across native PHP
@@ -36,6 +37,17 @@ final class NumericOperations
 {
     public static function add(mixed $a, mixed $b): mixed
     {
+        // Fast path for the overwhelmingly common case: two native ints.
+        // `is_int` doubles as the numeric check, so it skips `ensureNumeric`
+        // and the whole `is_float`/`instanceof` ladder below.
+        if (is_int($a) && is_int($b)) {
+            if (IntegerOverflow::onAdd($a, $b)) {
+                return NumericCoercion::collapseBigInt(BigInt::fromInt($a)->add(BigInt::fromInt($b)));
+            }
+
+            return $a + $b;
+        }
+
         NumericCoercion::ensureNumeric($a);
         NumericCoercion::ensureNumeric($b);
 
@@ -58,19 +70,21 @@ final class NumericOperations
             return $b->add(NumericCoercion::rationalOperand($a));
         }
 
-        if ($a instanceof BigInt || $b instanceof BigInt) {
-            return NumericCoercion::collapseBigInt(NumericCoercion::toBigInt($a)->add(NumericCoercion::toBigInt($b)));
-        }
-
-        if (IntegerOverflow::onAdd($a, $b)) {
-            return NumericCoercion::collapseBigInt(BigInt::fromInt($a)->add(BigInt::fromInt($b)));
-        }
-
-        return $a + $b;
+        // int+int is handled by the fast path, so at least one operand is a
+        // BigInt here; lift both and collapse the result back when it fits.
+        return NumericCoercion::collapseBigInt(NumericCoercion::toBigInt($a)->add(NumericCoercion::toBigInt($b)));
     }
 
     public static function subtract(mixed $a, mixed $b): mixed
     {
+        if (is_int($a) && is_int($b)) {
+            if (IntegerOverflow::onSubtract($a, $b)) {
+                return NumericCoercion::collapseBigInt(BigInt::fromInt($a)->subtract(BigInt::fromInt($b)));
+            }
+
+            return $a - $b;
+        }
+
         NumericCoercion::ensureNumeric($a);
         NumericCoercion::ensureNumeric($b);
 
@@ -91,19 +105,19 @@ final class NumericOperations
             return self::negate($b->subtract(NumericCoercion::rationalOperand($a)));
         }
 
-        if ($a instanceof BigInt || $b instanceof BigInt) {
-            return NumericCoercion::collapseBigInt(NumericCoercion::toBigInt($a)->subtract(NumericCoercion::toBigInt($b)));
-        }
-
-        if (IntegerOverflow::onSubtract($a, $b)) {
-            return NumericCoercion::collapseBigInt(BigInt::fromInt($a)->subtract(BigInt::fromInt($b)));
-        }
-
-        return $a - $b;
+        return NumericCoercion::collapseBigInt(NumericCoercion::toBigInt($a)->subtract(NumericCoercion::toBigInt($b)));
     }
 
     public static function multiply(mixed $a, mixed $b): mixed
     {
+        if (is_int($a) && is_int($b)) {
+            if (IntegerOverflow::onMultiply($a, $b)) {
+                return NumericCoercion::collapseBigInt(BigInt::fromInt($a)->multiply(BigInt::fromInt($b)));
+            }
+
+            return $a * $b;
+        }
+
         NumericCoercion::ensureNumeric($a);
         NumericCoercion::ensureNumeric($b);
 
@@ -123,15 +137,7 @@ final class NumericOperations
             return $b->multiply(NumericCoercion::rationalOperand($a));
         }
 
-        if ($a instanceof BigInt || $b instanceof BigInt) {
-            return NumericCoercion::collapseBigInt(NumericCoercion::toBigInt($a)->multiply(NumericCoercion::toBigInt($b)));
-        }
-
-        if (IntegerOverflow::onMultiply($a, $b)) {
-            return NumericCoercion::collapseBigInt(BigInt::fromInt($a)->multiply(BigInt::fromInt($b)));
-        }
-
-        return $a * $b;
+        return NumericCoercion::collapseBigInt(NumericCoercion::toBigInt($a)->multiply(NumericCoercion::toBigInt($b)));
     }
 
     /**
@@ -140,6 +146,18 @@ final class NumericOperations
      */
     public static function divide(mixed $a, mixed $b): mixed
     {
+        if (is_int($a) && is_int($b)) {
+            if ($b === 0) {
+                throw new DivisionByZeroError('Division by zero');
+            }
+
+            if ($a % $b === 0) {
+                return intdiv($a, $b);
+            }
+
+            return Ratio::create($a, $b);
+        }
+
         NumericCoercion::ensureNumeric($a);
         NumericCoercion::ensureNumeric($b);
 
@@ -170,19 +188,9 @@ final class NumericOperations
             return self::divide(self::multiply($a, $b->denominator()), $b->numerator());
         }
 
-        if ($a instanceof BigInt || $b instanceof BigInt) {
-            return Ratio::create(NumericCoercion::toBigInt($a), NumericCoercion::toBigInt($b));
-        }
-
-        if ($b === 0) {
-            throw new DivisionByZeroError('Division by zero');
-        }
-
-        if ($a % $b === 0) {
-            return intdiv($a, $b);
-        }
-
-        return Ratio::create($a, $b);
+        // int/int is handled by the fast path, so at least one BigInt operand
+        // remains; an exact rational result is created and auto-collapsed.
+        return Ratio::create(NumericCoercion::toBigInt($a), NumericCoercion::toBigInt($b));
     }
 
     public static function negate(mixed $a): mixed
@@ -206,6 +214,10 @@ final class NumericOperations
 
     public static function compare(mixed $a, mixed $b): int
     {
+        if (is_int($a) && is_int($b)) {
+            return $a <=> $b;
+        }
+
         NumericCoercion::ensureNumeric($a);
         NumericCoercion::ensureNumeric($b);
 
@@ -225,15 +237,15 @@ final class NumericOperations
             return -$b->compareTo(NumericCoercion::rationalOperand($a));
         }
 
-        if ($a instanceof BigInt || $b instanceof BigInt) {
-            return NumericCoercion::toBigInt($a)->compareTo(NumericCoercion::toBigInt($b));
-        }
-
-        return $a <=> $b;
+        return NumericCoercion::toBigInt($a)->compareTo(NumericCoercion::toBigInt($b));
     }
 
     public static function isEqual(mixed $a, mixed $b): bool
     {
+        if (is_int($a) && is_int($b)) {
+            return $a === $b;
+        }
+
         NumericCoercion::ensureNumeric($a);
         NumericCoercion::ensureNumeric($b);
 
@@ -253,11 +265,7 @@ final class NumericOperations
             return $b->equals($a);
         }
 
-        if ($a instanceof BigInt || $b instanceof BigInt) {
-            return NumericCoercion::toBigInt($a)->equals(NumericCoercion::toBigInt($b));
-        }
-
-        return $a === $b;
+        return NumericCoercion::toBigInt($a)->equals(NumericCoercion::toBigInt($b));
     }
 
     public static function isZero(mixed $a): bool

--- a/tests/php/Benchmark/Lang/NumericOperationsBench.php
+++ b/tests/php/Benchmark/Lang/NumericOperationsBench.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Lang;
+
+use Phel\Lang\NumericOperations;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+
+/**
+ * Native-int arithmetic dispatch micro-benchmark.
+ *
+ * The compiler routes every Phel `+ - * < =` on numbers through
+ * {@see NumericOperations}. The overwhelmingly common runtime case is two
+ * native PHP ints (loop counters, indexes, small sums), which the dispatch
+ * ladders reach only after every `is_float`/`instanceof` check fails. This
+ * measures that hot path.
+ */
+final class NumericOperationsBench
+{
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(5)
+     */
+    public function bench_int_add(): void
+    {
+        for ($i = 0; $i < 32; ++$i) {
+            NumericOperations::add($i, 7);
+        }
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(5)
+     */
+    public function bench_int_compare(): void
+    {
+        for ($i = 0; $i < 32; ++$i) {
+            NumericOperations::compare($i, 16);
+        }
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(5)
+     */
+    public function bench_int_is_equal(): void
+    {
+        for ($i = 0; $i < 32; ++$i) {
+            NumericOperations::isEqual($i, 16);
+        }
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(5)
+     */
+    public function bench_int_multiply(): void
+    {
+        for ($i = 0; $i < 32; ++$i) {
+            NumericOperations::multiply($i, 3);
+        }
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Every Phel `+ - * / < =` on numbers is routed through `NumericOperations`. The overwhelmingly common runtime operand pair is two native PHP ints (loop counters, indexes, sums), yet that case was reached *last* — only after `ensureNumeric` on both operands plus the full `is_float`/`instanceof BigDecimal`/`Ratio`/`BigInt` ladder failed.

## 💡 Goal

Make the hot path cheap without changing any semantics.

## 🔖 Changes

- Hoist a leading `is_int($a) && is_int($b)` fast path into `add`, `subtract`, `multiply`, `divide`, `compare` and `isEqual`. `is_int` doubles as the numeric check, so the fast path also skips `ensureNumeric`. The now-unreachable trailing native-int branch collapses into the existing BigInt tail (no dead code).
- New `NumericOperationsBench` isolating the int dispatch.

Contagion order, overflow-to-`BigInt` promotion, and all results are unchanged.

### 📊 Benchmark (per 32 ops, `NumericOperationsBench`, rstdev <2.3%)

| op | before | after | speedup |
|----|--------|-------|---------|
| `compare` (`<`,`>`,…) | 2.01μs | 0.56μs | ~3.6x |
| `=` (`isEqual`) | 2.05μs | 0.56μs | ~3.7x |
| `+` (`add`) | 2.49μs | 1.00μs | ~2.5x |
| `*` (`multiply`) | 3.45μs | 1.94μs | ~1.8x |

Verified: `NumericOperationsTest` + numeric unit suite (329 tests), full `phel test` core suite (5964 tests), phpstan/psalm all green.