### PR TITLE
perf(lang): fast-path native-int quot/rem/mod in NumericOperations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Faster native-int arithmetic: `NumericOperations` (`+ - * /`, `compare`, `=`) now fast-paths two native PHP ints ahead of the `is_float`/`instanceof` dispatch ladder, skipping the per-call `ensureNumeric` validation and the type probes that the common case never needs. Micro-benchmarked per 32 ops (`NumericOperationsBench`): `compare` 2.01μs→0.56μs and `=` 2.05μs→0.56μs (~3.7x), `+` 2.49μs→1.00μs (~2.5x), `*` 3.45μs→1.94μs (~1.8x). Behaviour, contagion order, and overflow-to-`BigInt` promotion are unchanged
+- Faster native-int `quot`/`rem`/`mod` (`NumericOperations`): same native-int fast path now covers integer quotient, remainder and floor-modulo. `mod` benefits most because it previously composed `rem`, `isZero`, two `compare`s and `add` (each running its own dispatch ladder); the int path now computes directly. Micro-benchmarked per 32 ops: `mod` 7.41μs→0.90μs (~8.2x), `rem` 2.97μs→0.63μs (~4.7x), `quot` 3.00μs→0.76μs (~4x). Results unchanged
 
 ### Fixed
 

--- a/src/php/Lang/NumericOperations.php
+++ b/src/php/Lang/NumericOperations.php
@@ -345,6 +345,14 @@ final class NumericOperations
      */
     public static function quot(mixed $a, mixed $b): mixed
     {
+        if (is_int($a) && is_int($b)) {
+            if ($b === 0) {
+                throw new DivisionByZeroError('Division by zero');
+            }
+
+            return intdiv($a, $b);
+        }
+
         NumericCoercion::ensureNumeric($a);
         NumericCoercion::ensureNumeric($b);
 
@@ -371,11 +379,7 @@ final class NumericOperations
             return NumericCoercion::truncateToInt($quotient);
         }
 
-        if ($a instanceof BigInt || $b instanceof BigInt) {
-            return NumericCoercion::collapseBigInt(NumericCoercion::toBigInt($a)->divide(NumericCoercion::toBigInt($b)));
-        }
-
-        return intdiv($a, $b);
+        return NumericCoercion::collapseBigInt(NumericCoercion::toBigInt($a)->divide(NumericCoercion::toBigInt($b)));
     }
 
     /**
@@ -383,6 +387,14 @@ final class NumericOperations
      */
     public static function rem(mixed $a, mixed $b): mixed
     {
+        if (is_int($a) && is_int($b)) {
+            if ($b === 0) {
+                throw new DivisionByZeroError('Division by zero');
+            }
+
+            return $a % $b;
+        }
+
         NumericCoercion::ensureNumeric($a);
         NumericCoercion::ensureNumeric($b);
 
@@ -408,14 +420,11 @@ final class NumericOperations
             return self::subtract($a, self::multiply($b, $q));
         }
 
-        if ($a instanceof BigInt || $b instanceof BigInt) {
-            $aBig = NumericCoercion::toBigInt($a);
-            $bBig = NumericCoercion::toBigInt($b);
-            $q = $aBig->divide($bBig);
-            return NumericCoercion::collapseBigInt($aBig->subtract($bBig->multiply($q)));
-        }
+        $aBig = NumericCoercion::toBigInt($a);
+        $bBig = NumericCoercion::toBigInt($b);
+        $q = $aBig->divide($bBig);
 
-        return ($a) % ($b);
+        return NumericCoercion::collapseBigInt($aBig->subtract($bBig->multiply($q)));
     }
 
     /**
@@ -424,6 +433,21 @@ final class NumericOperations
      */
     public static function mod(mixed $a, mixed $b): mixed
     {
+        if (is_int($a) && is_int($b)) {
+            if ($b === 0) {
+                throw new DivisionByZeroError('Modulo by zero');
+            }
+
+            $rem = $a % $b;
+            // Floor-modulo: the result takes the sign of the divisor, so a
+            // truncated remainder whose sign differs is shifted by `b`.
+            if ($rem !== 0 && ($rem < 0) !== ($b < 0)) {
+                return $rem + $b;
+            }
+
+            return $rem;
+        }
+
         NumericCoercion::ensureNumeric($a);
         NumericCoercion::ensureNumeric($b);
 

--- a/tests/php/Benchmark/Lang/NumericOperationsBench.php
+++ b/tests/php/Benchmark/Lang/NumericOperationsBench.php
@@ -66,4 +66,40 @@ final class NumericOperationsBench
             NumericOperations::multiply($i, 3);
         }
     }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(5)
+     */
+    public function bench_int_quot(): void
+    {
+        for ($i = 0; $i < 32; ++$i) {
+            NumericOperations::quot($i, 3);
+        }
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(5)
+     */
+    public function bench_int_rem(): void
+    {
+        for ($i = 0; $i < 32; ++$i) {
+            NumericOperations::rem($i, 3);
+        }
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(5)
+     */
+    public function bench_int_mod(): void
+    {
+        for ($i = 0; $i < 32; ++$i) {
+            NumericOperations::mod($i, 3);
+        }
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Follow-up to #2458, which fast-pathed two native PHP ints in `+ - * / < =`. The integer-division family (`quot`, `rem`, `mod`) still reached its native path only after `ensureNumeric` + the full `is_float`/`instanceof` ladder. `mod` was the worst: it composed `rem`, `isZero`, two `compare`s and `add`, each running its own dispatch ladder.

## 💡 Goal

Extend the same native-int fast path to the modular operations.

## 🔖 Changes

- Leading `is_int($a) && is_int($b)` fast path in `quot`, `rem`, `mod`. `quot`/`rem` go straight to `intdiv`/`%` after a zero check; `mod` computes the floor-modulo directly (`$r = $a % $b; sign-adjust by $b`) instead of routing through five dispatched ops. The now-unreachable trailing native-int branches collapse into the BigInt tails (no dead code).
- `NumericOperationsBench` extended with `quot`/`rem`/`mod`.

Floor-modulo sign semantics, zero handling and BigInt promotion are unchanged.

### 📊 Benchmark (per 32 ops, `NumericOperationsBench`, rstdev <2.4%)

| op | before | after | speedup |
|----|--------|-------|---------|
| `mod` | 7.41μs | 0.90μs | ~8.2x |
| `rem` | 2.97μs | 0.63μs | ~4.7x |
| `quot` | 3.00μs | 0.76μs | ~4x |

Verified: numeric unit suite (329 tests), full `phel test` core suite (5964 tests), phpstan + psalm all green.