### PR TITLE
perf(core): drop apply round-trip in arithmetic nil check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 - Faster native-int arithmetic: `NumericOperations` (`+ - * /`, `compare`, `=`) now fast-paths two native PHP ints ahead of the `is_float`/`instanceof` dispatch ladder, skipping the per-call `ensureNumeric` validation and the type probes that the common case never needs. Micro-benchmarked per 32 ops (`NumericOperationsBench`): `compare` 2.01μs→0.56μs and `=` 2.05μs→0.56μs (~3.7x), `+` 2.49μs→1.00μs (~2.5x), `*` 3.45μs→1.94μs (~1.8x). Behaviour, contagion order, and overflow-to-`BigInt` promotion are unchanged
 - Faster native-int `quot`/`rem`/`mod` (`NumericOperations`): same native-int fast path now covers integer quotient, remainder and floor-modulo. `mod` benefits most because it previously composed `rem`, `isZero`, two `compare`s and `add` (each running its own dispatch ladder); the int path now computes directly. Micro-benchmarked per 32 ops: `mod` 7.41μs→0.90μs (~8.2x), `rem` 2.97μs→0.63μs (~4.7x), `quot` 3.00μs→0.76μs (~4x). Results unchanged
+- Faster core arithmetic wrappers: `+ - * /` and `bit-and`/`bit-or`/`bit-xor` no longer round-trip their already-collected variadic args through `apply` to reach the internal nil check. The hot path now calls `assert-non-nil-coll` on the arg collection directly, removing one function call plus an argument spread-and-re-collect per arithmetic operation. An arithmetic-dense workload (~8M ops via `reduce`) drops from ~32.8s to ~24.3s (~26% faster) end to end; the nil-argument error is unchanged
 
 ### Fixed
 

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -17,11 +17,15 @@
 ;; Math helpers
 ;; ---
 
-(defn- assert-non-nil
-  [& xs]
+(defn- assert-non-nil-coll
+  [xs]
   (foreach [x xs]
     (when (php/=== nil x)
       (throw (php/new \InvalidArgumentException "Arithmetic functions do not accept nil values")))))
+
+(defn- assert-non-nil
+  [& xs]
+  (assert-non-nil-coll xs))
 
 ;; -----------------
 ;; Bitwise operation
@@ -34,7 +38,7 @@
    :see-also ["bit-or" "bit-xor" "bit-not"]}
   [x y & args]
   (let [all (concat [x y] args)]
-    (apply assert-non-nil all)
+    (assert-non-nil-coll all)
     (reduce #(php/& %1 %2) all)))
 
 (defn bit-or
@@ -44,7 +48,7 @@
    :see-also ["bit-and" "bit-xor" "bit-not"]}
   [x y & args]
   (let [all (concat [x y] args)]
-    (apply assert-non-nil all)
+    (assert-non-nil-coll all)
     (reduce #(php/| %1 %2) all)))
 
 (defn bit-xor
@@ -54,7 +58,7 @@
    :see-also ["bit-and" "bit-or" "bit-not"]}
   [x y & args]
   (let [all (concat [x y] args)]
-    (apply assert-non-nil all)
+    (assert-non-nil-coll all)
     (reduce #(php/^ %1 %2) all)))
 
 (defn bit-not
@@ -125,7 +129,7 @@
   {:example "(+ 1 2 3) ; => 6"
    :see-also ["-" "*" "/" "sum"]}
   [& xs]
-  (apply assert-non-nil xs)
+  (assert-non-nil-coll xs)
   (case (count xs)
     0 0
     1 (first xs)
@@ -137,7 +141,7 @@
   {:example "(- 10 3 2) ; => 5\n(- 4) ; => -4"
    :see-also ["+" "*" "/"]}
   [& xs]
-  (apply assert-non-nil xs)
+  (assert-non-nil-coll xs)
   (case (count xs)
     0 0
     1 (php/:: NumericOperations (negate (first xs)))
@@ -149,7 +153,7 @@
   {:example "(* 2 3 4) ; => 24"
    :see-also ["+" "-" "/"]}
   [& xs]
-  (apply assert-non-nil xs)
+  (assert-non-nil-coll xs)
   (case (count xs)
     0 1
     1 (first xs)
@@ -166,7 +170,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(/ 1 2) ; => 1/2\n(/ 10 2) ; => 5"
    :see-also ["+" "-" "*" "quot" "mod"]}
   [& xs]
-  (apply assert-non-nil xs)
+  (assert-non-nil-coll xs)
   (case (count xs)
     0 1
     1 (php/:: NumericOperations (divide 1 (first xs)))


### PR DESCRIPTION
## 🤔 Background

Every `+ - * /` (and `bit-and`/`bit-or`/`bit-xor`) call validated its operands with `(apply assert-non-nil xs)`, where `xs` is the wrapper's already-collected variadic arg list. `apply` spreads `xs` back into positional arguments and the variadic `assert-non-nil [& xs]` immediately re-collects them — a pure round-trip plus an extra function call on *every* arithmetic operation.

Profiling an arithmetic-dense workload showed `assert-non-nil` among the top self-time functions, driven entirely by call volume.

## 💡 Goal

Remove the per-op `apply` round-trip without changing the nil-check behaviour.

## 🔖 Changes

- Add `assert-non-nil-coll`, which takes the operand collection directly. The hot wrappers (`+ - * /`, `bit-and/or/xor`) call it on `xs`/`all` instead of `(apply assert-non-nil …)`. The variadic `assert-non-nil` remains as a thin adapter for the fixed-arg (`bit-shift`, `quot`/`rem`/`mod`, …) and inline call sites.

Semantically identical — the same `InvalidArgumentException` fires on a nil operand.

### 📊 Measurement (end-to-end wall clock)

Reproducible workload — `reduce` over 1,000,000 steps, ~8 arithmetic ops each (~8M ops):

```clojure
(defn step [acc i]
  (-> acc (+ (* i 3)) (- (mod i 7)) (+ (* i i)) (- (mod (+ i 1) 5))))
(reduce step 0 (range 1000000))
```

| | wall clock (3 runs) |
|---|---|
| before | 32.66s / 32.77s / 32.82s |
| after | 24.92s / 23.99s / 24.11s |

**~26% faster**, stable across runs (±0.5%). Both states already include the native-int dispatch fast paths from #2458/#2459, so the delta is purely the `apply` removal.

Verified: full `phel test` core suite (5964 tests) green.