### PR TITLE
feat(lsp): resolve PHP interop receiver via :use aliases and multi-line forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Dispatch / call sites:
 
 ### Fixed
 
-- LSP/REPL PHP interop completion, hover, and signature help now resolve the receiver class through `(:use ...)` / `(use ...)` import aliases (short names or `:as` aliases) and across multi-line `(php/-> ...)` / `(php/:: ...)` forms; both previously produced no completion and silently fell back to plain Phel (follow-up to #2431)
+- LSP/REPL PHP interop completion, hover, and signature help now resolve the receiver class through `(:use ...)` / `(use ...)` import aliases (short names or `:as` aliases) and across multi-line `(php/-> ...)` / `(php/:: ...)` forms; both previously produced no completion and silently fell back to plain Phel (follow-up to #2431; #2461)
 - `phel build` from the PHAR now compiles and harvests every `(load ...)` stdlib secondary into the output tree, so `php out/index.php` runs standalone (regression from the precompiled-stdlib bundle in #2443; #2449)
 - `phel test`/`phel run` with a missing file path no longer leaks a raw `file_get_contents()` warning before the clean `Unable to read file "..."` error (#2442)
 - PHP 8.5: guard `ReflectionClass::getConstant('BOUND_TO')` behind `hasConstant()` and mark the deprecated-setter tests `#[IgnoreDeprecations]`, so `composer test` runs deprecation-free (#2455)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Dispatch / call sites:
 
 ### Fixed
 
-- LSP/REPL PHP interop completion, hover, and signature help now resolve the receiver class through `(:use ...)` / `(use ...)` import aliases (short names or `:as` aliases) and across multi-line `(php/-> ...)` / `(php/:: ...)` forms; both previously produced no completion and silently fell back to plain Phel (follow-up to #2431; #2461)
+- PHP interop completion/hover/signature help now resolves the receiver class through `(:use ...)`/`(use ...)` import aliases and across multi-line forms (follow-up to #2431; #2461)
 - `phel build` from the PHAR now compiles and harvests every `(load ...)` stdlib secondary into the output tree, so `php out/index.php` runs standalone (regression from the precompiled-stdlib bundle in #2443; #2449)
 - `phel test`/`phel run` with a missing file path no longer leaks a raw `file_get_contents()` warning before the clean `Unable to read file "..."` error (#2442)
 - PHP 8.5: guard `ReflectionClass::getConstant('BOUND_TO')` behind `hasConstant()` and mark the deprecated-setter tests `#[IgnoreDeprecations]`, so `composer test` runs deprecation-free (#2455)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Dispatch / call sites:
 
 ### Fixed
 
+- LSP/REPL PHP interop completion, hover, and signature help now resolve the receiver class through `(:use ...)` / `(use ...)` import aliases (short names or `:as` aliases) and across multi-line `(php/-> ...)` / `(php/:: ...)` forms; both previously produced no completion and silently fell back to plain Phel (follow-up to #2431)
 - `phel build` from the PHAR now compiles and harvests every `(load ...)` stdlib secondary into the output tree, so `php out/index.php` runs standalone (regression from the precompiled-stdlib bundle in #2443; #2449)
 - `phel test`/`phel run` with a missing file path no longer leaks a raw `file_get_contents()` warning before the clean `Unable to read file "..."` error (#2442)
 - PHP 8.5: guard `ReflectionClass::getConstant('BOUND_TO')` behind `hasConstant()` and mark the deprecated-setter tests `#[IgnoreDeprecations]`, so `composer test` runs deprecation-free (#2455)

--- a/src/php/Api/Application/CursorText.php
+++ b/src/php/Api/Application/CursorText.php
@@ -60,12 +60,14 @@ final class CursorText
     /**
      * Returns `$prefix` from the position of the outermost `(` that is still
      * open at its end, so callers only see the form the cursor is inside.
-     * String literals and `;` line comments are skipped while balancing.
+     * String literals and `;` line comments are skipped while balancing. Only
+     * parens are tracked (not `[`/`{`): the interop regexes are paren-delimited,
+     * so brackets/braces do not affect which `(` is outermost.
      */
     private static function fromEnclosingForm(string $prefix): string
     {
         $length = strlen($prefix);
-        $depthOpen = [];
+        $openParens = [];
         $inString = false;
         $i = 0;
 
@@ -89,21 +91,21 @@ final class CursorText
                     break;
                 }
 
-                $i = $newline;
+                $i = $newline + 1;
                 continue;
             } elseif ($char === '(') {
-                $depthOpen[] = $i;
+                $openParens[] = $i;
             } elseif ($char === ')') {
-                array_pop($depthOpen);
+                array_pop($openParens);
             }
 
             ++$i;
         }
 
-        if ($depthOpen === []) {
+        if ($openParens === []) {
             return $prefix;
         }
 
-        return substr($prefix, $depthOpen[0]);
+        return substr($prefix, $openParens[0]);
     }
 }

--- a/src/php/Api/Application/CursorText.php
+++ b/src/php/Api/Application/CursorText.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace Phel\Api\Application;
 
+use function array_pop;
+use function array_slice;
+use function implode;
 use function max;
 use function preg_match;
 use function preg_split;
 use function strlen;
+use function strpos;
 use function substr;
 
 /**
@@ -17,7 +21,11 @@ use function substr;
 final class CursorText
 {
     /**
-     * The text on `$line` up to (not including) the cursor column.
+     * The source up to (not including) the cursor, trimmed to the start of the
+     * outermost interop form still open at the cursor. Spanning multiple lines
+     * lets the resolver see a `(php/-> recv\n  (method ...))` whose opener sits
+     * on an earlier line; trimming to the enclosing form stops an earlier,
+     * already-closed sibling form from hijacking the (anchored, lazy) regexes.
      */
     public static function before(string $source, int $line, int $col): string
     {
@@ -26,7 +34,10 @@ final class CursorText
             return '';
         }
 
-        return substr($lines[$line - 1], 0, max(0, $col - 1));
+        $prefixLines = array_slice($lines, 0, $line - 1);
+        $prefixLines[] = substr($lines[$line - 1], 0, max(0, $col - 1));
+
+        return self::fromEnclosingForm(implode("\n", $prefixLines));
     }
 
     /**
@@ -44,5 +55,55 @@ final class CursorText
         }
 
         return $col;
+    }
+
+    /**
+     * Returns `$prefix` from the position of the outermost `(` that is still
+     * open at its end, so callers only see the form the cursor is inside.
+     * String literals and `;` line comments are skipped while balancing.
+     */
+    private static function fromEnclosingForm(string $prefix): string
+    {
+        $length = strlen($prefix);
+        $depthOpen = [];
+        $inString = false;
+        $i = 0;
+
+        while ($i < $length) {
+            $char = $prefix[$i];
+
+            if ($inString) {
+                if ($char === '\\') {
+                    $i += 2;
+                    continue;
+                }
+
+                if ($char === '"') {
+                    $inString = false;
+                }
+            } elseif ($char === '"') {
+                $inString = true;
+            } elseif ($char === ';') {
+                $newline = strpos($prefix, "\n", $i);
+                if ($newline === false) {
+                    break;
+                }
+
+                $i = $newline;
+                continue;
+            } elseif ($char === '(') {
+                $depthOpen[] = $i;
+            } elseif ($char === ')') {
+                array_pop($depthOpen);
+            }
+
+            ++$i;
+        }
+
+        if ($depthOpen === []) {
+            return $prefix;
+        }
+
+        return substr($prefix, $depthOpen[0]);
     }
 }

--- a/src/php/Api/Application/PhpImportAliasExtractor.php
+++ b/src/php/Api/Application/PhpImportAliasExtractor.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use function array_merge;
+use function count;
+use function explode;
+use function ltrim;
+use function preg_match_all;
+use function preg_split;
+use function str_replace;
+use function trim;
+
+/**
+ * Extracts the `short-name => fully-qualified-name` table for PHP classes
+ * imported via `(ns ... (:use Foo\Bar :as B))` or top-level `(use ...)`.
+ * Detection is lexical so it keeps working on a mid-edit, unparseable buffer.
+ */
+final class PhpImportAliasExtractor
+{
+    /**
+     * @return array<string, string>
+     */
+    public function extract(string $source): array
+    {
+        if (preg_match_all('/\(\s*(?::use|use)\s+([^()]*)\)/', $source, $clauses) === false) {
+            return [];
+        }
+
+        $aliases = [];
+        foreach ($clauses[1] as $clause) {
+            $aliases = array_merge($aliases, $this->clauseAliases($clause));
+        }
+
+        return $aliases;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function clauseAliases(string $clause): array
+    {
+        $tokens = preg_split('/\s+/', trim($clause)) ?: [];
+        $count = count($tokens);
+        $aliases = [];
+        $i = 0;
+
+        while ($i < $count) {
+            $import = $tokens[$i];
+            ++$i;
+
+            if ($import === '') {
+                continue;
+            }
+
+            if ($import[0] === ':') {
+                continue;
+            }
+
+            $fqn = $this->normalize($import);
+            if ($fqn === '') {
+                continue;
+            }
+
+            [$alias, $i] = $this->aliasFor($tokens, $count, $i, $fqn);
+            $aliases[$alias] = $fqn;
+        }
+
+        return $aliases;
+    }
+
+    /**
+     * Resolves the alias for an import: an explicit `:as Alias` when present,
+     * otherwise the last `\`-segment of the import. Returns the alias paired
+     * with the token index to continue scanning from.
+     *
+     * @param list<string> $tokens
+     *
+     * @return array{string, int}
+     */
+    private function aliasFor(array $tokens, int $count, int $i, string $fqn): array
+    {
+        if ($i + 1 < $count && $tokens[$i] === ':as') {
+            return [$this->normalize($tokens[$i + 1]), $i + 2];
+        }
+
+        $segments = explode('\\', $fqn);
+
+        return [end($segments), $i];
+    }
+
+    private function normalize(string $name): string
+    {
+        return str_replace('.', '\\', ltrim($name, '\\'));
+    }
+}

--- a/src/php/Api/Application/PhpInteropContextResolver.php
+++ b/src/php/Api/Application/PhpInteropContextResolver.php
@@ -6,9 +6,14 @@ namespace Phel\Api\Application;
 
 use Phel\Api\Transfer\PhpInteropContext;
 
+use function count;
+use function explode;
 use function ltrim;
 use function preg_match;
+use function preg_match_all;
 use function preg_quote;
+use function preg_split;
+use function str_replace;
 use function trim;
 
 /**
@@ -17,6 +22,10 @@ use function trim;
  * working while the buffer is mid-edit and unparseable; an unrecognised
  * position yields {@see PhpInteropContext::none()} so completion degrades to
  * the normal Phel behaviour.
+ *
+ * Short class names imported via `(ns ... (:use Foo\Bar [:as B]))` or top-level
+ * `(use ...)` are mapped back to their fully-qualified name so the reflector can
+ * resolve them.
  */
 final readonly class PhpInteropContextResolver
 {
@@ -68,17 +77,18 @@ final readonly class PhpInteropContextResolver
 
     /**
      * Resolves a receiver expression to a class name. Handles a class literal
-     * (`\Foo`, `Foo\Bar`), an inline `(php/new \Foo ...)`, or a bare symbol
-     * whose `:tag` / reader-tag / `(php/new ...)` binding is found in the
-     * source. Returns '' when the type is unknown.
+     * (`\Foo`, `Foo\Bar`), an inline `(php/new \Foo ...)`, an imported short
+     * name (`(:use Foo\Bar)` → `Bar`), or a bare symbol whose `:tag` /
+     * reader-tag / `(php/new ...)` binding is found in the source. Returns ''
+     * when the type is unknown.
      */
     private function resolveReceiverClass(string $receiver, string $source): string
     {
         $receiver = trim($receiver);
 
         // Inline construction: (php/-> (php/new \Foo ...) ...)
-        if (preg_match('/\(\s*php\/new\s+\\\\?([A-Za-z0-9_\\\\]+)/', $receiver, $m) === 1) {
-            return ltrim($m[1], '\\');
+        if (preg_match('/\(\s*php\/new\s+\\\\?([A-Za-z0-9_\\\\.]+)/', $receiver, $m) === 1) {
+            return $this->mapAlias($m[1], $source);
         }
 
         // Class literal: \Foo, \Foo\Bar, or Foo\Bar.
@@ -90,8 +100,13 @@ final readonly class PhpInteropContextResolver
             return $m[1];
         }
 
-        // Bare symbol: look up its type from the surrounding source.
+        // Bare symbol: an imported short name first, else a typed local binding.
         if (preg_match('/^[A-Za-z_][A-Za-z0-9_\-]*$/', $receiver) === 1) {
+            $imported = $this->aliasMap($source)[$receiver] ?? '';
+            if ($imported !== '') {
+                return $imported;
+            }
+
             return $this->resolveSymbolTag($receiver, $source);
         }
 
@@ -101,27 +116,103 @@ final readonly class PhpInteropContextResolver
     /**
      * Searches the source for a type annotation of a local binding named
      * `$symbol`: a `^{:tag \Type}` map, a `^\Type` reader tag, or a
-     * `[symbol (php/new \Type ...)]` binding.
+     * `[symbol (php/new \Type ...)]` binding. The resolved name is mapped
+     * through the import-alias table so a `:use`d short name becomes its FQN.
      */
     private function resolveSymbolTag(string $symbol, string $source): string
     {
         $quoted = preg_quote($symbol, '/');
+        $name = '';
 
         // ^{:tag \Type} symbol  /  ^{:tag Type} symbol
-        if (preg_match('/\^\{[^}]*:tag\s+\\\\?([A-Za-z0-9_\\\\]+)[^}]*\}\s+' . $quoted . '\b/', $source, $m) === 1) {
-            return ltrim($m[1], '\\');
+        if (preg_match('/\^\{[^}]*:tag\s+\\\\?([A-Za-z0-9_\\\\.]+)[^}]*\}\s+' . $quoted . '\b/', $source, $m) === 1) {
+            $name = $m[1];
+        } elseif (preg_match('/\^\\\\?([A-Za-z_][A-Za-z0-9_\\\\.]*)\s+' . $quoted . '\b/', $source, $m) === 1) {
+            // ^\Type symbol  /  ^Type symbol
+            $name = $m[1];
+        } elseif (preg_match('/\b' . $quoted . '\s+\(\s*php\/new\s+\\\\?([A-Za-z0-9_\\\\.]+)/', $source, $m) === 1) {
+            // [symbol (php/new \Type ...)]  binding
+            $name = $m[1];
         }
 
-        // ^\Type symbol  /  ^Type symbol
-        if (preg_match('/\^\\\\?([A-Za-z_][A-Za-z0-9_\\\\]*)\s+' . $quoted . '\b/', $source, $m) === 1) {
-            return ltrim($m[1], '\\');
+        if ($name === '') {
+            return '';
         }
 
-        // [symbol (php/new \Type ...)]  binding
-        if (preg_match('/\b' . $quoted . '\s+\(\s*php\/new\s+\\\\?([A-Za-z0-9_\\\\]+)/', $source, $m) === 1) {
-            return ltrim($m[1], '\\');
+        return $this->mapAlias($name, $source);
+    }
+
+    /**
+     * Maps a (possibly short, possibly `.`-separated) class name to its
+     * fully-qualified `\`-separated form, using the import-alias table when the
+     * name is an imported alias and otherwise normalising it as-is.
+     */
+    private function mapAlias(string $name, string $source): string
+    {
+        $normalized = str_replace('.', '\\', ltrim($name, '\\'));
+
+        return $this->aliasMap($source)[$normalized] ?? $normalized;
+    }
+
+    /**
+     * Builds the `short-name => FQN` table from every `(:use ...)` (inside an
+     * `ns` form) and top-level `(use ...)` clause in the source. Honours
+     * `:as Alias`; otherwise the alias is the last `\`-segment of the import.
+     *
+     * @return array<string, string>
+     */
+    private function aliasMap(string $source): array
+    {
+        $map = [];
+
+        if (preg_match_all('/\(\s*(?::use|use)\s+([^()]*)\)/', $source, $clauses) === false) {
+            return $map;
         }
 
-        return '';
+        foreach ($clauses[1] as $clause) {
+            $this->collectAliases($clause, $map);
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array<string, string> $map
+     */
+    private function collectAliases(string $clause, array &$map): void
+    {
+        $tokens = preg_split('/\s+/', trim($clause)) ?: [];
+        $count = count($tokens);
+        $i = 0;
+
+        while ($i < $count) {
+            $token = $tokens[$i];
+            ++$i;
+            if ($token === '') {
+                continue;
+            }
+
+            if ($token[0] === ':') {
+                continue;
+            }
+
+            $fqn = str_replace('.', '\\', ltrim($token, '\\'));
+            if ($fqn === '') {
+                continue;
+            }
+
+            $alias = '';
+            if ($i + 1 < $count && $tokens[$i] === ':as') {
+                $alias = $tokens[$i + 1];
+                $i += 2;
+            }
+
+            if ($alias === '') {
+                $parts = explode('\\', $fqn);
+                $alias = $parts[count($parts) - 1];
+            }
+
+            $map[str_replace('.', '\\', ltrim($alias, '\\'))] = $fqn;
+        }
     }
 }

--- a/src/php/Api/Application/PhpInteropContextResolver.php
+++ b/src/php/Api/Application/PhpInteropContextResolver.php
@@ -6,13 +6,9 @@ namespace Phel\Api\Application;
 
 use Phel\Api\Transfer\PhpInteropContext;
 
-use function count;
-use function explode;
 use function ltrim;
 use function preg_match;
-use function preg_match_all;
 use function preg_quote;
-use function preg_split;
 use function str_replace;
 use function trim;
 
@@ -23,12 +19,16 @@ use function trim;
  * position yields {@see PhpInteropContext::none()} so completion degrades to
  * the normal Phel behaviour.
  *
- * Short class names imported via `(ns ... (:use Foo\Bar [:as B]))` or top-level
- * `(use ...)` are mapped back to their fully-qualified name so the reflector can
- * resolve them.
+ * Short class names imported via `(ns ... (:use Foo\Bar :as B))` or top-level
+ * `(use ...)` are mapped back to their fully-qualified name (via
+ * {@see PhpImportAliasExtractor}) so the reflector can resolve them.
  */
 final readonly class PhpInteropContextResolver
 {
+    public function __construct(
+        private PhpImportAliasExtractor $aliasExtractor = new PhpImportAliasExtractor(),
+    ) {}
+
     /**
      * @param int $line 1-based line number
      * @param int $col  1-based cursor column
@@ -39,22 +39,12 @@ final readonly class PhpInteropContextResolver
 
         // (php/-> receiver method|)  or  (php/-> receiver (method|))
         if (preg_match('/\(\s*php\/->\s+(.+?)\s+\(?([A-Za-z0-9_]*)$/s', $before, $m) === 1) {
-            $class = $this->resolveReceiverClass($m[1], $source);
-            if ($class !== '') {
-                return new PhpInteropContext(PhpInteropContext::KIND_INSTANCE_MEMBER, $m[2], $class);
-            }
-
-            return PhpInteropContext::none();
+            return $this->memberContext(PhpInteropContext::KIND_INSTANCE_MEMBER, $m, $source);
         }
 
         // (php/:: Class method|)  or  (php/:: Class (method|))
         if (preg_match('/\(\s*php\/::\s+(.+?)\s+\(?([A-Za-z0-9_]*)$/s', $before, $m) === 1) {
-            $class = $this->resolveReceiverClass($m[1], $source);
-            if ($class !== '') {
-                return new PhpInteropContext(PhpInteropContext::KIND_STATIC_MEMBER, $m[2], $class);
-            }
-
-            return PhpInteropContext::none();
+            return $this->memberContext(PhpInteropContext::KIND_STATIC_MEMBER, $m, $source);
         }
 
         // (php/new \Foo|
@@ -76,38 +66,58 @@ final readonly class PhpInteropContextResolver
     }
 
     /**
+     * Builds an instance/static member context from a matched `(php/-> ...)` /
+     * `(php/:: ...)` form, resolving the receiver to a class. Yields
+     * {@see PhpInteropContext::none()} when the receiver type is unknown.
+     *
+     * @param array{0: string, 1: string, 2: string} $m
+     */
+    private function memberContext(string $kind, array $m, string $source): PhpInteropContext
+    {
+        $aliases = $this->aliasExtractor->extract($source);
+        $class = $this->resolveReceiverClass($m[1], $source, $aliases);
+
+        if ($class === '') {
+            return PhpInteropContext::none();
+        }
+
+        return new PhpInteropContext($kind, $m[2], $class);
+    }
+
+    /**
      * Resolves a receiver expression to a class name. Handles a class literal
      * (`\Foo`, `Foo\Bar`), an inline `(php/new \Foo ...)`, an imported short
      * name (`(:use Foo\Bar)` → `Bar`), or a bare symbol whose `:tag` /
      * reader-tag / `(php/new ...)` binding is found in the source. Returns ''
      * when the type is unknown.
+     *
+     * @param array<string, string> $aliases
      */
-    private function resolveReceiverClass(string $receiver, string $source): string
+    private function resolveReceiverClass(string $receiver, string $source, array $aliases): string
     {
         $receiver = trim($receiver);
 
         // Inline construction: (php/-> (php/new \Foo ...) ...)
         if (preg_match('/\(\s*php\/new\s+\\\\?([A-Za-z0-9_\\\\.]+)/', $receiver, $m) === 1) {
-            return $this->mapAlias($m[1], $source);
+            return $this->mapAlias($m[1], $aliases);
         }
 
-        // Class literal: \Foo, \Foo\Bar, or Foo\Bar.
+        // Class literal kept separate from the bare-symbol branch below so a
+        // single unqualified name (e.g. `Widget`) is NOT treated as a literal
+        // and can instead resolve through the import-alias table.
+        // Multi-segment literal: \Foo\Bar or Foo\Bar.
         if (preg_match('/^\\\\?([A-Za-z_]\w*(?:\\\\[A-Za-z_]\w*)+)$/', $receiver, $m) === 1) {
             return ltrim($m[1], '\\');
         }
 
+        // Single segment with a leading backslash: \Foo.
         if (preg_match('/^\\\\([A-Za-z_]\w*)$/', $receiver, $m) === 1) {
             return $m[1];
         }
 
         // Bare symbol: an imported short name first, else a typed local binding.
         if (preg_match('/^[A-Za-z_][A-Za-z0-9_\-]*$/', $receiver) === 1) {
-            $imported = $this->aliasMap($source)[$receiver] ?? '';
-            if ($imported !== '') {
-                return $imported;
-            }
-
-            return $this->resolveSymbolTag($receiver, $source);
+            return $aliases[$receiver] ?? $this->resolveSymbolTag($receiver, $source, $aliases);
         }
 
         return '';
@@ -118,8 +128,10 @@ final readonly class PhpInteropContextResolver
      * `$symbol`: a `^{:tag \Type}` map, a `^\Type` reader tag, or a
      * `[symbol (php/new \Type ...)]` binding. The resolved name is mapped
      * through the import-alias table so a `:use`d short name becomes its FQN.
+     *
+     * @param array<string, string> $aliases
      */
-    private function resolveSymbolTag(string $symbol, string $source): string
+    private function resolveSymbolTag(string $symbol, string $source, array $aliases): string
     {
         $quoted = preg_quote($symbol, '/');
         $name = '';
@@ -139,80 +151,20 @@ final readonly class PhpInteropContextResolver
             return '';
         }
 
-        return $this->mapAlias($name, $source);
+        return $this->mapAlias($name, $aliases);
     }
 
     /**
      * Maps a (possibly short, possibly `.`-separated) class name to its
      * fully-qualified `\`-separated form, using the import-alias table when the
      * name is an imported alias and otherwise normalising it as-is.
+     *
+     * @param array<string, string> $aliases
      */
-    private function mapAlias(string $name, string $source): string
+    private function mapAlias(string $name, array $aliases): string
     {
         $normalized = str_replace('.', '\\', ltrim($name, '\\'));
 
-        return $this->aliasMap($source)[$normalized] ?? $normalized;
-    }
-
-    /**
-     * Builds the `short-name => FQN` table from every `(:use ...)` (inside an
-     * `ns` form) and top-level `(use ...)` clause in the source. Honours
-     * `:as Alias`; otherwise the alias is the last `\`-segment of the import.
-     *
-     * @return array<string, string>
-     */
-    private function aliasMap(string $source): array
-    {
-        $map = [];
-
-        if (preg_match_all('/\(\s*(?::use|use)\s+([^()]*)\)/', $source, $clauses) === false) {
-            return $map;
-        }
-
-        foreach ($clauses[1] as $clause) {
-            $this->collectAliases($clause, $map);
-        }
-
-        return $map;
-    }
-
-    /**
-     * @param array<string, string> $map
-     */
-    private function collectAliases(string $clause, array &$map): void
-    {
-        $tokens = preg_split('/\s+/', trim($clause)) ?: [];
-        $count = count($tokens);
-        $i = 0;
-
-        while ($i < $count) {
-            $token = $tokens[$i];
-            ++$i;
-            if ($token === '') {
-                continue;
-            }
-
-            if ($token[0] === ':') {
-                continue;
-            }
-
-            $fqn = str_replace('.', '\\', ltrim($token, '\\'));
-            if ($fqn === '') {
-                continue;
-            }
-
-            $alias = '';
-            if ($i + 1 < $count && $tokens[$i] === ':as') {
-                $alias = $tokens[$i + 1];
-                $i += 2;
-            }
-
-            if ($alias === '') {
-                $parts = explode('\\', $fqn);
-                $alias = $parts[count($parts) - 1];
-            }
-
-            $map[str_replace('.', '\\', ltrim($alias, '\\'))] = $fqn;
-        }
+        return $aliases[$normalized] ?? $normalized;
     }
 }

--- a/src/php/Api/CLAUDE.md
+++ b/src/php/Api/CLAUDE.md
@@ -9,7 +9,7 @@ REPL autocompletion, function introspection, documentation, and user-code semant
 - `analyzeSource(string, string): list<Diagnostic>`: parse and analyze, return diagnostics
 - `findSymbolMetadata(string, string = 'user')`: symbol lookup in registry and static catalog
 - `indexProject`, `resolveSymbol`, `findReferences`, `completeAtPoint`: project-level symbol tooling (`ProjectIndex`, `Definition`, `Location`, `Completion` transfers)
-- PHP interop tooling: `completeAtPoint` returns interop completions when the cursor is in a `php/`-interop position (else Phel completions); `phpInteropHoverAt`/`phpInteropSignatureAt` return reflected hover markdown / LSP signature help. Backed by `PhpInteropReflector` (reflection + composer classmap), `PhpInteropContextResolver` (lexical receiver-type resolution from `:tag`/inline `php/new`/binding), `PhpInteropCompleter`, and `PhpInteropDocResolver`. All degrade to empty/null on unknown types or reflection failure
+- PHP interop tooling: `completeAtPoint` returns interop completions when the cursor is in a `php/`-interop position (else Phel completions); `phpInteropHoverAt`/`phpInteropSignatureAt` return reflected hover markdown / LSP signature help. Backed by `PhpInteropReflector` (reflection + composer classmap), `PhpInteropContextResolver` (lexical receiver-type resolution from `:tag`/inline `php/new`/binding, `(:use ...)`/`(use ...)` import aliases incl. `:as`, multi-line forms via `CursorText::before` which trims to the enclosing form), `PhpInteropCompleter`, and `PhpInteropDocResolver`. All degrade to empty/null on unknown types or reflection failure
 - `createApiDaemon()`: long-running JSON-RPC daemon
 
 ## Dependencies

--- a/tests/php/Integration/Lsp/PhpInteropLspTest.php
+++ b/tests/php/Integration/Lsp/PhpInteropLspTest.php
@@ -54,7 +54,7 @@ final class PhpInteropLspTest extends TestCase
 
         // Cursor right after "createFr" on line 2.
         $result = $this->completion()->handle(
-            $this->params($uri, line: 1, character: 18),
+            $this->params($uri, line: 1, character: 19),
             $session,
         );
 

--- a/tests/php/Integration/Lsp/PhpInteropLspTest.php
+++ b/tests/php/Integration/Lsp/PhpInteropLspTest.php
@@ -46,6 +46,44 @@ final class PhpInteropLspTest extends TestCase
 
     #[PreserveGlobalState(false)]
     #[RunInSeparateProcess]
+    public function test_completion_lists_static_members_for_use_aliased_class(): void
+    {
+        $uri = 'file:///x.phel';
+        $source = "(ns app (:use DateTimeImmutable :as DT))\n(php/:: DT createFr)";
+        $session = $this->sessionWith($uri, $source);
+
+        // Cursor right after "createFr" on line 2.
+        $result = $this->completion()->handle(
+            $this->params($uri, line: 1, character: 18),
+            $session,
+        );
+
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('createFromFormat', $labels);
+        self::assertContains('createFromInterface', $labels);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_completion_lists_instance_methods_for_multiline_receiver(): void
+    {
+        $uri = 'file:///x.phel';
+        $source = "(php/-> (php/new \\DateTimeImmutable)\n  (getTim))";
+        $session = $this->sessionWith($uri, $source);
+
+        // Cursor right after "(getTim" on line 2.
+        $result = $this->completion()->handle(
+            $this->params($uri, line: 1, character: 9),
+            $session,
+        );
+
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('getTimestamp', $labels);
+        self::assertContains('getTimezone', $labels);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function test_completion_lists_class_names_after_php_new(): void
     {
         $uri = 'file:///x.phel';

--- a/tests/php/Unit/Api/Application/PhpImportAliasExtractorTest.php
+++ b/tests/php/Unit/Api/Application/PhpImportAliasExtractorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\PhpImportAliasExtractor;
+use PHPUnit\Framework\TestCase;
+
+final class PhpImportAliasExtractorTest extends TestCase
+{
+    private PhpImportAliasExtractor $extractor;
+
+    protected function setUp(): void
+    {
+        $this->extractor = new PhpImportAliasExtractor();
+    }
+
+    public function test_ns_use_maps_last_segment_to_fqn(): void
+    {
+        $aliases = $this->extractor->extract('(ns app (:use Some\\Long\\Widget))');
+
+        self::assertSame(['Widget' => 'Some\\Long\\Widget'], $aliases);
+    }
+
+    public function test_top_level_use_is_collected(): void
+    {
+        $aliases = $this->extractor->extract('(use Some\\Long\\Widget)');
+
+        self::assertSame(['Widget' => 'Some\\Long\\Widget'], $aliases);
+    }
+
+    public function test_as_alias_overrides_the_short_name(): void
+    {
+        $aliases = $this->extractor->extract('(ns app (:use Some\\Long\\Widget :as W))');
+
+        self::assertSame(['W' => 'Some\\Long\\Widget'], $aliases);
+    }
+
+    public function test_multiple_imports_in_one_clause(): void
+    {
+        $aliases = $this->extractor->extract('(ns app (:use A\\Foo B\\Bar :as Baz))');
+
+        self::assertSame(['Foo' => 'A\\Foo', 'Baz' => 'B\\Bar'], $aliases);
+    }
+
+    public function test_dot_separator_is_normalised_to_backslash(): void
+    {
+        $aliases = $this->extractor->extract('(use Some.Long.Widget)');
+
+        self::assertSame(['Widget' => 'Some\\Long\\Widget'], $aliases);
+    }
+
+    public function test_source_without_imports_yields_empty_map(): void
+    {
+        self::assertSame([], $this->extractor->extract('(defn foo [x] (inc x))'));
+    }
+
+    public function test_use_prefixed_symbol_is_not_mistaken_for_an_import(): void
+    {
+        self::assertSame([], $this->extractor->extract('(use-fixtures :each setup)'));
+    }
+}

--- a/tests/php/Unit/Api/Application/PhpInteropContextResolverTest.php
+++ b/tests/php/Unit/Api/Application/PhpInteropContextResolverTest.php
@@ -91,6 +91,72 @@ final class PhpInteropContextResolverTest extends TestCase
         self::assertSame('strle', $context->prefix);
     }
 
+    public function test_static_member_via_use_alias(): void
+    {
+        $source = "(ns app (:use Some\\Long\\Widget))\n(php/:: Widget create";
+        $context = $this->resolveAtEnd($source);
+
+        self::assertSame(PhpInteropContext::KIND_STATIC_MEMBER, $context->kind);
+        self::assertSame('Some\\Long\\Widget', $context->class);
+        self::assertSame('create', $context->prefix);
+    }
+
+    public function test_static_member_via_use_alias_with_as(): void
+    {
+        $source = "(ns app (:use Some\\Long\\Widget :as W))\n(php/:: W create";
+        $context = $this->resolveAtEnd($source);
+
+        self::assertSame(PhpInteropContext::KIND_STATIC_MEMBER, $context->kind);
+        self::assertSame('Some\\Long\\Widget', $context->class);
+    }
+
+    public function test_static_member_via_top_level_use(): void
+    {
+        $source = "(use Some\\Long\\Widget)\n(php/:: Widget create";
+        $context = $this->resolveAtEnd($source);
+
+        self::assertSame(PhpInteropContext::KIND_STATIC_MEMBER, $context->kind);
+        self::assertSame('Some\\Long\\Widget', $context->class);
+    }
+
+    public function test_instance_member_via_use_alias_php_new_binding(): void
+    {
+        $source = "(ns app (:use Some\\Long\\Widget))\n(let [w (php/new Widget)]\n  (php/-> w handle";
+        $context = $this->resolveAtEnd($source);
+
+        self::assertSame(PhpInteropContext::KIND_INSTANCE_MEMBER, $context->kind);
+        self::assertSame('Some\\Long\\Widget', $context->class);
+        self::assertSame('handle', $context->prefix);
+    }
+
+    public function test_instance_member_via_use_alias_reader_tag(): void
+    {
+        $source = "(ns app (:use Some\\Long\\Widget :as W))\n(let [^W w (x)]\n  (php/-> w handle";
+        $context = $this->resolveAtEnd($source);
+
+        self::assertSame(PhpInteropContext::KIND_INSTANCE_MEMBER, $context->kind);
+        self::assertSame('Some\\Long\\Widget', $context->class);
+    }
+
+    public function test_instance_member_with_multiline_form(): void
+    {
+        $source = "(php/-> (php/new \\DateTimeImmutable)\n  get";
+        $context = $this->resolveAtEnd($source);
+
+        self::assertSame(PhpInteropContext::KIND_INSTANCE_MEMBER, $context->kind);
+        self::assertSame('DateTimeImmutable', $context->class);
+        self::assertSame('get', $context->prefix);
+    }
+
+    public function test_earlier_closed_form_does_not_hijack_completion(): void
+    {
+        $source = "(php/-> (php/new \\DateTimeImmutable) (getTimestamp))\n(php/strle";
+        $context = $this->resolveAtEnd($source);
+
+        self::assertSame(PhpInteropContext::KIND_GLOBAL_FUNCTION, $context->kind);
+        self::assertSame('strle', $context->prefix);
+    }
+
     public function test_unknown_receiver_type_is_none(): void
     {
         $source = '(php/-> mystery-thing get';

--- a/tests/php/Unit/Api/Application/PhpInteropDocResolverTest.php
+++ b/tests/php/Unit/Api/Application/PhpInteropDocResolverTest.php
@@ -67,6 +67,26 @@ final class PhpInteropDocResolverTest extends TestCase
         self::assertStringContainsString('setTimestamp(', $help['signatures'][0]['label']);
     }
 
+    public function test_signature_help_for_multiline_method_call(): void
+    {
+        $source = "(php/-> (php/new \\DateTimeImmutable)\n  (setTimestamp ";
+        $help = $this->resolver->signatureAt($source, 2, strlen('  (setTimestamp ') + 1);
+
+        self::assertNotNull($help);
+        self::assertStringContainsString('setTimestamp(', $help['signatures'][0]['label']);
+    }
+
+    public function test_hover_on_multiline_instance_method(): void
+    {
+        // Line 2 is "  getTimestamp"; cursor sits inside the method name.
+        $source = "(php/-> (php/new \\DateTimeImmutable)\n  getTimestamp";
+
+        $hover = $this->resolver->hoverAt($source, 2, 6);
+
+        self::assertNotNull($hover);
+        self::assertStringContainsString('getTimestamp', $hover);
+    }
+
     public function test_signature_help_null_for_plain_phel(): void
     {
         self::assertNull($this->resolver->signatureAt('(map inc ', 1, 9));


### PR DESCRIPTION
## 🤔 Background

The LSP/REPL PHP-interop tooling shipped in #2431 (completion, hover, signature help for `php/->`, `php/::`, `php/new`) resolves the receiver class lexically. Two common cases fell through that resolution and silently degraded to plain Phel completion with no diagnostic:

1. **Imported short names.** A class brought in with `(ns app (:use Doctrine\ORM\EntityManager))` (or top-level `(use ...)`) was kept as the bare literal `EntityManager`, which the reflector cannot map to its FQN, so `(php/-> em ...)` / `(php/:: EntityManager ...)` / `(php/new EntityManager ...)` produced nothing. The project's own `docs/examples/09_php-integration.phel` only works because its `:use` names happen to be top-level (no namespace).
2. **Multi-line forms.** `CursorText::before` returned only the cursor's own line, so an idiomatic fluent chain whose opener sits on an earlier line —
   ```phel
   (php/-> (php/new \DateTimeImmutable)
     (setTimestamp ...))
   ```
   — was invisible to the resolver.

## 💡 Goal

Make receiver/class resolution see import aliases and multi-line forms, so completion, hover, and signature help all work in the dominant real-world interop shapes. Everything stays lexical and degrades to empty on unknown types (no new diagnostics).

## 🔖 Changes

- **`PhpInteropContextResolver`**: builds a `short-name => FQN` table from every `(:use ...)` and top-level `(use ...)` clause (honouring `:as`, normalising `.` → `\`, alias = last `\`-segment), and maps bare receivers, `:tag`/reader-tag bindings, and inline `(php/new ...)` results through it.
- **`CursorText::before`**: returns the prefix back to the enclosing still-open `(` form (string- and `;`-comment-aware) instead of just the current line. This lets a multi-line receiver be seen and, as a bonus, stops an earlier already-closed sibling form from hijacking the anchored, lazy regexes.
- Unit coverage in `PhpInteropContextResolverTest` (alias static/`:as`/top-level/`php/new`-binding/reader-tag, multi-line, anti-hijack) and `PhpInteropDocResolverTest` (multi-line signature + hover); LSP integration coverage in `PhpInteropLspTest` (alias static completion via a real reflected class, multi-line instance completion).
- `CHANGELOG.md` (Unreleased → Fixed) and `src/php/Api/CLAUDE.md` updated.

Follow-up to #2431. Not addressed here (separate lower-value gaps surfaced while scoping): `SignatureInformation.parameters` / cursor-tracked `activeParameter`, richer class/property/constant hover, and string/comment-aware completion suppression.
