### PR TITLE
fix(printer): render NAN without a PHP coercion warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Dispatch / call sites:
 
 ### Fixed
 
+- Printing a `NAN` value (e.g. `(println (/ 0.0 0.0))`) no longer leaks a PHP `unexpected NAN value was coerced to string` warning; it renders `NAN`, matching `INF`/`-INF`
 - PHP interop completion/hover/signature help now resolves the receiver class through `(:use ...)`/`(use ...)` import aliases and across multi-line forms (follow-up to #2431; #2461)
 - PHP interop signature help is now complete against LSP 3.17: each signature carries per-parameter `parameters` and the method's phpdoc, `activeParameter` tracks the argument under the cursor, and the enclosing call is found by a balanced-paren scan so a chained `(php/-> x (a ...) (b ...) (c ⟂` reports the innermost method instead of the first (follow-up to #2431; #2462)
 - PHP interop hover now covers instance properties, static constants and enum cases, and classes (kind, parent/interfaces, constructor signature), and renders the symbol's phpdoc (method/function/property/constant/class) when present, instead of only resolving methods (follow-up to #2431; #2463)

--- a/src/php/Shared/Printer/TypePrinter/NumberPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/NumberPrinter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Printer\TypePrinter;
 
+use function is_float;
+use function is_nan;
 use function sprintf;
 
 /**
@@ -18,6 +20,12 @@ final class NumberPrinter implements TypePrinterInterface
      */
     public function print(mixed $form): string
     {
+        // Casting NAN to string emits a PHP warning; render it explicitly,
+        // matching the `INF`/`-INF` rendering PHP produces for infinities.
+        if (is_float($form) && is_nan($form)) {
+            return $this->color('NAN');
+        }
+
         return $this->color((string) $form);
     }
 

--- a/tests/php/Unit/Printer/TypePrinter/NumberPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/NumberPrinterTest.php
@@ -8,6 +8,7 @@ use Generator;
 use Phel\Shared\Printer\TypePrinter\NumberPrinter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 final class NumberPrinterTest extends TestCase
 {
@@ -31,5 +32,33 @@ final class NumberPrinterTest extends TestCase
             '1.02',
             1.02,
         ];
+
+        yield 'nan' => [
+            'NAN',
+            NAN,
+        ];
+
+        yield 'positive infinity' => [
+            'INF',
+            INF,
+        ];
+
+        yield 'negative infinity' => [
+            '-INF',
+            -INF,
+        ];
+    }
+
+    public function test_print_nan_does_not_emit_a_php_warning(): void
+    {
+        set_error_handler(static function (int $errno, string $errstr): bool {
+            throw new RuntimeException($errstr);
+        });
+
+        try {
+            self::assertSame('NAN', new NumberPrinter()->print(NAN));
+        } finally {
+            restore_error_handler();
+        }
     }
 }


### PR DESCRIPTION
## 🤔 Background

Printing a `NAN` float leaked a PHP runtime warning into command/REPL output:

```
$ phel eval "(+ 1 ##NaN)"
PHP Warning:  unexpected NAN value was coerced to string in .../NumberPrinter.php on line 21
NAN
```

`NumberPrinter::print()` does `(string) $form`; PHP 8 emits a warning when casting `NAN` to string (but not `INF`/`-INF`).

## 🔖 Changes

- Special-case `is_nan()` in `NumberPrinter::print()` to render `NAN` directly, so no cast warning fires. Output is unchanged (`NAN`), now consistent and warning-free with the existing `INF`/`-INF` rendering.
- `NumberPrinterTest` gains `NAN`/`INF`/`-INF` cases plus an assertion that printing `NAN` raises no PHP warning.

Found via an adversarial bug-hunt of the runtime; reproduced and verified.
