### PR TITLE
fix(compiler): allow declaring a single implicit macro param (&form / &env)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Dispatch / call sites:
 
 ### Fixed
 
+- `defmacro` with only one of the implicit `&form`/`&env` params declared (e.g. `(defmacro m [&form x] ...)`) no longer fails to compile with `Redefinition of parameter $_AMPERSAND_form`; the injector now de-duplicates a partially-declared implicit param
 - PHP interop completion/hover/signature help now resolves the receiver class through `(:use ...)`/`(use ...)` import aliases and across multi-line forms (follow-up to #2431; #2461)
 - PHP interop signature help is now complete against LSP 3.17: each signature carries per-parameter `parameters` and the method's phpdoc, `activeParameter` tracks the argument under the cursor, and the enclosing call is found by a balanced-paren scan so a chained `(php/-> x (a ...) (b ...) (c ⟂` reports the innermost method instead of the first (follow-up to #2431; #2462)
 - PHP interop hover now covers instance properties, static constants and enum cases, and classes (kind, parent/interfaces, constructor signature), and renders the symbol's phpdoc (method/function/property/constant/class) when present, instead of only resolving methods (follow-up to #2431; #2463)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/MacroFormRewriter.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/MacroFormRewriter.php
@@ -12,6 +12,7 @@ use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 
 use function count;
+use function in_array;
 use function is_string;
 
 /**
@@ -164,7 +165,7 @@ final readonly class MacroFormRewriter
     private function prependImplicitParams(PersistentVectorInterface $params): PersistentVectorInterface
     {
         // Idempotency / shadowing guard: if the first two params are already `&form` and `&env`,
-        // leave the vector untouched so users can explicitly shadow.
+        // leave the vector untouched so users can explicitly shadow (preserves vector meta).
         if (count($params) >= 2) {
             $first = $params->get(0);
             $second = $params->get(1);
@@ -176,10 +177,22 @@ final readonly class MacroFormRewriter
             }
         }
 
+        // Otherwise drop any stray `&form`/`&env` the user declared (only one of
+        // them, or not as the leading pair): re-injecting alongside it would emit
+        // a duplicate PHP parameter and fail to compile. Then prepend both.
+        $rest = [];
+        foreach ($params->toArray() as $param) {
+            if ($param instanceof Symbol && in_array($param->getName(), ['&form', '&env'], true)) {
+                continue;
+            }
+
+            $rest[] = $param;
+        }
+
         $formSymbol = Symbol::create('&form')->copyLocationFrom($params);
         $envSymbol = Symbol::create('&env')->copyLocationFrom($params);
 
-        return Phel::vector([$formSymbol, $envSymbol, ...$params->toArray()])
+        return Phel::vector([$formSymbol, $envSymbol, ...$rest])
             ->copyLocationFrom($params);
     }
 }

--- a/tests/phel/core/defmacro-env.phel
+++ b/tests/phel/core/defmacro-env.phel
@@ -73,3 +73,19 @@
 
 (deftest test-explicit-shadow-receives-call-form
   (is (= '(explicit-shadow :marker) (explicit-shadow :marker))))
+
+;; --- Declaring only one of &form / &env must not duplicate the injected
+;;     parameter (regression: `[&form]` / `[&env x]` alone used to fail to
+;;     compile with "Redefinition of parameter $_AMPERSAND_form"). ---
+
+(defmacro only-form [&form x] `'~&form)
+
+(deftest test-shadow-only-form-receives-call-form
+  (is (= '(only-form 7) (only-form 7))))
+
+(defmacro only-env-has-local? [&env sym] (contains? &env sym))
+
+(deftest test-shadow-only-env-reflects-bindings
+  (let [a 1]
+    (is (= true (only-env-has-local? a)))
+    (is (= false (only-env-has-local? b)))))


### PR DESCRIPTION
## 🤔 Background

`defmacro` injects `&form` (the call form) and `&env` (lexical bindings) as the two leading params of the generated function. The injector's idempotency guard only skipped re-injection when **both** were already declared as the first two params. Declaring just one of them duplicated it:

```
$ phel eval "(defmacro m [&form x] nil)"
PHP Fatal error: Redefinition of parameter $_AMPERSAND_form ...
```

`[&form ...]`, `[&env ...]`, or either not as the leading pair all hit this.

## 🔖 Changes

- `MacroFormRewriter::prependImplicitParams()` now drops any `&form`/`&env` the user already declared (in any position) before prepending both, so the compiled function never carries a duplicate parameter. The existing fast path for the canonical `[&form &env ...]` shape (which preserves vector meta) is kept.
- `tests/phel/core/defmacro-env.phel` gains regression tests for `[&form x]` (receives the call form) and `[&env sym]` (reflects lexical bindings).

Found via an adversarial bug-hunt of the compiler; reproduced and verified (`&form`/`&env` remain functionally accessible).
