### PR TITLE
fix(stdlib): json empty-map/numeric-key handling and string pad guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Dispatch / call sites:
 
 ### Fixed
 
+- `phel\json`: an empty map now encodes to `{}` (was `[]`), and numeric JSON object keys (which `json_decode` coerces to ints) now decode to keywords instead of collapsing to a single `nil` key
 - `defmacro` with only one of the implicit `&form`/`&env` params declared (e.g. `(defmacro m [&form x] ...)`) no longer fails to compile with `Redefinition of parameter $_AMPERSAND_form`; the injector now de-duplicates a partially-declared implicit param
 - Printing a `NAN` value (e.g. `(println (/ 0.0 0.0))`) no longer leaks a PHP `unexpected NAN value was coerced to string` warning; it renders `NAN`, matching `INF`/`-INF`
 - PHP interop completion/hover/signature help now resolves the receiver class through `(:use ...)`/`(use ...)` import aliases and across multi-line forms (follow-up to #2431; #2461)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Dispatch / call sites:
 
 ### Fixed
 
+- `phel\string`: `pad-left`/`pad-right`/`pad-both` with an empty pad string now fall back to a single space instead of raising an uncatchable PHP `str_pad(): Argument #3 must not be empty` error
 - `phel\json`: an empty map now encodes to `{}` (was `[]`), and numeric JSON object keys (which `json_decode` coerces to ints) now decode to keywords instead of collapsing to a single `nil` key
 - `defmacro` with only one of the implicit `&form`/`&env` params declared (e.g. `(defmacro m [&form x] ...)`) no longer fails to compile with `Redefinition of parameter $_AMPERSAND_form`; the injector now de-duplicates a partially-declared implicit param
 - Printing a `NAN` value (e.g. `(println (/ 0.0 0.0))`) no longer leaks a PHP `unexpected NAN value was coerced to string` warning; it renders `NAN`, matching `INF`/`-INF`

--- a/src/phel/json.phel
+++ b/src/phel/json.phel
@@ -23,11 +23,14 @@
    :see-also ["encode" "decode-value"]}
   [x]
   (cond
-    (php/is_iterable x) (encode-value-iterable x)
-    (symbol? x)         (name x)
-    (keyword? x)        (name x)
-    (float? x)          (str x)
-    true                x))
+    ; An empty map must encode as a JSON object `{}`, not the `[]` an empty
+    ; php/array would produce; a stdClass forces object encoding.
+    (and (map? x) (empty? x)) (php/new \stdClass)
+    (php/is_iterable x)       (encode-value-iterable x)
+    (symbol? x)               (name x)
+    (keyword? x)              (name x)
+    (float? x)                (str x)
+    true                      x))
 
 (defn encode
   "Encodes a Phel value to a JSON string."
@@ -50,7 +53,10 @@
     (indexed? x)   (for [v :in x] (decode-value v))
     (php-array? x) (let [hashmap (transient {})]
                      (foreach [k v x]
-                       (php/-> hashmap (put (keyword k) (decode-value v))))
+                       ; JSON object keys are strings, but php/json_decode coerces
+                       ; numeric keys to ints; stringify first so `(keyword k)`
+                       ; never collapses them to a single nil key.
+                       (php/-> hashmap (put (keyword (str k)) (decode-value v))))
                      (persistent hashmap))
     true           x))
 

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -260,23 +260,29 @@ This is a convenience function for converting strings to character sequences. Pr
   [s]
   (split s "/\\r?\\n/"))
 
+(defn- pad-or-space
+  "The pad string to use, defaulting to a single space. An empty (or nil) pad
+  string would make PHP's `str_pad` raise an uncatchable argument error."
+  [pad-str]
+  (if (or (nil? pad-str) (= "" pad-str)) " " pad-str))
+
 (defn pad-left
   "Returns a string padded on the left side to length len."
   {:example "(pad-left \"hello\" 10) ; => \"     hello\""}
   [s len & [pad-str]]
   (assert-string s)
-  (php/str_pad s len (or pad-str " ") php/STR_PAD_LEFT))
+  (php/str_pad s len (pad-or-space pad-str) php/STR_PAD_LEFT))
 
 (defn pad-right
   "Returns a string padded on the right side to length len."
   {:example "(pad-right \"hello\" 10) ; => \"hello     \""}
   [s len & [pad-str]]
   (assert-string s)
-  (php/str_pad s len (or pad-str " ") php/STR_PAD_RIGHT))
+  (php/str_pad s len (pad-or-space pad-str) php/STR_PAD_RIGHT))
 
 (defn pad-both
   "Returns a string padded on both sides to length len."
   {:example "(pad-both \"hello\" 11) ; => \"   hello   \""}
   [s len & [pad-str]]
   (assert-string s)
-  (php/str_pad s len (or pad-str " ") php/STR_PAD_BOTH))
+  (php/str_pad s len (pad-or-space pad-str) php/STR_PAD_BOTH))

--- a/tests/phel/json/decode/value.phel
+++ b/tests/phel/json/decode/value.phel
@@ -38,3 +38,8 @@
           :vat_number "12345678901"
           :zip_code "10000"}
          (json/decode sample-data)))))
+
+(deftest test-json-decode-numeric-keys-become-keywords
+  ; php/json_decode coerces numeric object keys to ints; they must still
+  ; become keywords, not collapse to a single nil key.
+  (is (= {:1 "one" :2 "two"} (json/decode "{\"1\":\"one\",\"2\":\"two\"}"))))

--- a/tests/phel/json/encode/value.phel
+++ b/tests/phel/json/encode/value.phel
@@ -56,6 +56,10 @@
   (is (= "[1,2,3]" (json/encode [1 2 3])))
   (is (= "[1,2,[1,2]]" (json/encode [1 2 [1 2]]))))
 
+(deftest test-json-encode-empty-map-is-object
+  (is (= "{}" (json/encode {})))
+  (is (= "[]" (json/encode []))))
+
 (deftest test-json-encode-set
   (is (= "[1,2,3]" (json/encode (hash-set 1 2 3))))
   (is (= "[1,2,[1,2]]" (json/encode (hash-set 1 2 (hash-set 1 2))))))

--- a/tests/phel/string.phel
+++ b/tests/phel/string.phel
@@ -226,6 +226,12 @@
   (is (= " foo " (s/pad-both "foo" 5)))
   (is (= "0foo0" (s/pad-both "foo" 5 "0"))))
 
+(deftest test-pad-empty-pad-string-falls-back-to-space
+  ; An empty pad string used to throw an uncatchable PHP str_pad error.
+  (is (= "  foo" (s/pad-left "foo" 5 "")))
+  (is (= "foo  " (s/pad-right "foo" 5 "")))
+  (is (= " foo " (s/pad-both "foo" 5 ""))))
+
 ;; `n`/`k`/`i` are bound (not literals) so the compile-time string-param tag
 ;; check doesn't fire; this exercises the runtime guard the way the
 ;; clojure-test-suite does (values flow in through an `are` binding).


### PR DESCRIPTION
## 🤔 Background

An adversarial runtime bug-hunt surfaced three reproducible stdlib correctness bugs (each verified by running the snippet).

## 🔖 Changes

**`phel\json`**
- `(json/encode {})` produced `"[]"` (an empty `php/array` is ambiguous and `json_encode`s as an array). It now forces object encoding via a `stdClass`, yielding `"{}"`.
- On decode, `json_decode` coerces numeric object keys to PHP ints, and `(keyword <int>)` returns `nil` — so `{"1":"one","2":"two"}` collapsed to `{nil "two"}`. Keys are now stringified before `(keyword ...)`, decoding to `{:1 "one" :2 "two"}`.

**`phel\string`**
- `pad-left`/`pad-right`/`pad-both` with an empty pad string passed `""` straight to PHP `str_pad`, raising an uncatchable `Argument #3 must not be empty` error (an empty string is truthy in Phel, so `(or pad-str " ")` did not guard it). They now fall back to a single space.

Tests added for each. The full `phel test` suite (5970 cases) stays green.

Note: a related finding — `(json/encode 3.14)` encoding floats as JSON **strings** — is intentionally **not** changed here, since an existing test (`tests/phel/json/encode/value.phel`) asserts that behavior; flagged separately for a maintainer decision.
