### PR TITLE
fix(lang): struct field access with a non-keyword key no longer crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Dispatch / call sites:
 
 ### Fixed
 
+- Reading a struct field with a non-keyword key (e.g. `(get s 'field)` with a symbol) no longer crashes with a PHP `TypeError`; symbols and strings match the field by name (consistent with `find`/`contains?`) and other key types miss gracefully (return `nil`)
 - `phel\string`: `pad-left`/`pad-right`/`pad-both` with an empty pad string now fall back to a single space instead of raising an uncatchable PHP `str_pad(): Argument #3 must not be empty` error
 - `phel\json`: an empty map now encodes to `{}` (was `[]`), and numeric JSON object keys (which `json_decode` coerces to ints) now decode to keywords instead of collapsing to a single `nil` key
 - `defmacro` with only one of the implicit `&form`/`&env` params declared (e.g. `(defmacro m [&form x] ...)`) no longer fails to compile with `Redefinition of parameter $_AMPERSAND_form`; the injector now de-duplicates a partially-declared implicit param

--- a/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
+++ b/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
@@ -10,6 +10,7 @@ use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\Collections\Map\AbstractPersistentMap;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
+use Phel\Lang\NamedInterface;
 use Phel\Lang\TypeFactory;
 use Phel\Shared\Munge;
 use Phel\Shared\MungeInterface;
@@ -97,7 +98,9 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     #[Override]
     public function offsetGet(mixed $offset): mixed
     {
-        return $this->find($this->normalizeOffset($offset));
+        $key = $this->normalizeOffset($offset);
+
+        return $key instanceof Keyword ? $this->find($key) : null;
     }
 
     /**
@@ -106,7 +109,9 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     #[Override]
     public function offsetExists(mixed $offset): bool
     {
-        return $this->contains($this->normalizeOffset($offset));
+        $key = $this->normalizeOffset($offset);
+
+        return $key instanceof Keyword && $this->contains($key);
     }
 
     public function getIterator(): Traversable
@@ -153,14 +158,26 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     }
 
     /**
-     * Coerces a string field name to its keyword; passes a keyword offset
-     * through unchanged.
-     *
-     * @param Keyword|string $offset
+     * Coerces an offset to the keyword used as the struct key: a keyword passes
+     * through, a string or any named value (e.g. a symbol) maps by name —
+     * consistent with `find`/`contains`, which already match by name. Any other
+     * key type yields null so the lookup misses instead of raising a TypeError.
      */
-    private function normalizeOffset(mixed $offset): Keyword
+    private function normalizeOffset(mixed $offset): ?Keyword
     {
-        return is_string($offset) ? Keyword::create($offset) : $offset;
+        if ($offset instanceof Keyword) {
+            return $offset;
+        }
+
+        if (is_string($offset)) {
+            return Keyword::create($offset);
+        }
+
+        if ($offset instanceof NamedInterface) {
+            return Keyword::create($offset->getName());
+        }
+
+        return null;
     }
 
     /**

--- a/tests/php/Unit/Lang/Collections/Struct/StructTest.php
+++ b/tests/php/Unit/Lang/Collections/Struct/StructTest.php
@@ -9,6 +9,7 @@ use Phel;
 use Phel\Lang\Collections\Map\PersistentHashMap;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
 use Phel\Lang\TypeFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -40,6 +41,26 @@ final class StructTest extends TestCase
         $s = FakeStruct::fromKVs(Keyword::create('a'), 1, Keyword::create('b'), 2);
         $isset = isset($s[Keyword::create('c')]);
         self::assertFalse($isset);
+    }
+
+    public function test_offset_get_with_symbol_matches_by_name(): void
+    {
+        $s = FakeStruct::fromKVs(Keyword::create('a'), 1, Keyword::create('b'), 2);
+        self::assertSame(1, $s[Symbol::create('a')]);
+        self::assertArrayHasKey(Symbol::create('a'), $s);
+    }
+
+    public function test_offset_get_with_string_matches_by_name(): void
+    {
+        $s = FakeStruct::fromKVs(Keyword::create('a'), 1, Keyword::create('b'), 2);
+        self::assertSame(2, $s['b']);
+    }
+
+    public function test_offset_get_with_unsupported_key_misses_without_error(): void
+    {
+        $s = FakeStruct::fromKVs(Keyword::create('a'), 1, Keyword::create('b'), 2);
+        self::assertNull($s[42]);
+        self::assertArrayNotHasKey(42, $s);
     }
 
     public function test_remove(): void


### PR DESCRIPTION
## 🤔 Background

Reading a struct field with a non-keyword key crashed:

```phel
(defstruct Point [x y])
(get (Point 10 20) 'x)
; PHP TypeError: AbstractPersistentStruct::normalizeOffset(): Return value
; must be of type Keyword, Symbol returned
```

`offsetGet`/`offsetExists` route through `normalizeOffset`, which was typed `: Keyword` but returned a `Symbol` offset verbatim. Note `find`/`contains` already match keys **by name**, so `(contains? s 'x)` returned `true` while `(get s 'x)` threw — an inconsistency on top of the crash.

## 🔖 Changes

- `normalizeOffset` now returns `?Keyword`: a keyword passes through, a string or any `NamedInterface` (e.g. a symbol) maps to the keyword by name (consistent with `find`/`contains`), and any other key type yields `null` so the lookup misses gracefully instead of raising a `TypeError`.
- `offsetGet` returns `null` and `offsetExists` returns `false` for a null-normalized key.
- `StructTest` gains cases for symbol-by-name access, string-by-name access, and an unsupported (int) key missing without error.

Found via an adversarial runtime bug-hunt; reproduced and verified. 976 `Lang` unit tests stay green.
