### PR TITLE
fix(stdlib): transit map round-trip and html void elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Dispatch / call sites:
 
 ### Fixed
 
+- `phel\html`: void elements (`br`, `img`, `input`, ...) are now always self-closing and ignore any mistakenly-supplied children, instead of emitting invalid markup like `<br>content</br>`
 - `phel\transit`: empty maps now round-trip as maps (were decoding back as empty vectors), and numeric string keys (e.g. `{"1" "one"}`) stay strings instead of becoming ints after a write/read round-trip
 - Reading a struct field with a non-keyword key (e.g. `(get s 'field)` with a symbol) no longer crashes with a PHP `TypeError`; symbols and strings match the field by name (consistent with `find`/`contains?`) and other key types miss gracefully (return `nil`)
 - `phel\string`: `pad-left`/`pad-right`/`pad-both` with an empty pad string now fall back to a single space instead of raising an uncatchable PHP `str_pad(): Argument #3 must not be empty` error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Dispatch / call sites:
 
 ### Fixed
 
+- `phel\transit`: empty maps now round-trip as maps (were decoding back as empty vectors), and numeric string keys (e.g. `{"1" "one"}`) stay strings instead of becoming ints after a write/read round-trip
 - Reading a struct field with a non-keyword key (e.g. `(get s 'field)` with a symbol) no longer crashes with a PHP `TypeError`; symbols and strings match the field by name (consistent with `find`/`contains?`) and other key types miss gracefully (return `nil`)
 - `phel\string`: `pad-left`/`pad-right`/`pad-both` with an empty pad string now fall back to a single space instead of raising an uncatchable PHP `str_pad(): Argument #3 must not be empty` error
 - `phel\json`: an empty map now encodes to `{}` (was `[]`), and numeric JSON object keys (which `json_decode` coerces to ints) now decode to keywords instead of collapsing to a single `nil` key

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -21,8 +21,11 @@
                  "hr" "img" "input" "keygen" "link" "meta" "param"
                  "source" "track" "wbr"))
 
-(defn- container-tag? [tag content]
-  (or content (not (contains? void-tags tag))))
+(defn- container-tag? [tag]
+  ; Void elements (br, img, input, ...) are always self-closing per the HTML
+  ; spec: they never render a closing tag or children, even if children were
+  ; mistakenly supplied.
+  (not (contains? void-tags tag)))
 
 (defn- normalize-element [[tag & content]]
   (do
@@ -74,7 +77,7 @@
   "Renders an Element."
   [element]
   (let [[tag attrs content] (normalize-element element)]
-    (if (container-tag? tag content)
+    (if (container-tag? tag)
       (str
        "<" tag (render-attrs attrs) ">"
        (render-html content)
@@ -115,7 +118,7 @@
   "Compiles a element."
   [element]
   (let [[tag attrs content] (normalize-element element)]
-    (if (container-tag? tag content)
+    (if (container-tag? tag)
       `(str
         ~(str "<" tag) ~(compile-attrs attrs) ">"
         ~@(compile-seq content)

--- a/src/phel/transit.phel
+++ b/src/phel/transit.phel
@@ -149,7 +149,11 @@
   [obj opts]
   (let [acc (transient {})]
     (foreach [k v obj]
-      (php/-> acc (put (decode k opts) (decode v opts))))
+      ;; JSON object keys are always strings, but php/json_decode coerces
+      ;; numeric ones to ints; restore the string so a key like "1" decodes
+      ;; to the string "1" rather than the int 1.
+      (let [k (if (php/is_int k) (php/strval k) k)]
+        (php/-> acc (put (decode k opts) (decode v opts)))))
     (persistent acc)))
 
 (defn- decode
@@ -219,9 +223,12 @@
   (str "~t" (php/-> d (format "Y-m-d\\TH:i:s.vP"))))
 
 (defn- string-keys?
-  "True when every key in `m` is a plain Phel string."
+  "True when `m` is non-empty and every key is a plain Phel string. An empty
+  map is excluded so it round-trips through the `~#cmap` form instead of an
+  empty JSON array (which would decode back as a vector)."
   [m]
-  (every? string? (keys m)))
+  (and (not (empty? m))
+       (every? string? (keys m))))
 
 (defn- encode-map [m]
   (if (string-keys? m)

--- a/tests/phel/html.phel
+++ b/tests/phel/html.phel
@@ -25,6 +25,13 @@
   (is (= "<colgroup span=\"2\"></colgroup>" (html [:colgroup {:span 2}])))
   (is (= "<colgroup><col /></colgroup>" (html [:colgroup [:col]]))))
 
+(deftest void-tags-ignore-content
+  ;; Void elements stay self-closing even when children are (mistakenly)
+  ;; supplied; they must not emit a closing tag (e.g. never "<br>x</br>").
+  (is (= "<br />" (html [:br "ignored"])))
+  (is (= "<img src=\"x\" />" (html [:img {:src "x"} "alt"])))
+  (is (= "<input type=\"text\" />" (html [:input {:type "text"} "x"]))))
+
 (deftest tags-with-text-content
   (is (= "<text>Lorem Ipsum</text>" (html [:text "Lorem Ipsum"])))
   (is (= "<text>foobar</text>" (html [:text "foo" "bar"]))))

--- a/tests/phel/transit/write.phel
+++ b/tests/phel/transit/write.phel
@@ -52,3 +52,12 @@
                    {:name "Bob"   :tags #{:guest}}]
            :total 2}]
     (is (= v (transit/read-string (transit/write-string v))))))
+
+(deftest test-round-trip-empty-and-numeric-keyed-maps
+  (let [rt (fn [x] (transit/read-string (transit/write-string x)))]
+    ;; empty maps must stay maps (used to decode back as empty vectors)
+    (is (= {} (rt {})))
+    (is (= {:a {}} (rt {:a {}})))
+    ;; numeric string keys must stay strings (json coerces them to ints)
+    (is (= {"1" "one" "2" "two"} (rt {"1" "one" "2" "two"})))
+    (is (= {"a" 1 "b" 2} (rt {"a" 1 "b" 2})))))


### PR DESCRIPTION
## 🤔 Background

A reproducible-bug hunt over the stdlib surfaced two correctness bugs.

## 🔖 Changes

**`phel\transit`** (data round-trips)
- An empty map encoded as an empty `php/array` (`string-keys?` is vacuously true with no keys), which `json_encode` emits as `[]` and the reader decodes back as a **vector**. Empty maps now route through the `~#cmap` form and round-trip as maps (any nesting level).
- Numeric string keys (`{"1" "one"}`) were coerced to ints by `json_decode`; `decode-object` now restores int keys to strings, so `(= m (read-string (write-string m)))` holds for string-keyed maps.

**`phel\html`** (markup correctness)
- `container-tag?` returned true whenever children were present, so a void element with content rendered invalid markup (`[:br "x"]` → `<br>x</br>`, `[:img {..} "alt"]` → `<img ..>alt</img>`). Void elements (`br`/`img`/`input`/…) are now always self-closing and drop mistakenly-supplied children, matching hiccup and the HTML spec.

Tests added for both. The full `phel test` suite (5980 cases) stays green.

Found via an adversarial runtime bug-hunt; each reproduced and verified. Related float-type round-trip findings (whole-number floats, `#inst` writing) are tracked separately as they stem from the shared printer.
