### PR TITLE
fix(test): use class name instead of self in intersection return type

### DIFF
--- a/tests/php/Unit/Api/Application/Fixtures/ChainFixture.php
+++ b/tests/php/Unit/Api/Application/Fixtures/ChainFixture.php
@@ -46,7 +46,7 @@ final class ChainFixture implements Stringable
         return $this->name === '' ? 0 : $this;
     }
 
-    public function andStringable(): self&Stringable
+    public function andStringable(): ChainFixture&Stringable
     {
         return $this;
     }


### PR DESCRIPTION
## 🤔 Background

The `Tests` CI job on `main` has been failing since #2472. The fixture `ChainFixture` declares `andStringable(): self&Stringable`, but PHP rejects `self` inside an intersection type with a **fatal error at class-load time** (`Type self cannot be part of an intersection type`). Because the fatal aborts the whole PHP process, the entire test suite dies before assertions run — surfacing as both a "Premature end of PHP process" on the 8.4 job and a hard error on the symfony/console compat job.

## 💡 Goal

Get the `Tests` job green again on `main`.

## 🔖 Changes

- `tests/php/Unit/Api/Application/Fixtures/ChainFixture.php`: replace `self&Stringable` with the concrete `ChainFixture&Stringable` in the `andStringable()` return type. Intersection types only accept class/interface names, not `self`.

Verified locally: `PhpInteropContextResolverTest` passes (30 tests, 61 assertions).

Not a user-facing change, so no CHANGELOG entry.