### PR TITLE
fix(lang): make NAN usable as a map/set key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `NAN` used as a map/set key is now retrievable: `get`/`contains?` find it and re-`assoc` updates in place, while scalar `(= NAN NAN)` stays `false` (#2475)
 - `phel\html`: void elements (`br`, `img`, `input`, ...) are now always self-closing and ignore supplied children, instead of emitting invalid markup like `<br>content</br>`
 - `phel\transit`: empty maps now round-trip as maps (were decoding as empty vectors), and numeric string keys (e.g. `{"1" "one"}`) stay strings instead of becoming ints
 - Reading a struct field with a non-keyword key (e.g. `(get s 'field)`) no longer crashes with a PHP `TypeError`; symbols and strings match by name, other key types return `nil`

--- a/src/php/Lang/Collections/HashSet/PersistentHashSet.php
+++ b/src/php/Lang/Collections/HashSet/PersistentHashSet.php
@@ -9,6 +9,9 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\HasherInterface;
 use Traversable;
 
+use function is_float;
+use function is_nan;
+
 /**
  * @template V
  *
@@ -110,6 +113,13 @@ final class PersistentHashSet extends AbstractType implements PersistentHashSetI
         }
 
         foreach ($this as $value) {
+            // A NaN element is never `=` to itself, so a set carrying one is
+            // unequal to any distinct set (identical sets short-circuit via
+            // `===` before reaching here). Membership lookup still matches NaN.
+            if (is_float($value) && is_nan($value)) {
+                return false;
+            }
+
             if (!$other->contains($value)) {
                 return false;
             }

--- a/src/php/Lang/Collections/Map/AbstractPersistentMap.php
+++ b/src/php/Lang/Collections/Map/AbstractPersistentMap.php
@@ -9,6 +9,9 @@ use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
 
+use function is_float;
+use function is_nan;
+
 /**
  * @template K
  * @template V
@@ -73,6 +76,13 @@ abstract class AbstractPersistentMap extends AbstractType implements PersistentM
         }
 
         foreach ($this as $key => $value) {
+            // A NaN key is never `=` to itself, so a map carrying one is
+            // unequal to any distinct map (identical maps short-circuit via
+            // `===` before reaching here). Key *lookup* still matches NaN.
+            if (is_float($key) && is_nan($key)) {
+                return false;
+            }
+
             if (!$other->contains($key)) {
                 return false;
             }

--- a/src/php/Lang/Collections/Map/HashCollisionNode.php
+++ b/src/php/Lang/Collections/Map/HashCollisionNode.php
@@ -130,7 +130,7 @@ final class HashCollisionNode implements HashMapNodeInterface
     private function findIndex(mixed $key): int
     {
         for ($i = 0; $i < 2 * $this->count; $i += 2) {
-            if ($this->equalizer->equals($key, $this->objects[$i])) {
+            if ($this->equalizer->equalsKey($key, $this->objects[$i])) {
                 return $i;
             }
         }

--- a/src/php/Lang/Collections/Map/IndexedNode.php
+++ b/src/php/Lang/Collections/Map/IndexedNode.php
@@ -58,7 +58,7 @@ final readonly class IndexedNode implements HashMapNodeInterface
             }
 
             /** @var TValue $currentValue */
-            if ($this->equalizer->equals($key, $currentKey)) {
+            if ($this->equalizer->equalsKey($key, $currentKey)) {
                 return $this->updateKey($index, $currentValue, $value);
             }
 
@@ -119,7 +119,7 @@ final readonly class IndexedNode implements HashMapNodeInterface
             return $result;
         }
 
-        if ($this->equalizer->equals($key, $currentKey)) {
+        if ($this->equalizer->equalsKey($key, $currentKey)) {
             if (count($this->objects) === 1) {
                 return null;
             }
@@ -156,7 +156,7 @@ final readonly class IndexedNode implements HashMapNodeInterface
             return $node->find($shift + 5, $hash, $key, $notFound);
         }
 
-        if ($this->equalizer->equals($key, $currentKey)) {
+        if ($this->equalizer->equalsKey($key, $currentKey)) {
             return $currentValue;
         }
 

--- a/src/php/Lang/Collections/Map/PersistentArrayMap.php
+++ b/src/php/Lang/Collections/Map/PersistentArrayMap.php
@@ -185,7 +185,7 @@ final class PersistentArrayMap extends AbstractPersistentMap
     {
         for ($i = 0, $cnt = count($this->array); $i < $cnt; $i += 2) {
             $k = $this->array[$i];
-            if ($this->equalizer->equals($k, $key)) {
+            if ($this->equalizer->equalsKey($k, $key)) {
                 return $i;
             }
         }

--- a/src/php/Lang/Collections/Map/TransientArrayMap.php
+++ b/src/php/Lang/Collections/Map/TransientArrayMap.php
@@ -160,7 +160,7 @@ final class TransientArrayMap implements TransientMapInterface
     {
         for ($i = 0, $cnt = count($this->array); $i < $cnt; $i += 2) {
             $k = $this->array[$i];
-            if ($this->equalizer->equals($k, $key)) {
+            if ($this->equalizer->equalsKey($k, $key)) {
                 return $i;
             }
         }

--- a/src/php/Lang/Equalizer.php
+++ b/src/php/Lang/Equalizer.php
@@ -6,6 +6,7 @@ namespace Phel\Lang;
 
 use Gacela\Container\Attribute\Singleton;
 
+use function is_float;
 use function is_int;
 
 #[Singleton]
@@ -40,6 +41,17 @@ final class Equalizer implements EqualizerInterface
         }
 
         return false;
+    }
+
+    public function equalsKey(mixed $a, mixed $b): bool
+    {
+        if ($this->equals($a, $b)) {
+            return true;
+        }
+
+        // Collection key equality treats NaN as equal to itself so a NaN key
+        // stays retrievable, unlike scalar `=` which follows IEEE-754.
+        return is_float($a) && is_float($b) && is_nan($a) && is_nan($b);
     }
 
     /**

--- a/src/php/Lang/EqualizerInterface.php
+++ b/src/php/Lang/EqualizerInterface.php
@@ -10,4 +10,15 @@ interface EqualizerInterface
      * @return bool True, if $a is equals $b
      */
     public function equals(mixed $a, mixed $b): bool;
+
+    /**
+     * Equality used for collection keys/elements (map, set, hashed lookup).
+     *
+     * Differs from {@see self::equals()} only for NaN: a NaN key matches
+     * itself (Java Double.equals semantics) so it stays retrievable, while
+     * scalar `=` keeps NaN unequal to itself (IEEE-754).
+     *
+     * @return bool True, if $a is equals $b as a collection key
+     */
+    public function equalsKey(mixed $a, mixed $b): bool;
 }

--- a/tests/phel/core/nan-map-keys.phel
+++ b/tests/phel/core/nan-map-keys.phel
@@ -15,3 +15,10 @@
 
 (deftest test-scalar-equality-of-nan-unchanged
   (is (not (= nan nan)) "scalar = keeps NaN unequal to itself (IEEE-754)"))
+
+(deftest test-collections-with-nan-are-structurally-unequal
+  ;; Key lookup matches NaN, but structural = of distinct collections does
+  ;; not (matches Clojure; see clojure-test-suite eq.cljc "collections unequal").
+  (is (not (= {nan 1} {nan 1})) "distinct maps with a NaN key are not =")
+  (is (not (= (set [nan]) (set [nan]))) "distinct sets with a NaN element are not =")
+  (is (not (= [nan] [nan])) "distinct vectors with a NaN element are not ="))

--- a/tests/phel/core/nan-map-keys.phel
+++ b/tests/phel/core/nan-map-keys.phel
@@ -1,0 +1,17 @@
+(ns phel-test.core.nan-map-keys
+  (:require phel.test :refer [deftest is]))
+
+(def- nan php/NAN)
+
+(deftest test-nan-as-map-key
+  (is (= "value" (get {nan "value"} nan)) "get with a NaN key returns its value")
+  (is (contains? {nan "value"} nan) "contains? finds a NaN key")
+  (is (= 1 (count (assoc (assoc {} nan 1) nan 2))) "re-assoc with the same NaN key updates in place")
+  (is (= 2 (get (assoc (assoc {} nan 1) nan 2) nan)) "re-assoc with the same NaN key overwrites the value"))
+
+(deftest test-nan-as-set-element
+  (is (contains? (set [nan]) nan) "contains? finds a NaN set element")
+  (is (= 1 (count (set [nan nan]))) "duplicate NaN elements collapse into one"))
+
+(deftest test-scalar-equality-of-nan-unchanged
+  (is (not (= nan nan)) "scalar = keeps NaN unequal to itself (IEEE-754)"))

--- a/tests/php/Unit/Lang/Collections/SimpleEqualizer.php
+++ b/tests/php/Unit/Lang/Collections/SimpleEqualizer.php
@@ -6,10 +6,22 @@ namespace PhelTest\Unit\Lang\Collections;
 
 use Phel\Lang\EqualizerInterface;
 
+use function is_float;
+use function is_nan;
+
 final class SimpleEqualizer implements EqualizerInterface
 {
     public function equals(mixed $a, mixed $b): bool
     {
         return $a === $b;
+    }
+
+    public function equalsKey(mixed $a, mixed $b): bool
+    {
+        if ($this->equals($a, $b)) {
+            return true;
+        }
+
+        return is_float($a) && is_float($b) && is_nan($a) && is_nan($b);
     }
 }

--- a/tests/php/Unit/Lang/EqualizerTest.php
+++ b/tests/php/Unit/Lang/EqualizerTest.php
@@ -100,4 +100,25 @@ final class EqualizerTest extends TestCase
         self::assertTrue($this->equalizer->equals($sameHalf, $half));
         self::assertFalse($this->equalizer->equals($half, $third));
     }
+
+    public function test_scalar_equals_keeps_nan_unequal(): void
+    {
+        // Scalar `=` follows IEEE-754: NaN is never equal to itself.
+        self::assertFalse($this->equalizer->equals(NAN, NAN));
+    }
+
+    public function test_equals_key_treats_nan_as_equal(): void
+    {
+        // Collection key equality follows Java Double.equals: NaN matches
+        // itself so it can serve as a stable map/set key.
+        self::assertTrue($this->equalizer->equalsKey(NAN, NAN));
+    }
+
+    public function test_equals_key_matches_equals_for_non_nan(): void
+    {
+        self::assertTrue($this->equalizer->equalsKey(1, 1));
+        self::assertFalse($this->equalizer->equalsKey(1, 2));
+        self::assertFalse($this->equalizer->equalsKey(NAN, 1.0));
+        self::assertFalse($this->equalizer->equalsKey(1.0, NAN));
+    }
 }


### PR DESCRIPTION
## 🤔 Background

`NAN` used as a map key was unretrievable and duplicated on re-`assoc`: `Equalizer::equals(NaN, NaN)` is `false` (IEEE-754), so although `Hasher` gives NaN a stable hash and the key lands in a bucket, the key-equality check never matches. Lookups missed and `assoc` could not find the existing entry to overwrite.

## 💡 Goal

Make collection key equality treat NaN as equal to itself (Clojure/Java `Double.equals` semantics) so NaN works as a stable map/set key, **without** changing scalar `(= NAN NAN)`, which stays `false`.

## 🔖 Changes

- Add `EqualizerInterface::equalsKey` — `equals()` plus a NaN-equals-itself special case — and use it at every map-node **key** comparison site (`IndexedNode`, `HashCollisionNode`, `PersistentArrayMap`, `TransientArrayMap`). Sets are map-backed, so they are covered too.
- Value comparisons and scalar `=` keep using `equals()` unchanged.
- Tests: `EqualizerTest` (scalar `=` stays false, `equalsKey` matches NaN), and a `nan-map-keys.phel` core test for `get`/`contains?`/`assoc`/set behavior.

Scope: handles direct NaN scalar keys and NaN set elements (the reported symptoms). A vector/map that *contains* NaN used as a key is out of scope — matching Clojure there needs a separate deep key-equality traversal that must not change `(= [NAN] [NAN])` (which stays `false`, as in Clojure).

The mandatory refactor pass surfaced no further changes.

Closes #2475