### PR TITLE
fix(json): encode floats as JSON numbers, not strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - `NAN` used as a map/set key is now retrievable: `get`/`contains?` find it and re-`assoc` updates in place, while scalar `(= NAN NAN)` stays `false` (#2475)
+- `phel\json`: `encode` now emits floats as JSON numbers (`(json/encode 3.14)` → `3.14`) instead of quoted strings, so values round-trip; float map keys stay quoted strings as JSON requires (#2477)
 - `phel\html`: void elements (`br`, `img`, `input`, ...) are now always self-closing and ignore supplied children, instead of emitting invalid markup like `<br>content</br>`
 - `phel\transit`: empty maps now round-trip as maps (were decoding as empty vectors), and numeric string keys (e.g. `{"1" "one"}`) stay strings instead of becoming ints
 - Reading a struct field with a non-keyword key (e.g. `(get s 'field)`) no longer crashes with a PHP `TypeError`; symbols and strings match by name, other key types return `nil`

--- a/src/phel/json.phel
+++ b/src/phel/json.phel
@@ -9,12 +9,21 @@
 
 (declare encode-value)
 
+(defn- encode-key
+  "Encodes a map key. JSON object keys are always strings, and a PHP array
+  float key would be truncated to an int, so floats are stringified here
+  (values keep their numeric type via `encode-value`)."
+  [k]
+  (if (float? k)
+    (str k)
+    (encode-value k)))
+
 (defn- encode-value-iterable [x]
   (let [arr (php/array)]
     (foreach [k v x]
       (when-not (valid-key? k)
         (throw (php/new JsonException "Key can only be an integer, float, symbol, keyword or a string.")))
-      (php/aset arr (encode-value k) (encode-value v)))
+      (php/aset arr (encode-key k) (encode-value v)))
     arr))
 
 (defn encode-value
@@ -29,7 +38,6 @@
     (php/is_iterable x)       (encode-value-iterable x)
     (symbol? x)               (name x)
     (keyword? x)              (name x)
-    (float? x)                (str x)
     true                      x))
 
 (defn encode

--- a/tests/phel/json/encode/value.phel
+++ b/tests/phel/json/encode/value.phel
@@ -15,7 +15,8 @@
   (is (= "1" (json/encode 1))))
 
 (deftest test-json-encode-float
-  (is (= "\"3.14\"" (json/encode 3.14))))
+  (is (= "3.14" (json/encode 3.14)) "a float encodes as a JSON number, not a string")
+  (is (= 3.14 (json/decode (json/encode 3.14))) "a float round-trips through encode/decode"))
 
 (deftest test-json-encode-string
   (is (= "\"string\"" (json/encode "string"))))


### PR DESCRIPTION
## 🤔 Background

`encode-value` mapped every float through `(str x)` before `json_encode`, so `(json/encode 3.14)` produced the quoted JSON **string** `"3.14"` instead of the number `3.14`. This broke type round-trip (`(json/decode (json/encode 3.14))` returned a string) and emitted non-standard JSON for floats.

## 💡 Goal

Encode float **values** as JSON numbers so they round-trip, while keeping float **keys** as quoted strings (JSON object keys are always strings, and a PHP array float key would silently truncate to an int).

## 🔖 Changes

- `encode-value`: drop the float→string conversion so floats reach `json_encode` as numbers (`json_encode(3.14)` already yields `3.14`).
- New `encode-key` helper stringifies float keys; `encode-value-iterable` uses it. Int/keyword/symbol/string keys are unchanged.
- Update `test-json-encode-float` to assert the number form plus a round-trip; float-key tests in `keys.phel` keep asserting `"3.14"`.

Note: `1.0` encodes as `1` — JSON has no float/int distinction, so this is standard `json_encode` behavior, not a regression. NaN/Infinity remain unsupported by standard JSON and are out of scope. Refactor pass surfaced no further changes.

Closes #2477