### PR TITLE
fix(parser): keep full name of multi-slash keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 - `NAN` used as a map/set key is now retrievable: `get`/`contains?` find it and re-`assoc` updates in place, while scalar `(= NAN NAN)` stays `false` (#2475)
 - `phel\json`: `encode` now emits floats as JSON numbers (`(json/encode 3.14)` → `3.14`) instead of quoted strings, so values round-trip; float map keys stay quoted strings as JSON requires (#2477)
+- A keyword literal with multiple slashes (e.g. `:a/b/c`) now keeps everything after the first `/` as the name (namespace `a`, name `b/c`), matching Clojure, instead of silently truncating to `:a/b` (#2478)
 - `phel\html`: void elements (`br`, `img`, `input`, ...) are now always self-closing and ignore supplied children, instead of emitting invalid markup like `<br>content</br>`
 - `phel\transit`: empty maps now round-trip as maps (were decoding as empty vectors), and numeric string keys (e.g. `{"1" "one"}`) stay strings instead of becoming ints
 - Reading a struct field with a non-keyword key (e.g. `(get s 'field)`) no longer crashes with a PHP `TypeError`; symbols and strings match by name, other key types return `nil`

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
@@ -27,7 +27,11 @@ use function strlen;
 
 final readonly class AtomParser
 {
-    private const string REGEX_KEYWORD = '/:(?<second_colon>:?)((?<namespace>[^\/]+)\/)?(?<keyword>[^\/]+)/';
+    // Anchored end-to-end so the whole token is consumed. The name part
+    // allows `/` after its first char, matching Clojure: `:a/b/c` is
+    // namespace `a` with name `b/c` (previously the trailing `/c` was
+    // silently dropped). A bare `:/` still fails (name cannot start with `/`).
+    private const string REGEX_KEYWORD = '/^:(?<second_colon>:?)((?<namespace>[^\/]+)\/)?(?<keyword>[^\/].*)$/';
 
     private const string REGEX_BINARY_NUMBER = '/^([+-])?0[bB]([01]+(?:_[01]+)*)$/';
 

--- a/tests/phel/core/basic-constructors.phel
+++ b/tests/phel/core/basic-constructors.phel
@@ -35,7 +35,11 @@
       "keyword literal with special characters round-trips against (keyword string)")
   (is (= :abc*+!-_'?<>=/abc*+!-_'?<>=
          (keyword "abc*+!-_'?<>=" "abc*+!-_'?<>="))
-      "namespaced keyword literal with special characters round-trips against (keyword ns name)"))
+      "namespaced keyword literal with special characters round-trips against (keyword ns name)")
+  (is (= "b/c" (name :a/b/c)) "keyword literal keeps everything after the first / as the name")
+  (is (= "a" (namespace :a/b/c)) "keyword literal namespace is the part before the first /")
+  (is (not (= :a/b/c :a/b)) "a multi-slash keyword is not truncated to its first segment")
+  (is (= :a/b/c (keyword "a" "b/c")) "multi-slash keyword literal matches (keyword ns name)"))
 
 (deftest create-hash-map
   (is (= {:a 1 :b 2} (hash-map :a 1 :b 2)) "construct hash-map"))

--- a/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
+++ b/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
@@ -158,6 +158,26 @@ final class AtomParserTest extends TestCase
         );
     }
 
+    public function test_parse_keyword_with_slash_in_name(): void
+    {
+        // Clojure keeps everything after the first `/` as the name, so
+        // `:a/b/c` is namespace `a` with name `b/c` (not silently truncated).
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 6);
+        $this->assertEquals(
+            new KeywordNode(
+                ':a/b/c',
+                $start,
+                $end,
+                Keyword::create('b/c', 'a'),
+            ),
+            $parser->parse(
+                new Token(Token::T_ATOM, ':a/b/c', $start, $end),
+            ),
+        );
+    }
+
     public function test_parse_invalid_keyword(): void
     {
         $this->expectException(KeywordParserException::class);


### PR DESCRIPTION
## 🤔 Background

`REGEX_KEYWORD` in `AtomParser` was unanchored (no trailing `$`) and its name group was `[^\/]+`, so a keyword like `:a/b/c` matched the `:a/b` prefix and silently dropped `/c`. Result: `:a/b/c` read as `:a/b`, and `(= :a/b/c :a/b)` was `true`. Symbols already handled this correctly (`'a/b/c` → ns `a`, name `b/c`).

## 💡 Goal

Parse the full keyword, matching Clojure: everything after the first `/` is the name, so `:a/b/c` is namespace `a` with name `b/c`.

## 🔖 Changes

- Anchor `REGEX_KEYWORD` end-to-end and allow `/` in the name after its first char (`[^\/].*`). `:a/b/c` → ns `a`, name `b/c`; `:/` still fails (a name cannot start with `/`), preserving existing behavior.
- Unit test `test_parse_keyword_with_slash_in_name` and runtime tests in `basic-constructors.phel`.

Refactor pass surfaced no further changes.

Closes #2478