### PR TITLE
fix(printer): align float printing with str

### DIFF
--- a/.github/workflows/run-clojure-test-suite.yml
+++ b/.github/workflows/run-clojure-test-suite.yml
@@ -38,7 +38,7 @@ jobs:
           # PR/push runs gate against a pinned, reproducible suite commit; the
           # nightly cron tracks `main` to surface upstream drift; dispatch can
           # override either way.
-          ref: ${{ github.event.inputs.suite-ref || (github.event_name == 'schedule' && 'main' || '7d3db18b7d55abcae3411dcfdede99049f1bfe8a') }}
+          ref: ${{ github.event.inputs.suite-ref || (github.event_name == 'schedule' && 'main' || 'c79e3f988799ce39d65632b1388b407d62612435') }}
           path: clojure-test-suite
 
       - uses: shivammathur/setup-php@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - `NAN` used as a map/set key is now retrievable: `get`/`contains?` find it and re-`assoc` updates in place, while scalar `(= NAN NAN)` stays `false` (#2475)
 - `phel\json`: `encode` now emits floats as JSON numbers (`(json/encode 3.14)` → `3.14`) instead of quoted strings, so values round-trip; float map keys stay quoted strings as JSON requires (#2477)
 - A keyword literal with multiple slashes (e.g. `:a/b/c`) now keeps everything after the first `/` as the name (namespace `a`, name `b/c`), matching Clojure, instead of silently truncating to `:a/b` (#2478)
+- Float printing is now consistent between `str` and `print`/`println`/`print-str`/REPL: integer-valued floats keep their `.0` (`17.0`, not `17`), and the special values render `NaN`/`Infinity`/`-Infinity` (not `NAN`/`INF`/`-INF`) (#2479)
 - `phel\html`: void elements (`br`, `img`, `input`, ...) are now always self-closing and ignore supplied children, instead of emitting invalid markup like `<br>content</br>`
 - `phel\transit`: empty maps now round-trip as maps (were decoding as empty vectors), and numeric string keys (e.g. `{"1" "one"}`) stay strings instead of becoming ints
 - Reading a struct field with a non-keyword key (e.g. `(get s 'field)`) no longer crashes with a PHP `TypeError`; symbols and strings match by name, other key types return `nil`

--- a/src/php/Shared/Printer/TypePrinter/NumberPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/NumberPrinter.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Phel\Shared\Printer\TypePrinter;
 
 use function is_float;
+use function is_infinite;
 use function is_nan;
+use function preg_match;
 use function sprintf;
 
 /**
@@ -20,13 +22,34 @@ final class NumberPrinter implements TypePrinterInterface
      */
     public function print(mixed $form): string
     {
-        // Casting NAN to string emits a PHP warning; render it explicitly,
-        // matching the `INF`/`-INF` rendering PHP produces for infinities.
-        if (is_float($form) && is_nan($form)) {
-            return $this->color('NAN');
+        if (is_float($form)) {
+            return $this->color($this->printFloat($form));
         }
 
         return $this->color((string) $form);
+    }
+
+    /**
+     * Renders a float so it agrees with `str`/`float-to-str` (in
+     * `src/phel/core/strings.phel`): integer-valued floats keep their `.0`,
+     * and the special values spell out readably. Keep both in lockstep.
+     */
+    private function printFloat(float $form): string
+    {
+        if (is_nan($form)) {
+            return 'NaN';
+        }
+
+        if (is_infinite($form)) {
+            return $form > 0 ? 'Infinity' : '-Infinity';
+        }
+
+        $str = (string) $form;
+
+        // A plain cast drops the trailing `.0` (so `17.0` becomes `17`),
+        // which would make a float indistinguishable from an int. Restore
+        // it unless the cast already carries a decimal point or exponent.
+        return preg_match('/[.eE]/', $str) === 1 ? $str : $str . '.0';
     }
 
     private function color(string $str): string

--- a/tests/php/Unit/Printer/TypePrinter/NumberPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/NumberPrinterTest.php
@@ -33,18 +33,23 @@ final class NumberPrinterTest extends TestCase
             1.02,
         ];
 
+        yield 'integer-valued float keeps .0' => [
+            '17.0',
+            17.0,
+        ];
+
         yield 'nan' => [
-            'NAN',
+            'NaN',
             NAN,
         ];
 
         yield 'positive infinity' => [
-            'INF',
+            'Infinity',
             INF,
         ];
 
         yield 'negative infinity' => [
-            '-INF',
+            '-Infinity',
             -INF,
         ];
     }
@@ -56,7 +61,7 @@ final class NumberPrinterTest extends TestCase
         });
 
         try {
-            self::assertSame('NAN', new NumberPrinter()->print(NAN));
+            self::assertSame('NaN', new NumberPrinter()->print(NAN));
         } finally {
             restore_error_handler();
         }


### PR DESCRIPTION
## 🤔 Background

`str` (via `float-to-str`) and `print`/`println`/`print-str`/REPL (via the Printer's `NumberPrinter`) rendered floats differently:

| value | `str` | Printer (before) |
|---|---|---|
| `17.0` | `17.0` | `17` |
| `##NaN` | `NaN` | `NAN` |
| `##Inf` | `Infinity` | `INF` |
| `##-Inf` | `-Infinity` | `-INF` |

`NumberPrinter` cast floats with `(string)`, dropping the trailing `.0` and using PHP's `NAN`/`INF` spellings.

## 💡 Goal

Make the two paths agree: the Printer now renders floats exactly like `str`/`float-to-str`.

## 🔖 Changes

- `NumberPrinter::printFloat`: integer-valued floats keep `.0` (`17.0`), and `NaN`/`Infinity`/`-Infinity` spell out, matching `src/phel/core/strings.phel` `float-to-str` (kept in lockstep, cross-referenced in a comment).
- Update `NumberPrinterTest`.
- Bump the pinned `clojure-test-suite` SHA: its `print-str` test had a `:phel` bucket asserting `17.0 → "17"`; that bucket is dropped so Phel uses the `:default` `17.0`. Suite `main` already updated.

This changes REPL/`println`/`print-str` output of floats broadly (the intended alignment). Maintainer-approved direction.

Closes #2479