### PR TITLE
fix(core): support multi-arity protocol methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - `phel\json`: floats encode as JSON numbers so values round-trip; empty maps encode to `{}` (#2477)
 - Keyword literals with multiple slashes (`:a/b/c`) keep everything after the first `/` as the name, matching Clojure (#2478)
 - Consistent float printing across `str`/`print`/REPL: integer floats keep `.0`, specials render `NaN`/`Infinity`/`-Infinity` (#2479)
+- Protocol methods declared with multiple arities now dispatch on every arity, not just the last installed one (#2481)
 - `phel\html`: void elements (`br`, `img`, ...) are always self-closing and ignore children
 - `phel\transit`: empty maps round-trip as maps, and numeric string keys stay strings
 - Reading a struct field with a non-keyword key no longer crashes; symbols/strings match by name, else `nil`

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -439,10 +439,12 @@ A `:default` type can be registered via `extend-type` as a fallback when no spec
   (let [pname-str (php/-> protocol-name (getName))
         ;; `arglists` holds every declared arity vector, so a multi-arity
         ;; method like `(say [this] [this name])` dispatches on all of them.
+        ;; Keep only the arity vectors: a spec may carry a trailing docstring
+        ;; (`(bar [this a b] "doc")`), which must not be treated as an arity.
         methods   (for [spec :in method-specs
                         :let [mname (first spec)
                               mname-str (php/-> mname (getName))
-                              arglists (rest spec)
+                              arglists (filter vector? (rest spec))
                               dsym (php/:: Symbol
                                            (create (php/. pname-str "--" mname-str "--dispatch")))]]
                     [mname mname-str arglists dsym])]

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -437,32 +437,36 @@ A `:default` type can be registered via `extend-type` as a fallback when no spec
    :see-also ["extend-type" "satisfies?" "extends?" "protocol-type-key"]}
   [protocol-name & method-specs]
   (let [pname-str (php/-> protocol-name (getName))
+        ;; `arglists` holds every declared arity vector, so a multi-arity
+        ;; method like `(say [this] [this name])` dispatches on all of them.
         methods   (for [spec :in method-specs
                         :let [mname (first spec)
                               mname-str (php/-> mname (getName))
-                              margs (second spec)
+                              arglists (rest spec)
                               dsym (php/:: Symbol
                                            (create (php/. pname-str "--" mname-str "--dispatch")))]]
-                    [mname mname-str margs dsym])]
+                    [mname mname-str arglists dsym])]
     `(do
        ~@(for [[_ _ _ dsym] :in methods]
            `(def ~dsym {:private true} (atom {})))
        (def ~protocol-name
          {:name ~pname-str
           :dispatch [~@(for [[_ _ _ dsym] :in methods] dsym)]})
-       ~@(for [[mname mname-str margs dsym] :in methods]
-           `(defn ~mname ~margs
-              (let [dk             (protocol-type-key ~(first margs))
-                    dispatch-table (deref ~dsym)
-                    impl           (get dispatch-table dk)]
-                (if impl
-                  (impl ~@margs)
-                  (let [default-impl (get dispatch-table :default)]
-                    (if default-impl
-                      (default-impl ~@margs)
-                      (throw (php/new \InvalidArgumentException
-                                      (str "No implementation of '" ~mname-str
-                                           "' for type: " dk))))))))))))
+       ~@(for [[mname mname-str arglists dsym] :in methods]
+           `(defn ~mname
+              ~@(for [margs :in arglists]
+                  `(~margs
+                    (let [dk             (protocol-type-key ~(first margs))
+                          dispatch-table (deref ~dsym)
+                          impl           (get dispatch-table dk)]
+                      (if impl
+                        (impl ~@margs)
+                        (let [default-impl (get dispatch-table :default)]
+                          (if default-impl
+                            (default-impl ~@margs)
+                            (throw (php/new \InvalidArgumentException
+                                            (str "No implementation of '" ~mname-str
+                                                 "' for type: " dk))))))))))))))
 
 (defn- group-protocol-specs
   "Splits a flat protocol spec list into `[[header [methods]] ...]` groups.
@@ -530,17 +534,18 @@ A `:default` type can be registered via `extend-type` as a fallback when no spec
                           proto-tag  (if proto-ns
                                        (php/-> proto-name (getFullName))
                                        (php/. *ns* "\\" proto-str))]
-                      (reduce
-                       (fn [inner method]
-                         (let [mname-str (php/-> (first method) (getName))
-                               margs     (second method)
-                               body      (next (next method))
-                               dsym      (php/:: Symbol
-                                                 (create (php/. proto-str "--" mname-str "--dispatch")))]
-                           (conj inner `(swap! ~dsym assoc ~type-key (fn ~margs ~@body)))))
+                      ;; Group the impls by method name so a method declared
+                      ;; with several arities installs ONE multi-arity fn,
+                      ;; instead of each arity overwriting the previous swap.
+                      (concat
                        (conj acc
                              `(register-protocol-implementor! ~type-key ~proto-name ~proto-tag))
-                       methods)))
+                       (for [[mname-str method-group] :pairs (group-by (fn [m] (php/-> (first m) (getName))) methods)]
+                         (let [dsym (php/:: Symbol
+                                            (create (php/. proto-str "--" mname-str "--dispatch")))]
+                           `(swap! ~dsym assoc ~type-key
+                                   (fn ~@(for [arity :in method-group]
+                                           `(~(second arity) ~@(next (next arity)))))))))))
                   []
                   groups)]
     `(do ~@swaps)))

--- a/tests/phel/core/protocols.phel
+++ b/tests/phel/core/protocols.phel
@@ -255,3 +255,39 @@
 (deftest test-protocol-multi-expression-body
   (is (= "3 items, first: :a" (summarize [:a :b :c]))
       "multi-expression body works"))
+
+;; --- Multi-arity protocol methods ---
+
+(defprotocol Greet
+  (say [this]
+       [this name]
+       [this greeting name]))
+
+(extend-type :string
+  Greet
+  (say [this] (str "hi from " this))
+  (say [this name] (str this " says hi to " name))
+  (say [this greeting name] (str this ": " greeting ", " name)))
+
+(extend-type :default
+  Greet
+  (say [this] "default greeting"))
+
+(deftest test-multi-arity-protocol-dispatch
+  (is (= "hi from a" (say "a")) "one-arg arity")
+  (is (= "a says hi to b" (say "a" "b")) "two-arg arity")
+  (is (= "a: hello, b" (say "a" "hello" "b")) "three-arg arity"))
+
+(deftest test-multi-arity-protocol-default-fallback
+  (is (= "default greeting" (say 42)) "falls back to :default for the supported arity"))
+
+(defprotocol Sized
+  (sz [this] [this unit]))
+
+(deftest test-multi-arity-via-extend-protocol
+  (extend-protocol Sized
+    :string (sz [this] (php/strlen this)) (sz [this unit] (str (php/strlen this) unit))
+    :vector (sz [this] (count this)))
+  (is (= 5 (sz "hello")) "extend-protocol one-arg")
+  (is (= "5px" (sz "hello" "px")) "extend-protocol two-arg")
+  (is (= 3 (sz [1 2 3])) "extend-protocol single-arity type"))

--- a/tests/phel/core/protocols.phel
+++ b/tests/phel/core/protocols.phel
@@ -291,3 +291,21 @@
   (is (= 5 (sz "hello")) "extend-protocol one-arg")
   (is (= "5px" (sz "hello" "px")) "extend-protocol two-arg")
   (is (= 3 (sz [1 2 3])) "extend-protocol single-arity type"))
+
+;; --- Protocol method with a trailing docstring ---
+;; A docstring after the arity vector(s) must not be treated as an arity.
+
+(defprotocol Depictable
+  (depict [this a b] "depict docstring")
+  (outline [this] [this detail] "outline docstring"))
+
+(extend-type :string
+  Depictable
+  (depict [this a b] (str this ":" a b))
+  (outline [this] (str "outline:" this))
+  (outline [this detail] (str "outline:" this ":" detail)))
+
+(deftest test-protocol-method-with-docstring
+  (is (= "x:12" (depict "x" 1 2)) "single-arity method with docstring dispatches")
+  (is (= "outline:x" (outline "x")) "multi-arity-with-docstring: one-arg")
+  (is (= "outline:x:big" (outline "x" "big")) "multi-arity-with-docstring: two-arg"))


### PR DESCRIPTION
## 🤔 Background

A protocol method declared with multiple arities failed at runtime:

```phel
(defprotocol Greet (say [this] [this name]))
(extend-type :string Greet
  (say [this] (str "no-arg:" this))
  (say [this name] (str "with-arg:" name)))
(say "test")        ;; => Too few arguments ... 1 passed and exactly 2 expected
```

Two root causes in `src/phel/core/protocols.phel`:
- `defprotocol` built the dispatch fn from only the **first** declared arity (`(second spec)`).
- `extend-type` emitted one `swap!` per impl method, so two same-named arities overwrote each other in the dispatch atom — only the last survived.

## 💡 Goal

Multi-arity protocol methods dispatch by arity like regular fns, matching Clojure.

## 🔖 Changes

- `defprotocol`: generate a **multi-arity** dispatch fn covering every declared arity vector.
- `extend-type`: group impls by method name and install **one multi-arity fn** per method (single `swap!`), instead of one-swap-per-arity.
- `extend-protocol`, `deftype`, `defrecord` inherit the fix (they expand through `extend-type`).
- Tests in `protocols.phel` covering 1/2/3-arity dispatch, `:default` fallback, single-arity regression, and `extend-protocol`.

Note: multi-arity `reify` is out of scope — it delegates to PHP methods via `reify*` and would need PHP-level arity dispatch; this PR covers `defprotocol`/`extend-type` as the issue specifies. Refactor pass surfaced no further changes.

Closes #2481