### PR TITLE
fix(lang): rename core `argv` to `*argv*` (Clojure-aligned, breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this project will be documented in this file.
 - Native-int fast path in `NumericOperations` for `+ - * / < =`, `quot`/`rem`/`mod`; ~1.8–8x per op (#2458 #2459)
 - Core arithmetic and `bit-*` ops drop the per-op `apply` round-trip; ~26% on arithmetic-heavy workloads (#2460)
 
+### Changed
+
+- **Breaking**: the runtime CLI-args var is now `*argv*` (earmuffed), matching `*program*` and Clojure's `*command-line-args*`; the old `argv` name was removed. Replace `argv` with `*argv*` in scripts that read command-line arguments (#2494)
+
 ### Fixed
 
 - `NAN` map/set keys are now retrievable via `get`/`contains?`/`assoc`, while `(= NAN NAN)` stays `false` (#2475)

--- a/docs/examples/12_cli.phel
+++ b/docs/examples/12_cli.phel
@@ -89,7 +89,7 @@
                  :aliases ["clear"]
                  :run     wipe-todos}]}))
 
-;; Pass Phel's `argv` explicitly so Symfony sees the user arguments rather
+;; Pass Phel's `*argv*` explicitly so Symfony sees the user arguments rather
 ;; than `phel run <file> ...`. `cli/argv` wraps a vector of tokens into a
 ;; Symfony `ArgvInput`.
-(cli/run app (cli/argv argv))
+(cli/run app (cli/argv *argv*))

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -189,7 +189,7 @@ Maps are treated as a sequence of entries: `(first {:a 1})` returns a typed `Map
   (let [prog (php/aget php/$GLOBALS "__phel_program")]
     (if (php/=== prog nil) "" prog)))
 
-(def argv
+(def *argv*
   "Vector of user arguments passed to the script (excludes program name). Use *program* to get the script path or namespace."
   (let [argv-raw (php/aget php/$GLOBALS "__phel_argv")]
     (if (php/=== argv-raw nil)

--- a/tests/php/Integration/Run/Command/Run/Fixtures/argv-script.phel
+++ b/tests/php/Integration/Run/Command/Run/Fixtures/argv-script.phel
@@ -2,7 +2,7 @@
 
 ;; Print program and argv for testing
 (php/print (str "program:" *program* "\n"))
-(php/print (str "count:" (php/count argv) "\n"))
-(php/print (str "first:" (php/aget argv 0) "\n"))
-(when (php/>= (php/count argv) 2)
-  (php/print (str "second:" (php/aget argv 1) "\n")))
+(php/print (str "count:" (php/count *argv*) "\n"))
+(php/print (str "first:" (php/aget *argv* 0) "\n"))
+(when (php/>= (php/count *argv*) 2)
+  (php/print (str "second:" (php/aget *argv* 1) "\n")))


### PR DESCRIPTION
## 🤔 Background

During a holistic QA pass of the `## Unreleased` changes I scaffolded and ran the bundled `cli-wordcount` template (`phel init --template=cli-wordcount`) and it failed to compile:

```
[PHEL001] Cannot resolve symbol '*argv*'. Did you mean 'argv'?
  (run (vec *argv*))
```

The root cause is a naming inconsistency in core: `*program*` is earmuffed, but the CLI-args var was defined as plain `argv` (added back in 2021, before the `*program*` convention existed). Every piece of agent guidance and the example "instinctively" reached for the convention-correct `*argv*` — which didn't exist — so any CLI written by following the docs failed to compile.

Clojure settles the convention: command-line arguments live in `clojure.core/*command-line-args*` — a dynamic, earmuffed var. Phel aims for Clojure-aligned semantics, and `*program*` already follows it, so `argv` was the outlier.

## 💡 Goal

Make the runtime CLI-args var Clojure-aligned and consistent with `*program*` by renaming `argv` → `*argv*`. This unblocks the `cli-wordcount` example and makes all existing agent docs (which already say `*argv*`) correct.

## 🔖 Changes

- **Breaking**: renamed core `argv` → `*argv*` (earmuffed). The old `argv` name is removed; scripts reading command-line args must use `*argv*`. The compiler's symbol suggester points stragglers at `*argv*`.
- Updated the `argv-script` integration fixture and the `docs/examples/12_cli.phel` example to `*argv*`.
- Added a `### Changed` **Breaking** note to the `## Unreleased` CHANGELOG section.

The bundled example, agent guides (`RULES.md`, `common-gotchas.md`, `cli-tool.md`, `SKILL.md`) and the example source already referenced `*argv*`, so they now resolve correctly with no further edits.

Verified: full quality gate (`composer test`) green; `cli-wordcount` scaffolded from the rebuilt PHAR runs against stdin and file args.
