### PR TITLE
fix(router): reject bare-string routes instead of iterating characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `phel\router`: passing a bare string (or a sequence of bare strings) now raises a clear error instead of silently iterating the string character-by-character into garbage routes (#2487)
 - `NAN` map/set keys are now retrievable via `get`/`contains?`/`assoc`, while `(= NAN NAN)` stays `false` (#2475)
 - `phel\json`: floats encode as JSON numbers so values round-trip; empty maps encode to `{}` (#2477)
 - Keyword literals with multiple slashes (`:a/b/c`) keep everything after the first `/` as the name, matching Clojure (#2478)

--- a/src/phel/router.phel
+++ b/src/phel/router.phel
@@ -19,8 +19,15 @@
   (mapcat |(walk-one $ prefix-path prev-data) routes))
 
 (defn- walk-one [routes prefix-path prev-data]
+  (when (string? routes)
+    (throw (php/new \InvalidArgumentException
+                    (str "router expects a route vector `[path data? children*]` or a vector of such routes, got a bare string: \""
+                         routes "\". Wrap it like [\"" routes "\"]."))))
   (let [head (first routes)]
     (cond
+      (empty? routes)
+      []
+
       (vector? head)
       (walk-many routes prefix-path prev-data)
 
@@ -34,7 +41,12 @@
             next-data     (deep-merge prev-data data)]
         (if (empty? childs)
           [[full-path next-data]]
-          (walk-many (keep identity childs) full-path next-data))))))
+          (walk-many (keep identity childs) full-path next-data)))
+
+      :else
+      (throw (php/new \InvalidArgumentException
+                      (str "router route must start with a string path, got: "
+                           (type head) " in route " (print-str routes)))))))
 
 (defn flatten-routes
   "Flattens nested routes to a vector of `[path data]` tuples.

--- a/tests/phel/router/flatten.phel
+++ b/tests/phel/router/flatten.phel
@@ -25,4 +25,12 @@
           ["" {:name ::admin}]
           ["/db" {:name ::db :middleware [::connect]}]]
          ["/ping" {:name ::ping}]] "" {}))
-      "nested routes"))
+      "nested routes")
+  (is (= [] (flatten-routes [] "" {}))
+      "empty route vector flattens to no routes"))
+
+(deftest flatten-routes-rejects-bare-string-test
+  (is (thrown? \InvalidArgumentException (flatten-routes "/ping" "" {}))
+      "a bare string is rejected instead of iterated character-by-character")
+  (is (thrown? \InvalidArgumentException (flatten-routes ["/ping" "/pong"] "" {}))
+      "a sequence of bare strings is rejected instead of producing garbage routes"))


### PR DESCRIPTION
## 🤔 Background

Closes #2487.

`phel\router`'s `flatten-routes`/`walk-one` start with `(first routes)`. The intended input is a route vector `[path data? children*]` (or a vector of such routes), but `first`/`rest` work on strings too — so a bare string was walked character-by-character into garbage routes:

```phel
(router "/ping")            ; => [[/p {}] [/i {}] [/n {}] [/g {}]]   (per-character!)
(router ["/ping" "/pong"])  ; => [[/ping/p {}] [/ping/o {}] ...]
```

The second case hits the same path: `"/ping"` is taken as the route path and `"/pong"` becomes a "child", which `walk-one` then iterates as a string.

## 💡 Goal

Fail loudly on bare-string misuse instead of silently producing nonsense routes, while keeping every valid form working.

## 🔖 Changes

- `walk-one` now raises a clear `InvalidArgumentException` when it receives a string, naming the value and pointing at the correct `["/ping"]` wrapping.
- A non-string route whose head is neither a path string nor a child vector also errors clearly (e.g. a map/number where a path is expected).
- The guard is intentionally narrow (string, not "must be a persistent vector"): programmatically-built route collections — e.g. routes assembled via `for`/`map`, as the `match-by-path` test does — keep working.
- Empty input (`[]`) still flattens to `[]`.
- Regression tests in `tests/phel/router/flatten.phel` for the bare-string and string-sequence cases, plus the empty-input case.

## Behaviour

| Input | Before | After |
|---|---|---|
| `["/ping"]` | `[["/ping" {}]]` | `[["/ping" {}]]` |
| `[["/ping"] ["/pong"]]` | 2 routes | 2 routes |
| nested route tree | flattened | flattened |
| `"/ping"` | per-character garbage | clear error |
| `["/ping" "/pong"]` | garbage routes | clear error |

Full quality gate green (`composer test`): static analysis clean, PHPUnit 4539 pass, core 5998 pass, 0 failures.
