### PR TITLE
fix(compiler): recur targets the loop frame, not a shadowing binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - `phel\router`: passing a bare string (or a sequence of bare strings) now raises a clear error instead of silently iterating the string character-by-character into garbage routes (#2487)
+- `loop`/`fn` `recur` inside a `let` (or any inner binding) that shadows a loop binding / fn param now updates the loop variable instead of the shadowing binding, fixing a silent infinite loop (#2482)
 - `NAN` map/set keys are now retrievable via `get`/`contains?`/`assoc`, while `(= NAN NAN)` stays `false` (#2475)
 - `phel\json`: floats encode as JSON numbers so values round-trip; empty maps encode to `{}` (#2477)
 - Keyword literals with multiple slashes (`:a/b/c`) keep everything after the first `/` as the name, matching Clojure (#2478)

--- a/src/php/Compiler/Domain/Analyzer/Ast/RecurFrame.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/RecurFrame.php
@@ -10,12 +10,23 @@ final class RecurFrame
 {
     private bool $isActive = false;
 
+    /** @var list<Symbol> */
+    private readonly array $shadows;
+
     /**
-     * @param list<Symbol> $params
+     * @param list<Symbol>  $params  the original binding/param symbols (used for arity and tag checks)
+     * @param ?list<Symbol> $shadows The PHP-variable symbols a `recur` must assign to, one per param.
+     *                               For `loop` these are the binding shadow names; for `fn` they are the
+     *                               params themselves (fn params are not shadow-renamed). Defaults to
+     *                               `$params` so `recur` targets the frame's own variables rather than
+     *                               whatever binding currently shadows the name at the recur site.
      */
     public function __construct(
         private readonly array $params,
-    ) {}
+        ?array $shadows = null,
+    ) {
+        $this->shadows = $shadows ?? $params;
+    }
 
     public function setIsActive(bool $isActive): void
     {
@@ -33,5 +44,15 @@ final class RecurFrame
     public function getParams(): array
     {
         return $this->params;
+    }
+
+    /**
+     * The PHP-variable symbols a `recur` must assign to, one per param.
+     *
+     * @return list<Symbol>
+     */
+    public function getShadows(): array
+    {
+        return $this->shadows;
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoopSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoopSymbol.php
@@ -118,11 +118,17 @@ final readonly class LoopSymbol implements SpecialFormAnalyzerInterface
         $bindings = $this->analyzeBindings($bindingVector, $env->withDisallowRecurFrame());
 
         $locals = [];
+        $shadows = [];
         foreach ($bindings as $binding) {
             $locals[] = $binding->getSymbol();
+            $shadows[] = $binding->getShadow();
         }
 
-        $recurFrame = new RecurFrame($locals);
+        // `recur` must assign to the loop's own binding variables (the shadow
+        // names), not whatever inner `let` happens to re-shadow the same name
+        // at the recur site — otherwise a shadowing `let` makes the loop
+        // binding never update and the loop spins forever.
+        $recurFrame = new RecurFrame($locals, $shadows);
 
         $bodyEnv = $env->withMergedLocals($locals);
         $bodyEnv = ($env->isContext(NodeEnvironment::CONTEXT_EXPRESSION))

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/RecurEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/RecurEmitter.php
@@ -37,13 +37,11 @@ final class RecurEmitter implements NodeEmitterInterface
      */
     private function emitDirect(RecurNode $node): void
     {
-        $params = $node->getFrame()->getParams();
+        $shadows = $node->getFrame()->getShadows();
         foreach ($node->getExpressions() as $i => $expr) {
-            $paramSym = $params[$i];
-            $shadowedSymbol = $node->getEnv()->getShadowed($paramSym);
-            $normalizedParam = $shadowedSymbol instanceof Symbol ? $shadowedSymbol : $paramSym;
+            $targetSym = $shadows[$i];
 
-            $this->outputEmitter->emitPhpVariable($normalizedParam, $paramSym->getStartLocation());
+            $this->outputEmitter->emitPhpVariable($targetSym, $targetSym->getStartLocation());
             $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
             $this->outputEmitter->emitNode($expr);
             $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
@@ -68,14 +66,12 @@ final class RecurEmitter implements NodeEmitterInterface
             $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
         }
 
-        $params = $node->getFrame()->getParams();
+        $shadows = $node->getFrame()->getShadows();
 
         foreach ($tempSyms as $i => $tempSym) {
-            $paramSym = $params[$i];
-            $shadowedSymbol = $node->getEnv()->getShadowed($paramSym);
-            $normalizedParam = $shadowedSymbol instanceof Symbol ? $shadowedSymbol : $paramSym;
+            $targetSym = $shadows[$i];
 
-            $this->outputEmitter->emitPhpVariable($normalizedParam, $paramSym->getStartLocation());
+            $this->outputEmitter->emitPhpVariable($targetSym, $targetSym->getStartLocation());
             $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
             $this->outputEmitter->emitPhpVariable($tempSym, $node->getStartSourceLocation());
             $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
@@ -93,16 +89,13 @@ final class RecurEmitter implements NodeEmitterInterface
      */
     private function canSkipTempVars(RecurNode $node): bool
     {
-        $env = $node->getEnv();
-
-        // For each param slot, the recur emit assigns to the *shadowed*
-        // PHP variable. Match against the same shadowed name that any
-        // `LocalVarNode` in the recur expressions will carry, so the
+        // For each param slot, the recur emit assigns to the frame's own
+        // target (shadow) PHP variable. Match against the same name that any
+        // `LocalVarNode` in the recur expressions resolves to, so the
         // detector compares apples to apples.
         $paramNames = [];
-        foreach ($node->getFrame()->getParams() as $p) {
-            $shadow = $env->getShadowed($p);
-            $paramNames[] = $shadow instanceof Symbol ? $shadow->getName() : $p->getName();
+        foreach ($node->getFrame()->getShadows() as $shadow) {
+            $paramNames[] = $shadow->getName();
         }
 
         foreach ($node->getExpressions() as $i => $expr) {

--- a/tests/phel/core/loop-recur.phel
+++ b/tests/phel/core/loop-recur.phel
@@ -1,0 +1,46 @@
+(ns phel-test.core.loop-recur
+  (:require phel.test :refer [deftest is]))
+
+;; --- Regression: recur inside a let that shadows the loop binding ---
+;; Previously recur assigned the inner let's variable instead of the loop's,
+;; so the loop binding never updated and the loop spun forever (#2482).
+
+(deftest test-recur-with-shadowing-let
+  (is (= :done
+         (loop [x 0]
+           (if (>= x 3)
+             :done
+             (let [x (+ x 100)]
+               (recur (+ x 1))))))
+      "recur targets the loop binding, not the shadowing let"))
+
+(deftest test-recur-in-fn-with-shadowing-let
+  (let [f (fn f [x]
+            (if (>= x 3)
+              :done
+              (let [x (+ x 100)]
+                (recur (+ x 1)))))]
+    (is (= :done (f 0))
+        "fn recur targets the param, not the shadowing let")))
+
+(deftest test-recur-multi-binding-one-shadowed
+  (is (= [2 13]
+         (loop [x 0 y 10]
+           (if (>= x 2)
+             [x y]
+             (let [x (+ x 1)]
+               (recur x (+ y x))))))
+      "only the shadowed binding is re-bound; the other recurs normally"))
+
+;; --- Existing behaviour stays correct ---
+
+(deftest test-recur-plain-loop
+  (is (= 10 (loop [i 0 acc 0]
+              (if (>= i 5) acc (recur (inc i) (+ acc i)))))
+      "plain loop accumulates"))
+
+(deftest test-recur-swap-uses-temp-vars
+  (is (= [2 1]
+         (loop [a 1 b 2 n 0]
+           (if (>= n 3) [a b] (recur b a (inc n)))))
+      "swapping recur args reads the pre-recur values"))

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/LoopSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/LoopSymbolTest.php
@@ -130,12 +130,12 @@ final class LoopSymbolTest extends TestCase
                     ),
                 ],
                 new DoNode(
-                    $env->withAddedRecurFrame(new RecurFrame([Symbol::create('a')]))
+                    $env->withAddedRecurFrame(new RecurFrame([Symbol::create('a')], [Symbol::create('a_1')]))
                         ->withLocals([Symbol::create('a')])
                         ->withShadowedLocal(Symbol::create('a'), Symbol::create('a_1')),
                     [],
                     new LiteralNode(
-                        $env->withAddedRecurFrame(new RecurFrame([Symbol::create('a')]))
+                        $env->withAddedRecurFrame(new RecurFrame([Symbol::create('a')], [Symbol::create('a_1')]))
                             ->withLocals([Symbol::create('a')])
                             ->withShadowedLocal(Symbol::create('a'), Symbol::create('a_1')),
                         null,


### PR DESCRIPTION
## 🤔 Background

Closes #2482.

`recur` inside a `let` (or any inner binding) that **shadows** a loop binding or fn param recurred the wrong variable, hanging forever:

```phel
(loop [x 0]
  (if (>= x 3)
    :done
    (let [x (+ x 100)]   ; shadows the loop's x
      (recur (+ x 1)))))
;; expected :done, actual: infinite loop
```

Each binding gets a unique PHP variable via a shadow gensym (`x_1` for the loop, `x_2` for the inner `let`). `RecurEmitter` resolved the assignment target with `getEnv()->getShadowed(x)` **at the recur site**, which returns the *innermost* shadow (`x_2`) — so `recur` wrote `$x_2` and the loop's `$x_1` never changed. The same bug affected `fn` params shadowed by an inner binding.

## 💡 Goal

`recur` must always assign to the loop/fn frame's own variables, regardless of what an inner scope re-shadows.

## 🔖 Changes

- `RecurFrame` now carries the **target (shadow) symbol per param** alongside the original params: the loop binding's shadow for `loop`, the param itself for `fn` (fn params aren't shadow-renamed). Defaults to the params, so callers that don't pass shadows are unaffected.
- `LoopSymbol` passes the binding shadows when building the frame.
- `RecurEmitter` assigns to the frame's shadow targets (in both the direct and temp-var paths) and detects aliasing against those names, instead of resolving the recur-site shadow.
- Updated `LoopSymbolTest` (the expected `RecurFrame` now records the shadow), and added behavioural regression tests in `tests/phel/core/loop-recur.phel` (loop + fn shadowing, multi-binding with one shadowed, plain loop, and the swap/temp-var path).

## Verification

- The two hanging snippets now return `:done`.
- Full quality gate (`composer test`): static analysis clean, PHPUnit 4539 pass, core 6000 pass, 0 failures.
- `clojure-test-suite` (pinned SHA `c79e3f98`): 5474 pass, 0 failures.
