### PR TITLE
fix(transit): preserve float type on round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Constant folding of integer arithmetic (`+`/`-`/`*`) that overflows `PHP_INT_MAX` no longer disagrees with the runtime: `(* 2 4611686018427387904)` now keeps runtime dispatch and promotes to `BigInt` (matching the `let`-bound form) instead of silently folding to a `float`; also fixes a stray PHP warning at the exact `2^63` boundary (#2483)
+- `phel\transit`: whole-number floats (`1.0`, `0.0`, `-0.0`, `1.5e10`) now round-trip as floats instead of decoding back as ints, by preserving the trailing decimal in the JSON output (`JSON_PRESERVE_ZERO_FRACTION`) (#2485)
 - `phel\router`: passing a bare string (or a sequence of bare strings) now raises a clear error instead of silently iterating the string character-by-character into garbage routes (#2487)
 - `loop`/`fn` `recur` inside a `let` (or any inner binding) that shadows a loop binding / fn param now updates the loop variable instead of the shadowing binding, fixing a silent infinite loop (#2482)
 - `NAN` map/set keys are now retrievable via `get`/`contains?`/`assoc`, while `(= NAN NAN)` stays `false` (#2475)

--- a/src/phel/transit.phel
+++ b/src/phel/transit.phel
@@ -3,7 +3,8 @@
   (:use Phel.Lang.Symbol)
   (:use Phel.Lang.UUID)
   (:use \JSON_UNESCAPED_SLASHES)
-  (:use \JSON_UNESCAPED_UNICODE))
+  (:use \JSON_UNESCAPED_UNICODE)
+  (:use \JSON_PRESERVE_ZERO_FRACTION))
 
 ;; phel.transit: read and write Transit+JSON-Verbose data.
 ;;
@@ -56,7 +57,9 @@
 (def- RESERVED-LETTERS #{"~" "^" "`"})
 
 (def- json-flags
-  (bit-or JSON_UNESCAPED_SLASHES JSON_UNESCAPED_UNICODE))
+  ;; JSON_PRESERVE_ZERO_FRACTION keeps whole-number floats (1.0, -0.0, 1.5e10)
+  ;; rendered with a decimal point so they read back as floats, not ints.
+  (bit-or JSON_UNESCAPED_SLASHES JSON_UNESCAPED_UNICODE JSON_PRESERVE_ZERO_FRACTION))
 
 ;; ---------------------------------------------------------------------------
 ;; Reading

--- a/tests/phel/edn/write.phel
+++ b/tests/phel/edn/write.phel
@@ -14,6 +14,15 @@
   (is (= "-7"   (edn/write-string -7)))
   (is (= "3.14" (edn/write-string 3.14))))
 
+(deftest test-round-trip-floats
+  ;; whole-number floats must stay floats through a write/read round-trip
+  ;; (a writer that drops the trailing `.0` would read them back as ints)
+  (let [rt (fn [x] (edn/read-string (edn/write-string x)))]
+    (foreach [v [1.0 0.0 100.0 1.5e10 3.14]]
+      (is (= v (rt v)) (str "round-trip " v))
+      (is (float? (rt v)) (str "stays float " v)))
+    (is (= "-0.0" (edn/write-string -0.0)))))
+
 (deftest test-write-string
   (is (= "\"hello\"" (edn/write-string "hello"))))
 

--- a/tests/phel/transit/write.phel
+++ b/tests/phel/transit/write.phel
@@ -61,3 +61,19 @@
     ;; numeric string keys must stay strings (json coerces them to ints)
     (is (= {"1" "one" "2" "two"} (rt {"1" "one" "2" "two"})))
     (is (= {"a" 1 "b" 2} (rt {"a" 1 "b" 2})))))
+
+(deftest test-write-float-keeps-decimal
+  ;; whole-number floats must serialise with a decimal point so they
+  ;; read back as floats, not ints (JSON_PRESERVE_ZERO_FRACTION)
+  (is (= "1.0" (transit/write-string 1.0)))
+  (is (= "0.0" (transit/write-string 0.0)))
+  (is (= "-0.0" (transit/write-string -0.0)))
+  (is (= "100.0" (transit/write-string 100.0))))
+
+(deftest test-round-trip-floats
+  (let [rt (fn [x] (transit/read-string (transit/write-string x)))]
+    (foreach [v [1.0 0.0 100.0 1.5e10 3.14]]
+      (is (= v (rt v)) (str "round-trip " v))
+      (is (float? (rt v)) (str "stays float " v)))
+    ;; -0.0 keeps its negative sign through the round-trip
+    (is (= "-0.0" (transit/write-string (rt -0.0))))))


### PR DESCRIPTION
## 🤔 Background

`phel\transit` lost float type for whole-number floats on a write/read round-trip. The writer rendered `1.0`, `0.0`, `-0.0`, `1.5e10` as bare JSON numbers without a decimal point (`1`, `0`, `-0`, `15000000000`), so `json_decode` read them back as ints:

```phel
(transit/read-string (transit/write-string 1.0))  ; => 1 (int) — was 1.0
```

So `(= x (round-trip x))` was `false` for every whole-number float. Floats with a fractional part (`3.14`) round-tripped fine.

The edn half of #2485 was already resolved by #2479 (readable `NumberPrinter` now keeps `.0`); this PR fixes the remaining transit path and adds regression tests for both.

## 💡 Goal

Make `phel\transit` round-trip floats losslessly, matching `phel\edn`.

## 🔖 Changes

- `phel\transit`: add `JSON_PRESERVE_ZERO_FRACTION` to the `json_encode` flags so whole-number floats keep a trailing decimal (`1.0`, `-0.0`, `1.5e10`) and decode back as floats.
- Tests: transit float write + round-trip (type preservation, negative zero); edn float round-trip tests to lock the #2479 behavior.
- `CHANGELOG.md` updated under `## Unreleased`.

The change is a single encoder flag, so no separate refactor commit was warranted; the touched files were reviewed and need no further cleanup.

Closes #2485
