### PR TITLE
fix(printer): write DateTimeInterface as #inst literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `phel\edn`: `#inst` values (`\DateTimeInterface`) now write back as `#inst "<ISO-8601>"` instead of an error string, so they round-trip (mirrors `#uuid`); the readable Printer gained a `DateTimePrinter` strategy (#2486)
 - Constant folding of integer arithmetic (`+`/`-`/`*`) that overflows `PHP_INT_MAX` no longer disagrees with the runtime: `(* 2 4611686018427387904)` now keeps runtime dispatch and promotes to `BigInt` (matching the `let`-bound form) instead of silently folding to a `float`; also fixes a stray PHP warning at the exact `2^63` boundary (#2483)
 - `phel\router`: passing a bare string (or a sequence of bare strings) now raises a clear error instead of silently iterating the string character-by-character into garbage routes (#2487)
 - `loop`/`fn` `recur` inside a `let` (or any inner binding) that shadows a loop binding / fn param now updates the loop variable instead of the shadowing binding, fixing a silent infinite loop (#2482)

--- a/src/php/Shared/Printer/Printer.php
+++ b/src/php/Shared/Printer/Printer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Printer;
 
+use DateTimeInterface;
 use Phel\Lang\Atom;
 use Phel\Lang\BigDecimal;
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
@@ -28,6 +29,7 @@ use Phel\Shared\Printer\TypePrinter\AtomPrinter;
 use Phel\Shared\Printer\TypePrinter\BigDecimalPrinter;
 use Phel\Shared\Printer\TypePrinter\BooleanPrinter;
 use Phel\Shared\Printer\TypePrinter\ConsPrinter;
+use Phel\Shared\Printer\TypePrinter\DateTimePrinter;
 use Phel\Shared\Printer\TypePrinter\FnPrinter;
 use Phel\Shared\Printer\TypePrinter\KeywordPrinter;
 use Phel\Shared\Printer\TypePrinter\LazySeqPrinter;
@@ -131,6 +133,7 @@ final readonly class Printer implements PrinterInterface
             $form instanceof Ratio => new RatioPrinter($this->withColor),
             $form instanceof BigDecimal => new BigDecimalPrinter($this->withColor),
             $form instanceof UUID => new UUIDPrinter($this->withColor),
+            $form instanceof DateTimeInterface => new DateTimePrinter($this->withColor),
             $form instanceof FnInterface => new FnPrinter(),
             method_exists($form, '__toString') => new ToStringPrinter(),
             new ReflectionClass($form)->isAnonymous() => new AnonymousClassPrinter(),

--- a/src/php/Shared/Printer/TypePrinter/DateTimePrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/DateTimePrinter.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared\Printer\TypePrinter;
+
+use DateTimeInterface;
+
+use function sprintf;
+
+/**
+ * Prints a `\DateTimeInterface` as the `#inst "<ISO-8601>"` tagged literal
+ * that {@see \Phel\Lang\TagHandlers\InstTagHandler} reads, so instants
+ * round-trip through `edn`/`pr-str` — analogous to `#uuid`/{@see UUIDPrinter}.
+ *
+ * Microseconds are emitted only when present, keeping whole-second
+ * timestamps compact (`2026-06-17T00:00:00+00:00`).
+ *
+ * @implements TypePrinterInterface<DateTimeInterface>
+ */
+final class DateTimePrinter implements TypePrinterInterface
+{
+    use WithColorTrait;
+
+    /**
+     * @param DateTimeInterface $form
+     */
+    public function print(mixed $form): string
+    {
+        $format = (int) $form->format('u') === 0
+            ? 'Y-m-d\TH:i:sP'
+            : 'Y-m-d\TH:i:s.uP';
+
+        return $this->color(sprintf('#inst "%s"', $form->format($format)));
+    }
+
+    private function color(string $str): string
+    {
+        if ($this->withColor) {
+            return sprintf("\033[0;92m%s\033[0m", $str);
+        }
+
+        return $str;
+    }
+}

--- a/tests/phel/edn/write.phel
+++ b/tests/phel/edn/write.phel
@@ -45,6 +45,17 @@
     (is (php/instanceof round-tripped \Phel\Lang\UUID))
     (is (= (str u) (str round-tripped)) "UUID round-trips through EDN")))
 
+(deftest test-write-inst-round-trip
+  (let [i             (edn/read-string "#inst \"2026-06-17T08:30:15Z\"")
+        written       (edn/write-string i)
+        round-tripped (edn/read-string written)]
+    (is (= "#inst \"2026-06-17T08:30:15+00:00\"" written) "inst writes as #inst literal")
+    (is (php/instanceof round-tripped \DateTimeImmutable))
+    (is (php/== i round-tripped) "inst round-trips to an equal instant"))
+  ;; sub-second precision survives the round-trip
+  (let [micros (edn/read-string "#inst \"2026-06-17T08:30:15.123456Z\"")]
+    (is (php/== micros (edn/read-string (edn/write-string micros))))))
+
 (deftest test-write-string-all
   (is (= "1 2 3" (edn/write-string-all [1 2 3])))
   (is (= ""      (edn/write-string-all [])))

--- a/tests/php/Unit/Printer/TypePrinter/DateTimePrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/DateTimePrinterTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Printer\TypePrinter;
+
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+use Generator;
+use Phel\Shared\Printer\TypePrinter\DateTimePrinter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DateTimePrinterTest extends TestCase
+{
+    #[DataProvider('providerPrint')]
+    public function test_print(DateTimeInterface $form, string $expected): void
+    {
+        self::assertSame($expected, new DateTimePrinter()->print($form));
+    }
+
+    public static function providerPrint(): Generator
+    {
+        $utc = new DateTimeZone('UTC');
+
+        yield 'whole seconds keep no fraction' => [
+            new DateTimeImmutable('2026-06-17T00:00:00', $utc),
+            '#inst "2026-06-17T00:00:00+00:00"',
+        ];
+
+        yield 'microseconds preserved' => [
+            new DateTimeImmutable('2026-06-17T08:30:15.123456', $utc),
+            '#inst "2026-06-17T08:30:15.123456+00:00"',
+        ];
+
+        yield 'non-utc offset preserved' => [
+            new DateTimeImmutable('2026-06-17T08:30:15', new DateTimeZone('+02:00')),
+            '#inst "2026-06-17T08:30:15+02:00"',
+        ];
+
+        yield 'mutable DateTime also prints' => [
+            new DateTime('2026-06-17T00:00:00', $utc),
+            '#inst "2026-06-17T00:00:00+00:00"',
+        ];
+    }
+}

--- a/tests/php/Unit/Printer/TypePrinter/NonPrintableClassPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/NonPrintableClassPrinterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Printer\TypePrinter;
 
-use DateTime;
+use ArrayObject;
 use Generator;
 use Phel\Shared\Printer\TypePrinter\NonPrintableClassPrinter;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -21,9 +21,9 @@ final class NonPrintableClassPrinterTest extends TestCase
 
     public static function providerPrint(): Generator
     {
-        yield 'cannot print DateTime' => [
-            new DateTime(),
-            'Printer cannot print this type: DateTime',
+        yield 'cannot print ArrayObject' => [
+            new ArrayObject(),
+            'Printer cannot print this type: ArrayObject',
         ];
 
         yield 'cannot print stdClass' => [


### PR DESCRIPTION
## 🤔 Background

`phel\edn` could read an `#inst "..."` literal into a `\DateTimeImmutable`, but could not write it back. The readable Printer had no `DateTime` strategy, so a `DateTimeInterface` fell through to `NonPrintableClassPrinter` and `edn/write-string` returned the literal string `"Printer cannot print this type: DateTimeImmutable"`:

```phel
(def i (edn/read-string "#inst \"2026-06-17T00:00:00Z\""))
(edn/write-string i)
; => "Printer cannot print this type: DateTimeImmutable"
```

Round-trip was broken: re-reading that string yielded the symbol `Printer`.

## 💡 Goal

`#inst`-tagged `\DateTimeInterface` values print as `#inst "<ISO-8601>"` (the form `InstTagHandler` reads) so they round-trip, mirroring how `#uuid`/`UUIDPrinter` already works.

## 🔖 Changes

- New `DateTimePrinter` `TypePrinter` strategy renders `\DateTimeInterface` (covers `DateTime` and `DateTimeImmutable`) as `#inst "<ISO-8601>"`. Microseconds are emitted only when present, so whole-second timestamps stay compact (`2026-06-17T00:00:00+00:00`).
- Registered it in `Printer::createObjectTypePrinter()` ahead of the fallback chain.
- Tests: `DateTimePrinterTest` (whole seconds, microseconds, non-UTC offset, mutable `DateTime`); Phel-level edn `#inst` round-trip (equal instant + sub-second precision); updated `NonPrintableClassPrinterTest` to use `ArrayObject` now that `DateTime` is printable.
- `CHANGELOG.md` updated under `## Unreleased`.

Note: this changes how `\DateTimeInterface` prints everywhere — previously it errored, now it renders `#inst "..."` in both readable and non-readable output (consistent with `#uuid`).

Closes #2486
