### PR TITLE
docs(cli): document shell completion install + global-binary prerequisite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - `phel doc` now offers shell completion for its arguments: `phel doc <TAB>` completes fully qualified function names (`core/map`, ...), `--ns=<TAB>` completes the namespaces that own documented functions, and `--format=<TAB>` completes `table`/`json`. Install the completion script with `phel completion zsh` (or `bash`/`fish`) (#2451)
 - More shell completion for known option values: `phel compile --target=<TAB>` (`php`), plus `phel test --coverage=<TAB>` (`text`/`clover`), `--reporter=<TAB>` (`default`/`testdox`/`dot`/`tap`/`junit-xml`), and `--parallel=<TAB>` (`auto`/`max`) (#2451)
 - `phel run <TAB>` and `phel test <TAB>` / `phel test --ns=<TAB>` now complete the project's namespaces (source, test, and vendor source dirs); the shell narrows them as you type. Backed by a new `RunFacade::getAllNamespaces()` (#2451)
+- README "Get Started" now documents shell completion: `bash`/`zsh`/`fish` install snippets plus the `#compdef phel` global-binary prerequisite (completion only fires for a binary named `phel` on `$PATH`, so `./vendor/bin/phel` and `./bin/phel` dev checkouts need a global symlink first) (#2451)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - `phel doc` now offers shell completion for its arguments: `phel doc <TAB>` completes fully qualified function names (`core/map`, ...), `--ns=<TAB>` completes the namespaces that own documented functions, and `--format=<TAB>` completes `table`/`json`. Install the completion script with `phel completion zsh` (or `bash`/`fish`) (#2451)
 - More shell completion for known option values: `phel compile --target=<TAB>` (`php`), plus `phel test --coverage=<TAB>` (`text`/`clover`), `--reporter=<TAB>` (`default`/`testdox`/`dot`/`tap`/`junit-xml`), and `--parallel=<TAB>` (`auto`/`max`) (#2451)
 - `phel run <TAB>` and `phel test <TAB>` / `phel test --ns=<TAB>` now complete the project's namespaces (source, test, and vendor source dirs); the shell narrows them as you type. Backed by a new `RunFacade::getAllNamespaces()` (#2451)
-- README "Get Started" now documents shell completion: `bash`/`zsh`/`fish` install snippets plus the `#compdef phel` global-binary prerequisite (completion only fires for a binary named `phel` on `$PATH`, so `./vendor/bin/phel` and `./bin/phel` dev checkouts need a global symlink first) (#2451)
+- README "Get Started" now documents shell completion: `bash`/`zsh`/`fish` install snippets plus the `#compdef phel` global-binary prerequisite (completion only fires for a binary named `phel` on `$PATH`, so `./vendor/bin/phel` and `./bin/phel` dev checkouts need a global symlink first) (#2500)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,30 @@ echo '(println "hi")' | ./vendor/bin/phel eval -
 ./vendor/bin/phel eval - < script.phel
 ```
 
+**4. Enable shell completion (optional)**
+
+`./vendor/bin/phel completion` dumps a tab-completion script for `bash`, `zsh`, or `fish`. It completes commands, their options, and dynamic values (function names for `doc`, project namespaces for `run`/`test`).
+
+```sh
+# bash — restart your shell afterwards
+./vendor/bin/phel completion bash | sudo tee /etc/bash_completion.d/phel
+
+# zsh — write into a directory on your $fpath
+./vendor/bin/phel completion zsh > "${fpath[1]}/_phel"
+
+# fish
+./vendor/bin/phel completion fish > ~/.config/fish/completions/phel.fish
+```
+
+The zsh script starts with `#compdef phel`, so completion only triggers for a binary named `phel` on your `$PATH`. If you call `./vendor/bin/phel` (or `./bin/phel` in a dev checkout), symlink a global `phel` first, e.g. on macOS + Homebrew:
+
+```sh
+phel completion zsh > "$(brew --prefix)/share/zsh/site-functions/_phel"
+ln -sf "$PWD/bin/phel" "$(brew --prefix)/bin/phel"   # global `phel` so #compdef matches
+rm -f ~/.zcompdump*                                  # force compinit to rebuild
+# then open a new shell
+```
+
 > Prefer a project template? [`web-skeleton`](https://github.com/phel-lang/web-skeleton) or [`cli-skeleton`](https://github.com/phel-lang/cli-skeleton): click **Use this template** for a one-click start.
 
 <details>


### PR DESCRIPTION
## 🤔 Background

`phel completion` (Symfony Console) was undocumented, and tab-completion silently never fires unless a binary literally named `phel` is on `$PATH` (the generated zsh script starts with `#compdef phel`).

## 💡 Goal

Document shell completion and the global-binary prerequisite so a newcomer can enable it in one command.

## 🔖 Changes

- README "Get Started" gains a "Enable shell completion (optional)" section: `bash`/`zsh`/`fish` install snippets, plus the `#compdef phel` global-binary prerequisite with a macOS + Homebrew symlink recipe for `./bin/phel` / `./vendor/bin/phel` dev checkouts.
- `CHANGELOG.md` updated under `## Unreleased`.

User-facing CLI reference pages live on phel-lang.org (separate repo); the in-repo deliverable is the README. The `phel completion bash|zsh|fish` commands were verified to emit valid scripts (zsh starts with `#compdef phel`).

Closes #2500
