### PR TITLE
feat(cli): offer shell-completion tip after init / agent-install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - The PHAR ships `phel.core` precompiled, cutting cold-start `run`/`test`/`eval` from ~1.2s to ~0.2s (#2443)
 - `phel doctor` reports whether OPcache persists the compiled-code cache across CLI runs, with fixes (#2446)
 - Shell completion for `phel doc`, option values, and project namespaces; `bash`/`zsh`/`fish` install docs (#2451)
+- `phel init` and `phel agent-install` now end with an optional shell-completion tip tailored to your `$SHELL` (`phel completion zsh`, ...), pointing at the README install steps (#2501)
 - LSP PHP interop completion/hover/signature help (follow-up to #2431): `(:use ...)`/`(use ...)` alias resolution (#2461), LSP 3.17 signature help (#2462), hover for properties/constants/enum cases/classes (#2463), `php/->` chain and union/intersection type resolution (#2464), suppression inside strings and comments (#2465), and refined class-name completion (#2466)
 
 ### Performance

--- a/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
+++ b/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
@@ -120,6 +120,8 @@ HELP)
         if (!$dryRun) {
             $output->writeln('');
             $output->writeln('<info>Done.</info>');
+
+            ShellCompletionTip::writeTo($output);
         }
 
         return Command::SUCCESS;

--- a/src/php/Run/Infrastructure/Command/InitCommand.php
+++ b/src/php/Run/Infrastructure/Command/InitCommand.php
@@ -398,6 +398,8 @@ final class InitCommand extends Command
         $output->writeln('  1. Install dependencies: <comment>composer install</comment>');
         $output->writeln('  2. Run the tests:        <comment>./vendor/bin/phel test</comment>');
         $output->writeln('  3. See the README for how to run the app.');
+
+        ShellCompletionTip::writeTo($output);
     }
 
     private function printNextSteps(OutputInterface $output, string $mainFilename, bool $noTests): void
@@ -415,5 +417,7 @@ final class InitCommand extends Command
 
         $output->writeln(sprintf('  %d. Start the REPL: <comment>./vendor/bin/phel repl</comment>', $step++));
         $output->writeln(sprintf('  %d. Build for production: <comment>./vendor/bin/phel build</comment>', $step));
+
+        ShellCompletionTip::writeTo($output);
     }
 }

--- a/src/php/Run/Infrastructure/Command/ShellCompletionTip.php
+++ b/src/php/Run/Infrastructure/Command/ShellCompletionTip.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Infrastructure\Command;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function basename;
+use function getenv;
+use function in_array;
+use function is_string;
+use function sprintf;
+
+/**
+ * Renders the optional "enable shell completion" tip shown at the end of
+ * `phel init` / `phel agent-install`.
+ *
+ * Completion is opt-in: the tip surfaces the exact `phel completion <shell>`
+ * command (tailored to the user's `$SHELL` when recognised) and points to the
+ * README for the global-binary prerequisite. It never writes to the user's
+ * shell config, which would require OS-specific paths and (for bash) root.
+ */
+final readonly class ShellCompletionTip
+{
+    /** @var list<string> */
+    private const array SUPPORTED_SHELLS = ['bash', 'zsh', 'fish'];
+
+    /**
+     * Writes the tip, detecting the shell from the ambient `$SHELL`.
+     */
+    public static function writeTo(OutputInterface $output): void
+    {
+        foreach (self::lines(getenv('SHELL')) as $line) {
+            $output->writeln($line);
+        }
+    }
+
+    /**
+     * @param false|string|null $shellEnv the raw `$SHELL` value (path to the
+     *                                    login shell), or false/null when unset
+     *
+     * @return list<string> output lines, ready to write verbatim
+     */
+    public static function lines(string|false|null $shellEnv): array
+    {
+        $shell = self::detectShell($shellEnv);
+
+        return [
+            '',
+            '<info>Enable shell completion (optional):</info>',
+            sprintf('  <comment>phel completion %s</comment>', $shell ?? 'bash|zsh|fish'),
+            '  See the README "shell completion" section for install paths and the global-binary note.',
+        ];
+    }
+
+    private static function detectShell(string|false|null $shellEnv): ?string
+    {
+        if (!is_string($shellEnv) || $shellEnv === '') {
+            return null;
+        }
+
+        $name = basename($shellEnv);
+
+        return in_array($name, self::SUPPORTED_SHELLS, true) ? $name : null;
+    }
+}

--- a/tests/php/Integration/Run/Command/Init/InitCommandTest.php
+++ b/tests/php/Integration/Run/Command/Init/InitCommandTest.php
@@ -328,6 +328,7 @@ final class InitCommandTest extends TestCase
         self::assertStringContainsString('phel test', $outputContent);
         self::assertStringContainsString('phel repl', $outputContent);
         self::assertStringContainsString('phel build', $outputContent);
+        self::assertStringContainsString('phel completion', $outputContent);
     }
 
     public function test_does_not_show_message_for_existing_gitignore(): void

--- a/tests/php/Unit/Run/Infrastructure/Command/ShellCompletionTipTest.php
+++ b/tests/php/Unit/Run/Infrastructure/Command/ShellCompletionTipTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Infrastructure\Command;
+
+use Phel\Run\Infrastructure\Command\ShellCompletionTip;
+use PHPUnit\Framework\TestCase;
+
+use function implode;
+
+final class ShellCompletionTipTest extends TestCase
+{
+    public function test_tailors_command_to_a_recognised_shell(): void
+    {
+        $text = implode("\n", ShellCompletionTip::lines('/usr/bin/zsh'));
+
+        self::assertStringContainsString('phel completion zsh', $text);
+        self::assertStringNotContainsString('bash|zsh|fish', $text);
+    }
+
+    public function test_falls_back_to_generic_command_for_unknown_shell(): void
+    {
+        $text = implode("\n", ShellCompletionTip::lines('/usr/bin/nu'));
+
+        self::assertStringContainsString('phel completion bash|zsh|fish', $text);
+    }
+
+    public function test_falls_back_when_shell_env_is_absent(): void
+    {
+        self::assertStringContainsString(
+            'phel completion bash|zsh|fish',
+            implode("\n", ShellCompletionTip::lines(false)),
+        );
+        self::assertStringContainsString(
+            'phel completion bash|zsh|fish',
+            implode("\n", ShellCompletionTip::lines(null)),
+        );
+        self::assertStringContainsString(
+            'phel completion bash|zsh|fish',
+            implode("\n", ShellCompletionTip::lines('')),
+        );
+    }
+
+    public function test_always_mentions_completion_and_readme(): void
+    {
+        $text = implode("\n", ShellCompletionTip::lines('/bin/bash'));
+
+        self::assertStringContainsString('shell completion', $text);
+        self::assertStringContainsString('README', $text);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Even with completion documented (#2500), enabling it is a separate manual step a newcomer may never discover.

## 💡 Goal

Surface shell completion at the moment a project is set up, opt-in and never silent.

## 🔖 Changes

- New `ShellCompletionTip` helper: `lines($shellEnv)` builds an optional "enable shell completion" tip, tailored to the user's `$SHELL` (`phel completion zsh` when bash/zsh/fish is detected, generic `bash|zsh|fish` otherwise); `writeTo($output)` writes it.
- `phel init` (regular + template next-steps) and `phel agent-install` (after a successful, non-dry-run install) now print the tip.
- Tests: unit coverage for shell detection / fallbacks; integration assertion that `phel init` output mentions `phel completion`.
- `CHANGELOG.md` updated under `## Unreleased`.

### Scope note

The tip is intentionally informational and never writes to the user's shell config. A true auto-installer would need OS-specific destinations (bash `/etc/bash_completion.d` needs root, zsh `$fpath`, fish `~/.config/fish/completions`) and is too fragile to run unattended; the tip gives the exact command instead. This matches how comparable CLIs surface completion.

Closes #2501
