### PR TITLE
feat(cli): align short aliases across commands + document conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - `phel doctor` reports whether OPcache persists the compiled-code cache across CLI runs, with fixes (#2446)
 - Shell completion for `phel doc`, option values, and project namespaces; `bash`/`zsh`/`fish` install docs (#2451)
 - `phel init` and `phel agent-install` now end with an optional shell-completion tip tailored to your `$SHELL` (`phel completion zsh`, ...), pointing at the README install steps (#2501)
+- Consistent CLI short aliases (additive, no renames): `--format` also accepts `-f` (`doc`, `lint`, `profile`), `--output` accepts `-o` (`profile`, `test`), and `--sort` accepts `-s` (`profile`); conventions documented in `docs/internals/cli-flag-conventions.md` (#2502)
 - LSP PHP interop completion/hover/signature help (follow-up to #2431): `(:use ...)`/`(use ...)` alias resolution (#2461), LSP 3.17 signature help (#2462), hover for properties/constants/enum cases/classes (#2463), `php/->` chain and union/intersection type resolution (#2464), suppression inside strings and comments (#2465), and refined class-name completion (#2466)
 
 ### Performance

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -9,6 +9,7 @@
 5. [Runtime](runtime.md): `Lang/`, persistent collections, `Registry`, `\Phel` facade.
 6. [Benchmarks](benchmarks.md): PHPBench setup.
 7. [FAQ](faq.md): grouped by reader.
+8. [CLI flag conventions](cli-flag-conventions.md): standard option names + short aliases.
 
 ## What to read for what
 

--- a/docs/internals/cli-flag-conventions.md
+++ b/docs/internals/cli-flag-conventions.md
@@ -1,0 +1,42 @@
+# CLI Flag Conventions
+
+Conventions for option names and short aliases across Phel's CLI commands, so
+muscle memory transfers between commands. New commands MUST follow these.
+
+## Standard options
+
+| Concept | Long | Short | Notes |
+|---|---|---|---|
+| Output format | `--format` | `-f` | Value flag (`table`/`json`/...). `-f` is also `--filter` on `phel test` (pre-existing); a command never has both, so there is no in-command clash. |
+| Output destination (file) | `--output` | `-o` | Write the report/result to a file instead of stdout. |
+| Sort order | `--sort` | `-s` | Value flag (e.g. `phel profile --sort`). |
+| Disable caching | `--no-cache` | — | Boolean. Paired with `--cache` where a default-on cache exists (`build`). |
+| Config file path | `--config` | — | Path to a command-specific config. |
+| Preview without writing | `--dry-run` | — | Boolean; print intended actions only. |
+| Overwrite existing files | `--force` | — | Boolean. |
+| Optimization level | `--optimization-level` | `-O` | `build`/`compile`. |
+
+Global flags (`--help/-h`, `--quiet/-q`, `--verbose/-v`, `--version/-V`,
+`--no-interaction/-n`, `--ansi/--no-ansi`) come from Symfony Console; never
+re-declare them or reuse their short letters.
+
+## Reserved short letters
+
+`-h -q -v -V -n` are Symfony globals. Within Phel commands: `-f` = format
+(or filter on `test`), `-o` = output, `-s` = sort, `-O` = optimization level,
+`-t` is command-local (`compile --target`, `init --template`, `run --with-time`),
+`-p` = port (`nrepl`), `-m` = minimal (`init`), `-b` = backend (`watch`).
+
+## Known drift (deferred — needs a deprecation cycle)
+
+These would be breaking renames, so they are intentionally left for a separate
+change that keeps the old name as a deprecated alias first:
+
+- `phel index --out` should become `--output` (`-o`) to match `profile`/`test`.
+- `phel test --reporter` overlaps conceptually with `--format`; it stays a
+  distinct, repeatable flag for now (it selects reporters, not a single format).
+- `phel config --json` is a boolean shorthand for "format = json"; left as-is.
+
+When adding such a rename, register the new name + short alias, keep the old
+option accepted (mark it deprecated in the description), and read whichever is
+provided.

--- a/src/php/Api/Infrastructure/Command/DocCommand.php
+++ b/src/php/Api/Infrastructure/Command/DocCommand.php
@@ -54,7 +54,7 @@ final class DocCommand extends Command
             )
             ->addOption(
                 self::OPTION_FORMAT,
-                null,
+                'f',
                 InputOption::VALUE_REQUIRED,
                 'Specify the output format.',
                 'table',

--- a/src/php/Lint/Infrastructure/Command/LintCommand.php
+++ b/src/php/Lint/Infrastructure/Command/LintCommand.php
@@ -70,7 +70,7 @@ final class LintCommand extends Command
             )
             ->addOption(
                 self::OPT_FORMAT,
-                null,
+                'f',
                 InputOption::VALUE_REQUIRED,
                 'Output format: human, json, github.',
                 HumanFormatter::NAME,

--- a/src/php/Profile/Infrastructure/Command/ProfileCommand.php
+++ b/src/php/Profile/Infrastructure/Command/ProfileCommand.php
@@ -67,9 +67,9 @@ final class ProfileCommand extends Command
             ->addArgument(self::ARG_PATH, InputArgument::OPTIONAL, 'File path or namespace to profile.')
             ->addArgument(self::ARG_ARGV, InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Optional script arguments.', [])
             ->addOption(self::OPT_TOP, null, InputOption::VALUE_REQUIRED, 'Show top N fns in the table.', (string) ProfileConfig::DEFAULT_TOP)
-            ->addOption(self::OPT_FORMAT, null, InputOption::VALUE_REQUIRED, 'Output format: table, json, both.', ReportFormat::Table->value)
-            ->addOption(self::OPT_OUTPUT, null, InputOption::VALUE_REQUIRED, 'Write JSON report to this file.')
-            ->addOption(self::OPT_SORT, null, InputOption::VALUE_REQUIRED, 'Sort fns by: self, total, calls, avg.', SortOrder::SelfTime->value)
+            ->addOption(self::OPT_FORMAT, 'f', InputOption::VALUE_REQUIRED, 'Output format: table, json, both.', ReportFormat::Table->value)
+            ->addOption(self::OPT_OUTPUT, 'o', InputOption::VALUE_REQUIRED, 'Write JSON report to this file.')
+            ->addOption(self::OPT_SORT, 's', InputOption::VALUE_REQUIRED, 'Sort fns by: self, total, calls, avg.', SortOrder::SelfTime->value)
             ->addOption(self::OPT_NO_COMPILE_PHASES, null, InputOption::VALUE_NONE, 'Skip the compile-time phase report.');
     }
 

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -88,7 +88,7 @@ final class TestCommand extends Command
                 ['default', 'testdox', 'dot', 'tap', 'junit-xml'],
             )->addOption(
                 TestCommandOptionParser::OPT_OUTPUT,
-                null,
+                'o',
                 InputOption::VALUE_REQUIRED,
                 'Write the junit-xml reporter to a file instead of stdout.',
             )->addOption(

--- a/tests/php/Unit/Console/CliFlagConventionsTest.php
+++ b/tests/php/Unit/Console/CliFlagConventionsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Console;
+
+use Phel\Api\Infrastructure\Command\DocCommand;
+use Phel\Lint\Infrastructure\Command\LintCommand;
+use Phel\Profile\Infrastructure\Command\ProfileCommand;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * Guards the short-alias conventions documented in
+ * docs/internals/cli-flag-conventions.md: --format=-f, --output=-o, --sort=-s.
+ */
+final class CliFlagConventionsTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{Command, string, string}>
+     */
+    public static function provider(): iterable
+    {
+        yield 'doc --format' => [new DocCommand(), 'format', 'f'];
+        yield 'lint --format' => [new LintCommand(), 'format', 'f'];
+        yield 'profile --format' => [new ProfileCommand(), 'format', 'f'];
+        yield 'profile --output' => [new ProfileCommand(), 'output', 'o'];
+        yield 'profile --sort' => [new ProfileCommand(), 'sort', 's'];
+    }
+
+    #[DataProvider('provider')]
+    public function test_option_has_expected_short_alias(Command $command, string $option, string $short): void
+    {
+        self::assertSame(
+            $short,
+            $command->getDefinition()->getOption($option)->getShortcut(),
+        );
+    }
+}

--- a/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
+++ b/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
@@ -128,6 +128,12 @@ final class TestCommandOptionsWiringTest extends TestCase
         self::assertStringContainsString('glob', strtolower($ns->getDescription()));
     }
 
+    public function test_output_option_has_o_short_alias(): void
+    {
+        // CLI flag convention: --output is -o across commands.
+        self::assertSame('o', $this->optionFor('output')->getShortcut());
+    }
+
     public function test_coverage_option_completes_formats(): void
     {
         $tester = new CommandCompletionTester(new TestCommand());


### PR DESCRIPTION
## 🤔 Background

Flags drifted across commands: `--format` (doc/lint/profile) had no short alias while equivalent concepts elsewhere did, output-destination was `--out` on `index` but `--output` on `profile`/`test`, etc. Renaming flags would break user scripts, so the audit separates safe additive fixes from breaking renames.

## 💡 Goal

Make equivalent flags share a short alias across commands, without breaking any existing invocation, and document the conventions so new commands stay consistent.

## 🔖 Changes

- Additive short aliases (no renames, zero breakage; each letter was free on its command):
  - `--format` -> `-f`: `doc`, `lint`, `profile`
  - `--output` -> `-o`: `profile`, `test`
  - `--sort` -> `-s`: `profile`
- New contributor doc `docs/internals/cli-flag-conventions.md` (linked from the internals index): standard option names + short aliases, reserved letters, and the deferred breaking renames.
- Tests: `CliFlagConventionsTest` (doc/lint/profile short aliases) + a `test --output` short-alias assertion.
- `CHANGELOG.md` updated under `## Unreleased`.

### Scope note

Breaking renames (`index --out` -> `--output`, `test --reporter` overlap, `config --json`) are intentionally deferred to https://github.com/phel-lang/phel-lang/issues/2511 since they need a deprecation cycle.

Closes #2502
