### PR TITLE
feat(cli): add --help usage examples to every command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Shell completion for `phel doc`, option values, and project namespaces; `bash`/`zsh`/`fish` install docs (#2451)
 - `phel init` and `phel agent-install` now end with an optional shell-completion tip tailored to your `$SHELL` (`phel completion zsh`, ...), pointing at the README install steps (#2501)
 - Consistent CLI short aliases (additive, no renames): `--format` also accepts `-f` (`doc`, `lint`, `profile`), `--output` accepts `-o` (`profile`, `test`), and `--sort` accepts `-s` (`profile`); conventions documented in `docs/internals/cli-flag-conventions.md` (#2502)
+- Every CLI command's `--help` now includes a usage example block (previously most had only a one-line description); a test guards that coverage going forward (#2503)
 - LSP PHP interop completion/hover/signature help (follow-up to #2431): `(:use ...)`/`(use ...)` alias resolution (#2461), LSP 3.17 signature help (#2462), hover for properties/constants/enum cases/classes (#2463), `php/->` chain and union/intersection type resolution (#2464), suppression inside strings and comments (#2465), and refined class-name completion (#2466)
 
 ### Performance

--- a/src/php/Api/Infrastructure/Command/AnalyzeCommand.php
+++ b/src/php/Api/Infrastructure/Command/AnalyzeCommand.php
@@ -31,6 +31,12 @@ final class AnalyzeCommand extends Command
     {
         $this->setName('analyze')
             ->setDescription('Run semantic analysis on a single Phel source file and emit JSON diagnostics')
+            ->setHelp(<<<'HELP'
+Emits analyzer diagnostics (unresolved symbols, arity errors, ...) as JSON.
+
+<info>Example:</info>
+  <comment>phel analyze src/main.phel</comment>
+HELP)
             ->addArgument('file', InputArgument::REQUIRED, 'Path to a .phel source file');
     }
 

--- a/src/php/Api/Infrastructure/Command/ApiDaemonCommand.php
+++ b/src/php/Api/Infrastructure/Command/ApiDaemonCommand.php
@@ -24,7 +24,13 @@ final class ApiDaemonCommand extends Command
         $this->setName('api-daemon')
             ->setDescription(
                 'Long-running JSON-RPC daemon exposing the Api semantic analysis facade over newline-delimited JSON (stdio).',
-            );
+            )
+            ->setHelp(<<<'HELP'
+Editors/tools drive this over stdio; you rarely run it by hand.
+
+<info>Example:</info>
+  <comment>phel api-daemon</comment>   Start the daemon, reading JSON-RPC from stdin
+HELP);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/php/Api/Infrastructure/Command/DocCommand.php
+++ b/src/php/Api/Infrastructure/Command/DocCommand.php
@@ -37,6 +37,13 @@ final class DocCommand extends Command
     {
         $this->setName('doc')
             ->setDescription('Display the docs for any/all phel functions')
+            ->setHelp(<<<'HELP'
+Prints docstrings, signatures, and examples for Phel functions.
+
+<info>Examples:</info>
+  <comment>phel doc map</comment>              Show docs for a single function
+  <comment>phel doc --format=json</comment>    Emit all docs as JSON
+HELP)
             ->addArgument(
                 'search',
                 InputArgument::OPTIONAL,

--- a/src/php/Api/Infrastructure/Command/IndexCommand.php
+++ b/src/php/Api/Infrastructure/Command/IndexCommand.php
@@ -31,6 +31,12 @@ final class IndexCommand extends Command
     {
         $this->setName('index')
             ->setDescription('Build a project-level symbol index across one or more source directories')
+            ->setHelp(<<<'HELP'
+Scans directories for `.phel` files and indexes their symbols (for tooling).
+
+<info>Example:</info>
+  <comment>phel index src tests --out=index.json</comment>
+HELP)
             ->addArgument(
                 'dirs',
                 InputArgument::IS_ARRAY | InputArgument::REQUIRED,

--- a/src/php/Build/Infrastructure/Command/BuildCommand.php
+++ b/src/php/Build/Infrastructure/Command/BuildCommand.php
@@ -41,6 +41,13 @@ final class BuildCommand extends Command
     {
         $this->setName('build')
             ->setDescription('Build the current project')
+            ->setHelp(<<<'HELP'
+Compiles every project namespace to PHP in the output directory.
+
+<info>Examples:</info>
+  <comment>phel build</comment>                  Incremental build using the cache
+  <comment>phel build --no-cache -O2</comment>     Clean, fully optimized build
+HELP)
             ->addOption(self::OPTION_CACHE, null, InputOption::VALUE_NEGATABLE, 'Enable cache', true)
             ->addOption(self::OPTION_SOURCE_MAP, null, InputOption::VALUE_NEGATABLE, 'Enable source maps', true)
             ->addOption(

--- a/src/php/Build/Infrastructure/Command/CacheClearCommand.php
+++ b/src/php/Build/Infrastructure/Command/CacheClearCommand.php
@@ -21,7 +21,13 @@ final class CacheClearCommand extends Command
     protected function configure(): void
     {
         $this->setName('cache:clear')
-            ->setDescription('Clear the temp and cache directories');
+            ->setDescription('Clear the temp and cache directories')
+            ->setHelp(<<<'HELP'
+Removes compiled-code, namespace, and temp caches; the next run rebuilds them.
+
+<info>Example:</info>
+  <comment>phel cache:clear</comment>
+HELP);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/php/Formatter/Infrastructure/Command/FormatCommand.php
+++ b/src/php/Formatter/Infrastructure/Command/FormatCommand.php
@@ -27,6 +27,13 @@ final class FormatCommand extends Command
     {
         $this->setName('format')
             ->setDescription('Formats the given files')
+            ->setHelp(<<<'HELP'
+Reformats `.phel` files in place (defaults to the project's format dirs).
+
+<info>Examples:</info>
+  <comment>phel format</comment>                Format all configured directories
+  <comment>phel format src/main.phel --dry-run</comment>   Preview changes only
+HELP)
             ->setAliases(['fmt'])
             ->addArgument(
                 'paths',

--- a/src/php/Interop/Infrastructure/Command/ExportCommand.php
+++ b/src/php/Interop/Infrastructure/Command/ExportCommand.php
@@ -26,7 +26,14 @@ final class ExportCommand extends Command
     protected function configure(): void
     {
         $this->setName('export')
-            ->setDescription('Export all definitions with the meta data `{:export true}` as PHP classes');
+            ->setDescription('Export all definitions with the meta data `{:export true}` as PHP classes')
+            ->setHelp(<<<'HELP'
+Generates PHP wrapper classes for every `^{:export true}` Phel function so
+PHP code can call them. Reads the export dirs/prefix from your config.
+
+<info>Example:</info>
+  <comment>phel export</comment>
+HELP);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/php/Lint/Infrastructure/Command/LintCommand.php
+++ b/src/php/Lint/Infrastructure/Command/LintCommand.php
@@ -62,6 +62,14 @@ final class LintCommand extends Command
     protected function configure(): void
     {
         $this->setDescription('Run the semantic linter on one or more Phel files or directories.')
+            ->setHelp(<<<'HELP'
+Reports semantic issues (unresolved symbols, arity, unused bindings, ...)
+without rewriting files. Exit code 1 on errors.
+
+<info>Examples:</info>
+  <comment>phel lint</comment>                  Lint the configured source dirs
+  <comment>phel lint src --format=json</comment>   Machine-readable diagnostics
+HELP)
             ->addArgument(
                 self::ARG_PATHS,
                 InputArgument::IS_ARRAY,

--- a/src/php/Lsp/Infrastructure/Command/LspCommand.php
+++ b/src/php/Lsp/Infrastructure/Command/LspCommand.php
@@ -37,7 +37,14 @@ final class LspCommand extends Command
     {
         $this->setDescription(
             'Start the Phel Language Server (LSP v3.17 over stdio, JSON-RPC 2.0 with Content-Length framing).',
-        );
+        )
+            ->setHelp(<<<'HELP'
+Editors spawn this over stdio for hover/completion/diagnostics; you rarely
+run it by hand.
+
+<info>Example:</info>
+  <comment>phel lsp</comment>   Start the language server on stdio
+HELP);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/php/Nrepl/Infrastructure/Command/NreplCommand.php
+++ b/src/php/Nrepl/Infrastructure/Command/NreplCommand.php
@@ -36,6 +36,13 @@ final class NreplCommand extends Command
     protected function configure(): void
     {
         $this->setDescription('Start an nREPL server for editor tooling (bencode-over-TCP protocol).')
+            ->setHelp(<<<'HELP'
+Starts an nREPL server your editor (Cursive, Calva, CIDER, Conjure) connects to.
+
+<info>Examples:</info>
+  <comment>phel nrepl</comment>             Listen on the default 127.0.0.1:7888
+  <comment>phel nrepl --port=0</comment>    Bind a random free port
+HELP)
             ->addOption(
                 'port',
                 'p',

--- a/src/php/Profile/Infrastructure/Command/ProfileCommand.php
+++ b/src/php/Profile/Infrastructure/Command/ProfileCommand.php
@@ -64,6 +64,13 @@ final class ProfileCommand extends Command
     protected function configure(): void
     {
         $this->setDescription('Profile a Phel script: per-fn call counts and timings, plus compile-time phase costs.')
+            ->setHelp(<<<'HELP'
+Runs a script under the profiler and reports the hottest functions.
+
+<info>Examples:</info>
+  <comment>phel profile src/main.phel</comment>            Table of the top functions
+  <comment>phel profile src/main.phel --sort=total --format=json</comment>
+HELP)
             ->addArgument(self::ARG_PATH, InputArgument::OPTIONAL, 'File path or namespace to profile.')
             ->addArgument(self::ARG_ARGV, InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Optional script arguments.', [])
             ->addOption(self::OPT_TOP, null, InputOption::VALUE_REQUIRED, 'Show top N fns in the table.', (string) ProfileConfig::DEFAULT_TOP)

--- a/src/php/Run/Infrastructure/Command/CompileCommand.php
+++ b/src/php/Run/Infrastructure/Command/CompileCommand.php
@@ -49,6 +49,13 @@ final class CompileCommand extends Command
     {
         $this->setName('compile')
             ->setDescription('Compile a Phel snippet and print the emitted PHP. Does not evaluate.')
+            ->setHelp(<<<'HELP'
+Prints the PHP a snippet/file/stdin compiles to, without running it.
+
+<info>Examples:</info>
+  <comment>phel compile '(+ 1 2)'</comment>      Compile an inline expression
+  <comment>echo '(println "hi")' | phel compile -</comment>   Compile from stdin
+HELP)
             ->addArgument(
                 'source',
                 InputArgument::OPTIONAL,

--- a/src/php/Run/Infrastructure/Command/ConfigCommand.php
+++ b/src/php/Run/Infrastructure/Command/ConfigCommand.php
@@ -32,6 +32,13 @@ final class ConfigCommand extends Command
     {
         $this->setName('config')
             ->setDescription('Show the effective Phel configuration and where it comes from')
+            ->setHelp(<<<'HELP'
+Prints the merged config (defaults + phel-config.php + overrides) and its source.
+
+<info>Examples:</info>
+  <comment>phel config</comment>          Human-readable, annotated with origins
+  <comment>phel config --json</comment>   Machine-readable effective config
+HELP)
             ->addOption(
                 self::OPT_JSON,
                 null,

--- a/src/php/Run/Infrastructure/Command/DoctorCommand.php
+++ b/src/php/Run/Infrastructure/Command/DoctorCommand.php
@@ -29,7 +29,14 @@ final class DoctorCommand extends Command
     protected function configure(): void
     {
         $this->setName('doctor')
-            ->setDescription('Check system requirements for running the Phel CLI');
+            ->setDescription('Check system requirements for running the Phel CLI')
+            ->setHelp(<<<'HELP'
+Checks PHP version/extensions, module health, and cold-start performance
+(OPcache CLI caching), printing actionable fixes for anything missing.
+
+<info>Example:</info>
+  <comment>phel doctor</comment>
+HELP);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/php/Run/Infrastructure/Command/EvalCommand.php
+++ b/src/php/Run/Infrastructure/Command/EvalCommand.php
@@ -37,6 +37,13 @@ final class EvalCommand extends Command
     {
         $this->setName('eval')
             ->setDescription('Evaluate a Phel expression and print the result')
+            ->setHelp(<<<'HELP'
+Evaluates a Phel expression (or stdin) and prints its value.
+
+<info>Examples:</info>
+  <comment>phel eval '(+ 1 2)'</comment>      Evaluate an inline expression
+  <comment>echo '(* 6 7)' | phel eval -</comment>   Evaluate from stdin
+HELP)
             ->addArgument(
                 'expression',
                 InputArgument::OPTIONAL,

--- a/src/php/Run/Infrastructure/Command/InitCommand.php
+++ b/src/php/Run/Infrastructure/Command/InitCommand.php
@@ -54,6 +54,14 @@ final class InitCommand extends Command
     {
         $this->setName('init')
             ->setDescription('Initialize a new Phel project with minimal configuration')
+            ->setHelp(<<<'HELP'
+Scaffolds phel-config.php, a main namespace, a test, and .gitignore in the
+current directory. Use --template to start from a bundled example.
+
+<info>Examples:</info>
+  <comment>phel init my-app</comment>                Flat layout in the current directory
+  <comment>phel init my-app --template=http-json-api</comment>   Scaffold an example
+HELP)
             ->addArgument(
                 self::ARG_PROJECT_NAME,
                 InputArgument::OPTIONAL,

--- a/src/php/Run/Infrastructure/Command/NsCommand.php
+++ b/src/php/Run/Infrastructure/Command/NsCommand.php
@@ -32,6 +32,13 @@ class NsCommand extends Command
             ->setName('ns')
             ->setAliases(['loaded-ns'])
             ->setDescription('Display all loaded namespaces or inspect a namespace')
+            ->setHelp(<<<'HELP'
+Lists loaded namespaces, or shows the definitions of one you name.
+
+<info>Examples:</info>
+  <comment>phel ns</comment>                 List all loaded namespaces
+  <comment>phel ns phel\core --simple</comment>   Names only, for one namespace
+HELP)
             ->addArgument('inspect', InputArgument::OPTIONAL, 'Namespace to inspect')
             ->addOption('simple', 's', InputOption::VALUE_NONE, 'Display only namespace names');
     }

--- a/src/php/Run/Infrastructure/Command/ReplCommand.php
+++ b/src/php/Run/Infrastructure/Command/ReplCommand.php
@@ -92,7 +92,13 @@ final class ReplCommand extends Command
 
     protected function configure(): void
     {
-        $this->setDescription('Start a Repl');
+        $this->setDescription('Start a Repl')
+            ->setHelp(<<<'HELP'
+Starts an interactive Phel REPL with history, completion, and *1/*2/*3/*e.
+
+<info>Example:</info>
+  <comment>phel repl</comment>
+HELP);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/php/Run/Infrastructure/Command/RunCommand.php
+++ b/src/php/Run/Infrastructure/Command/RunCommand.php
@@ -36,6 +36,14 @@ final class RunCommand extends Command
     {
         $this->setName('run')
             ->setDescription('Runs a script')
+            ->setHelp(<<<'HELP'
+Compiles and runs a Phel file or namespace (auto-detects the entry point
+when omitted). Arguments after the path are passed to the script as *argv*.
+
+<info>Examples:</info>
+  <comment>phel run</comment>                    Run the auto-detected entry point
+  <comment>phel run src/main.phel arg1 arg2</comment>   Run a file with arguments
+HELP)
             ->addArgument(
                 'path',
                 InputArgument::OPTIONAL,

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -52,6 +52,13 @@ final class TestCommand extends Command
             ->setDescription(
                 'Tests the given files. If no filenames are provided all tests in the "tests" directory are executed',
             )
+            ->setHelp(<<<'HELP'
+Runs the test suite (all tests by default, or the files/namespaces you pass).
+
+<info>Examples:</info>
+  <comment>phel test</comment>                     Run every test
+  <comment>phel test --filter=greet --parallel</comment>   Filter by name, run in parallel
+HELP)
             ->addArgument(
                 TestCommandOptionParser::ARG_PATHS,
                 InputArgument::IS_ARRAY | InputArgument::OPTIONAL,

--- a/src/php/Watch/Infrastructure/Command/WatchCommand.php
+++ b/src/php/Watch/Infrastructure/Command/WatchCommand.php
@@ -52,6 +52,13 @@ final class WatchCommand extends Command
     protected function configure(): void
     {
         $this->setDescription('Watch Phel files and reload namespaces on change.')
+            ->setHelp(<<<'HELP'
+Watches source dirs and re-evaluates changed namespaces in dependency order.
+
+<info>Examples:</info>
+  <comment>phel watch</comment>                Watch the configured source dirs
+  <comment>phel watch src -b polling</comment>   Watch a dir with the polling backend
+HELP)
             ->addArgument(
                 self::ARG_PATHS,
                 InputArgument::IS_ARRAY,

--- a/tests/php/Integration/Console/CommandHelpCoverageTest.php
+++ b/tests/php/Integration/Console/CommandHelpCoverageTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Console;
+
+use Phel;
+use Phel\Console\ConsoleFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+
+use function in_array;
+use function str_contains;
+use function stripos;
+use function trim;
+
+/**
+ * Every Phel CLI command must carry a one-line description and a `--help`
+ * block with at least one usage example (#2503).
+ */
+final class CommandHelpCoverageTest extends TestCase
+{
+    /** @var list<string> Symfony/Gacela built-ins and hidden helpers. */
+    private const array SKIP = [
+        'help', 'list', 'completion', '_test-worker', '_complete',
+        'cache:warm', 'debug:container', 'debug:dependencies', 'debug:modules',
+        'list:modules', 'profile:report', 'validate:config',
+    ];
+
+    public function test_every_command_has_description_and_example(): void
+    {
+        Phel::bootstrap(__DIR__);
+        $application = new ConsoleFactory()->createConsoleBootstrap();
+
+        $checked = 0;
+        foreach ($application->all() as $command) {
+            $name = (string) $command->getName();
+            if (in_array($name, self::SKIP, true)) {
+                continue;
+            }
+
+            $this->assertCommandDocumented($command, $name);
+            ++$checked;
+        }
+
+        self::assertGreaterThan(15, $checked, 'expected to audit the full command surface');
+    }
+
+    private function assertCommandDocumented(Command $command, string $name): void
+    {
+        self::assertNotSame('', trim($command->getDescription()), $name . ' is missing a description');
+
+        $help = trim($command->getHelp());
+        self::assertNotSame('', $help, $name . ' is missing a --help block');
+        self::assertTrue(
+            str_contains($help, 'phel ') || stripos($help, 'example') !== false,
+            $name . ' --help has no usage example',
+        );
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Every command already had a one-line description, but most had no `--help` body, so `phel <cmd> --help` gave no usage example. Discoverability suffers when users can't see how to invoke a command.

## 💡 Goal

Every CLI command's `--help` shows a one-line description and at least one usage example.

## 🔖 Changes

- Added a concise `setHelp(...)` block with at least one example to the 22 commands that lacked one: `analyze`, `api-daemon`, `doc`, `index`, `build`, `cache:clear`, `format`, `export`, `compile`, `config`, `doctor`, `eval`, `init`, `ns`, `run`, `lint`, `nrepl`, `test`, `watch`, `lsp`, `repl`, `profile`. (`agent-install` already had one.)
- New `CommandHelpCoverageTest` walks the entire registered command surface and asserts each has a description + an example block, so new commands keep parity.
- `CHANGELOG.md` updated under `## Unreleased`.

Closes #2503
