### PR TITLE
feat(repl): complete special forms and native symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - `phel init` and `phel agent-install` now end with an optional shell-completion tip tailored to your `$SHELL` (`phel completion zsh`, ...), pointing at the README install steps (#2501)
 - Consistent CLI short aliases (additive, no renames): `--format` also accepts `-f` (`doc`, `lint`, `profile`), `--output` accepts `-o` (`profile`, `test`), and `--sort` accepts `-s` (`profile`); conventions documented in `docs/internals/cli-flag-conventions.md` (#2502)
 - Every CLI command's `--help` now includes a usage example block (previously most had only a one-line description); a test guards that coverage going forward (#2503)
+- REPL/nREPL autocompletion now also completes special forms and native symbols (`def`, `defn`, `fn`, `let`, `if`, `recur`, `try`, `ns`, ...), which previously never appeared since they are compiler symbols, not registry definitions (#2505)
 - LSP PHP interop completion/hover/signature help (follow-up to #2431): `(:use ...)`/`(use ...)` alias resolution (#2461), LSP 3.17 signature help (#2462), hover for properties/constants/enum cases/classes (#2463), `php/->` chain and union/intersection type resolution (#2464), suppression inside strings and comments (#2465), and refined class-name completion (#2466)
 
 ### Performance

--- a/src/php/Api/ApiFactory.php
+++ b/src/php/Api/ApiFactory.php
@@ -31,6 +31,7 @@ use Phel\Api\Domain\SourceAnalyzerInterface;
 use Phel\Api\Domain\SymbolMetadataFinderInterface;
 use Phel\Api\Domain\SymbolResolverInterface;
 use Phel\Api\Infrastructure\Daemon\ApiDaemon;
+use Phel\Api\Infrastructure\NativeSymbolCatalog;
 use Phel\Api\Infrastructure\PhelFnLoader;
 use Phel\Api\Infrastructure\PhelFunctionRuntimeLoader;
 use Phel\Shared\Facade\CompilerFacadeInterface;
@@ -48,6 +49,7 @@ final class ApiFactory extends AbstractFactory
             $this->createPhelFnLoader(),
             $this->getConfig()->allNamespaces(),
             $this->getCompilerFacade()->getGlobalEnvironment(),
+            nativeSymbolNames: array_keys(NativeSymbolCatalog::definitions()),
         );
     }
 

--- a/src/php/Api/Application/ReplCompleter.php
+++ b/src/php/Api/Application/ReplCompleter.php
@@ -33,12 +33,16 @@ final class ReplCompleter implements ReplCompleterInterface
 
     /**
      * @param list<string> $allNamespaces
+     * @param list<string> $nativeSymbolNames special-form / native symbol names
+     *                                        (def, fn, let, ...) to offer as
+     *                                        completions
      */
     public function __construct(
         private readonly PhelFnLoaderInterface $phelFnLoader,
         private readonly array $allNamespaces = [],
         private readonly ?GlobalEnvironmentInterface $globalEnvironment = null,
         ?PhpSymbolCatalog $phpSymbols = null,
+        private readonly array $nativeSymbolNames = [],
     ) {
         $this->phpSymbols = $phpSymbols ?? new PhpSymbolCatalog();
     }
@@ -156,6 +160,16 @@ final class ReplCompleter implements ReplCompleterInterface
                     $type = $this->resolveDefinitionType($nsName, $name, $definition);
                     $matches[$name] = new CompletionResultTransfer($name, $type);
                 }
+            }
+        }
+
+        // Special forms and other native symbols (def, fn, let, if, recur,
+        // try, throw, ns, ...) are compiler symbols, not registry definitions,
+        // so they are absent above. Add any that match and were not already
+        // contributed by the registry (real defs keep their richer type).
+        foreach ($this->nativeSymbolNames as $name) {
+            if (str_starts_with($name, $input) && !isset($matches[$name])) {
+                $matches[$name] = new CompletionResultTransfer($name, 'special-form');
             }
         }
 

--- a/tests/php/Unit/Run/Domain/Repl/ReplCompleterTest.php
+++ b/tests/php/Unit/Run/Domain/Repl/ReplCompleterTest.php
@@ -230,6 +230,53 @@ final class ReplCompleterTest extends TestCase
         self::assertContainsOnlyString($results);
     }
 
+    public function test_special_forms_are_completed(): void
+    {
+        $phelFnLoader = self::createStub(PhelFnLoaderInterface::class);
+        $completer = new ReplCompleter(
+            $phelFnLoader,
+            [],
+            null,
+            null,
+            ['def', 'defn', 'defmacro', 'let', 'if'],
+        );
+
+        $matches = $completer->complete('def');
+
+        self::assertContains('def', $matches);
+        self::assertContains('defn', $matches);
+        self::assertContains('defmacro', $matches);
+        self::assertNotContains('let', $matches);
+    }
+
+    public function test_special_form_has_special_form_type(): void
+    {
+        $phelFnLoader = self::createStub(PhelFnLoaderInterface::class);
+        $completer = new ReplCompleter($phelFnLoader, [], null, null, ['recur']);
+
+        $results = $completer->completeWithTypes('rec');
+
+        self::assertCount(1, $results);
+        self::assertSame('recur', $results[0]->candidate);
+        self::assertSame('special-form', $results[0]->type);
+    }
+
+    public function test_registry_definition_wins_over_native_symbol_type(): void
+    {
+        // A real def shadowing a native name keeps its richer registry type.
+        $fn = self::createStub(FnInterface::class);
+        Phel::addDefinition('phel.core', 'apply', $fn);
+
+        $phelFnLoader = self::createStub(PhelFnLoaderInterface::class);
+        $completer = new ReplCompleter($phelFnLoader, [], null, null, ['apply']);
+
+        $results = $completer->completeWithTypes('app');
+        $apply = array_find($results, static fn($r): bool => $r->candidate === 'apply');
+
+        self::assertNotNull($apply);
+        self::assertSame('function', $apply->type);
+    }
+
     public function test_qualified_function_in_non_core_namespace(): void
     {
         $fn = self::createStub(FnInterface::class);


### PR DESCRIPTION
## 🤔 Background

REPL/nREPL autocompletion only iterated registry definitions, so special forms and native symbols (`def`, `defn`, `fn`, `let`, `if`, `recur`, `try`, `ns`, ...) never completed, even though they are among the most-typed symbols. These are compiler symbols, not registry defs.

## 💡 Goal

Make REPL completion richer by also offering special forms / native symbols.

## 🔖 Changes

- `ReplCompleter` now also offers the `NativeSymbolCatalog` symbol names (typed `special-form`), deduped so a real `def` shadowing a native name keeps its richer registry type.
- Names are injected via the constructor (wired from the catalog in `ApiFactory`), keeping the Application layer off Infrastructure.
- Tests: special forms complete, carry the `special-form` type, and registry defs win on name clashes.
- `CHANGELOG.md` updated under `## Unreleased`.

Verified end-to-end via `ApiFacade::replComplete('de')` → `def`, `defn`, `defmacro`, `defstruct`; `recur` for `recu`.

### Scope note

#2505 also mentions "inline doc on tab". That is a distinct, larger UX change (PHP `readline` exposes no per-candidate doc-render hook), tracked separately in https://github.com/phel-lang/phel-lang/issues/2515.

Closes #2505
