### PR TITLE
feat(cli): short aliases for high-frequency commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Every CLI command's `--help` now includes a usage example block (previously most had only a one-line description); a test guards that coverage going forward (#2503)
 - REPL/nREPL autocompletion now also completes special forms and native symbols (`def`, `defn`, `fn`, `let`, `if`, `recur`, `try`, `ns`, ...), which previously never appeared since they are compiler symbols, not registry definitions (#2505)
 - Non-REPL command errors (`phel run`/`test`/`eval`/...) now print the same actionable hints the REPL shows (undefined symbol, wrong arity, value not callable), e.g. `hint: 'foo' is not defined. Check the spelling, or add (:require ...) ...` (#2506)
+- Short aliases for high-frequency commands: `phel r` (run), `t` (test), `b` (build), `e` (eval); `fmt` (format) already existed (#2507)
 - LSP PHP interop completion/hover/signature help (follow-up to #2431): `(:use ...)`/`(use ...)` alias resolution (#2461), LSP 3.17 signature help (#2462), hover for properties/constants/enum cases/classes (#2463), `php/->` chain and union/intersection type resolution (#2464), suppression inside strings and comments (#2465), and refined class-name completion (#2466)
 
 ### Performance

--- a/docs/internals/cli-flag-conventions.md
+++ b/docs/internals/cli-flag-conventions.md
@@ -27,6 +27,12 @@ re-declare them or reuse their short letters.
 `-t` is command-local (`compile --target`, `init --template`, `run --with-time`),
 `-p` = port (`nrepl`), `-m` = minimal (`init`), `-b` = backend (`watch`).
 
+## Command aliases
+
+High-frequency commands have short aliases (Symfony `setAliases`): `run`→`r`,
+`test`→`t`, `build`→`b`, `eval`→`e`, `format`→`fmt`. Keep aliases unique across
+the whole command surface; an ambiguous alias makes `find()` throw.
+
 ## Known drift (deferred — needs a deprecation cycle)
 
 These would be breaking renames, so they are intentionally left for a separate

--- a/src/php/Build/Infrastructure/Command/BuildCommand.php
+++ b/src/php/Build/Infrastructure/Command/BuildCommand.php
@@ -40,6 +40,7 @@ final class BuildCommand extends Command
     protected function configure(): void
     {
         $this->setName('build')
+            ->setAliases(['b'])
             ->setDescription('Build the current project')
             ->setHelp(<<<'HELP'
 Compiles every project namespace to PHP in the output directory.

--- a/src/php/Run/Infrastructure/Command/EvalCommand.php
+++ b/src/php/Run/Infrastructure/Command/EvalCommand.php
@@ -36,6 +36,7 @@ final class EvalCommand extends Command
     protected function configure(): void
     {
         $this->setName('eval')
+            ->setAliases(['e'])
             ->setDescription('Evaluate a Phel expression and print the result')
             ->setHelp(<<<'HELP'
 Evaluates a Phel expression (or stdin) and prints its value.

--- a/src/php/Run/Infrastructure/Command/RunCommand.php
+++ b/src/php/Run/Infrastructure/Command/RunCommand.php
@@ -35,6 +35,7 @@ final class RunCommand extends Command
     protected function configure(): void
     {
         $this->setName('run')
+            ->setAliases(['r'])
             ->setDescription('Runs a script')
             ->setHelp(<<<'HELP'
 Compiles and runs a Phel file or namespace (auto-detects the entry point

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -49,6 +49,7 @@ final class TestCommand extends Command
     protected function configure(): void
     {
         $this->setName(self::COMMAND_NAME)
+            ->setAliases(['t'])
             ->setDescription(
                 'Tests the given files. If no filenames are provided all tests in the "tests" directory are executed',
             )

--- a/tests/php/Unit/Console/CommandAliasesTest.php
+++ b/tests/php/Unit/Console/CommandAliasesTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Console;
+
+use Phel;
+use Phel\Console\ConsoleFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Short aliases for high-frequency commands (#2507).
+ */
+final class CommandAliasesTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provider(): iterable
+    {
+        yield 'run -> r' => ['run', 'r'];
+        yield 'test -> t' => ['test', 't'];
+        yield 'build -> b' => ['build', 'b'];
+        yield 'eval -> e' => ['eval', 'e'];
+        yield 'format -> fmt' => ['format', 'fmt'];
+    }
+
+    #[DataProvider('provider')]
+    public function test_alias_resolves_to_command(string $name, string $alias): void
+    {
+        Phel::bootstrap(__DIR__);
+        $application = new ConsoleFactory()->createConsoleBootstrap();
+
+        // find() resolves both canonical names and aliases; an unknown or
+        // ambiguous alias would throw.
+        self::assertSame($name, $application->find($alias)->getName());
+    }
+}


### PR DESCRIPTION
## 🤔 Background

High-frequency commands required typing their full name every time.

## 💡 Goal

Add short, unambiguous aliases for the most-used commands.

## 🔖 Changes

- Symfony command aliases: `run`→`r`, `test`→`t`, `build`→`b`, `eval`→`e` (`format`→`fmt` already existed). So `phel r`, `phel t`, `phel b`, `phel e` work.
- Documented in `docs/internals/cli-flag-conventions.md` (new "Command aliases" section).
- `CommandAliasesTest` resolves each alias through the real console application (an ambiguous/missing alias would make `find()` throw).
- `CHANGELOG.md` updated under `## Unreleased`.

Verified: `echo '(+ 40 2)' | phel e -` prints `42`.

Closes #2507
