### PR TITLE
feat(cli): rename drifting flags with deprecated aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- CLI flag renames with backward-compatible deprecated aliases: `phel index --output`/`-o` (old `--out` still works), `phel config --format=json` (old `--json` still works). Deprecated flags print a notice on stderr; stdout stays clean. `phel test --reporter` is intentionally kept distinct (#2511)
 - **Breaking**: the runtime CLI-args var is now `*argv*` (earmuffed), matching `*program*` and Clojure's `*command-line-args*`; the old `argv` name was removed. Replace `argv` with `*argv*` in scripts that read command-line arguments (#2494)
 
 ### Fixed

--- a/docs/internals/cli-flag-conventions.md
+++ b/docs/internals/cli-flag-conventions.md
@@ -33,16 +33,18 @@ High-frequency commands have short aliases (Symfony `setAliases`): `run`→`r`,
 `test`→`t`, `build`→`b`, `eval`→`e`, `format`→`fmt`. Keep aliases unique across
 the whole command surface; an ambiguous alias makes `find()` throw.
 
-## Known drift (deferred — needs a deprecation cycle)
+## Renamed options (deprecated aliases kept)
 
-These would be breaking renames, so they are intentionally left for a separate
-change that keeps the old name as a deprecated alias first:
+These were aligned to the conventions above; the old names still work but are
+marked `[deprecated]` and print a one-line notice (via
+`Phel\Shared\Console\DeprecatedOptionWarner`, written to stderr so it never
+corrupts machine-readable stdout):
 
-- `phel index --out` should become `--output` (`-o`) to match `profile`/`test`.
-- `phel test --reporter` overlaps conceptually with `--format`; it stays a
-  distinct, repeatable flag for now (it selects reporters, not a single format).
-- `phel config --json` is a boolean shorthand for "format = json"; left as-is.
+- `phel index --output` (`-o`) is canonical; `--out` is the deprecated alias.
+- `phel config --format=json` is canonical; `--json` is the deprecated alias.
+- `phel test --reporter` stays a distinct, repeatable flag (it selects
+  reporters, not a single output format) — intentionally **not** renamed.
 
-When adding such a rename, register the new name + short alias, keep the old
-option accepted (mark it deprecated in the description), and read whichever is
-provided.
+When renaming an option: register the new name + short alias, keep the old
+option accepted (mark it `[deprecated]` in the description), warn via
+`DeprecatedOptionWarner`, and read whichever is provided (new wins).

--- a/src/php/Api/Infrastructure/Command/IndexCommand.php
+++ b/src/php/Api/Infrastructure/Command/IndexCommand.php
@@ -7,6 +7,7 @@ namespace Phel\Api\Infrastructure\Command;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Api\ApiFacade;
+use Phel\Shared\Console\DeprecatedOptionWarner;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -35,7 +36,7 @@ final class IndexCommand extends Command
 Scans directories for `.phel` files and indexes their symbols (for tooling).
 
 <info>Example:</info>
-  <comment>phel index src tests --out=index.json</comment>
+  <comment>phel index src tests --output=index.json</comment>
 HELP)
             ->addArgument(
                 'dirs',
@@ -43,10 +44,16 @@ HELP)
                 'Directories to scan for .phel files',
             )
             ->addOption(
+                'output',
+                'o',
+                InputOption::VALUE_REQUIRED,
+                'Optional path to persist the full index as JSON',
+            )
+            ->addOption(
                 'out',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Optional path to persist the full index as JSON',
+                '[deprecated] use --output instead',
             );
     }
 
@@ -65,7 +72,16 @@ HELP)
 
         $output->writeln(json_encode($summary, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
 
-        $out = $input->getOption('out');
+        $deprecatedOut = $input->getOption('out');
+        if (is_string($deprecatedOut) && $deprecatedOut !== '') {
+            DeprecatedOptionWarner::warn($output, 'out', 'output');
+        }
+
+        $out = $input->getOption('output');
+        if (!is_string($out) || $out === '') {
+            $out = $deprecatedOut;
+        }
+
         if (is_string($out) && $out !== '') {
             $written = @file_put_contents(
                 $out,

--- a/src/php/Run/Infrastructure/Command/ConfigCommand.php
+++ b/src/php/Run/Infrastructure/Command/ConfigCommand.php
@@ -6,6 +6,8 @@ namespace Phel\Run\Infrastructure\Command;
 
 use Phel\Run\Domain\Config\EffectiveConfigReader;
 use Phel\Run\Domain\Config\EffectiveConfigResult;
+use Phel\Shared\Console\DeprecatedOptionWarner;
+use Phel\Shared\ScalarCoercion;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -22,6 +24,12 @@ final class ConfigCommand extends Command
 {
     private const string OPT_JSON = 'json';
 
+    private const string OPT_FORMAT = 'format';
+
+    private const string FORMAT_TEXT = 'text';
+
+    private const string FORMAT_JSON = 'json';
+
     public function __construct(
         private readonly EffectiveConfigReader $reader = new EffectiveConfigReader(),
     ) {
@@ -36,14 +44,22 @@ final class ConfigCommand extends Command
 Prints the merged config (defaults + phel-config.php + overrides) and its source.
 
 <info>Examples:</info>
-  <comment>phel config</comment>          Human-readable, annotated with origins
-  <comment>phel config --json</comment>   Machine-readable effective config
+  <comment>phel config</comment>             Human-readable, annotated with origins
+  <comment>phel config --format=json</comment>   Machine-readable effective config
 HELP)
+            ->addOption(
+                self::OPT_FORMAT,
+                'f',
+                InputOption::VALUE_REQUIRED,
+                'Output format: text, json',
+                self::FORMAT_TEXT,
+                [self::FORMAT_TEXT, self::FORMAT_JSON],
+            )
             ->addOption(
                 self::OPT_JSON,
                 null,
                 InputOption::VALUE_NONE,
-                'Print only the effective config as JSON (machine-readable)',
+                '[deprecated] use --format=json instead',
             );
     }
 
@@ -52,6 +68,13 @@ HELP)
         $effective = $this->reader->read();
 
         if ($input->getOption(self::OPT_JSON) === true) {
+            DeprecatedOptionWarner::warn($output, 'json', 'format=json');
+        }
+
+        $asJson = $input->getOption(self::OPT_JSON) === true
+            || ScalarCoercion::toString($input->getOption(self::OPT_FORMAT)) === self::FORMAT_JSON;
+
+        if ($asJson) {
             $output->writeln($this->toJson($effective->values));
 
             return Command::SUCCESS;

--- a/src/php/Shared/Console/DeprecatedOptionWarner.php
+++ b/src/php/Shared/Console/DeprecatedOptionWarner.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared\Console;
+
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function sprintf;
+
+/**
+ * Emits a one-line deprecation notice for a CLI option that has been renamed.
+ *
+ * The notice goes to stderr (when available) so it never corrupts a command's
+ * machine-readable stdout (e.g. `phel config --json`).
+ */
+final readonly class DeprecatedOptionWarner
+{
+    public static function warn(OutputInterface $output, string $deprecated, string $replacement): void
+    {
+        $stream = $output instanceof ConsoleOutputInterface
+            ? $output->getErrorOutput()
+            : $output;
+
+        $stream->writeln(sprintf(
+            '<comment>Warning: --%s is deprecated; use --%s instead.</comment>',
+            $deprecated,
+            $replacement,
+        ));
+    }
+}

--- a/tests/php/Integration/Run/Command/Config/ConfigCommandTest.php
+++ b/tests/php/Integration/Run/Command/Config/ConfigCommandTest.php
@@ -51,11 +51,11 @@ final class ConfigCommandTest extends TestCase
         self::assertStringContainsString('not found', $display);
     }
 
-    public function test_json_option_emits_only_valid_json(): void
+    public function test_format_json_emits_only_valid_json(): void
     {
         $tester = new CommandTester(new ConfigCommand());
 
-        $exitCode = $tester->execute(['--json' => true]);
+        $exitCode = $tester->execute(['--format' => 'json']);
 
         self::assertSame(0, $exitCode);
 
@@ -64,5 +64,18 @@ final class ConfigCommandTest extends TestCase
         self::assertSame(['src/phel'], $decoded[PhelConfig::SRC_DIRS]);
         self::assertSame('vendor', $decoded[PhelConfig::VENDOR_DIR]);
         self::assertArrayNotHasKey('Sources:', $decoded);
+    }
+
+    public function test_deprecated_json_flag_still_emits_json_with_a_warning(): void
+    {
+        $tester = new CommandTester(new ConfigCommand());
+
+        $exitCode = $tester->execute(['--json' => true], ['capture_stderr_separately' => true]);
+
+        self::assertSame(0, $exitCode);
+        // stdout stays valid JSON; the deprecation notice goes to stderr.
+        $decoded = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['src/phel'], $decoded[PhelConfig::SRC_DIRS]);
+        self::assertStringContainsString('--json is deprecated', $tester->getErrorOutput());
     }
 }

--- a/tests/php/Unit/Api/Infrastructure/Command/IndexCommandOptionsTest.php
+++ b/tests/php/Unit/Api/Infrastructure/Command/IndexCommandOptionsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Infrastructure\Command;
+
+use Phel\Api\Infrastructure\Command\IndexCommand;
+use PHPUnit\Framework\TestCase;
+
+final class IndexCommandOptionsTest extends TestCase
+{
+    public function test_output_is_canonical_with_o_short_alias(): void
+    {
+        $definition = new IndexCommand()->getDefinition();
+
+        self::assertTrue($definition->hasOption('output'));
+        self::assertSame('o', $definition->getOption('output')->getShortcut());
+    }
+
+    public function test_out_is_kept_as_a_deprecated_alias(): void
+    {
+        $definition = new IndexCommand()->getDefinition();
+
+        self::assertTrue($definition->hasOption('out'), 'old --out stays for back-compat');
+        self::assertStringContainsString('deprecated', $definition->getOption('out')->getDescription());
+    }
+}

--- a/tests/php/Unit/Shared/Console/DeprecatedOptionWarnerTest.php
+++ b/tests/php/Unit/Shared/Console/DeprecatedOptionWarnerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared\Console;
+
+use Phel\Shared\Console\DeprecatedOptionWarner;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class DeprecatedOptionWarnerTest extends TestCase
+{
+    public function test_writes_notice_naming_old_and_new_option(): void
+    {
+        // Plain (non-console) output: falls back to the single stream.
+        $output = new BufferedOutput();
+
+        DeprecatedOptionWarner::warn($output, 'out', 'output');
+
+        $text = $output->fetch();
+        self::assertStringContainsString('--out is deprecated', $text);
+        self::assertStringContainsString('use --output', $text);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Follow-up to #2502, which applied only additive short aliases and left the breaking flag renames for a deprecation cycle.

## 💡 Goal

Align the drifting option names to the conventions while keeping the old names working.

## 🔖 Changes

- `phel index`: `--output` (`-o`) is now canonical; `--out` stays as a deprecated alias.
- `phel config`: `--format=json` (`-f`) is now canonical; `--json` stays as a deprecated alias.
- New `Phel\Shared\Console\DeprecatedOptionWarner`: prints a one-line `Warning: --X is deprecated; use --Y instead.` to **stderr** (so it never corrupts machine-readable stdout like `config --format=json`). New name wins when both are given.
- `phel test --reporter` is intentionally left as a distinct, repeatable flag (it selects reporters, not a single output format).
- Tests: warner unit test, index option-wiring test, config tests split into `--format=json` (clean JSON) and the deprecated `--json` (JSON on stdout + notice on stderr, captured separately).
- Docs: `cli-flag-conventions.md` "Known drift" section updated to "Renamed options (deprecated aliases kept)".
- `CHANGELOG.md` updated under `## Unreleased`.

Verified e2e: `phel index src --out=...` and `phel config --json` still work and print a deprecation notice on stderr; the new `--output`/`--format=json` are clean.

Closes #2511
