### PR TITLE
feat(repl): inline doc on tab for a unique completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Consistent CLI short aliases (additive, no renames): `--format` also accepts `-f` (`doc`, `lint`, `profile`), `--output` accepts `-o` (`profile`, `test`), and `--sort` accepts `-s` (`profile`); conventions documented in `docs/internals/cli-flag-conventions.md` (#2502)
 - Every CLI command's `--help` now includes a usage example block (previously most had only a one-line description); a test guards that coverage going forward (#2503)
 - REPL/nREPL autocompletion now also completes special forms and native symbols (`def`, `defn`, `fn`, `let`, `if`, `recur`, `try`, `ns`, ...), which previously never appeared since they are compiler symbols, not registry definitions (#2505)
+- REPL Tab on a unique completion now shows the symbol's inline doc (`<signature>: <summary>`); also exposed as `ApiFacade::completionDoc()` (#2515)
 - Non-REPL command errors (`phel run`/`test`/`eval`/...) now print the same actionable hints the REPL shows (undefined symbol, wrong arity, value not callable), e.g. `hint: 'foo' is not defined. Check the spelling, or add (:require ...) ...` (#2506)
 - Short aliases for high-frequency commands: `phel r` (run), `t` (test), `b` (build), `e` (eval); `fmt` (format) already existed (#2507)
 - New `docs/cli-reference.md` (CLI reference & DX guide): every command in one table, the dev loop, and a `compile` vs `eval` vs `run` vs `build` comparison (#2508)

--- a/src/php/Api/ApiFacade.php
+++ b/src/php/Api/ApiFacade.php
@@ -124,6 +124,13 @@ final class ApiFacade extends AbstractFacade implements ApiFacadeInterface
             ->find($symbol, $currentNs);
     }
 
+    public function completionDoc(string $candidate, string $currentNs = 'user'): ?string
+    {
+        return $this->getFactory()
+            ->createCompletionDocResolver()
+            ->resolve($candidate, $currentNs);
+    }
+
     /**
      * Markdown hover for the PHP-interop symbol under the cursor (method,
      * static member, global function, class), or null when not applicable.

--- a/src/php/Api/ApiFactory.php
+++ b/src/php/Api/ApiFactory.php
@@ -8,6 +8,8 @@ use Gacela\Framework\AbstractFactory;
 use Phel\Api\Application\Analysis\LexAndParseStage;
 use Phel\Api\Application\Analysis\PreloadDependenciesStage;
 use Phel\Api\Application\Analysis\ReadAndAnalyzeStage;
+use Phel\Api\Application\CompletionDocFormatter;
+use Phel\Api\Application\CompletionDocResolver;
 use Phel\Api\Application\PhelFnGroupKeyGenerator;
 use Phel\Api\Application\PhelFnNormalizer;
 use Phel\Api\Application\PhpInteropCompleter;
@@ -50,6 +52,14 @@ final class ApiFactory extends AbstractFactory
             $this->getConfig()->allNamespaces(),
             $this->getCompilerFacade()->getGlobalEnvironment(),
             nativeSymbolNames: array_keys(NativeSymbolCatalog::definitions()),
+        );
+    }
+
+    public function createCompletionDocResolver(): CompletionDocResolver
+    {
+        return new CompletionDocResolver(
+            $this->createSymbolMetadataFinder(),
+            new CompletionDocFormatter(),
         );
     }
 

--- a/src/php/Api/Application/CompletionDocFormatter.php
+++ b/src/php/Api/Application/CompletionDocFormatter.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use Phel\Api\Transfer\PhelFunction;
+
+use function preg_replace;
+use function rtrim;
+use function strlen;
+use function substr;
+use function trim;
+
+/**
+ * Builds the one-line documentation string shown inline in the REPL when a
+ * Tab completion resolves to a single candidate: `<signature>: <summary>`.
+ */
+final readonly class CompletionDocFormatter
+{
+    private const int MAX_SUMMARY = 100;
+
+    public function format(PhelFunction $fn): ?string
+    {
+        $signature = trim($fn->signatures[0] ?? $fn->name);
+        $summary = $this->firstLine($fn->description !== '' ? $fn->description : $fn->doc);
+
+        if ($signature === '' && $summary === '') {
+            return null;
+        }
+
+        if ($summary === '') {
+            return $signature;
+        }
+
+        if ($signature === '') {
+            return $summary;
+        }
+
+        return $signature . ': ' . $summary;
+    }
+
+    private function firstLine(string $text): string
+    {
+        // Drop markdown code-fence markers that appear in some `:doc` blocks.
+        $withoutFences = (string) preg_replace('/```[a-z]*/', ' ', $text);
+        $normalized = trim((string) preg_replace('/\s+/', ' ', $withoutFences));
+        if ($normalized === '') {
+            return '';
+        }
+
+        if (strlen($normalized) <= self::MAX_SUMMARY) {
+            return $normalized;
+        }
+
+        return rtrim(substr($normalized, 0, self::MAX_SUMMARY)) . '...';
+    }
+}

--- a/src/php/Api/Application/CompletionDocResolver.php
+++ b/src/php/Api/Application/CompletionDocResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use Phel\Api\Domain\SymbolMetadataFinderInterface;
+use Phel\Api\Transfer\PhelFunction;
+
+use function str_starts_with;
+
+/**
+ * Resolves the one-line inline doc shown in the REPL on Tab for a completion
+ * candidate: looks up its metadata and formats `<signature>: <summary>`.
+ */
+final readonly class CompletionDocResolver
+{
+    public function __construct(
+        private SymbolMetadataFinderInterface $metadataFinder,
+        private CompletionDocFormatter $formatter,
+    ) {}
+
+    public function resolve(string $candidate, string $currentNs = 'user'): ?string
+    {
+        // PHP-interop candidates (php/...) have no Phel metadata; skip them.
+        if ($candidate === '' || str_starts_with($candidate, 'php/')) {
+            return null;
+        }
+
+        $metadata = $this->metadataFinder->find($candidate, $currentNs);
+        if (!$metadata instanceof PhelFunction) {
+            return null;
+        }
+
+        return $this->formatter->format($metadata);
+    }
+}

--- a/src/php/Run/Domain/Repl/ReplCommandSystemIo.php
+++ b/src/php/Run/Domain/Repl/ReplCommandSystemIo.php
@@ -11,6 +11,8 @@ use Phel\Shared\Parser\ReadModel\CodeSnippet;
 use Phel\Shared\ScalarCoercion;
 use Throwable;
 
+use function count;
+
 final readonly class ReplCommandSystemIo implements ReplCommandIoInterface
 {
     public function __construct(
@@ -20,7 +22,7 @@ final readonly class ReplCommandSystemIo implements ReplCommandIoInterface
         private ReplErrorFormatter $errorFormatter,
     ) {
         readline_completion_function(
-            $this->apiFacade->replComplete(...),
+            $this->completeWithInlineDoc(...),
         );
     }
 
@@ -95,6 +97,27 @@ final readonly class ReplCommandSystemIo implements ReplCommandIoInterface
         $haystack = ScalarCoercion::toString(readline_info('library_version'));
 
         return stripos($haystack, 'editline') === false;
+    }
+
+    /**
+     * Completion callback that, when the input resolves to a single candidate,
+     * prints that candidate's one-line doc inline before readline redraws the
+     * prompt — so Tab on a unique/focused symbol surfaces its signature + doc.
+     *
+     * @return list<string>
+     */
+    private function completeWithInlineDoc(string $input): array
+    {
+        $matches = $this->apiFacade->replComplete($input);
+
+        if (count($matches) === 1) {
+            $doc = $this->apiFacade->completionDoc($matches[0]);
+            if ($doc !== null && $doc !== '') {
+                echo PHP_EOL . $doc . PHP_EOL; // phpcs:ignore
+            }
+        }
+
+        return $matches;
     }
 
 }

--- a/src/php/Shared/Facade/ApiFacadeInterface.php
+++ b/src/php/Shared/Facade/ApiFacadeInterface.php
@@ -35,4 +35,11 @@ interface ApiFacadeInterface
      * session-defined definitions in addition to core/library functions.
      */
     public function findSymbolMetadata(string $symbol, string $currentNs = 'user'): ?PhelFunction;
+
+    /**
+     * One-line documentation (`<signature>: <summary>`) for a completion
+     * candidate, shown inline in the REPL on Tab. Null when the candidate has
+     * no Phel metadata (e.g. `php/...` interop names).
+     */
+    public function completionDoc(string $candidate, string $currentNs = 'user'): ?string;
 }

--- a/tests/php/Unit/Api/Application/CompletionDocFormatterTest.php
+++ b/tests/php/Unit/Api/Application/CompletionDocFormatterTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\CompletionDocFormatter;
+use Phel\Api\Transfer\PhelFunction;
+use PHPUnit\Framework\TestCase;
+
+use function str_repeat;
+use function strlen;
+
+final class CompletionDocFormatterTest extends TestCase
+{
+    private CompletionDocFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new CompletionDocFormatter();
+    }
+
+    public function test_combines_signature_and_summary(): void
+    {
+        $fn = PhelFunction::fromArray([
+            'name' => 'map',
+            'signatures' => ['(map f coll)'],
+            'desc' => 'Returns a lazy sequence.',
+        ]);
+
+        self::assertSame('(map f coll): Returns a lazy sequence.', $this->formatter->format($fn));
+    }
+
+    public function test_falls_back_to_name_when_no_signature(): void
+    {
+        $fn = PhelFunction::fromArray(['name' => 'x', 'desc' => 'A var.']);
+
+        self::assertSame('x: A var.', $this->formatter->format($fn));
+    }
+
+    public function test_signature_only_when_no_summary(): void
+    {
+        $fn = PhelFunction::fromArray(['name' => 'foo', 'signatures' => ['(foo a)']]);
+
+        self::assertSame('(foo a)', $this->formatter->format($fn));
+    }
+
+    public function test_uses_doc_when_description_empty(): void
+    {
+        $fn = PhelFunction::fromArray([
+            'name' => 'foo',
+            'signatures' => ['(foo)'],
+            'doc' => "line one\nline two",
+        ]);
+
+        self::assertSame('(foo): line one line two', $this->formatter->format($fn));
+    }
+
+    public function test_truncates_long_summaries(): void
+    {
+        $fn = PhelFunction::fromArray([
+            'name' => 'foo',
+            'signatures' => ['(foo)'],
+            'desc' => str_repeat('word ', 60),
+        ]);
+
+        $result = (string) $this->formatter->format($fn);
+        self::assertStringEndsWith('...', $result);
+        self::assertLessThan(130, strlen($result));
+    }
+
+    public function test_null_when_nothing_to_show(): void
+    {
+        self::assertNull($this->formatter->format(PhelFunction::fromArray([])));
+    }
+}

--- a/tests/php/Unit/Api/Application/CompletionDocResolverTest.php
+++ b/tests/php/Unit/Api/Application/CompletionDocResolverTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\CompletionDocFormatter;
+use Phel\Api\Application\CompletionDocResolver;
+use Phel\Api\Domain\SymbolMetadataFinderInterface;
+use Phel\Api\Transfer\PhelFunction;
+use PHPUnit\Framework\TestCase;
+
+final class CompletionDocResolverTest extends TestCase
+{
+    public function test_resolves_signature_and_summary_for_known_symbol(): void
+    {
+        $finder = $this->createStub(SymbolMetadataFinderInterface::class);
+        $finder->method('find')->willReturn(PhelFunction::fromArray([
+            'name' => 'map',
+            'signatures' => ['(map f coll)'],
+            'desc' => 'Maps over a collection.',
+        ]));
+
+        $resolver = new CompletionDocResolver($finder, new CompletionDocFormatter());
+
+        self::assertSame('(map f coll): Maps over a collection.', $resolver->resolve('map'));
+    }
+
+    public function test_skips_php_interop_candidates(): void
+    {
+        $finder = $this->createMock(SymbolMetadataFinderInterface::class);
+        $finder->expects(self::never())->method('find');
+
+        $resolver = new CompletionDocResolver($finder, new CompletionDocFormatter());
+
+        self::assertNull($resolver->resolve('php/strlen'));
+        self::assertNull($resolver->resolve(''));
+    }
+
+    public function test_null_when_symbol_has_no_metadata(): void
+    {
+        $finder = $this->createStub(SymbolMetadataFinderInterface::class);
+        $finder->method('find')->willReturn(null);
+
+        $resolver = new CompletionDocResolver($finder, new CompletionDocFormatter());
+
+        self::assertNull($resolver->resolve('unknown-symbol'));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Follow-up to #2505, which added special forms/native symbols to REPL completion. The remaining piece: show a candidate's docstring inline on Tab.

## 💡 Goal

Pressing Tab on a unique/focused completion surfaces its `:doc` (signature + summary) inline in the terminal REPL.

## 🔖 Changes

- `ApiFacade::completionDoc(candidate, currentNs)`: returns a one-line `<signature>: <summary>` for a completion candidate, or null for `php/...` interop names / unknown symbols. Backed by `CompletionDocResolver` (reuses the existing symbol-metadata finder, works for registry defs **and** special forms) + a pure `CompletionDocFormatter` (first signature, summary normalized, code-fence markers stripped, truncated to ~100 chars).
- `ReplCommandSystemIo` wraps the readline completion callback: when the input resolves to exactly one match, it prints that symbol's doc before readline redraws the prompt.
- Tests: formatter (combine/fallbacks/truncate/null) and resolver (known symbol, `php/` skip, no-metadata null). Verified e2e via `ApiFacade::completionDoc('map'|'def'|'recur')`.
- `CHANGELOG.md` updated under `## Unreleased`.

### Note

PHP's `readline` exposes no per-candidate doc-render hook, so the inline doc is printed from the completion callback on a **unique** match (the standard approach within readline's constraints) rather than as a live preview while cycling candidates. The doc lookup is fully reusable (also handy for nREPL/editor tooling).

Closes #2515
