### PR TITLE
fix(phar): ship shell-completion scripts in the PHAR

### DIFF
--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -92,9 +92,6 @@ final class PharBuilder
     private array $excludeExtensions = [
         '.log' => true,
         '.svg' => true,
-        '.bash' => true,
-        '.zsh' => true,
-        '.fish' => true,
     ];
 
     /**

--- a/tests/php/Integration/Phar/PharExecutionTest.php
+++ b/tests/php/Integration/Phar/PharExecutionTest.php
@@ -145,6 +145,26 @@ final class PharExecutionTest extends TestCase
         );
     }
 
+    public function test_phar_ships_shell_completion_scripts(): void
+    {
+        // Regression: the PHAR build must not exclude Symfony's
+        // Resources/completion.{bash,zsh,fish} (e.g. via a `.bash`/`.zsh`/`.fish`
+        // extension filter), or `phel completion <shell>` reports
+        // "supported shells: ''" and tab-completion is dead for PHAR installs.
+        $bash = $this->runPhar(['completion', 'bash']);
+        self::assertSame(
+            0,
+            $bash['exit'],
+            sprintf("completion bash failed.\nstdout:\n%s\nstderr:\n%s", $bash['stdout'], $bash['stderr']),
+        );
+        self::assertStringNotContainsString('not supported', $bash['stdout'] . $bash['stderr']);
+        self::assertStringContainsString('complete', $bash['stdout']);
+
+        $zsh = $this->runPhar(['completion', 'zsh']);
+        self::assertSame(0, $zsh['exit']);
+        self::assertStringContainsString('#compdef', $zsh['stdout']);
+    }
+
     public function test_phar_eval_stdin(): void
     {
         $result = $this->runPharWithStdin(['eval', '-'], "(println (+ 1 2 3))\n");


### PR DESCRIPTION
## 🤔 Background

Full-regression validation of the published **v0.45.0** PHAR found shell completion broken: `phel completion bash|zsh|fish` printed `supported shells: ""` and emitted no script. Tab-completion (the headline 0.45 DX feature, #2451/#2452/#2453/#2454) is dead for everyone who installs via the PHAR. It works fine on source/dev builds.

## 🔎 Root cause

`build/build-phar.php` excluded `.bash`, `.zsh`, `.fish` by extension. That also dropped `vendor/symfony/console/Resources/completion.{bash,zsh,fish}` — the templates Symfony's `CompletionCommand` reads to know which shells it supports. With them gone, the supported-shell list is empty.

## 🔖 Changes

- Stop excluding `.bash`/`.zsh`/`.fish` from the PHAR (keep only `.log`/`.svg`). Adds ~6.5 KB; PHAR stays 1.94 MB.
- `PharExecutionTest`: new guard asserting `completion bash` emits a `complete` script and `completion zsh` emits `#compdef`.

## ✅ Verification

Rebuilt via `build/phar.sh` (1.939 MB):
- `completion zsh` → `#compdef phel`, `completion bash` → 94-line script, `completion fish` → 29 lines.
- `PharExecutionTest` 5/5 green.

Note: v0.45.0 is already published; this fixes forward. Suggest a `v0.45.1` patch so PHAR users get working completion.
