### PR TITLE
fix(repl): show not-defined hint even with a did-you-mean suggestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- The "not defined" error hint now also shows when the compiler appends a `Did you mean ...?` suggestion (a trailing period previously suppressed it)
+
 ## [0.45.1](https://github.com/phel-lang/phel-lang/compare/v0.45.0...v0.45.1) - 2026-06-20
 
 ### Fixed

--- a/src/php/Shared/Exceptions/Hint/UndefinedSymbolHint.php
+++ b/src/php/Shared/Exceptions/Hint/UndefinedSymbolHint.php
@@ -29,7 +29,8 @@ final class UndefinedSymbolHint implements ExceptionHintInterface
     private function extract(string $message): ?string
     {
         $patterns = [
-            '/Cannot resolve symbol \'?([^\']+?)\'?(?:\s|$)/',
+            // Trailing `.` covers the analyzer's `. Did you mean ...?` suffix.
+            '/Cannot resolve symbol \'?([^\']+?)\'?(?:[.\s]|$)/',
             '/Undefined (?:variable|constant|function) [\'"$]?([^\'"]+?)[\'"]?(?:\s|$|\.)/',
             '/Call to undefined function ([\\w\\\\]+)\\(\\)/',
         ];

--- a/tests/php/Unit/Shared/Exceptions/Hint/UndefinedSymbolHintTest.php
+++ b/tests/php/Unit/Shared/Exceptions/Hint/UndefinedSymbolHintTest.php
@@ -20,6 +20,17 @@ final class UndefinedSymbolHintTest extends TestCase
         self::assertStringContainsString(':require', $hint->hint($e));
     }
 
+    public function test_extracts_when_compiler_appends_did_you_mean(): void
+    {
+        // The analyzer appends ". Did you mean ...?" for near-matches; the
+        // period after the quoted name must not stop the hint from firing.
+        $hint = new UndefinedSymbolHint();
+        $e = new Error("Cannot resolve symbol 'nope'. Did you mean 'not', 'not=', or 'name'?");
+
+        self::assertTrue($hint->appliesTo($e));
+        self::assertStringContainsString("'nope' is not defined", $hint->hint($e));
+    }
+
     public function test_extracts_undefined_function(): void
     {
         $hint = new UndefinedSymbolHint();


### PR DESCRIPTION
## Background

Full QA regression of v0.45.1 found the actionable "is not defined" hint (#2506) silently dropped when the compiler appends a `. Did you mean ...?` suggestion.

## Root cause

`UndefinedSymbolHint`'s regex anchored on `'name'` followed by `\s|$`. The suggestion variant is `Cannot resolve symbol 'nope'. Did you mean ...` — the period after the closing quote breaks the anchor, so no match, no hint.

## Fix

Allow a trailing `.` in the anchor (`(?:[.\s]|$)`). Hint now fires in both cases.

## Verify

- New unit test for the did-you-mean message; suite green.
- E2e: `phel run` on `(nope 1)` now prints both the `Did you mean` line and `hint: 'nope' is not defined ...`.

Low impact (did-you-mean already guides), but the hint should still appear.