### PR TITLE
perf(emitter): context-aware IIFE elision for php/-> and php/::

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Performance
+
+- `php/->` and `php/::` now emit leaner PHP, dropping the closure wrapper for simple targets and statement/return-context calls (#2524)
+
 ### Fixed
 
 - The "not defined" error hint now also shows when the compiler appends a `Did you mean ...?` suggestion (a trailing period previously suppressed it)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectCallEmitter.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MethodCallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpNamedArgNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PropertyOrConstantAccessNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Symbol;
@@ -24,42 +27,132 @@ final class PhpObjectCallEmitter implements NodeEmitterInterface
     {
         assert($node instanceof PhpObjectCallNode);
 
-        $this->emitPhpObjectCallBegin($node);
-        $this->emitPhpObjectCallArguments($node);
-        $this->emitPhpObjectCallEnd($node);
-    }
-
-    private function emitPhpObjectCallBegin(PhpObjectCallNode $node): void
-    {
-        $fnCode = $node->isStatic() ? '::' : '->';
         $targetExpr = $node->getTargetExpr();
 
-        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
+        // A `PhpClassNameNode` target is an inherently static `Class::m(...)`
+        // call; like the legacy fast path, it never needed value isolation, so
+        // it always emits inline without a temp or an IIFE.
+        if ($targetExpr instanceof PhpClassNameNode) {
+            $this->emitSimpleTarget($node);
 
-        if ($node->isStatic() && $targetExpr instanceof PhpClassNameNode) {
-            $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
-            $this->outputEmitter->emitStr($targetExpr->getAbsolutePhpName(), $targetExpr->getName()->getStartLocation());
-            $this->outputEmitter->emitStr($fnCode, $node->getStartSourceLocation());
-        } else {
-            $this->outputEmitter->emitFnWrapPrefix(
-                $node->getEnv(),
-                $node->getStartSourceLocation(),
-                new ByRefLocalCollector()->collect($node),
-            );
-
-            $targetSym = Symbol::gen('target_');
-            $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
-            $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
-            $this->outputEmitter->emitNode($targetExpr);
-            $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
-
-            $this->outputEmitter->emitStr('return ', $node->getStartSourceLocation());
-            $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
-            $this->outputEmitter->emitStr($fnCode, $node->getStartSourceLocation());
+            return;
         }
+
+        // An instance call whose method receives a bare local argument relies
+        // on the IIFE's by-value `use($local)` capture as a copy barrier: a
+        // by-reference PHP parameter must not write back into the Phel binding
+        // (only `(php/ref local)` opts into that). Keep the IIFE in that case.
+        if ($this->hasByValueLocalArg($node)) {
+            $this->emitWrappedTarget($node);
+
+            return;
+        }
+
+        if ($targetExpr instanceof LocalVarNode) {
+            $this->emitSimpleTarget($node);
+
+            return;
+        }
+
+        if ($node->getEnv()->isContext(NodeEnvironment::CONTEXT_EXPRESSION)) {
+            $this->emitWrappedTarget($node);
+
+            return;
+        }
+
+        $this->emitStatementTarget($node);
     }
 
-    private function emitPhpObjectCallArguments(PhpObjectCallNode $node): void
+    /**
+     * Simple target (`LocalVarNode` / `PhpClassNameNode`): no temp var and no
+     * IIFE in any context. Emits `(<target><fn><call>)` directly.
+     */
+    private function emitSimpleTarget(PhpObjectCallNode $node): void
+    {
+        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
+
+        $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
+        $this->emitTarget($node);
+        $this->outputEmitter->emitStr($this->fnCode($node), $node->getStartSourceLocation());
+        $this->emitCall($node);
+        $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
+
+        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+    }
+
+    /**
+     * Computed target in expression context: wrap in an IIFE so the temp var
+     * (which guarantees exactly-once target evaluation) can host a `return`.
+     */
+    private function emitWrappedTarget(PhpObjectCallNode $node): void
+    {
+        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
+
+        $this->outputEmitter->emitFnWrapPrefix(
+            $node->getEnv(),
+            $node->getStartSourceLocation(),
+            new ByRefLocalCollector()->collect($node),
+        );
+
+        $targetSym = Symbol::gen('target_');
+        $this->emitTempAssignment($node, $targetSym);
+
+        $this->outputEmitter->emitStr('return ', $node->getStartSourceLocation());
+        $this->emitTargetCall($node, $targetSym);
+        $this->outputEmitter->emitStr(';', $node->getStartSourceLocation());
+
+        $this->outputEmitter->emitFnWrapSuffix($node->getStartSourceLocation());
+
+        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+    }
+
+    /**
+     * Computed target in statement/return context: emit plain statements
+     * (`$target_N = <target>;` then the call) without an IIFE. The temp var
+     * still guarantees exactly-once target evaluation.
+     */
+    private function emitStatementTarget(PhpObjectCallNode $node): void
+    {
+        $targetSym = Symbol::gen('target_');
+        $this->emitTempAssignment($node, $targetSym);
+
+        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
+        $this->emitTargetCall($node, $targetSym);
+        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+    }
+
+    private function emitTempAssignment(PhpObjectCallNode $node, Symbol $targetSym): void
+    {
+        $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
+        $this->emitTarget($node);
+        $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
+    }
+
+    private function emitTargetCall(PhpObjectCallNode $node, Symbol $targetSym): void
+    {
+        $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr($this->fnCode($node), $node->getStartSourceLocation());
+        $this->emitCall($node);
+    }
+
+    private function emitTarget(PhpObjectCallNode $node): void
+    {
+        $targetExpr = $node->getTargetExpr();
+
+        if ($targetExpr instanceof PhpClassNameNode) {
+            $this->outputEmitter->emitStr(
+                $targetExpr->getAbsolutePhpName(),
+                $targetExpr->getName()->getStartLocation(),
+            );
+
+            return;
+        }
+
+        $this->outputEmitter->emitNode($targetExpr);
+    }
+
+    private function emitCall(PhpObjectCallNode $node): void
     {
         $callExpr = $node->getCallExpr();
 
@@ -75,17 +168,36 @@ final class PhpObjectCallEmitter implements NodeEmitterInterface
         }
     }
 
-    private function emitPhpObjectCallEnd(PhpObjectCallNode $node): void
+    /**
+     * Whether the call passes a bare local variable as a top-level method
+     * argument. PHP binds a by-reference parameter only to a variable handed
+     * in directly (`$obj->m($x)`), so only a top-level `LocalVarNode` (or a
+     * named argument wrapping one) can leak a write back into a Phel binding.
+     * Such args need the IIFE's by-value `use(...)` copy barrier; `php/ref`
+     * args (a `PhpRefNode`) opt into the write-back and are excluded.
+     */
+    private function hasByValueLocalArg(PhpObjectCallNode $node): bool
     {
-        $targetExpr = $node->getTargetExpr();
-
-        if ($targetExpr instanceof PhpClassNameNode && $node->isStatic()) {
-            $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
-        } else {
-            $this->outputEmitter->emitStr(';', $node->getStartSourceLocation());
-            $this->outputEmitter->emitFnWrapSuffix($node->getStartSourceLocation());
+        $callExpr = $node->getCallExpr();
+        if (!$callExpr instanceof MethodCallNode) {
+            return false;
         }
 
-        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+        foreach ($callExpr->getArgs() as $arg) {
+            if ($arg instanceof PhpNamedArgNode) {
+                $arg = $arg->getValueExpr();
+            }
+
+            if ($arg instanceof LocalVarNode) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function fnCode(PhpObjectCallNode $node): string
+    {
+        return $node->isStatic() ? '::' : '->';
     }
 }

--- a/tests/php/Integration/Fixtures/Call/dot-method-call-no-args.test
+++ b/tests/php/Integration/Fixtures/Call/dot-method-call-no-args.test
@@ -1,7 +1,5 @@
 --PHEL--
 (.getTimestamp (php/new \DateTimeImmutable))
 --PHP--
-(function() {
-  $target_1 = (new \DateTimeImmutable());
-  return $target_1->getTimestamp();
-})();
+$target_1 = (new \DateTimeImmutable());
+$target_1->getTimestamp();

--- a/tests/php/Integration/Fixtures/Call/dot-method-call.test
+++ b/tests/php/Integration/Fixtures/Call/dot-method-call.test
@@ -1,7 +1,5 @@
 --PHEL--
 (.modify (php/new \DateTimeImmutable) "9 msec")
 --PHP--
-(function() {
-  $target_1 = (new \DateTimeImmutable());
-  return $target_1->modify("9 msec");
-})();
+$target_1 = (new \DateTimeImmutable());
+$target_1->modify("9 msec");

--- a/tests/php/Integration/Fixtures/Call/dot-property-access.test
+++ b/tests/php/Integration/Fixtures/Call/dot-property-access.test
@@ -1,7 +1,5 @@
 --PHEL--
 (.-y (php/new \DateInterval "PT30S"))
 --PHP--
-(function() {
-  $target_1 = (new \DateInterval("PT30S"));
-  return $target_1->y;
-})();
+$target_1 = (new \DateInterval("PT30S"));
+$target_1->y;

--- a/tests/php/Integration/Fixtures/Call/php-method-call-by-ref.test
+++ b/tests/php/Integration/Fixtures/Call/php-method-call-by-ref.test
@@ -3,7 +3,4 @@
 --PHP--
 $x_1 = 1;
 $o_2 = (new \ArrayObject());
-(function() use(&$x_1,$o_2) {
-  $target_3 = $o_2;
-  return $target_3->offsetSet(0, $x_1);
-})();
+($o_2->offsetSet(0, $x_1));

--- a/tests/php/Integration/Fixtures/Call/php-method-call-fn.test
+++ b/tests/php/Integration/Fixtures/Call/php-method-call-fn.test
@@ -1,7 +1,5 @@
 --PHEL--
 (php/-> (php/new \DateTimeImmutable) (getTimestamp))
 --PHP--
-(function() {
-  $target_1 = (new \DateTimeImmutable());
-  return $target_1->getTimestamp();
-})();
+$target_1 = (new \DateTimeImmutable());
+$target_1->getTimestamp();

--- a/tests/php/Integration/Fixtures/Call/php-method-call-named-args.test
+++ b/tests/php/Integration/Fixtures/Call/php-method-call-named-args.test
@@ -2,7 +2,4 @@
 (let [o (php/new \ArrayObject)] (php/-> o (setFlags :& :flags 1)))
 --PHP--
 $o_1 = (new \ArrayObject());
-(function() use($o_1) {
-  $target_2 = $o_1;
-  return $target_2->setFlags(flags: 1);
-})();
+($o_1->setFlags(flags: 1));

--- a/tests/php/Integration/Fixtures/Call/php-method-call-one-arg.test
+++ b/tests/php/Integration/Fixtures/Call/php-method-call-one-arg.test
@@ -1,7 +1,5 @@
 --PHEL--
 (php/-> (php/new \DateTimeImmutable) (modify "9 msec"))
 --PHP--
-(function() {
-  $target_1 = (new \DateTimeImmutable());
-  return $target_1->modify("9 msec");
-})();
+$target_1 = (new \DateTimeImmutable());
+$target_1->modify("9 msec");

--- a/tests/php/Integration/Fixtures/Call/php-method-call-two-args.test
+++ b/tests/php/Integration/Fixtures/Call/php-method-call-two-args.test
@@ -1,7 +1,5 @@
 --PHEL--
 (php/-> (php/new \DateTimeImmutable) (setTime 1 1))
 --PHP--
-(function() {
-  $target_1 = (new \DateTimeImmutable());
-  return $target_1->setTime(1, 1);
-})();
+$target_1 = (new \DateTimeImmutable());
+$target_1->setTime(1, 1);

--- a/tests/php/Integration/Fixtures/Call/php-method-chain.test
+++ b/tests/php/Integration/Fixtures/Call/php-method-chain.test
@@ -1,10 +1,8 @@
 --PHEL--
 (php/-> (php/new \DateTimeImmutable) (modify "+1 day") (format "Y-m-d"))
 --PHP--
-(function() {
-  $target_1 = (function() {
-    $target_2 = (new \DateTimeImmutable());
-    return $target_2->modify("+1 day");
-  })();
-  return $target_1->format("Y-m-d");
+$target_1 = (function() {
+  $target_2 = (new \DateTimeImmutable());
+  return $target_2->modify("+1 day");
 })();
+$target_1->format("Y-m-d");

--- a/tests/php/Integration/Fixtures/Call/php-nested-property-call.test
+++ b/tests/php/Integration/Fixtures/Call/php-nested-property-call.test
@@ -1,13 +1,11 @@
 --PHEL--
 (php/-> (php/new \SimpleXMLElement "<root><user id='1'><data><name>John</name></data></user></root>") user data name)
 --PHP--
-(function() {
-  $target_1 = (function() {
-    $target_2 = (function() {
-      $target_3 = (new \SimpleXMLElement("<root><user id='1'><data><name>John</name></data></user></root>"));
-      return $target_3->user;
-    })();
-    return $target_2->data;
+$target_1 = (function() {
+  $target_2 = (function() {
+    $target_3 = (new \SimpleXMLElement("<root><user id='1'><data><name>John</name></data></user></root>"));
+    return $target_3->user;
   })();
-  return $target_1->name;
+  return $target_2->data;
 })();
+$target_1->name;

--- a/tests/php/Integration/Fixtures/Call/php-object-call-local-target.test
+++ b/tests/php/Integration/Fixtures/Call/php-object-call-local-target.test
@@ -1,0 +1,5 @@
+--PHEL--
+(let [o (php/new \ArrayObject)] (php/-> o (count)))
+--PHP--
+$o_1 = (new \ArrayObject());
+($o_1->count());

--- a/tests/php/Integration/Fixtures/Call/php-object-call-statement.test
+++ b/tests/php/Integration/Fixtures/Call/php-object-call-statement.test
@@ -1,0 +1,5 @@
+--PHEL--
+(do (php/-> (php/new \DateTimeImmutable) (modify "+1 day")) :ok)
+--PHP--
+$target_1 = (new \DateTimeImmutable());
+$target_1->modify("+1 day");

--- a/tests/php/Integration/Fixtures/Call/php-property-call.test
+++ b/tests/php/Integration/Fixtures/Call/php-property-call.test
@@ -1,7 +1,5 @@
 --PHEL--
 (php/-> (php/new \DateInterval "PT30S") y)
 --PHP--
-(function() {
-  $target_1 = (new \DateInterval("PT30S"));
-  return $target_1->y;
-})();
+$target_1 = (new \DateInterval("PT30S"));
+$target_1->y;

--- a/tests/php/Integration/Fixtures/Call/php-property-method-call.test
+++ b/tests/php/Integration/Fixtures/Call/php-property-method-call.test
@@ -1,10 +1,8 @@
 --PHEL--
 (php/-> (php/new \SimpleXMLElement "<root><user id='1'/></root>") user (count))
 --PHP--
-(function() {
-  $target_1 = (function() {
-    $target_2 = (new \SimpleXMLElement("<root><user id='1'/></root>"));
-    return $target_2->user;
-  })();
-  return $target_1->count();
+$target_1 = (function() {
+  $target_2 = (new \SimpleXMLElement("<root><user id='1'/></root>"));
+  return $target_2->user;
 })();
+$target_1->count();

--- a/tests/php/Integration/Fixtures/Def/defenum-php-method.test
+++ b/tests/php/Integration/Fixtures/Def/defenum-php-method.test
@@ -8,10 +8,7 @@ enum Level: int {
 
   public function doubled() {
     $this_1 = $this;
-    return (2 * (function() use($this_1) {
-      $target_2 = $this_1;
-      return $target_2->value;
-    })());
+    return (2 * ($this_1->value));
   }
 }
 }

--- a/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
@@ -34,10 +34,7 @@ interface IPlayer {
 
     public function __invoke($p) {
       if ((is_a($p, "interface_instance\\IPlayer"))) {
-        return (function() use($p) {
-          $target_1 = $p;
-          return $target_1->choose();
-        })();
+        return ($p->choose());
       } else {
         throw (new \InvalidArgumentException("Value doesn't implement interface IPlayer"));
       }
@@ -63,8 +60,8 @@ interface IPlayer {
     public function __invoke($p, $me, $you) {
       if ((is_a($p, "interface_instance\\IPlayer"))) {
         return (function() use($p,$me,$you) {
-          $target_2 = $p;
-          return $target_2->update_strategy($me, $you);
+          $target_1 = $p;
+          return $target_1->update_strategy($me, $you);
         })();
       } else {
         throw (new \InvalidArgumentException("Value doesn't implement interface IPlayer"));

--- a/tests/php/Integration/Fixtures/Def/definterface.test
+++ b/tests/php/Integration/Fixtures/Def/definterface.test
@@ -32,10 +32,7 @@ interface IPlayer {
 
     public function __invoke($p) {
       if ((is_a($p, "user\\IPlayer"))) {
-        return (function() use($p) {
-          $target_1 = $p;
-          return $target_1->choose();
-        })();
+        return ($p->choose());
       } else {
         throw (new \InvalidArgumentException("Value doesn't implement interface IPlayer"));
       }
@@ -61,8 +58,8 @@ interface IPlayer {
     public function __invoke($p, $me, $you) {
       if ((is_a($p, "user\\IPlayer"))) {
         return (function() use($p,$me,$you) {
-          $target_2 = $p;
-          return $target_2->update_strategy($me, $you);
+          $target_1 = $p;
+          return $target_1->update_strategy($me, $you);
         })();
       } else {
         throw (new \InvalidArgumentException("Value doesn't implement interface IPlayer"));

--- a/tests/php/Integration/Fixtures/Def/defstruct-two-interfaces.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-two-interfaces.test
@@ -53,10 +53,7 @@ final class my_type_with_two_interfaces extends \Phel\Lang\Collections\Struct\Ab
   public function foobar() {
     $v = $this->v;
     $this_3 = $this;
-    return (function() use($v,$this_3) {
-      $target_4 = $this_3;
-      return $target_4->foo();
-    })();
+    return ($this_3->foo());
   }
 }
 }


### PR DESCRIPTION
## 🤔 Background

Native `php/->` and `php/::` calls with a computed target always compiled to an immediately-invoked closure — `(function() use(...) { $target_1 = …; return $target_1->m(); })()` — regardless of context. That allocates a closure and a call frame on every evaluation, even where the wrapper is unnecessary. Other emitters (`ThrowEmitter`, `ForeachEmitter`, `DoEmitter`) already gate the IIFE on `NodeEnvironment` context; the object-call emitter did not.

## 💡 Goal

Emit the leanest correct PHP for `php/->` / `php/::` by eliding the closure and temp variable when they aren't needed, without changing semantics.

## 🔖 Changes

- In statement/return context, emit plain statements instead of an IIFE.
- For a simple target (a local variable or a class name), emit `$local->m(...)` / `Class::m(...)` directly — no `target_` temp, in any context.
- Keep the IIFE + temp only for expression-context computed targets, **and** for instance calls passing a bare local argument: the by-value `use($local)` capture is a copy barrier so a PHP by-reference parameter cannot write back into the Phel binding (only `(php/ref local)` opts into that). Covered by `tests/phel/core/interop-by-ref.phel`.
- `ByRefLocalCollector` now runs only on the IIFE path.
- Added fixtures `Call/php-object-call-statement.test`, `Call/php-object-call-local-target.test`; regenerated 16 affected goldens.
- CHANGELOG updated under `## Unreleased`.

Verified: full `composer test` green (static analysis + 4587 unit/integration + 6043 core). No public API or module-structure change.

Closes #2524
