### PR TITLE
perf(emitter): elide IIFE for php/oset in statement context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Performance
 
 - `php/->` and `php/::` now emit leaner PHP, dropping the closure wrapper for simple targets and statement/return-context calls (#2524)
+- `php/oset` in statement context now compiles to a direct property assignment instead of a closure wrapper (#2525)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectSetEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectSetEmitter.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectSetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PropertyOrConstantAccessNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Symbol;
@@ -25,6 +26,24 @@ final class PhpObjectSetEmitter implements NodeEmitterInterface
         $targetExpr = $node->getLeftExpr()->getTargetExpr();
         $callExpr = $node->getLeftExpr()->getCallExpr();
         assert($callExpr instanceof PropertyOrConstantAccessNode);
+
+        // `php/oset` is contractually required to evaluate to the *target
+        // object* (not the assigned value, as a bare PHP `$o->p = v` would
+        // yield). Whenever the value is consumed - expression or return
+        // context - we must host a temp + `return $target` inside an IIFE to
+        // preserve that semantics. In statement context the value is
+        // discarded, so we emit the assignment directly with no closure and
+        // no temp: the target is still evaluated exactly once inline.
+        if ($node->getEnv()->isContext(NodeEnvironment::CONTEXT_STATEMENT)) {
+            $this->outputEmitter->emitNode($targetExpr);
+            $this->outputEmitter->emitStr($fnCode, $node->getStartSourceLocation());
+            $this->outputEmitter->emitStr($callExpr->getName()->getName(), $callExpr->getName()->getStartLocation());
+            $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
+            $this->outputEmitter->emitNode($node->getRightExpr());
+            $this->outputEmitter->emitStr(';', $node->getStartSourceLocation());
+
+            return;
+        }
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
 

--- a/tests/phel/core/special-forms.phel
+++ b/tests/phel/core/special-forms.phel
@@ -4,6 +4,15 @@
 (deftest test-set-object-property
   (is (= "foo" (php/-> (php/oset (php/-> (php/new \stdClass) name) "foo") name)) "set value to stdClass"))
 
+(deftest test-oset-expression-returns-target-object
+  ;; `php/oset` as an expression must evaluate to the *target object*, not
+  ;; the assigned value (a bare PHP `$o->p = v` would yield `v`). Reading the
+  ;; property back off the result proves the target object flowed out.
+  (let [o   (php/new \stdClass)
+        ret (php/oset (php/-> o name) "bar")]
+    (is (php/=== o ret) "oset expression returns the same target object")
+    (is (= "bar" (php/-> ret name)) "the property was set on the returned object")))
+
 (deftest test-nested-php-object-call
   (let [xml-string "<root><user id='1'><name>John</name></user></root>"
         xml        (php/new \SimpleXMLElement xml-string)]

--- a/tests/php/Integration/Fixtures/Call/php-oset-local-target.test
+++ b/tests/php/Integration/Fixtures/Call/php-oset-local-target.test
@@ -1,0 +1,6 @@
+--PHEL--
+(let [o (php/new \stdClass)]
+  (php/oset (php/-> o name) "test"))
+--PHP--
+$o_1 = (new \stdClass());
+$o_1->name = "test";

--- a/tests/php/Integration/Fixtures/Call/php-oset-statement.test
+++ b/tests/php/Integration/Fixtures/Call/php-oset-statement.test
@@ -1,0 +1,14 @@
+--PHEL--
+(def o (php/new \stdClass))
+(php/oset (php/-> o name) "test")
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "o",
+  (new \stdClass()),
+  \Phel::map(
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/php-oset-statement.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/php-oset-statement.test", 1, 27)
+  )
+);
+\Phel::getDefinition("user", "o")->name = "test";

--- a/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
+++ b/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
@@ -11,8 +11,4 @@
     \Phel\Lang\Keyword::create("end-location"), \Phel::location("PhpObjectSet/set-class-property.test", 1, 27)
   )
 );
-(function() {
-  $target_1 = \Phel::getDefinition("user", "a");
-  $target_1->name = "test";
-  return $target_1;
-})();
+\Phel::getDefinition("user", "a")->name = "test";


### PR DESCRIPTION
## 🤔 Background

`php/oset` always compiled to an immediately-invoked closure that stored the target in a temp and returned it — even in statement context, where the returned value is discarded, making both the closure and the temp pure overhead.

## 💡 Goal

Drop the closure for `php/oset` where the result is unused, while strictly preserving its return-value contract.

## 🔖 Changes

- In statement context, emit a direct `$target->prop = $value;` assignment — no closure, no temp; the target is still evaluated exactly once inline.
- Expression and return context keep the existing temp + IIFE + `return $target` form, because `php/oset` is contractually required to evaluate to the **target object** (not the assigned value a bare `$o->p = v` would yield). Pinned by a new behavioral test `test-oset-expression-returns-target-object` in `tests/phel/core/special-forms.phel`.
- Added fixtures `Call/php-oset-statement.test`, `Call/php-oset-local-target.test`; updated `PhpObjectSet/set-class-property.test`.
- CHANGELOG updated under `## Unreleased`.

Verified: full `composer test` green (static analysis + unit/integration + core, incl. the new behavioral test).

Closes #2525
