### PR TITLE
perf(emitter): elide temp/guard/IIFE for php/new with known class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Performance
 
 - `php/->` and `php/::` now emit leaner PHP, dropping the closure wrapper for simple targets and statement/return-context calls (#2524)
+- `php/new` with a known class now compiles to a direct `(new Class(...))` instead of a closure wrapper with a runtime guard (#2526)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpNewEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpNewEmitter.php
@@ -8,12 +8,14 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpNewNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Symbol;
 
 use function assert;
 use function is_string;
+use function str_starts_with;
 
 final class PhpNewEmitter implements NodeEmitterInterface
 {
@@ -23,73 +25,115 @@ final class PhpNewEmitter implements NodeEmitterInterface
     {
         assert($node instanceof PhpNewNode);
 
-        $this->emitPhpNewBegin($node);
-        $this->emitPhpNewArgs($node);
-        $this->emitPhpNewEnd($node);
+        $classExpr = $node->getClassExpr();
+        $staticClassName = $this->staticClassName($classExpr);
+
+        if ($staticClassName !== null) {
+            $this->emitStaticClassNew($node, $staticClassName);
+            return;
+        }
+
+        $this->emitDynamicNew($node, $classExpr);
     }
 
-    private function emitPhpNewBegin(PhpNewNode $node): void
+    /**
+     * Returns the absolute PHP class name when the class expression is known at
+     * compile time (a resolved class-name node or a literal string), or null
+     * when the class is only known at runtime (a variable, call, ...).
+     */
+    private function staticClassName(AbstractNode $classExpr): ?string
+    {
+        if ($classExpr instanceof PhpClassNameNode) {
+            return $classExpr->getAbsolutePhpName();
+        }
+
+        if ($classExpr instanceof LiteralNode && is_string($classExpr->getValue())) {
+            return $this->absoluteClassName($classExpr->getValue());
+        }
+
+        return null;
+    }
+
+    /**
+     * Forces an absolute (global-namespace) class name so direct `new <name>`
+     * emission matches the runtime semantics of `new $string`, which always
+     * resolves from the global namespace and never prepends the current one.
+     */
+    private function absoluteClassName(string $className): string
+    {
+        if (str_starts_with($className, '\\')) {
+            return $className;
+        }
+
+        return '\\' . $className;
+    }
+
+    /**
+     * Emits `(new <Class>(...))` directly: no `target_` temp, no guard, no IIFE.
+     */
+    private function emitStaticClassNew(PhpNewNode $node, string $className): void
     {
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $classExpr = $node->getClassExpr();
 
-        if ($classExpr instanceof PhpClassNameNode) {
-            $this->outputEmitter->emitStr('(new ', $node->getStartSourceLocation());
-            $this->outputEmitter->emitStr($classExpr->getAbsolutePhpName(), $classExpr->getName()->getStartLocation());
-            $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
-        } else {
+        $this->outputEmitter->emitStr('(new ', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr($className, $node->getClassExpr()->getStartSourceLocation());
+        $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
+        $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('))', $node->getStartSourceLocation());
+
+        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+    }
+
+    /**
+     * Emits a runtime-class construction with a `target_` temp and an
+     * `is_string()/is_object()` guard. The construction is wrapped in an IIFE
+     * only in expression context; in statement/return context the temp, guard
+     * and `new` are emitted as plain statements.
+     */
+    private function emitDynamicNew(PhpNewNode $node, AbstractNode $classExpr): void
+    {
+        $isExpr = $node->getEnv()->isContext(NodeEnvironment::CONTEXT_EXPRESSION);
+
+        if ($isExpr) {
             $this->outputEmitter->emitFnWrapPrefix(
                 $node->getEnv(),
                 $node->getStartSourceLocation(),
                 new ByRefLocalCollector()->collect($node),
             );
-
-            $targetSym = Symbol::gen('target_');
-            $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
-            $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
-            $this->outputEmitter->emitNode($classExpr);
-            $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
-
-            $targetVar = '$' . $targetSym->getName();
-            if (!$this->isKnownValidClassExpr($classExpr)) {
-                $this->outputEmitter->emitStr(
-                    'if (!is_string(' . $targetVar . ') && !is_object(' . $targetVar . ')) {',
-                    $node->getStartSourceLocation(),
-                );
-                $this->outputEmitter->emitLine();
-                $this->outputEmitter->emitStr(
-                    'throw new \InvalidArgumentException(sprintf("php/new expects a class name or object, %s given (%s)", get_debug_type(' . $targetVar . '), var_export(' . $targetVar . ', true)));',
-                    $node->getStartSourceLocation(),
-                );
-                $this->outputEmitter->emitLine();
-                $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
-            }
-
-            $this->outputEmitter->emitStr('return new ' . $targetVar . '(', $node->getStartSourceLocation());
         }
-    }
 
-    private function emitPhpNewArgs(PhpNewNode $node): void
-    {
-        $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
-    }
+        $targetSym = Symbol::gen('target_');
+        $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
+        $this->outputEmitter->emitNode($classExpr);
+        $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
 
-    private function isKnownValidClassExpr(AbstractNode $classExpr): bool
-    {
-        return $classExpr instanceof LiteralNode && is_string($classExpr->getValue());
-    }
+        $targetVar = '$' . $targetSym->getName();
+        $this->outputEmitter->emitStr(
+            'if (!is_string(' . $targetVar . ') && !is_object(' . $targetVar . ')) {',
+            $node->getStartSourceLocation(),
+        );
+        $this->outputEmitter->emitLine();
+        $this->outputEmitter->emitStr(
+            'throw new \InvalidArgumentException(sprintf("php/new expects a class name or object, %s given (%s)", get_debug_type(' . $targetVar . '), var_export(' . $targetVar . ', true)));',
+            $node->getStartSourceLocation(),
+        );
+        $this->outputEmitter->emitLine();
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
 
-    private function emitPhpNewEnd(PhpNewNode $node): void
-    {
-        $classExpr = $node->getClassExpr();
-
-        if ($classExpr instanceof PhpClassNameNode) {
-            $this->outputEmitter->emitStr('))', $node->getStartSourceLocation());
-        } else {
+        if ($isExpr) {
+            $this->outputEmitter->emitStr('return new ' . $targetVar . '(', $node->getStartSourceLocation());
+            $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
             $this->outputEmitter->emitStr(');', $node->getStartSourceLocation());
             $this->outputEmitter->emitFnWrapSuffix($node->getStartSourceLocation());
+            $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+            return;
         }
 
+        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('new ' . $targetVar . '(', $node->getStartSourceLocation());
+        $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
     }
 }

--- a/tests/phel/core/special-forms.phel
+++ b/tests/phel/core/special-forms.phel
@@ -9,6 +9,18 @@
         xml        (php/new \SimpleXMLElement xml-string)]
     (is (= "John" (str (php/-> xml user name))))))
 
+(deftest test-php-new-dynamic-class-from-variable
+  (let [cls "\\DateTimeZone"
+        tz  (php/new cls "Europe/Berlin")]
+    (is (= "Europe/Berlin" (php/-> tz (getName)))
+        "php/new with a class held in a variable resolves at runtime")))
+
+(deftest test-php-new-dynamic-invalid-class-throws
+  (is (thrown? \InvalidArgumentException
+        (let [cls 42]
+          (php/new cls)))
+      "php/new with a non-string, non-object class value throws InvalidArgumentException"))
+
 (deftest test-def-duplication
   (let [form (read-string "(do (def a \"first\") (def a \"second\") a)")]
     (is (= "second" (eval form)))))

--- a/tests/php/Integration/Fixtures/New/new-dynamic-class-statement.test
+++ b/tests/php/Integration/Fixtures/New/new-dynamic-class-statement.test
@@ -1,0 +1,9 @@
+--PHEL--
+(let [cls "\\DateTimeImmutable"] (php/new cls) :done)
+--PHP--
+$cls_1 = "\\DateTimeImmutable";
+$target_2 = $cls_1;
+if (!is_string($target_2) && !is_object($target_2)) {
+throw new \InvalidArgumentException(sprintf("php/new expects a class name or object, %s given (%s)", get_debug_type($target_2), var_export($target_2, true)));
+}
+new $target_2();

--- a/tests/php/Integration/Fixtures/New/new-from-string.test
+++ b/tests/php/Integration/Fixtures/New/new-from-string.test
@@ -1,7 +1,4 @@
 --PHEL--
 (php/new "\\DateTimeImmutable")
 --PHP--
-(function() {
-  $target_1 = "\\DateTimeImmutable";
-  return new $target_1();
-})();
+(new \DateTimeImmutable());

--- a/tests/php/Integration/Fixtures/New/new-literal-string-class.test
+++ b/tests/php/Integration/Fixtures/New/new-literal-string-class.test
@@ -1,0 +1,4 @@
+--PHEL--
+(php/new "\\DateTimeZone" "Europe/Berlin")
+--PHP--
+(new \DateTimeZone("Europe/Berlin"));

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -52,10 +52,7 @@ final class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
     public const BOUND_TO = "hello_world\\abc";
 
     public function __invoke($a) {
-      return (function() use($a) {
-        $target_1 = "hello_world\\abc";
-        return new $target_1($a);
-      })();
+      return (new \hello_world\abc($a));
     }
   },
   \Phel::map(


### PR DESCRIPTION
## 🤔 Background

`php/new` with a non-class-name expression always wrapped construction in an IIFE with a `target_` temp and an `is_string()/is_object()` runtime guard — even for a literal-string class, and even in statement/return context where the IIFE is unnecessary.

## 💡 Goal

Emit direct construction for statically-known classes and elide the IIFE where context allows, keeping the runtime guard only where it's genuinely needed.

## 🔖 Changes

- A statically-known class (a resolved class name or a literal string) now compiles to a direct `(new \Class(...))` — no temp, no guard.
- For a dynamic class, the IIFE is elided in statement/return context (temp + guard emitted as plain statements); the full IIFE + guard remains in expression context.
- The `is_string()/is_object()` guard and `InvalidArgumentException` are retained for genuinely dynamic class expressions. Pinned by `test-php-new-dynamic-invalid-class-throws` in `tests/phel/core/special-forms.phel`.
- Literal-string classes are emitted as **absolute** names (leading `\`): PHP resolves `new $string` from the global namespace, but bare `new Foo\Bar` is namespace-relative — without normalizing, `defstruct`'s generated constructor broke. Regression-covered by `Ns/munge-ns.test`.
- Added fixtures `New/new-literal-string-class.test`, `New/new-dynamic-class-statement.test`; updated `New/new-from-string.test`, `Ns/munge-ns.test`.
- CHANGELOG updated under `## Unreleased`.

Verified: full `composer test` green (static analysis + unit/integration + core, incl. the new behavioral tests).

Closes #2526
