### PR TITLE
perf(emitter): specialize push/conj and variadic dissoc on tagged collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - `php/->` and `php/::` now emit leaner PHP, dropping the closure wrapper for simple targets and statement/return-context calls (#2524)
 - `php/new` with a known class now compiles to a direct `(new Class(...))` instead of a closure wrapper with a runtime guard (#2526)
 - `php/oset` in statement context now compiles to a direct property assignment instead of a closure wrapper (#2525)
+- `push` on a tagged `PersistentVectorInterface` and variadic `dissoc` on a tagged `PersistentMapInterface` now compile to direct persistent-collection method calls (`->append(...)`, chained `->remove(...)`) instead of routing through the runtime dispatch (#2527)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/AssocConjSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/AssocConjSpecialization.php
@@ -28,15 +28,19 @@ final readonly class AssocConjSpecialization
     private function __construct() {}
 
     /**
-     * `(assoc coll k v)` 3-arg / `(conj coll x)` 2-arg / `(dissoc coll k)` 2-arg
-     * specialise to a direct method call when the target carries an
-     * inferred persistent-collection tag:
+     * `(assoc coll k v)` 3-arg / `(conj coll x)` 2-arg / `(push coll x)`
+     * 2-arg / `(dissoc coll k)` 2-arg specialise to a direct method call
+     * when the target carries an inferred persistent-collection tag:
      *
-     *  - `PersistentMapInterface`  → `put` / `cons` (n/a) / `remove`
-     *  - `PersistentVectorInterface` → `update` / `append` / (n/a)
+     *  - `PersistentMapInterface`  → `put` / `remove`
+     *  - `PersistentVectorInterface` → `update` / `append`
      *
-     * Skips variadic / extra-arg arities — those need a loop the runtime
-     * dispatch handles separately.
+     * `push` is the deprecated alias for the 2-arg `conj` (its body is
+     * `(conj coll x)`), so on a vector it appends exactly like `conj`.
+     *
+     * Variadic `dissoc` is handled by {@see self::typedDissocKeys()};
+     * variadic `assoc` / `conj` need a runtime loop and are not specialised
+     * here.
      */
     public static function typedAssocConjDissocMethod(CallNode $node): ?string
     {
@@ -71,7 +75,7 @@ final readonly class AssocConjSpecialization
             };
         }
 
-        if ($name === 'conj' && $argCount === 2) {
+        if (($name === 'conj' || $name === 'push') && $argCount === 2) {
             return match ($tag) {
                 PersistentVectorInterface::class => 'append',
                 default => null,
@@ -88,6 +92,56 @@ final readonly class AssocConjSpecialization
     public static function isTypedAssocConjDissoc(CallNode $node): bool
     {
         return self::typedAssocConjDissocMethod($node) !== null;
+    }
+
+    /**
+     * `(dissoc m k1 k2 …)` on a `PersistentMapInterface`-tagged target with
+     * one or more keys specialises to a chain of `->remove($k)` calls. The
+     * runtime `dissoc` loops `dissoc-one` over the keys left-to-right, each
+     * step calling `remove` on the map, so the emitted chain preserves key
+     * order.
+     *
+     * The single-key arity overlaps {@see self::typedAssocConjDissocMethod()}
+     * — both lower to the same `->remove($k)` — but the emitter consults
+     * this predicate first, so the variadic emitter owns every typed
+     * `dissoc`.
+     *
+     * @return list<AbstractNode>|null the key argument nodes, or null when
+     *                                 the call is not a typed `dissoc`
+     */
+    public static function typedDissocKeys(CallNode $node): ?array
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return null;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || $fn->getName()->getName() !== 'dissoc'
+        ) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) < 2) {
+            return null;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        if (TagNormalizer::normalise($target->getInferredType()) !== PersistentMapInterface::class) {
+            return null;
+        }
+
+        return array_slice($args, 1);
+    }
+
+    public static function isTypedDissocKeys(CallNode $node): bool
+    {
+        return self::typedDissocKeys($node) !== null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -126,6 +126,10 @@ final readonly class CallSpecialization
             return true;
         }
 
+        if (AssocConjSpecialization::isTypedDissocKeys($node)) {
+            return true;
+        }
+
         if (AssocConjSpecialization::isTypedAssocConjDissoc($node)) {
             return true;
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/AssocConjCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/AssocConjCallEmitter.php
@@ -13,8 +13,9 @@ use function count;
 
 /**
  * Specialisations gated by {@see AssocConjSpecialization}: a transient-backed
- * chain of `(assoc m k v)` / `(conj v x)` calls, and the single-step
- * `(assoc ...)` / `(conj ...)` / `(dissoc ...)` on a typed persistent target.
+ * chain of `(assoc m k v)` / `(conj v x)` calls, the variadic
+ * `(dissoc m k1 k2 …)` lowered to a `->remove()` chain, and the single-step
+ * `(assoc ...)` / `(conj ...)` / `(push ...)` on a typed persistent target.
  */
 final readonly class AssocConjCallEmitter implements SpecializedCallEmitterInterface
 {
@@ -28,7 +29,42 @@ final readonly class AssocConjCallEmitter implements SpecializedCallEmitterInter
             return true;
         }
 
+        if ($this->tryEmitTypedDissocKeys($node)) {
+            return true;
+        }
+
         return $this->tryEmitTypedAssocConjDissoc($node);
+    }
+
+    /**
+     * Specialise `(dissoc m k1 k2 …)` on a `PersistentMapInterface`-tagged
+     * target to a chain of `->remove($k)` calls — one per key, in the same
+     * left-to-right order the runtime `dissoc` loop applies them. Each
+     * `remove` returns a new persistent map, so chaining matches the
+     * runtime's per-key folding semantics. Owns every typed `dissoc`
+     * (including the single-key arity, which emits the same `->remove($k)`
+     * the generic single-step path would).
+     */
+    private function tryEmitTypedDissocKeys(CallNode $node): bool
+    {
+        $keys = AssocConjSpecialization::typedDissocKeys($node);
+        if ($keys === null) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($args[0]);
+
+        foreach ($keys as $key) {
+            $this->outputEmitter->emitStr('->remove(', $loc);
+            $this->outputEmitter->emitNode($key);
+            $this->outputEmitter->emitStr(')', $loc);
+        }
+
+        $this->outputEmitter->emitStr(')', $loc);
+        return true;
     }
 
     /**

--- a/tests/phel/core/push-dissoc-typed-collection.phel
+++ b/tests/phel/core/push-dissoc-typed-collection.phel
@@ -1,0 +1,45 @@
+(ns phel-test.core.push-dissoc-typed-collection
+  (:require phel.test :refer [deftest is]))
+
+;; Tagged targets take the specialised emitter path
+;; (direct PersistentVector::append / PersistentMap::remove chain);
+;; the untagged counterparts go through the runtime dispatch. Both
+;; must agree.
+
+(defn- push-tagged [^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" v x]
+  (push v x))
+
+(defn- push-untagged [v x]
+  (push v x))
+
+(defn- dissoc-tagged [^"\Phel\Lang\Collections\Map\PersistentMapInterface" m & ks]
+  (apply dissoc m ks))
+
+(defn- dissoc-tagged-2 [^"\Phel\Lang\Collections\Map\PersistentMapInterface" m a b]
+  (dissoc m a b))
+
+(defn- dissoc-tagged-3 [^"\Phel\Lang\Collections\Map\PersistentMapInterface" m a b c]
+  (dissoc m a b c))
+
+(defn- dissoc-tagged-1 [^"\Phel\Lang\Collections\Map\PersistentMapInterface" m a]
+  (dissoc m a))
+
+(deftest test-push-typed-vector-matches-runtime
+  (is (= [1 2 3] (push-tagged [1 2] 3)) "specialised push appends to a vector")
+  (is (= (push-untagged [1 2] 3) (push-tagged [1 2] 3))
+      "tagged push agrees with untagged push")
+  (is (= [99] (push-tagged [] 99)) "specialised push onto empty vector"))
+
+(deftest test-dissoc-variadic-typed-map-matches-runtime
+  (is (= {:b 2} (dissoc-tagged-1 {:a 1 :b 2} :a))
+      "single-key dissoc removes the key")
+  (is (= {:c 3} (dissoc-tagged-2 {:a 1 :b 2 :c 3} :a :b))
+      "two-key dissoc removes both keys")
+  (is (= {} (dissoc-tagged-3 {:a 1 :b 2 :c 3} :a :b :c))
+      "three-key dissoc removes all keys")
+  (is (= {:b 2 :c 3} (dissoc-tagged {:a 1 :b 2 :c 3} :a :missing))
+      "dissoc ignores missing keys, applied left-to-right"))
+
+(deftest test-dissoc-key-order-independent-of-tag
+  (is (= (dissoc {:a 1 :b 2 :c 3} :a :c) (dissoc-tagged-2 {:a 1 :b 2 :c 3} :a :c))
+      "tagged variadic dissoc agrees with untagged runtime dissoc"))

--- a/tests/php/Integration/Fixtures/Call/dissoc-variadic-typed.test
+++ b/tests/php/Integration/Fixtures/Call/dissoc-variadic-typed.test
@@ -1,0 +1,8 @@
+--PHEL--
+(fn [^\Phel\Lang\Collections\Map\PersistentMapInterface m]
+  [(dissoc m :a) (dissoc m :a :b) (dissoc m :a :b :c)])
+--PHP--
+(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m) {
+  static $__phel_const_0, $__phel_const_1, $__phel_const_2, $__phel_const_3, $__phel_const_4, $__phel_const_5;
+  return \Phel::vector([($m->remove(($__phel_const_0 ??= \Phel\Lang\Keyword::create("a")))), ($m->remove(($__phel_const_1 ??= \Phel\Lang\Keyword::create("a")))->remove(($__phel_const_2 ??= \Phel\Lang\Keyword::create("b")))), ($m->remove(($__phel_const_3 ??= \Phel\Lang\Keyword::create("a")))->remove(($__phel_const_4 ??= \Phel\Lang\Keyword::create("b")))->remove(($__phel_const_5 ??= \Phel\Lang\Keyword::create("c"))))]);
+});

--- a/tests/php/Integration/Fixtures/Call/push-typed-vector.test
+++ b/tests/php/Integration/Fixtures/Call/push-typed-vector.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [^\Phel\Lang\Collections\Vector\PersistentVectorInterface v]
+  (push v 99))
+--PHP--
+(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
+  return ($v->append(99));
+});


### PR DESCRIPTION
## 🤔 Background

`push` and variadic `dissoc` always routed through the runtime: a registry `__invoke` plus a cond-walk over collection shapes — even when the analyzer already knows the target is a persistent vector/map via a `:tag`. The existing specialization layer already lowers `assoc`/`conj`/single-step `dissoc`; these two were gaps.

## 💡 Goal

Lower tag-known `push`/`conj` and variadic `dissoc` to direct persistent-collection method calls, with no behavior change.

## 🔖 Changes

- `push` on a `^PersistentVectorInterface` local → `($v->append($x))` (`push` is defined as `(conj coll x)`; vector `conj` appends).
- Variadic `dissoc` on a `^PersistentMapInterface` local → left-to-right `($m->remove($k1)->remove($k2)...)`, matching the runtime fold (missing keys are no-ops). Single-key `dissoc` output is unchanged.
- Only tag-gated `LocalVarNode` targets specialize; untagged calls fall back to dispatch unchanged. Predicate/emitter ordering keeps the cache scanner aligned (no orphan call-slots).
- Fixtures: `Call/push-typed-vector.test`, `Call/dissoc-variadic-typed.test`; behavioral test `tests/phel/core/push-dissoc-typed-collection.phel` (tagged results == untagged runtime results, incl. missing-key/order cases).

Verified: full `composer test` green (static analysis + 6055 unit/integration/core).

Closes #2527
