### PR TITLE
perf(emitter): specialize constant-index nth and second on tagged vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - `php/new` with a known class now compiles to a direct `(new Class(...))` instead of a closure wrapper with a runtime guard (#2526)
 - `php/oset` in statement context now compiles to a direct property assignment instead of a closure wrapper (#2525)
 - `push` on a tagged `PersistentVectorInterface` and variadic `dissoc` on a tagged `PersistentMapInterface` now compile to direct persistent-collection method calls (`->append(...)`, chained `->remove(...)`) instead of routing through the runtime dispatch (#2527)
+- `(second v)` on a tagged persistent vector now compiles to a guarded `($v->count() > 1 ? $v->get(1) : null)` instead of the runtime `first`/`next` dispatch, preserving the nil-out-of-range contract (#2530)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/TypedCollectionCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/TypedCollectionCallEmitter.php
@@ -12,9 +12,10 @@ use function count;
 
 /**
  * Specialisations gated by {@see TypedCollectionMethodSpecialization}:
- * `(nth v i)` / `(count v)` on a tagged `PersistentVectorInterface`, and
- * `(first s)` / `(rest s)` on a tagged seq. Each collapses a runtime cond
- * chain over the collection shapes to one direct method call.
+ * `(nth v i)` / `(count v)` / `(second v)` on a tagged
+ * `PersistentVectorInterface`, and `(first s)` / `(rest s)` on a tagged
+ * seq. Each collapses a runtime cond chain over the collection shapes to
+ * one direct method call.
  */
 final readonly class TypedCollectionCallEmitter implements SpecializedCallEmitterInterface
 {
@@ -24,11 +25,40 @@ final readonly class TypedCollectionCallEmitter implements SpecializedCallEmitte
 
     public function tryEmit(CallNode $node): bool
     {
+        if ($this->tryEmitTypedVectorSecond($node)) {
+            return true;
+        }
+
         if ($this->tryEmitTypedVectorAccessor($node)) {
             return true;
         }
 
         return $this->tryEmitTypedSeqAccessor($node);
+    }
+
+    /**
+     * Specialise `(second v)` on a tagged `PersistentVectorInterface`
+     * target. The runtime `phel.core/second` is `(first (next v))`,
+     * which returns nil — never throws — when the vector has fewer than
+     * two elements. A bare `$v->get(1)` would throw out of range, so the
+     * lowering keeps the nil contract behind a length guard:
+     * `($v->count() > 1 ? $v->get(1) : null)`. The target is a
+     * `LocalVarNode` (a bare variable), so emitting it twice is safe.
+     */
+    private function tryEmitTypedVectorSecond(CallNode $node): bool
+    {
+        if (!TypedCollectionMethodSpecialization::isTypedVectorSecond($node)) {
+            return false;
+        }
+
+        $target = $node->getArguments()[0];
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($target);
+        $this->outputEmitter->emitStr('->count() > 1 ? ', $loc);
+        $this->outputEmitter->emitNode($target);
+        $this->outputEmitter->emitStr('->get(1) : null)', $loc);
+        return true;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecialization.php
@@ -84,7 +84,49 @@ final readonly class TypedCollectionMethodSpecialization
 
     public static function isTypedVectorAccessor(CallNode $node): bool
     {
-        return self::typedVectorMethodCall($node) !== null;
+        if (self::typedVectorMethodCall($node) !== null) {
+            return true;
+        }
+
+        return self::isTypedVectorSecond($node);
+    }
+
+    /**
+     * `(second v)` where the analyser has tagged the target as
+     * `PersistentVectorInterface`. The runtime `phel.core/second` is
+     * `(first (next v))`, which returns nil when the vector has fewer
+     * than two elements — it never throws. A bare `$v->get(1)` would
+     * throw out of range, so this is only safe behind a length guard;
+     * {@see NodeEmitter\Specialized\TypedCollectionCallEmitter} emits
+     * `($v->count() > 1 ? $v->get(1) : null)`, preserving the nil
+     * contract while collapsing the runtime `first`/`next` cond chains.
+     */
+    public static function isTypedVectorSecond(CallNode $node): bool
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return false;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return false;
+        }
+
+        if ($fn->getName()->getName() !== 'second') {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return false;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return false;
+        }
+
+        return TagNormalizer::normalise($target->getInferredType()) === PersistentVectorInterface::class;
     }
 
     /**

--- a/tests/phel/core/get-typed-collection.phel
+++ b/tests/phel/core/get-typed-collection.phel
@@ -1,11 +1,17 @@
 (ns phel-test.core.get-typed-collection
-  (:require phel.test :refer [deftest is]))
+  (:require phel.test :refer [deftest is thrown?]))
 
 (defn- read-vec [^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" v ^int i]
   (get v i))
 
 (defn- read-map [^"\Phel\Lang\Collections\Map\PersistentMapInterface" m k]
   (get m k))
+
+(defn- nth-const [^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" v]
+  (nth v 1))
+
+(defn- second-vec [^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" v]
+  (second v))
 
 (deftest test-get-on-typed-vector
   (is (= 10 (read-vec [10 20 30] 0)) "specialised get hits PersistentVector::get")
@@ -14,3 +20,17 @@
 (deftest test-get-on-typed-map-miss-returns-nil
   (is (= 1 (read-map {:a 1 :b 2} :a)) "specialised get hits PersistentMap::find")
   (is (nil? (read-map {:a 1} :missing)) "specialised get returns nil for missing key"))
+
+(deftest test-nth-constant-index-on-typed-vector
+  (is (= 20 (nth-const [10 20 30])) "specialised constant-index nth hits PersistentVector::get")
+  (is (thrown? \Throwable (nth-const [10]))
+      "specialised nth throws out of range, matching runtime nth")
+  (is (thrown? \Throwable (nth [10] 1))
+      "runtime nth also throws out of range"))
+
+(deftest test-second-on-typed-vector
+  (is (= 20 (second-vec [10 20 30])) "specialised second returns the element at index 1")
+  (is (nil? (second-vec [10])) "specialised second returns nil out of range, never throws")
+  (is (nil? (second-vec [])) "specialised second on empty vector returns nil")
+  (is (= (second [10 20]) (second-vec [10 20])) "specialised second matches runtime in range")
+  (is (= (second [10]) (second-vec [10])) "specialised second matches runtime out of range"))

--- a/tests/php/Integration/Fixtures/Call/nth-constant-index-typed-vector.test
+++ b/tests/php/Integration/Fixtures/Call/nth-constant-index-typed-vector.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" v] (nth v 2))
+--PHP--
+(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
+  return ($v->get(2));
+});

--- a/tests/php/Integration/Fixtures/Call/second-typed-vector.test
+++ b/tests/php/Integration/Fixtures/Call/second-typed-vector.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" v] (second v))
+--PHP--
+(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
+  return ($v->count() > 1 ? $v->get(1) : null);
+});


### PR DESCRIPTION
## 🤔 Background

`nth` and the fixed-position alias `second` route through the runtime even when the analyzer knows the target is a persistent vector via a `:tag`. The 2-arg `nth` was already specialized; `second` was not.

## 💡 Goal

Lower tag-known constant-index access to direct vector method calls, preserving each function's out-of-range contract exactly.

## 🔖 Changes

- `(second ^PersistentVectorInterface v)` → `($v->count() > 1 ? $v->get(1) : null)`. `second` returns **nil** out of range (never throws), so the direct `->get(1)` is length-guarded. Gated on a bare `LocalVarNode` target so double-emission is side-effect-safe.
- `(nth ^vec v <int-literal>)` was already lowered to `($v->get(N))` by the existing 2-arg `nth` path; locked in with a fixture. `nth` throws out of range, matching `->get`.
- Other aliases (`ffirst`/`fnext`/`nfirst`/`nnext`) return nil out of range and don't map to a single nil-safe positional method, so they correctly stay on dispatch.
- Fixtures: `Call/second-typed-vector.test`, `Call/nth-constant-index-typed-vector.test`; behavioral tests in `tests/phel/core/get-typed-collection.phel` (in-range, out-of-range throw/nil, parity with untagged runtime).

Verified: full `composer test` green (static analysis + 6055 core); ~2.4× on a 2M-call `second` microbench.

Closes #2530
