### PR TITLE
refactor(emitter): extract shared context-aware IIFE/statement dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ All notable changes to this project will be documented in this file.
 - `(second v)` on a tagged persistent vector now compiles to a guarded `($v->count() > 1 ? $v->get(1) : null)` instead of the runtime `first`/`next` dispatch, preserving the nil-out-of-range contract (#2530)
 - `=` and `not=` over string literals now fold to a boolean at compile time instead of dispatching at runtime (#2531)
 - `get-in` with a literal key path on a `:tag`ged map/vector now compiles to an unrolled null-coalescing subscript chain instead of dispatching to the runtime traversal loop (#2529)
+- The interop emitters (`php/->`, `php/oset`, `php/new`) now share one context-aware IIFE/statement kernel and only scan for `php/ref` by-reference locals when an IIFE is actually emitted, cutting compile-time work (#2536, subsumes #2532)
 
 ### Fixed
 
 - The "not defined" error hint now also shows when the compiler appends a `Did you mean ...?` suggestion (a trailing period previously suppressed it)
+- `php/oset` in return context now elides the redundant closure wrapper, matching `php/->`'s return-context behavior (#2536)
 
 ## [0.45.1](https://github.com/phel-lang/phel-lang/compare/v0.45.0...v0.45.1) - 2026-06-20
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/ContextualWrapEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/ContextualWrapEmitter.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
+use Phel\Lang\SourceLocation;
+
+/**
+ * Shared "context-aware IIFE-or-statements" kernel for the interop emitters
+ * (`php/->`, `php/oset`, `php/new`) whose computed target needs a temp var to
+ * guarantee exactly-once evaluation.
+ *
+ * In expression context the setup + result must live inside an IIFE so the temp
+ * can host a `return`; the by-reference local capture (`ByRefLocalCollector`)
+ * is computed lazily here, only on this path. In statement and return context
+ * the IIFE is elided: the setup runs as plain statements and the result is
+ * bracketed with the usual context prefix/suffix.
+ */
+final readonly class ContextualWrapEmitter
+{
+    public function __construct(private OutputEmitterInterface $outputEmitter) {}
+
+    /**
+     * @param callable():void $emitSetup      emits the temp assignment(s) and any
+     *                                        guards as plain statements; runs in
+     *                                        every context, exactly once
+     * @param callable():void $emitResultExpr emits the bare value-producing
+     *                                        expression (no `return`, no `;`)
+     */
+    public function emit(
+        AbstractNode $node,
+        callable $emitSetup,
+        callable $emitResultExpr,
+    ): void {
+        $env = $node->getEnv();
+        $loc = $node->getStartSourceLocation();
+
+        if ($env->isContext(NodeEnvironment::CONTEXT_EXPRESSION)) {
+            $this->emitWrapped($env, $loc, $node, $emitSetup, $emitResultExpr);
+
+            return;
+        }
+
+        $emitSetup();
+        $this->outputEmitter->emitContextPrefix($env, $loc);
+        $emitResultExpr();
+        $this->outputEmitter->emitContextSuffix($env, $loc);
+    }
+
+    /**
+     * @param callable():void $emitSetup
+     * @param callable():void $emitResultExpr
+     */
+    private function emitWrapped(
+        NodeEnvironmentInterface $env,
+        ?SourceLocation $loc,
+        AbstractNode $node,
+        callable $emitSetup,
+        callable $emitResultExpr,
+    ): void {
+        $this->outputEmitter->emitFnWrapPrefix(
+            $env,
+            $loc,
+            new ByRefLocalCollector()->collect($node),
+        );
+
+        $emitSetup();
+
+        $this->outputEmitter->emitStr('return ', $loc);
+        $emitResultExpr();
+        $this->outputEmitter->emitStr(';', $loc);
+
+        $this->outputEmitter->emitFnWrapSuffix($loc);
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpNewEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpNewEmitter.php
@@ -8,8 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpNewNode;
-use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
-use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\ContextualWrapEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Symbol;
 
@@ -86,54 +85,40 @@ final class PhpNewEmitter implements NodeEmitterInterface
 
     /**
      * Emits a runtime-class construction with a `target_` temp and an
-     * `is_string()/is_object()` guard. The construction is wrapped in an IIFE
+     * `is_string()/is_object()` guard. The shared kernel wraps it in an IIFE
      * only in expression context; in statement/return context the temp, guard
      * and `new` are emitted as plain statements.
      */
     private function emitDynamicNew(PhpNewNode $node, AbstractNode $classExpr): void
     {
-        $isExpr = $node->getEnv()->isContext(NodeEnvironment::CONTEXT_EXPRESSION);
-
-        if ($isExpr) {
-            $this->outputEmitter->emitFnWrapPrefix(
-                $node->getEnv(),
-                $node->getStartSourceLocation(),
-                new ByRefLocalCollector()->collect($node),
-            );
-        }
-
         $targetSym = Symbol::gen('target_');
-        $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
-        $this->outputEmitter->emitNode($classExpr);
-        $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
-
         $targetVar = '$' . $targetSym->getName();
-        $this->outputEmitter->emitStr(
-            'if (!is_string(' . $targetVar . ') && !is_object(' . $targetVar . ')) {',
-            $node->getStartSourceLocation(),
-        );
-        $this->outputEmitter->emitLine();
-        $this->outputEmitter->emitStr(
-            'throw new \InvalidArgumentException(sprintf("php/new expects a class name or object, %s given (%s)", get_debug_type(' . $targetVar . '), var_export(' . $targetVar . ', true)));',
-            $node->getStartSourceLocation(),
-        );
-        $this->outputEmitter->emitLine();
-        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
 
-        if ($isExpr) {
-            $this->outputEmitter->emitStr('return new ' . $targetVar . '(', $node->getStartSourceLocation());
-            $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
-            $this->outputEmitter->emitStr(');', $node->getStartSourceLocation());
-            $this->outputEmitter->emitFnWrapSuffix($node->getStartSourceLocation());
-            $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
-            return;
-        }
+        new ContextualWrapEmitter($this->outputEmitter)->emit(
+            $node,
+            function () use ($node, $classExpr, $targetSym, $targetVar): void {
+                $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
+                $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
+                $this->outputEmitter->emitNode($classExpr);
+                $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
 
-        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('new ' . $targetVar . '(', $node->getStartSourceLocation());
-        $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
-        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+                $this->outputEmitter->emitStr(
+                    'if (!is_string(' . $targetVar . ') && !is_object(' . $targetVar . ')) {',
+                    $node->getStartSourceLocation(),
+                );
+                $this->outputEmitter->emitLine();
+                $this->outputEmitter->emitStr(
+                    'throw new \InvalidArgumentException(sprintf("php/new expects a class name or object, %s given (%s)", get_debug_type(' . $targetVar . '), var_export(' . $targetVar . ', true)));',
+                    $node->getStartSourceLocation(),
+                );
+                $this->outputEmitter->emitLine();
+                $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+            },
+            function () use ($node, $targetVar): void {
+                $this->outputEmitter->emitStr('new ' . $targetVar . '(', $node->getStartSourceLocation());
+                $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
+                $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
+            },
+        );
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectCallEmitter.php
@@ -11,8 +11,8 @@ use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpNamedArgNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PropertyOrConstantAccessNode;
-use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\ContextualWrapEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Symbol;
 use RuntimeException;
@@ -41,9 +41,10 @@ final class PhpObjectCallEmitter implements NodeEmitterInterface
         // An instance call whose method receives a bare local argument relies
         // on the IIFE's by-value `use($local)` capture as a copy barrier: a
         // by-reference PHP parameter must not write back into the Phel binding
-        // (only `(php/ref local)` opts into that). Keep the IIFE in that case.
+        // (only `(php/ref local)` opts into that). Keep the IIFE in that case,
+        // in every context.
         if ($this->hasByValueLocalArg($node)) {
-            $this->emitWrappedTarget($node);
+            $this->emitForcedWrappedTarget($node);
 
             return;
         }
@@ -54,13 +55,7 @@ final class PhpObjectCallEmitter implements NodeEmitterInterface
             return;
         }
 
-        if ($node->getEnv()->isContext(NodeEnvironment::CONTEXT_EXPRESSION)) {
-            $this->emitWrappedTarget($node);
-
-            return;
-        }
-
-        $this->emitStatementTarget($node);
+        $this->emitComputedTarget($node);
     }
 
     /**
@@ -81,10 +76,32 @@ final class PhpObjectCallEmitter implements NodeEmitterInterface
     }
 
     /**
-     * Computed target in expression context: wrap in an IIFE so the temp var
-     * (which guarantees exactly-once target evaluation) can host a `return`.
+     * Computed target: a `target_` temp guarantees exactly-once target
+     * evaluation. The shared kernel wraps it in an IIFE only in expression
+     * context (where a `return` is needed); in statement/return context it
+     * emits plain statements.
      */
-    private function emitWrappedTarget(PhpObjectCallNode $node): void
+    private function emitComputedTarget(PhpObjectCallNode $node): void
+    {
+        $targetSym = Symbol::gen('target_');
+
+        new ContextualWrapEmitter($this->outputEmitter)->emit(
+            $node,
+            function () use ($node, $targetSym): void {
+                $this->emitTempAssignment($node, $targetSym);
+            },
+            function () use ($node, $targetSym): void {
+                $this->emitTargetCall($node, $targetSym);
+            },
+        );
+    }
+
+    /**
+     * Forced IIFE: the by-value `use($local)` capture is a copy barrier that
+     * must hold in every context, so the closure is emitted regardless of
+     * whether the result is consumed.
+     */
+    private function emitForcedWrappedTarget(PhpObjectCallNode $node): void
     {
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
 
@@ -103,21 +120,6 @@ final class PhpObjectCallEmitter implements NodeEmitterInterface
 
         $this->outputEmitter->emitFnWrapSuffix($node->getStartSourceLocation());
 
-        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
-    }
-
-    /**
-     * Computed target in statement/return context: emit plain statements
-     * (`$target_N = <target>;` then the call) without an IIFE. The temp var
-     * still guarantees exactly-once target evaluation.
-     */
-    private function emitStatementTarget(PhpObjectCallNode $node): void
-    {
-        $targetSym = Symbol::gen('target_');
-        $this->emitTempAssignment($node, $targetSym);
-
-        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->emitTargetCall($node, $targetSym);
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
     }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectSetEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectSetEmitter.php
@@ -8,7 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectSetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PropertyOrConstantAccessNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
-use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\ContextualWrapEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Symbol;
 
@@ -26,18 +26,18 @@ final class PhpObjectSetEmitter implements NodeEmitterInterface
         $targetExpr = $node->getLeftExpr()->getTargetExpr();
         $callExpr = $node->getLeftExpr()->getCallExpr();
         assert($callExpr instanceof PropertyOrConstantAccessNode);
+        $propertyName = $callExpr->getName()->getName();
+        $propertyLoc = $callExpr->getName()->getStartLocation();
 
         // `php/oset` is contractually required to evaluate to the *target
         // object* (not the assigned value, as a bare PHP `$o->p = v` would
-        // yield). Whenever the value is consumed - expression or return
-        // context - we must host a temp + `return $target` inside an IIFE to
-        // preserve that semantics. In statement context the value is
-        // discarded, so we emit the assignment directly with no closure and
-        // no temp: the target is still evaluated exactly once inline.
+        // yield). In statement context the value is discarded, so we emit the
+        // assignment directly with no closure and no temp: the target is still
+        // evaluated exactly once inline.
         if ($node->getEnv()->isContext(NodeEnvironment::CONTEXT_STATEMENT)) {
             $this->outputEmitter->emitNode($targetExpr);
             $this->outputEmitter->emitStr($fnCode, $node->getStartSourceLocation());
-            $this->outputEmitter->emitStr($callExpr->getName()->getName(), $callExpr->getName()->getStartLocation());
+            $this->outputEmitter->emitStr($propertyName, $propertyLoc);
             $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
             $this->outputEmitter->emitNode($node->getRightExpr());
             $this->outputEmitter->emitStr(';', $node->getStartSourceLocation());
@@ -45,33 +45,31 @@ final class PhpObjectSetEmitter implements NodeEmitterInterface
             return;
         }
 
-        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-
-        $this->outputEmitter->emitFnWrapPrefix(
-            $node->getEnv(),
-            $node->getStartSourceLocation(),
-            new ByRefLocalCollector()->collect($node),
-        );
-
+        // Expression or return context: the value is consumed, so we host a
+        // temp and yield `$target` to preserve the "returns the target object"
+        // semantics. The shared kernel wraps it in an IIFE only in expression
+        // context; in return context it elides the closure and emits plain
+        // statements ending in `return $target;`.
         $targetSym = Symbol::gen('target_');
-        $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
-        $this->outputEmitter->emitNode($targetExpr);
-        $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
 
-        $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr($fnCode, $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr($callExpr->getName()->getName(), $callExpr->getName()->getStartLocation());
-        $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
-        $this->outputEmitter->emitNode($node->getRightExpr());
-        $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
+        new ContextualWrapEmitter($this->outputEmitter)->emit(
+            $node,
+            function () use ($node, $targetExpr, $fnCode, $propertyName, $propertyLoc, $targetSym): void {
+                $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
+                $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
+                $this->outputEmitter->emitNode($targetExpr);
+                $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
 
-        $this->outputEmitter->emitStr('return ', $node->getStartSourceLocation());
-        $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr(';', $node->getStartSourceLocation());
-
-        $this->outputEmitter->emitFnWrapSuffix($node->getStartSourceLocation());
-
-        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+                $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
+                $this->outputEmitter->emitStr($fnCode, $node->getStartSourceLocation());
+                $this->outputEmitter->emitStr($propertyName, $propertyLoc);
+                $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
+                $this->outputEmitter->emitNode($node->getRightExpr());
+                $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
+            },
+            function () use ($node, $targetSym): void {
+                $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
+            },
+        );
     }
 }

--- a/tests/php/Integration/Fixtures/PhpObjectSet/oset-return-context.test
+++ b/tests/php/Integration/Fixtures/PhpObjectSet/oset-return-context.test
@@ -1,0 +1,8 @@
+--PHEL--
+(fn [] (php/oset (php/-> (php/new \stdClass) name) "test"))
+--PHP--
+(function() {
+  $target_1 = (new \stdClass());
+  $target_1->name = "test";
+  return $target_1;
+});


### PR DESCRIPTION
## 🤔 Background

After #2524/#2525/#2526, the three interop emitters (`php/->`/`php/::`, `php/oset`, `php/new`) carried a near-identical "context-aware IIFE-or-statements" shape: the verbatim `emitFnWrapPrefix(..., ByRefLocalCollector->collect($node))` block, the temp-assignment, context prefix/suffix, and the IIFE-vs-statements dispatch. `php/oset` also still wrapped *return* context in an IIFE that `php/->` already elided.

## 💡 Goal

Consolidate the shared kernel, run the by-reference scan lazily (only when an IIFE is actually emitted — subsuming #2532), and make the emitters consistent.

## 🔖 Changes

- New `ContextualWrapEmitter` encapsulating the IIFE-or-statements decision: in expression context it wraps a temp + `return` in an IIFE (and only then computes `ByRefLocalCollector`); in statement/return context it emits plain statements bracketed by the usual context prefix/suffix.
- `PhpObjectCallEmitter`, `PhpObjectSetEmitter`, `PhpNewEmitter` refactored to supply only their setup + result expression.
- **`php/oset` gains return-context IIFE elision** to match `php/->` (the inconsistency noted in #2536). New golden `PhpObjectSet/oset-return-context.test`.
- `ByRefLocalCollector` now runs only on the IIFE path (closes #2532 — lazy by-ref scan).

## Preserved (verified by existing behavioral tests)
- ObjectCall simple-target + by-value-local-arg fast paths; New static-class path + guard + absolute-name normalization; ObjectSet returns the target object.

Verified: full `composer test` green (static analysis clean, 917 integration, 6047 core).

Closes #2536
Closes #2532
