### PR TITLE
perf(emitter): specialize string-tagged count/first to native mb ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - `=` and `not=` over string literals now fold to a boolean at compile time instead of dispatching at runtime (#2531)
 - `get-in` with a literal key path on a `:tag`ged map/vector now compiles to an unrolled null-coalescing subscript chain instead of dispatching to the runtime traversal loop (#2529)
 - The interop emitters (`php/->`, `php/oset`, `php/new`) now share one context-aware IIFE/statement kernel and only scan for `php/ref` by-reference locals when an IIFE is actually emitted, cutting compile-time work (#2536, subsumes #2532)
+- `count` and `first` on a `^string`-tagged target now compile to native multibyte ops (`mb_strlen($s)`, `($s === '' ? null : mb_substr($s, 0, 1))`) instead of dispatching to the runtime collection cond chain (#2528)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -78,6 +78,14 @@ final readonly class CallSpecialization
             return true;
         }
 
+        if (self::isTypedStringCount($node)) {
+            return true;
+        }
+
+        if (self::isTypedStringFirst($node)) {
+            return true;
+        }
+
         if (NilAndBooleanCheckSpecialization::isNilCheck($node)) {
             return true;
         }
@@ -300,6 +308,35 @@ final readonly class CallSpecialization
     }
 
     /**
+     * `(count s)` where the analyser has tagged `s` as a PHP `string`.
+     * The runtime `count` body walks a cond chain over the standard
+     * collection shapes before reaching `(php/mb_strlen coll)` for the
+     * `(php/is_string coll)` branch; for a `string`-tagged target the
+     * only branch that ever fires is that multibyte length. The emitter
+     * lowers it to `mb_strlen($s)` — the same default-encoding call the
+     * runtime makes, so it stays byte-for-byte equivalent for multibyte
+     * input.
+     */
+    public static function isTypedStringCount(CallNode $node): bool
+    {
+        return self::isTypedStringCall($node, 'count');
+    }
+
+    /**
+     * `(first s)` where the analyser has tagged `s` as a PHP `string`.
+     * The runtime `first` body reaches `first-of-string` for the
+     * `(php/is_string xs)` branch, which is
+     * `(if (php/=== "" s) nil (php/mb_substr s 0 1))`. The emitter lowers
+     * it to `($s === '' ? null : mb_substr($s, 0, 1))` — the same
+     * default-encoding multibyte slice plus the empty-string nil guard,
+     * preserving the contract that an empty string yields nil.
+     */
+    public static function isTypedStringFirst(CallNode $node): bool
+    {
+        return self::isTypedStringCall($node, 'first');
+    }
+
+    /**
      * `(str ...)` whose every argument compiles to a string-typed
      * expression: string literals or `LocalVarNode`s tagged `string`.
      */
@@ -322,6 +359,36 @@ final readonly class CallSpecialization
         }
 
         return array_all($args, static fn(AbstractNode $arg): bool => self::isStringConcatable($arg));
+    }
+
+    /**
+     * Shared shape check for a single-arg `phel.core` call whose only
+     * argument is a `LocalVarNode` tagged as a PHP `string`.
+     */
+    private static function isTypedStringCall(CallNode $node, string $fnName): bool
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return false;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || $fn->getName()->getName() !== $fnName
+        ) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return false;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return false;
+        }
+
+        return TagNormalizer::normalise($target->getInferredType()) === 'string';
     }
 
     private static function isStringConcatable(AbstractNode $arg): bool

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/CoreFnCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/CoreFnCallEmitter.php
@@ -36,7 +36,15 @@ final readonly class CoreFnCallEmitter implements SpecializedCallEmitterInterfac
             return true;
         }
 
-        return $this->tryEmitTypedPhpArrayCount($node);
+        if ($this->tryEmitTypedPhpArrayCount($node)) {
+            return true;
+        }
+
+        if ($this->tryEmitTypedStringCount($node)) {
+            return true;
+        }
+
+        return $this->tryEmitTypedStringFirst($node);
     }
 
     /**
@@ -145,6 +153,50 @@ final readonly class CoreFnCallEmitter implements SpecializedCallEmitterInterfac
         $this->outputEmitter->emitStr('count(', $loc);
         $this->outputEmitter->emitNode($node->getArguments()[0]);
         $this->outputEmitter->emitStr(')', $loc);
+        return true;
+    }
+
+    /**
+     * Specialise `(count s)` on a target tagged `string` to a native
+     * `mb_strlen($s)` call. The runtime `count` body reaches
+     * `(php/mb_strlen coll)` for the string branch, so the multibyte
+     * codepoint count is byte-for-byte identical.
+     */
+    private function tryEmitTypedStringCount(CallNode $node): bool
+    {
+        if (!CallSpecialization::isTypedStringCount($node)) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('mb_strlen(', $loc);
+        $this->outputEmitter->emitNode($node->getArguments()[0]);
+        $this->outputEmitter->emitStr(')', $loc);
+        return true;
+    }
+
+    /**
+     * Specialise `(first s)` on a target tagged `string` to the native
+     * multibyte first-char slice with the empty-string nil guard. The
+     * runtime `first` reaches `first-of-string`, i.e.
+     * `(if (php/=== "" s) nil (php/mb_substr s 0 1))`; the emitted
+     * `($s === '' ? null : mb_substr($s, 0, 1))` preserves both the nil
+     * contract and the multibyte slice.
+     */
+    private function tryEmitTypedStringFirst(CallNode $node): bool
+    {
+        if (!CallSpecialization::isTypedStringFirst($node)) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $arg = $node->getArguments()[0];
+
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($arg);
+        $this->outputEmitter->emitStr(" === '' ? null : mb_substr(", $loc);
+        $this->outputEmitter->emitNode($arg);
+        $this->outputEmitter->emitStr(', 0, 1))', $loc);
         return true;
     }
 }

--- a/tests/phel/core/basic-sequence-operation.phel
+++ b/tests/phel/core/basic-sequence-operation.phel
@@ -40,6 +40,26 @@
   (is (contains? #{[1] [2]} (first #{[1] [2]})) "first of set")
   (is (nil? (first nil)) "frist of nil"))
 
+;; `^string`-tagged count/first lower to native `mb_strlen` /
+;; `mb_substr`; assert they equal the untagged runtime dispatch,
+;; including multibyte (codepoint, not byte) input.
+(defn- count-tagged [^string s] (count s))
+(defn- first-tagged [^string s] (first s))
+
+(deftest test-count-tagged-string
+  (is (= (count "hello") (count-tagged "hello")) "count tagged ascii")
+  (is (= (count "héllo") (count-tagged "héllo")) "count tagged multibyte")
+  (is (= 5 (count-tagged "héllo")) "count tagged multibyte is codepoints not bytes")
+  (is (= (count "😀x") (count-tagged "😀x")) "count tagged astral plane")
+  (is (= (count "") (count-tagged "")) "count tagged empty"))
+
+(deftest test-first-tagged-string
+  (is (= (first "hello") (first-tagged "hello")) "first tagged ascii")
+  (is (= (first "héllo") (first-tagged "héllo")) "first tagged multibyte")
+  (is (= "😀" (first-tagged "😀x")) "first tagged astral plane is a full codepoint")
+  (is (= (first "😀x") (first-tagged "😀x")) "first tagged astral plane matches runtime")
+  (is (nil? (first-tagged "")) "first tagged empty is nil"))
+
 (deftest test-ffirst
   (is (= 1 (ffirst [[1]])) "ffirst of nested vector")
   (is (nil? (ffirst [1])) "ffirst of vector")

--- a/tests/php/Integration/Fixtures/Call/count-first-typed-string.test
+++ b/tests/php/Integration/Fixtures/Call/count-first-typed-string.test
@@ -1,0 +1,9 @@
+--PHEL--
+(fn [^string s] (count s))
+(fn [^string s] (first s))
+--PHP--
+(function(string $s) {
+  return mb_strlen($s);
+});(function(string $s) {
+  return ($s === '' ? null : mb_substr($s, 0, 1));
+});


### PR DESCRIPTION
## 🤔 Background

`count` and `first` on a string always routed through the runtime collection cond-chain, even when the analyzer knows the target is a string via a `:tag`.

## 💡 Goal

Lower tag-known string `count`/`first` to the exact native multibyte ops the runtime uses — no behavior change, including multibyte input.

## 🔖 Changes

- `(count ^string s)` → `mb_strlen($s)` — the runtime `count` string branch is `(php/mb_strlen coll)`, so this is byte-for-byte identical (default encoding).
- `(first ^string s)` → `($s === '' ? null : mb_substr($s, 0, 1))` — mirrors the runtime `first-of-string` (empty → nil, else default-encoding first codepoint). The arg is re-emitted twice, safe because the predicate requires a `LocalVarNode`.
- Only single-arg `phel.core` calls on a `^string` `LocalVarNode` specialize; untagged falls back to dispatch. `empty? ^string` was already specialized — not duplicated.
- Fixtures: `Call/count-first-typed-string.test`; multibyte behavioral tests in `tests/phel/core/basic-sequence-operation.phel` (`"héllo"` count=5 codepoints, `"😀x"` first=astral codepoint, empty → 0/nil), asserting tagged == untagged runtime.

Verified: full `composer test` green (static analysis clean, 927 integration, 4611 PHPUnit / 6098 phel core, 0 failures).

Closes #2528
