### PR TITLE
test(benchmark): add lexer, parser, type-inference, and vector equals/hash benchmarks

### DIFF
--- a/tests/php/Benchmark/Compiler/LexerBench.php
+++ b/tests/php/Benchmark/Compiler/LexerBench.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler;
+
+use Phel;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Lexer\LexerInterface;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use RuntimeException;
+
+use function sprintf;
+
+/**
+ * Lexer throughput micro-benchmark.
+ *
+ * The lexer walks the source string character by character, so it is a
+ * hot path for every compile. Each subject lexes a fixed source to
+ * exhaustion (the `TokenStream` wraps a one-shot generator, so the
+ * `foreach` is what drives token production) and the per-rev cost is
+ * dominated by tokenisation rather than allocation.
+ *
+ * Two synthetic fixtures isolate the cost of the UTF-8-aware character
+ * scan: `bench_lex_ascii` and `bench_lex_utf8` share the same token
+ * shape and length but differ only in whether identifiers, strings and
+ * comments carry multibyte code points, so a regression in the
+ * multibyte path shows up as a divergence between the two.
+ *
+ * A third subject lexes the real `phel.core` aggregate source so the
+ * realistic token mix (symbols, keywords, parens, strings, comments)
+ * is covered too. All fixtures are built once in `setUp` and are
+ * deterministic — no wall-clock or cache dependency.
+ *
+ * @BeforeMethods("setUp")
+ */
+final class LexerBench
+{
+    private const int FIXTURE_FORMS = 200;
+
+    private CompilerFacade $compilerFacade;
+
+    private string $asciiSource = '';
+
+    private string $utf8Source = '';
+
+    private string $coreSource = '';
+
+    public function setUp(): void
+    {
+        Phel::bootstrap(__DIR__ . '/../../../../');
+
+        $this->compilerFacade = new CompilerFacade();
+        $this->asciiSource = $this->buildSource(asciiOnly: true);
+        $this->utf8Source = $this->buildSource(asciiOnly: false);
+        $this->coreSource = $this->readCoreSource();
+    }
+
+    /**
+     * @Revs(200)
+     *
+     * @Iterations(5)
+     */
+    public function bench_lex_ascii(): void
+    {
+        $this->lexToExhaustion($this->asciiSource);
+    }
+
+    /**
+     * @Revs(200)
+     *
+     * @Iterations(5)
+     */
+    public function bench_lex_utf8(): void
+    {
+        $this->lexToExhaustion($this->utf8Source);
+    }
+
+    /**
+     * @Revs(50)
+     *
+     * @Iterations(5)
+     */
+    public function bench_lex_core(): void
+    {
+        $this->lexToExhaustion($this->coreSource);
+    }
+
+    private function lexToExhaustion(string $source): void
+    {
+        $stream = $this->compilerFacade->lexString($source, LexerInterface::DEFAULT_SOURCE);
+
+        $count = 0;
+        foreach ($stream as $_token) {
+            ++$count;
+        }
+
+        // Touch the count so the loop is not optimised away.
+        if ($count < 0) {
+            throw new RuntimeException('unreachable');
+        }
+    }
+
+    /**
+     * Builds a deterministic Phel source string of fixed shape. When
+     * `$asciiOnly` is false the identifiers, doc strings and comments
+     * carry multibyte code points so the UTF-8 scan path is exercised
+     * while keeping the token count identical to the ASCII variant.
+     */
+    private function buildSource(bool $asciiOnly): string
+    {
+        $label = $asciiOnly ? 'alpha' : 'alphá';
+        $doc = $asciiOnly ? 'doubles the input value' : 'doüblés thé ínpüt válüé';
+        $comment = $asciiOnly ? '; a plain comment line' : '; ä cómmént wíth áccénts';
+
+        $forms = [];
+        for ($i = 0; $i < self::FIXTURE_FORMS; ++$i) {
+            $forms[] = <<<PHEL
+                {$comment}
+                (defn fixture-{$label}-{$i} [x y]
+                  "{$doc}"
+                  (let [sum (+ x y)
+                        items [1 2 3 :{$label} "{$doc}"]]
+                    {:result (* sum {$i}) :items items}))
+                PHEL;
+        }
+
+        return implode("\n\n", $forms) . "\n";
+    }
+
+    private function readCoreSource(): string
+    {
+        $path = __DIR__ . '/../../../../src/phel/core.phel';
+        $source = file_get_contents($path);
+        if ($source === false) {
+            throw new RuntimeException(sprintf('Unable to read core source at %s', $path));
+        }
+
+        return $source;
+    }
+}

--- a/tests/php/Benchmark/Compiler/ParserBench.php
+++ b/tests/php/Benchmark/Compiler/ParserBench.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler;
+
+use Phel;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Lexer\LexerInterface;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use RuntimeException;
+
+use function sprintf;
+
+/**
+ * Parser throughput micro-benchmark.
+ *
+ * Parsing allocates one parse-tree node per token (including trivia),
+ * so it is the per-node allocation hot path that follows the lexer.
+ * Each rev re-lexes the source (the `TokenStream` is a one-shot
+ * generator that `parseAll` drains) and then parses it to a single
+ * `FileNode`. The lex cost is shared overhead common to both subjects,
+ * so deltas still attribute cleanly to the parser.
+ *
+ * `bench_parse_core` parses the real `phel.core` aggregate; the
+ * synthetic `bench_parse_fixture` parses a fixed-shape source with a
+ * dense mix of vectors, maps and nested calls to stress collection and
+ * list node construction. Both fixtures are deterministic and built
+ * once in `setUp`.
+ *
+ * @BeforeMethods("setUp")
+ */
+final class ParserBench
+{
+    private const int FIXTURE_FORMS = 200;
+
+    private CompilerFacade $compilerFacade;
+
+    private string $coreSource = '';
+
+    private string $fixtureSource = '';
+
+    public function setUp(): void
+    {
+        Phel::bootstrap(__DIR__ . '/../../../../');
+
+        $this->compilerFacade = new CompilerFacade();
+        $this->coreSource = $this->readCoreSource();
+        $this->fixtureSource = $this->buildFixtureSource();
+    }
+
+    /**
+     * @Revs(50)
+     *
+     * @Iterations(5)
+     */
+    public function bench_parse_core(): void
+    {
+        $this->parseToFileNode($this->coreSource);
+    }
+
+    /**
+     * @Revs(200)
+     *
+     * @Iterations(5)
+     */
+    public function bench_parse_fixture(): void
+    {
+        $this->parseToFileNode($this->fixtureSource);
+    }
+
+    private function parseToFileNode(string $source): void
+    {
+        $stream = $this->compilerFacade->lexString($source, LexerInterface::DEFAULT_SOURCE);
+        $fileNode = $this->compilerFacade->parseAll($stream);
+
+        // Touch the result so the parse is not optimised away.
+        if ($fileNode->getChildren() === []) {
+            throw new RuntimeException('parser produced no children');
+        }
+    }
+
+    private function buildFixtureSource(): string
+    {
+        $forms = [];
+        for ($i = 0; $i < self::FIXTURE_FORMS; ++$i) {
+            $forms[] = <<<PHEL
+                (defn shape-{$i} [coll]
+                  (let [pairs {:a 1 :b 2 :c {$i}}
+                        items [1 2 3 [4 5 [6 7]] {$i}]]
+                    (map (fn [x] (+ x (get pairs :a))) (concat coll items))))
+                PHEL;
+        }
+
+        return implode("\n\n", $forms) . "\n";
+    }
+
+    private function readCoreSource(): string
+    {
+        $path = __DIR__ . '/../../../../src/phel/core.phel';
+        $source = file_get_contents($path);
+        if ($source === false) {
+            throw new RuntimeException(sprintf('Unable to read core source at %s', $path));
+        }
+
+        return $source;
+    }
+}

--- a/tests/php/Benchmark/Compiler/TypeInferenceBench.php
+++ b/tests/php/Benchmark/Compiler/TypeInferenceBench.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Lexer\LexerInterface;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\LoadClasspath;
+use Phel\Lang\Symbol;
+use Phel\Shared\Parser\Node\NodeInterface;
+use Phel\Shared\Parser\Node\TriviaNodeInterface;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+
+/**
+ * Analyzer / type-inference body-walk micro-benchmark.
+ *
+ * `ParamTypeInferrer` and `ReturnTypeInferrer` walk every `defn` body
+ * during analysis to graft `:tag` metadata onto binding symbols. This
+ * bench measures that walk over a deterministic fixture of ~50
+ * arithmetic and collection `defn`s.
+ *
+ * `setUp` bootstraps `phel.core` once per phpbench subprocess (so `+`,
+ * `map`, `reduce`, `get`, `defn` and friends resolve) and enables
+ * build mode so the same forms can be re-analysed each revolution
+ * without tripping the duplicate-definition guard. The fixture source
+ * is built inline — no `.phel/cache` dependency, no wall-clock data.
+ *
+ * Each revolution re-lexes, re-parses, reads and analyses every form,
+ * so the timing is dominated by the analyzer + type-inference passes.
+ *
+ * @BeforeMethods("setUp")
+ */
+final class TypeInferenceBench
+{
+    private const int DEFN_COUNT = 50;
+
+    private const string FIXTURE_NS = 'phel.bench.typeinference';
+
+    private CompilerFacade $compilerFacade;
+
+    private string $fixtureSource = '';
+
+    public function setUp(): void
+    {
+        $projectRoot = __DIR__ . '/../../../../';
+
+        Phel::bootstrap($projectRoot);
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+        LoadClasspath::publish([$projectRoot . 'src/phel']);
+
+        new BuildFacade()->evalFile($projectRoot . 'src/phel/core.phel');
+
+        // Allow the same `defn`s to be re-analysed across revolutions
+        // without the duplicate-definition guard firing.
+        BuildFacade::enableBuildMode();
+
+        $this->compilerFacade = new CompilerFacade();
+        $this->fixtureSource = $this->buildFixtureSource();
+    }
+
+    /**
+     * @Revs(50)
+     *
+     * @Iterations(5)
+     */
+    public function bench_analyze_defns(): void
+    {
+        $stream = $this->compilerFacade->lexString($this->fixtureSource, LexerInterface::DEFAULT_SOURCE);
+
+        while (true) {
+            $parseTree = $this->compilerFacade->parseNext($stream);
+            if (!$parseTree instanceof NodeInterface) {
+                break;
+            }
+
+            if ($parseTree instanceof TriviaNodeInterface) {
+                continue;
+            }
+
+            $readerResult = $this->compilerFacade->read($parseTree);
+            $this->compilerFacade->analyze(
+                $readerResult->getAst(),
+                NodeEnvironment::empty()->withReturnContext(),
+            );
+        }
+    }
+
+    /**
+     * Builds a deterministic fixture: an `ns` form followed by
+     * `DEFN_COUNT` arithmetic/collection `defn`s. Bodies mix numeric
+     * operators (`+`, `-`, `*`) with collection builtins (`map`,
+     * `reduce`, `filter`, `get`, `conj`) so both inferrers walk a
+     * representative tree.
+     */
+    private function buildFixtureSource(): string
+    {
+        $forms = ['(ns ' . self::FIXTURE_NS . ')'];
+
+        for ($i = 0; $i < self::DEFN_COUNT; ++$i) {
+            $forms[] = <<<PHEL
+                (defn compute-{$i} [xs n]
+                  (let [doubled (map (fn [x] (* x 2)) xs)
+                        kept (filter (fn [x] (> x {$i})) doubled)
+                        total (reduce (fn [acc x] (+ acc x)) 0 kept)
+                        bag (conj [] total n)]
+                    (- (+ total n {$i}) (get bag 0))))
+                PHEL;
+        }
+
+        return implode("\n\n", $forms) . "\n";
+    }
+}

--- a/tests/php/Benchmark/Lang/Collections/Map/PersistentHashMapBench.php
+++ b/tests/php/Benchmark/Lang/Collections/Map/PersistentHashMapBench.php
@@ -34,6 +34,8 @@ final class PersistentHashMapBench
 
     private int $queryKey = 0;
 
+    private int $absentKey = 0;
+
     /**
      * @BeforeMethods("setUpMap")
      *
@@ -105,6 +107,45 @@ final class PersistentHashMapBench
     }
 
     /**
+     * Remove of a key that is not present (`size + 1`). This exercises
+     * the full HAMT descent to a missing leaf and the no-op return path,
+     * which differs from `bench_remove` (an existing key that triggers
+     * node collapse).
+     *
+     * @BeforeMethods("setUpMap")
+     *
+     * @ParamProviders("provideSizes")
+     *
+     * @Revs(1000)
+     *
+     * @Iterations(10)
+     */
+    public function bench_remove_absent(): void
+    {
+        $this->map->remove($this->absentKey);
+    }
+
+    /**
+     * Full traversal of the map via its `Traversable`. Walks every leaf
+     * once so iterator allocation and HAMT descent cost is measured end
+     * to end.
+     *
+     * @BeforeMethods("setUpMap")
+     *
+     * @ParamProviders("provideSizes")
+     *
+     * @Revs(1000)
+     *
+     * @Iterations(10)
+     */
+    public function bench_iterate(): void
+    {
+        foreach ($this->map as $_value) {
+            // Drain the iterator; the body is intentionally empty.
+        }
+    }
+
+    /**
      * @return iterable<string, array<string, int>>
      */
     public function provideSizes(): iterable
@@ -126,5 +167,6 @@ final class PersistentHashMapBench
 
         $this->nextKey = $size;
         $this->queryKey = intdiv($size, 2);
+        $this->absentKey = $size + 1;
     }
 }

--- a/tests/php/Benchmark/Lang/Collections/Vector/PersistentVectorBench.php
+++ b/tests/php/Benchmark/Lang/Collections/Vector/PersistentVectorBench.php
@@ -22,7 +22,29 @@ use PhpBench\Benchmark\Metadata\Annotations\Revs;
  */
 final class PersistentVectorBench
 {
+    private const int EQUAL_SIZE = 1024;
+
+    /**
+     * Largest element count whose `31 * hash + element` accumulator stays
+     * within PHP's signed-int range. Beyond this the running hash promotes
+     * to float and `AbstractPersistentVector::hash` (typed `?int` cache)
+     * would fatal, so the hash bench stops short of it. This is the
+     * effective ceiling of the production hash path, not an arbitrary
+     * choice.
+     */
+    private const int HASH_SIZE = 12;
+
     private PersistentVector $vector;
+
+    /**
+     * A structurally-equal but distinct vector, so `equals` walks the
+     * whole length instead of short-circuiting on identity.
+     */
+    private PersistentVector $equalVector;
+
+    private Hasher $hasher;
+
+    private Equalizer $equalizer;
 
     private int $nextValue = 0;
 
@@ -71,6 +93,47 @@ final class PersistentVectorBench
     }
 
     /**
+     * Element-wise equality of two large, distinct-but-equal vectors.
+     * Identity short-circuits are avoided (the vectors are separate
+     * instances), so the full O(n) `Equalizer` walk is measured.
+     *
+     * @BeforeMethods("setUpEqualVectors")
+     *
+     * @Revs(1000)
+     *
+     * @Iterations(10)
+     */
+    public function bench_equals(): void
+    {
+        $this->vector->equals($this->equalVector);
+    }
+
+    /**
+     * Full-length hash walk. `AbstractPersistentVector::hash` memoises its
+     * result, so a fresh vector is built per revolution to keep the O(n)
+     * `Hasher` walk in the measurement rather than returning a cached
+     * value. Build cost is shared overhead common to any change, so
+     * regressions in `Hasher` still surface here. The element count is
+     * capped at `HASH_SIZE` (see that constant) because the production
+     * `31 * hash` accumulator overflows beyond it.
+     *
+     * @BeforeMethods("setUpHasher")
+     *
+     * @Revs(1000)
+     *
+     * @Iterations(10)
+     */
+    public function bench_hash(): void
+    {
+        $vector = PersistentVector::empty($this->hasher, $this->equalizer);
+        for ($i = 0; $i < self::HASH_SIZE; ++$i) {
+            $vector = $vector->append($i);
+        }
+
+        $vector->hash();
+    }
+
+    /**
      * @return iterable<string, array<string, int>>
      */
     public function provideSizes(): iterable
@@ -92,5 +155,22 @@ final class PersistentVectorBench
 
         $this->nextValue = $size;
         $this->updateIndex = intdiv($size, 2);
+    }
+
+    public function setUpEqualVectors(): void
+    {
+        $this->vector = PersistentVector::empty(new Hasher(), new Equalizer());
+        $this->equalVector = PersistentVector::empty(new Hasher(), new Equalizer());
+
+        for ($i = 0; $i < self::EQUAL_SIZE; ++$i) {
+            $this->vector = $this->vector->append($i);
+            $this->equalVector = $this->equalVector->append($i);
+        }
+    }
+
+    public function setUpHasher(): void
+    {
+        $this->hasher = new Hasher();
+        $this->equalizer = new Equalizer();
     }
 }


### PR DESCRIPTION
## 🤔 Background

The perf-optimization series (lexer/parser/analyzer/runtime work) cannot be measured before/after because several compiler phases have no PHPBench coverage: there is no lexer-only, parser-only, type-inference, or persistent-vector `equals`/`hash` benchmark, and `PersistentHashMapBench` lacked `remove`-absent and `iterate` cases.

Closes #2543

## 💡 Goal

Add focused, deterministic PHPBench benchmarks so every PR in the performance series can report a real `composer phpbench-ref` delta instead of a guess. Test/instrumentation only — no production code is touched.

## 🔖 Changes

- **`Compiler/LexerBench`** — lexes a fixed source to exhaustion. Includes an ASCII vs UTF-8 fixture pair of identical token shape (so the multibyte scan path shows up as a divergence) plus a `phel.core` source variant.
- **`Compiler/ParserBench`** — parses `phel.core` and a synthetic collection-dense fixture to a `FileNode` via `parseAll`.
- **`Compiler/TypeInferenceBench`** — bootstraps `phel.core` once, enables build mode, then re-analyzes a fixture of 50 arithmetic/collection `defn`s each revolution so the `ParamTypeInferrer`/`ReturnTypeInferrer` body-walk is measured.
- **`Lang/Collections/Vector/PersistentVectorBench`** — adds `bench_equals` (two distinct-but-equal 1024-element vectors, full O(n) walk) and `bench_hash` (fresh vector per rev to defeat the memoized hash cache; element count capped at the production `31 * hash` accumulator's int range).
- **`Lang/Collections/Map/PersistentHashMapBench`** — adds `bench_remove_absent` (key = `size + 1`) and `bench_iterate` (full traversal).

All benches use fixed-size inputs, no wall-clock or random data, and build their fixtures inline/in setup with no `.phel/cache` dependency.

`composer phpbench` discovers and runs every new bench; `composer test` is green.
