### PR TITLE
perf(lexer): gate per-token deprecation checks behind a single lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - PHP interop (`php/->`, `php/::`, `php/new`, `php/oset`) now compiles to direct expressions or statements instead of wrapping every call in a closure (#2524, #2525, #2526, #2532, #2536)
 - Type-tagged core calls now compile straight to native operations: `push`/`dissoc` to persistent-collection methods (#2527), `second`/`get-in` to direct vector/map access (#2530, #2529), and `count`/`first` on strings to `mb_strlen`/`mb_substr` (#2528)
 - `=` and `not=` over string literals now fold to a boolean at compile time (#2531)
+- The lexer skips per-token deprecation checks for the common token types via a single lookup (#2546)
 
 ### Fixed
 

--- a/src/php/Compiler/Application/Lexer.php
+++ b/src/php/Compiler/Application/Lexer.php
@@ -56,6 +56,20 @@ final class Lexer implements LexerInterface
         "(#')", // var-quote prefix (index: 29 = T_VAR_QUOTE) - `#'foo` expands to `(var foo)` in the reader, yielding a `PhelVar` handle to the named definition
     ];
 
+    /**
+     * Token types that can trigger a deprecation warning. Common tokens
+     * (parens, atoms, whitespace, ...) are absent, so a single isset() lookup
+     * lets them skip the per-token deprecation checks below entirely.
+     *
+     * @var array<int,true>
+     */
+    private const array DEPRECATABLE_TYPES = [
+        Token::T_COMMENT => true,
+        Token::T_FN => true,
+        Token::T_UNQUOTE_SPLICING => true,
+        Token::T_UNQUOTE => true,
+    ];
+
     private const string MULTILINE_COMMENT_BEGIN = '#|';
 
     private const string MULTILINE_COMMENT_END = '|#';
@@ -118,32 +132,34 @@ final class Lexer implements LexerInterface
                 $endLocation = $this->createSourceLocation($source);
                 $tokenType = count($matches);
 
-                if ($tokenType === Token::T_COMMENT && str_starts_with($matches[0], '#')) {
-                    @trigger_error(
-                        sprintf('Bare "#" line comments are deprecated and will be removed in Phel v0.33. Use ";" or ";;" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
-                        E_USER_DEPRECATED,
-                    );
-                }
+                if (isset(self::DEPRECATABLE_TYPES[$tokenType])) {
+                    if ($tokenType === Token::T_COMMENT && str_starts_with($matches[0], '#')) {
+                        @trigger_error(
+                            sprintf('Bare "#" line comments are deprecated and will be removed in Phel v0.33. Use ";" or ";;" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
+                            E_USER_DEPRECATED,
+                        );
+                    }
 
-                if ($tokenType === Token::T_FN) {
-                    @trigger_error(
-                        sprintf('Using "|()" for short functions is deprecated, use "#()" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
-                        E_USER_DEPRECATED,
-                    );
-                }
+                    if ($tokenType === Token::T_FN) {
+                        @trigger_error(
+                            sprintf('Using "|()" for short functions is deprecated, use "#()" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
+                            E_USER_DEPRECATED,
+                        );
+                    }
 
-                if ($tokenType === Token::T_UNQUOTE_SPLICING && $matches[0] === ',@') {
-                    @trigger_error(
-                        sprintf('Using "," for unquote-splicing is deprecated, use "~@" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
-                        E_USER_DEPRECATED,
-                    );
-                }
+                    if ($tokenType === Token::T_UNQUOTE_SPLICING && $matches[0] === ',@') {
+                        @trigger_error(
+                            sprintf('Using "," for unquote-splicing is deprecated, use "~@" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
+                            E_USER_DEPRECATED,
+                        );
+                    }
 
-                if ($tokenType === Token::T_UNQUOTE && $matches[0] === ',') {
-                    @trigger_error(
-                        sprintf('Using "," for unquote is deprecated, use "~" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
-                        E_USER_DEPRECATED,
-                    );
+                    if ($tokenType === Token::T_UNQUOTE && $matches[0] === ',') {
+                        @trigger_error(
+                            sprintf('Using "," for unquote is deprecated, use "~" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
+                            E_USER_DEPRECATED,
+                        );
+                    }
                 }
 
                 yield new Token($tokenType, $matches[0], $startLocation, $endLocation);

--- a/tests/php/Unit/Compiler/Lexer/LexerTest.php
+++ b/tests/php/Unit/Compiler/Lexer/LexerTest.php
@@ -471,6 +471,23 @@ final class LexerTest extends TestCase
         self::assertNull($warning);
     }
 
+    public function test_non_deprecatable_token_stream_emits_no_deprecation(): void
+    {
+        $warning = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
+            $warning = $errstr;
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $this->lex('(+ 1 2)');
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertNull($warning);
+    }
+
     public function test_regex_literal(): void
     {
         self::assertEquals(


### PR DESCRIPTION
## 🤔 Background

The lexer's per-token loop ran up to four sequential deprecation `@trigger_error` comparisons after **every** successful match — even for the overwhelmingly common tokens (parens, atoms, whitespace, newlines) that can never be deprecated. Across a large file like `phel.core` that is thousands of redundant string comparisons per parse, in a hot path.

The shared `LexerBench` added in #2543 (now on `main`, under `tests/php/Benchmark/Compiler/`) drains the `phel.core` token stream to completion and is the harness to measure this with.

## 💡 Goal

Let common tokens short-circuit the entire deprecation section with a single `isset()` lookup, while emitting byte-identical deprecation warnings for exactly the same inputs.

## 🔖 Changes

- Added a precomputed `private const array DEPRECATABLE_TYPES` (`array<int,true>`) in `Lexer` mapping the four deprecatable token types — `T_COMMENT`, `T_FN`, `T_UNQUOTE_SPLICING`, `T_UNQUOTE` — to `true`.
- Wrapped the existing four `@trigger_error` checks in a single `if (isset(self::DEPRECATABLE_TYPES[$tokenType]))` guard. The inner checks and their evaluation order are unchanged; the `yield new Token(...)` stays outside the guard.
- No semantic change: the same `E_USER_DEPRECATED` messages still fire for `#`-prefixed comments, `|()` short fns, `,@` unquote-splicing, and `,` unquote, and for nothing else. Message text and source-location formatting are untouched.
- Added a focused unit test asserting a non-deprecatable stream (`(+ 1 2)`) emits zero deprecation warnings; existing deprecation tests continue to assert the same messages.

`composer test` is green (cs-fixer / Psalm / PHPStan / Rector clean; PHPUnit 0 failures; `phel test` 6098 passed, 0 failed).

<!-- Remember to add a mention about the fix/feature to the 'unreleased' section at the beginning of CHANGELOG.md for changes that are worth including in release notes. -->

Closes #2546
