### PR TITLE
perf(lang): skip Fiber::getCurrent() on global reads via a DynamicScope active-flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Type-tagged core calls now compile straight to native operations: `push`/`dissoc` to persistent-collection methods (#2527), `second`/`get-in` to direct vector/map access (#2530, #2529), and `count`/`first` on strings to `mb_strlen`/`mb_substr` (#2528)
 - `=` and `not=` over string literals now fold to a boolean at compile time (#2531)
 - The lexer skips per-token deprecation checks for the common token types via a single lookup (#2546)
+- Global symbol reads skip the per-call dynamic-scope/Fiber check when no dynamic bindings are active (#2545)
 
 ### Fixed
 

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -66,12 +66,17 @@ final class Phel extends InternalPhel
      */
     public static function getDefinition(string $ns, string $name): mixed
     {
-        // Hot path: every resolved symbol hits this. Probe the scope for
-        // *any* live frame first (O(1)) so the common "no binding active"
-        // case skips the string concat and stack walk entirely.
-        $scope = DynamicScope::getInstance();
-        if ($scope->hasAnyBinding() && $scope->hasBinding($ns, $name)) {
-            return $scope->getBinding($ns, $name);
+        // Hot path: every resolved symbol hits this. Read the process-global
+        // latch first so that when no dynamic binding has ever been
+        // established (the overwhelming common case) we skip the singleton
+        // fetch and the `Fiber::getCurrent()` call inside hasAnyBinding()
+        // entirely. A stale `true` falls through to the full hasAnyBinding()
+        // + hasBinding() check, which correctly returns the registry value.
+        if (DynamicScope::$anyActive) {
+            $scope = DynamicScope::getInstance();
+            if ($scope->hasAnyBinding() && $scope->hasBinding($ns, $name)) {
+                return $scope->getBinding($ns, $name);
+            }
         }
 
         return Registry::getInstance()->getDefinition($ns, $name);

--- a/src/php/Lang/DynamicScope.php
+++ b/src/php/Lang/DynamicScope.php
@@ -28,6 +28,22 @@ final class DynamicScope
 
     public const string MODE_REDEFS = 'redefs';
 
+    /**
+     * Conservative one-way latch: flipped to `true` the first time any
+     * binding frame is pushed and only reset in {@see self::clear()}.
+     * It is never cleared on `popFrame()`, so it can read stale-`true`
+     * (frames were pushed then all popped) but never stale-`false` while
+     * a binding is live in any fiber. The hot global-read path
+     * ({@see \Phel::getDefinition()}) reads this static first and only
+     * pays the {@see self::getInstance()} singleton fetch plus the
+     * `Fiber::getCurrent()` call in {@see self::hasAnyBinding()} when the
+     * latch is set. A stale `true` harmlessly falls through to that
+     * correct slow check, which reports "no binding" and returns the
+     * registry value; a `false` is only ever seen before any frame was
+     * ever pushed, so skipping the scope probe is always correct.
+     */
+    public static bool $anyActive = false;
+
     private static ?DynamicScope $instance = null;
 
     /**
@@ -71,6 +87,7 @@ final class DynamicScope
 
     public function clear(): void
     {
+        self::$anyActive = false;
         $this->mainStack = [];
         $this->mainRecordings = [];
         /** @var WeakMap<Fiber<mixed, mixed, mixed, mixed>, list<array<string, mixed>>> $map */
@@ -147,6 +164,12 @@ final class DynamicScope
      */
     public function pushFrame(array $frame): void
     {
+        // Latch on the first (and every) read-visible frame push. This is
+        // the sole path that installs a frame onto mainStack/fiberStacks;
+        // setBinding only mutates existing frames, recordings are not
+        // read-visible, so keying the latch here covers every path.
+        self::$anyActive = true;
+
         /** @var Fiber<mixed, mixed, mixed, mixed>|null $fiber */
         $fiber = Fiber::getCurrent();
         if (!$fiber instanceof Fiber) {

--- a/tests/php/Unit/Lang/DynamicScopeTest.php
+++ b/tests/php/Unit/Lang/DynamicScopeTest.php
@@ -30,6 +30,56 @@ final class DynamicScopeTest extends TestCase
         self::assertFalse($scope->hasAnyBinding(), 'fresh scope reports no active frames');
     }
 
+    public function test_any_active_latch_is_false_before_any_push(): void
+    {
+        // With no dynamic binding ever established, the latch stays false so
+        // the hot global-read path skips getInstance() + Fiber::getCurrent().
+        self::assertFalse(DynamicScope::$anyActive);
+
+        $scope = DynamicScope::getInstance();
+        // A read still resolves correctly while the latch is false.
+        self::assertFalse($scope->hasBinding('ns', 'x'));
+    }
+
+    public function test_any_active_latch_sets_on_push_and_stays_set_after_pop(): void
+    {
+        $scope = DynamicScope::getInstance();
+        self::assertFalse(DynamicScope::$anyActive);
+
+        $scope->pushFrame(['ns/x' => 1]);
+        self::assertTrue(DynamicScope::$anyActive, 'latch flips on first frame push');
+
+        // Conservative one-way latch: popping all frames does NOT reset it,
+        // so a binding live in any fiber can never be missed.
+        $scope->popFrame();
+        self::assertTrue(DynamicScope::$anyActive, 'latch stays set after pop');
+    }
+
+    public function test_any_active_latch_resets_only_on_clear(): void
+    {
+        $scope = DynamicScope::getInstance();
+        $scope->pushFrame(['ns/x' => 1]);
+        $scope->popFrame();
+        self::assertTrue(DynamicScope::$anyActive);
+
+        $scope->clear();
+        self::assertFalse(DynamicScope::$anyActive, 'clear() resets the latch');
+    }
+
+    public function test_bound_value_is_seen_inside_binding_with_latch_set(): void
+    {
+        $scope = DynamicScope::getInstance();
+
+        $seen = $scope->withFrame(['ns/x' => 'bound'], static function () use ($scope): mixed {
+            self::assertTrue(DynamicScope::$anyActive, 'latch is set inside the binding');
+            self::assertTrue($scope->hasAnyBinding());
+
+            return $scope->getBinding('ns', 'x');
+        });
+
+        self::assertSame('bound', $seen);
+    }
+
     public function test_has_any_binding_flips_with_push_pop(): void
     {
         $scope = DynamicScope::getInstance();

--- a/tests/php/Unit/Phel/PhelRegistryProxyTest.php
+++ b/tests/php/Unit/Phel/PhelRegistryProxyTest.php
@@ -6,10 +6,16 @@ namespace PhelTest\Unit\Phel;
 
 use BadMethodCallException;
 use Phel;
+use Phel\Lang\DynamicScope;
 use PHPUnit\Framework\TestCase;
 
 final class PhelRegistryProxyTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        DynamicScope::getInstance()->clear();
+    }
+
     public function test_calls_registry_when_method_is_not_defined(): void
     {
         Phel::clear();
@@ -25,5 +31,33 @@ final class PhelRegistryProxyTest extends TestCase
         $this->expectExceptionMessage('Method "nonExistingMethod" does not exist');
 
         Phel::nonExistingMethod();
+    }
+
+    public function test_get_definition_returns_registry_value_when_no_binding_active(): void
+    {
+        Phel::clear();
+        DynamicScope::getInstance()->clear();
+        Phel::addDefinition('ns', 'x', 'root');
+
+        // No dynamic binding ever established: the latch is off and the read
+        // returns the registry (root) value without consulting the scope.
+        self::assertFalse(DynamicScope::$anyActive);
+        self::assertSame('root', Phel::getDefinition('ns', 'x'));
+    }
+
+    public function test_get_definition_returns_bound_value_inside_dynamic_binding(): void
+    {
+        Phel::clear();
+        DynamicScope::getInstance()->clear();
+        Phel::addDefinition('ns', 'x', 'root');
+
+        $seen = DynamicScope::getInstance()->withFrame(
+            ['ns/x' => 'bound'],
+            static fn(): mixed => Phel::getDefinition('ns', 'x'),
+        );
+
+        self::assertSame('bound', $seen, 'dynamic binding overrides the root read');
+        // Outside the binding the root value is seen again.
+        self::assertSame('root', Phel::getDefinition('ns', 'x'));
     }
 }


### PR DESCRIPTION
## 🤔 Background

Every un-cached global var read goes through `Phel::getDefinition()`, which called `DynamicScope::getInstance()->hasAnyBinding()` — and that, in turn, calls `Fiber::getCurrent()` on every single invocation. So even when no `binding` / `with-redefs` is ever active (the overwhelming common case), every resolved global symbol paid a singleton fetch plus a `Fiber::getCurrent()` call.

Closes #2545

## 💡 Goal

When no dynamic binding has ever been established, the hot read path skips both `DynamicScope::getInstance()` and `Fiber::getCurrent()` by reading a single process-global `bool` first. When a binding has been active, behavior is exactly as before (full `hasAnyBinding()` + `hasBinding()` checks).

## 🔖 Changes

- `DynamicScope`: added a conservative one-way latch `public static bool $anyActive = false`.
  - Set to `true` at the top of `pushFrame()` — the sole path that installs a read-visible frame onto `mainStack`/`fiberStacks` (`withFrame` calls it; `setBinding` only mutates existing frames; recordings are not read-visible). Audited every frame-push caller to confirm this covers all paths.
  - Reset to `false` **only** in `clear()`; never cleared on `popFrame()`.
- `\Phel::getDefinition()`: reads `DynamicScope::$anyActive` first and only consults the scope when set. A stale `true` (frames pushed then all popped) harmlessly falls through to the existing `hasAnyBinding()` + `hasBinding()` slow check, which returns the registry value — no wrong value can ever be returned, and a binding live in any fiber can never be missed.
- Tests:
  - `DynamicScopeTest`: latch is `false` before any push, sets on push, stays set after pop, resets only on `clear()`; bound value is seen inside a `withFrame` with the latch set.
  - `PhelRegistryProxyTest`: `getDefinition` returns the registry root value when no binding is active, and the bound value inside a dynamic binding (root again outside).
- `CHANGELOG.md`: one-line note under `## Unreleased` → `### Performance`.

<!-- Remember to add a mention about the fix/feature to the 'unreleased' section at the beginning of CHANGELOG.md for changes that are worth including in release notes. -->
