### PR TITLE
perf(analyzer): short-circuit NodeEnvironment setters when value is unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - `=` and `not=` over string literals now fold to a boolean at compile time (#2531)
 - The lexer skips per-token deprecation checks for the common token types via a single lookup (#2546)
 - Global symbol reads skip the per-call dynamic-scope/Fiber check when no dynamic bindings are active (#2545)
+- The analyzer no longer clones the node environment when a context/binding setter is a no-op, cutting allocations on call-heavy code (#2552)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
@@ -193,6 +193,10 @@ final class NodeEnvironment implements NodeEnvironmentInterface
 
     public function withContext(string $context): static
     {
+        if ($this->context === $context) {
+            return $this;
+        }
+
         $result = clone $this;
         $result->context = $context;
 
@@ -201,6 +205,10 @@ final class NodeEnvironment implements NodeEnvironmentInterface
 
     public function withUseGlobalReference(bool $useGlobalReference): NodeEnvironmentInterface
     {
+        if ($this->globalReference === $useGlobalReference) {
+            return $this;
+        }
+
         $result = clone $this;
         $result->globalReference = $useGlobalReference;
 
@@ -225,6 +233,10 @@ final class NodeEnvironment implements NodeEnvironmentInterface
 
     public function withBoundTo(string $boundTo): NodeEnvironmentInterface
     {
+        if ($this->boundTo === $boundTo) {
+            return $this;
+        }
+
         $result = clone $this;
         $result->boundTo = $boundTo;
 

--- a/tests/php/Unit/Compiler/Analyzer/Environment/NodeEnvironmentTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/NodeEnvironmentTest.php
@@ -103,4 +103,55 @@ final class NodeEnvironmentTest extends TestCase
         self::assertTrue($env->hasLocal(Symbol::create('c')));
         self::assertCount(3, $env->getLocals());
     }
+
+    public function test_with_context_returns_same_instance_when_unchanged(): void
+    {
+        $env = NodeEnvironment::empty();
+
+        self::assertSame($env, $env->withContext($env->getContext()));
+    }
+
+    public function test_with_context_returns_new_instance_when_changed(): void
+    {
+        $env = NodeEnvironment::empty();
+        $next = $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION);
+
+        self::assertNotSame($env, $next);
+        self::assertSame(NodeEnvironment::CONTEXT_EXPRESSION, $next->getContext());
+        self::assertSame(NodeEnvironment::CONTEXT_STATEMENT, $env->getContext());
+    }
+
+    public function test_with_use_global_reference_returns_same_instance_when_unchanged(): void
+    {
+        $env = NodeEnvironment::empty();
+
+        self::assertSame($env, $env->withUseGlobalReference($env->useGlobalReference()));
+    }
+
+    public function test_with_use_global_reference_returns_new_instance_when_changed(): void
+    {
+        $env = NodeEnvironment::empty();
+        $next = $env->withUseGlobalReference(true);
+
+        self::assertNotSame($env, $next);
+        self::assertTrue($next->useGlobalReference());
+        self::assertFalse($env->useGlobalReference());
+    }
+
+    public function test_with_bound_to_returns_same_instance_when_unchanged(): void
+    {
+        $env = NodeEnvironment::empty();
+
+        self::assertSame($env, $env->withBoundTo($env->getBoundTo()));
+    }
+
+    public function test_with_bound_to_returns_new_instance_when_changed(): void
+    {
+        $env = NodeEnvironment::empty();
+        $next = $env->withBoundTo('user\\foo');
+
+        self::assertNotSame($env, $next);
+        self::assertSame('user\\foo', $next->getBoundTo());
+        self::assertSame('', $env->getBoundTo());
+    }
 }


### PR DESCRIPTION
## 🤔 Background

`NodeEnvironment` is immutable — every mutator clones `$this`. The context/binding
setters (`withContext`, `withUseGlobalReference`, `withBoundTo`) cloned
unconditionally, even when handed their already-current value. On the hottest
analyzer path (per-argument context flips in `InvokeSymbol::arguments()`) this is
pure allocation: each clone also copies the derived index arrays (`localsByName`,
`shadowedReverse`) that a context flip never changes.

## 💡 Goal

Return `$this` when a context/binding setter is a no-op, so call-heavy compiles
avoid the redundant clone and array copies. Behaviorally identical — the
environment is immutable by contract and no caller mutates a returned env in place
(properties are private, written only inside the class's own `with*` methods).

## 🔖 Changes

- `withContext()`: return `$this` when `$this->context === $context` before cloning.
- `withUseGlobalReference()`: return `$this` when the flag is unchanged.
- `withBoundTo()`: return `$this` when the bound-to value is unchanged.
- The wrapper helpers (`withReturnContext`, `withStatementContext`,
  `withExpressionContext`, `withEnvContext`) are unchanged and benefit transitively.
- Unit tests assert each guarded setter returns the **same** instance for an
  unchanged value and a **new**, correctly-mutated instance for a different value.

Closes #2552
