### PR TITLE
perf(lang): use identity comparison in persistent map remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - PHP interop (`php/->`, `php/::`, `php/new`, `php/oset`) now compiles to direct expressions or statements instead of wrapping every call in a closure (#2524, #2525, #2526, #2532, #2536)
 - Type-tagged core calls now compile straight to native operations: `push`/`dissoc` to persistent-collection methods (#2527), `second`/`get-in` to direct vector/map access (#2530, #2529), and `count`/`first` on strings to `mb_strlen`/`mb_substr` (#2528)
 - `=` and `not=` over string literals now fold to a boolean at compile time (#2531)
+- `dissoc`/`remove` on a large persistent map no longer does an O(n) deep node comparison on the no-op path (#2544)
 
 ### Fixed
 

--- a/src/php/Lang/Collections/Map/PersistentHashMap.php
+++ b/src/php/Lang/Collections/Map/PersistentHashMap.php
@@ -148,7 +148,7 @@ final class PersistentHashMap extends AbstractPersistentMap
 
         $newRoot = $this->root->remove(0, $this->hasher->hash($key), $key);
 
-        if ($newRoot == $this->root) {
+        if ($newRoot === $this->root) {
             return $this;
         }
 

--- a/src/php/Lang/Collections/Map/TransientHashMap.php
+++ b/src/php/Lang/Collections/Map/TransientHashMap.php
@@ -126,7 +126,7 @@ final class TransientHashMap implements TransientMapInterface
 
         $newRoot = $this->root->remove(0, $this->hasher->hash($key), $key);
 
-        if ($newRoot != $this->root) {
+        if ($newRoot !== $this->root) {
             $this->root = $newRoot;
             --$this->count;
         }

--- a/tests/php/Unit/Lang/Collections/Map/PersistentHashMapTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/PersistentHashMapTest.php
@@ -136,6 +136,42 @@ final class PersistentHashMapTest extends TestCase
         self::assertNull($h->find(1));
     }
 
+    public function test_remove_absent_key_on_large_map_returns_same_instance(): void
+    {
+        $size = 100;
+        $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer());
+        for ($i = 0; $i < $size; ++$i) {
+            $h = $h->put($i, $i);
+        }
+
+        $result = $h->remove($size + 1);
+
+        // No-op removal returns the original map by identity (O(1) identity check).
+        self::assertSame($h, $result);
+        self::assertTrue($h->equals($result));
+        self::assertCount($size, $result);
+    }
+
+    public function test_remove_present_key_on_large_map(): void
+    {
+        $size = 100;
+        $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer());
+        for ($i = 0; $i < $size; ++$i) {
+            $h = $h->put($i, $i);
+        }
+
+        $result = $h->remove(42);
+
+        self::assertNotSame($h, $result);
+        self::assertCount($size - 1, $result);
+        self::assertFalse($result->contains(42));
+        self::assertNull($result->find(42));
+        // Original map is untouched (persistent).
+        self::assertCount($size, $h);
+        self::assertTrue($h->contains(42));
+        self::assertSame(42, $h->find(42));
+    }
+
     public function test_equals(): void
     {
         $h1 = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())

--- a/tests/php/Unit/Lang/Collections/Map/TransientHashMapTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/TransientHashMapTest.php
@@ -120,4 +120,38 @@ final class TransientHashMapTest extends TestCase
         self::assertFalse($h->contains(1));
         self::assertNull($h->find(1));
     }
+
+    public function test_remove_absent_key_on_large_map_is_noop(): void
+    {
+        $size = 100;
+        $h = TransientHashMap::empty(new ModuloHasher(), new SimpleEqualizer());
+        for ($i = 0; $i < $size; ++$i) {
+            $h = $h->put($i, $i);
+        }
+
+        $result = $h->remove($size + 1);
+
+        // No-op removal leaves count and entries untouched (O(1) identity check).
+        self::assertSame($h, $result);
+        self::assertCount($size, $result);
+        self::assertTrue($result->contains(0));
+        self::assertTrue($result->contains($size - 1));
+    }
+
+    public function test_remove_present_key_on_large_map(): void
+    {
+        $size = 100;
+        $h = TransientHashMap::empty(new ModuloHasher(), new SimpleEqualizer());
+        for ($i = 0; $i < $size; ++$i) {
+            $h = $h->put($i, $i);
+        }
+
+        $h->remove(42);
+
+        self::assertCount($size - 1, $h);
+        self::assertFalse($h->contains(42));
+        self::assertNull($h->find(42));
+        self::assertTrue($h->contains(41));
+        self::assertTrue($h->contains(43));
+    }
 }


### PR DESCRIPTION
Closes #2544

## 🤔 Background

`PersistentHashMap::remove()` and `TransientHashMap::remove()` compared the HAMT root before/after a node `remove()` with loose `==` / `!=`. PHP's loose comparison on objects recurses member-by-member into nested objects, so comparing a HAMT root walks the entire trie — O(n) in the map size, paid on every `remove`/`dissoc`, and worst on the common absent-key no-op.

## 💡 Goal

Detect "no structural change" by object identity in O(1). The node layer already signals "no change" by returning the same instance (`return $this;`) and compares internally with `===` (see `ArrayNode::remove()` at `:96`, `:101`, `:102`). The `put` path in both files already uses `===` / `!==`. This brings `remove` in line with that existing identity contract — strictly more correct and faster, with no behavioral delta.

## 🔖 Changes

- `PersistentHashMap.php:151` — `if ($newRoot == $this->root)` → `if ($newRoot === $this->root)`.
- `TransientHashMap.php:129` — `if ($newRoot != $this->root)` → `if ($newRoot !== $this->root)`.
- Tests: added `test_remove_absent_key_*` (no-op returns the same instance, equal map, unchanged count) and `test_remove_present_key_on_large_map` for both `PersistentHashMap` and `TransientHashMap`, building a 100-entry map so the root is a real multi-level HAMT (well past the 8-element node threshold).
- CHANGELOG: one line under `## Unreleased` → `### Performance`.

The shared benchmark `PersistentHashMapBench::bench_remove_absent` (added in #2543) isolates exactly this no-op path. `composer test` is green (static analysis clean; 4616 PHPUnit tests, 0 errors; 6098 Phel core tests, 0 failures).
