### PR TITLE
perf(analyzer): memoize stateless sub-analyzers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - PHP interop (`php/->`, `php/::`, `php/new`, `php/oset`) now compiles to direct expressions or statements instead of wrapping every call in a closure (#2524, #2525, #2526, #2532, #2536)
 - Type-tagged core calls now compile straight to native operations: `push`/`dissoc` to persistent-collection methods (#2527), `second`/`get-in` to direct vector/map access (#2530, #2529), and `count`/`first` on strings to `mb_strlen`/`mb_substr` (#2528)
 - `=` and `not=` over string literals now fold to a boolean at compile time (#2531)
+- The analyzer reuses stateless sub-analyzers (literal/constant-folder/let-simplifier) instead of allocating them per node (#2553)
 
 ### Fixed
 

--- a/src/php/Compiler/Application/Analyzer.php
+++ b/src/php/Compiler/Application/Analyzer.php
@@ -37,6 +37,8 @@ use function is_string;
 
 final class Analyzer implements AnalyzerInterface
 {
+    private ?AnalyzeLiteral $literalAnalyzer = null;
+
     private ?AnalyzePersistentList $listAnalyzer = null;
 
     private ?AnalyzeSymbol $symbolAnalyzer = null;
@@ -159,7 +161,8 @@ final class Analyzer implements AnalyzerInterface
         NodeEnvironmentInterface $env,
     ): AbstractNode {
         if ($this->isLiteral($x)) {
-            return new AnalyzeLiteral()->analyze($x, $env);
+            $this->literalAnalyzer ??= new AnalyzeLiteral();
+            return $this->literalAnalyzer->analyze($x, $env);
         }
 
         if ($x instanceof Symbol) {
@@ -191,7 +194,8 @@ final class Analyzer implements AnalyzerInterface
         // yields `DateTimeImmutable`). Any object that is not one of the
         // persistent types above is treated as an opaque literal value.
         if (is_object($x) && !$x instanceof TypeInterface) {
-            return new AnalyzeLiteral()->analyze($x, $env);
+            $this->literalAnalyzer ??= new AnalyzeLiteral();
+            return $this->literalAnalyzer->analyze($x, $env);
         }
 
         throw new AnalyzerException('Unhandled type: ' . var_export($x, true));

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/IfSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/IfSymbol.php
@@ -23,6 +23,8 @@ final class IfSymbol implements SpecialFormAnalyzerInterface
 {
     use WithAnalyzerTrait;
 
+    private ?ConstantFolder $constantFolder = null;
+
     /**
      * @param PersistentListInterface<mixed> $list
      */
@@ -38,7 +40,8 @@ final class IfSymbol implements SpecialFormAnalyzerInterface
             $list->getStartLocation(),
         );
 
-        return new ConstantFolder()->foldIf($node) ?? $node;
+        $this->constantFolder ??= new ConstantFolder();
+        return $this->constantFolder->foldIf($node) ?? $node;
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -48,6 +48,7 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
     public function __construct(
         private AnalyzerInterface $analyzer,
         ?CallInliner $callInliner = null,
+        private ConstantFolder $constantFolder = new ConstantFolder(),
     ) {
         $this->callInliner = $callInliner ?? new CallInliner();
     }
@@ -100,7 +101,7 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
             $list->getStartLocation(),
         );
 
-        return new ConstantFolder()->fold($call) ?? $call;
+        return $this->constantFolder->fold($call) ?? $call;
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
@@ -31,6 +31,7 @@ final readonly class LetSymbol implements SpecialFormAnalyzerInterface
     public function __construct(
         private AnalyzerInterface $analyzer,
         private DeconstructorInterface $deconstructor,
+        private LetSimplifier $letSimplifier = new LetSimplifier(),
     ) {}
 
     /**
@@ -115,7 +116,7 @@ final readonly class LetSymbol implements SpecialFormAnalyzerInterface
             $list->getStartLocation(),
         );
 
-        return new LetSimplifier()->simplify($node);
+        return $this->letSimplifier->simplify($node);
     }
 
     /**

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzeLiteralTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzeLiteralTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Compiler\Analyzer;
 
+use Phel\Compiler\Application\Analyzer;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\AnalyzeLiteral;
 use Phel\Lang\Symbol;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 final class AnalyzeLiteralTest extends TestCase
 {
@@ -44,5 +47,28 @@ final class AnalyzeLiteralTest extends TestCase
             new LiteralNode($env, [1, 2]),
             $this->literalAnalyzer->analyze([1, 2], $env),
         );
+    }
+
+    public function test_analyzer_reuses_a_single_literal_analyzer_instance(): void
+    {
+        $analyzer = new Analyzer(new GlobalEnvironment());
+        $env = NodeEnvironment::empty();
+
+        $first = $analyzer->analyze(1, $env);
+        $reused = $this->literalAnalyzerOf($analyzer);
+        $second = $analyzer->analyze('two', $env);
+
+        self::assertSame($reused, $this->literalAnalyzerOf($analyzer));
+        self::assertEquals(new LiteralNode($env, 1), $first);
+        self::assertEquals(new LiteralNode($env, 'two'), $second);
+    }
+
+    private function literalAnalyzerOf(Analyzer $analyzer): AnalyzeLiteral
+    {
+        $property = new ReflectionProperty(Analyzer::class, 'literalAnalyzer');
+        $value = $property->getValue($analyzer);
+        self::assertInstanceOf(AnalyzeLiteral::class, $value);
+
+        return $value;
     }
 }


### PR DESCRIPTION
## 🤔 Background

The analyzer instantiated `new AnalyzeLiteral()` on every literal node — the most frequent node type — while every other sub-analyzer (symbol/list/vector/set/map) is memoized via `??=`. The per-form special-form analyzers likewise re-`new`'d their stateless helpers (`ConstantFolder` in `if`/invoke, `LetSimplifier` in `let`) on each invocation.

## 💡 Goal

Stop allocating throwaway sub-analyzers per node by reusing a single instance of each clearly-stateless helper, with no behavioral change.

## 🔖 Changes

- `Analyzer` memoizes `AnalyzeLiteral` via a `?AnalyzeLiteral $literalAnalyzer` field and `??=`, mirroring its sibling analyzers, used at both literal paths.
- `InvokeSymbol` and `LetSymbol` (both `final readonly` with constructors) take the helper as a default-instantiated constructor argument (`ConstantFolder`, `LetSimplifier` respectively).
- `IfSymbol` (uses the shared `WithAnalyzerTrait` constructor) lazily memoizes `ConstantFolder` via `??=`.
- Audited `ParamTypeInferrer`/`ReturnTypeInferrer`: both carry transient per-call state (`observations`/`guarded`, `sawOperator`). They are **left constructed per call** — out of scope here (#4 addresses their redundant walks). `MacroFormRewriter`/`DefArglistBuilder` also left as-is.
- Added a unit test asserting the analyzer reuses a single literal-analyzer instance across calls and still produces correct literal nodes.

`AnalyzeLiteral`, `ConstantFolder`, and `LetSimplifier` take arguments and return fresh nodes without mutating instance state, so a shared instance is safe. `composer test` is green (4613 tests; static analysis — cs-fixer/psalm/phpstan/rector — all pass).

Closes #2553
