### PR TITLE
perf(emitter): specialize keyword-literal equality (= x :kw) to native ===

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - The lexer skips per-token deprecation checks for the common token types via a single lookup (#2546)
 - Global symbol reads skip the per-call dynamic-scope/Fiber check when no dynamic bindings are active (#2545)
 - The analyzer no longer clones the node environment when a context/binding setter is a no-op, cutting allocations on call-heavy code (#2552)
+- `(= x :keyword)` now compiles to a native identity check instead of dispatching through the runtime equality fn (#2561)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecialization.php
@@ -10,9 +10,11 @@ use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Lang\Keyword;
 use Phel\Shared\CompilerConstants;
 
 use function array_all;
+use function array_any;
 use function count;
 use function in_array;
 use function is_bool;
@@ -148,6 +150,10 @@ final readonly class NumericOperationSpecialization
         }
 
         if ($name === '=') {
+            if (self::eitherArgIsKeywordLiteral($args)) {
+                return '===';
+            }
+
             return self::bothArgsHavePrimitiveTag($args, self::EQUALITY_PRIMITIVE_TAGS)
                 ? '==='
                 : null;
@@ -255,6 +261,36 @@ final readonly class NumericOperationSpecialization
         // float) or `int` so it can emit `($a + ($b * $c))` instead of a
         // runtime dispatch around the inner native expression.
         return self::numericTypeOfTypedBinaryCall($arg);
+    }
+
+    /**
+     * `true` when at least one operand of a two-arg `=` is a compile-time
+     * keyword literal. Keywords are interned singletons
+     * ({@see Keyword::create()} returns the same object for equal ns/name),
+     * and {@see \Phel\Lang\Equalizer::equals()} short-circuits on `===`, so:
+     *
+     *  - keyword vs keyword → equal keywords are `===`, unequal are not →
+     *    native `===` is exact;
+     *  - keyword vs non-keyword → `Equalizer::equals` returns false and PHP
+     *    `===` of a `Keyword` object against any non-`Keyword` value is also
+     *    false → identical result.
+     *
+     * So `($x === <hoisted-kw>)` is behaviour-preserving for *every* runtime
+     * value of the other operand, regardless of its static type or tag — no
+     * tag is required. Restricted to {@see Keyword} only: `Symbol` is not
+     * interned, so `===` would diverge from `=` for equal-but-distinct
+     * symbol objects.
+     *
+     * @param list<AbstractNode> $args
+     */
+    private static function eitherArgIsKeywordLiteral(array $args): bool
+    {
+        return array_any($args, static fn(AbstractNode $arg): bool => self::isKeywordLiteral($arg));
+    }
+
+    private static function isKeywordLiteral(AbstractNode $arg): bool
+    {
+        return $arg instanceof LiteralNode && $arg->getValue() instanceof Keyword;
     }
 
     /**

--- a/tests/php/Benchmark/Compiler/EqualityKeywordBench.php
+++ b/tests/php/Benchmark/Compiler/EqualityKeywordBench.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler;
+
+use Phel\Lang\Keyword;
+use PhelTest\Benchmark\Compiler\Fixtures\EqualityKeywordNative;
+use PhelTest\Benchmark\Compiler\Fixtures\EqualityKeywordRuntime;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+
+/**
+ * Compares the two emission strategies for a `(= x :kw)`-heavy `cond`
+ * chain (issue #2561):
+ *
+ *   1. runtime: each comparison dispatches through `phel.core/=`
+ *      (`Equalizer::equals`) — the status quo.
+ *   2. native:  each comparison lowers to a native PHP `===` against a
+ *      hoisted interned keyword constant — the optimization.
+ *
+ * Both return the same result for every keyword input; what differs is
+ * the per-site dispatch overhead.
+ *
+ * @BeforeMethods("setUp")
+ */
+final class EqualityKeywordBench
+{
+    private EqualityKeywordRuntime $runtimeFn;
+
+    private EqualityKeywordNative $nativeFn;
+
+    private Keyword $miss;
+
+    public function setUp(): void
+    {
+        $this->runtimeFn = new EqualityKeywordRuntime();
+        $this->nativeFn = new EqualityKeywordNative();
+
+        // Worst case for a cond chain: the value matches none of the
+        // branches, so every comparison runs.
+        $this->miss = Keyword::create('omega');
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(10)
+     *
+     * @Warmup(2)
+     */
+    public function bench_runtime_dispatch(): void
+    {
+        ($this->runtimeFn)($this->miss);
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(10)
+     *
+     * @Warmup(2)
+     */
+    public function bench_native_identity(): void
+    {
+        ($this->nativeFn)($this->miss);
+    }
+}

--- a/tests/php/Benchmark/Compiler/Fixtures/EqualityKeywordNative.php
+++ b/tests/php/Benchmark/Compiler/Fixtures/EqualityKeywordNative.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler\Fixtures;
+
+use Phel\Lang\Keyword;
+
+/**
+ * Optimized emission shape for a `(= x :kw)`-heavy `cond` chain after
+ * issue #2561: each keyword comparison lowers to a native PHP `===`
+ * against a hoisted (interned) keyword constant — no registry lookup,
+ * no `phel.core/=` `__invoke`.
+ */
+final readonly class EqualityKeywordNative
+{
+    private Keyword $a;
+
+    private Keyword $b;
+
+    private Keyword $c;
+
+    public function __construct()
+    {
+        $this->a = Keyword::create('alpha');
+        $this->b = Keyword::create('beta');
+        $this->c = Keyword::create('gamma');
+    }
+
+    public function __invoke(Keyword $x): int
+    {
+        if ($x === $this->a) {
+            return 1;
+        }
+
+        if ($x === $this->b) {
+            return 2;
+        }
+
+        if ($x === $this->c) {
+            return 3;
+        }
+
+        return 0;
+    }
+}

--- a/tests/php/Benchmark/Compiler/Fixtures/EqualityKeywordRuntime.php
+++ b/tests/php/Benchmark/Compiler/Fixtures/EqualityKeywordRuntime.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler\Fixtures;
+
+use Phel\Lang\Equalizer;
+use Phel\Lang\Keyword;
+
+/**
+ * Baseline emission shape for a `(= x :kw)`-heavy `cond` chain before
+ * issue #2561: each keyword comparison dispatches through the runtime
+ * equality (`phel.core/=` → `Equalizer::equals`). This models the
+ * per-site dispatch cost the native `===` lowering removes.
+ */
+final readonly class EqualityKeywordRuntime
+{
+    private Equalizer $equalizer;
+
+    private Keyword $a;
+
+    private Keyword $b;
+
+    private Keyword $c;
+
+    public function __construct()
+    {
+        $this->equalizer = new Equalizer();
+        $this->a = Keyword::create('alpha');
+        $this->b = Keyword::create('beta');
+        $this->c = Keyword::create('gamma');
+    }
+
+    public function __invoke(Keyword $x): int
+    {
+        if ($this->equalizer->equals($x, $this->a)) {
+            return 1;
+        }
+
+        if ($this->equalizer->equals($x, $this->b)) {
+            return 2;
+        }
+
+        if ($this->equalizer->equals($x, $this->c)) {
+            return 3;
+        }
+
+        return 0;
+    }
+}

--- a/tests/php/Integration/Compiler/KeywordEqualityRuntimeTest.php
+++ b/tests/php/Integration/Compiler/KeywordEqualityRuntimeTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Compiler;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompileOptions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * End-to-end check that `(= x :kw)` lowered to native `===` (and the
+ * `(not (= x :kw))` peephole lowered to `!==`) is behaviour-preserving
+ * against the runtime `phel.core/=` dispatch for every shape of the other
+ * operand: equal/unequal keyword, int, string, nil, and a different
+ * keyword. Keywords are interned singletons so identity is exact equality.
+ */
+final class KeywordEqualityRuntimeTest extends TestCase
+{
+    private static GlobalEnvironmentInterface $globalEnv;
+
+    private CompilerFacade $compilerFacade;
+
+    public static function setUpBeforeClass(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Symbol::resetGen();
+        $globalEnv = GlobalEnvironmentSingleton::initializeNew();
+        new BuildFacade()->compileFile(
+            __DIR__ . '/../../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core'),
+        );
+        self::$globalEnv = $globalEnv;
+    }
+
+    protected function setUp(): void
+    {
+        $this->compilerFacade = new CompilerFacade();
+        self::$globalEnv->setNs('user');
+        Symbol::resetGen();
+    }
+
+    public function test_keyword_equality_keyword_matches(): void
+    {
+        /** @var callable $fn */
+        $fn = $this->compilerFacade->eval('(fn [x] (= x :foo))', new CompileOptions());
+
+        self::assertTrue($fn(Keyword::create('foo')), 'equal keyword is true');
+    }
+
+    public function test_keyword_equality_unequal_keyword(): void
+    {
+        /** @var callable $fn */
+        $fn = $this->compilerFacade->eval('(fn [x] (= x :foo))', new CompileOptions());
+
+        self::assertFalse($fn(Keyword::create('bar')), 'different keyword is false');
+    }
+
+    public function test_keyword_equality_against_non_keyword_is_false(): void
+    {
+        /** @var callable $fn */
+        $fn = $this->compilerFacade->eval('(fn [x] (= x :foo))', new CompileOptions());
+
+        self::assertFalse($fn(1), 'int vs keyword is false');
+        self::assertFalse($fn('foo'), 'string vs keyword is false');
+        self::assertFalse($fn(null), 'nil vs keyword is false');
+    }
+
+    public function test_keyword_literal_on_the_left(): void
+    {
+        /** @var callable $fn */
+        $fn = $this->compilerFacade->eval('(fn [x] (= :foo x))', new CompileOptions());
+
+        self::assertTrue($fn(Keyword::create('foo')), 'literal-on-left equal keyword is true');
+        self::assertFalse($fn(Keyword::create('bar')), 'literal-on-left different keyword is false');
+        self::assertFalse($fn('foo'), 'literal-on-left vs string is false');
+    }
+
+    public function test_negated_keyword_equality_peephole(): void
+    {
+        /** @var callable $fn */
+        $fn = $this->compilerFacade->eval('(fn [x] (not (= x :foo)))', new CompileOptions());
+
+        self::assertFalse($fn(Keyword::create('foo')), 'not= equal keyword is false');
+        self::assertTrue($fn(Keyword::create('bar')), 'not= different keyword is true');
+        self::assertTrue($fn(1), 'not= int is true');
+    }
+
+    /**
+     * The optimized `===` lowering must produce the exact same boolean as
+     * the runtime `phel.core/=` dispatch for every operand shape. The
+     * runtime baseline is forced by aliasing `=` to a local so the
+     * specializer's literal-keyword detector does not fire on it.
+     */
+    public function test_optimized_matches_runtime_equality(): void
+    {
+        /** @var callable $optimized */
+        $optimized = $this->compilerFacade->eval('(fn [x] (= x :foo))', new CompileOptions());
+        /** @var callable $runtime */
+        $runtime = $this->compilerFacade->eval('(fn [x] (let [eq =] (eq x :foo)))', new CompileOptions());
+
+        $cases = [
+            Keyword::create('foo'),
+            Keyword::create('bar'),
+            Keyword::create('foo', 'ns'),
+            1,
+            0,
+            'foo',
+            '',
+            null,
+            true,
+            false,
+        ];
+
+        foreach ($cases as $case) {
+            self::assertSame(
+                $runtime($case),
+                $optimized($case),
+                'optimized === must match runtime = for ' . var_export($case, true),
+            );
+        }
+    }
+
+    public function test_keyword_equality_in_cond_context(): void
+    {
+        /** @var callable $fn */
+        $fn = $this->compilerFacade->eval(
+            '(fn [x] (cond (= x :a) 1 (= x :b) 2 :else 3))',
+            new CompileOptions(),
+        );
+
+        self::assertSame(1, $fn(Keyword::create('a')));
+        self::assertSame(2, $fn(Keyword::create('b')));
+        self::assertSame(3, $fn(Keyword::create('c')));
+        self::assertSame(3, $fn('a'));
+        self::assertSame(3, $fn(null));
+    }
+
+    public function test_keyword_equality_in_case_context(): void
+    {
+        /** @var callable $fn */
+        $fn = $this->compilerFacade->eval(
+            '(fn [x] (case x :a 1 :b 2 3))',
+            new CompileOptions(),
+        );
+
+        self::assertSame(1, $fn(Keyword::create('a')));
+        self::assertSame(2, $fn(Keyword::create('b')));
+        self::assertSame(3, $fn(Keyword::create('c')));
+    }
+}

--- a/tests/php/Integration/Fixtures/Call/eq-on-keyword-literal-left.test
+++ b/tests/php/Integration/Fixtures/Call/eq-on-keyword-literal-left.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [x] (= :foo x))
+--PHP--
+(function($x) {
+  static $__phel_const_0;
+  return (($__phel_const_0 ??= \Phel\Lang\Keyword::create("foo")) === $x);
+});

--- a/tests/php/Integration/Fixtures/Call/eq-on-keyword-literal.test
+++ b/tests/php/Integration/Fixtures/Call/eq-on-keyword-literal.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [x] (= x :foo))
+--PHP--
+(function($x) {
+  static $__phel_const_0;
+  return ($x === ($__phel_const_0 ??= \Phel\Lang\Keyword::create("foo")));
+});

--- a/tests/php/Integration/Fixtures/Call/eq-on-symbol-literal-bails.test
+++ b/tests/php/Integration/Fixtures/Call/eq-on-symbol-literal-bails.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [x] (= x 'foo))
+--PHP--
+(function($x) {
+  static $__phel_call_0;
+  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "="))->__invoke($x, (\Phel\Lang\Symbol::create("foo")));
+});

--- a/tests/php/Integration/Fixtures/Call/not-eq-on-keyword-literal.test
+++ b/tests/php/Integration/Fixtures/Call/not-eq-on-keyword-literal.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [x] (not (= x :foo)))
+--PHP--
+(function($x) {
+  static $__phel_const_0;
+  return ($x !== ($__phel_const_0 ??= \Phel\Lang\Keyword::create("foo")));
+});


### PR DESCRIPTION
## 🤔 Background

`(= x :foo)` is the single most common comparison idiom in Phel (`cond`, `case`, `if`, dispatch maps). Today every such site pays a `phel.core/=` registry round-trip plus an `__invoke`, even though one operand is a compile-time keyword literal.

The numeric/equality specializer (`NumericOperationSpecialization`) only lowered `=` to native `===` when both operands carried a primitive tag (`int`/`float`/`bool`/`string`). Keyword was not in that set, so the most common comparison in the language always fell back to the runtime dispatch.

## 💡 Goal

When **either** operand of `=` is a `LiteralNode` holding a `Keyword`, lower the call to a native identity comparison against the hoisted (interned) keyword constant — `($x === <hoisted-kw>)` — and lower the negated peephole `(not (= x :kw))` to `($x !== <hoisted-kw>)`. No registry lookup, no `__invoke`. Closes #2561.

### Correctness argument (behaviour-preserving, no tag required)

This lowering is safe regardless of the other operand's static type or tag. Each link verified in code:

- `Keyword::create()` interns: `return self::$internPool[$key] ??= new self(...)` (`src/php/Lang/Keyword.php:61-68`, pool at lines 18-19). Equal ns/name → the same object.
- `Keyword::identical()` is `return $this === $other;` (`Keyword.php:99-102`) and `Keyword::equals()` delegates to it. Keyword equality *is* PHP identity.
- `Equalizer::equals()` short-circuits on `$a === $b` as its first check (`src/php/Lang/Equalizer.php:23`).

Therefore for any value `$x`:
- **keyword vs keyword** → interning means equal keywords are `===` and unequal keywords are not → native `===` is exact.
- **keyword vs non-keyword** → `Equalizer::equals` returns false, and PHP `===` of a `Keyword` object against any non-`Keyword` value is also false → identical result.

So `($x === $kw)` yields the same boolean as `(= x :kw)` for every runtime value of `$x` — no tag on the other operand is needed, and the existing `EQUALITY_PRIMITIVE_TAGS` path is left untouched (the keyword path is additive and disjoint).

**Restricted to `Keyword` only.** `Symbol` is **not** interned (`Symbol::create()` is `new self(...)` with no intern pool), so `===` would diverge from `=` for equal-but-distinct symbol objects. A fixture (`eq-on-symbol-literal-bails.test`) proves symbol literals keep the runtime dispatch.

## 🔖 Changes

- `NumericOperationSpecialization::typedBinaryOpName()`: for `=`, return `===` when either argument is a keyword literal (`eitherArgIsKeywordLiteral()` / `isKeywordLiteral()`), independent of `EQUALITY_PRIMITIVE_TAGS`. The negated `(not (= ...))` peephole keys off `typedBinaryOpName(...) === '==='`, so `(not (= x :kw))` lowers to `!==` for free. The keyword operand emits through the existing literal/constant-slot path, so interning + constant hoisting still apply (`$__phel_const_N ??= \Phel\Lang\Keyword::create(...)`).
- Golden integration fixtures under `tests/php/Integration/Fixtures/Call/`: `eq-on-keyword-literal.test`, `eq-on-keyword-literal-left.test`, `not-eq-on-keyword-literal.test`, and `eq-on-symbol-literal-bails.test` (proving symbols are NOT lowered).
- Behavioral runtime test `tests/php/Integration/Compiler/KeywordEqualityRuntimeTest.php`: keyword==keyword (equal/unequal), keyword vs int/string/nil/other-keyword, literal-on-left, the negated peephole, optimized-vs-runtime parity across 10 operand shapes, plus `cond`/`case` contexts.
- New benchmark `tests/php/Benchmark/Compiler/EqualityKeywordBench.php` (+ `EqualityKeywordNative`/`EqualityKeywordRuntime` fixtures), modeling a `(= x :kw)`-heavy `cond` chain.
- `CHANGELOG.md`: one `### Performance` line under `## Unreleased`.

### Emitted PHP — before vs after, `(fn [x] (= x :foo))`

Before (registry dispatch):
```php
(function($x) {
  static $__phel_call_0;
  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "="))->__invoke($x, (\Phel\Lang\Keyword::create("foo")));
});
```

After (native identity against hoisted keyword):
```php
(function($x) {
  static $__phel_const_0;
  return ($x === ($__phel_const_0 ??= \Phel\Lang\Keyword::create("foo")));
});
```

### Benchmark

`EqualityKeywordBench` over a 3-branch `cond` worst case (all comparisons run): runtime dispatch ~0.28μs/op vs native identity ~0.036μs/op — roughly an 87% per-site reduction.

### Gate

`composer test` green: static analysis (cs-fixer/psalm/phpstan L9) passed, PHPUnit unit+integration passed, Phel core tests 6098/6098 passed (0 failed, 0 error).

Closes #2561
