### PR TITLE
perf(console): lazy-load CLI commands via Symfony CommandLoaderInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Global symbol reads skip the per-call dynamic-scope/Fiber check when no dynamic bindings are active (#2545)
 - The analyzer no longer clones the node environment when a context/binding setter is a no-op, cutting allocations on call-heavy code (#2552)
 - `(= x :keyword)` now compiles to a native identity check instead of dispatching through the runtime equality fn (#2561)
+- CLI commands are now lazy-loaded via Symfony's command loader, so each invocation constructs only the dispatched command instead of every command (#2558)
 
 ### Fixed
 

--- a/src/php/Console/CLAUDE.md
+++ b/src/php/Console/CLAUDE.md
@@ -9,7 +9,9 @@ CLI application entry point: bootstraps Symfony Console, registers commands, det
 
 ## CLI Commands
 
-Registered via `ConsoleProvider::COMMANDS` from per-module `ConsoleCommandProviderInterface` impls in `Infrastructure/Command/*Commands.php` (one provider per module: Run, Api, Build, Formatter, Interop, Lint, Lsp, Nrepl, Profile, Watch, plus Framework debug commands). Sibling Command classes are wired via these providers, not via Facade injection.
+Lazy-loaded via `LazyCommandLoader` (`Infrastructure/Command/`), a Symfony `CommandLoaderInterface` that the factory wires onto the application with `setCommandLoader()`. Each per-module `ConsoleCommandProviderInterface` impl in `Infrastructure/Command/*Commands.php` (one provider per module: Run, Api, Build, Formatter, Interop, Lint, Lsp, Nrepl, Profile, Watch, plus Framework debug commands) exposes its commands as `LazyCommand` wrappers carrying name/aliases/description/hidden metadata up front, so only the dispatched command is constructed per invocation while `list`/`help` and alias resolution stay accurate. `ConsoleProvider::LAZY_COMMANDS` aggregates them. Sibling Command classes are wired via these providers, not via Facade injection.
+
+The metadata declared in the providers is drift-guarded by `LazyCommandMetadataTest`, which builds each command and asserts the wrapper matches `configure()`.
 
 ## Dependencies
 

--- a/src/php/Console/ConsoleFactory.php
+++ b/src/php/Console/ConsoleFactory.php
@@ -7,10 +7,12 @@ namespace Phel\Console;
 use Gacela\Framework\AbstractConfig;
 use Gacela\Framework\AbstractFactory;
 use Phel\Console\Application\ArgvInputSanitizer;
+use Phel\Console\Infrastructure\Command\LazyCommandLoader;
 use Phel\Console\Infrastructure\ConsoleBootstrap;
 use Phel\Filesystem\FilesystemFacadeInterface;
 use Phel\Shared\VersionResolver;
-use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LazyCommand;
+use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
 
 /**
  * @extends AbstractFactory<AbstractConfig>
@@ -25,21 +27,18 @@ final class ConsoleFactory extends AbstractFactory
 
     public function createConsoleBootstrap(): ConsoleBootstrap
     {
-        return new ConsoleBootstrap(
+        $bootstrap = new ConsoleBootstrap(
             self::CONSOLE_NAME,
             $this->createVersionResolver()->resolve(),
         );
+        $bootstrap->setCommandLoader($this->createCommandLoader());
+
+        return $bootstrap;
     }
 
-    /**
-     * @return list<Command>
-     */
-    public function getConsoleCommands(): array
+    public function createCommandLoader(): CommandLoaderInterface
     {
-        /** @var list<Command> $commands */
-        $commands = $this->getProvidedDependency(ConsoleProvider::COMMANDS);
-
-        return $commands;
+        return new LazyCommandLoader($this->getLazyCommands());
     }
 
     public function getFilesystemFacade(): FilesystemFacadeInterface
@@ -58,5 +57,16 @@ final class ConsoleFactory extends AbstractFactory
     public function createArgvInputSanitizer(): ArgvInputSanitizer
     {
         return new ArgvInputSanitizer();
+    }
+
+    /**
+     * @return list<LazyCommand>
+     */
+    private function getLazyCommands(): array
+    {
+        /** @var list<LazyCommand> $commands */
+        $commands = $this->getProvidedDependency(ConsoleProvider::LAZY_COMMANDS);
+
+        return $commands;
     }
 }

--- a/src/php/Console/ConsoleProvider.php
+++ b/src/php/Console/ConsoleProvider.php
@@ -20,11 +20,11 @@ use Phel\Console\Infrastructure\Command\ProfileCommands;
 use Phel\Console\Infrastructure\Command\RunCommands;
 use Phel\Console\Infrastructure\Command\WatchCommands;
 use Phel\Filesystem\FilesystemFacade;
-use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LazyCommand;
 
 final class ConsoleProvider extends AbstractProvider
 {
-    public const string COMMANDS = 'COMMANDS';
+    public const string LAZY_COMMANDS = 'LAZY_COMMANDS';
 
     public const string FACADE_FILESYSTEM = 'FACADE_FILESYSTEM';
 
@@ -35,18 +35,22 @@ final class ConsoleProvider extends AbstractProvider
     }
 
     /**
-     * Aggregates every CLI command from the per-module providers listed in
-     * commandProviders(); command order follows that list. Exposed as the
-     * COMMANDS dependency consumed by ConsoleBootstrap.
+     * Aggregates the lazily-instantiated CLI commands from the per-module
+     * providers listed in commandProviders(); command order follows that list.
+     * Exposed as the LAZY_COMMANDS dependency consumed by ConsoleBootstrap to
+     * build the lazy command loader, so only the dispatched command is
+     * instantiated per invocation while list/help metadata stays available.
      *
-     * @return list<Command>
+     * @return list<LazyCommand>
      */
-    #[Provides(self::COMMANDS)]
-    public function commands(): array
+    #[Provides(self::LAZY_COMMANDS)]
+    public function lazyCommands(): array
     {
         $commands = [];
         foreach ($this->commandProviders() as $provider) {
-            array_push($commands, ...$provider->commands());
+            foreach ($provider->lazyCommands() as $command) {
+                $commands[] = $command;
+            }
         }
 
         return $commands;

--- a/src/php/Console/Domain/ConsoleCommandProviderInterface.php
+++ b/src/php/Console/Domain/ConsoleCommandProviderInterface.php
@@ -4,17 +4,19 @@ declare(strict_types=1);
 
 namespace Phel\Console\Domain;
 
-use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LazyCommand;
 
 /**
- * Per-module provider of Symfony Console commands. Each module implements this
- * to expose its own commands; ConsoleProvider aggregates every implementation
- * via its COMMANDS dependency to build the full CLI.
+ * Per-module provider of Symfony Console commands. Each module exposes its
+ * commands as lazily-instantiated {@see LazyCommand} wrappers carrying the
+ * name/aliases/description/hidden metadata up front, so the CLI can render
+ * list/help and resolve aliases without constructing every command;
+ * ConsoleProvider aggregates every implementation into the command loader.
  */
 interface ConsoleCommandProviderInterface
 {
     /**
-     * @return list<Command>
+     * @return list<LazyCommand>
      */
-    public function commands(): array;
+    public function lazyCommands(): array;
 }

--- a/src/php/Console/Infrastructure/Command/ApiCommands.php
+++ b/src/php/Console/Infrastructure/Command/ApiCommands.php
@@ -9,16 +9,17 @@ use Phel\Api\Infrastructure\Command\ApiDaemonCommand;
 use Phel\Api\Infrastructure\Command\DocCommand;
 use Phel\Api\Infrastructure\Command\IndexCommand;
 use Phel\Console\Domain\ConsoleCommandProviderInterface;
+use Symfony\Component\Console\Command\LazyCommand;
 
 final class ApiCommands implements ConsoleCommandProviderInterface
 {
-    public function commands(): array
+    public function lazyCommands(): array
     {
         return [
-            new DocCommand(),
-            new AnalyzeCommand(),
-            new IndexCommand(),
-            new ApiDaemonCommand(),
+            new LazyCommand('doc', [], 'Display the docs for any/all phel functions', false, static fn(): DocCommand => new DocCommand()),
+            new LazyCommand('analyze', [], 'Run semantic analysis on a single Phel source file and emit JSON diagnostics', false, static fn(): AnalyzeCommand => new AnalyzeCommand()),
+            new LazyCommand('index', [], 'Build a project-level symbol index across one or more source directories', false, static fn(): IndexCommand => new IndexCommand()),
+            new LazyCommand('api-daemon', [], 'Long-running JSON-RPC daemon exposing the Api semantic analysis facade over newline-delimited JSON (stdio).', false, static fn(): ApiDaemonCommand => new ApiDaemonCommand()),
         ];
     }
 }

--- a/src/php/Console/Infrastructure/Command/BuildCommands.php
+++ b/src/php/Console/Infrastructure/Command/BuildCommands.php
@@ -7,14 +7,15 @@ namespace Phel\Console\Infrastructure\Command;
 use Phel\Build\Infrastructure\Command\BuildCommand;
 use Phel\Build\Infrastructure\Command\CacheClearCommand;
 use Phel\Console\Domain\ConsoleCommandProviderInterface;
+use Symfony\Component\Console\Command\LazyCommand;
 
 final class BuildCommands implements ConsoleCommandProviderInterface
 {
-    public function commands(): array
+    public function lazyCommands(): array
     {
         return [
-            new BuildCommand(),
-            new CacheClearCommand(),
+            new LazyCommand('build', ['b'], 'Build the current project', false, static fn(): BuildCommand => new BuildCommand()),
+            new LazyCommand('cache:clear', [], 'Clear the temp and cache directories', false, static fn(): CacheClearCommand => new CacheClearCommand()),
         ];
     }
 }

--- a/src/php/Console/Infrastructure/Command/FormatterCommands.php
+++ b/src/php/Console/Infrastructure/Command/FormatterCommands.php
@@ -6,13 +6,14 @@ namespace Phel\Console\Infrastructure\Command;
 
 use Phel\Console\Domain\ConsoleCommandProviderInterface;
 use Phel\Formatter\Infrastructure\Command\FormatCommand;
+use Symfony\Component\Console\Command\LazyCommand;
 
 final class FormatterCommands implements ConsoleCommandProviderInterface
 {
-    public function commands(): array
+    public function lazyCommands(): array
     {
         return [
-            new FormatCommand(),
+            new LazyCommand('format', ['fmt'], 'Formats the given files', false, static fn(): FormatCommand => new FormatCommand()),
         ];
     }
 }

--- a/src/php/Console/Infrastructure/Command/FrameworkCommands.php
+++ b/src/php/Console/Infrastructure/Command/FrameworkCommands.php
@@ -12,19 +12,20 @@ use Gacela\Console\Infrastructure\Command\ListModulesCommand;
 use Gacela\Console\Infrastructure\Command\ProfileReportCommand;
 use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
 use Phel\Console\Domain\ConsoleCommandProviderInterface;
+use Symfony\Component\Console\Command\LazyCommand;
 
 final class FrameworkCommands implements ConsoleCommandProviderInterface
 {
-    public function commands(): array
+    public function lazyCommands(): array
     {
         return [
-            new CacheWarmCommand(),
-            new DebugContainerCommand(),
-            new DebugDependenciesCommand(),
-            new DebugModulesCommand(),
-            new ListModulesCommand(),
-            new ProfileReportCommand(),
-            new ValidateConfigCommand(),
+            new LazyCommand('cache:warm', [], 'Pre-resolve all module classes and warm the cache for production', false, static fn(): CacheWarmCommand => new CacheWarmCommand()),
+            new LazyCommand('debug:container', [], 'Display container debugging information (user bindings and plugins only)', false, static fn(): DebugContainerCommand => new DebugContainerCommand()),
+            new LazyCommand('debug:dependencies', [], 'Show the constructor parameters of a class and their resolvability through the container', false, static fn(): DebugDependenciesCommand => new DebugDependenciesCommand()),
+            new LazyCommand('debug:modules', [], 'Show dependency resolvability of every Gacela module pillar (Facade, Factory, Config, Provider)', false, static fn(): DebugModulesCommand => new DebugModulesCommand()),
+            new LazyCommand('list:modules', [], 'Render all modules found', false, static fn(): ListModulesCommand => new ListModulesCommand()),
+            new LazyCommand('profile:report', [], 'Display performance profiling report', false, static fn(): ProfileReportCommand => new ProfileReportCommand()),
+            new LazyCommand('validate:config', [], 'Validate Gacela configuration for errors and best practices', false, static fn(): ValidateConfigCommand => new ValidateConfigCommand()),
         ];
     }
 }

--- a/src/php/Console/Infrastructure/Command/InteropCommands.php
+++ b/src/php/Console/Infrastructure/Command/InteropCommands.php
@@ -6,13 +6,14 @@ namespace Phel\Console\Infrastructure\Command;
 
 use Phel\Console\Domain\ConsoleCommandProviderInterface;
 use Phel\Interop\Infrastructure\Command\ExportCommand;
+use Symfony\Component\Console\Command\LazyCommand;
 
 final class InteropCommands implements ConsoleCommandProviderInterface
 {
-    public function commands(): array
+    public function lazyCommands(): array
     {
         return [
-            new ExportCommand(),
+            new LazyCommand('export', [], 'Export all definitions with the meta data `{:export true}` as PHP classes', false, static fn(): ExportCommand => new ExportCommand()),
         ];
     }
 }

--- a/src/php/Console/Infrastructure/Command/LazyCommandLoader.php
+++ b/src/php/Console/Infrastructure/Command/LazyCommandLoader.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Infrastructure\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LazyCommand;
+use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
+
+use function array_key_exists;
+use function array_keys;
+use function sprintf;
+
+/**
+ * Symfony command loader backed by {@see LazyCommand} wrappers. Each wrapper
+ * carries name/aliases/description/hidden metadata up front, so list/help
+ * rendering and alias resolution work without constructing a command; the
+ * underlying command is built only when it is actually dispatched. The
+ * dispatched command is therefore the only one instantiated per invocation.
+ */
+final readonly class LazyCommandLoader implements CommandLoaderInterface
+{
+    /** @var array<string, LazyCommand> indexed by canonical name and every alias */
+    private array $commandsByName;
+
+    /**
+     * @param list<LazyCommand> $commands
+     */
+    public function __construct(array $commands)
+    {
+        $index = [];
+        foreach ($commands as $command) {
+            $index[(string) $command->getName()] = $command;
+            foreach ($command->getAliases() as $alias) {
+                $index[$alias] = $command;
+            }
+        }
+
+        $this->commandsByName = $index;
+    }
+
+    public function get(string $name): Command
+    {
+        if (!$this->has($name)) {
+            throw new CommandNotFoundException(sprintf('Command "%s" does not exist.', $name));
+        }
+
+        return $this->commandsByName[$name];
+    }
+
+    public function has(string $name): bool
+    {
+        return array_key_exists($name, $this->commandsByName);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getNames(): array
+    {
+        return array_keys($this->commandsByName);
+    }
+}

--- a/src/php/Console/Infrastructure/Command/LintCommands.php
+++ b/src/php/Console/Infrastructure/Command/LintCommands.php
@@ -6,13 +6,14 @@ namespace Phel\Console\Infrastructure\Command;
 
 use Phel\Console\Domain\ConsoleCommandProviderInterface;
 use Phel\Lint\Infrastructure\Command\LintCommand;
+use Symfony\Component\Console\Command\LazyCommand;
 
 final class LintCommands implements ConsoleCommandProviderInterface
 {
-    public function commands(): array
+    public function lazyCommands(): array
     {
         return [
-            new LintCommand(),
+            new LazyCommand('lint', [], 'Run the semantic linter on one or more Phel files or directories.', false, static fn(): LintCommand => new LintCommand()),
         ];
     }
 }

--- a/src/php/Console/Infrastructure/Command/LspCommands.php
+++ b/src/php/Console/Infrastructure/Command/LspCommands.php
@@ -6,13 +6,14 @@ namespace Phel\Console\Infrastructure\Command;
 
 use Phel\Console\Domain\ConsoleCommandProviderInterface;
 use Phel\Lsp\Infrastructure\Command\LspCommand;
+use Symfony\Component\Console\Command\LazyCommand;
 
 final class LspCommands implements ConsoleCommandProviderInterface
 {
-    public function commands(): array
+    public function lazyCommands(): array
     {
         return [
-            new LspCommand(),
+            new LazyCommand('lsp', [], 'Start the Phel Language Server (LSP v3.17 over stdio, JSON-RPC 2.0 with Content-Length framing).', false, static fn(): LspCommand => new LspCommand()),
         ];
     }
 }

--- a/src/php/Console/Infrastructure/Command/NreplCommands.php
+++ b/src/php/Console/Infrastructure/Command/NreplCommands.php
@@ -6,13 +6,14 @@ namespace Phel\Console\Infrastructure\Command;
 
 use Phel\Console\Domain\ConsoleCommandProviderInterface;
 use Phel\Nrepl\Infrastructure\Command\NreplCommand;
+use Symfony\Component\Console\Command\LazyCommand;
 
 final class NreplCommands implements ConsoleCommandProviderInterface
 {
-    public function commands(): array
+    public function lazyCommands(): array
     {
         return [
-            new NreplCommand(),
+            new LazyCommand('nrepl', [], 'Start an nREPL server for editor tooling (bencode-over-TCP protocol).', false, static fn(): NreplCommand => new NreplCommand()),
         ];
     }
 }

--- a/src/php/Console/Infrastructure/Command/ProfileCommands.php
+++ b/src/php/Console/Infrastructure/Command/ProfileCommands.php
@@ -6,13 +6,14 @@ namespace Phel\Console\Infrastructure\Command;
 
 use Phel\Console\Domain\ConsoleCommandProviderInterface;
 use Phel\Profile\Infrastructure\Command\ProfileCommand;
+use Symfony\Component\Console\Command\LazyCommand;
 
 final class ProfileCommands implements ConsoleCommandProviderInterface
 {
-    public function commands(): array
+    public function lazyCommands(): array
     {
         return [
-            new ProfileCommand(),
+            new LazyCommand('profile', [], 'Profile a Phel script: per-fn call counts and timings, plus compile-time phase costs.', false, static fn(): ProfileCommand => new ProfileCommand()),
         ];
     }
 }

--- a/src/php/Console/Infrastructure/Command/RunCommands.php
+++ b/src/php/Console/Infrastructure/Command/RunCommands.php
@@ -16,23 +16,24 @@ use Phel\Run\Infrastructure\Command\ReplCommand;
 use Phel\Run\Infrastructure\Command\RunCommand;
 use Phel\Run\Infrastructure\Command\TestCommand;
 use Phel\Run\Infrastructure\Command\TestWorkerCommand;
+use Symfony\Component\Console\Command\LazyCommand;
 
 final class RunCommands implements ConsoleCommandProviderInterface
 {
-    public function commands(): array
+    public function lazyCommands(): array
     {
         return [
-            new InitCommand(),
-            new AgentInstallCommand(),
-            new NsCommand(),
-            new ReplCommand(),
-            new EvalCommand(),
-            new CompileCommand(),
-            new RunCommand(),
-            new TestCommand(),
-            new TestWorkerCommand(),
-            new DoctorCommand(),
-            new ConfigCommand(),
+            new LazyCommand('init', [], 'Initialize a new Phel project with minimal configuration', false, static fn(): InitCommand => new InitCommand()),
+            new LazyCommand('agent-install', [], 'Install agent skill files (Claude, Cursor, Codex, Gemini, Copilot, Aider) into the current project', false, static fn(): AgentInstallCommand => new AgentInstallCommand()),
+            new LazyCommand('ns', ['loaded-ns'], 'Display all loaded namespaces or inspect a namespace', false, static fn(): NsCommand => new NsCommand()),
+            new LazyCommand('repl', [], 'Start a Repl', false, static fn(): ReplCommand => new ReplCommand()),
+            new LazyCommand('eval', ['e'], 'Evaluate a Phel expression and print the result', false, static fn(): EvalCommand => new EvalCommand()),
+            new LazyCommand('compile', [], 'Compile a Phel snippet and print the emitted PHP. Does not evaluate.', false, static fn(): CompileCommand => new CompileCommand()),
+            new LazyCommand('run', ['r'], 'Runs a script', false, static fn(): RunCommand => new RunCommand()),
+            new LazyCommand(TestCommand::COMMAND_NAME, ['t'], 'Tests the given files. If no filenames are provided all tests in the "tests" directory are executed', false, static fn(): TestCommand => new TestCommand()),
+            new LazyCommand(TestWorkerCommand::COMMAND_NAME, [], 'Internal: parallel test worker. Not for direct use.', true, static fn(): TestWorkerCommand => new TestWorkerCommand()),
+            new LazyCommand('doctor', [], 'Check system requirements for running the Phel CLI', false, static fn(): DoctorCommand => new DoctorCommand()),
+            new LazyCommand('config', [], 'Show the effective Phel configuration and where it comes from', false, static fn(): ConfigCommand => new ConfigCommand()),
         ];
     }
 }

--- a/src/php/Console/Infrastructure/Command/WatchCommands.php
+++ b/src/php/Console/Infrastructure/Command/WatchCommands.php
@@ -6,13 +6,14 @@ namespace Phel\Console\Infrastructure\Command;
 
 use Phel\Console\Domain\ConsoleCommandProviderInterface;
 use Phel\Watch\Infrastructure\Command\WatchCommand;
+use Symfony\Component\Console\Command\LazyCommand;
 
 final class WatchCommands implements ConsoleCommandProviderInterface
 {
-    public function commands(): array
+    public function lazyCommands(): array
     {
         return [
-            new WatchCommand(),
+            new LazyCommand('watch', [], 'Watch Phel files and reload namespaces on change.', false, static fn(): WatchCommand => new WatchCommand()),
         ];
     }
 }

--- a/src/php/Console/Infrastructure/ConsoleBootstrap.php
+++ b/src/php/Console/Infrastructure/ConsoleBootstrap.php
@@ -10,7 +10,6 @@ use Override;
 use Phel\Console\Application\WarnDeprecationsFlag;
 use Phel\Console\ConsoleFactory;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -58,21 +57,6 @@ final class ConsoleBootstrap extends Application
         $this->getFactory()->getFilesystemFacade()->clearAll();
 
         exit($exitCode);
-    }
-
-    /**
-     * @return array<string,Command>
-     */
-    #[Override]
-    protected function getDefaultCommands(): array
-    {
-        $commands = parent::getDefaultCommands();
-
-        foreach ($this->getFactory()->getConsoleCommands() as $command) {
-            $commands[$command->getName()] = $command;
-        }
-
-        return $commands;
     }
 
     /**

--- a/tests/php/Integration/Console/LazyCommandMetadataTest.php
+++ b/tests/php/Integration/Console/LazyCommandMetadataTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Console;
+
+use Phel;
+use Phel\Console\ConsoleFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\LazyCommand;
+
+use function array_keys;
+use function count;
+use function sort;
+
+/**
+ * Guards that the lazy command loader exposes the same name/alias/description/
+ * hidden metadata that each command declares in its own configure(), so the
+ * list/help output stays accurate without eagerly building every command.
+ */
+final class LazyCommandMetadataTest extends TestCase
+{
+    public function test_lazy_metadata_matches_each_constructed_command(): void
+    {
+        Phel::bootstrap(__DIR__);
+        $loader = new ConsoleFactory()->createCommandLoader();
+
+        $canonicalNames = [];
+        foreach ($loader->getNames() as $name) {
+            $lazy = $loader->get($name);
+            self::assertInstanceOf(LazyCommand::class, $lazy);
+
+            // Reading metadata off the LazyCommand must reflect the wrapped
+            // command once it is finally constructed.
+            $real = $lazy->getCommand();
+
+            self::assertSame($real->getName(), $lazy->getName(), $name . ': name drift');
+            self::assertSame($real->getDescription(), $lazy->getDescription(), $name . ': description drift');
+            self::assertSame($real->getAliases(), $lazy->getAliases(), $name . ': alias drift');
+            self::assertSame($real->isHidden(), $lazy->isHidden(), $name . ': hidden drift');
+
+            $canonicalNames[$lazy->getName()] = true;
+        }
+
+        $names = array_keys($canonicalNames);
+        sort($names);
+
+        self::assertContains('repl', $names, 'default command must be registered');
+        self::assertContains('_test-worker', $names, 'hidden worker command must be registered');
+        self::assertGreaterThan(20, count($names), 'expected the full command surface to be exposed');
+    }
+
+    public function test_default_command_repl_is_resolvable_through_the_loader(): void
+    {
+        Phel::bootstrap(__DIR__);
+        $application = new ConsoleFactory()->createConsoleBootstrap();
+
+        self::assertTrue($application->has('repl'));
+        self::assertSame('repl', $application->find('repl')->getName());
+    }
+}

--- a/tests/php/Unit/Console/Infrastructure/Command/LazyCommandLoaderTest.php
+++ b/tests/php/Unit/Console/Infrastructure/Command/LazyCommandLoaderTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Console\Infrastructure\Command;
+
+use Phel\Console\Infrastructure\Command\LazyCommandLoader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LazyCommand;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
+
+final class LazyCommandLoaderTest extends TestCase
+{
+    public function test_get_constructs_only_the_requested_command(): void
+    {
+        $built = [];
+
+        $loader = new LazyCommandLoader([
+            $this->lazyCommand('alpha', [], static function () use (&$built): Command {
+                $built[] = 'alpha';
+
+                return new Command('alpha');
+            }),
+            $this->lazyCommand('beta', [], static function () use (&$built): Command {
+                $built[] = 'beta';
+
+                return new Command('beta');
+            }),
+        ]);
+
+        $command = $loader->get('alpha');
+        self::assertInstanceOf(LazyCommand::class, $command);
+        self::assertSame('alpha', $command->getName());
+
+        // The underlying command is only constructed when actually used; the
+        // sibling command's factory is never touched.
+        $command->getCommand();
+        self::assertSame(['alpha'], $built, 'only the requested command factory should run');
+    }
+
+    public function test_metadata_is_available_without_constructing_the_command(): void
+    {
+        $built = false;
+
+        $loader = new LazyCommandLoader([
+            $this->lazyCommand('gamma', ['g'], static function () use (&$built): Command {
+                $built = true;
+
+                return new Command('gamma');
+            }, 'Gamma description'),
+        ]);
+
+        $command = $loader->get('gamma');
+
+        self::assertSame('gamma', $command->getName());
+        self::assertSame(['g'], $command->getAliases());
+        self::assertSame('Gamma description', $command->getDescription());
+        self::assertFalse($built, 'reading metadata must not trigger the factory');
+    }
+
+    public function test_has_and_get_resolve_aliases(): void
+    {
+        $loader = new LazyCommandLoader([
+            $this->lazyCommand('delta', ['d', 'dl'], static fn(): Command => new Command('delta')),
+        ]);
+
+        self::assertTrue($loader->has('delta'));
+        self::assertTrue($loader->has('d'));
+        self::assertTrue($loader->has('dl'));
+        self::assertFalse($loader->has('unknown'));
+
+        self::assertSame('delta', $loader->get('d')->getName());
+        self::assertSame('delta', $loader->get('dl')->getName());
+    }
+
+    public function test_get_names_lists_canonical_names_and_aliases(): void
+    {
+        $loader = new LazyCommandLoader([
+            $this->lazyCommand('epsilon', ['e'], static fn(): Command => new Command('epsilon')),
+            $this->lazyCommand('zeta', [], static fn(): Command => new Command('zeta')),
+        ]);
+
+        self::assertSame(['epsilon', 'e', 'zeta'], $loader->getNames());
+    }
+
+    public function test_get_throws_for_unknown_command(): void
+    {
+        $loader = new LazyCommandLoader([]);
+
+        $this->expectException(CommandNotFoundException::class);
+        $loader->get('missing');
+    }
+
+    /**
+     * @param list<string> $aliases
+     */
+    private function lazyCommand(string $name, array $aliases, callable $factory, string $description = ''): LazyCommand
+    {
+        return new LazyCommand($name, $aliases, $description, false, $factory(...));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Every CLI invocation used to instantiate all 11 per-module command-provider groups and ~30+ `Command` objects through `ConsoleProvider::commands()`, even though exactly one command is dispatched. Some of those constructors pull facades, and with OPcache off the unused command classes are also parsed on every run.

## 💡 Goal

Construct only the dispatched command per invocation (plus the metadata `list`/`help` needs), by registering commands lazily through Symfony's `CommandLoaderInterface`.

Closes #2558

## 🔖 Changes

- Added `LazyCommandLoader` (`src/php/Console/Infrastructure/Command/`) implementing Symfony's `CommandLoaderInterface`, backed by `LazyCommand` wrappers indexed by canonical name and every alias.
- Reworked `ConsoleCommandProviderInterface`: each per-module provider (`*Commands.php`) now exposes `lazyCommands(): list<LazyCommand>` carrying name/aliases/description/hidden metadata up front plus a factory closure, instead of returning eagerly-instantiated `Command` objects.
- `ConsoleProvider` aggregates the providers into `LAZY_COMMANDS`; `ConsoleFactory::createConsoleBootstrap()` wires the loader via `setCommandLoader()`. Removed the eager `getDefaultCommands()` override in `ConsoleBootstrap`.
- Metadata lives in the providers, so `list` renders descriptions and aliases without instantiating commands; alias resolution (`r`→`run`, `t`→`test`, `b`→`build`, `e`→`eval`, `fmt`→`format`, `loaded-ns`→`ns`), the default `repl` command, the hidden `_test-worker`, and namespaced commands (`cache:*`, `debug:*`, …) all still resolve through the loader.
- Tests: `LazyCommandLoaderTest` (unit) asserts only the requested command is constructed and that metadata is readable without triggering the factory; `LazyCommandMetadataTest` (integration) drift-guards the declared metadata against each command's own `configure()` and confirms `repl`/`_test-worker` are registered.
- Updated `src/php/Console/CLAUDE.md` and added a `### Performance` entry to `CHANGELOG.md`.

### Benchmark

Command-registration path (`ConsoleFactory::createCommandLoader()` + resolving the dispatched command), 200 iterations, PHP 8.5:

| Path | per invocation |
|---|---|
| Eager (construct all commands, old behaviour) | 0.028 ms |
| Lazy + construct the 1 dispatched command (new) | 0.003 ms |

~89% less command-construction work per run (the dispatched command is the only one built). End-to-end wall-clock of `phel --version` (bootstrap-dominated) with OPcache on: ~94.1 ms → ~92.6 ms over 40 runs. The win grows with OPcache off (unused command classes are no longer parsed) and as the command surface grows. `list`/`help` (rare meta commands) still enumerate every command and therefore build them, which is the intended trade-off.
