### PR TITLE
perf(analyzer): eliminate redundant type-inference body walks in defn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - The analyzer no longer clones the node environment when a context/binding setter is a no-op, cutting allocations on call-heavy code (#2552)
 - `(= x :keyword)` now compiles to a native identity check instead of dispatching through the runtime equality fn (#2561)
 - CLI commands are now lazy-loaded via Symfony's command loader, so each invocation constructs only the dispatched command instead of every command (#2558)
+- A typed `defn` now walks its body twice instead of three times: return-type inference runs once after param tags are grafted instead of also running inline in `FnSymbol` (#2555)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
@@ -22,6 +22,13 @@ final class NodeEnvironment implements NodeEnvironmentInterface
     private bool $globalReference = false;
 
     /**
+     * Set by `DefSymbol` on a `def`-owned single-arity fn so
+     * `FnSymbol::analyzeSingle` skips its inline return-type inference walk;
+     * `DefSymbol` runs that walk once after grafting param tags.
+     */
+    private bool $returnInferenceDeferred = false;
+
+    /**
      * Derived index of $locals keyed by name (first occurrence wins), kept in
      * sync with $locals so lookups are O(1) instead of a linear scan.
      *
@@ -241,6 +248,23 @@ final class NodeEnvironment implements NodeEnvironmentInterface
         $result->boundTo = $boundTo;
 
         return $result;
+    }
+
+    public function withReturnInferenceDeferred(bool $deferred): NodeEnvironmentInterface
+    {
+        if ($this->returnInferenceDeferred === $deferred) {
+            return $this;
+        }
+
+        $result = clone $this;
+        $result->returnInferenceDeferred = $deferred;
+
+        return $result;
+    }
+
+    public function isReturnInferenceDeferred(): bool
+    {
+        return $this->returnInferenceDeferred;
     }
 
     public function getCurrentRecurFrame(): ?RecurFrame

--- a/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironmentInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironmentInterface.php
@@ -63,9 +63,21 @@ interface NodeEnvironmentInterface extends ContextualEnvironmentInterface
 
     public function withBoundTo(string $boundTo): self;
 
+    /**
+     * Marks the env of a `def`-owned single-arity fn whose return-type
+     * inference is deferred to `DefSymbol`. Set so `FnSymbol::analyzeSingle`
+     * skips its inline {@see \Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ReturnTypeInferrer}
+     * walk (one body traversal), letting `DefSymbol` run it once after
+     * param tags are grafted. Anonymous, multi-arity, and nested fns leave
+     * it `false`.
+     */
+    public function withReturnInferenceDeferred(bool $deferred): self;
+
     public function getCurrentRecurFrame(): ?RecurFrame;
 
     public function getBoundTo(): string;
+
+    public function isReturnInferenceDeferred(): bool;
 
     public function useGlobalReference(): bool;
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -304,7 +304,14 @@ final readonly class DefSymbol implements SpecialFormAnalyzerInterface
     ): AbstractNode {
         $initEnv = $env
             ->withExpressionContext()
-            ->withDisallowRecurFrame();
+            ->withDisallowRecurFrame()
+            // A single-arity def fn defers its return-type inference to
+            // `graftInferredParamTags` (run once after param tags are grafted),
+            // so `FnSymbol::analyzeSingle` skips its inline inference walk and
+            // the body is traversed twice instead of three times. `FnSymbol`
+            // clears this flag for nested and multi-arity fns, which keep
+            // inferring their return type inline.
+            ->withReturnInferenceDeferred(true);
 
         // The self-call shortcut keys off boundTo. For memoised defs the
         // wrapper, not the inner fn, must receive recursive calls, so leave
@@ -419,10 +426,17 @@ final readonly class DefSymbol implements SpecialFormAnalyzerInterface
      *
      * Mutates the param Symbols held by `FnNode::$params` in place via
      * `Symbol::withMeta`. The variadic tail and any leading macro
-     * implicit params are excluded. After grafting, re-runs return-type
-     * inference so the body's tail expression sees the now-tagged
-     * locals and the fn surfaces a return-type declaration when it
-     * could not before.
+     * implicit params are excluded.
+     *
+     * This is also where the fn's single return-type inference walk runs:
+     * `FnSymbol::analyzeSingle` defers it (see
+     * {@see NodeEnvironmentInterface::withReturnInferenceDeferred()}) so the
+     * walk happens exactly once here, AFTER param tags are grafted, letting
+     * the body's tail expression see the now-tagged locals. The ordering is
+     * load-bearing: graft first, infer the return type second. The
+     * inference still runs when no param tag is grafted (or there are no
+     * scalar params), because `FnSymbol` skipped its inline walk; a declared
+     * return type is left untouched by `fillInferredReturnType`.
      */
     private function graftInferredParamTags(
         FnNode $fnNode,
@@ -431,43 +445,39 @@ final readonly class DefSymbol implements SpecialFormAnalyzerInterface
         ?string $selfName = null,
     ): void {
         $params = $this->scalarParamSlice($fnNode, $skipFirst);
-        if ($params === []) {
-            return;
-        }
 
-        $inferred = new ParamTypeInferrer()->infer(
-            $fnNode->getBody(),
-            $params,
-            $fnNode->isVariadic(),
-            $selfNamespace,
-            $selfName,
-        );
+        if ($params !== []) {
+            $inferred = new ParamTypeInferrer()->infer(
+                $fnNode->getBody(),
+                $params,
+                $fnNode->isVariadic(),
+                $selfNamespace,
+                $selfName,
+            );
 
-        if ($inferred === []) {
-            return;
-        }
+            foreach ($params as $param) {
+                $tag = $inferred[$param->getName()] ?? null;
+                if ($tag === null) {
+                    continue;
+                }
 
-        $grafted = false;
-        foreach ($params as $param) {
-            $tag = $inferred[$param->getName()] ?? null;
-            if ($tag === null) {
-                continue;
+                $existing = $param->getMeta();
+                if ($existing instanceof PersistentMapInterface
+                    && $existing->find(Keyword::create('tag')) !== null
+                ) {
+                    continue;
+                }
+
+                $merged = ($existing ?? Phel::map())
+                    ->put(Keyword::create('tag'), Symbol::create($tag));
+                $param->withMeta($merged);
             }
-
-            $existing = $param->getMeta();
-            if ($existing instanceof PersistentMapInterface
-                && $existing->find(Keyword::create('tag')) !== null
-            ) {
-                continue;
-            }
-
-            $merged = ($existing ?? Phel::map())
-                ->put(Keyword::create('tag'), Symbol::create($tag));
-            $param->withMeta($merged);
-            $grafted = true;
         }
 
-        if ($grafted && $fnNode->getReturnType() === null) {
+        // Single return-type walk for the def fn, deferred from
+        // `FnSymbol::analyzeSingle`. Runs after grafting so the tail sees the
+        // tagged locals; a no-op when the fn already carries a declared type.
+        if ($fnNode->getReturnType() === null) {
             $fnNode->fillInferredReturnType(
                 new ReturnTypeInferrer()->infer(
                     $fnNode->getBody(),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -65,6 +65,11 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
             throw AnalyzerException::withLocation("Second argument of 'fn must be a vector", $list);
         }
 
+        // Multi-arity defs do not get the deferred-then-grafted single walk
+        // (`DefSymbol::graftInferredParamTags` only runs for single-arity
+        // FnNodes), so each child must keep inferring its return type inline.
+        $childEnv = $env->withReturnInferenceDeferred(false);
+
         $fnNodes = [];
         $hasVariadic = false;
         $count = count($list);
@@ -79,7 +84,7 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
                     Symbol::create(Symbol::NAME_FN)->copyLocationFrom($clause),
                     ...$clause->toArray(),
                 ])->copyLocationFrom($clause),
-                $env,
+                $childEnv,
                 $name,
             );
 
@@ -187,14 +192,23 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
             );
         }
 
-        $returnType = $declaredReturnType
-            ?? $this->returnTypeInferrer->infer(
-                $body,
-                $fnSymbolTuple->params(),
-                $fnSymbolTuple->isVariadic(),
-                $selfNs,
-                $selfNameStr,
-            );
+        // For a `def`-owned single-arity fn the return-type inference is
+        // deferred to `DefSymbol::graftInferredParamTags`, which runs the
+        // single walk after grafting param tags. Skip the inline walk here so
+        // the body is not traversed an extra time; leave the type null for
+        // `DefSymbol` to fill. A declared `:tag` always wins and never defers.
+        if ($declaredReturnType === null && $env->isReturnInferenceDeferred()) {
+            $returnType = null;
+        } else {
+            $returnType = $declaredReturnType
+                ?? $this->returnTypeInferrer->infer(
+                    $body,
+                    $fnSymbolTuple->params(),
+                    $fnSymbolTuple->isVariadic(),
+                    $selfNs,
+                    $selfNameStr,
+                );
+        }
 
         return new FnNode(
             $env,
@@ -314,7 +328,11 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
         $bodyEnv = $env
             ->withMergedLocals($locals)
             ->withReturnContext()
-            ->withAddedRecurFrame($recurFrame);
+            ->withAddedRecurFrame($recurFrame)
+            // The deferral applies only to this fn's own return type; nested
+            // fns inside the body have no grafting step, so they must keep
+            // inferring their return type inline.
+            ->withReturnInferenceDeferred(false);
 
         return $this->analyzer->analyze($body, $bodyEnv);
     }

--- a/tests/php/Integration/Fixtures/Def/defmacro-skips-type-inference.test
+++ b/tests/php/Integration/Fixtures/Def/defmacro-skips-type-inference.test
@@ -1,0 +1,24 @@
+--PHEL--
+(defmacro plus1 [x] `(php/+ ~x 1))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "plus1",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\plus1";
+
+    public function __invoke($_AMPERSAND_form, $_AMPERSAND_env, $x) {
+      static $__phel_call_0, $__phel_call_1, $__phel_call_2, $__phel_call_3;
+      return (\Phel::getDefinition("phel.core", "list"))(...\Phel\Lang\Seq::toApplyArguments(($__phel_call_0 ??= \Phel::getDefinition("phel.core", "concat"))->__invoke(($__phel_call_1 ??= \Phel::getDefinition("phel.core", "list"))->__invoke((\Phel\Lang\Symbol::create("php/+"))), ($__phel_call_2 ??= \Phel::getDefinition("phel.core", "list"))->__invoke($x), ($__phel_call_3 ??= \Phel::getDefinition("phel.core", "list"))->__invoke(1))));
+    }
+  },
+  \Phel::map(
+    \Phel\Lang\Keyword::create("macro"), true,
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(plus1 x)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defmacro-skips-type-inference.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defmacro-skips-type-inference.test", 1, 34),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/defn-multi-arity-infers-return.test
+++ b/tests/php/Integration/Fixtures/Def/defn-multi-arity-infers-return.test
@@ -1,0 +1,38 @@
+--PHEL--
+(defn poly ([a] (php/+ a 1)) ([a b] (php/+ a b)))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "poly",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\poly";
+    private $fn0;
+    private $fn1;
+
+    public function __construct() {
+      $this->fn0 = (function($a) {
+        return ($a + 1);
+      });
+      $this->fn1 = (function($a, $b) {
+        return ($a + $b);
+      });
+    }
+
+    public function __invoke(...$args) {
+      return match (\count($args)) {
+        1 => ($this->fn0)($args[0]),
+        2 => ($this->fn1)($args[0], $args[1]),
+        default => throw new \InvalidArgumentException("No matching function arity"),
+      };
+    }
+  },
+  \Phel::map(
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(poly a)\n(poly a b)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-multi-arity-infers-return.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-multi-arity-infers-return.test", 1, 49),
+    "min-arity", 1,
+    "is-variadic", false,
+    "max-arity", 2,
+    "arglists", "([a] [a b])"
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/defn-no-params-infers-return.test
+++ b/tests/php/Integration/Fixtures/Def/defn-no-params-infers-return.test
@@ -1,0 +1,23 @@
+--PHEL--
+(defn two [] (php/+ 1 1))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "two",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\two";
+
+    public function __invoke(): int {
+      return (1 + 1);
+    }
+  },
+  \Phel::map(
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(two)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-no-params-infers-return.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-no-params-infers-return.test", 1, 25),
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/defn-return-from-grafted-params.test
+++ b/tests/php/Integration/Fixtures/Def/defn-return-from-grafted-params.test
@@ -1,0 +1,23 @@
+--PHEL--
+(defn add2 [a b] (php/+ (php/+ a b) 0))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "add2",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\add2";
+
+    public function __invoke(int $a, int $b): int {
+      return (($a + $b) + 0);
+    }
+  },
+  \Phel::map(
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add2 a b)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-return-from-grafted-params.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-return-from-grafted-params.test", 1, 39),
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[a b]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/defn-untagged-param-infers-return.test
+++ b/tests/php/Integration/Fixtures/Def/defn-untagged-param-infers-return.test
@@ -1,0 +1,23 @@
+--PHEL--
+(defn const-two [x] (php/+ 1 1))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "const-two",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\const_two";
+
+    public function __invoke($x): int {
+      return (1 + 1);
+    }
+  },
+  \Phel::map(
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(const-two x)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-untagged-param-infers-return.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-untagged-param-infers-return.test", 1, 32),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
+);

--- a/tests/php/Unit/Compiler/Analyzer/Environment/NodeEnvironmentTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/NodeEnvironmentTest.php
@@ -154,4 +154,28 @@ final class NodeEnvironmentTest extends TestCase
         self::assertSame('user\\foo', $next->getBoundTo());
         self::assertSame('', $env->getBoundTo());
     }
+
+    public function test_return_inference_deferred_defaults_to_false(): void
+    {
+        $env = NodeEnvironment::empty();
+
+        self::assertFalse($env->isReturnInferenceDeferred());
+    }
+
+    public function test_with_return_inference_deferred_returns_same_instance_when_unchanged(): void
+    {
+        $env = NodeEnvironment::empty();
+
+        self::assertSame($env, $env->withReturnInferenceDeferred(false));
+    }
+
+    public function test_with_return_inference_deferred_returns_new_instance_when_changed(): void
+    {
+        $env = NodeEnvironment::empty();
+        $next = $env->withReturnInferenceDeferred(true);
+
+        self::assertNotSame($env, $next);
+        self::assertTrue($next->isReturnInferenceDeferred());
+        self::assertFalse($env->isReturnInferenceDeferred());
+    }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
@@ -121,6 +121,7 @@ final class DefSymbolTest extends TestCase
                     $env
                         ->withExpressionContext()
                         ->withDisallowRecurFrame()
+                        ->withReturnInferenceDeferred(true)
                         ->withBoundTo('user\name'),
                     'any value',
                 ),
@@ -162,6 +163,7 @@ final class DefSymbolTest extends TestCase
                     $env
                         ->withExpressionContext()
                         ->withDisallowRecurFrame()
+                        ->withReturnInferenceDeferred(true)
                         ->withBoundTo('user\name'),
                     'any value',
                 ),
@@ -203,6 +205,7 @@ final class DefSymbolTest extends TestCase
                     $env
                         ->withExpressionContext()
                         ->withDisallowRecurFrame()
+                        ->withReturnInferenceDeferred(true)
                         ->withBoundTo('user\name'),
                     'any value',
                 ),
@@ -283,6 +286,7 @@ final class DefSymbolTest extends TestCase
                     $env
                         ->withExpressionContext()
                         ->withDisallowRecurFrame()
+                        ->withReturnInferenceDeferred(true)
                         ->withBoundTo('user\name'),
                     'any value',
                 ),


### PR DESCRIPTION
## 🤔 Background

A non-macro `defn` body was walked **three times** by the type inferrers:

1. `FnSymbol::analyzeSingle` ran `ReturnTypeInferrer::infer` (full body descent).
2. `DefSymbol::graftInferredParamTags` ran `ParamTypeInferrer::infer` (another full descent).
3. If a param tag was grafted and no return type was set, it re-ran `ReturnTypeInferrer::infer` (a third descent).

So a tagged `defn` body was traversed 3×, even though the final return walk only needs to run once — after the param tags are grafted — so the body's tail expression sees the now-tagged locals.

Closes #2555

## 💡 Goal

Run return-type inference **once** per `defn`, after param tags are grafted, so a tagged `defn` body is walked twice (one param walk + one return walk) instead of three times. No behavioral change: param tags and return tags stay byte-identical to before.

## 🔖 Changes

- Added a `NodeEnvironment` marker `withReturnInferenceDeferred(bool)` / `isReturnInferenceDeferred()`. `DefSymbol::analyzeInit` sets it on the init env so a `def`-owned single-arity fn signals that its return inference is deferred.
- `FnSymbol::analyzeSingle` skips its inline `ReturnTypeInferrer` walk when the flag is set and no return type is declared (leaving the type `null` for `DefSymbol` to fill). A declared `:tag` always wins and never defers.
- `DefSymbol::graftInferredParamTags` now runs the single `ReturnTypeInferrer` walk once, **after** grafting param tags (preserving the documented ordering), and runs it on the ungrafted/no-scalar-param paths too — because `FnSymbol` skipped its inline walk. `FnNode::fillInferredReturnType` keeps a declared return type untouched.
- `FnSymbol` clears the flag for **multi-arity** children (they have no grafting step — `DefSymbol::graftInferredParamTags` only runs for single-arity `FnNode`s) and for **nested** fns inside a body (cleared in `analyzeBody`), so both keep inferring their return type inline exactly as before.
- Anonymous `fn`s (no `def`) never get the flag, so their single `FnSymbol` return inference is unchanged.

### Tests

- New `NodeEnvironmentTest` cases for the marker (default false, immutability, no-op short-circuit).
- Updated `DefSymbolTest` expected init-node env to include the new flag.
- New integration fixtures guarding the semantics:
  - `defn-return-from-grafted-params.test` — return type depends on two grafted param tags (graft-before-infer ordering).
  - `defn-no-params-infers-return.test` — no params, return still inferred (regression guard for the ungrafted path).
  - `defn-untagged-param-infers-return.test` — param present but untagged, return still inferred.
  - `defn-multi-arity-infers-return.test` — multi-arity defn keeps its per-child inline inference.
  - `defmacro-skips-type-inference.test` — macro `defn` skips inference entirely.
- All existing type-inference fixtures stay green; compiled output verified byte-identical against the base for every case (param-tag and return-tag emission unchanged).

### Benchmark

`tests/php/Benchmark/Compiler/TypeInferenceBench.php` (~50 arithmetic/collection `defn`s, param + return tags inferred):

| | mode |
|---|---|
| baseline | 24.285ms |
| this branch | 22.816ms |
| **delta** | **-6.05%** (±1.84%) |
