### PR TITLE
perf(lang): identity short-circuit in Symbol equals/identical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - CLI commands are now lazy-loaded via Symfony's command loader, so each invocation constructs only the dispatched command instead of every command (#2558)
 - A typed `defn` now walks its body twice instead of three times: return-type inference runs once after param tags are grafted instead of also running inline in `FnSymbol` (#2555)
 - The REPL now loads only `phel.core` (plus the startup namespace's requires) at boot; other bundled `phel.*` modules load lazily on first reference, cutting time-to-prompt by ~34% (#2559)
+- `Symbol` equality short-circuits on identity and compares its backing fields directly instead of through getters, speeding up the symbol comparisons that dominate compiler environment lookups (#2551)
 
 ### Fixed
 

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -209,9 +209,14 @@ final class Symbol extends AbstractType implements IdenticalInterface, FnInterfa
 
     public function equals(mixed $other): bool
     {
-        return $other instanceof self
-            && $this->name === $other->getName()
-            && $this->namespace === $other->getNamespace();
+        // Identity is sufficient (but not necessary): Symbols are not interned
+        // (each carries a per-occurrence source location), so two value-equal
+        // Symbols may be distinct instances. The `===` true case is a correct
+        // shortcut; the false case falls through to direct field comparison.
+        return $this === $other
+            || ($other instanceof self
+                && $this->name === $other->name
+                && $this->namespace === $other->namespace);
     }
 
     public function identical(mixed $other): bool

--- a/tests/php/Benchmark/Lang/SymbolBench.php
+++ b/tests/php/Benchmark/Lang/SymbolBench.php
@@ -21,9 +21,12 @@ final class SymbolBench
 {
     private Symbol $symbol;
 
+    private Symbol $valueEqual;
+
     public function setUp(): void
     {
         $this->symbol = Symbol::createForNamespace('phel\\core', 'map-indexed');
+        $this->valueEqual = Symbol::createForNamespace('phel\\core', 'map-indexed');
     }
 
     /**
@@ -38,6 +41,29 @@ final class SymbolBench
         $symbol = $this->symbol;
         for ($i = 0; $i < 16; ++$i) {
             $symbol->hash();
+        }
+    }
+
+    /**
+     * `Symbol::equals()` micro-benchmark.
+     *
+     * Environment lookups compare a symbol against itself (identity fast
+     * path) and against distinct, value-equal instances (field comparison).
+     * Both branches are exercised here.
+     *
+     * @Revs(100000)
+     *
+     * @Iterations(5)
+     *
+     * @BeforeMethods("setUp")
+     */
+    public function bench_equals(): void
+    {
+        $symbol = $this->symbol;
+        $valueEqual = $this->valueEqual;
+        for ($i = 0; $i < 16; ++$i) {
+            $symbol->equals($symbol);
+            $symbol->equals($valueEqual);
         }
     }
 }

--- a/tests/php/Unit/Lang/SymbolTest.php
+++ b/tests/php/Unit/Lang/SymbolTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Lang;
 
+use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use PHPUnit\Framework\TestCase;
 
@@ -94,5 +95,72 @@ final class SymbolTest extends TestCase
         $this->assertFalse($s3->identical($s1));
         $this->assertFalse($s1->identical($s4));
         $this->assertFalse($s4->identical($s1));
+    }
+
+    public function test_equals_same_instance(): void
+    {
+        $s = Symbol::createForNamespace('namespace', 'test');
+
+        $this->assertTrue($s->equals($s));
+        $this->assertTrue($s->identical($s));
+    }
+
+    public function test_equals_distinct_value_equal_instances(): void
+    {
+        $s1 = Symbol::createForNamespace('namespace', 'test');
+        $s2 = Symbol::createForNamespace('namespace', 'test');
+
+        $this->assertNotSame($s1, $s2);
+        $this->assertTrue($s1->equals($s2));
+        $this->assertTrue($s2->equals($s1));
+    }
+
+    public function test_equals_differing_name(): void
+    {
+        $s1 = Symbol::createForNamespace('namespace', 'test');
+        $s2 = Symbol::createForNamespace('namespace', 'other');
+
+        $this->assertFalse($s1->equals($s2));
+        $this->assertFalse($s2->equals($s1));
+    }
+
+    public function test_equals_differing_namespace(): void
+    {
+        $s1 = Symbol::createForNamespace('namespace', 'test');
+        $s2 = Symbol::createForNamespace('other', 'test');
+
+        $this->assertFalse($s1->equals($s2));
+        $this->assertFalse($s2->equals($s1));
+    }
+
+    public function test_equals_null_namespace_vs_set_namespace(): void
+    {
+        $s1 = Symbol::createForNamespace(null, 'test');
+        $s2 = Symbol::createForNamespace('namespace', 'test');
+
+        $this->assertFalse($s1->equals($s2));
+        $this->assertFalse($s2->equals($s1));
+    }
+
+    public function test_equals_non_symbol_argument(): void
+    {
+        $s = Symbol::createForNamespace('namespace', 'test');
+
+        $this->assertFalse($s->equals('namespace/test'));
+        $this->assertFalse($s->equals(null));
+    }
+
+    public function test_value_equal_symbols_keep_independent_source_locations(): void
+    {
+        $s1 = Symbol::createForNamespace('namespace', 'test');
+        $s2 = Symbol::createForNamespace('namespace', 'test');
+
+        $s1->setStartLocation(new SourceLocation('a.phel', 1, 0));
+        $s2->setStartLocation(new SourceLocation('b.phel', 2, 4));
+
+        $this->assertTrue($s1->equals($s2));
+        $this->assertNotSame($s1->getStartLocation(), $s2->getStartLocation());
+        $this->assertSame('a.phel', $s1->getStartLocation()?->getFile());
+        $this->assertSame('b.phel', $s2->getStartLocation()?->getFile());
     }
 }


### PR DESCRIPTION
## 🤔 Background

`Symbol::equals()` always performed two string comparisons through getter dispatch (`$other->getName()`, `$other->getNamespace()`), with no `$this === $other` fast path, and `identical()` just delegates to it. Symbol equality is hot during analysis (local/global resolution, environment lookups), so the per-call dispatch overhead adds up.

Symbols are **not** interned (each carries a per-occurrence, mutable `SourceLocation` and meta), so `$this === $other` can be `false` for two value-equal symbols. The identity check is therefore an *additional* fast path, not a replacement: the `===` true case is a correct shortcut (same object ⇒ equal), and the false case still falls through to the field comparison.

Closes #2551

## 💡 Goal

Return `true` immediately when comparing a symbol to itself, and otherwise compare the `name`/`namespace` backing fields directly (no getter dispatch), without changing equality semantics or Symbol identity/allocation.

## 🔖 Changes

- `src/php/Lang/Symbol.php`: `equals()` now short-circuits on `$this === $other`, then compares `$this->name`/`$this->namespace` against `$other->name`/`$other->namespace` directly. `identical()` keeps delegating to `equals()`. The `$other instanceof self` guard is retained so non-Symbol args still return `false`. No interning introduced; source locations stay per-occurrence.
- `tests/php/Unit/Lang/SymbolTest.php`: added focused cases — self-equality (`equals`/`identical`), two distinct value-equal instances, differing name, differing namespace, null-namespace vs set-namespace, non-Symbol argument, and source-location independence of two value-equal symbols.
- `tests/php/Benchmark/Lang/SymbolBench.php`: added `bench_equals` exercising both the identity fast path and the distinct-instance field comparison.
- `CHANGELOG.md`: one line under `## Unreleased -> ### Performance`.

### Benchmark

`SymbolBench::bench_equals`, `--revs=100000 --its=5`, xdebug/opcache off:

| subject | baseline (main) | this branch | delta |
|---|---|---|---|
| `bench_equals` | 1.224us | 0.601us | **-50.9%** |

(`bench_repeated_hash` is unchanged code; its reported delta is run-to-run variance.)

### Gate

`composer test` -> green: Passed: 6098, Failed: 0, Error: 0 (plus cs-fixer / psalm / phpstan / rector clean).
