### PR TITLE
perf(emitter): dedup keyword constant slots by value within a function scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - The REPL now loads only `phel.core` (plus the startup namespace's requires) at boot; other bundled `phel.*` modules load lazily on first reference, cutting time-to-prompt by ~34% (#2559)
 - `Symbol` equality short-circuits on identity and compares its backing fields directly instead of through getters, speeding up the symbol comparisons that dominate compiler environment lookups (#2551)
 - The directory-scan namespace index is now persisted across runs, so warm invocations skip re-walking the source tree (and its per-file `filemtime` sweep) when nothing changed; per-file mtimes plus a directory mtime + file-count check keep it from ever serving stale namespace info (#2560)
+- Repeating the same keyword (or scalar) literal in a function body now shares one cached `static` slot instead of one per occurrence, shrinking generated PHP and the closure capture list (#2564)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/ConstantScope.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/ConstantScope.php
@@ -5,7 +5,15 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\Cache;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Lang\Keyword;
 use SplObjectStorage;
+
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_string;
+use function var_export;
 
 /**
  * Per-fn-body scope tracking which nodes will be hoisted to a `static` PHP
@@ -19,6 +27,14 @@ use SplObjectStorage;
  *
  * Counters and lookups are independent so the emitter can render distinct
  * `static $__phel_const_*` and `static $__phel_call_*` declarations.
+ *
+ * Constant slots dedup cacheable scalar/keyword literals **by value**: since
+ * keywords are interned singletons (and scalars immutable), every occurrence
+ * of the same value collapses to a single shared slot — one `??=` guard and
+ * one `use (&...)` capture entry. Collection literals stay identity-keyed
+ * (their construction is not a cheap interned singleton). The per-node map
+ * still points every collapsed node at the shared slot, so the emitter
+ * resolves slots by node as before and never references an uncaptured slot.
  */
 final class ConstantScope
 {
@@ -27,6 +43,13 @@ final class ConstantScope
 
     /** @var SplObjectStorage<AbstractNode, int> */
     private SplObjectStorage $callSlots;
+
+    /**
+     * Value key (for dedup-by-value literals) → shared slot id.
+     *
+     * @var array<string, int>
+     */
+    private array $valueSlots = [];
 
     private int $nextConstId = 0;
 
@@ -40,13 +63,27 @@ final class ConstantScope
 
     public function reserve(AbstractNode $node): int
     {
-        if (!$this->constSlots->offsetExists($node)) {
-            $this->constSlots[$node] = $this->nextConstId++;
+        if ($this->constSlots->offsetExists($node)) {
+            /** @var int $existing */
+            $existing = $this->constSlots[$node];
+            return $existing;
         }
 
-        /** @var int $id */
-        $id = $this->constSlots[$node];
-        return $id;
+        $valueKey = $this->valueKey($node);
+        if ($valueKey !== null) {
+            // Cacheable scalar/keyword literal: dedup by value. Reuse the
+            // shared slot if this value was already reserved, otherwise
+            // allocate one. Either way the per-node map records the shared
+            // slot so `lookup($node)` resolves every occurrence to it and the
+            // emitter never references an uncaptured slot.
+            $slot = $this->valueSlots[$valueKey] ??= $this->nextConstId++;
+            $this->constSlots[$node] = $slot;
+
+            return $slot;
+        }
+
+        $this->constSlots[$node] = $this->nextConstId++;
+        return $this->constSlots[$node];
     }
 
     public function lookup(AbstractNode $node): ?int
@@ -90,5 +127,51 @@ final class ConstantScope
     public function callSlotCount(): int
     {
         return $this->nextCallId;
+    }
+
+    /**
+     * Stable value key for a cacheable scalar/keyword literal, or `null` for
+     * any node that must stay identity-keyed (collections, symbols, numeric
+     * value types, etc.). Type-tagged so `1` (int) and `"1"` (string) never
+     * collide, and keywords never collide with a same-named string.
+     */
+    private function valueKey(AbstractNode $node): ?string
+    {
+        if (!$node instanceof LiteralNode) {
+            return null;
+        }
+
+        $value = $node->getValue();
+
+        if ($value instanceof Keyword) {
+            $namespace = $value->getNamespace();
+            return $namespace !== null
+                ? 'kw:' . $namespace . '/' . $value->getName()
+                : 'kw:' . $value->getName();
+        }
+
+        if (is_string($value)) {
+            return 'str:' . $value;
+        }
+
+        if (is_int($value)) {
+            return 'int:' . $value;
+        }
+
+        if (is_float($value)) {
+            // `var_export` round-trips a float deterministically (NAN/INF
+            // included), so distinct floats never share a slot key.
+            return 'float:' . var_export($value, true);
+        }
+
+        if (is_bool($value)) {
+            return 'bool:' . ($value ? '1' : '0');
+        }
+
+        if ($value === null) {
+            return 'nil';
+        }
+
+        return null;
     }
 }

--- a/tests/php/Benchmark/Compiler/KeywordSlotDedupBench.php
+++ b/tests/php/Benchmark/Compiler/KeywordSlotDedupBench.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler;
+
+use Phel;
+use Phel\Compiler\CompilerFacade;
+use Phel\Shared\CompileOptions;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+
+use function implode;
+use function str_repeat;
+
+/**
+ * Compile-path benchmark for the constant-slot dedup (issue #2564).
+ *
+ * Compiles a fn body that repeats the *same* keyword many times. Before
+ * the dedup, each occurrence reserved its own `$__phel_const_N` slot (so N
+ * `??=` guards, N `use (&...)` capture entries, N `static` declarations);
+ * after the dedup all occurrences of the same keyword collapse to one slot.
+ *
+ * `bench_compile_repeated_keyword` stresses the collapsing path (one
+ * keyword repeated `OCCURRENCES` times); `bench_compile_distinct_keywords`
+ * is the control (distinct keywords keep distinct slots, so emitter work is
+ * unchanged). The delta between the two isolates the dedup bookkeeping.
+ *
+ * @BeforeMethods("setUp")
+ */
+final class KeywordSlotDedupBench
+{
+    private const int OCCURRENCES = 64;
+
+    private CompilerFacade $compilerFacade;
+
+    private string $repeatedKeywordSource = '';
+
+    private string $distinctKeywordsSource = '';
+
+    public function setUp(): void
+    {
+        Phel::bootstrap(__DIR__ . '/../../../../');
+
+        $this->compilerFacade = new CompilerFacade();
+        $this->repeatedKeywordSource = $this->buildRepeatedKeywordSource();
+        $this->distinctKeywordsSource = $this->buildDistinctKeywordsSource();
+    }
+
+    /**
+     * @Revs(50)
+     *
+     * @Iterations(5)
+     *
+     * @Warmup(1)
+     */
+    public function bench_compile_repeated_keyword(): void
+    {
+        $this->compilerFacade->compile($this->repeatedKeywordSource, new CompileOptions());
+    }
+
+    /**
+     * @Revs(50)
+     *
+     * @Iterations(5)
+     *
+     * @Warmup(1)
+     */
+    public function bench_compile_distinct_keywords(): void
+    {
+        $this->compilerFacade->compile($this->distinctKeywordsSource, new CompileOptions());
+    }
+
+    private function buildRepeatedKeywordSource(): string
+    {
+        // (fn [m] [(:k m) (:k m) ...]) — same keyword OCCURRENCES times.
+        $accessor = '(:k m)';
+        $body = str_repeat($accessor . ' ', self::OCCURRENCES);
+
+        return '(fn [m] [' . $body . '])';
+    }
+
+    private function buildDistinctKeywordsSource(): string
+    {
+        // (fn [m] [(:k0 m) (:k1 m) ...]) — distinct keywords, no dedup.
+        $accessors = [];
+        for ($i = 0; $i < self::OCCURRENCES; ++$i) {
+            $accessors[] = '(:k' . $i . ' m)';
+        }
+
+        return '(fn [m] [' . implode(' ', $accessors) . '])';
+    }
+}

--- a/tests/php/Integration/Compiler/ConstantHoistingRuntimeTest.php
+++ b/tests/php/Integration/Compiler/ConstantHoistingRuntimeTest.php
@@ -9,6 +9,8 @@ use Phel\Build\BuildFacade;
 use Phel\Compiler\CompilerFacade;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use Phel\Shared\CompileOptions;
 use PHPUnit\Framework\TestCase;
@@ -99,6 +101,38 @@ final class ConstantHoistingRuntimeTest extends TestCase
         $second = $fn(42);
 
         self::assertSame($first, $second);
+    }
+
+    public function test_repeated_keyword_dedups_to_one_slot_without_changing_runtime(): void
+    {
+        // `:k` appears three times in the body. The slots dedup to a single
+        // `$__phel_const_0`, but the runtime result must be unchanged: each
+        // keyword accessor still reads the right value from the map.
+        $php = $this->compilerFacade
+            ->compile('(fn [m] [(:k m) (:k m) (:k m)])', new CompileOptions())
+            ->getPhpCode();
+
+        self::assertStringContainsString('static $__phel_const_0;', $php);
+        self::assertStringNotContainsString('$__phel_const_1', $php);
+
+        /** @var callable $fn */
+        $fn = $this->compilerFacade->eval('(fn [m] [(:k m) (:k m) (:k m)])', new CompileOptions());
+        /** @var PersistentVectorInterface $result */
+        $result = $fn(Phel::map(Keyword::create('k'), 7));
+
+        self::assertSame(7, $result[0]);
+        self::assertSame(7, $result[1]);
+        self::assertSame(7, $result[2]);
+    }
+
+    public function test_distinct_keywords_keep_distinct_slots(): void
+    {
+        $php = $this->compilerFacade
+            ->compile('(fn [m] [(:a m) (:b m) (:a m)])', new CompileOptions())
+            ->getPhpCode();
+
+        self::assertStringContainsString('static $__phel_const_0, $__phel_const_1;', $php);
+        self::assertStringNotContainsString('$__phel_const_2', $php);
     }
 
     public function test_nested_fn_has_independent_static_scope(): void

--- a/tests/php/Integration/Fixtures/Call/assoc-conj-dissoc-typed.test
+++ b/tests/php/Integration/Fixtures/Call/assoc-conj-dissoc-typed.test
@@ -4,6 +4,6 @@
   [(assoc m :k 1) (conj v 99) (dissoc m :k)])
 --PHP--
 (function(\Phel\Lang\Collections\Map\PersistentMapInterface $m, \Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
-  static $__phel_const_0, $__phel_const_1;
-  return \Phel::vector([($m->put(($__phel_const_0 ??= \Phel\Lang\Keyword::create("k")), 1)), ($v->append(99)), ($m->remove(($__phel_const_1 ??= \Phel\Lang\Keyword::create("k"))))]);
+  static $__phel_const_0;
+  return \Phel::vector([($m->put(($__phel_const_0 ??= \Phel\Lang\Keyword::create("k")), 1)), ($v->append(99)), ($m->remove(($__phel_const_0 ??= \Phel\Lang\Keyword::create("k"))))]);
 });

--- a/tests/php/Integration/Fixtures/Call/dissoc-variadic-typed.test
+++ b/tests/php/Integration/Fixtures/Call/dissoc-variadic-typed.test
@@ -3,6 +3,6 @@
   [(dissoc m :a) (dissoc m :a :b) (dissoc m :a :b :c)])
 --PHP--
 (function(\Phel\Lang\Collections\Map\PersistentMapInterface $m) {
-  static $__phel_const_0, $__phel_const_1, $__phel_const_2, $__phel_const_3, $__phel_const_4, $__phel_const_5;
-  return \Phel::vector([($m->remove(($__phel_const_0 ??= \Phel\Lang\Keyword::create("a")))), ($m->remove(($__phel_const_1 ??= \Phel\Lang\Keyword::create("a")))->remove(($__phel_const_2 ??= \Phel\Lang\Keyword::create("b")))), ($m->remove(($__phel_const_3 ??= \Phel\Lang\Keyword::create("a")))->remove(($__phel_const_4 ??= \Phel\Lang\Keyword::create("b")))->remove(($__phel_const_5 ??= \Phel\Lang\Keyword::create("c"))))]);
+  static $__phel_const_0, $__phel_const_1, $__phel_const_2;
+  return \Phel::vector([($m->remove(($__phel_const_0 ??= \Phel\Lang\Keyword::create("a")))), ($m->remove(($__phel_const_0 ??= \Phel\Lang\Keyword::create("a")))->remove(($__phel_const_1 ??= \Phel\Lang\Keyword::create("b")))), ($m->remove(($__phel_const_0 ??= \Phel\Lang\Keyword::create("a")))->remove(($__phel_const_1 ??= \Phel\Lang\Keyword::create("b")))->remove(($__phel_const_2 ??= \Phel\Lang\Keyword::create("c"))))]);
 });

--- a/tests/php/Integration/Fixtures/ConstantHoisting/collection-repeated-stays-identity-keyed.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/collection-repeated-stays-identity-keyed.test
@@ -1,0 +1,12 @@
+--PHEL--
+(fn [b] (if b [1 2] [1 2]))
+--PHP--
+(function($b) {
+  static $__phel_const_0, $__phel_const_1;
+  if (($__truthy = $b) !== null && $__truthy !== false) {
+    return ($__phel_const_0 ??= \Phel::vector([1, 2]));
+  } else {
+    return ($__phel_const_1 ??= \Phel::vector([1, 2]));
+  }
+
+});

--- a/tests/php/Integration/Fixtures/ConstantHoisting/keyword-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/keyword-in-fn-body.test
@@ -2,6 +2,6 @@
 (fn [m] [(:foo m) (:foo m) (:bar m)])
 --PHP--
 (function($m) {
-  static $__phel_const_0, $__phel_const_1, $__phel_const_2;
-  return \Phel::vector([(($__phel_const_0 ??= \Phel\Lang\Keyword::create("foo")))($m), (($__phel_const_1 ??= \Phel\Lang\Keyword::create("foo")))($m), (($__phel_const_2 ??= \Phel\Lang\Keyword::create("bar")))($m)]);
+  static $__phel_const_0, $__phel_const_1;
+  return \Phel::vector([(($__phel_const_0 ??= \Phel\Lang\Keyword::create("foo")))($m), (($__phel_const_0 ??= \Phel\Lang\Keyword::create("foo")))($m), (($__phel_const_1 ??= \Phel\Lang\Keyword::create("bar")))($m)]);
 });

--- a/tests/php/Integration/Fixtures/ConstantHoisting/keyword-repeated-thrice.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/keyword-repeated-thrice.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [m] [(:status m) (:status m) (:status m)])
+--PHP--
+(function($m) {
+  static $__phel_const_0;
+  return \Phel::vector([(($__phel_const_0 ??= \Phel\Lang\Keyword::create("status")))($m), (($__phel_const_0 ??= \Phel\Lang\Keyword::create("status")))($m), (($__phel_const_0 ??= \Phel\Lang\Keyword::create("status")))($m)]);
+});

--- a/tests/php/Integration/Fixtures/ConstantHoisting/keyword-two-distinct-deduped.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/keyword-two-distinct-deduped.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [m] [(:a m) (:b m) (:a m) (:b m)])
+--PHP--
+(function($m) {
+  static $__phel_const_0, $__phel_const_1;
+  return \Phel::vector([(($__phel_const_0 ??= \Phel\Lang\Keyword::create("a")))($m), (($__phel_const_1 ??= \Phel\Lang\Keyword::create("b")))($m), (($__phel_const_0 ??= \Phel\Lang\Keyword::create("a")))($m), (($__phel_const_1 ??= \Phel\Lang\Keyword::create("b")))($m)]);
+});

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/ConstantScopeTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/ConstantScopeTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\ConstantHoisting;
 
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\ConstantScope;
+use Phel\Lang\Keyword;
 use PHPUnit\Framework\TestCase;
 
 final class ConstantScopeTest extends TestCase
@@ -53,5 +55,77 @@ final class ConstantScopeTest extends TestCase
         $scope->reserve($node);
 
         self::assertSame(0, $scope->lookup($node));
+    }
+
+    public function test_same_keyword_value_shares_one_slot(): void
+    {
+        $scope = new ConstantScope();
+        $first = new LiteralNode(NodeEnvironment::empty(), Keyword::create('foo'));
+        $second = new LiteralNode(NodeEnvironment::empty(), Keyword::create('foo'));
+
+        self::assertSame(0, $scope->reserve($first));
+        self::assertSame(0, $scope->reserve($second));
+        self::assertSame(0, $scope->lookup($first));
+        self::assertSame(0, $scope->lookup($second));
+        self::assertSame(1, $scope->count());
+    }
+
+    public function test_distinct_keywords_get_distinct_slots(): void
+    {
+        $scope = new ConstantScope();
+        $a = new LiteralNode(NodeEnvironment::empty(), Keyword::create('a'));
+        $b = new LiteralNode(NodeEnvironment::empty(), Keyword::create('b'));
+
+        self::assertSame(0, $scope->reserve($a));
+        self::assertSame(1, $scope->reserve($b));
+        self::assertSame(2, $scope->count());
+    }
+
+    public function test_namespaced_keyword_does_not_collide_with_bare_name(): void
+    {
+        $scope = new ConstantScope();
+        $bare = new LiteralNode(NodeEnvironment::empty(), Keyword::create('foo'));
+        $namespaced = new LiteralNode(NodeEnvironment::empty(), Keyword::create('foo', 'my-ns'));
+
+        self::assertSame(0, $scope->reserve($bare));
+        self::assertSame(1, $scope->reserve($namespaced));
+        self::assertSame(2, $scope->count());
+    }
+
+    public function test_same_scalar_value_shares_one_slot(): void
+    {
+        $scope = new ConstantScope();
+        $first = new LiteralNode(NodeEnvironment::empty(), 42);
+        $second = new LiteralNode(NodeEnvironment::empty(), 42);
+
+        self::assertSame(0, $scope->reserve($first));
+        self::assertSame(0, $scope->reserve($second));
+        self::assertSame(1, $scope->count());
+    }
+
+    public function test_int_and_same_looking_string_do_not_collide(): void
+    {
+        $scope = new ConstantScope();
+        $int = new LiteralNode(NodeEnvironment::empty(), 1);
+        $string = new LiteralNode(NodeEnvironment::empty(), '1');
+
+        self::assertSame(0, $scope->reserve($int));
+        self::assertSame(1, $scope->reserve($string));
+        self::assertSame(2, $scope->count());
+    }
+
+    public function test_collection_literals_stay_identity_keyed(): void
+    {
+        $scope = new ConstantScope();
+        $first = new VectorNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 1),
+        ]);
+        $second = new VectorNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 1),
+        ]);
+
+        self::assertSame(0, $scope->reserve($first));
+        self::assertSame(1, $scope->reserve($second));
+        self::assertSame(2, $scope->count());
     }
 }


### PR DESCRIPTION
## 🤔 Background

Constant hoisting keyed slots by AST node **identity** (`SplObjectStorage` in `ConstantScope`), so the same keyword used N times in a function body reserved N separate `static $__phel_const_*` slots — N `??= Keyword::create(...)` guards plus N entries in the IIFE `use (&...)` capture list. Keywords are interned singletons (`Keyword::create()` returns `self::$internPool[$key] ??= …`), so all occurrences of `:foo` already resolve to the same object at runtime; the per-occurrence slots were pure bloat in generated PHP and the closure capture.

## 💡 Goal

Within a single `ConstantScope`, dedup cacheable keyword (and scalar) literals **by value**: all occurrences of the same value collapse to one shared slot — one `??=` guard, one `use (&...)` capture entry, one `static` declaration. Behavior is preserved because the value is interned/immutable. Collection literals (maps/vectors/sets) stay **identity-keyed** (their construction is not a cheap interned singleton).

## 🔖 Changes

- **`ConstantScope::reserve()`** adds a value→slot side table. Cacheable scalar/keyword `LiteralNode`s get a stable, type-tagged value key (`kw:ns/name`, `str:`, `int:`, `float:`, `bool:`, `nil`); the first occurrence allocates a slot, repeats reuse it. The per-node `SplObjectStorage` map still records the shared slot for **every** collapsed node, so `lookup($node)` resolves each occurrence to the same slot and the emitter never references an uncaptured slot. Collections fall through to the unchanged identity path.
- Slot ids stay contiguous (`0,1,2…`), so the `static $__phel_const_*` declaration (`MethodEmitter`) and the `use (&…)` capture loop (`OutputEmitter`) — both driven by `count()` — emit each slot exactly once. The `??=` guard is still emitted per occurrence (idempotent), now referencing the shared slot.
- Fixtures updated for the new emitted shape (slot churn): `keyword-in-fn-body`, `assoc-conj-dissoc-typed`, `dissoc-variadic-typed`. New golden fixtures: `keyword-repeated-thrice` (one keyword ×3 → one slot), `keyword-two-distinct-deduped` (two keywords, repeats reuse), `collection-repeated-stays-identity-keyed` (value-equal collections keep distinct slots).
- Unit tests on `ConstantScope` (same value shares a slot; distinct/namespaced keywords and int-vs-string don't collide; collections stay identity-keyed) and behavioral tests in `ConstantHoistingRuntimeTest` (runtime result unchanged after dedup).
- New compile-path benchmark `KeywordSlotDedupBench`.

### Before / after emitted PHP

`(fn [m] [(:foo m) (:foo m) (:bar m)])`

Before:
```php
(function($m) {
  static $__phel_const_0, $__phel_const_1, $__phel_const_2;
  return \Phel::vector([(($__phel_const_0 ??= \Phel\Lang\Keyword::create("foo")))($m), (($__phel_const_1 ??= \Phel\Lang\Keyword::create("foo")))($m), (($__phel_const_2 ??= \Phel\Lang\Keyword::create("bar")))($m)]);
});
```

After:
```php
(function($m) {
  static $__phel_const_0, $__phel_const_1;
  return \Phel::vector([(($__phel_const_0 ??= \Phel\Lang\Keyword::create("foo")))($m), (($__phel_const_0 ??= \Phel\Lang\Keyword::create("foo")))($m), (($__phel_const_1 ??= \Phel\Lang\Keyword::create("bar")))($m)]);
});
```

### Benchmark

Measured on a fn body repeating one keyword 64 times (`(fn [m] [(:k m) … ×64])`):

| Metric | main | branch | delta |
|---|---|---|---|
| distinct `$__phel_const_*` slots (= `static` decls = `use (&…)` capture entries) | 64 | 1 | −98.4% |
| emitted PHP bytes | 5154 | 3975 | −22.9% |

Compile-path time is flat (`KeywordSlotDedupBench`: repeated ~1.64ms vs distinct ~1.66ms over 50 revs × 5 its) — the dedup is cheap; the win is smaller generated PHP and a smaller closure capture list (less to JIT/OPcache, less per-allocation closure binding).

Closes #2564
