### PR TITLE
perf(lang): identity short-circuit + chunk iterator in persistent vector equals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - `Symbol` equality short-circuits on identity and compares its backing fields directly instead of through getters, speeding up the symbol comparisons that dominate compiler environment lookups (#2551)
 - The directory-scan namespace index is now persisted across runs, so warm invocations skip re-walking the source tree (and its per-file `filemtime` sweep) when nothing changed; per-file mtimes plus a directory mtime + file-count check keep it from ever serving stale namespace info (#2560)
 - Repeating the same keyword (or scalar) literal in a function body now shares one cached `static` slot instead of one per occurrence, shrinking generated PHP and the closure capture list (#2564)
+- Persistent vector equality (`=`) now short-circuits on identical instances and walks both vectors with their chunk-aware iterators instead of repeated O(log32 n) `get` lookups, making element-wise comparison O(n) (#2549)
 
 ### Fixed
 

--- a/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
+++ b/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Phel\Lang\Collections\Vector;
 
 use InvalidArgumentException;
+use Iterator;
+use IteratorAggregate;
 use Phel\Lang\AbstractType;
 use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\Collections\LazySeq\LazySeqInterface;
@@ -13,6 +15,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\EqualizerInterface;
 
 use Phel\Lang\HasherInterface;
+use Traversable;
 
 use function count;
 use function is_object;
@@ -92,16 +95,29 @@ abstract class AbstractPersistentVector extends AbstractType implements Persiste
 
     public function equals(mixed $other): bool
     {
+        if ($this === $other) {
+            return true;
+        }
+
         if ($other instanceof PersistentVectorInterface) {
-            $count = $this->count();
-            if ($count !== $other->count()) {
+            if ($this->count() !== $other->count()) {
                 return false;
             }
 
-            for ($i = 0; $i < $count; ++$i) {
-                if (!$this->equalizer->equals($this->get($i), $other->get($i))) {
+            // Walk both vectors in lockstep with their chunk-aware
+            // iterators (amortized O(1) per element — the same path
+            // `hash()` uses) instead of repeated O(log32 n) `get()`
+            // trie descents. The count check above guarantees both
+            // iterators stay valid over the same index range.
+            $thisIterator = $this->toIterator($this->getIterator());
+            $otherIterator = $this->toIterator($other->getIterator());
+            while ($thisIterator->valid()) {
+                if (!$this->equalizer->equals($thisIterator->current(), $otherIterator->current())) {
                     return false;
                 }
+
+                $thisIterator->next();
+                $otherIterator->next();
             }
 
             return true;
@@ -236,4 +252,24 @@ abstract class AbstractPersistentVector extends AbstractType implements Persiste
      * @return PersistentVectorInterface<T>
      */
     abstract protected function sliceNormalized(int $start, int $end): PersistentVectorInterface;
+
+    /**
+     * Unwraps a vector's `getIterator()` result so `valid` / `current` /
+     * `next` can be driven directly in the lockstep `equals` walk.
+     * `PersistentVector` yields a `RangeIterator`; `SubVector` yields a
+     * Generator — both are already `Iterator`s and pass straight through.
+     *
+     * @param Traversable<mixed, mixed> $traversable
+     *
+     * @return Iterator<mixed, mixed>
+     */
+    private function toIterator(Traversable $traversable): Iterator
+    {
+        while ($traversable instanceof IteratorAggregate) {
+            $traversable = $traversable->getIterator();
+        }
+
+        /** @var Iterator<mixed, mixed> $traversable */
+        return $traversable;
+    }
 }

--- a/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
@@ -15,6 +15,7 @@ use Phel\Lang\Collections\Vector\SubVector;
 use Phel\Lang\Collections\Vector\TransientVector;
 use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -409,6 +410,98 @@ final class PersistentVectorTest extends TestCase
 
         $this->assertTrue($vector1->equals($vector2));
         $this->assertTrue($vector2->equals($vector1));
+    }
+
+    public function test_equals_empty_vectors(): void
+    {
+        $vector1 = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
+        $vector2 = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
+
+        $this->assertTrue($vector1->equals($vector2));
+        $this->assertTrue($vector2->equals($vector1));
+    }
+
+    public function test_equals_identity_short_circuit(): void
+    {
+        $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, 100));
+
+        $this->assertTrue($vector->equals($vector));
+    }
+
+    #[DataProvider('provideMultiChunkSizes')]
+    public function test_equals_multi_chunk_equal_vectors(int $size): void
+    {
+        $elements = range(0, $size - 1);
+        $vector1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), $elements);
+        $vector2 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), $elements);
+
+        $this->assertNotSame($vector1, $vector2);
+        $this->assertTrue($vector1->equals($vector2));
+        $this->assertTrue($vector2->equals($vector1));
+    }
+
+    #[DataProvider('provideMultiChunkSizes')]
+    public function test_equals_multi_chunk_differs_at_first(int $size): void
+    {
+        $base = range(0, $size - 1);
+        $changed = $base;
+        $changed[0] = -1;
+
+        $vector1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), $base);
+        $vector2 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), $changed);
+
+        $this->assertFalse($vector1->equals($vector2));
+        $this->assertFalse($vector2->equals($vector1));
+    }
+
+    #[DataProvider('provideMultiChunkSizes')]
+    public function test_equals_multi_chunk_differs_at_middle(int $size): void
+    {
+        $base = range(0, $size - 1);
+        $changed = $base;
+        $changed[intdiv($size, 2)] = -1;
+
+        $vector1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), $base);
+        $vector2 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), $changed);
+
+        $this->assertFalse($vector1->equals($vector2));
+        $this->assertFalse($vector2->equals($vector1));
+    }
+
+    #[DataProvider('provideMultiChunkSizes')]
+    public function test_equals_multi_chunk_differs_at_last(int $size): void
+    {
+        $base = range(0, $size - 1);
+        $changed = $base;
+        $changed[$size - 1] = -1;
+
+        $vector1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), $base);
+        $vector2 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), $changed);
+
+        $this->assertFalse($vector1->equals($vector2));
+        $this->assertFalse($vector2->equals($vector1));
+    }
+
+    public function test_equals_multi_chunk_different_length(): void
+    {
+        $vector1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, 99));
+        $vector2 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, 100));
+
+        $this->assertFalse($vector1->equals($vector2));
+        $this->assertFalse($vector2->equals($vector1));
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function provideMultiChunkSizes(): iterable
+    {
+        yield 'single element' => [1];
+        yield 'full first chunk' => [31];
+        yield 'chunk boundary' => [32];
+        yield 'crosses one chunk' => [33];
+        yield 'depth two boundary' => [1024];
+        yield 'crosses depth two' => [1025];
     }
 
     public function test_offset_get(): void


### PR DESCRIPTION
## 🤔 Background

`AbstractPersistentVector::equals()` compared two vectors with an indexed loop that called `get($i)` on each side. Every `get()` walks the 32-way trie from the root (`getArrayForIndex`), so the per-element cost is O(log32 n) on both sides — O(n · log32 n) overall — and there was no early-out for comparing a vector against itself.

By contrast `hash()` already iterates correctly via the chunk-aware `RangeIterator`, which only re-fetches the backing leaf array at 32-element boundaries (amortized O(1) per element).

Closes #2549

## 💡 Goal

Make `equals()` return immediately for the same instance, keep the count-mismatch short-circuit, and otherwise walk both vectors with their chunk-aware iterators in lockstep — O(n) total instead of O(n · log32 n) — with no behavioral change.

## 🔖 Changes

- Added a `$this === $other` identity fast path at the top of `equals()`.
- Retained the `count()` mismatch short-circuit.
- Replaced the `for ($i ...) get($i)` loop with two iterators (from each vector's `getIterator()`) advanced in lockstep; the pairwise `equalizer->equals(...)` call and visit order are unchanged. A small `toIterator()` helper unwraps `IteratorAggregate` so `valid`/`current`/`next` can be driven directly (mirrors the existing `Cons::normalizeIterator` pattern). `PersistentVector` yields the chunk-aware `RangeIterator`; `SubVector` yields a generator.
- The `MapEntry`, `LazySeqInterface`, and `toArray()` branches are untouched.
- Added focused unit tests: empty vectors, identity short-circuit, and a data-provided sweep over sizes 1 / 31 / 32 / 33 / 1024 / 1025 covering equal vectors plus differences at the first / middle / last element and different lengths.
- CHANGELOG entry under `## Unreleased` → `### Performance`.

### Benchmark

`PersistentVectorBench::bench_equals` (two distinct-but-equal 1024-element vectors, full O(n) walk):

| | baseline (main) | branch | delta |
|---|---|---|---|
| `bench_equals` | 139.609μs | 118.592μs | **-15.05%** |

`composer phpbench-base` on the pre-change code, `composer phpbench-ref` on the branch (PHP 8.5.7, xdebug/opcache off).
