### PR TITLE
perf(lang): drop redundant array_values copy in HAMT node iterators (#2550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Persistent vector equality (`=`) now short-circuits on identical instances and walks both vectors with their chunk-aware iterators instead of repeated O(log32 n) `get` lookups, making element-wise comparison O(n) (#2549)
 - The emitter no longer compiles a regex per call when splicing a captured node into an expression position (`if` ternary, `and`/`or` short-circuit, type predicates); it uses a plain prefix check instead, with byte-identical output (#2565)
 - The compiled-code cache index is now written once at shutdown instead of after every compiled file, so a cold build of N namespaces no longer rewrites the whole index N times (O(N²) → O(N) index bytes written); the atomic-write + `flock` + disk-merge still keeps concurrent `phel test` workers from clobbering each other's entries (#2557)
+- Iterating a large persistent hash map no longer copies an `ArrayNode`'s child-node array twice: the redundant outer `array_values` is dropped so `ArrayNodeIterator` performs the single remaining copy (#2550)
 
 ### Fixed
 

--- a/src/php/Lang/Collections/Map/ArrayNode.php
+++ b/src/php/Lang/Collections/Map/ArrayNode.php
@@ -9,8 +9,6 @@ use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
 use Traversable;
 
-use function array_values;
-
 /**
  * @template K
  * @template V
@@ -137,7 +135,7 @@ final class ArrayNode implements HashMapNodeInterface, Countable
     public function getIterator(): Traversable
     {
         /** @var ArrayNodeIterator<K, V> $iterator */
-        $iterator = new ArrayNodeIterator(array_values($this->childNodes));
+        $iterator = new ArrayNodeIterator($this->childNodes);
         return $iterator;
     }
 

--- a/src/php/Lang/Collections/Map/ArrayNodeIterator.php
+++ b/src/php/Lang/Collections/Map/ArrayNodeIterator.php
@@ -30,10 +30,12 @@ final class ArrayNodeIterator implements Iterator
     private ?Iterator $nestedIterator = null;
 
     /**
-     * @param list<?HashMapNodeInterface<K, V>> $childNodes
+     * @param array<int, ?HashMapNodeInterface<K, V>> $childNodes
      */
     public function __construct(array $childNodes)
     {
+        // array_filter drops the null slots and array_values re-indexes
+        // into a gap-free list, so the caller may pass a sparse array.
         $this->childNodes = array_values(array_filter($childNodes));
         $this->count = count($this->childNodes);
     }

--- a/tests/php/Unit/Lang/Collections/Map/PersistentHashMapTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/PersistentHashMapTest.php
@@ -265,6 +265,95 @@ final class PersistentHashMapTest extends TestCase
         $this->assertSame([], $result);
     }
 
+    public function test_iteratable_on_large_map_yields_every_entry(): void
+    {
+        // A map this large forces IndexedNode promotion to ArrayNode
+        // (>= 16 children in a single node), so iteration walks the
+        // ArrayNode -> ArrayNodeIterator path under test.
+        $size = 2000;
+        $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer());
+        $expected = [];
+        for ($i = 0; $i < $size; ++$i) {
+            $h = $h->put($i, $i * 2);
+            $expected[$i] = $i * 2;
+        }
+
+        $collected = [];
+        foreach ($h as $k => $v) {
+            $collected[$k] = $v;
+        }
+
+        ksort($collected);
+
+        self::assertCount($size, $collected);
+        self::assertSame($expected, $collected);
+    }
+
+    public function test_iteratable_on_large_map_after_removals_drops_null_slots(): void
+    {
+        // After dissoc-ing keys, ArrayNode child slots become null. The
+        // iterator must still yield exactly the remaining entries and
+        // never surface a null slot (array_filter in ArrayNodeIterator).
+        $size = 2000;
+        $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer());
+        $expected = [];
+        for ($i = 0; $i < $size; ++$i) {
+            $h = $h->put($i, $i * 2);
+            $expected[$i] = $i * 2;
+        }
+
+        foreach ([0, 5, 500, 1234, 1500, 1999] as $removed) {
+            $h = $h->remove($removed);
+            unset($expected[$removed]);
+        }
+
+        $collected = [];
+        foreach ($h as $k => $v) {
+            $collected[$k] = $v;
+        }
+
+        ksort($collected);
+
+        self::assertCount($size - 6, $collected);
+        self::assertSame($expected, $collected);
+    }
+
+    public function test_merge_and_equals_on_large_maps(): void
+    {
+        // Behavioural guard over the iterator path: merge walks the
+        // source map's entries, and equals walks both. Two large maps
+        // built in different insertion orders must merge and compare
+        // identically.
+        $size = 1500;
+        $a = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer());
+        $b = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer());
+        for ($i = 0; $i < $size; ++$i) {
+            $a = $a->put($i, $i);
+        }
+
+        for ($i = $size - 1; $i >= 0; --$i) {
+            $b = $b->put($i, $i);
+        }
+
+        self::assertTrue($a->equals($b));
+        self::assertTrue($b->equals($a));
+
+        $merged = $a->merge($b);
+        self::assertCount($size, $merged);
+        self::assertTrue($merged->equals($a));
+
+        $collected = [];
+        foreach ($merged as $k => $v) {
+            $collected[$k] = $v;
+        }
+
+        ksort($collected);
+        self::assertCount($size, $collected);
+        for ($i = 0; $i < $size; ++$i) {
+            self::assertSame($i, $collected[$i]);
+        }
+    }
+
     public function test_hash_on_empty_map(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer());


### PR DESCRIPTION
## 🤔 Background

`ArrayNode::getIterator()` copied its 32-slot child-node array with `array_values()` before handing it to `ArrayNodeIterator`, whose constructor immediately copies again via `array_values(array_filter(...))`. That is two full array copies per `ArrayNode` per traversal. The sibling `IndexedNode` path already passes its array straight through, so the double-copy was specific to `ArrayNode`.

## 💡 Goal

One array copy per node per traversal instead of two, with identical iteration behavior.

## 🔖 Changes

- `ArrayNode::getIterator()` now passes `$this->childNodes` directly to `ArrayNodeIterator` (dropped the redundant outer `array_values`); removed the now-unused `array_values` import.
- `ArrayNodeIterator::__construct` keeps its single `array_values(array_filter($childNodes))` — the remaining copy that drops null slots and re-indexes — and its param doc widened to `array<int, ?...>` since it may now receive a sparse array.
- Added unit tests over large maps (forcing `ArrayNode` promotion): full-entry iteration, iteration after dissoc (null slots dropped), and merge/equals on two large maps.

Closes #2550