### PR TITLE
perf(lexer): ASCII fast-path for column tracking in moveCursor (#2547)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - The emitter no longer compiles a regex per call when splicing a captured node into an expression position (`if` ternary, `and`/`or` short-circuit, type predicates); it uses a plain prefix check instead, with byte-identical output (#2565)
 - The compiled-code cache index is now written once at shutdown instead of after every compiled file, so a cold build of N namespaces no longer rewrites the whole index N times (O(N²) → O(N) index bytes written); the atomic-write + `flock` + disk-merge still keeps concurrent `phel test` workers from clobbering each other's entries (#2557)
 - Iterating a large persistent hash map no longer copies an `ArrayNode`'s child-node array twice: the redundant outer `array_values` is dropped so `ArrayNodeIterator` performs the single remaining copy (#2550)
+- The lexer advances column positions with `strlen` instead of `mb_strlen` when the whole source is ASCII (decided once per parse via a single high-bit scan); multibyte sources keep the code-point `mb_strlen` path so reported columns are unchanged (#2547)
 
 ### Fixed
 

--- a/src/php/Compiler/Application/Lexer.php
+++ b/src/php/Compiler/Application/Lexer.php
@@ -80,6 +80,13 @@ final class Lexer implements LexerInterface
 
     private int $column = 0;
 
+    /**
+     * Whole-source ASCII flag, computed once per lexString. When the source
+     * contains no high-bit bytes, byte length equals code-point length, so
+     * column math can use the cheaper strlen() instead of mb_strlen().
+     */
+    private bool $isAscii = true;
+
     private readonly string $combinedRegex;
 
     public function __construct(
@@ -106,6 +113,9 @@ final class Lexer implements LexerInterface
         $this->cursor = 0;
         $this->line = $startingLine;
         $this->column = 0;
+        // One-time whole-source scan: most Phel source is pure ASCII, where
+        // strlen() === mb_strlen(), so moveCursor can take the cheaper path.
+        $this->isAscii = preg_match('/[\x80-\xFF]/', $code) === 0;
         $end = strlen($code);
 
         $startLocation = $this->createSourceLocation($source);
@@ -180,14 +190,21 @@ final class Lexer implements LexerInterface
         // however, are reported in code points so error locations line up with
         // what a user sees in multibyte (UTF-8) source. For ASCII the two are
         // identical, so column numbers are unchanged for ASCII-only code.
+        //
+        // When the whole source is ASCII (see $this->isAscii, set once per
+        // lexString) the byte count is the code-point count, so strlen() is
+        // used for the column math in both branches as a fast path; multibyte
+        // sources keep the mb_strlen() path for byte-for-byte identical
+        // columns.
         $this->cursor += strlen($str);
         $lastNewLinePos = strrpos($str, "\n");
 
         if ($lastNewLinePos !== false) {
             $this->line += substr_count($str, "\n");
-            $this->column = mb_strlen(substr($str, $lastNewLinePos + 1), 'UTF-8');
+            $tail = substr($str, $lastNewLinePos + 1);
+            $this->column = $this->isAscii ? strlen($tail) : mb_strlen($tail, 'UTF-8');
         } else {
-            $this->column += mb_strlen($str, 'UTF-8');
+            $this->column += $this->isAscii ? strlen($str) : mb_strlen($str, 'UTF-8');
         }
     }
 

--- a/tests/php/Unit/Compiler/Lexer/LexerTest.php
+++ b/tests/php/Unit/Compiler/Lexer/LexerTest.php
@@ -1058,6 +1058,23 @@ final class LexerTest extends TestCase
         self::assertSame('\\spaces', $tokens[0]->getCode());
     }
 
+    public function test_ascii_columns_use_byte_length_fast_path(): void
+    {
+        // Pure-ASCII source takes the strlen() fast path in moveCursor. Columns
+        // must still be byte-for-byte identical to the code-point count: this
+        // exercises both the no-newline increment branch and the post-newline
+        // reset branch over a multi-line ASCII source.
+        self::assertEquals(
+            [
+                new Token(Token::T_ATOM, 'foo', new SourceLocation('string', 1, 0), new SourceLocation('string', 1, 3)),
+                new Token(Token::T_NEWLINE, "\n", new SourceLocation('string', 1, 3), new SourceLocation('string', 2, 0)),
+                new Token(Token::T_ATOM, 'barbaz', new SourceLocation('string', 2, 0), new SourceLocation('string', 2, 6)),
+                new Token(Token::T_EOF, '', new SourceLocation('string', 2, 6), new SourceLocation('string', 2, 6)),
+            ],
+            $this->lex("foo\nbarbaz"),
+        );
+    }
+
     private function lex(string $string): array
     {
         $lexer = $this->compilerFactory->createLexer();


### PR DESCRIPTION
## 🤔 Background

`moveCursor` runs once per token and unconditionally used `mb_strlen(..., 'UTF-8')` to advance the column in code points — needed for correct error locations in multibyte source, but wasted work for the common case of pure-ASCII source where byte length equals code-point length.

## 💡 Goal

Use the cheaper `strlen` for column math when the whole source is ASCII, while keeping `mb_strlen` (byte-for-byte identical columns) for any source containing multibyte bytes. The decision is made once per parse, not per token.

## 🔖 Changes

- `Lexer` gains an `isAscii` flag set once per `lexString` via a single high-bit scan (`preg_match('/[\x80-\xFF]/', $code) === 0`).
- Both `moveCursor` branches (post-newline column reset and no-newline increment) use `strlen` when `isAscii`, else keep `mb_strlen(..., 'UTF-8')`.
- Added a unit test asserting ASCII multi-line columns over both branches; existing multibyte tests (`café` mid-line, `é` after a newline) already pin the code-point path and remain unchanged.

Closes #2547