### PR TITLE
fix(lang): wrap collection hash accumulators to 32-bit to avoid int overflow TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Hashing a persistent collection (vector, list, queue, lazy seq, hash/sorted set, or map) no longer throws a `TypeError` once it grows past ~13 elements: the rolling hash accumulator now wraps within a 32-bit range instead of silently overflowing to a float (#2567)
 - The "not defined" error hint now also shows when the compiler appends a `Did you mean ...?` suggestion (a trailing period previously suppressed it)
 - `php/oset` in return context now elides the redundant closure wrapper, matching `php/->`'s return-context behavior (#2536)
 

--- a/src/php/Lang/Collections/HashSet/PersistentHashSet.php
+++ b/src/php/Lang/Collections/HashSet/PersistentHashSet.php
@@ -21,14 +21,6 @@ use function is_nan;
  */
 final class PersistentHashSet extends AbstractType implements PersistentHashSetInterface
 {
-    /**
-     * Keeps the rolling hash accumulator inside a 32-bit unsigned range so
-     * the running sum can never silently promote to float (which would throw
-     * a TypeError when assigned to `?int $hashCache` under strict_types for
-     * large sets). Kept in lockstep with vector, list, queue and map hashing.
-     */
-    private const int HASH_MASK = 0xFFFFFFFF;
-
     private ?int $hashCache = null;
 
     /**
@@ -142,12 +134,7 @@ final class PersistentHashSet extends AbstractType implements PersistentHashSetI
             return $this->hashCache;
         }
 
-        $hash = 0;
-        foreach ($this->map as $value) {
-            $hash = ($hash + $this->hasher->hash($value)) & self::HASH_MASK;
-        }
-
-        return $this->hashCache = $hash;
+        return $this->hashCache = $this->hasher->unorderedHash($this->map);
     }
 
     /**

--- a/src/php/Lang/Collections/HashSet/PersistentHashSet.php
+++ b/src/php/Lang/Collections/HashSet/PersistentHashSet.php
@@ -21,6 +21,14 @@ use function is_nan;
  */
 final class PersistentHashSet extends AbstractType implements PersistentHashSetInterface
 {
+    /**
+     * Keeps the rolling hash accumulator inside a 32-bit unsigned range so
+     * the running sum can never silently promote to float (which would throw
+     * a TypeError when assigned to `?int $hashCache` under strict_types for
+     * large sets). Kept in lockstep with vector, list, queue and map hashing.
+     */
+    private const int HASH_MASK = 0xFFFFFFFF;
+
     private ?int $hashCache = null;
 
     /**
@@ -136,7 +144,7 @@ final class PersistentHashSet extends AbstractType implements PersistentHashSetI
 
         $hash = 0;
         foreach ($this->map as $value) {
-            $hash += $this->hasher->hash($value);
+            $hash = ($hash + $this->hasher->hash($value)) & self::HASH_MASK;
         }
 
         return $this->hashCache = $hash;

--- a/src/php/Lang/Collections/LazySeq/Cons.php
+++ b/src/php/Lang/Collections/LazySeq/Cons.php
@@ -28,6 +28,14 @@ use Traversable;
  */
 final class Cons extends AbstractType implements SeqInterface, IteratorAggregate
 {
+    /**
+     * Keeps the rolling hash accumulator inside a 32-bit unsigned range so
+     * `31 * $hashCache` never exceeds PHP_INT_MAX and silently promotes to
+     * float (which would corrupt the `int $hashCache` for long sequences).
+     * Kept in lockstep with vector, list, queue and map hashing.
+     */
+    private const int HASH_MASK = 0xFFFFFFFF;
+
     private int $hashCache = 0;
 
     /**
@@ -201,7 +209,7 @@ final class Cons extends AbstractType implements SeqInterface, IteratorAggregate
         if ($this->hashCache === 0) {
             $this->hashCache = 1;
             foreach ($this as $value) {
-                $this->hashCache = 31 * $this->hashCache + $this->hasher->hash($value);
+                $this->hashCache = (31 * $this->hashCache + $this->hasher->hash($value)) & self::HASH_MASK;
             }
         }
 

--- a/src/php/Lang/Collections/LazySeq/Cons.php
+++ b/src/php/Lang/Collections/LazySeq/Cons.php
@@ -28,14 +28,6 @@ use Traversable;
  */
 final class Cons extends AbstractType implements SeqInterface, IteratorAggregate
 {
-    /**
-     * Keeps the rolling hash accumulator inside a 32-bit unsigned range so
-     * `31 * $hashCache` never exceeds PHP_INT_MAX and silently promotes to
-     * float (which would corrupt the `int $hashCache` for long sequences).
-     * Kept in lockstep with vector, list, queue and map hashing.
-     */
-    private const int HASH_MASK = 0xFFFFFFFF;
-
     private int $hashCache = 0;
 
     /**
@@ -207,10 +199,7 @@ final class Cons extends AbstractType implements SeqInterface, IteratorAggregate
     public function hash(): int
     {
         if ($this->hashCache === 0) {
-            $this->hashCache = 1;
-            foreach ($this as $value) {
-                $this->hashCache = (31 * $this->hashCache + $this->hasher->hash($value)) & self::HASH_MASK;
-            }
+            $this->hashCache = $this->hasher->orderedHash($this);
         }
 
         return $this->hashCache;

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -33,6 +33,14 @@ use function is_object;
  */
 final class LazySeq extends AbstractType implements LazySeqInterface, Countable, IteratorAggregate
 {
+    /**
+     * Keeps the rolling hash accumulator inside a 32-bit unsigned range so
+     * `31 * $hash` never exceeds PHP_INT_MAX and silently promotes to float
+     * (which would throw a TypeError on the `: int` return for long
+     * sequences). Kept in lockstep with vector, list, queue and map hashing.
+     */
+    private const int HASH_MASK = 0xFFFFFFFF;
+
     /** @var callable|null The thunk that produces the sequence (null once realized) */
     private $fn;
 
@@ -407,7 +415,7 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
         // Realize and hash the sequence (similar to PersistentList)
         $hash = 1;
         foreach ($this as $value) {
-            $hash = 31 * $hash + $this->hasher->hash($value);
+            $hash = (31 * $hash + $this->hasher->hash($value)) & self::HASH_MASK;
         }
 
         return $hash;

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -33,14 +33,6 @@ use function is_object;
  */
 final class LazySeq extends AbstractType implements LazySeqInterface, Countable, IteratorAggregate
 {
-    /**
-     * Keeps the rolling hash accumulator inside a 32-bit unsigned range so
-     * `31 * $hash` never exceeds PHP_INT_MAX and silently promotes to float
-     * (which would throw a TypeError on the `: int` return for long
-     * sequences). Kept in lockstep with vector, list, queue and map hashing.
-     */
-    private const int HASH_MASK = 0xFFFFFFFF;
-
     /** @var callable|null The thunk that produces the sequence (null once realized) */
     private $fn;
 
@@ -413,12 +405,7 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
     public function hash(): int
     {
         // Realize and hash the sequence (similar to PersistentList)
-        $hash = 1;
-        foreach ($this as $value) {
-            $hash = (31 * $hash + $this->hasher->hash($value)) & self::HASH_MASK;
-        }
-
-        return $hash;
+        return $this->hasher->orderedHash($this);
     }
 
     public function equals(mixed $other): bool

--- a/src/php/Lang/Collections/LinkedList/PersistentList.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentList.php
@@ -26,6 +26,15 @@ use function count;
  */
 final class PersistentList extends AbstractType implements PersistentListInterface
 {
+    /**
+     * Keeps the rolling hash accumulator inside a 32-bit unsigned range so
+     * `31 * $hash` never exceeds PHP_INT_MAX and silently promotes to float
+     * (which would throw a TypeError when assigned to `?int $hashCache`
+     * under strict_types for long lists). Kept in lockstep with vector and
+     * map hashing.
+     */
+    private const int HASH_MASK = 0xFFFFFFFF;
+
     private ?int $hashCache = null;
 
     /**
@@ -189,7 +198,7 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
 
         $hash = 1;
         foreach ($this as $value) {
-            $hash = 31 * $hash + $this->hasher->hash($value);
+            $hash = (31 * $hash + $this->hasher->hash($value)) & self::HASH_MASK;
         }
 
         return $this->hashCache = $hash;

--- a/src/php/Lang/Collections/LinkedList/PersistentList.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentList.php
@@ -26,15 +26,6 @@ use function count;
  */
 final class PersistentList extends AbstractType implements PersistentListInterface
 {
-    /**
-     * Keeps the rolling hash accumulator inside a 32-bit unsigned range so
-     * `31 * $hash` never exceeds PHP_INT_MAX and silently promotes to float
-     * (which would throw a TypeError when assigned to `?int $hashCache`
-     * under strict_types for long lists). Kept in lockstep with vector and
-     * map hashing.
-     */
-    private const int HASH_MASK = 0xFFFFFFFF;
-
     private ?int $hashCache = null;
 
     /**
@@ -196,12 +187,7 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
             return $this->hashCache;
         }
 
-        $hash = 1;
-        foreach ($this as $value) {
-            $hash = (31 * $hash + $this->hasher->hash($value)) & self::HASH_MASK;
-        }
-
-        return $this->hashCache = $hash;
+        return $this->hashCache = $this->hasher->orderedHash($this);
     }
 
     /**

--- a/src/php/Lang/Collections/Map/AbstractPersistentMap.php
+++ b/src/php/Lang/Collections/Map/AbstractPersistentMap.php
@@ -22,6 +22,15 @@ use function is_nan;
  */
 abstract class AbstractPersistentMap extends AbstractType implements PersistentMapInterface
 {
+    /**
+     * Keeps the rolling hash accumulator inside a 32-bit unsigned range so
+     * the running sum can never silently promote to float (which would
+     * throw a TypeError when assigned to `?int $hashCache` under
+     * strict_types for large maps). Kept in lockstep with vector and list
+     * hashing.
+     */
+    private const int HASH_MASK = 0xFFFFFFFF;
+
     private ?int $hashCache = null;
 
     /**
@@ -59,7 +68,7 @@ abstract class AbstractPersistentMap extends AbstractType implements PersistentM
 
         $hash = 1;
         foreach ($this as $key => $value) {
-            $hash += $this->hasher->hash($key) ^ $this->hasher->hash($value);
+            $hash = ($hash + (($this->hasher->hash($key) ^ $this->hasher->hash($value)) & self::HASH_MASK)) & self::HASH_MASK;
         }
 
         return $this->hashCache = $hash;

--- a/src/php/Lang/Collections/Map/AbstractPersistentMap.php
+++ b/src/php/Lang/Collections/Map/AbstractPersistentMap.php
@@ -22,15 +22,6 @@ use function is_nan;
  */
 abstract class AbstractPersistentMap extends AbstractType implements PersistentMapInterface
 {
-    /**
-     * Keeps the rolling hash accumulator inside a 32-bit unsigned range so
-     * the running sum can never silently promote to float (which would
-     * throw a TypeError when assigned to `?int $hashCache` under
-     * strict_types for large maps). Kept in lockstep with vector and list
-     * hashing.
-     */
-    private const int HASH_MASK = 0xFFFFFFFF;
-
     private ?int $hashCache = null;
 
     /**
@@ -66,12 +57,7 @@ abstract class AbstractPersistentMap extends AbstractType implements PersistentM
             return $this->hashCache;
         }
 
-        $hash = 1;
-        foreach ($this as $key => $value) {
-            $hash = ($hash + (($this->hasher->hash($key) ^ $this->hasher->hash($value)) & self::HASH_MASK)) & self::HASH_MASK;
-        }
-
-        return $this->hashCache = $hash;
+        return $this->hashCache = $this->hasher->unorderedKeyedHash($this);
     }
 
     public function equals(mixed $other): bool

--- a/src/php/Lang/Collections/Queue/PersistentQueue.php
+++ b/src/php/Lang/Collections/Queue/PersistentQueue.php
@@ -43,6 +43,15 @@ use function array_reverse;
  */
 final class PersistentQueue extends AbstractType implements TypeInterface, Countable, IteratorAggregate, FirstInterface, CdrInterface, ConsInterface, PushInterface, PopInterface
 {
+    /**
+     * Keeps the rolling hash accumulator inside a 32-bit unsigned range so
+     * `31 * $hash` never exceeds PHP_INT_MAX and silently promotes to float
+     * (which would throw a TypeError when assigned to `?int $hashCache`
+     * under strict_types for large queues). Kept in lockstep with vector,
+     * list and map hashing.
+     */
+    private const int HASH_MASK = 0xFFFFFFFF;
+
     private ?int $hashCache = null;
 
     /**
@@ -229,7 +238,7 @@ final class PersistentQueue extends AbstractType implements TypeInterface, Count
 
         $hash = 1;
         foreach ($this as $value) {
-            $hash = 31 * $hash + $this->hasher->hash($value);
+            $hash = (31 * $hash + $this->hasher->hash($value)) & self::HASH_MASK;
         }
 
         return $this->hashCache = $hash;

--- a/src/php/Lang/Collections/Queue/PersistentQueue.php
+++ b/src/php/Lang/Collections/Queue/PersistentQueue.php
@@ -43,15 +43,6 @@ use function array_reverse;
  */
 final class PersistentQueue extends AbstractType implements TypeInterface, Countable, IteratorAggregate, FirstInterface, CdrInterface, ConsInterface, PushInterface, PopInterface
 {
-    /**
-     * Keeps the rolling hash accumulator inside a 32-bit unsigned range so
-     * `31 * $hash` never exceeds PHP_INT_MAX and silently promotes to float
-     * (which would throw a TypeError when assigned to `?int $hashCache`
-     * under strict_types for large queues). Kept in lockstep with vector,
-     * list and map hashing.
-     */
-    private const int HASH_MASK = 0xFFFFFFFF;
-
     private ?int $hashCache = null;
 
     /**
@@ -236,12 +227,7 @@ final class PersistentQueue extends AbstractType implements TypeInterface, Count
             return $this->hashCache;
         }
 
-        $hash = 1;
-        foreach ($this as $value) {
-            $hash = (31 * $hash + $this->hasher->hash($value)) & self::HASH_MASK;
-        }
-
-        return $this->hashCache = $hash;
+        return $this->hashCache = $this->hasher->orderedHash($this);
     }
 
     /**

--- a/src/php/Lang/Collections/SortedSet/PersistentSortedSet.php
+++ b/src/php/Lang/Collections/SortedSet/PersistentSortedSet.php
@@ -21,6 +21,14 @@ use Traversable;
  */
 final class PersistentSortedSet extends AbstractType implements PersistentHashSetInterface
 {
+    /**
+     * Keeps the rolling hash accumulator inside a 32-bit unsigned range so
+     * the running sum can never silently promote to float (which would
+     * corrupt the `int $hashCache` for large sets). Kept in lockstep with
+     * vector, list, queue and map hashing.
+     */
+    private const int HASH_MASK = 0xFFFFFFFF;
+
     private int $hashCache = 0;
 
     /**
@@ -122,7 +130,7 @@ final class PersistentSortedSet extends AbstractType implements PersistentHashSe
     {
         if ($this->hashCache === 0) {
             foreach ($this->map as $value) {
-                $this->hashCache += $this->hasher->hash($value);
+                $this->hashCache = ($this->hashCache + $this->hasher->hash($value)) & self::HASH_MASK;
             }
         }
 

--- a/src/php/Lang/Collections/SortedSet/PersistentSortedSet.php
+++ b/src/php/Lang/Collections/SortedSet/PersistentSortedSet.php
@@ -21,14 +21,6 @@ use Traversable;
  */
 final class PersistentSortedSet extends AbstractType implements PersistentHashSetInterface
 {
-    /**
-     * Keeps the rolling hash accumulator inside a 32-bit unsigned range so
-     * the running sum can never silently promote to float (which would
-     * corrupt the `int $hashCache` for large sets). Kept in lockstep with
-     * vector, list, queue and map hashing.
-     */
-    private const int HASH_MASK = 0xFFFFFFFF;
-
     private int $hashCache = 0;
 
     /**
@@ -129,9 +121,7 @@ final class PersistentSortedSet extends AbstractType implements PersistentHashSe
     public function hash(): int
     {
         if ($this->hashCache === 0) {
-            foreach ($this->map as $value) {
-                $this->hashCache = ($this->hashCache + $this->hasher->hash($value)) & self::HASH_MASK;
-            }
+            $this->hashCache = $this->hasher->unorderedHash($this->map);
         }
 
         return $this->hashCache;

--- a/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
+++ b/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
@@ -29,16 +29,6 @@ use function is_object;
  */
 abstract class AbstractPersistentVector extends AbstractType implements PersistentVectorInterface
 {
-    /**
-     * Keeps the rolling hash accumulator inside a 32-bit unsigned range.
-     * `31 * $hash` then never exceeds PHP_INT_MAX, so the accumulator can
-     * never silently promote to float (which would throw a TypeError when
-     * assigned to the `?int $hashCache` under strict_types — the bug seen
-     * with vectors of 13+ elements). 32 bits matches Clojure's hash width
-     * and the values produced by `Hasher` (crc32, float bit patterns).
-     */
-    private const int HASH_MASK = 0xFFFFFFFF;
-
     private ?int $hashCache = null;
 
     /**
@@ -95,12 +85,7 @@ abstract class AbstractPersistentVector extends AbstractType implements Persiste
             return $this->hashCache;
         }
 
-        $hash = 1;
-        foreach ($this as $obj) {
-            $hash = (31 * $hash + $this->hasher->hash($obj)) & self::HASH_MASK;
-        }
-
-        return $this->hashCache = $hash;
+        return $this->hashCache = $this->hasher->orderedHash($this);
     }
 
     public function equals(mixed $other): bool

--- a/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
+++ b/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
@@ -29,6 +29,16 @@ use function is_object;
  */
 abstract class AbstractPersistentVector extends AbstractType implements PersistentVectorInterface
 {
+    /**
+     * Keeps the rolling hash accumulator inside a 32-bit unsigned range.
+     * `31 * $hash` then never exceeds PHP_INT_MAX, so the accumulator can
+     * never silently promote to float (which would throw a TypeError when
+     * assigned to the `?int $hashCache` under strict_types — the bug seen
+     * with vectors of 13+ elements). 32 bits matches Clojure's hash width
+     * and the values produced by `Hasher` (crc32, float bit patterns).
+     */
+    private const int HASH_MASK = 0xFFFFFFFF;
+
     private ?int $hashCache = null;
 
     /**
@@ -87,7 +97,7 @@ abstract class AbstractPersistentVector extends AbstractType implements Persiste
 
         $hash = 1;
         foreach ($this as $obj) {
-            $hash = 31 * $hash + $this->hasher->hash($obj);
+            $hash = (31 * $hash + $this->hasher->hash($obj)) & self::HASH_MASK;
         }
 
         return $this->hashCache = $hash;

--- a/src/php/Lang/HashCombinerTrait.php
+++ b/src/php/Lang/HashCombinerTrait.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+/**
+ * Shared rolling-hash combinators used by the persistent collections.
+ *
+ * Every accumulator is wrapped to a 32-bit unsigned range (HASH_MASK) on each
+ * step so the running value can never exceed PHP_INT_MAX and silently promote
+ * to float — which, under strict_types, throws a TypeError the moment the
+ * result is assigned back to an `int`/`?int` hash cache. That was the bug
+ * behind #2567, originally observed with vectors of 13+ elements. 32 bits
+ * matches Clojure's hash width and the range produced by {@see Hasher}
+ * (crc32, float bit patterns).
+ *
+ * Implementations must provide `hash(mixed): int` (see {@see HasherInterface}).
+ */
+trait HashCombinerTrait
+{
+    private const int HASH_MASK = 0xFFFFFFFF;
+
+    /**
+     * Order-sensitive hash (Clojure's hashOrdered): seed 1, then
+     * `31 * $hash + hash($value)` per element. Used by sequential
+     * collections (vector, list, queue, lazy seq, cons).
+     */
+    public function orderedHash(iterable $values): int
+    {
+        $hash = 1;
+        foreach ($values as $value) {
+            $hash = (31 * $hash + $this->hash($value)) & self::HASH_MASK;
+        }
+
+        return $hash;
+    }
+
+    /**
+     * Order-insensitive hash (Clojure's hashUnordered): the running sum of
+     * element hashes, seeded at 0. Used by sets.
+     */
+    public function unorderedHash(iterable $values): int
+    {
+        $hash = 0;
+        foreach ($values as $value) {
+            $hash = ($hash + $this->hash($value)) & self::HASH_MASK;
+        }
+
+        return $hash;
+    }
+
+    /**
+     * Order-insensitive hash of key/value pairs: the running sum of
+     * `hash($key) ^ hash($value)`, seeded at 1. Used by maps.
+     */
+    public function unorderedKeyedHash(iterable $entries): int
+    {
+        $hash = 1;
+        foreach ($entries as $key => $value) {
+            $hash = ($hash + (($this->hash($key) ^ $this->hash($value)) & self::HASH_MASK)) & self::HASH_MASK;
+        }
+
+        return $hash;
+    }
+}

--- a/src/php/Lang/Hasher.php
+++ b/src/php/Lang/Hasher.php
@@ -20,6 +20,8 @@ use function is_string;
 #[Singleton]
 final class Hasher implements HasherInterface
 {
+    use HashCombinerTrait;
+
     private const int NULL_HASH_VALUE = 0;
 
     private const int TRUE_HASH_VALUE = 1231;

--- a/src/php/Lang/HasherInterface.php
+++ b/src/php/Lang/HasherInterface.php
@@ -10,4 +10,25 @@ interface HasherInterface
      * @return int The hash of the given value
      */
     public function hash(mixed $value): int;
+
+    /**
+     * Order-sensitive hash of a sequence of values (vectors, lists, ...).
+     *
+     * @param iterable<mixed> $values
+     */
+    public function orderedHash(iterable $values): int;
+
+    /**
+     * Order-insensitive hash of a collection of values (sets).
+     *
+     * @param iterable<mixed> $values
+     */
+    public function unorderedHash(iterable $values): int;
+
+    /**
+     * Order-insensitive hash of key/value pairs (maps).
+     *
+     * @param iterable<mixed, mixed> $entries
+     */
+    public function unorderedKeyedHash(iterable $entries): int;
 }

--- a/tests/php/Unit/Lang/Collections/LazySeq/LazySeqTest.php
+++ b/tests/php/Unit/Lang/Collections/LazySeq/LazySeqTest.php
@@ -418,4 +418,20 @@ final class LazySeqTest extends TestCase
         $lazySeq->first();
         $this->assertSame(1, $accessCount, 'Should use cached value');
     }
+
+    /**
+     * Regression for the int->float overflow in the `31 * $hash + ...`
+     * accumulator: hashing a long lazy seq must return a stable int instead
+     * of overflowing to a float and throwing a TypeError on the `: int`
+     * return.
+     */
+    public function test_hash_large_lazy_seq_returns_stable_int(): void
+    {
+        $lazySeq = LazySeq::fromArray($this->hasher, $this->equalizer, range(0, 999));
+
+        $hash = $lazySeq->hash();
+
+        $this->assertIsInt($hash);
+        $this->assertSame($hash, $lazySeq->hash());
+    }
 }

--- a/tests/php/Unit/Lang/Collections/LinkedList/PersistentListTest.php
+++ b/tests/php/Unit/Lang/Collections/LinkedList/PersistentListTest.php
@@ -14,6 +14,8 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentArrayMap;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVector;
+use Phel\Lang\Equalizer;
+use Phel\Lang\Hasher;
 use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
 use PHPUnit\Framework\TestCase;
@@ -188,6 +190,21 @@ final class PersistentListTest extends TestCase
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), [2]);
 
         $this->assertSame(33, $list->hash());
+    }
+
+    /**
+     * Regression for the int->float overflow in the `31 * $hash + ...`
+     * accumulator: a long list must still return a stable int hash instead
+     * of throwing a TypeError on the `?int $hashCache` assignment.
+     */
+    public function test_hash_large_list_returns_stable_int(): void
+    {
+        $list = PersistentList::fromArray(new Hasher(), new Equalizer(), range(0, 999));
+
+        $hash = $list->hash();
+
+        $this->assertIsInt($hash);
+        $this->assertSame($hash, $list->hash());
     }
 
     public function test_iterator(): void

--- a/tests/php/Unit/Lang/Collections/Map/PersistentHashMapTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/PersistentHashMapTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Lang\Collections\Map;
 
 use Phel\Lang\Collections\Map\PersistentHashMap;
+use Phel\Lang\Equalizer;
+use Phel\Lang\Hasher;
 use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
 use PHPUnit\Framework\TestCase;
@@ -367,5 +369,23 @@ final class PersistentHashMapTest extends TestCase
             ->put(1, 10);
 
         $this->assertSame(1 + (1 ^ 10), $h->hash());
+    }
+
+    /**
+     * Regression for the int->float overflow in the running hash sum: a
+     * large map must still return a stable int hash instead of throwing a
+     * TypeError on the `?int $hashCache` assignment.
+     */
+    public function test_hash_large_map_returns_stable_int(): void
+    {
+        $map = PersistentHashMap::empty(new Hasher(), new Equalizer());
+        for ($i = 0; $i < 1000; ++$i) {
+            $map = $map->put($i, $i * 7);
+        }
+
+        $hash = $map->hash();
+
+        $this->assertIsInt($hash);
+        $this->assertSame($hash, $map->hash());
     }
 }

--- a/tests/php/Unit/Lang/Collections/ModuloHasher.php
+++ b/tests/php/Unit/Lang/Collections/ModuloHasher.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Lang\Collections;
 
+use Phel\Lang\HashCombinerTrait;
 use Phel\Lang\HasherInterface;
 
 final readonly class ModuloHasher implements HasherInterface
 {
+    use HashCombinerTrait;
+
     public function __construct(
         private int $modulo = 10000,
     ) {}

--- a/tests/php/Unit/Lang/Collections/Queue/PersistentQueueTest.php
+++ b/tests/php/Unit/Lang/Collections/Queue/PersistentQueueTest.php
@@ -132,4 +132,19 @@ final class PersistentQueueTest extends TestCase
         self::assertSame($meta, $tagged->getMeta());
         self::assertTrue($q->equals($tagged));
     }
+
+    /**
+     * Regression for the int->float overflow in the `31 * $hash + ...`
+     * accumulator: a long queue must still return a stable int hash instead
+     * of throwing a TypeError on the `?int $hashCache` assignment.
+     */
+    public function test_hash_large_queue_returns_stable_int(): void
+    {
+        $q = PersistentQueue::fromArray($this->hasher, $this->equalizer, range(0, 999));
+
+        $hash = $q->hash();
+
+        self::assertIsInt($hash);
+        self::assertSame($hash, $q->hash());
+    }
 }

--- a/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Lang\Collections\Vector;
 
 use InvalidArgumentException;
+use Iterator;
 use Phel;
 use Phel\Lang\Collections\Exceptions\IndexOutOfBoundsException;
+use Phel\Lang\Collections\Map\PersistentHashMap;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVector;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Collections\Vector\RangeIterator;
 use Phel\Lang\Collections\Vector\SubVector;
 use Phel\Lang\Collections\Vector\TransientVector;
+use Phel\Lang\Equalizer;
+use Phel\Lang\Hasher;
 use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -549,5 +553,55 @@ final class PersistentVectorTest extends TestCase
         $this->assertTrue($vector->contains(0));
         $this->assertTrue($vector->contains(1));
         $this->assertFalse($vector->contains(2));
+    }
+
+    /**
+     * Regression for the int->float overflow: the rolling `31 * $hash + ...`
+     * accumulator used to promote to float once a vector had ~13+ elements,
+     * which then threw a TypeError when assigned to the `?int $hashCache`.
+     */
+    #[DataProvider('provideLargeVectorSizes')]
+    public function test_hash_large_vector_returns_stable_int(int $size): void
+    {
+        $vector = PersistentVector::fromArray(new Hasher(), new Equalizer(), range(0, $size - 1));
+
+        $hash = $vector->hash();
+
+        $this->assertIsInt($hash);
+        // Cached: a second call must return the exact same value.
+        $this->assertSame($hash, $vector->hash());
+    }
+
+    public static function provideLargeVectorSizes(): Iterator
+    {
+        yield '13 elements' => [13];
+        yield '40 elements' => [40];
+        yield '1000 elements' => [1000];
+    }
+
+    public function test_equal_large_vectors_have_equal_hash(): void
+    {
+        $left = PersistentVector::fromArray(new Hasher(), new Equalizer(), range(0, 999));
+        $right = PersistentVector::fromArray(new Hasher(), new Equalizer(), range(0, 999));
+
+        $this->assertTrue($left->equals($right));
+        $this->assertSame($left->hash(), $right->hash());
+    }
+
+    public function test_large_vector_works_as_hash_map_key(): void
+    {
+        $key = PersistentVector::fromArray(new Hasher(), new Equalizer(), range(0, 999));
+        $equalKey = PersistentVector::fromArray(new Hasher(), new Equalizer(), range(0, 999));
+
+        $map = PersistentHashMap::empty(new Hasher(), new Equalizer())
+            ->put($key, 'value');
+
+        // Lookup with an equal-but-distinct vector instance.
+        $this->assertSame('value', $map->find($equalKey));
+
+        // Inserting the equal key must dedup, not grow the map.
+        $map = $map->put($equalKey, 'other');
+        $this->assertCount(1, $map);
+        $this->assertSame('other', $map->find($key));
     }
 }


### PR DESCRIPTION
## 🤔 Background

`AbstractPersistentVector::hash()` threw a `TypeError` for any vector with ~13+ elements: the rolling accumulator `$hash = 31 * $hash + ...` overflows `PHP_INT_MAX`, becomes a `float`, and can no longer be assigned to the typed `?int $hashCache` under `declare(strict_types=1)`. The crash surfaces whenever such a vector is hashed — e.g. used as a key in a hash map/set once the collection grows past the array-map threshold.

Auditing the sibling collections showed the identical latent overflow in every hash accumulator that uses the `31 * $hash + …` (sequential) pattern, and the additive `+=` accumulators share the same float-promotion risk.

## 💡 Goal

No collection hash ever throws, regardless of size; results stay `int`, deterministic, and honor the hash/equals contract.

## 🔖 Changes

Each accumulator now wraps within a 32-bit unsigned range (`& 0xFFFFFFFF`) per step via a shared `HASH_MASK` constant, so the running value can never silently promote to float:

- **Sequential (`31 * $hash`)** — genuine crash at ~13 elements: `AbstractPersistentVector`, `PersistentList`, `PersistentQueue`, `LazySeq`, `Cons`.
- **Additive (`+=` / `+= xor`)** — defensive, kept in lockstep: `AbstractPersistentMap`, `PersistentHashSet`, `PersistentSortedSet`.

Regression tests (using the real `Hasher`, which actually overflows pre-fix) on 13/40/1000-element collections assert a stable `int` hash, equal-elements→equal-hash, and large-vector-as-hash-map-key for vector, list, queue, lazy seq, and map.

Closes #2567