### PR TITLE
ref(emitter): consolidate phel.core call guards into PhelCoreCall helper

### DIFF
--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/AssocConjSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/AssocConjSpecialization.php
@@ -6,11 +6,9 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
-use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
-use Phel\Shared\CompilerConstants;
 
 use function array_slice;
 use function array_unshift;
@@ -44,12 +42,8 @@ final readonly class AssocConjSpecialization
      */
     public static function typedAssocConjDissocMethod(CallNode $node): ?string
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return null;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+        $name = PhelCoreCall::nameOf($node);
+        if ($name === null) {
             return null;
         }
 
@@ -64,7 +58,6 @@ final readonly class AssocConjSpecialization
             return null;
         }
 
-        $name = $fn->getName()->getName();
         $argCount = count($args);
 
         if ($name === 'assoc' && $argCount === 3) {
@@ -111,14 +104,7 @@ final readonly class AssocConjSpecialization
      */
     public static function typedDissocKeys(CallNode $node): ?array
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return null;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== 'dissoc'
-        ) {
+        if (!PhelCoreCall::is($node, 'dissoc')) {
             return null;
         }
 
@@ -176,14 +162,7 @@ final readonly class AssocConjSpecialization
         $groups = [];
         $current = $node;
         while (true) {
-            $cFn = $current->getFn();
-            if (!$cFn instanceof GlobalVarNode) {
-                return null;
-            }
-
-            if ($cFn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-                || $cFn->getName()->getName() !== $opName
-            ) {
+            if (!PhelCoreCall::is($current, $opName)) {
                 return null;
             }
 
@@ -230,14 +209,7 @@ final readonly class AssocConjSpecialization
      */
     private static function classifyChainHead(CallNode $node): ?array
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-        ) {
-            return null;
-        }
-
-        return match ($fn->getName()->getName()) {
+        return match (PhelCoreCall::nameOf($node)) {
             'assoc' => ['assoc', 3, 'put', PersistentMapInterface::class],
             'conj' => ['conj', 2, 'append', PersistentVectorInterface::class],
             default => null,

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/AtomMethodSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/AtomMethodSpecialization.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
-use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
-use Phel\Shared\CompilerConstants;
 
 use function count;
 
@@ -30,14 +28,11 @@ final readonly class AtomMethodSpecialization
      */
     public static function atomMethodCall(CallNode $node): ?array
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-        ) {
+        $name = PhelCoreCall::nameOf($node);
+        if ($name === null) {
             return null;
         }
 
-        $name = $fn->getName()->getName();
         $argc = count($node->getArguments());
 
         if ($name === 'deref' && $argc === 1) {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -6,14 +6,12 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
-use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Lang\AbstractFn;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\FnInterface;
-use Phel\Shared\CompilerConstants;
 
 use function count;
 use function is_string;
@@ -181,14 +179,7 @@ final readonly class CallSpecialization
      */
     public static function typedGetAccessMethod(CallNode $node): ?string
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return null;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== 'get'
-        ) {
+        if (!PhelCoreCall::is($node, 'get')) {
             return null;
         }
 
@@ -249,14 +240,7 @@ final readonly class CallSpecialization
      */
     public static function isTypedPhpArrayGet(CallNode $node): bool
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return false;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== 'get'
-        ) {
+        if (!PhelCoreCall::is($node, 'get')) {
             return false;
         }
 
@@ -283,14 +267,7 @@ final readonly class CallSpecialization
      */
     public static function isTypedPhpArrayCount(CallNode $node): bool
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return false;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== 'count'
-        ) {
+        if (!PhelCoreCall::is($node, 'count')) {
             return false;
         }
 
@@ -342,14 +319,7 @@ final readonly class CallSpecialization
      */
     public static function isStrConcat(CallNode $node): bool
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return false;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== 'str'
-        ) {
+        if (!PhelCoreCall::is($node, 'str')) {
             return false;
         }
 
@@ -367,14 +337,7 @@ final readonly class CallSpecialization
      */
     private static function isTypedStringCall(CallNode $node, string $fnName): bool
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return false;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== $fnName
-        ) {
+        if (!PhelCoreCall::is($node, $fnName)) {
             return false;
         }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/GetInSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/GetInSpecialization.php
@@ -6,12 +6,10 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
-use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
-use Phel\Shared\CompilerConstants;
 
 use function count;
 
@@ -56,14 +54,7 @@ final readonly class GetInSpecialization
      */
     public static function literalPathKeys(CallNode $node): ?array
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return null;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== 'get-in'
-        ) {
+        if (!PhelCoreCall::is($node, 'get-in')) {
             return null;
         }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NilAndBooleanCheckSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NilAndBooleanCheckSpecialization.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
-use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
-use Phel\Shared\CompilerConstants;
 
 use function count;
 
@@ -69,14 +67,7 @@ final readonly class NilAndBooleanCheckSpecialization
 
     private static function isUnaryCoreCall(CallNode $node, string $name): bool
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return false;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== $name
-        ) {
+        if (!PhelCoreCall::is($node, $name)) {
             return false;
         }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecialization.php
@@ -6,12 +6,10 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
-use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Lang\Keyword;
-use Phel\Shared\CompilerConstants;
 
 use function array_all;
 use function array_any;
@@ -82,14 +80,7 @@ final readonly class NumericOperationSpecialization
      */
     public static function notEqPeepholeInner(CallNode $node): ?CallNode
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return null;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== 'not'
-        ) {
+        if (!PhelCoreCall::is($node, 'not')) {
             return null;
         }
 
@@ -123,12 +114,8 @@ final readonly class NumericOperationSpecialization
      */
     public static function typedBinaryOpName(CallNode $node): ?string
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return null;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+        $name = PhelCoreCall::nameOf($node);
+        if ($name === null) {
             return null;
         }
 
@@ -136,8 +123,6 @@ final readonly class NumericOperationSpecialization
         if (count($args) !== 2) {
             return null;
         }
-
-        $name = $fn->getName()->getName();
 
         if (isset(self::NUMERIC_BINARY_OPS[$name])) {
             if (self::isOverflowProneLiteralArithmetic($name, $args)) {
@@ -184,12 +169,8 @@ final readonly class NumericOperationSpecialization
      */
     public static function typedVariadicChain(CallNode $node): ?array
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return null;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+        $name = PhelCoreCall::nameOf($node);
+        if ($name === null) {
             return null;
         }
 
@@ -201,8 +182,6 @@ final readonly class NumericOperationSpecialization
         if (!self::allArgsAreTaggedNumericLocals($args)) {
             return null;
         }
-
-        $name = $fn->getName()->getName();
 
         if (in_array($name, ['+', '*'], true)) {
             return ['op' => self::NUMERIC_BINARY_OPS[$name], 'kind' => 'arith'];
@@ -375,14 +354,11 @@ final readonly class NumericOperationSpecialization
      */
     private static function numericTypeOfTypedBinaryCall(CallNode $node): ?string
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-        ) {
+        $name = PhelCoreCall::nameOf($node);
+        if ($name === null) {
             return null;
         }
 
-        $name = $fn->getName()->getName();
         if (!in_array($name, self::ARITHMETIC_OPS, true)) {
             return null;
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/PhelCoreCall.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/PhelCoreCall.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Shared\CompilerConstants;
+
+/**
+ * Shared shape check for a `CallNode` whose target resolves to a
+ * `phel.core` global function. Every emitter specialisation begins by
+ * asking "is this a call to phel.core/<name>?"; this collapses the
+ * repeated GlobalVarNode + namespace (+ name) guard into one place.
+ */
+final readonly class PhelCoreCall
+{
+    private function __construct() {}
+
+    /**
+     * The bare `phel.core` function name this call resolves to, or null
+     * when the call target is not a `phel.core` global var.
+     */
+    public static function nameOf(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return null;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return null;
+        }
+
+        return $fn->getName()->getName();
+    }
+
+    /**
+     * Whether this call resolves to `phel.core/<fnName>`.
+     */
+    public static function is(CallNode $node, string $fnName): bool
+    {
+        return self::nameOf($node) === $fnName;
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/TypePredicateSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/TypePredicateSpecialization.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
-use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
-use Phel\Shared\CompilerConstants;
 
 use function count;
 use function in_array;
@@ -36,19 +34,12 @@ final readonly class TypePredicateSpecialization
      */
     public static function typePredicateFragment(CallNode $node): ?string
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-        ) {
-            return null;
-        }
-
         $args = $node->getArguments();
         if (count($args) !== 1) {
             return null;
         }
 
-        return match ($fn->getName()->getName()) {
+        return match (PhelCoreCall::nameOf($node)) {
             'int?' => 'is_int(%s)',
             'float?', 'double?' => 'is_float(%s)',
             'string?' => 'is_string(%s)',
@@ -81,14 +72,11 @@ final readonly class TypePredicateSpecialization
      */
     public static function isNumericPredicate(CallNode $node): ?string
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-        ) {
+        $name = PhelCoreCall::nameOf($node);
+        if ($name === null) {
             return null;
         }
 
-        $name = $fn->getName()->getName();
         if (!in_array($name, ['zero?', 'pos?', 'neg?'], true)) {
             return null;
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecialization.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
-use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\SeqInterface;
-use Phel\Shared\CompilerConstants;
 
 use function count;
 
@@ -50,12 +48,8 @@ final readonly class TypedCollectionMethodSpecialization
      */
     public static function typedVectorMethodCall(CallNode $node): ?array
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return null;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+        $name = PhelCoreCall::nameOf($node);
+        if ($name === null) {
             return null;
         }
 
@@ -68,8 +62,6 @@ final readonly class TypedCollectionMethodSpecialization
         if (TagNormalizer::normalise($target->getInferredType()) !== PersistentVectorInterface::class) {
             return null;
         }
-
-        $name = $fn->getName()->getName();
 
         if ($name === 'count' && count($args) === 1) {
             return ['method' => 'count', 'args' => []];
@@ -103,16 +95,7 @@ final readonly class TypedCollectionMethodSpecialization
      */
     public static function isTypedVectorSecond(CallNode $node): bool
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return false;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
-            return false;
-        }
-
-        if ($fn->getName()->getName() !== 'second') {
+        if (!PhelCoreCall::is($node, 'second')) {
             return false;
         }
 
@@ -139,16 +122,11 @@ final readonly class TypedCollectionMethodSpecialization
      */
     public static function typedSeqMethodName(CallNode $node): ?string
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
+        $name = PhelCoreCall::nameOf($node);
+        if ($name === null) {
             return null;
         }
 
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
-            return null;
-        }
-
-        $name = $fn->getName()->getName();
         if (!isset(self::SEQ_METHODS[$name])) {
             return null;
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedValueSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedValueSpecialization.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
-use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
@@ -14,7 +13,6 @@ use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\ContainsInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Shared\CompilerConstants;
 
 use function count;
 use function in_array;
@@ -45,11 +43,7 @@ final readonly class TypedValueSpecialization
      */
     public static function containsCheckKind(CallNode $node): ?string
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== 'contains?'
-        ) {
+        if (!PhelCoreCall::is($node, 'contains?')) {
             return null;
         }
 
@@ -100,11 +94,7 @@ final readonly class TypedValueSpecialization
      */
     public static function emptyCheckFragment(CallNode $node): ?string
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== 'empty?'
-        ) {
+        if (!PhelCoreCall::is($node, 'empty?')) {
             return null;
         }
 
@@ -148,10 +138,8 @@ final readonly class TypedValueSpecialization
      */
     public static function namedAccessorMethod(CallNode $node): ?string
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode
-            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-        ) {
+        $name = PhelCoreCall::nameOf($node);
+        if ($name === null) {
             return null;
         }
 
@@ -170,7 +158,7 @@ final readonly class TypedValueSpecialization
             return null;
         }
 
-        return match ($fn->getName()->getName()) {
+        return match ($name) {
             'name' => 'getName',
             'namespace' => 'getNamespace',
             default => null,


### PR DESCRIPTION
## 🤔 Background

Yesterday's burst of call-site specialization PRs (#2533–#2542, #2573, #2579, #2581, …) each added a `*Specialization` class that begins by asking *"is this `CallNode` a call to `phel.core/<name>`?"*. The same guard ended up copy-pasted across **nine** emitter classes:

```php
$fn = $node->getFn();
if (!$fn instanceof GlobalVarNode) {
    return null;            // or false, depending on the method
}
if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
    || $fn->getName()->getName() !== '<name>'
) {
    return null;
}
```

This is a follow-up cleanup to #2585.

## 💡 Goal

Remove the duplication behind one shared helper, with **zero behavior change** — the analyzer-published types and the emitted PHP stay byte-for-byte identical.

## 🔖 Changes

- Add `PhelCoreCall` (`Compiler/Domain/Emitter/OutputEmitter/`) with:
  - `nameOf(CallNode): ?string` — the bare `phel.core` fn name, or `null` when the target is not a `phel.core` global var.
  - `is(CallNode, string): bool` — whether the call resolves to `phel.core/<fnName>`.
- Route every specialization predicate through it (24 call sites across `CallSpecialization`, `AssocConjSpecialization`, `TypedValueSpecialization`, `TypedCollectionMethodSpecialization`, `NumericOperationSpecialization`, `TypePredicateSpecialization`, `GetInSpecialization`, `NilAndBooleanCheckSpecialization`, `AtomMethodSpecialization`), preserving each method's original early-return value (`null` vs `false`). The `match ($fn->getName()->getName())` dispatch forms become `match (PhelCoreCall::nameOf($node))` (a non-`phel.core` call returns `null` → `default`, identical).
- Drop now-unused `GlobalVarNode` / `CompilerConstants` imports.

Net **−112 lines**. No new specialization family, no Facade/API change.

### ✅ Verification

- `composer phpstan` (level 9) — no errors
- `composer psalm` (level 1) — no errors
- `phpunit --testsuite=unit,integration` — green, including the exact-emitted-PHP integration fixtures (the only failure is the pre-existing `PharExecutionTest` shell-completion env issue, which fails identically on `main`)