### PR TITLE
ref(emitter): consolidate tagged-local-arg guards into TagNormalizer::ofLocalVar

### DIFF
--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/AssocConjSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/AssocConjSpecialization.php
@@ -48,12 +48,7 @@ final readonly class AssocConjSpecialization
         }
 
         $args = $node->getArguments();
-        $target = $args[0] ?? null;
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        $tag = TagNormalizer::normalise($target->getInferredType());
+        $tag = TagNormalizer::ofLocalVar($args[0] ?? null);
         if ($tag === null) {
             return null;
         }
@@ -113,12 +108,7 @@ final readonly class AssocConjSpecialization
             return null;
         }
 
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        if (TagNormalizer::normalise($target->getInferredType()) !== PersistentMapInterface::class) {
+        if (TagNormalizer::ofLocalVar($args[0]) !== PersistentMapInterface::class) {
             return null;
         }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -52,107 +52,33 @@ final readonly class CallSpecialization
 
     public static function isSpecialized(CallNode $node): bool
     {
-        if (self::isStrConcat($node)) {
-            return true;
-        }
-
-        if (TypedValueSpecialization::isKeywordFind($node)) {
-            return true;
-        }
-
-        if (self::isTypedGetAccess($node)) {
-            return true;
-        }
-
-        if (GetInSpecialization::isLiteralPathGetIn($node)) {
-            return true;
-        }
-
-        if (self::isTypedPhpArrayGet($node)) {
-            return true;
-        }
-
-        if (self::isTypedPhpArrayCount($node)) {
-            return true;
-        }
-
-        if (self::isTypedStringCount($node)) {
-            return true;
-        }
-
-        if (self::isTypedStringFirst($node)) {
-            return true;
-        }
-
-        if (NilAndBooleanCheckSpecialization::isNilCheck($node)) {
-            return true;
-        }
-
-        if (NilAndBooleanCheckSpecialization::isSomeCheck($node)) {
-            return true;
-        }
-
-        if (NilAndBooleanCheckSpecialization::isTrueCheck($node)) {
-            return true;
-        }
-
-        if (NilAndBooleanCheckSpecialization::isFalseCheck($node)) {
-            return true;
-        }
-
-        if (NilAndBooleanCheckSpecialization::isTruthyCheck($node)) {
-            return true;
-        }
-
-        if (TypePredicateSpecialization::isNumericPredicate($node) !== null) {
-            return true;
-        }
-
-        if (TypePredicateSpecialization::isTypePredicate($node)) {
-            return true;
-        }
-
-        if (TypedValueSpecialization::isNamedAccessor($node)) {
-            return true;
-        }
-
-        if (TypedValueSpecialization::isEmptyCheck($node)) {
-            return true;
-        }
-
-        if (TypedValueSpecialization::isContainsCheck($node)) {
-            return true;
-        }
-
-        if (AtomMethodSpecialization::isAtomMethodCall($node)) {
-            return true;
-        }
-
-        if (TypedCollectionMethodSpecialization::isTypedVectorAccessor($node)) {
-            return true;
-        }
-
-        if (TypedCollectionMethodSpecialization::isTypedSeqAccessor($node)) {
-            return true;
-        }
-
-        if (AssocConjSpecialization::isTypedDissocKeys($node)) {
-            return true;
-        }
-
-        if (AssocConjSpecialization::isTypedAssocConjDissoc($node)) {
-            return true;
-        }
-
-        if (AssocConjSpecialization::isAssocConjChain($node)) {
-            return true;
-        }
-
-        if (NumericOperationSpecialization::isNotEqPeephole($node)) {
-            return true;
-        }
-
-        if (NumericOperationSpecialization::isTypedVariadicChain($node)) {
+        if (self::isStrConcat($node)
+            || TypedValueSpecialization::isKeywordFind($node)
+            || self::isTypedGetAccess($node)
+            || GetInSpecialization::isLiteralPathGetIn($node)
+            || self::isTypedPhpArrayGet($node)
+            || self::isTypedPhpArrayCount($node)
+            || self::isTypedStringCount($node)
+            || self::isTypedStringFirst($node)
+            || NilAndBooleanCheckSpecialization::isNilCheck($node)
+            || NilAndBooleanCheckSpecialization::isSomeCheck($node)
+            || NilAndBooleanCheckSpecialization::isTrueCheck($node)
+            || NilAndBooleanCheckSpecialization::isFalseCheck($node)
+            || NilAndBooleanCheckSpecialization::isTruthyCheck($node)
+            || TypePredicateSpecialization::isNumericPredicate($node) !== null
+            || TypePredicateSpecialization::isTypePredicate($node)
+            || TypedValueSpecialization::isNamedAccessor($node)
+            || TypedValueSpecialization::isEmptyCheck($node)
+            || TypedValueSpecialization::isContainsCheck($node)
+            || AtomMethodSpecialization::isAtomMethodCall($node)
+            || TypedCollectionMethodSpecialization::isTypedVectorAccessor($node)
+            || TypedCollectionMethodSpecialization::isTypedSeqAccessor($node)
+            || AssocConjSpecialization::isTypedDissocKeys($node)
+            || AssocConjSpecialization::isTypedAssocConjDissoc($node)
+            || AssocConjSpecialization::isAssocConjChain($node)
+            || NumericOperationSpecialization::isNotEqPeephole($node)
+            || NumericOperationSpecialization::isTypedVariadicChain($node)
+        ) {
             return true;
         }
 
@@ -188,13 +114,7 @@ final readonly class CallSpecialization
             return null;
         }
 
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        $tag = TagNormalizer::normalise($target->getInferredType());
-        return match ($tag) {
+        return match (TagNormalizer::ofLocalVar($args[0])) {
             PersistentVectorInterface::class => 'get',
             PersistentMapInterface::class => 'find',
             default => null,
@@ -250,12 +170,7 @@ final readonly class CallSpecialization
             return false;
         }
 
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return false;
-        }
-
-        return TagNormalizer::normalise($target->getInferredType()) === 'array';
+        return TagNormalizer::ofLocalVar($args[0]) === 'array';
     }
 
     /**
@@ -276,12 +191,7 @@ final readonly class CallSpecialization
             return false;
         }
 
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return false;
-        }
-
-        return TagNormalizer::normalise($target->getInferredType()) === 'array';
+        return TagNormalizer::ofLocalVar($args[0]) === 'array';
     }
 
     /**
@@ -346,12 +256,7 @@ final readonly class CallSpecialization
             return false;
         }
 
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return false;
-        }
-
-        return TagNormalizer::normalise($target->getInferredType()) === 'string';
+        return TagNormalizer::ofLocalVar($args[0]) === 'string';
     }
 
     private static function isStringConcatable(AbstractNode $arg): bool
@@ -360,8 +265,7 @@ final readonly class CallSpecialization
             return true;
         }
 
-        $tag = TagNormalizer::normalise(NumericOperationSpecialization::inferredTypeOfNode($arg));
-        return $tag !== null && $tag === 'string';
+        return TagNormalizer::normalise(NumericOperationSpecialization::inferredTypeOfNode($arg)) === 'string';
     }
 
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/GetInSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/GetInSpecialization.php
@@ -6,7 +6,6 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
-use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
@@ -63,12 +62,7 @@ final readonly class GetInSpecialization
             return null;
         }
 
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        $tag = TagNormalizer::normalise($target->getInferredType());
+        $tag = TagNormalizer::ofLocalVar($args[0]);
         if ($tag !== PersistentMapInterface::class && $tag !== PersistentVectorInterface::class) {
             return null;
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowerer.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowerer.php
@@ -7,14 +7,13 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
-use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\PhelCoreCall;
 use Phel\Lang\Keyword;
-use Phel\Shared\CompilerConstants;
 
 use function count;
 use function in_array;
@@ -190,14 +189,8 @@ final readonly class IfChainMatchLowerer
             return null;
         }
 
-        $fn = $test->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return null;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || !in_array($fn->getName()->getName(), self::EQUALITY_FNS, true)
-        ) {
+        $name = PhelCoreCall::nameOf($test);
+        if ($name === null || !in_array($name, self::EQUALITY_FNS, true)) {
             return null;
         }
 
@@ -250,14 +243,8 @@ final readonly class IfChainMatchLowerer
             return self::NOT_FOLDABLE;
         }
 
-        $fn = $test->getFn();
-        if (!$fn instanceof GlobalVarNode) {
-            return self::NOT_FOLDABLE;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || !in_array($fn->getName()->getName(), self::EQUALITY_FNS, true)
-        ) {
+        $name = PhelCoreCall::nameOf($test);
+        if ($name === null || !in_array($name, self::EQUALITY_FNS, true)) {
             return self::NOT_FOLDABLE;
         }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/TagNormalizer.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/TagNormalizer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 
 use function ltrim;
@@ -31,5 +33,20 @@ final readonly class TagNormalizer
     public static function isPersistentMap(?string $tag): bool
     {
         return self::normalise($tag) === PersistentMapInterface::class;
+    }
+
+    /**
+     * The normalised inferred type tag of a node when it is a
+     * `LocalVarNode`, or `null` when the node is absent, not a local var,
+     * or carries no tag. Collapses the "is this argument a tagged local?"
+     * guard repeated across the call-site specialisations into one place.
+     */
+    public static function ofLocalVar(?AbstractNode $node): ?string
+    {
+        if (!$node instanceof LocalVarNode) {
+            return null;
+        }
+
+        return self::normalise($node->getInferredType());
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/TypePredicateSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/TypePredicateSpecialization.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
-use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 
 use function count;
 use function in_array;
@@ -86,12 +85,7 @@ final readonly class TypePredicateSpecialization
             return null;
         }
 
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        $tag = TagNormalizer::normalise($target->getInferredType());
+        $tag = TagNormalizer::ofLocalVar($args[0]);
         if ($tag !== 'int' && $tag !== 'float') {
             return null;
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecialization.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
-use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\SeqInterface;
@@ -54,12 +53,7 @@ final readonly class TypedCollectionMethodSpecialization
         }
 
         $args = $node->getArguments();
-        $target = $args[0] ?? null;
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        if (TagNormalizer::normalise($target->getInferredType()) !== PersistentVectorInterface::class) {
+        if (TagNormalizer::ofLocalVar($args[0] ?? null) !== PersistentVectorInterface::class) {
             return null;
         }
 
@@ -104,12 +98,7 @@ final readonly class TypedCollectionMethodSpecialization
             return false;
         }
 
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return false;
-        }
-
-        return TagNormalizer::normalise($target->getInferredType()) === PersistentVectorInterface::class;
+        return TagNormalizer::ofLocalVar($args[0]) === PersistentVectorInterface::class;
     }
 
     /**
@@ -136,12 +125,7 @@ final readonly class TypedCollectionMethodSpecialization
             return null;
         }
 
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        $tag = TagNormalizer::normalise($target->getInferredType());
+        $tag = TagNormalizer::ofLocalVar($args[0]);
         if ($tag === null || !isset(self::SEQ_TAGS[$tag])) {
             return null;
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedValueSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedValueSpecialization.php
@@ -52,12 +52,7 @@ final readonly class TypedValueSpecialization
             return null;
         }
 
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        $tag = TagNormalizer::normalise($target->getInferredType());
+        $tag = TagNormalizer::ofLocalVar($args[0]);
         if ($tag === null) {
             return null;
         }
@@ -103,17 +98,7 @@ final readonly class TypedValueSpecialization
             return null;
         }
 
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        $tag = TagNormalizer::normalise($target->getInferredType());
-        if ($tag === null) {
-            return null;
-        }
-
-        return match ($tag) {
+        return match (TagNormalizer::ofLocalVar($args[0])) {
             'array' => '(%s === [])',
             'string' => "(%s === '')",
             'int' => '(%s === 0)',
@@ -148,12 +133,7 @@ final readonly class TypedValueSpecialization
             return null;
         }
 
-        $target = $args[0];
-        if (!$target instanceof LocalVarNode) {
-            return null;
-        }
-
-        $tag = TagNormalizer::normalise($target->getInferredType());
+        $tag = TagNormalizer::ofLocalVar($args[0]);
         if ($tag !== Keyword::class && $tag !== Symbol::class) {
             return null;
         }


### PR DESCRIPTION
## 🤔 Background

Follow-up to #2587, which introduced `PhelCoreCall` to collapse the repeated "is this a call to `phel.core/<name>`?" guard across the emitter's call-site specialisation classes.

Reviewing that layer surfaced a second guard duplicated just as widely: every specialisation that lowers an operation on a *tagged local* repeats the same shape — take a positional argument, check it `instanceof LocalVarNode`, then read and normalise its inferred type tag:

```php
$target = $args[0];
if (!$target instanceof LocalVarNode) {
    return null;
}
$tag = TagNormalizer::normalise($target->getInferredType());
```

This appeared verbatim **14 times** across 6 classes.

## 💡 Goal

Continue the guard-consolidation started in #2587 — push the repeated tagged-local guard behind one named helper, and clean up the few remaining inconsistencies in the same layer. Pure refactor, no behaviour change.

## 🔖 Changes

- Add `TagNormalizer::ofLocalVar(?AbstractNode): ?string` — returns the normalised inferred tag of a node when it is a `LocalVarNode`, else `null` — and migrate all 14 call sites (`CallSpecialization`, `GetInSpecialization`, `TypePredicateSpecialization`, `TypedCollectionMethodSpecialization`, `TypedValueSpecialization`, `AssocConjSpecialization`).
- Migrate the two remaining hand-rolled `phel.core` guards in `IfChainMatchLowerer` (`GlobalVarNode` + namespace + name checks) to `PhelCoreCall::nameOf()`, dropping the now-unused `GlobalVarNode` / `CompilerConstants` imports.
- Flatten `CallSpecialization::isSpecialized()` from 27 `if (…) { return true; }` blocks into a single short-circuit chain (matching its sibling `isBoolReturningSpecialisation()`).
- Drop a redundant `$tag !== null && $tag === 'string'` check.

Net: **−150 lines**, one guard expressed once.

The intentional `instanceof LocalVarNode` checks left in place are not the same guard: the fn-target check in `isTypedAFnLocal`, the inference helper `inferredTypeOfNode` itself, the `CallNode`-vs-`LocalVarNode` dispatch loop in `assocConjChain` (which needs the narrowed type for its return), and `isKeywordFind`.

Verified: `composer test-quality` clean, `test-compiler` (4739 tests, the integration fixtures assert exact compiled PHP), and `test-core` (6098 Phel tests) all green. No CHANGELOG entry — internal refactor with no user-facing change, consistent with #2587.
