### PR TITLE
fix(lang): complete the collection hash/equals correctness fixes from #2567

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Hashing a persistent collection (vector, list, queue, lazy seq, hash/sorted set, or map) no longer throws a `TypeError` once it grows past ~13 elements: the rolling hash accumulator now wraps within a 32-bit range instead of silently overflowing to a float (#2567)
+- A chunked lazy seq (`ChunkedSeq`) now wraps its hash accumulator to 32-bit too — it was the one collection that escaped the #2567 fix and still overflowed past ~13 elements
+- A persistent map or hash/sorted set containing a `NaN` key/element is now equal to itself again: `equals` short-circuits on object identity before the element walk (a `NaN` never compares `=` to itself, which previously made such a collection unequal to itself)
+- A `Cons` cell or sorted set whose hash legitimately computes to `0` now caches it instead of recomputing on every `hash()` call (the cache sentinel was `0`, indistinguishable from a real zero hash)
 - The "not defined" error hint now also shows when the compiler appends a `Did you mean ...?` suggestion (a trailing period previously suppressed it)
 - `php/oset` in return context now elides the redundant closure wrapper, matching `php/->`'s return-context behavior (#2536)
 

--- a/src/php/Lang/Collections/HashSet/PersistentHashSet.php
+++ b/src/php/Lang/Collections/HashSet/PersistentHashSet.php
@@ -104,6 +104,10 @@ final class PersistentHashSet extends AbstractType implements PersistentHashSetI
 
     public function equals(mixed $other): bool
     {
+        if ($this === $other) {
+            return true;
+        }
+
         if (!$other instanceof PersistentHashSetInterface) {
             return false;
         }

--- a/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
+++ b/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
@@ -290,13 +290,10 @@ final class ChunkedSeq extends AbstractType implements LazySeqInterface, Countab
 
     public function hash(): int
     {
-        // Realize and hash the sequence (similar to PersistentList)
-        $hash = 1;
-        foreach ($this as $value) {
-            $hash = 31 * $hash + $this->hasher->hash($value);
-        }
-
-        return $hash;
+        // Realize and hash the sequence (similar to LazySeq). Delegating to
+        // orderedHash keeps the 32-bit accumulator wrap that prevents the int
+        // overflow fixed in #2585 — the bare `31 * $hash` loop here did not.
+        return $this->hasher->orderedHash($this);
     }
 
     public function equals(mixed $other): bool

--- a/src/php/Lang/Collections/LazySeq/Cons.php
+++ b/src/php/Lang/Collections/LazySeq/Cons.php
@@ -28,7 +28,7 @@ use Traversable;
  */
 final class Cons extends AbstractType implements SeqInterface, IteratorAggregate
 {
-    private int $hashCache = 0;
+    private ?int $hashCache = null;
 
     /**
      * @param T                                         $first
@@ -198,7 +198,7 @@ final class Cons extends AbstractType implements SeqInterface, IteratorAggregate
 
     public function hash(): int
     {
-        if ($this->hashCache === 0) {
+        if ($this->hashCache === null) {
             $this->hashCache = $this->hasher->orderedHash($this);
         }
 

--- a/src/php/Lang/Collections/Map/AbstractPersistentMap.php
+++ b/src/php/Lang/Collections/Map/AbstractPersistentMap.php
@@ -62,6 +62,10 @@ abstract class AbstractPersistentMap extends AbstractType implements PersistentM
 
     public function equals(mixed $other): bool
     {
+        if ($this === $other) {
+            return true;
+        }
+
         if (!$other instanceof PersistentMapInterface) {
             return false;
         }

--- a/src/php/Lang/Collections/SortedSet/PersistentSortedSet.php
+++ b/src/php/Lang/Collections/SortedSet/PersistentSortedSet.php
@@ -21,7 +21,7 @@ use Traversable;
  */
 final class PersistentSortedSet extends AbstractType implements PersistentHashSetInterface
 {
-    private int $hashCache = 0;
+    private ?int $hashCache = null;
 
     /**
      * @param PersistentMapInterface<mixed, mixed>|null $meta
@@ -101,6 +101,10 @@ final class PersistentSortedSet extends AbstractType implements PersistentHashSe
 
     public function equals(mixed $other): bool
     {
+        if ($this === $other) {
+            return true;
+        }
+
         if (!$other instanceof PersistentHashSetInterface) {
             return false;
         }
@@ -120,7 +124,7 @@ final class PersistentSortedSet extends AbstractType implements PersistentHashSe
 
     public function hash(): int
     {
-        if ($this->hashCache === 0) {
+        if ($this->hashCache === null) {
             $this->hashCache = $this->hasher->unorderedHash($this->map);
         }
 

--- a/tests/php/Unit/Lang/Collections/LazySeq/ChunkedSeqTest.php
+++ b/tests/php/Unit/Lang/Collections/LazySeq/ChunkedSeqTest.php
@@ -365,4 +365,20 @@ final class ChunkedSeqTest extends TestCase
         // (memoization should prevent re-invocation)
         $this->assertSame($countAfterFirst, $countAfterSecond, 'Generator should not be invoked again');
     }
+
+    /**
+     * Regression for the int->float overflow in the `31 * $hash + ...`
+     * accumulator: ChunkedSeq::hash() bypassed the 32-bit-masked orderedHash
+     * migration (#2585), so a long chunked seq would overflow to a float and
+     * throw a TypeError on the `: int` return. It must return a stable int.
+     */
+    public function test_hash_large_chunked_seq_returns_stable_int(): void
+    {
+        $chunkedSeq = ChunkedSeq::fromArray($this->hasher, $this->equalizer, range(0, 999), 32);
+
+        $hash = $chunkedSeq->hash();
+
+        $this->assertIsInt($hash);
+        $this->assertSame($hash, $chunkedSeq->hash());
+    }
 }

--- a/tests/php/Unit/Lang/Collections/Map/PersistentArrayMapTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/PersistentArrayMapTest.php
@@ -179,6 +179,21 @@ final class PersistentArrayMapTest extends TestCase
         $this->assertTrue($h2->equals($h1));
     }
 
+    /**
+     * Regression: a map carrying a NaN key was not equal to *itself*, because
+     * the element walk compares NaN against NaN (never `=`). The `$this ===
+     * $other` identity short-circuit — which the equals() comment already
+     * promised — makes a map reflexively equal again.
+     */
+    public function test_equals_is_reflexive_with_nan_key(): void
+    {
+        $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(NAN, 'foo')
+            ->put(1, 'bar');
+
+        $this->assertTrue($h->equals($h));
+    }
+
     public function test_equals_different_keys(): void
     {
         $h1 = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())


### PR DESCRIPTION
## 🤔 Background

While reviewing the performance batch from #2533–#2585 for further clean-up, three correctness gaps surfaced that the batch left behind — all in the persistent-collection hash/equality layer that #2567 touched.

## 💡 Goal

Finish the job #2567 started and close two related equality/cache edge cases. All three are genuine behaviour bugs (verified before/after), not style.

## 🔖 Changes

- **`ChunkedSeq::hash()` still overflowed.** It kept a bare `$hash = 31 * $hash + …` loop and never migrated to the 32-bit-masked `orderedHash()` like every other sequential collection in #2567. Past ~13 elements it overflowed to a float and threw a `TypeError` on the `: int` return. Now delegates to `orderedHash()` (matching `LazySeq`). Added the regression test #2567 added everywhere *except* here.
- **`equals()` was not reflexive for NaN-holding collections.** `AbstractPersistentMap`, `PersistentHashSet` and `PersistentSortedSet` lacked the `$this === $other` identity short-circuit — even though their own `equals()` comments already state "identical maps/sets short-circuit via `===` before reaching here". A `NaN` key/element never compares `=` to itself, so such a collection was **not equal to itself**. Verified: pre-fix `map.equals(map)` returned `false`, post-fix `true`. Added the guard + a regression test on the map.
- **`hashCache = 0` sentinel recomputed forever for a zero hash.** `Cons` and `PersistentSortedSet` checked `=== 0`, indistinguishable from a real zero hash; the other five collections already use `?int = null`. Standardised on `?int = null`.

Verified locally: `composer test-quality` clean, `test-compiler` (4741 tests — the one PHAR shell-completion failure is pre-existing and environment-specific, fails identically on `main`), `test-core` (6098).
