### PR TITLE
ref(lang): extract shared IteratorUnwrapper and LazySeqEquality helpers

### DIFF
--- a/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
+++ b/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
@@ -6,7 +6,6 @@ namespace Phel\Lang\Collections\LazySeq;
 
 use Countable;
 use Generator;
-use Iterator;
 use IteratorAggregate;
 use Phel\Lang\AbstractType;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -17,8 +16,6 @@ use Traversable;
 
 use function array_slice;
 use function count;
-use function is_array;
-use function is_object;
 
 /**
  * A chunked lazy sequence that realizes elements in batches for better performance.
@@ -303,108 +300,11 @@ final class ChunkedSeq extends AbstractType implements LazySeqInterface, Countab
             return true;
         }
 
-        $otherIter = $this->lazyIteratorFor($other);
+        $otherIter = LazySeqEquality::iteratorFor($other);
         if (!$otherIter instanceof Generator) {
             return false;
         }
 
-        return $this->walkPairwise($this->getIterator(), $otherIter, $this->equalizer);
-    }
-
-    /**
-     * Converts an arbitrary value into a lazy iterator, or returns `null`
-     * when the value is not sequence-like. Used by `equals` to compare
-     * element-by-element without realizing infinite lazy sequences.
-     */
-    private function lazyIteratorFor(mixed $value): ?Generator
-    {
-        if ($value instanceof Traversable) {
-            return (static function () use ($value): Generator {
-                foreach ($value as $v) {
-                    yield $v;
-                }
-            })();
-        }
-
-        if (is_array($value)) {
-            return (static function () use ($value): Generator {
-                foreach ($value as $v) {
-                    yield $v;
-                }
-            })();
-        }
-
-        if (is_object($value) && method_exists($value, 'toArray')) {
-            $array = $value->toArray();
-            return (static function () use ($array): Generator {
-                foreach ($array as $v) {
-                    yield $v;
-                }
-            })();
-        }
-
-        return null;
-    }
-
-    /**
-     * Walks two iterators in lockstep, comparing element-by-element via
-     * the equalizer. Returns `false` on the first divergence (either a
-     * length mismatch or an unequal element) and `true` only if both
-     * iterators exhaust at the same point.
-     *
-     * Running this against two infinite sequences loops forever, matching
-     * Clojure's behavior — it is the caller's responsibility to avoid
-     * comparing two infinite sequences for equality.
-     *
-     * @param Traversable<mixed> $left
-     * @param Traversable<mixed> $right
-     */
-    private function walkPairwise(Traversable $left, Traversable $right, EqualizerInterface $equalizer): bool
-    {
-        $leftIter = $this->asIterator($left);
-        $rightIter = $this->asIterator($right);
-
-        $leftIter->rewind();
-        $rightIter->rewind();
-
-        while (true) {
-            $leftValid = $leftIter->valid();
-            $rightValid = $rightIter->valid();
-            if ($leftValid !== $rightValid) {
-                return false;
-            }
-
-            if (!$leftValid) {
-                return true;
-            }
-
-            if (!$equalizer->equals($leftIter->current(), $rightIter->current())) {
-                return false;
-            }
-
-            $leftIter->next();
-            $rightIter->next();
-        }
-    }
-
-    /**
-     * Normalizes a `Traversable` into an `\Iterator`. Generators are
-     * already iterators, but an `IteratorAggregate` returns a nested
-     * Traversable that must be unwrapped before `valid`/`current`/`next`
-     * can be called directly.
-     */
-    /**
-     * @param Traversable<mixed> $traversable
-     *
-     * @return Iterator<mixed, mixed>
-     */
-    private function asIterator(Traversable $traversable): Iterator
-    {
-        while ($traversable instanceof IteratorAggregate) {
-            $traversable = $traversable->getIterator();
-        }
-
-        /** @var Iterator $traversable */
-        return $traversable;
+        return LazySeqEquality::walkPairwise($this->getIterator(), $otherIter, $this->equalizer);
     }
 }

--- a/src/php/Lang/Collections/LazySeq/Cons.php
+++ b/src/php/Lang/Collections/LazySeq/Cons.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Lang\Collections\LazySeq;
 
-use Iterator;
 use IteratorAggregate;
 use Phel\Lang\AbstractType;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -167,33 +166,7 @@ final class Cons extends AbstractType implements SeqInterface, IteratorAggregate
             return false;
         }
 
-        $leftIter = $this->getIterator();
-        $rightIter = $other instanceof IteratorAggregate ? $other->getIterator() : $other;
-
-        $left = $this->normalizeIterator($leftIter);
-        $right = $this->normalizeIterator($rightIter);
-
-        $left->rewind();
-        $right->rewind();
-
-        while (true) {
-            $lv = $left->valid();
-            $rv = $right->valid();
-            if ($lv !== $rv) {
-                return false;
-            }
-
-            if (!$lv) {
-                return true;
-            }
-
-            if (!$this->equalizer->equals($left->current(), $right->current())) {
-                return false;
-            }
-
-            $left->next();
-            $right->next();
-        }
+        return LazySeqEquality::walkPairwise($this->getIterator(), $other, $this->equalizer);
     }
 
     public function hash(): int
@@ -231,23 +204,5 @@ final class Cons extends AbstractType implements SeqInterface, IteratorAggregate
 
             $current = $next;
         }
-    }
-
-    /**
-     * Unwraps nested `IteratorAggregate` so `current` / `next` / `valid` can
-     * be driven directly. Generators are already iterators and pass through.
-     *
-     * @param Traversable<mixed, mixed> $traversable
-     *
-     * @return Iterator<mixed, mixed>
-     */
-    private function normalizeIterator(Traversable $traversable): Iterator
-    {
-        while ($traversable instanceof IteratorAggregate) {
-            $traversable = $traversable->getIterator();
-        }
-
-        /** @var Iterator $traversable */
-        return $traversable;
     }
 }

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -6,7 +6,6 @@ namespace Phel\Lang\Collections\LazySeq;
 
 use Countable;
 use Generator;
-use Iterator;
 use IteratorAggregate;
 use Phel\Lang\AbstractType;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -18,7 +17,6 @@ use Traversable;
 
 use function count;
 use function is_array;
-use function is_object;
 
 /**
  * A lazy sequence that defers computation until values are actually needed.
@@ -415,113 +413,12 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
             return true;
         }
 
-        $otherIter = $this->lazyIteratorFor($other);
+        $otherIter = LazySeqEquality::iteratorFor($other);
         if (!$otherIter instanceof Generator) {
             return false;
         }
 
-        return $this->walkPairwise($this->getIterator(), $otherIter, $this->equalizer);
-    }
-
-    /**
-     * Converts an arbitrary value into a lazy iterator, or returns `null`
-     * when the value is not sequence-like. Used by `equals` to compare
-     * element-by-element without realizing infinite lazy sequences.
-     */
-    /**
-     * @return Generator<int, mixed>|null
-     */
-    private function lazyIteratorFor(mixed $value): ?Generator
-    {
-        if ($value instanceof Traversable) {
-            return (static function () use ($value): Generator {
-                foreach ($value as $v) {
-                    yield $v;
-                }
-            })();
-        }
-
-        if (is_array($value)) {
-            return (static function () use ($value): Generator {
-                foreach ($value as $v) {
-                    yield $v;
-                }
-            })();
-        }
-
-        if (is_object($value) && method_exists($value, 'toArray')) {
-            $array = $value->toArray();
-            return (static function () use ($array): Generator {
-                foreach ($array as $v) {
-                    yield $v;
-                }
-            })();
-        }
-
-        return null;
-    }
-
-    /**
-     * Walks two iterators in lockstep, comparing element-by-element via
-     * the equalizer. Returns `false` on the first divergence (either a
-     * length mismatch or an unequal element) and `true` only if both
-     * iterators exhaust at the same point.
-     *
-     * Running this against two infinite sequences loops forever, matching
-     * Clojure's behavior — it is the caller's responsibility to avoid
-     * comparing two infinite sequences for equality.
-     */
-    /**
-     * @param Traversable<mixed> $left
-     * @param Traversable<mixed> $right
-     */
-    private function walkPairwise(Traversable $left, Traversable $right, EqualizerInterface $equalizer): bool
-    {
-        $leftIter = $this->asIterator($left);
-        $rightIter = $this->asIterator($right);
-
-        $leftIter->rewind();
-        $rightIter->rewind();
-
-        while (true) {
-            $leftValid = $leftIter->valid();
-            $rightValid = $rightIter->valid();
-            if ($leftValid !== $rightValid) {
-                return false;
-            }
-
-            if (!$leftValid) {
-                return true;
-            }
-
-            if (!$equalizer->equals($leftIter->current(), $rightIter->current())) {
-                return false;
-            }
-
-            $leftIter->next();
-            $rightIter->next();
-        }
-    }
-
-    /**
-     * Normalizes a `Traversable` into an `\Iterator`. Generators are
-     * already iterators, but an `IteratorAggregate` returns a nested
-     * Traversable that must be unwrapped before `valid`/`current`/`next`
-     * can be called directly.
-     */
-    /**
-     * @param Traversable<mixed> $traversable
-     *
-     * @return Iterator<mixed, mixed>
-     */
-    private function asIterator(Traversable $traversable): Iterator
-    {
-        while ($traversable instanceof IteratorAggregate) {
-            $traversable = $traversable->getIterator();
-        }
-
-        /** @var Iterator $traversable */
-        return $traversable;
+        return LazySeqEquality::walkPairwise($this->getIterator(), $otherIter, $this->equalizer);
     }
 
     /**

--- a/src/php/Lang/Collections/LazySeq/LazySeqEquality.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeqEquality.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang\Collections\LazySeq;
+
+use Generator;
+use Phel\Lang\EqualizerInterface;
+use Phel\Lang\IteratorUnwrapper;
+use Traversable;
+
+use function is_array;
+use function is_object;
+use function method_exists;
+
+/**
+ * Shared element-by-element equality for lazy sequences. `LazySeq`,
+ * `ChunkedSeq` and `Cons` all compared their elements with the same lockstep
+ * walk; this collapses the three copies (two verbatim, one inlined) into one
+ * place so a change to the accepted shapes or the divergence rule lands once.
+ */
+final readonly class LazySeqEquality
+{
+    private function __construct() {}
+
+    /**
+     * Converts an arbitrary value into a lazy iterator, or `null` when the
+     * value is not sequence-like. Lets equality compare element-by-element
+     * without realizing infinite lazy sequences.
+     *
+     * @return Generator<int, mixed>|null
+     */
+    public static function iteratorFor(mixed $value): ?Generator
+    {
+        if ($value instanceof Traversable) {
+            return (static function () use ($value): Generator {
+                foreach ($value as $v) {
+                    yield $v;
+                }
+            })();
+        }
+
+        if (is_array($value)) {
+            return (static function () use ($value): Generator {
+                foreach ($value as $v) {
+                    yield $v;
+                }
+            })();
+        }
+
+        if (is_object($value) && method_exists($value, 'toArray')) {
+            $array = $value->toArray();
+            return (static function () use ($array): Generator {
+                foreach ($array as $v) {
+                    yield $v;
+                }
+            })();
+        }
+
+        return null;
+    }
+
+    /**
+     * Walks two iterables in lockstep, comparing element-by-element via the
+     * equalizer. Returns `false` on the first divergence (a length mismatch
+     * or an unequal element) and `true` only if both exhaust at the same
+     * point.
+     *
+     * Running this against two infinite sequences loops forever, matching
+     * Clojure's behavior — it is the caller's responsibility to avoid
+     * comparing two infinite sequences for equality.
+     *
+     * @param Traversable<mixed> $left
+     * @param Traversable<mixed> $right
+     */
+    public static function walkPairwise(Traversable $left, Traversable $right, EqualizerInterface $equalizer): bool
+    {
+        $leftIter = IteratorUnwrapper::unwrap($left);
+        $rightIter = IteratorUnwrapper::unwrap($right);
+
+        $leftIter->rewind();
+        $rightIter->rewind();
+
+        while (true) {
+            $leftValid = $leftIter->valid();
+            $rightValid = $rightIter->valid();
+            if ($leftValid !== $rightValid) {
+                return false;
+            }
+
+            if (!$leftValid) {
+                return true;
+            }
+
+            if (!$equalizer->equals($leftIter->current(), $rightIter->current())) {
+                return false;
+            }
+
+            $leftIter->next();
+            $rightIter->next();
+        }
+    }
+}

--- a/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
+++ b/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
@@ -5,17 +5,14 @@ declare(strict_types=1);
 namespace Phel\Lang\Collections\Vector;
 
 use InvalidArgumentException;
-use Iterator;
-use IteratorAggregate;
 use Phel\Lang\AbstractType;
 use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\Collections\LazySeq\LazySeqInterface;
 use Phel\Lang\Collections\Map\MapEntry;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\EqualizerInterface;
-
 use Phel\Lang\HasherInterface;
-use Traversable;
+use Phel\Lang\IteratorUnwrapper;
 
 use function count;
 use function is_object;
@@ -104,8 +101,8 @@ abstract class AbstractPersistentVector extends AbstractType implements Persiste
             // `hash()` uses) instead of repeated O(log32 n) `get()`
             // trie descents. The count check above guarantees both
             // iterators stay valid over the same index range.
-            $thisIterator = $this->toIterator($this->getIterator());
-            $otherIterator = $this->toIterator($other->getIterator());
+            $thisIterator = IteratorUnwrapper::unwrap($this->getIterator());
+            $otherIterator = IteratorUnwrapper::unwrap($other->getIterator());
             while ($thisIterator->valid()) {
                 if (!$this->equalizer->equals($thisIterator->current(), $otherIterator->current())) {
                     return false;
@@ -247,24 +244,4 @@ abstract class AbstractPersistentVector extends AbstractType implements Persiste
      * @return PersistentVectorInterface<T>
      */
     abstract protected function sliceNormalized(int $start, int $end): PersistentVectorInterface;
-
-    /**
-     * Unwraps a vector's `getIterator()` result so `valid` / `current` /
-     * `next` can be driven directly in the lockstep `equals` walk.
-     * `PersistentVector` yields a `RangeIterator`; `SubVector` yields a
-     * Generator — both are already `Iterator`s and pass straight through.
-     *
-     * @param Traversable<mixed, mixed> $traversable
-     *
-     * @return Iterator<mixed, mixed>
-     */
-    private function toIterator(Traversable $traversable): Iterator
-    {
-        while ($traversable instanceof IteratorAggregate) {
-            $traversable = $traversable->getIterator();
-        }
-
-        /** @var Iterator<mixed, mixed> $traversable */
-        return $traversable;
-    }
 }

--- a/src/php/Lang/IteratorUnwrapper.php
+++ b/src/php/Lang/IteratorUnwrapper.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+use Iterator;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * Unwraps a `Traversable` into an `\Iterator` that can be driven directly
+ * with `rewind`/`valid`/`current`/`next`.
+ *
+ * Generators already are iterators, but an `IteratorAggregate` returns a
+ * nested `Traversable` (possibly several levels deep) that must be unwrapped
+ * first. Collapses the four byte-identical private unwrap helpers that lived
+ * on `AbstractPersistentVector`, `Cons`, `LazySeq` and `ChunkedSeq`.
+ */
+final readonly class IteratorUnwrapper
+{
+    private function __construct() {}
+
+    /**
+     * @param Traversable<mixed, mixed> $traversable
+     *
+     * @return Iterator<mixed, mixed>
+     */
+    public static function unwrap(Traversable $traversable): Iterator
+    {
+        while ($traversable instanceof IteratorAggregate) {
+            $traversable = $traversable->getIterator();
+        }
+
+        /** @var Iterator<mixed, mixed> $traversable */
+        return $traversable;
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Follow-up cleanup to the performance batch (#2533–#2585) and to #2589. The perf work that added chunked lazy seqs and identity short-circuits left the same iterator/equality logic copy-pasted across the collection types.

## 💡 Goal

Collapse the duplicated iterator-unwrap and lazy-seq equality logic into two shared helpers. Pure refactor, no behaviour change.

## 🔖 Changes

- **`Phel\Lang\IteratorUnwrapper::unwrap()`** — the same "unwrap nested `IteratorAggregate` into a drivable `Iterator`" loop existed as four byte-identical private helpers under four different names: `AbstractPersistentVector::toIterator`, `Cons::normalizeIterator`, `LazySeq::asIterator`, `ChunkedSeq::asIterator`. All four removed; callers delegate to the one helper.
- **`Phel\Lang\Collections\LazySeq\LazySeqEquality`** — `LazySeq` and `ChunkedSeq` carried verbatim copies of `lazyIteratorFor()` and `walkPairwise()`, and `Cons::equals` inlined a third copy of the lockstep walk. Consolidated into `iteratorFor()` + `walkPairwise()` (the walk unwraps internally via `IteratorUnwrapper`).

Net **−130 lines**, the lockstep walk and unwrap logic each expressed once.

The extracted bodies are identical to the originals; the walk only reads `current()`, so iterator key handling is irrelevant. Verified: `composer test-quality` clean, `test-compiler` (4741 — the one PHAR shell-completion failure is pre-existing and environment-specific), `test-core` (6098).
