### PR TITLE
ref(emitter): dedup specialized call emitters and shared expression helpers

### DIFF
--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -14,6 +14,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVector;
 use Phel\Lang\Keyword;
 use Phel\Lang\Ratio;
+use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use Phel\Lang\UUID;
 use Phel\Shared\Printer\PrinterInterface;
@@ -92,6 +93,7 @@ final readonly class LiteralEmitter
     {
         $this->outputEmitter->emitStr(
             '\Phel\Lang\BigInt::fromString("' . $x->__toString() . '")',
+            $x->getStartLocation(),
         );
     }
 
@@ -241,28 +243,7 @@ final readonly class LiteralEmitter
      */
     private function emitList(PersistentListInterface $x): void
     {
-        $count = count($x);
-        $this->outputEmitter->emitStr('\Phel::list([', $x->getStartLocation());
-
-        if ($count > 0) {
-            $this->outputEmitter->increaseIndentLevel();
-            $this->outputEmitter->emitLine();
-        }
-
-        foreach ($x as $i => $value) {
-            $this->outputEmitter->emitLiteral($value);
-            if ($i < $count - 1) {
-                $this->outputEmitter->emitStr(',', $x->getStartLocation());
-            }
-
-            $this->outputEmitter->emitLine();
-        }
-
-        if ($count > 0) {
-            $this->outputEmitter->decreaseIndentLevel();
-        }
-
-        $this->outputEmitter->emitStr('])', $x->getStartLocation());
+        $this->emitCollectionLiteral('\Phel::list([', $x, count($x), $x->getStartLocation());
     }
 
     /**
@@ -270,8 +251,30 @@ final readonly class LiteralEmitter
      */
     private function emitSet(PersistentHashSetInterface $x): void
     {
-        $count = count($x);
-        $this->outputEmitter->emitStr('\\Phel::set([', $x->getStartLocation());
+        $this->emitCollectionLiteral('\Phel::set([', $x, count($x), $x->getStartLocation());
+    }
+
+    /**
+     * @param PersistentVector<mixed> $x
+     */
+    private function emitVector(PersistentVector $x): void
+    {
+        $this->emitCollectionLiteral('\Phel::vector([', $x, count($x), $x->getStartLocation());
+    }
+
+    /**
+     * Emit a `\Phel::<ctor>([ … ])` collection literal: the opening token,
+     * one indented `emitLiteral` line per element (comma-separated), then the
+     * closing `])`. Shared by list / vector / set, which differ only in the
+     * constructor token. A manual element counter is used so a set — whose
+     * iteration does not yield integer keys — renders identically to the
+     * sequential collections.
+     *
+     * @param iterable<mixed> $values
+     */
+    private function emitCollectionLiteral(string $open, iterable $values, int $count, ?SourceLocation $loc): void
+    {
+        $this->outputEmitter->emitStr($open, $loc);
 
         if ($count > 0) {
             $this->outputEmitter->increaseIndentLevel();
@@ -279,10 +282,10 @@ final readonly class LiteralEmitter
         }
 
         $i = 0;
-        foreach ($x as $value) {
+        foreach ($values as $value) {
             $this->outputEmitter->emitLiteral($value);
             if ($i < $count - 1) {
-                $this->outputEmitter->emitStr(',', $x->getStartLocation());
+                $this->outputEmitter->emitStr(',', $loc);
             }
 
             $this->outputEmitter->emitLine();
@@ -293,36 +296,7 @@ final readonly class LiteralEmitter
             $this->outputEmitter->decreaseIndentLevel();
         }
 
-        $this->outputEmitter->emitStr('])', $x->getStartLocation());
-    }
-
-    /**
-     * @param PersistentVector<mixed> $x
-     */
-    private function emitVector(PersistentVector $x): void
-    {
-        $countVector = count($x);
-        $this->outputEmitter->emitStr('\Phel::vector([', $x->getStartLocation());
-
-        if ($countVector > 0) {
-            $this->outputEmitter->increaseIndentLevel();
-            $this->outputEmitter->emitLine();
-        }
-
-        foreach ($x as $i => $value) {
-            $this->outputEmitter->emitLiteral($value);
-            if ($i < $countVector - 1) {
-                $this->outputEmitter->emitStr(',', $x->getStartLocation());
-            }
-
-            $this->outputEmitter->emitLine();
-        }
-
-        if ($countVector > 0) {
-            $this->outputEmitter->decreaseIndentLevel();
-        }
-
-        $this->outputEmitter->emitStr('])', $x->getStartLocation());
+        $this->outputEmitter->emitStr('])', $loc);
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NilAndBooleanCheckSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NilAndBooleanCheckSpecialization.php
@@ -65,6 +65,24 @@ final readonly class NilAndBooleanCheckSpecialization
         return self::isUnaryCoreCall($node, 'truthy?');
     }
 
+    /**
+     * The native comparison suffix for the four single-arg identity checks
+     * (`nil?`/`some?`/`true?`/`false?`), spliced right after the emitted
+     * argument as `($arg<suffix>`. Returns `null` for any other call. The
+     * Phel-truthy probe (`truthy?`) is emitted separately — its shape is not
+     * a single trailing comparison.
+     */
+    public static function identityCheckSuffix(CallNode $node): ?string
+    {
+        return match (true) {
+            self::isNilCheck($node) => ' === null)',
+            self::isSomeCheck($node) => ' !== null)',
+            self::isTrueCheck($node) => ' === true)',
+            self::isFalseCheck($node) => ' === false)',
+            default => null,
+        };
+    }
+
     private static function isUnaryCoreCall(CallNode $node, string $name): bool
     {
         if (!PhelCoreCall::is($node, $name)) {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/AndOrShortCircuitLowerer.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/AndOrShortCircuitLowerer.php
@@ -6,14 +6,10 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\BindingNode;
-use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
-use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
-use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
-use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 
 use function count;
 
@@ -71,7 +67,7 @@ final class AndOrShortCircuitLowerer
         }
 
         foreach ($args as $arg) {
-            if (!self::isSimpleArg($arg)) {
+            if (!SimpleExpressionNode::is($arg, false)) {
                 return null;
             }
         }
@@ -138,31 +134,5 @@ final class AndOrShortCircuitLowerer
         }
 
         return $name === $binding->getSymbol()->getName();
-    }
-
-    /**
-     * Chain leaves are emitted directly into the surrounding `if (…)`
-     * test position, so each one must produce a PHP expression — not a
-     * sequence of statements wrapped in an IIFE. Accept the shapes the
-     * existing emitters render as a single expression irrespective of
-     * env context, plus `CallNode`s whose own arguments are also
-     * simple (the call itself is `($f)->__invoke($args)`, which is
-     * fine).
-     */
-    private static function isSimpleArg(AbstractNode $node): bool
-    {
-        if ($node instanceof LocalVarNode
-            || $node instanceof LiteralNode
-            || $node instanceof GlobalVarNode
-            || $node instanceof PhpVarNode
-        ) {
-            return true;
-        }
-
-        if ($node instanceof CallNode) {
-            return array_all([$node->getFn(), ...$node->getArguments()], static fn(AbstractNode $child): bool => self::isSimpleArg($child));
-        }
-
-        return false;
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -65,7 +65,7 @@ final readonly class CallEmitter implements NodeEmitterInterface
         $isYield = $fnNode instanceof PhpVarNode && $fnNode->getName() === 'yield';
 
         if (!$isYield) {
-            $this->emitContextPrefix($node);
+            $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
         }
 
         if ($fnNode instanceof PhpVarNode && $fnNode->isInfix()) {
@@ -78,23 +78,7 @@ final readonly class CallEmitter implements NodeEmitterInterface
             $this->emitPhpVarNode($node, $fnNode);
         }
 
-        $this->emitContextSuffix($node);
-    }
-
-    private function emitContextPrefix(CallNode $node): void
-    {
-        $this->outputEmitter->emitContextPrefix(
-            $node->getEnv(),
-            $node->getStartSourceLocation(),
-        );
-    }
-
-    private function emitContextSuffix(CallNode $node): void
-    {
-        $this->outputEmitter->emitContextSuffix(
-            $node->getEnv(),
-            $node->getStartSourceLocation(),
-        );
+        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
     }
 
     private function emitPhpVarNodeInfix(CallNode $node, PhpVarNode $fnNode): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowerer.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowerer.php
@@ -67,7 +67,7 @@ final readonly class IfChainMatchLowerer
         $current = $root;
 
         while ($current instanceof IfNode) {
-            $info = self::testInfo($current->getTestExpr());
+            $info = self::parseEqualityCall($current->getTestExpr());
             if ($info === null) {
                 return null;
             }
@@ -181,9 +181,13 @@ final readonly class IfChainMatchLowerer
     }
 
     /**
+     * Parse a `(= local lit)` / `(= lit local)` equality test into its
+     * (local-var, folded-literal) pair, or `null` when the call is not an
+     * eligible equality of a local against a primitive literal.
+     *
      * @return array{0: LocalVarNode, 1: mixed}|null
      */
-    private static function testInfo(AbstractNode $test): ?array
+    private static function parseEqualityCall(AbstractNode $test): ?array
     {
         if (!$test instanceof CallNode) {
             return null;
@@ -203,20 +207,12 @@ final readonly class IfChainMatchLowerer
 
         if ($lhs instanceof LocalVarNode) {
             $value = self::literalValue($rhs);
-            if ($value === self::NOT_FOLDABLE) {
-                return null;
-            }
-
-            return [$lhs, $value];
+            return $value === self::NOT_FOLDABLE ? null : [$lhs, $value];
         }
 
         if ($rhs instanceof LocalVarNode) {
             $value = self::literalValue($lhs);
-            if ($value === self::NOT_FOLDABLE) {
-                return null;
-            }
-
-            return [$rhs, $value];
+            return $value === self::NOT_FOLDABLE ? null : [$rhs, $value];
         }
 
         return null;
@@ -239,31 +235,14 @@ final readonly class IfChainMatchLowerer
 
     private static function matchEqualityTest(AbstractNode $test, string $activeShadow): mixed
     {
-        if (!$test instanceof CallNode) {
+        $parsed = self::parseEqualityCall($test);
+        if ($parsed === null) {
             return self::NOT_FOLDABLE;
         }
 
-        $name = PhelCoreCall::nameOf($test);
-        if ($name === null || !in_array($name, self::EQUALITY_FNS, true)) {
-            return self::NOT_FOLDABLE;
-        }
+        [$local, $value] = $parsed;
 
-        $args = $test->getArguments();
-        if (count($args) !== 2) {
-            return self::NOT_FOLDABLE;
-        }
-
-        [$lhs, $rhs] = $args;
-
-        if ($lhs instanceof LocalVarNode && $lhs->getName()->getName() === $activeShadow) {
-            return self::literalValue($rhs);
-        }
-
-        if ($rhs instanceof LocalVarNode && $rhs->getName()->getName() === $activeShadow) {
-            return self::literalValue($lhs);
-        }
-
-        return self::NOT_FOLDABLE;
+        return $local->getName()->getName() === $activeShadow ? $value : self::NOT_FOLDABLE;
     }
 
     private static function isPrimitive(mixed $value): bool

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
@@ -5,13 +5,8 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
-use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
-use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
-use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
-use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
-use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\BooleanExprDetector;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
@@ -61,7 +56,7 @@ final class IfEmitter implements NodeEmitterInterface
 
         $then = $node->getThenExpr();
         $else = $node->getElseExpr();
-        if (!self::isSimpleExpressionNode($then) || !self::isSimpleExpressionNode($else)) {
+        if (!SimpleExpressionNode::is($then, true) || !SimpleExpressionNode::is($else, true)) {
             return false;
         }
 
@@ -104,34 +99,6 @@ final class IfEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitLine('}', $loc);
 
         return true;
-    }
-
-    /**
-     * Chain leaves and ternary branches are emitted directly into a
-     * surrounding expression context, so each one must render as a
-     * single PHP expression — `LetNode` / `IfNode` in `RETURN`
-     * context expand to multi-statement bodies that the strip helper
-     * cannot safely flatten.
-     */
-    private static function isSimpleExpressionNode(AbstractNode $node): bool
-    {
-        if ($node instanceof DoNode) {
-            return $node->getStmts() === [] && self::isSimpleExpressionNode($node->getRet());
-        }
-
-        if ($node instanceof LocalVarNode
-            || $node instanceof LiteralNode
-            || $node instanceof GlobalVarNode
-            || $node instanceof PhpVarNode
-        ) {
-            return true;
-        }
-
-        if ($node instanceof CallNode) {
-            return array_all([$node->getFn(), ...$node->getArguments()], static fn(AbstractNode $child): bool => self::isSimpleExpressionNode($child));
-        }
-
-        return false;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/SimpleExpressionNode.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/SimpleExpressionNode.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+
+use function array_all;
+
+/**
+ * Whether an analysed node renders as a single PHP expression — no statement
+ * wrapping, no IIFE. Both the `if` ternary lowering ({@see IfEmitter}) and the
+ * `and`/`or` short-circuit lowering ({@see AndOrShortCircuitLowerer}) need this
+ * test before splicing a node into an expression position; this is their
+ * shared definition.
+ */
+final readonly class SimpleExpressionNode
+{
+    private function __construct() {}
+
+    /**
+     * @param bool $unwrapTransparentDo when true a `(do …)` whose body is a
+     *                                  single return expression is treated as
+     *                                  transparent (the `if` ternary lowerer
+     *                                  relies on this); when false a `do` is
+     *                                  never simple, preserving the and/or
+     *                                  lowerer's IIFE path
+     */
+    public static function is(AbstractNode $node, bool $unwrapTransparentDo): bool
+    {
+        if ($unwrapTransparentDo && $node instanceof DoNode) {
+            return $node->getStmts() === [] && self::is($node->getRet(), true);
+        }
+
+        if ($node instanceof LocalVarNode
+            || $node instanceof LiteralNode
+            || $node instanceof GlobalVarNode
+            || $node instanceof PhpVarNode
+        ) {
+            return true;
+        }
+
+        if ($node instanceof CallNode) {
+            return array_all([$node->getFn(), ...$node->getArguments()], static fn(AbstractNode $child): bool => self::is($child, $unwrapTransparentDo));
+        }
+
+        return false;
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/AssocConjCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/AssocConjCallEmitter.php
@@ -9,7 +9,6 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\AssocConjSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
 
 use function array_slice;
-use function count;
 
 /**
  * Specialisations gated by {@see AssocConjSpecialization}: a transient-backed
@@ -92,14 +91,7 @@ final readonly class AssocConjCallEmitter implements SpecializedCallEmitterInter
 
         foreach ($chain['groups'] as $group) {
             $this->outputEmitter->emitStr('->' . $chain['method'] . '(', $loc);
-            foreach ($group as $i => $arg) {
-                if ($i > 0) {
-                    $this->outputEmitter->emitStr(', ', $loc);
-                }
-
-                $this->outputEmitter->emitNode($arg);
-            }
-
+            $this->outputEmitter->emitArgList($group, $loc);
             $this->outputEmitter->emitStr(')', $loc);
         }
 
@@ -124,16 +116,7 @@ final readonly class AssocConjCallEmitter implements SpecializedCallEmitterInter
         $this->outputEmitter->emitStr('(', $loc);
         $this->outputEmitter->emitNode($args[0]);
         $this->outputEmitter->emitStr('->' . $method . '(', $loc);
-
-        $rest = array_slice($args, 1);
-        $count = count($rest);
-        foreach ($rest as $i => $arg) {
-            $this->outputEmitter->emitNode($arg);
-            if ($i < $count - 1) {
-                $this->outputEmitter->emitStr(', ', $loc);
-            }
-        }
-
+        $this->outputEmitter->emitArgList(array_slice($args, 1), $loc);
         $this->outputEmitter->emitStr('))', $loc);
         return true;
     }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/AtomMethodCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/AtomMethodCallEmitter.php
@@ -19,18 +19,13 @@ final readonly class AtomMethodCallEmitter implements SpecializedCallEmitterInte
         private OutputEmitterInterface $outputEmitter,
     ) {}
 
-    public function tryEmit(CallNode $node): bool
-    {
-        return $this->tryEmitAtomMethodCall($node);
-    }
-
     /**
      * `(deref x)` / `(reset! v val)` — emit the direct method call on
      * the target, skipping the registry lookup. No tag required: the
      * runtime body itself is a single `php/-> target (method ...)`, so
      * the failure mode (method not found) is identical to today.
      */
-    private function tryEmitAtomMethodCall(CallNode $node): bool
+    public function tryEmit(CallNode $node): bool
     {
         $shape = AtomMethodSpecialization::atomMethodCall($node);
         if ($shape === null) {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/NilBooleanCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/NilBooleanCallEmitter.php
@@ -22,83 +22,16 @@ final readonly class NilBooleanCallEmitter implements SpecializedCallEmitterInte
 
     public function tryEmit(CallNode $node): bool
     {
-        if ($this->tryEmitNilCheck($node)) {
-            return true;
-        }
-
-        if ($this->tryEmitSomeCheck($node)) {
-            return true;
-        }
-
-        if ($this->tryEmitTrueCheck($node)) {
-            return true;
-        }
-
-        if ($this->tryEmitFalseCheck($node)) {
+        $suffix = NilAndBooleanCheckSpecialization::identityCheckSuffix($node);
+        if ($suffix !== null) {
+            $loc = $node->getStartSourceLocation();
+            $this->outputEmitter->emitStr('(', $loc);
+            $this->outputEmitter->emitNode($node->getArguments()[0]);
+            $this->outputEmitter->emitStr($suffix, $loc);
             return true;
         }
 
         return $this->tryEmitTruthyCheck($node);
-    }
-
-    /**
-     * `(nil? x)` — emit `($x === null)` directly, bypassing the
-     * registry lookup and `id` adapter.
-     */
-    private function tryEmitNilCheck(CallNode $node): bool
-    {
-        if (!NilAndBooleanCheckSpecialization::isNilCheck($node)) {
-            return false;
-        }
-
-        $loc = $node->getStartSourceLocation();
-        $this->outputEmitter->emitStr('(', $loc);
-        $this->outputEmitter->emitNode($node->getArguments()[0]);
-        $this->outputEmitter->emitStr(' === null)', $loc);
-        return true;
-    }
-
-    /**
-     * `(some? x)` 1-arg — emit `($x !== null)` directly. The 2-arg
-     * overload `(some? pred coll)` keeps the runtime dispatch.
-     */
-    private function tryEmitSomeCheck(CallNode $node): bool
-    {
-        if (!NilAndBooleanCheckSpecialization::isSomeCheck($node)) {
-            return false;
-        }
-
-        $loc = $node->getStartSourceLocation();
-        $this->outputEmitter->emitStr('(', $loc);
-        $this->outputEmitter->emitNode($node->getArguments()[0]);
-        $this->outputEmitter->emitStr(' !== null)', $loc);
-        return true;
-    }
-
-    private function tryEmitTrueCheck(CallNode $node): bool
-    {
-        if (!NilAndBooleanCheckSpecialization::isTrueCheck($node)) {
-            return false;
-        }
-
-        $loc = $node->getStartSourceLocation();
-        $this->outputEmitter->emitStr('(', $loc);
-        $this->outputEmitter->emitNode($node->getArguments()[0]);
-        $this->outputEmitter->emitStr(' === true)', $loc);
-        return true;
-    }
-
-    private function tryEmitFalseCheck(CallNode $node): bool
-    {
-        if (!NilAndBooleanCheckSpecialization::isFalseCheck($node)) {
-            return false;
-        }
-
-        $loc = $node->getStartSourceLocation();
-        $this->outputEmitter->emitStr('(', $loc);
-        $this->outputEmitter->emitNode($node->getArguments()[0]);
-        $this->outputEmitter->emitStr(' === false)', $loc);
-        return true;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/TypePredicateCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/TypePredicateCallEmitter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\Specialized;
 
+use InvalidArgumentException;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\TypePredicateSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
@@ -50,7 +51,8 @@ final readonly class TypePredicateCallEmitter implements SpecializedCallEmitterI
             'zero?' => ' === 0',
             'pos?' => ' > 0',
             'neg?' => ' < 0',
-            default => ' === 0',
+            // isNumericPredicate only ever returns these three names.
+            default => throw new InvalidArgumentException(sprintf('Unhandled numeric predicate: %s', $name)),
         };
 
         $this->outputEmitter->emitStr($op . ')', $loc);

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/TypedCollectionCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/TypedCollectionCallEmitter.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\Specialized;
 
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\TypedCollectionMethodSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
 
-use function count;
+use function array_map;
 
 /**
  * Specialisations gated by {@see TypedCollectionMethodSpecialization}:
@@ -81,14 +82,8 @@ final readonly class TypedCollectionCallEmitter implements SpecializedCallEmitte
         $this->outputEmitter->emitNode($args[0]);
         $this->outputEmitter->emitStr('->' . $spec['method'] . '(', $loc);
 
-        $argCount = count($spec['args']);
-        foreach ($spec['args'] as $i => $argIndex) {
-            $this->outputEmitter->emitNode($args[$argIndex]);
-            if ($i < $argCount - 1) {
-                $this->outputEmitter->emitStr(', ', $loc);
-            }
-        }
-
+        $methodArgs = array_map(static fn(int $argIndex): AbstractNode => $args[$argIndex], $spec['args']);
+        $this->outputEmitter->emitArgList($methodArgs, $loc);
         $this->outputEmitter->emitStr('))', $loc);
         return true;
     }


### PR DESCRIPTION
## 🤔 Background

Follow-up cleanup to the performance batch (#2533–#2585) and to #2587/#2588, which consolidated the specialisation *eligibility* classes. This PR tidies the *emission* side and the shared emitter helpers that the perf work grew.

## 💡 Goal

Remove the duplication and trivial indirection in the specialised call emitters and the shared `if` / `and`/`or` lowering. Behaviour-preserving — the integration fixtures assert exact compiled PHP, and they all stay green.

## 🔖 Changes

- **`SimpleExpressionNode::is()`** — `IfEmitter` and `AndOrShortCircuitLowerer` carried near-identical "does this node render as a single PHP expression?" predicates. Their one real difference — `IfEmitter` unwraps a transparent `(do …)`, the and/or lowerer never does — is preserved via an explicit `$unwrapTransparentDo` flag, so neither path's output changes. (The divergence is now visible in one place rather than silently split across two files.)
- **`NilBooleanCallEmitter`** — four `tryEmitXCheck` methods differing only in the comparison suffix (`=== null`, `!== null`, `=== true`, `=== false`) collapse to one, driven by a new `NilAndBooleanCheckSpecialization::identityCheckSuffix()` fragment (matching the existing `typePredicateFragment`/`emptyCheckFragment` pattern).
- **`emitArgList`** — the manual `$i < $count - 1` comma loops in `AssocConjCallEmitter` (×2) and `TypedCollectionCallEmitter` now use the existing `OutputEmitterInterface::emitArgList` helper (byte-identical output; `array_slice` already re-indexes to 0-based).
- **`IfChainMatchLowerer`** — `testInfo` and `matchEqualityTest` shared a 20-line `(= local lit)` parser → one `parseEqualityCall` (the shadow-name filter stays in `matchEqualityTest`; behaviour-equivalent because `literalValue` of a local is always non-foldable).
- **`LiteralEmitter`** — `emitList`/`emitVector`/`emitSet` shared a ~20-line indent/comma/newline skeleton → one `emitCollectionLiteral` (also drops the odd `$countVector` local).
- **`emitBigInt` source location** — it was the only literal emitter not passing `$x->getStartLocation()` (UUID/BigDecimal do), so `BigInt` literals lost their source-map positions. Fixed.
- **Trivial indirection** — inline the pass-through `AtomMethodCallEmitter::tryEmitAtomMethodCall` and `CallEmitter`'s context prefix/suffix wrappers; replace an unreachable `match` default in `TypePredicateCallEmitter` with a `throw` (the eligibility check already constrains the name set).

Net **−144 lines**. Verified: `composer test-quality` clean, `test-compiler` (4741 — the one PHAR shell-completion failure is pre-existing and environment-specific), `test-core` (6098).
