### PR TITLE
ref(build): dedup folder/cache bookkeeping and name memo-key separators

### DIFF
--- a/src/php/Build/Application/DependenciesForNamespace.php
+++ b/src/php/Build/Application/DependenciesForNamespace.php
@@ -16,6 +16,18 @@ use function is_string;
 final class DependenciesForNamespace
 {
     /**
+     * Separates the individual items within one part of a memo key. A control
+     * byte no directory path or namespace can contain.
+     */
+    private const string MEMO_ITEM_SEPARATOR = "\0";
+
+    /**
+     * Separates the directories part of a memo key from the seed-namespaces
+     * part, so the two sets cannot collide across the boundary.
+     */
+    private const string MEMO_PART_SEPARATOR = "\x01";
+
+    /**
      * Intra-process memo keyed by `(dirs, seeds)` so the three root callers
      * (`FileRunner`, `DataReadersLoader`, `NamespaceLoader`) don't each re-derive
      * the same transitive dependency closure within one process.
@@ -107,6 +119,8 @@ final class DependenciesForNamespace
         $seeds = $ns;
         sort($seeds);
 
-        return implode("\0", $dirs) . "\x01" . implode("\0", $seeds);
+        return implode(self::MEMO_ITEM_SEPARATOR, $dirs)
+            . self::MEMO_PART_SEPARATOR
+            . implode(self::MEMO_ITEM_SEPARATOR, $seeds);
     }
 }

--- a/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
+++ b/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
@@ -29,6 +29,8 @@ use const TOKEN_PARSE;
  */
 final class CompiledCodeCache implements CompiledCodeCacheInterface
 {
+    use DeferredFlushTrait;
+
     /** @var array<string, CacheEntry> */
     private array $entries = [];
 
@@ -53,16 +55,6 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
     private array $touchedThisProcess = [];
 
     private bool $loaded = false;
-
-    /**
-     * Set when `put`/`invalidate` mutate the in-memory index. The index is
-     * written to disk exactly once per process at shutdown (see
-     * {@see registerShutdown()}), turning a cold build's index I/O from
-     * O(N²) bytes written (one full rewrite per `put`) into O(N).
-     */
-    private bool $indexDirty = false;
-
-    private bool $shutdownRegistered = false;
 
     private readonly CacheDirectory $directory;
 
@@ -165,7 +157,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
         unset($this->tombstones[$sourcePath]);
 
         $this->evictLRU();
-        $this->markDirty();
+        $this->markFlushPending();
 
         if (function_exists('opcache_compile_file')) {
             @opcache_compile_file($compiledPath);
@@ -227,7 +219,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
 
         unset($this->entries[$sourcePath], $this->touchedThisProcess[$sourcePath]);
         $this->tombstones[$sourcePath] = true;
-        $this->markDirty();
+        $this->markFlushPending();
     }
 
     /**
@@ -249,7 +241,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
         $this->tombstones = [];
         $this->touchedThisProcess = [];
         $this->saveEntries();
-        $this->indexDirty = false;
+        $this->clearFlushPending();
         $this->environmentStore->clearMemo();
     }
 
@@ -265,12 +257,12 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
      */
     public function save(): void
     {
-        if (!$this->indexDirty) {
+        if (!$this->isFlushPending()) {
             return;
         }
 
         $this->saveEntries();
-        $this->indexDirty = false;
+        $this->clearFlushPending();
     }
 
     private function loadEntries(): void
@@ -286,22 +278,6 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
     private function saveEntries(): void
     {
         $this->entries = $this->indexFile->save($this->entries, $this->tombstones);
-    }
-
-    private function markDirty(): void
-    {
-        $this->indexDirty = true;
-        $this->registerShutdown();
-    }
-
-    private function registerShutdown(): void
-    {
-        if ($this->shutdownRegistered) {
-            return;
-        }
-
-        register_shutdown_function([$this, 'save']);
-        $this->shutdownRegistered = true;
     }
 
     private function isValidPhp(string $phpCode): bool

--- a/src/php/Build/Infrastructure/Cache/DeferredFlushTrait.php
+++ b/src/php/Build/Infrastructure/Cache/DeferredFlushTrait.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Infrastructure\Cache;
+
+/**
+ * Shared "flush once at shutdown" bookkeeping for the on-disk caches. Both
+ * {@see CompiledCodeCache} and {@see PhpScanIndexCache} only mutate their
+ * in-memory index per `put`/`invalidate` and defer the disk write to a single
+ * `register_shutdown_function` flush, turning a cold build's index I/O from
+ * O(N²) into O(N). This keeps the dirty-flag + lazy-registration pair in one
+ * place; each cache still owns its own {@see save()} body.
+ */
+trait DeferredFlushTrait
+{
+    private bool $flushPending = false;
+
+    private bool $shutdownRegistered = false;
+
+    /**
+     * Each cache flushes its in-memory mutations to disk. Called exactly once
+     * per process at shutdown (and may also be called explicitly, e.g. by
+     * tests needing cross-instance persistence in the same process).
+     */
+    abstract public function save(): void;
+
+    /**
+     * Mark the in-memory state as needing a flush and ensure {@see save()}
+     * runs once at shutdown. Registration is lazy (not in the constructor) so
+     * a read-only process never installs a handler.
+     */
+    private function markFlushPending(): void
+    {
+        $this->flushPending = true;
+        if ($this->shutdownRegistered) {
+            return;
+        }
+
+        register_shutdown_function([$this, 'save']);
+        $this->shutdownRegistered = true;
+    }
+
+    private function isFlushPending(): bool
+    {
+        return $this->flushPending;
+    }
+
+    private function clearFlushPending(): void
+    {
+        $this->flushPending = false;
+    }
+}

--- a/src/php/Build/Infrastructure/Cache/PhpScanIndexCache.php
+++ b/src/php/Build/Infrastructure/Cache/PhpScanIndexCache.php
@@ -23,11 +23,9 @@ use function is_string;
  */
 final class PhpScanIndexCache implements ScanIndexCacheInterface
 {
+    use DeferredFlushTrait;
+
     private const string VERSION = '1.0';
-
-    private bool $dirty = false;
-
-    private bool $shutdownRegistered = false;
 
     /** @var array<string, ScanIndexEntry> */
     private array $entries;
@@ -59,13 +57,12 @@ final class PhpScanIndexCache implements ScanIndexCacheInterface
         }
 
         $this->entries[$dirSetKey] = new ScanIndexEntry($perDir, $files, $infos);
-        $this->dirty = true;
-        $this->registerShutdown();
+        $this->markFlushPending();
     }
 
     public function save(): void
     {
-        if (!$this->dirty) {
+        if (!$this->isFlushPending()) {
             return;
         }
 
@@ -99,7 +96,7 @@ final class PhpScanIndexCache implements ScanIndexCacheInterface
             rewind($handle);
             $content = '<?php return ' . var_export($this->toArray(), true) . ';';
             fwrite($handle, $content);
-            $this->dirty = false;
+            $this->clearFlushPending();
         } finally {
             flock($handle, LOCK_UN);
             fclose($handle);
@@ -113,7 +110,7 @@ final class PhpScanIndexCache implements ScanIndexCacheInterface
     public function clear(): void
     {
         $this->entries = [];
-        $this->dirty = false;
+        $this->clearFlushPending();
 
         if (file_exists($this->cacheFile)) {
             @unlink($this->cacheFile);
@@ -172,15 +169,5 @@ final class PhpScanIndexCache implements ScanIndexCacheInterface
             'version' => self::VERSION,
             'entries' => $entries,
         ];
-    }
-
-    private function registerShutdown(): void
-    {
-        if ($this->shutdownRegistered) {
-            return;
-        }
-
-        register_shutdown_function([$this, 'save']);
-        $this->shutdownRegistered = true;
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/LiteralArithmeticFolder.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/LiteralArithmeticFolder.php
@@ -30,6 +30,8 @@ use function min;
  */
 final readonly class LiteralArithmeticFolder
 {
+    use PairwiseLiteralFoldingTrait;
+
     /**
      * `2^63`, the smallest float strictly above `PHP_INT_MAX` (2^63 - 1).
      * Used as the exclusive upper bound for the int range because
@@ -86,12 +88,12 @@ final readonly class LiteralArithmeticFolder
             // Phel `=` is type-strict: `(= 1 1.0)` is `false`. Numeric
             // promotion is reserved for `<` / `<=` / `>` / `>=` which
             // compare values, not identities.
-            '=' => $this->compareAll($literals, static fn($a, $b): bool => $a === $b),
-            'not=' => $this->negate($this->compareAll($literals, static fn($a, $b): bool => $a === $b)),
-            '<' => $this->compareAll($literals, static fn($a, $b): bool => $a < $b),
-            '<=' => $this->compareAll($literals, static fn($a, $b): bool => $a <= $b),
-            '>' => $this->compareAll($literals, static fn($a, $b): bool => $a > $b),
-            '>=' => $this->compareAll($literals, static fn($a, $b): bool => $a >= $b),
+            '=' => $this->foldPairwise($literals, static fn($a, $b): bool => $a === $b),
+            'not=' => $this->negate($this->foldPairwise($literals, static fn($a, $b): bool => $a === $b)),
+            '<' => $this->foldPairwise($literals, static fn($a, $b): bool => $a < $b),
+            '<=' => $this->foldPairwise($literals, static fn($a, $b): bool => $a <= $b),
+            '>' => $this->foldPairwise($literals, static fn($a, $b): bool => $a > $b),
+            '>=' => $this->foldPairwise($literals, static fn($a, $b): bool => $a >= $b),
             'min' => $this->extremum($literals, true),
             'max' => $this->extremum($literals, false),
             'mod' => $this->modFloor($literals),
@@ -124,35 +126,6 @@ final readonly class LiteralArithmeticFolder
         }
 
         return $literals;
-    }
-
-    /**
-     * N-ary pairwise comparison. Phel mirrors Clojure: `(=)` is an arity
-     * error (skip), `(= x)` is `true`, otherwise consecutive pairs must
-     * all satisfy `cmp`.
-     *
-     * @param list<float|int>                      $literals
-     * @param callable(float|int, float|int): bool $cmp
-     */
-    private function compareAll(array $literals, callable $cmp): ?bool
-    {
-        $count = count($literals);
-        if ($count === 0) {
-            return null;
-        }
-
-        for ($i = 0; $i < $count - 1; ++$i) {
-            if (!$cmp($literals[$i], $literals[$i + 1])) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private function negate(?bool $value): ?bool
-    {
-        return $value === null ? null : !$value;
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/LiteralStringFolder.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/LiteralStringFolder.php
@@ -7,7 +7,6 @@ namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 
-use function count;
 use function is_string;
 
 /**
@@ -26,6 +25,8 @@ use function is_string;
  */
 final readonly class LiteralStringFolder
 {
+    use PairwiseLiteralFoldingTrait;
+
     /** @var array<string, true> */
     private const array SUPPORTED = ['=' => true, 'not=' => true];
 
@@ -49,8 +50,8 @@ final readonly class LiteralStringFolder
         }
 
         return match ($fnName) {
-            '=' => $this->allEqual($strings),
-            'not=' => $this->negate($this->allEqual($strings)),
+            '=' => $this->foldPairwise($strings, static fn($a, $b): bool => $a === $b),
+            'not=' => $this->negate($this->foldPairwise($strings, static fn($a, $b): bool => $a === $b)),
             default => null,
         };
     }
@@ -77,33 +78,5 @@ final readonly class LiteralStringFolder
         }
 
         return $strings;
-    }
-
-    /**
-     * N-ary pairwise equality. Phel mirrors Clojure: `(=)` is an arity error
-     * (skip), `(= x)` is `true`, otherwise consecutive pairs must all be
-     * value-equal.
-     *
-     * @param list<string> $strings
-     */
-    private function allEqual(array $strings): ?bool
-    {
-        $count = count($strings);
-        if ($count === 0) {
-            return null;
-        }
-
-        for ($i = 0; $i < $count - 1; ++$i) {
-            if ($strings[$i] !== $strings[$i + 1]) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private function negate(?bool $value): ?bool
-    {
-        return $value === null ? null : !$value;
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/PairwiseLiteralFoldingTrait.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/PairwiseLiteralFoldingTrait.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer;
+
+use function count;
+
+/**
+ * Shared helpers for the literal comparison folders. Phel's `=`/`not=`/`<`/…
+ * are n-ary and fold the same way: an empty arity is left for the runtime
+ * (Phel raises), a single operand is `true`, and otherwise every adjacent
+ * pair must satisfy the comparator. {@see LiteralStringFolder} and
+ * {@see LiteralArithmeticFolder} both reduced over this shape and both
+ * negated for `not=`; this keeps that logic in one place.
+ */
+trait PairwiseLiteralFoldingTrait
+{
+    /**
+     * Fold an n-ary chain of pairwise comparisons to a single bool, or `null`
+     * for an empty arity. Returns `false` on the first adjacent pair the
+     * comparator rejects, `true` when every pair (or a lone operand) passes.
+     *
+     * @param list<mixed>                  $literals
+     * @param callable(mixed, mixed): bool $compare
+     */
+    private function foldPairwise(array $literals, callable $compare): ?bool
+    {
+        $count = count($literals);
+        if ($count === 0) {
+            return null;
+        }
+
+        for ($i = 0; $i < $count - 1; ++$i) {
+            if (!$compare($literals[$i], $literals[$i + 1])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function negate(?bool $value): ?bool
+    {
+        return $value === null ? null : !$value;
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Final follow-up cleanup to the performance batch (#2533–#2585), after #2589/#2590/#2591. The perf work introduced a few pieces of duplicated bookkeeping and some unnamed magic constants in the build/analyzer layer.

## 💡 Goal

Remove that duplication and name the magic constants. Pure refactor, no behaviour change.

## 🔖 Changes

- **`PairwiseLiteralFoldingTrait`** — `LiteralStringFolder` and `LiteralArithmeticFolder` each carried a verbatim copy of the n-ary pairwise-fold loop (`allEqual` / `compareAll`) and an identical `negate()`. The string folder's `allEqual` is just the `===` special case of `compareAll`, so both now share `foldPairwise(callable)` + `negate()`.
- **`DeferredFlushTrait`** — `CompiledCodeCache` and `PhpScanIndexCache` had the same dirty-flag + lazy `register_shutdown_function` bookkeeping copy-pasted (under differently-named flags, `indexDirty` vs `dirty`). Extracted to one trait (`markFlushPending` / `isFlushPending` / `clearFlushPending` + an abstract `save()`); each cache keeps its own `save()` body.
- **`DependenciesForNamespace::memoKey`** — the `\0` / `\x01` separator bytes are now named constants (`MEMO_ITEM_SEPARATOR` / `MEMO_PART_SEPARATOR`) with the collision rationale documented, instead of bare magic bytes.

Verified: `composer test-quality` clean, `test-compiler` (4741 — the one PHAR shell-completion failure is pre-existing and environment-specific), `test-core` (6098).

## Deferred

Two further ideas from the review were intentionally left out as larger, separate concerns: making `NamespaceFileTracker` an injected instance instead of process-wide `static` state (touches `RunFactory` wiring + test isolation), and replacing the `LazyCommand` metadata magic-string tuples with named `Command::lazy()` constructors (30+ call sites, interacts with the drift-guard test). Happy to do either as its own PR.
