### PR TITLE
perf(emitter): specialize inc/dec on int/float-tagged locals to native +1/-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - PHP interop (`php/->`, `php/::`, `php/new`, `php/oset`) now compiles to direct expressions or statements instead of wrapping every call in a closure (#2524, #2525, #2526, #2532, #2536)
 - Type-tagged core calls now compile straight to native operations: `push`/`dissoc` to persistent-collection methods (#2527), `second`/`get-in` to direct vector/map access (#2530, #2529), and `count`/`first` on strings to `mb_strlen`/`mb_substr` (#2528)
+- `(inc x)`/`(dec x)` on an `^int`/`^float`-tagged local now compile to native `($x + 1)`/`($x - 1)` instead of dispatching through `NumericOperations`, matching the existing `(php/+ ^int x 1)` lowering (#2562)
 - `=` and `not=` over string literals now fold to a boolean at compile time (#2531)
 - `dissoc`/`remove` on a large persistent map no longer does an O(n) deep node comparison on the no-op path (#2544)
 - The analyzer reuses stateless sub-analyzers (literal/constant-folder/let-simplifier) instead of allocating them per node (#2553)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -78,6 +78,7 @@ final readonly class CallSpecialization
             || AssocConjSpecialization::isAssocConjChain($node)
             || NumericOperationSpecialization::isNotEqPeephole($node)
             || NumericOperationSpecialization::isTypedVariadicChain($node)
+            || NumericOperationSpecialization::isTypedIncDec($node)
         ) {
             return true;
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/NumericOperationCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/NumericOperationCallEmitter.php
@@ -33,7 +33,35 @@ final readonly class NumericOperationCallEmitter implements SpecializedCallEmitt
             return true;
         }
 
+        if ($this->tryEmitTypedIncDec($node)) {
+            return true;
+        }
+
         return $this->tryEmitTypedBinaryOp($node);
+    }
+
+    /**
+     * Single-arg `(inc x)` / `(dec x)` over a tagged primitive operand:
+     * emits `($x + 1)` / `($x - 1)` directly, skipping the
+     * `phel.core/inc` / `phel.core/dec` registry dispatch and the
+     * `NumericOperations::add`/`subtract` call. The literal `1` matches
+     * the right operand the runtime defns add/subtract.
+     *
+     * Eligibility lives on {@see NumericOperationSpecialization::typedIncDecOp()}.
+     */
+    private function tryEmitTypedIncDec(CallNode $node): bool
+    {
+        $op = NumericOperationSpecialization::typedIncDecOp($node);
+        if ($op === null) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($args[0]);
+        $this->outputEmitter->emitStr(' ' . $op . ' 1)', $loc);
+        return true;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecialization.php
@@ -54,6 +54,19 @@ final readonly class NumericOperationSpecialization
     ];
 
     /**
+     * Single-arg `phel.core` increment / decrement wrappers whose dispatch
+     * reduces to a native `($x + 1)` / `($x - 1)` when the operand is
+     * statically proven `int` / `float`. Maps the Phel name to the PHP
+     * operator the emitter splices before the literal `1`.
+     *
+     * @var array<string, string>
+     */
+    private const array INC_DEC_OPS = [
+        'inc' => '+',
+        'dec' => '-',
+    ];
+
+    /**
      * Arithmetic ops whose int result can overflow `PHP_INT_MAX` and promote
      * to `BigInt` at runtime. Comparison ops are excluded — they never overflow.
      *
@@ -150,6 +163,55 @@ final readonly class NumericOperationSpecialization
     public static function isTypedBinaryOp(CallNode $node): bool
     {
         return self::typedBinaryOpName($node) !== null;
+    }
+
+    /**
+     * Single-arg `(inc x)` / `(dec x)` where `x` is a statically proven
+     * primitive `int` / `float` operand. Returns the PHP operator to
+     * splice before a literal `1` (`($x + 1)` / `($x - 1)`), or `null`
+     * when the call is not specialisable.
+     *
+     * This is the 1-arg twin of the already-shipped `(+ ^int x 1)`
+     * lowering: `inc`/`dec` are defined in `phel.core` as a
+     * `NumericOperations::add`/`subtract` dispatch over a literal `1`, so
+     * a tagged operand collapses to the same native op `(php/+ ^int x 1)`
+     * already emits. The only divergence from the runtime — native `+`
+     * promoting an overflowing `int` to `float` instead of `BigInt` — is
+     * identical to that accepted policy.
+     *
+     * A **literal** operand is deliberately excluded: an int literal at
+     * `PHP_INT_MAX` would overflow under native `+ 1` and diverge from the
+     * runtime's `BigInt` promotion, exactly as a pure-literal `(+ ...)`
+     * chain bails via {@see self::isOverflowProneLiteralArithmetic()}. A
+     * nullable tag (`?int`) also fails the primitive-tag check, so the
+     * moot `assert-non-nil` guard in the runtime defns can never matter.
+     */
+    public static function typedIncDecOp(CallNode $node): ?string
+    {
+        $name = PhelCoreCall::nameOf($node);
+        if ($name === null || !isset(self::INC_DEC_OPS[$name])) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $operand = $args[0];
+        if ($operand instanceof LiteralNode) {
+            return null;
+        }
+
+        $tag = TagNormalizer::normalise(self::inferredTypeOfNode($operand));
+        return $tag !== null && in_array($tag, self::NUMERIC_PRIMITIVE_TAGS, true)
+            ? self::INC_DEC_OPS[$name]
+            : null;
+    }
+
+    public static function isTypedIncDec(CallNode $node): bool
+    {
+        return self::typedIncDecOp($node) !== null;
     }
 
     /**

--- a/tests/php/Integration/Fixtures/Call/dec-typed-int-local.test
+++ b/tests/php/Integration/Fixtures/Call/dec-typed-int-local.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^int x] (dec x))
+--PHP--
+(function(int $x) {
+  return ($x - 1);
+});

--- a/tests/php/Integration/Fixtures/Call/inc-typed-float-local.test
+++ b/tests/php/Integration/Fixtures/Call/inc-typed-float-local.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^float x] (inc x))
+--PHP--
+(function(float $x) {
+  return ($x + 1);
+});

--- a/tests/php/Integration/Fixtures/Call/inc-typed-int-local.test
+++ b/tests/php/Integration/Fixtures/Call/inc-typed-int-local.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^int x] (inc x))
+--PHP--
+(function(int $x) {
+  return ($x + 1);
+});

--- a/tests/php/Integration/Fixtures/Call/inc-untyped-local-bails.test
+++ b/tests/php/Integration/Fixtures/Call/inc-untyped-local-bails.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [x] (inc x))
+--PHP--
+(function($x) {
+  static $__phel_call_0;
+  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "inc"))->__invoke($x);
+});

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecializationTest.php
@@ -180,6 +180,64 @@ final class NumericOperationSpecializationTest extends TestCase
         self::assertSame('<', NumericOperationSpecialization::typedBinaryOpName($node));
     }
 
+    public function test_inc_on_int_local_lowers_to_plus(): void
+    {
+        $node = $this->coreCall('inc', [$this->localWithTag('x', 'int')]);
+
+        self::assertSame('+', NumericOperationSpecialization::typedIncDecOp($node));
+    }
+
+    public function test_dec_on_int_local_lowers_to_minus(): void
+    {
+        $node = $this->coreCall('dec', [$this->localWithTag('x', 'int')]);
+
+        self::assertSame('-', NumericOperationSpecialization::typedIncDecOp($node));
+    }
+
+    public function test_inc_on_float_local_lowers_to_plus(): void
+    {
+        $node = $this->coreCall('inc', [$this->localWithTag('x', 'float')]);
+
+        self::assertSame('+', NumericOperationSpecialization::typedIncDecOp($node));
+    }
+
+    public function test_inc_dec_skips_untagged_local(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('inc', [new LocalVarNode($env, Symbol::create('x'))]);
+
+        self::assertNull(NumericOperationSpecialization::typedIncDecOp($node));
+    }
+
+    public function test_inc_dec_skips_literal_operand(): void
+    {
+        // An int literal at PHP_INT_MAX would overflow under native `+ 1` and
+        // diverge from the runtime BigInt promotion — keep it on dispatch.
+        $env = $this->env();
+        $node = $this->coreCall('inc', [new LiteralNode($env, 4611686018427387904)]);
+
+        self::assertNull(NumericOperationSpecialization::typedIncDecOp($node));
+    }
+
+    public function test_inc_dec_skips_nullable_tag(): void
+    {
+        // A nullable tag re-admits the `assert-non-nil` guard the runtime
+        // defns carry, so the specialisation must not fire.
+        $node = $this->coreCall('inc', [$this->localWithTag('x', '?int')]);
+
+        self::assertNull(NumericOperationSpecialization::typedIncDecOp($node));
+    }
+
+    public function test_inc_dec_skips_two_arg_form(): void
+    {
+        $node = $this->coreCall('inc', [
+            $this->localWithTag('a', 'int'),
+            $this->localWithTag('b', 'int'),
+        ]);
+
+        self::assertNull(NumericOperationSpecialization::typedIncDecOp($node));
+    }
+
     private function env(): NodeEnvironment
     {
         return NodeEnvironment::empty()->withExpressionContext();


### PR DESCRIPTION
## 🤔 Background

`(inc x)` / `(dec x)` are defined in `phel.core` as a `NumericOperations::add`/`subtract` dispatch over a literal `1` (`src/phel/core/math.phel`). Even when `x` is statically tagged `^int`/`^float`, every call site pays the full `phel.core/inc` registry dispatch plus the `NumericOperations` polymorphic call — for what is fundamentally `($x + 1)`.

The native lowering already ships for binary arithmetic: `(php/+ ^int x 1)` → `($x + 1)` via `NumericOperationSpecialization`. This extends the same, accepted policy to the 1-arg `inc`/`dec` shape.

Closes #2562.

## 💡 Goal

For a single-arg `(inc <operand>)` / `(dec <operand>)` whose operand is statically proven `int`/`float`, emit native `($x + 1)` / `($x - 1)`, bypassing the registry dispatch — with no behavioral change for untyped code.

## 🔖 Changes

- **Eligibility** — `NumericOperationSpecialization::typedIncDecOp()` (+ `isTypedIncDec()`): fires only on the 1-arg form when the operand's normalised tag is `int`/`float`.
  - A **literal** operand is excluded: an int literal at `PHP_INT_MAX` would overflow under native `+ 1` and diverge from the runtime's `BigInt` promotion — exactly the existing pure-literal-arithmetic bail.
  - A **nullable** tag (`?int`) fails the primitive-tag check, so the (moot) `assert-non-nil` guard in the runtime defns can never matter.
- **Emission** — `NumericOperationCallEmitter::tryEmitTypedIncDec()` splices the operand before a literal `1`.
- **Dispatch** — registered in `CallSpecialization::isSpecialized()` so the call-site cache scanner and emitter agree (no orphan `static $__phel_call_N`).
- **Tests** — 6 unit cases on `typedIncDecOp` (int/float lower, untagged/literal/nullable/two-arg bail) + 4 golden fixtures under `Fixtures/Call/` (`inc`/`dec` int, `inc` float, untagged-bail).
- **CHANGELOG** — one-line Performance note.

### Semantics

The only divergence from the runtime — native `+` promoting an overflowing `int` to `float` instead of `BigInt` — is **identical to the already-shipped `(php/+ ^int x 1)` policy**. Verified end-to-end: `(inc ^int 41) => 42`, `(dec ^int 41) => 40`, `(inc ^float 1.5) => 2.5`, untagged `(inc 41) => 42` (still registry dispatch).

Full gate green (`test-quality`, 4751 compiler tests, 6098 core tests). The lone failing test — `PharExecutionTest::test_phar_ships_shell_completion_scripts` — is a pre-existing local environment quirk (fails identically on clean `main`) and passes in CI.