### PR TITLE
perf(emitter): specialize last on tagged persistent vectors to O(1) tail access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - PHP interop (`php/->`, `php/::`, `php/new`, `php/oset`) now compiles to direct expressions or statements instead of wrapping every call in a closure (#2524, #2525, #2526, #2532, #2536)
 - Type-tagged core calls now compile straight to native operations: `push`/`dissoc` to persistent-collection methods (#2527), `second`/`get-in` to direct vector/map access (#2530, #2529), and `count`/`first` on strings to `mb_strlen`/`mb_substr` (#2528)
 - `(inc x)`/`(dec x)` on an `^int`/`^float`-tagged local now compile to native `($x + 1)`/`($x - 1)` instead of dispatching through `NumericOperations`, matching the existing `(php/+ ^int x 1)` lowering (#2562)
+- `(last v)` on a tagged persistent vector now compiles to a count-guarded O(1) tail access (`($v->count() === 0 ? null : $v->get($v->count() - 1))`) instead of dispatching through `phel.core/last` and `peek` (#2563)
 - `=` and `not=` over string literals now fold to a boolean at compile time (#2531)
 - `dissoc`/`remove` on a large persistent map no longer does an O(n) deep node comparison on the no-op path (#2544)
 - The analyzer reuses stateless sub-analyzers (literal/constant-folder/let-simplifier) instead of allocating them per node (#2553)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/TypedCollectionCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/TypedCollectionCallEmitter.php
@@ -30,11 +30,43 @@ final readonly class TypedCollectionCallEmitter implements SpecializedCallEmitte
             return true;
         }
 
+        if ($this->tryEmitTypedVectorLast($node)) {
+            return true;
+        }
+
         if ($this->tryEmitTypedVectorAccessor($node)) {
             return true;
         }
 
         return $this->tryEmitTypedSeqAccessor($node);
+    }
+
+    /**
+     * Specialise `(last v)` on a tagged `PersistentVectorInterface`
+     * target to an O(1) tail access. A vector is never `seq?`, so the
+     * runtime `last` always falls to `peek`'s vector branch
+     * (`count` + indexed `aget`), which returns nil on empty — never
+     * throws. The lowering keeps that contract behind a guard:
+     * `($v->count() === 0 ? null : $v->get($v->count() - 1))`. The target
+     * is a `LocalVarNode` (a bare variable), so emitting it three times
+     * is side-effect-free.
+     */
+    private function tryEmitTypedVectorLast(CallNode $node): bool
+    {
+        if (!TypedCollectionMethodSpecialization::isTypedVectorLast($node)) {
+            return false;
+        }
+
+        $target = $node->getArguments()[0];
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($target);
+        $this->outputEmitter->emitStr('->count() === 0 ? null : ', $loc);
+        $this->outputEmitter->emitNode($target);
+        $this->outputEmitter->emitStr('->get(', $loc);
+        $this->outputEmitter->emitNode($target);
+        $this->outputEmitter->emitStr('->count() - 1))', $loc);
+        return true;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecialization.php
@@ -74,7 +74,11 @@ final readonly class TypedCollectionMethodSpecialization
             return true;
         }
 
-        return self::isTypedVectorSecond($node);
+        if (self::isTypedVectorSecond($node)) {
+            return true;
+        }
+
+        return self::isTypedVectorLast($node);
     }
 
     /**
@@ -90,6 +94,33 @@ final readonly class TypedCollectionMethodSpecialization
     public static function isTypedVectorSecond(CallNode $node): bool
     {
         if (!PhelCoreCall::is($node, 'second')) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return false;
+        }
+
+        return TagNormalizer::ofLocalVar($args[0]) === PersistentVectorInterface::class;
+    }
+
+    /**
+     * `(last v)` where the analyser has tagged the target as
+     * `PersistentVectorInterface`. A vector is never `seq?`
+     * (`seq?` covers only `LazySeqInterface` / `Cons` /
+     * `PersistentListInterface`), so the runtime `phel.core/last` always
+     * falls to `(peek v)`, whose vector branch is
+     * `(let [n (count v)] (if (php/=== 0 n) nil (php/aget v (php/- n 1))))`
+     * — an O(1) tail access, never the O(n) seq loop.
+     * {@see NodeEmitter\Specialized\TypedCollectionCallEmitter} emits
+     * `($v->count() === 0 ? null : $v->get($v->count() - 1))`, preserving
+     * the empty → nil contract while skipping the `last` (and nested
+     * `peek`) registry dispatch.
+     */
+    public static function isTypedVectorLast(CallNode $node): bool
+    {
+        if (!PhelCoreCall::is($node, 'last')) {
             return false;
         }
 

--- a/tests/php/Integration/Fixtures/Call/last-typed-vector.test
+++ b/tests/php/Integration/Fixtures/Call/last-typed-vector.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" v] (last v))
+--PHP--
+(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
+  return ($v->count() === 0 ? null : $v->get($v->count() - 1));
+});

--- a/tests/php/Integration/Fixtures/Call/last-untyped-bails.test
+++ b/tests/php/Integration/Fixtures/Call/last-untyped-bails.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [v] (last v))
+--PHP--
+(function($v) {
+  static $__phel_call_0;
+  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "last"))->__invoke($v);
+});

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecializationTest.php
@@ -96,6 +96,38 @@ final class TypedCollectionMethodSpecializationTest extends TestCase
         self::assertNull(TypedCollectionMethodSpecialization::typedSeqMethodName($node));
     }
 
+    public function test_last_on_typed_vector_is_specialised(): void
+    {
+        $node = $this->coreCall('last', [$this->vectorLocal('v')]);
+
+        self::assertTrue(TypedCollectionMethodSpecialization::isTypedVectorLast($node));
+        self::assertTrue(TypedCollectionMethodSpecialization::isTypedVectorAccessor($node));
+    }
+
+    public function test_last_on_untyped_local_falls_back(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('last', [new LocalVarNode($env, Symbol::create('v'))]);
+
+        self::assertFalse(TypedCollectionMethodSpecialization::isTypedVectorLast($node));
+    }
+
+    public function test_last_on_typed_seq_is_not_a_vector_last(): void
+    {
+        // A seq tag is not a vector, so `last` cannot collapse to the
+        // O(1) tail access — it could be an O(n) lazy seq.
+        $node = $this->coreCall('last', [$this->localWithTag('s', SeqInterface::class)]);
+
+        self::assertFalse(TypedCollectionMethodSpecialization::isTypedVectorLast($node));
+    }
+
+    public function test_last_with_wrong_arity_skips(): void
+    {
+        $node = $this->coreCall('last', [$this->vectorLocal('v'), new LiteralNode($this->env(), 0)]);
+
+        self::assertFalse(TypedCollectionMethodSpecialization::isTypedVectorLast($node));
+    }
+
     /**
      * @param list<AbstractNode> $args
      */


### PR DESCRIPTION
## 🤔 Background

`(last v)` on a statically-tagged persistent vector pays a full `phel.core/last` registry dispatch plus a nested `peek` dispatch — for what is fundamentally `$v->get($v->count() - 1)`.

A vector is never `seq?` (`seq?` covers only `LazySeqInterface` / `Cons` / `PersistentListInterface`), so the runtime `last` can never take its O(n) seq-walk branch for a vector: it always falls to `peek`, whose vector branch is the O(1) `(let [n (count v)] (if (php/=== 0 n) nil (php/aget v (php/- n 1))))`. This is a direct mirror of the already-shipped `second`-on-vector specialization.

Closes #2563.

## 💡 Goal

For `(last v)` where `v` is a `LocalVarNode` tagged `PersistentVectorInterface`, emit a nil-safe O(1) tail access, bypassing the `last` (and nested `peek`) registry dispatch — with no behavioral change for untagged or non-vector code.

## 🔖 Changes

- **Eligibility** — `TypedCollectionMethodSpecialization::isTypedVectorLast()`, folded into the existing `isTypedVectorAccessor()` (already registered in `CallSpecialization::isSpecialized()`).
- **Emission** — `TypedCollectionCallEmitter::tryEmitTypedVectorLast()` emits `($v->count() === 0 ? null : $v->get($v->count() - 1))`, preserving the empty → nil contract behind the count guard. The target is a `LocalVarNode`, so emitting it three times is side-effect-free.
- **Tests** — 4 unit cases on `isTypedVectorLast` (vector specialises; untagged/seq-tagged/wrong-arity bail) + 2 golden fixtures (`last-typed-vector`, `last-untyped-bails`).
- **CHANGELOG** — one-line Performance note.

### Semantics

Verified end-to-end: `(last [1 2 3]) => 3`, `(last []) => nil`, `(last [42]) => 42`; untagged `(last …)` still routes through the runtime and handles lists (`=> 9`) and lazy seqs (`(range 1 6) => 5`) correctly.

Full gate green (`test-quality`, 4757 compiler tests, 6098 core tests). The lone failing test — `PharExecutionTest::test_phar_ships_shell_completion_scripts` — is a pre-existing local environment quirk (fails identically on clean `main`) and passes in CI.