### PR TITLE
perf(parser): reuse sub-parser instances instead of allocating per node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Performance
 
+- The parser reuses its sub-parsers instead of allocating a fresh one per parsed node: the dependency-free ones (string/char/regex) are memoized on the factory and the `Parser`-dependent ones are built once in the `Parser` constructor (#2548)
 - PHP interop (`php/->`, `php/::`, `php/new`, `php/oset`) now compiles to direct expressions or statements instead of wrapping every call in a closure (#2524, #2525, #2526, #2532, #2536)
 - Type-tagged core calls now compile straight to native operations: `push`/`dissoc` to persistent-collection methods (#2527), `second`/`get-in` to direct vector/map access (#2530, #2529), and `count`/`first` on strings to `mb_strlen`/`mb_substr` (#2528)
 - `(inc x)`/`(dec x)` on an `^int`/`^float`-tagged local now compile to native `($x + 1)`/`($x - 1)` instead of dispatching through `NumericOperations`, matching the existing `(php/+ ^int x 1)` lowering (#2562)

--- a/src/php/Compiler/Application/Parser.php
+++ b/src/php/Compiler/Application/Parser.php
@@ -10,6 +10,11 @@ use Phel\Compiler\Domain\Parser\Exceptions\KeywordParserException;
 use Phel\Compiler\Domain\Parser\Exceptions\StringParserException;
 use Phel\Compiler\Domain\Parser\Exceptions\UnexpectedParserException;
 use Phel\Compiler\Domain\Parser\Exceptions\UnfinishedParserException;
+use Phel\Compiler\Domain\Parser\ExpressionParser\AtomParser;
+use Phel\Compiler\Domain\Parser\ExpressionParser\ListParser;
+use Phel\Compiler\Domain\Parser\ExpressionParser\MetaParser;
+use Phel\Compiler\Domain\Parser\ExpressionParser\QuoteParser;
+use Phel\Compiler\Domain\Parser\ExpressionParser\ReaderConditionalParser;
 use Phel\Compiler\Domain\Parser\ExpressionParserFactoryInterface;
 use Phel\Compiler\Domain\Parser\ParserInterface;
 use Phel\Shared\Parser\Node\AbstractAtomNode;
@@ -53,11 +58,33 @@ final readonly class Parser implements ParserInterface
     /** @var SplStack<bool> */
     private SplStack $quasiquoteStack;
 
+    /**
+     * The `Parser`-dependent sub-parsers each close over this `Parser`
+     * (or its fixed `$globalEnvironment`), both constant for the parser's
+     * lifetime, so they are built once here instead of being allocated
+     * afresh on every parsed node. The dependency-free sub-parsers
+     * (string / char / regex) are memoised on the factory instead.
+     */
+    private AtomParser $atomParser;
+
+    private ListParser $listParser;
+
+    private QuoteParser $quoteParser;
+
+    private MetaParser $metaParser;
+
+    private ReaderConditionalParser $readerConditionalParser;
+
     public function __construct(
         private ExpressionParserFactoryInterface $parserFactory,
-        private GlobalEnvironmentInterface $globalEnvironment,
+        GlobalEnvironmentInterface $globalEnvironment,
     ) {
         $this->quasiquoteStack = new SplStack();
+        $this->atomParser = $parserFactory->createAtomParser($globalEnvironment);
+        $this->listParser = $parserFactory->createListParser($this);
+        $this->quoteParser = $parserFactory->createQuoteParser($this);
+        $this->metaParser = $parserFactory->createMetaParser($this);
+        $this->readerConditionalParser = $parserFactory->createReaderConditionalParser($this);
     }
 
     /**
@@ -198,9 +225,7 @@ final readonly class Parser implements ParserInterface
     private function parseAtomNode(Token $token, TokenStream $tokenStream): AbstractAtomNode
     {
         try {
-            return $this->parserFactory
-                ->createAtomParser($this->globalEnvironment)
-                ->parse($token);
+            return $this->atomParser->parse($token);
         } catch (KeywordParserException $keywordParserException) {
             throw $this->createUnexceptedParserException($tokenStream, $token, $keywordParserException->getMessage());
         }
@@ -303,8 +328,7 @@ final readonly class Parser implements ParserInterface
      */
     private function parseFnListNode(Token $token, TokenStream $tokenStream): ListNode
     {
-        return $this->parserFactory
-            ->createListParser($this)
+        return $this->listParser
             ->parse($tokenStream, Token::T_CLOSE_PARENTHESIS, $token->getType());
     }
 
@@ -313,43 +337,37 @@ final readonly class Parser implements ParserInterface
      */
     private function parseArrayListNode(Token $token, TokenStream $tokenStream): ListNode
     {
-        return $this->parserFactory
-            ->createListParser($this)
+        return $this->listParser
             ->parse($tokenStream, Token::T_CLOSE_BRACKET, $token->getType());
     }
 
     private function parseMapListNode(Token $token, TokenStream $tokenStream): ListNode
     {
-        return $this->parserFactory
-            ->createListParser($this)
+        return $this->listParser
             ->parse($tokenStream, Token::T_CLOSE_BRACE, $token->getType());
     }
 
     private function parseSetListNode(Token $token, TokenStream $tokenStream): ListNode
     {
-        return $this->parserFactory
-            ->createListParser($this)
+        return $this->listParser
             ->parse($tokenStream, Token::T_CLOSE_BRACE, $token->getType());
     }
 
     private function parseQuoteNode(Token $token, TokenStream $tokenStream): QuoteNode
     {
-        return $this->parserFactory
-            ->createQuoteParser($this)
+        return $this->quoteParser
             ->parse($tokenStream, $token->getType());
     }
 
     private function parseReaderCondNode(TokenStream $tokenStream, Token $openToken): NodeInterface
     {
-        return $this->parserFactory
-            ->createReaderConditionalParser($this)
+        return $this->readerConditionalParser
             ->parseCond($tokenStream, $openToken);
     }
 
     private function parseReaderCondSplicingNode(TokenStream $tokenStream, Token $openToken): NodeInterface
     {
-        return $this->parserFactory
-            ->createReaderConditionalParser($this)
+        return $this->readerConditionalParser
             ->parseCondSplicing($tokenStream, $openToken);
     }
 
@@ -363,8 +381,7 @@ final readonly class Parser implements ParserInterface
 
     private function parseMetaNode(TokenStream $tokenStream): MetaNode
     {
-        return $this->parserFactory
-            ->createMetaParser($this)
+        return $this->metaParser
             ->parse($tokenStream);
     }
 

--- a/src/php/Compiler/Domain/Parser/ExpressionParserFactory.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParserFactory.php
@@ -17,6 +17,21 @@ use Phel\Compiler\Domain\Parser\ExpressionParser\StringParser;
 
 final class ExpressionParserFactory implements ExpressionParserFactoryInterface
 {
+    /**
+     * The dependency-free sub-parsers are stateless — every input reaches
+     * them as a `parse()` argument, nothing is stored per call — so one
+     * instance is reused for the lifetime of the factory instead of
+     * allocating a fresh object per parsed node. The `Parser`-dependent
+     * sub-parsers are not memoised here because they close over a
+     * specific `Parser`; the `Parser` builds those once in its own
+     * constructor.
+     */
+    private ?StringParser $stringParser = null;
+
+    private ?CharParser $charParser = null;
+
+    private ?RegexParser $regexParser = null;
+
     public function createAtomParser(GlobalEnvironmentInterface $globalEnvironment): AtomParser
     {
         return new AtomParser($globalEnvironment);
@@ -24,17 +39,17 @@ final class ExpressionParserFactory implements ExpressionParserFactoryInterface
 
     public function createStringParser(): StringParser
     {
-        return new StringParser();
+        return $this->stringParser ??= new StringParser();
     }
 
     public function createCharParser(): CharParser
     {
-        return new CharParser();
+        return $this->charParser ??= new CharParser();
     }
 
     public function createRegexParser(): RegexParser
     {
-        return new RegexParser();
+        return $this->regexParser ??= new RegexParser();
     }
 
     public function createListParser(Parser $parser): ListParser

--- a/tests/php/Integration/Compiler/Parser/ParserTest.php
+++ b/tests/php/Integration/Compiler/Parser/ParserTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace PhelTest\Integration\Compiler\Parser;
 
 use Phel;
+use Phel\Compiler\Application\Parser;
 use Phel\Compiler\CompilerFacade;
 use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
 use Phel\Compiler\Domain\Parser\Exceptions\UnexpectedParserException;
+use Phel\Compiler\Domain\Parser\ExpressionParserFactory;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
@@ -830,6 +832,27 @@ final class ParserTest extends TestCase
         /** @var TaggedLiteralNode $node */
         $node = $this->parse('#?(:phel (#cpp 1) :default 0)');
         self::assertInstanceOf(ListNode::class, $node);
+    }
+
+    public function test_repeated_parse_through_same_parser_is_identical(): void
+    {
+        // The sub-parsers are now reused across nodes (memoised on the
+        // factory / built once in the Parser constructor). They must carry
+        // no per-call state: parsing the same source twice through ONE
+        // Parser instance must yield byte-identical trees, exercising every
+        // memoised sub-parser (atom, string, char, regex, list, quote,
+        // meta, reader-conditional).
+        $source = <<<'PHEL'
+            (a :b 1) [\x "s" #"re"] {:k 'v} #{1} `(~x ~@xs) ^:m s #?(:phel 1) [#?@(:phel [2])]
+            PHEL;
+
+        $parser = new Parser(new ExpressionParserFactory(), GlobalEnvironmentSingleton::getInstance());
+
+        $first = $parser->parseAll($this->compilerFacade->lexString($source));
+        $second = $parser->parseAll($this->compilerFacade->lexString($source));
+
+        self::assertEquals($first, $second);
+        self::assertNotSame([], $first->getChildren());
     }
 
     private function parse(string $string): NodeInterface


### PR DESCRIPTION
## 🤔 Background

`ExpressionParserFactory` allocated a fresh sub-parser (`new XParser(...)`) for **every** node parsed — thousands of short-lived objects per file, churning the GC (notably in the REPL). The sub-parsers are stateless (every input arrives as a `parse()` argument; nothing is stored per call) or hold only a constant reference, so they can be reused.

Closes #2548.

## 💡 Goal

Remove the per-node sub-parser allocations while keeping the parse tree (and source locations) byte-for-byte identical.

## 🔖 Changes

- **Factory** — the three dependency-free sub-parsers (`StringParser`, `CharParser`, `RegexParser`) are memoized with `??=`, so one instance serves the factory's lifetime.
- **Parser** — the five `Parser`-dependent sub-parsers (`AtomParser`, `ListParser`, `QuoteParser`, `MetaParser`, `ReaderConditionalParser`) are built **once** in the constructor (where `$this` and `$globalEnvironment` are fixed) and stored as properties; the `parseXNode` call sites use the cached instances instead of `new`-ing per node.
- `globalEnvironment` is demoted from a promoted property to a plain constructor parameter (it is now only consumed when building the `AtomParser`).
- The public `ExpressionParserFactoryInterface` is unchanged — the create methods are still used (once) for construction.
- **Test** — a regression test parses a diverse source (atom/string/char/regex/list/quote/meta/reader-conditional) twice through one `Parser` and asserts identical trees, guarding against accidental shared mutable state.
- **CHANGELOG** — one-line Performance note.

### Semantics

Pure throughput change — no semantic delta. Each sub-parser was confirmed stateless across `parse()` calls (`final readonly` where applicable; only constants + an injected dependency as state). `AtomParser` is **not** memoized on the factory because it closes over a per-`Parser` `$globalEnvironment`; it is built once per `Parser` instead.

### Benchmark (`ParserBench`, existing)

| subject | main | branch | Δ |
|---|---|---|---|
| `bench_parse_core` (real `phel.core`) | 1.497 ms | 1.413 ms | ~5.6% faster |
| `bench_parse_fixture` (dense vectors/maps/calls) | 15.52 ms | 14.60 ms | ~5.9% faster |

Full gate green (`test-quality`, 4758 compiler tests incl. the new regression, 6098 core tests). The lone failing test — `PharExecutionTest::test_phar_ships_shell_completion_scripts` — is a pre-existing local environment quirk (fails identically on clean `main`) and passes in CI.