### PR TITLE
perf(analyzer): inline let-bodied pure defns in CallInliner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Performance
 
+- The call inliner (opt level >= 2) now inlines `let`-bodied pure `defn`s: a single intermediate binding (the common small-helper shape) no longer blocks inlining, and a `let`/`do` body is also recognized as structurally pure so unannotated helpers inline without a `^:pure` tag (#2586)
 - The parser reuses its sub-parsers instead of allocating a fresh one per parsed node: the dependency-free ones (string/char/regex) are memoized on the factory and the `Parser`-dependent ones are built once in the `Parser` constructor (#2548)
 - PHP interop (`php/->`, `php/::`, `php/new`, `php/oset`) now compiles to direct expressions or statements instead of wrapping every call in a closure (#2524, #2525, #2526, #2532, #2536)
 - Type-tagged core calls now compile straight to native operations: `push`/`dissoc` to persistent-collection methods (#2527), `second`/`get-in` to direct vector/map access (#2530, #2529), and `count`/`first` on strings to `mb_strlen`/`mb_substr` (#2528)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
@@ -230,6 +230,26 @@ final readonly class CallInliner
             return $this->countUsesInAll($name, $node->getKeyValues());
         }
 
+        if ($node instanceof LetNode) {
+            // A `let` shadow is a gensym, never a parameter name, so summing
+            // the inits and the body counts only genuine parameter uses.
+            $count = $this->countUses($name, $node->getBodyExpr());
+            foreach ($node->getBindings() as $binding) {
+                $count += $this->countUses($name, $binding->getInitExpr());
+            }
+
+            return $count;
+        }
+
+        if ($node instanceof DoNode) {
+            $count = $this->countUses($name, $node->getRet());
+            foreach ($node->getStmts() as $stmt) {
+                $count += $this->countUses($name, $stmt);
+            }
+
+            return $count;
+        }
+
         return 0;
     }
 
@@ -303,7 +323,91 @@ final readonly class CallInliner
             return $keyValues === null ? null : new MapNode($ctx->targetEnv(), $keyValues, $ctx->loc);
         }
 
+        if ($node instanceof LetNode) {
+            return $this->rebaseLet($node, $ctx);
+        }
+
+        if ($node instanceof DoNode) {
+            return $this->rebaseDo($node, $ctx);
+        }
+
         return null;
+    }
+
+    /**
+     * Rebases a `do` body wrapper. `let`/`if`/`fn` bodies are stored as a
+     * `DoNode`, so a let-bodied callee always reaches the rebaser through
+     * one. Only the statement-free form is spliceable — mirroring the
+     * `tryInline` fn-body gate — so a `do` carrying leading statements
+     * (which would need their own per-statement context handling) aborts
+     * the inline. The wrapper is preserved so downstream passes that
+     * expect a `DoNode` body keep working.
+     */
+    private function rebaseDo(DoNode $node, RebaseContext $ctx): ?AbstractNode
+    {
+        if ($node->getStmts() !== []) {
+            return null;
+        }
+
+        $ret = $this->rebase($node->getRet(), $ctx);
+
+        return $ret instanceof AbstractNode
+            ? new DoNode($ctx->targetEnv(), [], $ret, $ctx->loc)
+            : null;
+    }
+
+    /**
+     * Rebases a (non-loop) `let` from the callee body onto the call site.
+     *
+     * Each binding gets a FRESH gensym shadow, so the inlined scope can
+     * never collide with a caller local or with another copy of the same
+     * `defn` spliced into the same PHP scope. References to the old
+     * shadow — in later binding inits and in the body — are remapped
+     * through the same substitution map used for parameters, so the walk
+     * stays in `inBody` mode and rewrites every reference exactly once.
+     *
+     * Bindings are processed in order: each init sees the parameters plus
+     * the freshly-remapped shadows of the preceding bindings, preserving
+     * sequential `let` semantics. A `loop` is never rebased — it owns its
+     * `recur` targets, which the inliner must not disturb.
+     */
+    private function rebaseLet(LetNode $node, RebaseContext $ctx): ?AbstractNode
+    {
+        if ($node->isLoop()) {
+            return null;
+        }
+
+        // A `let` in expression context emits as an IIFE whose body must
+        // `return`; in any other context the body shares the let's own
+        // context. This mirrors the binding-wrapper let built in `tryInline`.
+        $bodyContext = $ctx->context === NodeEnvironment::CONTEXT_EXPRESSION
+            ? NodeEnvironment::CONTEXT_RETURN
+            : $ctx->context;
+
+        $paramMap = $ctx->paramMap;
+        $bindings = [];
+        foreach ($node->getBindings() as $binding) {
+            // Inits emit as expressions (`$shadow = <init>;`) and may
+            // reference params or earlier bindings, so rebase them in
+            // expression context with the substitutions accumulated so far.
+            $initCtx = new RebaseContext($ctx->env, NodeEnvironment::CONTEXT_EXPRESSION, $ctx->loc, $paramMap, true);
+            $init = $this->rebase($binding->getInitExpr(), $initCtx);
+            if (!$init instanceof AbstractNode) {
+                return null;
+            }
+
+            $shadow = Symbol::gen($binding->getShadow()->getName() . '_')->copyLocationFrom($binding->getShadow());
+            $bindings[] = new BindingNode($ctx->targetEnv(), $binding->getSymbol(), $shadow, $init, $ctx->loc);
+            $paramMap[$binding->getShadow()->getName()] = new LocalVarNode($ctx->env, $shadow, $ctx->loc);
+        }
+
+        $bodyCtx = new RebaseContext($ctx->env, $bodyContext, $ctx->loc, $paramMap, true);
+        $body = $this->rebase($node->getBodyExpr(), $bodyCtx);
+        if (!$body instanceof AbstractNode) {
+            return null;
+        }
+
+        return new LetNode($ctx->targetEnv(), $bindings, $body, false, $ctx->loc);
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/SymbolicPurityDetector.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/SymbolicPurityDetector.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\BindingNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
@@ -146,6 +149,24 @@ final readonly class SymbolicPurityDetector
             return !$node->getLiteralMeta() instanceof MapNode && $this->allPure($node->getKeyValues());
         }
 
+        // A non-loop `let` is pure when every binding init and its body are
+        // pure: introducing locals and reading them back has no observable
+        // effect. A `loop` is excluded — `recur` is control flow the
+        // inliner never rebases. This keeps the oracle in lockstep with
+        // what {@see CallInliner} can splice, so a let-bodied pure `defn`
+        // both passes the purity gate and rebases.
+        if ($node instanceof LetNode) {
+            return !$node->isLoop()
+                && $this->allPureBindings($node)
+                && $this->isPure($node->getBodyExpr());
+        }
+
+        // `let`/`if`/`fn` bodies are wrapped in a `DoNode`; it is pure when
+        // every leading statement and the return expression are pure.
+        if ($node instanceof DoNode) {
+            return $this->allPure($node->getStmts()) && $this->isPure($node->getRet());
+        }
+
         return false;
     }
 
@@ -155,6 +176,14 @@ final readonly class SymbolicPurityDetector
     public function isPureAnnotated(PersistentMapInterface $meta): bool
     {
         return (bool) $meta[Keyword::create('pure')];
+    }
+
+    private function allPureBindings(LetNode $node): bool
+    {
+        return array_all(
+            $node->getBindings(),
+            fn(BindingNode $binding): bool => $this->isPure($binding->getInitExpr()),
+        );
     }
 
     /**

--- a/tests/php/Integration/Compiler/CallInlineRuntimeTest.php
+++ b/tests/php/Integration/Compiler/CallInlineRuntimeTest.php
@@ -220,36 +220,95 @@ final class CallInlineRuntimeTest extends TestCase
         self::assertSame(42, $this->compilerFacade->eval('(to-int "42")', $options));
     }
 
-    public function test_call_to_pure_annotated_fn_inside_a_body_is_inlined(): void
+    public function test_let_bodied_pure_annotated_fn_is_inlined(): void
     {
         $options = new CompileOptions()->setOptimizationLevel(2);
-        // `psquare` has a `let` body the rebaser cannot splice, so it is
-        // never inlined as a callee — its call survives inside a body. The
-        // `^:pure` tag still makes that surviving call a pure operator, so
-        // `uses-pure` becomes inlinable; only its own frame disappears.
+        // A `let`-bodied `^:pure` callee is now spliced wherever it is
+        // called: `psquare` inlines into `uses-pure`'s body, then
+        // `uses-pure` itself inlines into the call site — both frames gone.
         $this->compilerFacade->eval('(defn ^:pure psquare [x] (let [y x] (* y y)))', $options);
         $this->compilerFacade->eval('(defn uses-pure [n] (+ (psquare n) 1))', $options);
 
         $php = $this->compilerFacade->compile('(uses-pure 5)', $options)->getPhpCode();
 
         self::assertStringNotContainsString('uses-pure', $php);
-        self::assertStringContainsString('psquare', $php);
+        self::assertStringNotContainsString('psquare', $php);
         self::assertSame(26, $this->compilerFacade->eval('(uses-pure 5)', $options));
     }
 
-    public function test_unannotated_user_fn_in_body_keeps_dispatch(): void
+    public function test_let_bodied_structurally_pure_fn_is_inlined_without_annotation(): void
     {
         $options = new CompileOptions()->setOptimizationLevel(2);
-        // Same non-inlinable `let`-body shape but without `^:pure`: the call
-        // is impure to the detector, so `uses-plain`'s body is not provable
-        // pure and `uses-plain` keeps dispatching.
+        // No `^:pure` tag: the detector proves the `let` body pure
+        // structurally (locals + `*` are side-effect-free), so the
+        // let-bodied callee inlines on its own.
         $this->compilerFacade->eval('(defn psquare-plain [x] (let [y x] (* y y)))', $options);
-        $this->compilerFacade->eval('(defn uses-plain [n] (+ (psquare-plain n) 1))', $options);
 
-        $php = $this->compilerFacade->compile('(uses-plain 5)', $options)->getPhpCode();
+        $php = $this->compilerFacade->compile('(psquare-plain 6)', $options)->getPhpCode();
 
-        self::assertStringContainsString('uses-plain', $php);
-        self::assertSame(26, $this->compilerFacade->eval('(uses-plain 5)', $options));
+        self::assertStringNotContainsString('psquare-plain', $php);
+        self::assertSame(36, $this->compilerFacade->eval('(psquare-plain 6)', $options));
+    }
+
+    public function test_let_bodied_impure_unannotated_fn_keeps_dispatch(): void
+    {
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        // A `let` body that is not provably pure (here `str`, not in the
+        // purity allowlist) and carries no `^:pure` tag keeps dispatching.
+        $this->compilerFacade->eval('(defn shout-plain [x] (let [y x] (str y "!")))', $options);
+
+        $php = $this->compilerFacade->compile('(shout-plain "hi")', $options)->getPhpCode();
+
+        self::assertStringContainsString('shout-plain', $php);
+        self::assertSame('hi!', $this->compilerFacade->eval('(shout-plain "hi")', $options));
+    }
+
+    public function test_let_bodied_callee_with_nested_let_if_or_is_inlined(): void
+    {
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        // The issue's motivating example: a hot per-iteration helper whose
+        // body binds one intermediate and branches on it. `^:pure` plus the
+        // new `let` rebasing means the frame disappears at every call site.
+        $this->compilerFacade->eval(
+            '(defn ^:pure cell [grid x y] (let [row (get grid y)] (if (nil? row) :wall (or (get row x) :wall))))',
+            $options,
+        );
+
+        $php = $this->compilerFacade->compile('(let [g {0 {0 :a}}] (cell g 0 0))', $options)->getPhpCode();
+        self::assertStringNotContainsString('cell', $php);
+
+        // Every branch preserves the runtime semantics.
+        self::assertTrue($this->compilerFacade->eval('(= :a (let [g {0 {0 :a}}] (cell g 0 0)))', $options));
+        self::assertTrue($this->compilerFacade->eval('(= :wall (cell {} 5 5))', $options));
+        self::assertTrue($this->compilerFacade->eval('(= :wall (cell {0 {}} 9 0))', $options));
+    }
+
+    public function test_let_bodied_inline_preserves_sequential_binding_semantics(): void
+    {
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        // Sequential bindings where a later init reads an earlier shadow and
+        // the param is reused: the fresh-shadow remap must keep them wired.
+        $this->compilerFacade->eval('(defn ^:pure step [n] (let [a (+ n 1) b (* a 2)] (+ a b)))', $options);
+
+        $php = $this->compilerFacade->compile('(step 3)', $options)->getPhpCode();
+
+        self::assertStringNotContainsString('step', $php);
+        // a = 4, b = 8 => 12
+        self::assertSame(12, $this->compilerFacade->eval('(step 3)', $options));
+    }
+
+    public function test_let_bodied_inline_evaluates_impure_arg_once(): void
+    {
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval('(def let-calls (atom 0))', $options);
+        $this->compilerFacade->eval('(defn let-bump [] (swap! let-calls inc))', $options);
+        // Param used twice inside the let body; an impure arg must bind once.
+        $this->compilerFacade->eval('(defn ^:pure let-twice [x] (let [y x] (+ y x)))', $options);
+
+        $result = $this->compilerFacade->eval('(let-twice (let-bump))', $options);
+
+        self::assertSame(2, $result);
+        self::assertSame(1, $this->compilerFacade->eval('(deref let-calls)', $options));
     }
 
     public function test_multi_arity_defn_inlines_the_matching_arity(): void

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/CallInlinerTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/CallInlinerTest.php
@@ -7,6 +7,7 @@ namespace PhelTest\Unit\Compiler\Analyzer\TypeAnalyzer\Simplification;
 use Phel;
 use Phel\Compiler\Application\Analyzer;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\BindingNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
 use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
@@ -173,6 +174,27 @@ final class CallInlinerTest extends TestCase
         self::assertSame('z', $args[1]->getName()->getName());
     }
 
+    public function test_inlines_let_bodied_defn_rebasing_the_let(): void
+    {
+        // (defn f [x] (let [y x] (+ y 1))) called with caller local z:
+        // the let is rebased (no dispatch), the param substitutes into the
+        // binding init, and the body references a FRESH shadow.
+        $this->seedDefn('f', ['x'], $this->letBody('x'));
+
+        $result = $this->inline('f', [new LocalVarNode($this->env, Symbol::create('z'))]);
+
+        self::assertInstanceOf(LetNode::class, $result);
+        self::assertCount(1, $result->getBindings());
+
+        $binding = $result->getBindings()[0];
+        $init = $binding->getInitExpr();
+        self::assertInstanceOf(LocalVarNode::class, $init);
+        self::assertSame('z', $init->getName()->getName());
+
+        // The shadow is regenerated so repeated inlines never collide.
+        self::assertNotSame('y_shadow', $binding->getShadow()->getName());
+    }
+
     public function test_declines_impure_body(): void
     {
         // (defn log-it [x] (println x)) -> body is side-effecting
@@ -321,6 +343,29 @@ final class CallInlinerTest extends TestCase
         );
 
         return new DoNode($this->env, [], $ret);
+    }
+
+    private function letBody(string $param): DoNode
+    {
+        // (let [y <param>] (+ y 1)) wrapped in a DoNode, as the analyzer
+        // stores a single-expression fn body.
+        $shadow = Symbol::create('y_shadow');
+        $binding = new BindingNode(
+            $this->env,
+            Symbol::create('y'),
+            $shadow,
+            new LocalVarNode($this->env, Symbol::create($param)),
+        );
+
+        $letInner = new DoNode($this->env, [], new CallNode(
+            $this->env,
+            new GlobalVarNode($this->env, CompilerConstants::PHEL_CORE_NAMESPACE, Symbol::create('+'), Phel::map()),
+            [new LocalVarNode($this->env, $shadow), new LiteralNode($this->env, 1)],
+        ));
+
+        $let = new LetNode($this->env, [$binding], $letInner, false);
+
+        return new DoNode($this->env, [], $let);
     }
 
     private function squareBody(string $param): DoNode

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/SymbolicPurityDetectorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/SymbolicPurityDetectorTest.php
@@ -6,15 +6,18 @@ namespace PhelTest\Unit\Compiler\Analyzer\TypeAnalyzer\Simplification;
 
 use Phel;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\BindingNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ThrowNode;
 use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification\SymbolicPurityDetector;
@@ -159,10 +162,72 @@ final class SymbolicPurityDetectorTest extends TestCase
 
     public function test_unhandled_node_type_is_impure(): void
     {
-        // A `do` node is outside the whitelist, so it defaults to impure.
+        // A `throw` node is outside the whitelist, so it defaults to impure.
         self::assertFalse($this->detector->isPure(
-            new DoNode($this->env, [], new LiteralNode($this->env, 1)),
+            new ThrowNode($this->env, new LiteralNode($this->env, 1)),
         ));
+    }
+
+    public function test_do_node_of_pure_contents_is_pure(): void
+    {
+        // `let`/`if`/`fn` bodies are stored as a `DoNode`; one whose
+        // statements and return expression are all pure is pure.
+        $node = new DoNode(
+            $this->env,
+            [new LiteralNode($this->env, 1)],
+            $this->coreCall('+', [new LocalVarNode($this->env, Symbol::create('x')), new LiteralNode($this->env, 1)]),
+        );
+
+        self::assertTrue($this->detector->isPure($node));
+    }
+
+    public function test_do_node_with_impure_statement_is_impure(): void
+    {
+        $node = new DoNode(
+            $this->env,
+            [$this->coreCall('println', [new LiteralNode($this->env, 1)])],
+            new LiteralNode($this->env, 1),
+        );
+
+        self::assertFalse($this->detector->isPure($node));
+    }
+
+    public function test_let_with_pure_bindings_and_body_is_pure(): void
+    {
+        // (let [y x] (+ y 1)) — pure init, pure body.
+        $shadow = Symbol::create('y_shadow');
+        $binding = new BindingNode($this->env, Symbol::create('y'), $shadow, new LocalVarNode($this->env, Symbol::create('x')));
+        $body = new DoNode($this->env, [], $this->coreCall('+', [
+            new LocalVarNode($this->env, $shadow),
+            new LiteralNode($this->env, 1),
+        ]));
+
+        self::assertTrue($this->detector->isPure(new LetNode($this->env, [$binding], $body, false)));
+    }
+
+    public function test_let_with_impure_binding_init_is_impure(): void
+    {
+        // (let [y (println x)] y) — the binding init has an effect.
+        $shadow = Symbol::create('y_shadow');
+        $binding = new BindingNode(
+            $this->env,
+            Symbol::create('y'),
+            $shadow,
+            $this->coreCall('println', [new LocalVarNode($this->env, Symbol::create('x'))]),
+        );
+        $body = new DoNode($this->env, [], new LocalVarNode($this->env, $shadow));
+
+        self::assertFalse($this->detector->isPure(new LetNode($this->env, [$binding], $body, false)));
+    }
+
+    public function test_loop_is_impure(): void
+    {
+        // A `loop` owns `recur` control flow the inliner never rebases.
+        $shadow = Symbol::create('y_shadow');
+        $binding = new BindingNode($this->env, Symbol::create('y'), $shadow, new LiteralNode($this->env, 0));
+        $body = new DoNode($this->env, [], new LocalVarNode($this->env, $shadow));
+
+        self::assertFalse($this->detector->isPure(new LetNode($this->env, [$binding], $body, true)));
     }
 
     public function test_vector_of_pure_elements_is_pure(): void


### PR DESCRIPTION
## 🤔 Background

`CallInliner` (opt level >= 2) only inlined a `defn` whose body's return node was in its rebase whitelist (`LiteralNode`, `CallNode`, `IfNode`, vector/set/map, …). A `LetNode` was not on the list, so any otherwise-pure single-expression `defn` whose body is a `let` — the common shape for a small helper that binds one intermediate — silently fell back to dispatch, even with `^:pure`. In practice the highest-value inlining candidates were exactly the ones excluded (hit while adopting opt level 2 in phel-doom; see Chemaclass/phel-doom#166).

Closes #2586.

## 💡 Goal

Teach the rebaser to splice a `let` (and the `do` wrapper that holds every `let`/`if`/`fn` body) onto the call site, keeping the existing soundness rules — and recognize a pure `let`/`do` body in the purity oracle so these helpers inline.

## 🔖 Changes

**`CallInliner`**
- **`rebaseLet`** — rebases a non-loop `let`: each binding gets a **fresh gensym shadow**, and old→new shadow references are remapped through the same `paramMap` substitution machinery used for parameters. Bindings are processed in order so each init sees the params plus the preceding bindings (sequential `let` semantics). The let's env/body contexts mirror the binding-wrapper `let` already built in `tryInline` (expression → IIFE whose body returns). A `loop` is never rebased (it owns `recur`).
- **`rebaseDo`** — `let`/`if`/`fn` bodies are stored as a `DoNode`; the statement-free form is unwrapped-and-rebuilt (matching the `tryInline` fn-body gate), and a `do` with leading statements aborts the inline.
- **`countUses`** — now descends into `LetNode`/`DoNode` so a parameter used inside a let body is counted (a `let` shadow is a gensym, never a param name, so the sum stays exact).

**`SymbolicPurityDetector`**
- `isPure` now proves a non-loop `let` pure when every binding init + body are pure, and a `do` pure when every statement + return are pure. This keeps the oracle in lockstep with what the rebaser can splice, so let-bodied helpers inline **even without `^:pure`** when structurally provable (e.g. `(defn f [x] (let [y x] (* y y)))`).

**Soundness.** Fresh shadows make every inline hermetic (no collision across call sites or with caller locals). Effect ordering/single-evaluation is unchanged: impure args still bind once; the purity gate + structural rebasing preserve binding order and count. `LetSimplifier`/`LocalVarReferences` already fully enumerate `LetNode`, so the final wrap simplifies correctly.

## ✅ Verification

New runtime tests (frames disappear + correct results), including the issue's motivating example:

```phel
(defn ^:pure cell [grid x y] (let [row (get grid y)] (if (nil? row) :wall (or (get row x) :wall))))
```

verified across all three branches (hit → value, nil row → `:wall`, nil cell → `:wall`; note the `or` itself expands to a nested `let`). Plus: structurally-pure unannotated inlining, sequential bindings, impure-arg-evaluated-once, and an unannotated impure (`str`) body that correctly keeps dispatch. Unit tests cover the rebase (fresh shadow + param substitution) and the new `let`/`do` purity rules.

The compiled stdlib is unaffected (it builds at the default opt level < 2). Full gate green (`test-quality`, 4768 compiler tests, 6098 core tests). The lone failing test — `PharExecutionTest::test_phar_ships_shell_completion_scripts` — is a pre-existing local environment quirk (fails identically on clean `main`) and passes in CI.