### PR TITLE
perf(run): ship phel.ini and guide persistent OPcache file cache via doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Performance
 
+- `phel doctor` now ships a ready-to-use `phel.ini` and gives precise guidance for enabling a persistent CLI OPcache file cache (which lets warm runs reuse compiled opcode across processes), including the caveat that `opcache.file_cache` must be an existing absolute directory kept outside `phel clear-cache` (#2556)
 - Analyzing a `let`/`loop` binding vector now updates the derived locals/shadow indexes incrementally (one O(1) `withLocalAndShadow` per binding) instead of rebuilding both from scratch per binding, cutting wide-scope analysis from O(N²) to O(N) (#2554)
 - The call inliner (opt level >= 2) now inlines `let`-bodied pure `defn`s: a single intermediate binding (the common small-helper shape) no longer blocks inlining, and a `let`/`do` body is also recognized as structurally pure so unannotated helpers inline without a `^:pure` tag (#2586)
 - The parser reuses its sub-parsers instead of allocating a fresh one per parsed node: the dependency-free ones (string/char/regex) are memoized on the factory and the `Parser`-dependent ones are built once in the `Parser` constructor (#2548)

--- a/phel.ini
+++ b/phel.ini
@@ -1,0 +1,33 @@
+; Phel CLI performance tuning — persistent OPcache for warm runs.
+;
+; OPcache is OFF for the CLI SAPI by default, so every `phel` process
+; re-parses the compiled PHP stored under your Phel cache from scratch.
+; Enabling the CLI OPcache *and* a persistent on-disk file cache lets that
+; opcode survive across separate CLI invocations, cutting warm-run startup
+; substantially (scales with how many namespaces your project loads).
+;
+; `opcache.enable_cli` and `opcache.file_cache` CANNOT be changed at runtime
+; (an `ini_set()` is ignored / rejected), so apply this file at launch:
+;
+;   php -c phel.ini vendor/bin/phel run src/main.phel
+;
+; or merge these settings into the php.ini your CLI already loads, or pass
+; them inline with `-d` flags. Verify with `phel doctor`.
+
+opcache.enable=1
+opcache.enable_cli=1
+
+; IMPORTANT: opcache.file_cache must be an ABSOLUTE path to a directory that
+; ALREADY EXISTS and is writable — PHP aborts at startup with
+; "opcache.file_cache must be a full path of an accessible directory"
+; otherwise. A relative path is rejected.
+;
+; Pick a stable location that is NOT wiped by `phel clear-cache` (do not nest
+; it inside .phel/cache, or clearing the cache will make every later run
+; abort). Create the directory first, e.g.:
+;
+;   mkdir -p /tmp/phel-opcache
+;
+; then uncomment and adjust the absolute path below:
+;
+; opcache.file_cache=/tmp/phel-opcache

--- a/src/php/Run/Infrastructure/Command/DoctorCommand.php
+++ b/src/php/Run/Infrastructure/Command/DoctorCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function dirname;
 use function extension_loaded;
 use function ini_get;
 use function sprintf;
@@ -107,6 +108,7 @@ HELP);
             opcacheLoaded: extension_loaded('Zend OPcache'),
             enableCli: (bool) ini_get('opcache.enable_cli'),
             fileCacheConfigured: (string) ini_get('opcache.file_cache') !== '',
+            iniTemplatePath: $this->bundledIniTemplatePath(),
         );
 
         if ($advice->optimal) {
@@ -118,6 +120,17 @@ HELP);
         foreach ($advice->messages as $message) {
             $output->writeln(sprintf(' - OPcache CLI caching: <comment>TIP</comment> %s', $message));
         }
+    }
+
+    /**
+     * Absolute path to the `phel.ini` template bundled at the package root,
+     * or null when it cannot be found (e.g. a trimmed distribution).
+     */
+    private function bundledIniTemplatePath(): ?string
+    {
+        $path = dirname(__DIR__, 5) . '/phel.ini';
+
+        return is_file($path) ? $path : null;
     }
 
     private function formatLevel(HealthStatus $status): string

--- a/src/php/Shared/Performance/OpcacheAdvisor.php
+++ b/src/php/Shared/Performance/OpcacheAdvisor.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Performance;
 
+use function sprintf;
+
 /**
  * Evaluates whether OPcache is configured to persist the compiled-code cache
  * across CLI invocations, and produces actionable advice when it is not.
@@ -15,10 +17,17 @@ namespace Phel\Shared\Performance;
  */
 final class OpcacheAdvisor
 {
+    /**
+     * @param string|null $iniTemplatePath Absolute path to a bundled
+     *                                     `phel.ini` to point users at when
+     *                                     the config is not optimal, or null
+     *                                     when none is available.
+     */
     public function advise(
         bool $opcacheLoaded,
         bool $enableCli,
         bool $fileCacheConfigured,
+        ?string $iniTemplatePath = null,
     ): OpcacheAdvice {
         if (!$opcacheLoaded) {
             return new OpcacheAdvice(false, [
@@ -32,13 +41,24 @@ final class OpcacheAdvisor
         }
 
         if (!$fileCacheConfigured) {
-            $messages[] = 'opcache.file_cache is not configured. Point it at a writable directory (e.g. opcache.file_cache=/tmp/phel-opcache) to persist the compiled cache across processes.';
+            // file_cache must be an absolute path to a directory that already
+            // exists, or PHP aborts at startup; warn explicitly so enabling it
+            // does not trade one problem for a worse one.
+            $messages[] = 'opcache.file_cache is not configured. Point it at an existing, writable, absolute directory (e.g. create /tmp/phel-opcache first, then opcache.file_cache=/tmp/phel-opcache) to persist the compiled cache across processes. PHP aborts at startup if the path is missing or relative, so keep it outside caches that "phel clear-cache" wipes.';
         }
 
         if ($messages === []) {
             return new OpcacheAdvice(true, [
                 'OPcache CLI caching is fully configured.',
             ]);
+        }
+
+        if ($iniTemplatePath !== null) {
+            $messages[] = sprintf(
+                'A ready-to-use config ships at %s — run e.g. `php -c %s vendor/bin/phel run ...` (uncomment opcache.file_cache there first).',
+                $iniTemplatePath,
+                $iniTemplatePath,
+            );
         }
 
         return new OpcacheAdvice(false, $messages);

--- a/tests/php/Unit/Shared/Performance/OpcacheAdvisorTest.php
+++ b/tests/php/Unit/Shared/Performance/OpcacheAdvisorTest.php
@@ -59,4 +59,44 @@ final class OpcacheAdvisorTest extends TestCase
         self::assertTrue($advice->optimal);
         self::assertCount(1, $advice->messages);
     }
+
+    public function test_file_cache_advice_warns_about_absolute_existing_path(): void
+    {
+        $advice = new OpcacheAdvisor()->advise(
+            opcacheLoaded: true,
+            enableCli: true,
+            fileCacheConfigured: false,
+        );
+
+        // The fix must not trade one startup failure for another: PHP aborts
+        // when file_cache is missing or relative, so the caveat is explicit.
+        self::assertStringContainsStringIgnoringCase('absolute', $advice->messages[0]);
+        self::assertStringContainsStringIgnoringCase('aborts', $advice->messages[0]);
+    }
+
+    public function test_ini_template_pointer_is_appended_when_not_optimal(): void
+    {
+        $advice = new OpcacheAdvisor()->advise(
+            opcacheLoaded: true,
+            enableCli: false,
+            fileCacheConfigured: false,
+            iniTemplatePath: '/pkg/phel.ini',
+        );
+
+        self::assertFalse($advice->optimal);
+        self::assertStringContainsString('/pkg/phel.ini', implode("\n", $advice->messages));
+    }
+
+    public function test_ini_template_pointer_is_omitted_when_optimal(): void
+    {
+        $advice = new OpcacheAdvisor()->advise(
+            opcacheLoaded: true,
+            enableCli: true,
+            fileCacheConfigured: true,
+            iniTemplatePath: '/pkg/phel.ini',
+        );
+
+        self::assertTrue($advice->optimal);
+        self::assertStringNotContainsString('/pkg/phel.ini', implode("\n", $advice->messages));
+    }
 }


### PR DESCRIPTION
## 🤔 Background

A warm `phel run` re-`require`s the compiled PHP under the Phel cache every process, and with OPcache CLI off that opcode is re-parsed each time. A persistent on-disk `opcache.file_cache` lets it survive across CLI invocations (the cross-process win #2444's shared-memory-only warming did not deliver).

Per the chosen activation route (doctor + ini, the safe/non-invasive option — no `bin/phel` re-exec), this ships a ready-to-use config and makes `phel doctor` guide users to enable it correctly.

Closes #2556.

## ⚠️ What I verified first (and why the recommendation is careful)

I probed OPcache's behavior with the target PHP before writing the recommendation:

- `opcache.enable_cli` / `opcache.file_cache` **cannot** be set at runtime (`ini_set` is ignored), so they must be applied at launch — confirmed.
- `opcache.file_cache` **must be an absolute path to a directory that already exists**, or PHP **aborts at startup** (`"opcache.file_cache must be a full path of an accessible directory"`). A **relative** path is rejected outright.
- Therefore pointing it inside `.phel/cache` (as the issue sketched) is an active footgun: `phel clear-cache` would delete the dir and make every later run abort.

So the recommendation steers users to an **existing, absolute, persistent** directory **outside** the clearable cache — no risky auto-wiring. Verified end-to-end: with `-d opcache.enable_cli=1 -d opcache.file_cache=<existing abs dir>`, `phel doctor` reports "fully configured" and a run populates the file cache (`.bin` opcode files) that the next process reuses.

## 🔖 Changes

- **`phel.ini`** (new, package root) — a heavily-commented template: `opcache.enable=1` + `opcache.enable_cli=1`, plus a commented `opcache.file_cache=` placeholder spelling out the absolute / must-exist / keep-outside-clear-cache caveats and the `php -c phel.ini vendor/bin/phel …` usage. Ships in the composer dist (not export-ignored).
- **`OpcacheAdvisor`** — the `file_cache` advice now states it must be an existing, writable, **absolute** directory and that PHP aborts otherwise; an optional `iniTemplatePath` appends a pointer to the bundled `phel.ini` when the config is not optimal. Backward compatible (param defaults to null).
- **`DoctorCommand`** — resolves the bundled `phel.ini` path (graceful null in trimmed/PHAR distributions) and passes it to the advisor. `opcache_compile_file` warming in `CompiledCodeCache` is unchanged — with `file_cache` enabled it now persists.
- Tests for the new caveat text and ini pointer (present when not optimal, omitted when optimal).

No change to how `bin/phel` launches; the win is opt-in. Full gate green (`test-quality`, 4774 compiler tests, 6098 core tests). The lone failing test — `PharExecutionTest::test_phar_ships_shell_completion_scripts` — is a pre-existing local environment quirk (fails identically on clean `main`) and passes in CI.