### PR TITLE
fix(run): suppress doctor's phel.ini pointer in PHAR builds

### DIFF
--- a/src/php/Run/Infrastructure/Command/DoctorCommand.php
+++ b/src/php/Run/Infrastructure/Command/DoctorCommand.php
@@ -8,6 +8,7 @@ use Gacela\Framework\Health\HealthChecker;
 use Gacela\Framework\Health\HealthStatus;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
+use Phar;
 use Phel\Run\RunFacade;
 use Phel\Shared\Performance\OpcacheAdvisor;
 use Symfony\Component\Console\Command\Command;
@@ -124,10 +125,17 @@ HELP);
 
     /**
      * Absolute path to the `phel.ini` template bundled at the package root,
-     * or null when it cannot be found (e.g. a trimmed distribution).
+     * or null when it cannot be usefully referenced — a trimmed distribution
+     * (file absent) or a PHAR run, where the file resolves to a `phar://…`
+     * path that PHP cannot load via `php -c`. PHAR users still get the
+     * generic OPcache tips, just without a broken config pointer.
      */
     private function bundledIniTemplatePath(): ?string
     {
+        if (Phar::running(false) !== '') {
+            return null;
+        }
+
         $path = dirname(__DIR__, 5) . '/phel.ini';
 
         return is_file($path) ? $path : null;

--- a/tests/php/Integration/Phar/PharExecutionTest.php
+++ b/tests/php/Integration/Phar/PharExecutionTest.php
@@ -177,6 +177,16 @@ final class PharExecutionTest extends TestCase
         self::assertStringContainsString('6', $result['stdout']);
     }
 
+    public function test_phar_doctor_does_not_point_to_an_unusable_phar_ini(): void
+    {
+        // Regression: `phel doctor`'s OPcache tip must not suggest
+        // `php -c phar://…/phel.ini`, which PHP cannot load from inside a
+        // PHAR. The generic tips still show; only the broken pointer is gone.
+        $result = $this->runPhar(['doctor']);
+
+        self::assertStringNotContainsString('phar://', $result['stdout']);
+    }
+
     /**
      * @param list<string> $args
      *


### PR DESCRIPTION
## 🤔 Background

Found during a full PHAR regression QA of the just-merged #2556. In a PHAR install, `phel doctor`'s OPcache tip resolved the bundled `phel.ini` to a `phar://…/phel.phar/phel.ini` path and suggested:

```
php -c phar:///…/phel.phar/phel.ini vendor/bin/phel run ...
```

PHP **cannot** load an ini file from inside a PHAR via `-c`, so that suggestion is broken for exactly the audience most likely to hit it.

## 🔖 Changes

- `DoctorCommand::bundledIniTemplatePath()` returns `null` when running inside a PHAR (`Phar::running()`), so the broken pointer is dropped. PHAR users still get the two actionable OPcache tips (`enable_cli`, `file_cache` with its absolute/must-exist caveats); only the unusable `php -c` line is gone. Composer/source installs (real filesystem path) keep the working pointer.
- Regression test in `PharExecutionTest` asserting `phel doctor` output contains no `phar://`.

## ✅ Verification

Rebuilt the PHAR and confirmed: PHAR-mode doctor shows the generic tips with no `phar://` pointer; source-mode still prints the working absolute `phel.ini` path. Verified as part of a broader QA pass (run/eval/test/build/compile/format/lint/doc/completion/repl + the #2562/#2563/#2586/#2554/#2567 features and fixes all working in the built PHAR).