### PR TITLE
feat(config): surface config validation in `phel config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `phel config` now validates the effective configuration and reports problems (such as source directories that must be relative) in a dedicated "Validation" section
+
 ### Performance
 
 - Compile interop to native PHP: `php/->`, `php/::`, `php/new`, and `php/oset` emit direct expressions/statements instead of closure wrappers (#2524, #2525, #2526, #2532, #2536)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `phel config` now validates the effective configuration and reports problems (such as source directories that must be relative) in a dedicated "Validation" section
+- `phel config` now validates the effective configuration and reports problems (such as source directories that must be relative) in a dedicated "Validation" section (#2600)
 
 ### Performance
 

--- a/src/php/Run/Domain/Config/ConfigDiagnostics.php
+++ b/src/php/Run/Domain/Config/ConfigDiagnostics.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Config;
+
+use Phel\Config\PhelConfig;
+use Phel\Shared\ScalarCoercion;
+
+use function array_map;
+
+/**
+ * Inspects the effective, merged Phel configuration and reports problems with
+ * it. This is where the otherwise-unused {@see PhelConfig::validate()} rules
+ * are actually surfaced to the user, alongside checks (such as missing
+ * directories) that need the project root and so cannot live in the pure
+ * Config leaf module.
+ *
+ * Diagnostics are advisory: the CLI commands decide whether to fail.
+ */
+final class ConfigDiagnostics
+{
+    /**
+     * @param array<string, mixed> $values the effective merged config, shaped
+     *                                     like {@see PhelConfig::jsonSerialize()}
+     *
+     * @return list<ConfigIssue>
+     */
+    public function analyze(array $values): array
+    {
+        return $this->relativePathErrors($values);
+    }
+
+    /**
+     * Runs the pure {@see PhelConfig::validate()} rules against the effective
+     * config (e.g. directories that must be relative).
+     *
+     * @param array<string, mixed> $values
+     *
+     * @return list<ConfigIssue>
+     */
+    private function relativePathErrors(array $values): array
+    {
+        $config = new PhelConfig()
+            ->withSrcDirs(ScalarCoercion::toStringList($values[PhelConfig::SRC_DIRS] ?? null))
+            ->withTestDirs(ScalarCoercion::toStringList($values[PhelConfig::TEST_DIRS] ?? null))
+            ->withVendorDir(ScalarCoercion::toString($values[PhelConfig::VENDOR_DIR] ?? null));
+
+        return array_map(
+            ConfigIssue::error(...),
+            $config->validate(),
+        );
+    }
+}

--- a/src/php/Run/Domain/Config/ConfigIssue.php
+++ b/src/php/Run/Domain/Config/ConfigIssue.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Config;
+
+/**
+ * A single finding about the effective Phel configuration, surfaced by
+ * `phel config` and `phel doctor`.
+ */
+final readonly class ConfigIssue
+{
+    public function __construct(
+        public ConfigIssueLevel $level,
+        public string $message,
+    ) {}
+
+    public static function error(string $message): self
+    {
+        return new self(ConfigIssueLevel::Error, $message);
+    }
+
+    public static function warning(string $message): self
+    {
+        return new self(ConfigIssueLevel::Warning, $message);
+    }
+
+    public function isError(): bool
+    {
+        return $this->level === ConfigIssueLevel::Error;
+    }
+}

--- a/src/php/Run/Domain/Config/ConfigIssueLevel.php
+++ b/src/php/Run/Domain/Config/ConfigIssueLevel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Config;
+
+/**
+ * Severity of a configuration diagnostic. Errors mean the config is wrong and
+ * something will break; warnings flag likely mistakes that still let Phel run.
+ */
+enum ConfigIssueLevel: string
+{
+    case Error = 'error';
+    case Warning = 'warning';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Error => 'ERROR',
+            self::Warning => 'WARNING',
+        };
+    }
+}

--- a/src/php/Run/Infrastructure/Command/ConfigCommand.php
+++ b/src/php/Run/Infrastructure/Command/ConfigCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Run\Infrastructure\Command;
 
+use Phel\Run\Domain\Config\ConfigDiagnostics;
+use Phel\Run\Domain\Config\ConfigIssue;
 use Phel\Run\Domain\Config\EffectiveConfigReader;
 use Phel\Run\Domain\Config\EffectiveConfigResult;
 use Phel\Shared\Console\DeprecatedOptionWarner;
@@ -32,6 +34,7 @@ final class ConfigCommand extends Command
 
     public function __construct(
         private readonly EffectiveConfigReader $reader = new EffectiveConfigReader(),
+        private readonly ConfigDiagnostics $diagnostics = new ConfigDiagnostics(),
     ) {
         parent::__construct();
     }
@@ -84,8 +87,35 @@ HELP)
         $output->writeln('');
         $output->writeln('<comment>Effective config:</comment>');
         $output->writeln($this->toJson($effective->values));
+        $this->writeValidation($output, $this->diagnostics->analyze($effective->values));
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * @param list<ConfigIssue> $issues
+     */
+    private function writeValidation(OutputInterface $output, array $issues): void
+    {
+        $output->writeln('');
+        $output->writeln('<comment>Validation:</comment>');
+
+        if ($issues === []) {
+            $output->writeln(' - <info>no issues found</info>');
+
+            return;
+        }
+
+        foreach ($issues as $issue) {
+            $tag = $issue->isError() ? 'error' : 'comment';
+            $output->writeln(sprintf(
+                ' - <%s>%s</%s> %s',
+                $tag,
+                $issue->level->label(),
+                $tag,
+                $issue->message,
+            ));
+        }
     }
 
     private function writeSources(OutputInterface $output, EffectiveConfigResult $effective): void

--- a/tests/php/Integration/Run/Command/Config/ConfigCommandTest.php
+++ b/tests/php/Integration/Run/Command/Config/ConfigCommandTest.php
@@ -49,6 +49,27 @@ final class ConfigCommandTest extends TestCase
         self::assertStringContainsString('src/phel', $display);
         // This fixture dir has no phel-config.php, so it is auto-detected.
         self::assertStringContainsString('not found', $display);
+        // The (relative) fixture config is valid, so validation reports clean.
+        self::assertStringContainsString('Validation:', $display);
+        self::assertStringContainsString('no issues found', $display);
+    }
+
+    public function test_absolute_src_dir_is_reported_in_the_validation_section(): void
+    {
+        $this->resetContainer();
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addAppConfigKeyValue(PhelConfig::SRC_DIRS, ['/absolute/src']);
+        });
+
+        $tester = new CommandTester(new ConfigCommand());
+        $exitCode = $tester->execute([]);
+
+        $display = $tester->getDisplay();
+        // Surfacing is non-fatal: `phel config` stays informational (exit 0).
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('Validation:', $display);
+        self::assertStringContainsString('ERROR', $display);
+        self::assertStringContainsString('/absolute/src', $display);
     }
 
     public function test_format_json_emits_only_valid_json(): void

--- a/tests/php/Unit/Run/Domain/Config/ConfigDiagnosticsTest.php
+++ b/tests/php/Unit/Run/Domain/Config/ConfigDiagnosticsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Domain\Config;
+
+use Phel\Config\PhelConfig;
+use Phel\Run\Domain\Config\ConfigDiagnostics;
+use Phel\Run\Domain\Config\ConfigIssueLevel;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigDiagnosticsTest extends TestCase
+{
+    private ConfigDiagnostics $diagnostics;
+
+    protected function setUp(): void
+    {
+        $this->diagnostics = new ConfigDiagnostics();
+    }
+
+    public function test_relative_dirs_produce_no_issues(): void
+    {
+        $issues = $this->diagnostics->analyze([
+            PhelConfig::SRC_DIRS => ['src'],
+            PhelConfig::TEST_DIRS => ['tests'],
+            PhelConfig::VENDOR_DIR => 'vendor',
+        ]);
+
+        self::assertSame([], $issues);
+    }
+
+    public function test_missing_keys_produce_no_issues(): void
+    {
+        self::assertSame([], $this->diagnostics->analyze([]));
+    }
+
+    public function test_absolute_src_dir_is_reported_as_an_error(): void
+    {
+        $issues = $this->diagnostics->analyze([
+            PhelConfig::SRC_DIRS => ['/absolute/src'],
+        ]);
+
+        self::assertCount(1, $issues);
+        self::assertSame(ConfigIssueLevel::Error, $issues[0]->level);
+        self::assertStringContainsString('/absolute/src', $issues[0]->message);
+        self::assertStringContainsString('should be relative', $issues[0]->message);
+    }
+
+    public function test_absolute_dirs_across_keys_are_aggregated(): void
+    {
+        $issues = $this->diagnostics->analyze([
+            PhelConfig::SRC_DIRS => ['/abs/src'],
+            PhelConfig::TEST_DIRS => ['/abs/tests'],
+            PhelConfig::VENDOR_DIR => '/abs/vendor',
+        ]);
+
+        self::assertCount(3, $issues);
+        foreach ($issues as $issue) {
+            self::assertSame(ConfigIssueLevel::Error, $issue->level);
+        }
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`PhelConfig::validate()` (and its `PhelConfigValidator`) exists and is unit-tested, but nothing ever calls it during normal CLI use — a misconfigured `phel-config.php` only blows up deep in the build/run pipeline with a cryptic error, never pointing back at the config.

This is the first of a short series improving `phel-config.php` developer experience.

## 💡 Goal

Make configuration problems visible at the place users already look — `phel config` — without changing any runtime behavior.

## 🔖 Changes

- New `Phel\Run\Domain\Config\ConfigDiagnostics`: runs the pure `PhelConfig::validate()` rules against the **effective merged config** and returns severity-tagged `ConfigIssue`s. Lives in the Run layer so later filesystem-aware checks (missing dirs) can be added without polluting the pure `Config` leaf module.
- `ConfigIssue` + `ConfigIssueLevel` (Error/Warning) value objects.
- `phel config` (text output) gains a **Validation** section: `no issues found` when clean, or one line per issue. JSON output is unchanged (stays pure machine-readable config).
- Non-fatal by design: `phel config` stays informational (exit 0). A follow-up wires the same diagnostics into `phel doctor`, which will gate on errors.
- Tests: `ConfigDiagnosticsTest` (unit) + new `ConfigCommandTest` cases (clean config reports clean; an absolute `src-dirs` surfaces an ERROR).

CHANGELOG updated under Unreleased → Added.