### PR TITLE
feat(config): expand config validation checks (missing dirs, empty src, opt level)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `phel config` now validates the effective configuration and reports problems in a dedicated "Validation" section: directories that must be relative, source/test directories that do not exist, no source directories configured, and unknown optimization levels (#2600)
+- `phel config` now validates the effective configuration and reports problems in a dedicated "Validation" section: directories that must be relative, source/test directories that do not exist, no source directories configured, and unknown optimization levels (#2600, #2601)
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `phel config` now validates the effective configuration and reports problems (such as source directories that must be relative) in a dedicated "Validation" section (#2600)
+- `phel config` now validates the effective configuration and reports problems in a dedicated "Validation" section: directories that must be relative, source/test directories that do not exist, no source directories configured, and unknown optimization levels (#2600)
 
 ### Performance
 

--- a/src/php/Run/Domain/Config/ConfigDiagnostics.php
+++ b/src/php/Run/Domain/Config/ConfigDiagnostics.php
@@ -7,7 +7,14 @@ namespace Phel\Run\Domain\Config;
 use Phel\Config\PhelConfig;
 use Phel\Shared\ScalarCoercion;
 
+use function array_key_exists;
 use function array_map;
+use function in_array;
+use function is_dir;
+use function rtrim;
+use function sprintf;
+use function str_starts_with;
+use function ucfirst;
 
 /**
  * Inspects the effective, merged Phel configuration and reports problems with
@@ -20,15 +27,25 @@ use function array_map;
  */
 final class ConfigDiagnostics
 {
+    /** @var list<int> */
+    private const array SUPPORTED_OPTIMIZATION_LEVELS = [0, 1, 2];
+
     /**
-     * @param array<string, mixed> $values the effective merged config, shaped
-     *                                     like {@see PhelConfig::jsonSerialize()}
+     * @param array<string, mixed> $values      the effective merged config,
+     *                                          shaped like {@see PhelConfig::jsonSerialize()}
+     * @param string               $projectRoot directory that relative config
+     *                                          paths resolve against
      *
      * @return list<ConfigIssue>
      */
-    public function analyze(array $values): array
+    public function analyze(array $values, string $projectRoot): array
     {
-        return $this->relativePathErrors($values);
+        return [
+            ...$this->relativePathErrors($values),
+            ...$this->emptySourceWarnings($values),
+            ...$this->missingDirectoryWarnings($values, $projectRoot),
+            ...$this->optimizationLevelWarnings($values),
+        ];
     }
 
     /**
@@ -50,5 +67,86 @@ final class ConfigDiagnostics
             ConfigIssue::error(...),
             $config->validate(),
         );
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     *
+     * @return list<ConfigIssue>
+     */
+    private function emptySourceWarnings(array $values): array
+    {
+        if (!array_key_exists(PhelConfig::SRC_DIRS, $values)) {
+            return [];
+        }
+
+        if (ScalarCoercion::toStringList($values[PhelConfig::SRC_DIRS]) !== []) {
+            return [];
+        }
+
+        return [ConfigIssue::warning('No source directories are configured; nothing will be compiled')];
+    }
+
+    /**
+     * Relative source/test directories that do not exist on disk are almost
+     * always a typo. Absolute paths are intentionally skipped here: they are
+     * already flagged by the relative-path rule, so we avoid double-reporting.
+     *
+     * @param array<string, mixed> $values
+     *
+     * @return list<ConfigIssue>
+     */
+    private function missingDirectoryWarnings(array $values, string $projectRoot): array
+    {
+        $root = rtrim($projectRoot, '/');
+        $groups = [
+            'source' => ScalarCoercion::toStringList($values[PhelConfig::SRC_DIRS] ?? null),
+            'test' => ScalarCoercion::toStringList($values[PhelConfig::TEST_DIRS] ?? null),
+        ];
+
+        $issues = [];
+        foreach ($groups as $label => $dirs) {
+            foreach ($dirs as $dir) {
+                if ($dir === '') {
+                    continue;
+                }
+
+                if (str_starts_with($dir, '/')) {
+                    continue;
+                }
+
+                if (!is_dir($root . '/' . $dir)) {
+                    $issues[] = ConfigIssue::warning(sprintf(
+                        "%s directory '%s' does not exist",
+                        ucfirst($label),
+                        $dir,
+                    ));
+                }
+            }
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     *
+     * @return list<ConfigIssue>
+     */
+    private function optimizationLevelWarnings(array $values): array
+    {
+        if (!array_key_exists(PhelConfig::OPTIMIZATION_LEVEL, $values)) {
+            return [];
+        }
+
+        $level = ScalarCoercion::toInt($values[PhelConfig::OPTIMIZATION_LEVEL]);
+        if (in_array($level, self::SUPPORTED_OPTIMIZATION_LEVELS, true)) {
+            return [];
+        }
+
+        return [ConfigIssue::warning(sprintf(
+            'Unknown optimization level %d; supported levels are 0, 1, 2',
+            $level,
+        ))];
     }
 }

--- a/src/php/Run/Infrastructure/Command/ConfigCommand.php
+++ b/src/php/Run/Infrastructure/Command/ConfigCommand.php
@@ -87,7 +87,10 @@ HELP)
         $output->writeln('');
         $output->writeln('<comment>Effective config:</comment>');
         $output->writeln($this->toJson($effective->values));
-        $this->writeValidation($output, $this->diagnostics->analyze($effective->values));
+        $this->writeValidation(
+            $output,
+            $this->diagnostics->analyze($effective->values, $effective->projectRoot),
+        );
 
         return Command::SUCCESS;
     }

--- a/tests/php/Integration/Run/Command/Config/ConfigCommandTest.php
+++ b/tests/php/Integration/Run/Command/Config/ConfigCommandTest.php
@@ -49,7 +49,27 @@ final class ConfigCommandTest extends TestCase
         self::assertStringContainsString('src/phel', $display);
         // This fixture dir has no phel-config.php, so it is auto-detected.
         self::assertStringContainsString('not found', $display);
-        // The (relative) fixture config is valid, so validation reports clean.
+        // The fixture's src/phel does not exist on disk, so validation warns.
+        self::assertStringContainsString('Validation:', $display);
+        self::assertStringContainsString('WARNING', $display);
+        self::assertStringContainsString("Source directory 'src/phel' does not exist", $display);
+    }
+
+    public function test_valid_config_reports_no_validation_issues(): void
+    {
+        $this->resetContainer();
+        // Point src/test dirs at the project root, which always exists, so the
+        // config validates clean.
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addAppConfigKeyValue(PhelConfig::SRC_DIRS, ['.']);
+            $config->addAppConfigKeyValue(PhelConfig::TEST_DIRS, ['.']);
+        });
+
+        $tester = new CommandTester(new ConfigCommand());
+        $exitCode = $tester->execute([]);
+
+        $display = $tester->getDisplay();
+        self::assertSame(0, $exitCode);
         self::assertStringContainsString('Validation:', $display);
         self::assertStringContainsString('no issues found', $display);
     }

--- a/tests/php/Unit/Run/Domain/Config/ConfigDiagnosticsTest.php
+++ b/tests/php/Unit/Run/Domain/Config/ConfigDiagnosticsTest.php
@@ -9,54 +9,98 @@ use Phel\Run\Domain\Config\ConfigDiagnostics;
 use Phel\Run\Domain\Config\ConfigIssueLevel;
 use PHPUnit\Framework\TestCase;
 
+use function bin2hex;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function sys_get_temp_dir;
+
 final class ConfigDiagnosticsTest extends TestCase
 {
     private ConfigDiagnostics $diagnostics;
 
+    private string $root;
+
     protected function setUp(): void
     {
         $this->diagnostics = new ConfigDiagnostics();
+        $this->root = sys_get_temp_dir() . '/phel-diag-' . bin2hex(random_bytes(6));
+        mkdir($this->root, 0755, true);
     }
 
-    public function test_relative_dirs_produce_no_issues(): void
+    protected function tearDown(): void
     {
+        @rmdir($this->root . '/src');
+        @rmdir($this->root . '/tests');
+        @rmdir($this->root);
+    }
+
+    public function test_existing_relative_dirs_produce_no_issues(): void
+    {
+        mkdir($this->root . '/src');
+        mkdir($this->root . '/tests');
+
         $issues = $this->diagnostics->analyze([
             PhelConfig::SRC_DIRS => ['src'],
             PhelConfig::TEST_DIRS => ['tests'],
             PhelConfig::VENDOR_DIR => 'vendor',
-        ]);
+            PhelConfig::OPTIMIZATION_LEVEL => 2,
+        ], $this->root);
 
         self::assertSame([], $issues);
     }
 
     public function test_missing_keys_produce_no_issues(): void
     {
-        self::assertSame([], $this->diagnostics->analyze([]));
+        self::assertSame([], $this->diagnostics->analyze([], $this->root));
     }
 
-    public function test_absolute_src_dir_is_reported_as_an_error(): void
+    public function test_absolute_src_dir_reports_an_error_and_not_a_missing_warning(): void
     {
         $issues = $this->diagnostics->analyze([
             PhelConfig::SRC_DIRS => ['/absolute/src'],
-        ]);
+        ], $this->root);
 
+        // Absolute dirs are flagged once (relative-path error), never doubled
+        // up with a "does not exist" warning.
         self::assertCount(1, $issues);
         self::assertSame(ConfigIssueLevel::Error, $issues[0]->level);
-        self::assertStringContainsString('/absolute/src', $issues[0]->message);
         self::assertStringContainsString('should be relative', $issues[0]->message);
     }
 
-    public function test_absolute_dirs_across_keys_are_aggregated(): void
+    public function test_missing_relative_source_dir_warns(): void
     {
         $issues = $this->diagnostics->analyze([
-            PhelConfig::SRC_DIRS => ['/abs/src'],
-            PhelConfig::TEST_DIRS => ['/abs/tests'],
-            PhelConfig::VENDOR_DIR => '/abs/vendor',
-        ]);
+            PhelConfig::SRC_DIRS => ['does-not-exist'],
+        ], $this->root);
 
-        self::assertCount(3, $issues);
-        foreach ($issues as $issue) {
-            self::assertSame(ConfigIssueLevel::Error, $issue->level);
-        }
+        self::assertCount(1, $issues);
+        self::assertSame(ConfigIssueLevel::Warning, $issues[0]->level);
+        self::assertStringContainsString("Source directory 'does-not-exist' does not exist", $issues[0]->message);
+    }
+
+    public function test_empty_source_dirs_warn(): void
+    {
+        $issues = $this->diagnostics->analyze([
+            PhelConfig::SRC_DIRS => [],
+        ], $this->root);
+
+        self::assertCount(1, $issues);
+        self::assertSame(ConfigIssueLevel::Warning, $issues[0]->level);
+        self::assertStringContainsString('nothing will be compiled', $issues[0]->message);
+    }
+
+    public function test_unknown_optimization_level_warns(): void
+    {
+        mkdir($this->root . '/src');
+
+        $issues = $this->diagnostics->analyze([
+            PhelConfig::SRC_DIRS => ['src'],
+            PhelConfig::OPTIMIZATION_LEVEL => 5,
+        ], $this->root);
+
+        self::assertCount(1, $issues);
+        self::assertSame(ConfigIssueLevel::Warning, $issues[0]->level);
+        self::assertStringContainsString('optimization level 5', $issues[0]->message);
     }
 }


### PR DESCRIPTION
## 🤔 Background

Follow-up to #2600, which surfaced `PhelConfig::validate()` in `phel config`. That first pass only carried the existing relative-path rule. The most common config mistakes — a typo in a source directory, an empty `src-dirs`, an out-of-range optimization level — still went unreported.

## 💡 Goal

Catch the likely config mistakes and report them as warnings, so users see them in `phel config` (and, in a later PR, `phel doctor`).

## 🔖 Changes

- `ConfigDiagnostics::analyze()` now also returns **warning**-level issues:
  - relative `src-dirs`/`test-dirs` that do not exist on disk (resolved against the project root),
  - an empty `src-dirs` list ("nothing will be compiled"),
  - an optimization level outside `{0, 1, 2}`.
- Filesystem checks live in the Run layer (they need the project root); the pure `Config` leaf module stays I/O-free and its `PhelConfigValidator` tests are untouched.
- Absolute directories are reported once via the existing relative-path **error** and deliberately skipped by the missing-dir check, so they are never double-reported.
- `analyze()` gains a `projectRoot` argument; `ConfigCommand` passes the effective project root.
- Tests: `ConfigDiagnosticsTest` rewritten around a temp project dir (existing/missing/empty/absolute dirs, opt level); `ConfigCommandTest` updated (the fixture's `src/phel` is absent, so it now correctly warns) plus a new clean-config case.

CHANGELOG updated under Unreleased → Added.