### PR TITLE
feat(config): warn on config values with the wrong type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `phel config` now validates the effective configuration and reports problems in a dedicated "Validation" section: directories that must be relative, source/test directories that do not exist, no source directories configured, and unknown optimization levels (#2600, #2601)
+- `phel config` now validates the effective configuration and reports problems in a dedicated "Validation" section: directories that must be relative, source/test directories that do not exist, no source directories configured, unknown optimization levels, and config values with the wrong type (#2600, #2601, #2602)
 
 ### Performance
 

--- a/src/php/Run/Domain/Config/ConfigDiagnostics.php
+++ b/src/php/Run/Domain/Config/ConfigDiagnostics.php
@@ -10,6 +10,7 @@ use Phel\Shared\ScalarCoercion;
 use function array_key_exists;
 use function array_map;
 use function in_array;
+use function is_array;
 use function is_dir;
 use function rtrim;
 use function sprintf;
@@ -42,6 +43,7 @@ final class ConfigDiagnostics
     {
         return [
             ...$this->relativePathErrors($values),
+            ...$this->typeMismatchWarnings($values),
             ...$this->emptySourceWarnings($values),
             ...$this->missingDirectoryWarnings($values, $projectRoot),
             ...$this->optimizationLevelWarnings($values),
@@ -80,7 +82,10 @@ final class ConfigDiagnostics
             return [];
         }
 
-        if (ScalarCoercion::toStringList($values[PhelConfig::SRC_DIRS]) !== []) {
+        // A non-array value is a type mismatch, reported separately; do not
+        // also claim "no source directories" for it.
+        $raw = $values[PhelConfig::SRC_DIRS];
+        if (!is_array($raw) || $raw !== []) {
             return [];
         }
 
@@ -148,5 +153,49 @@ final class ConfigDiagnostics
             'Unknown optimization level %d; supported levels are 0, 1, 2',
             $level,
         ))];
+    }
+
+    /**
+     * Flags config values whose type does not match the expected shape. Such
+     * values are otherwise silently coerced to a default (e.g. a `src-dirs`
+     * string becomes an empty list), discarding the user's intent without a
+     * trace.
+     *
+     * @param array<string, mixed> $values
+     *
+     * @return list<ConfigIssue>
+     */
+    private function typeMismatchWarnings(array $values): array
+    {
+        $listKeys = [
+            PhelConfig::SRC_DIRS,
+            PhelConfig::TEST_DIRS,
+            PhelConfig::FORMAT_DIRS,
+            PhelConfig::IGNORE_WHEN_BUILDING,
+            PhelConfig::NO_CACHE_WHEN_BUILDING,
+        ];
+
+        $issues = [];
+        foreach ($listKeys as $key) {
+            if (array_key_exists($key, $values) && !is_array($values[$key])) {
+                $issues[] = ConfigIssue::warning(sprintf(
+                    "Config key '%s' should be a list of strings, got %s; the value will be ignored",
+                    $key,
+                    get_debug_type($values[$key]),
+                ));
+            }
+        }
+
+        if (array_key_exists(PhelConfig::OPTIMIZATION_LEVEL, $values)
+            && !is_numeric($values[PhelConfig::OPTIMIZATION_LEVEL])
+        ) {
+            $issues[] = ConfigIssue::warning(sprintf(
+                "Config key '%s' should be an integer, got %s; the value will be ignored",
+                PhelConfig::OPTIMIZATION_LEVEL,
+                get_debug_type($values[PhelConfig::OPTIMIZATION_LEVEL]),
+            ));
+        }
+
+        return $issues;
     }
 }

--- a/tests/php/Unit/Run/Domain/Config/ConfigDiagnosticsTest.php
+++ b/tests/php/Unit/Run/Domain/Config/ConfigDiagnosticsTest.php
@@ -103,4 +103,30 @@ final class ConfigDiagnosticsTest extends TestCase
         self::assertSame(ConfigIssueLevel::Warning, $issues[0]->level);
         self::assertStringContainsString('optimization level 5', $issues[0]->message);
     }
+
+    public function test_non_array_src_dirs_warns_about_the_type_only(): void
+    {
+        $issues = $this->diagnostics->analyze([
+            PhelConfig::SRC_DIRS => 'src',
+        ], $this->root);
+
+        // Exactly one issue: the type mismatch, not a misleading
+        // "no source directories" warning from the coerced-to-empty value.
+        self::assertCount(1, $issues);
+        self::assertSame(ConfigIssueLevel::Warning, $issues[0]->level);
+        self::assertStringContainsString("Config key 'src-dirs' should be a list of strings", $issues[0]->message);
+        self::assertStringContainsString('got string', $issues[0]->message);
+    }
+
+    public function test_non_numeric_optimization_level_warns_about_the_type(): void
+    {
+        $issues = $this->diagnostics->analyze([
+            PhelConfig::OPTIMIZATION_LEVEL => 'fast',
+        ], $this->root);
+
+        self::assertCount(1, $issues);
+        self::assertSame(ConfigIssueLevel::Warning, $issues[0]->level);
+        self::assertStringContainsString("Config key 'optimization-level' should be an integer", $issues[0]->message);
+        self::assertStringContainsString('got string', $issues[0]->message);
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Follow-up to #2600/#2601. When a `phel-config.php` (or a raw-array config) sets a key to the wrong type — `src-dirs => "src"` instead of `["src"]`, or `optimization-level => "fast"` — the value is silently coerced to a default. The user's intent vanishes with no warning, and the only symptom is confusing downstream behavior (e.g. a misleading "no source directories" message).

## 💡 Goal

Tell the user when a config value has the wrong type and is being ignored.

## 🔖 Changes

- `ConfigDiagnostics` now inspects the **raw** merged values for type mismatches:
  - list-shaped keys (`src-dirs`, `test-dirs`, `format-dirs`, `ignore-when-building`, `no-cache-when-building`) set to a non-array,
  - a non-numeric `optimization-level`.
  
  Each reports a warning naming the key and the actual type (`got string`), noting the value will be ignored.
- The empty-source check now defers to this clearer message for non-array `src-dirs`, so a wrong type yields one precise warning instead of a misleading "no source directories" one.
- `ScalarCoercion` is intentionally left unchanged — it is a general pure utility used well beyond config, so the warning lives at the diagnostics layer.
- Tests: non-array `src-dirs` and non-numeric `optimization-level` each produce exactly one type warning.

CHANGELOG updated under Unreleased → Added.