### PR TITLE
feat(doctor): check project configuration in `phel doctor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `phel config` now validates the effective configuration and reports problems in a dedicated "Validation" section: directories that must be relative, source/test directories that do not exist, no source directories configured, unknown optimization levels, and config values with the wrong type (#2600, #2601, #2602)
+- `phel doctor` now checks the project configuration: it fails on config errors and surfaces warnings as tips (#2603)
 
 ### Performance
 

--- a/src/php/Run/Infrastructure/Command/DoctorCommand.php
+++ b/src/php/Run/Infrastructure/Command/DoctorCommand.php
@@ -9,6 +9,8 @@ use Gacela\Framework\Health\HealthStatus;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Phar;
+use Phel\Run\Domain\Config\ConfigDiagnostics;
+use Phel\Run\Domain\Config\EffectiveConfigReader;
 use Phel\Run\RunFacade;
 use Phel\Shared\Performance\OpcacheAdvisor;
 use Symfony\Component\Console\Command\Command;
@@ -33,8 +35,9 @@ final class DoctorCommand extends Command
         $this->setName('doctor')
             ->setDescription('Check system requirements for running the Phel CLI')
             ->setHelp(<<<'HELP'
-Checks PHP version/extensions, module health, and cold-start performance
-(OPcache CLI caching), printing actionable fixes for anything missing.
+Checks PHP version/extensions, module health, project configuration, and
+cold-start performance (OPcache CLI caching), printing actionable fixes for
+anything missing.
 
 <info>Example:</info>
   <comment>phel doctor</comment>
@@ -45,9 +48,10 @@ HELP);
     {
         $systemOk = $this->checkSystemRequirements($output);
         $modulesOk = $this->checkModuleHealth($output);
+        $configOk = $this->checkConfiguration($output);
         $this->checkPerformance($output);
 
-        if ($systemOk && $modulesOk) {
+        if ($systemOk && $modulesOk && $configOk) {
             $output->writeln('<info>Your system meets all requirements.</info>');
 
             return Command::SUCCESS;
@@ -98,6 +102,37 @@ HELP);
         }
 
         return !$report->hasUnhealthyModules();
+    }
+
+    /**
+     * Reports problems with the effective project configuration. Errors fail
+     * the check (and so the command); warnings are surfaced as tips.
+     */
+    private function checkConfiguration(OutputInterface $output): bool
+    {
+        $output->writeln('');
+        $output->writeln('Checking configuration:');
+
+        $effective = new EffectiveConfigReader()->read();
+        $issues = new ConfigDiagnostics()->analyze($effective->values, $effective->projectRoot);
+
+        if ($issues === []) {
+            $output->writeln(' - <info>OK</info> no configuration problems found');
+
+            return true;
+        }
+
+        $ok = true;
+        foreach ($issues as $issue) {
+            if ($issue->isError()) {
+                $ok = false;
+                $output->writeln(sprintf(' - <error>FAIL</error> %s', $issue->message));
+            } else {
+                $output->writeln(sprintf(' - <comment>TIP</comment> %s', $issue->message));
+            }
+        }
+
+        return $ok;
     }
 
     private function checkPerformance(OutputInterface $output): void

--- a/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
+++ b/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
@@ -57,6 +57,40 @@ final class DoctorCommandTest extends TestCase
         self::assertStringContainsString('OPcache CLI caching:', $rendered);
     }
 
+    public function test_doctor_reports_a_configuration_section(): void
+    {
+        $output = new BufferedOutput();
+
+        new DoctorCommand()->run(
+            $this->createStub(InputInterface::class),
+            $output,
+        );
+
+        self::assertStringContainsString('Checking configuration:', $output->fetch());
+    }
+
+    public function test_doctor_fails_when_configuration_has_an_error(): void
+    {
+        $this->resetContainer();
+        $tempDir = $this->containerTempDir();
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($tempDir): void {
+            $config->addAppConfigKeyValue(PhelConfig::TEMP_DIR, $tempDir);
+            $config->addAppConfigKeyValue(PhelConfig::SRC_DIRS, ['/absolute/src']);
+        });
+
+        $output = new BufferedOutput();
+        $exitCode = new DoctorCommand()->run(
+            $this->createStub(InputInterface::class),
+            $output,
+        );
+
+        $rendered = $output->fetch();
+        self::assertSame(1, $exitCode, 'an absolute src dir is a config error and must fail doctor');
+        self::assertStringContainsString('Checking configuration:', $rendered);
+        self::assertStringContainsString('/absolute/src', $rendered);
+        self::assertStringContainsString('does not meet all requirements', $rendered);
+    }
+
     public function test_doctor_succeeds_when_temp_dir_does_not_exist_yet(): void
     {
         $this->resetContainer();


### PR DESCRIPTION
## 🤔 Background

#2600–#2602 built `ConfigDiagnostics` and surfaced it (informationally) in `phel config`. But `phel doctor` is the command users actually run when something is off — and it did not look at the project configuration at all.

## 💡 Goal

Make `phel doctor` the gate for configuration health, reusing the same diagnostics.

## 🔖 Changes

- New "Checking configuration" section in `phel doctor`, alongside the existing requirements / module-health / performance sections.
- Runs `ConfigDiagnostics` on the effective config. **Errors fail** the command (consistent with the system/module checks and exit code); **warnings** are shown as `TIP`s and do not fail.
- Reuses `EffectiveConfigReader` + `ConfigDiagnostics` directly (same module), matching how `checkPerformance` instantiates `OpcacheAdvisor`.
- `doctor --help` updated to mention the configuration check.
- Tests: doctor renders the configuration section; an absolute `src-dirs` makes doctor exit non-zero with the error surfaced. Existing success/temp-dir tests stay green (their fixtures set no `src-dirs`, so there are no issues).

CHANGELOG updated under Unreleased → Added.