### PR TITLE
feat(config): wrap a broken phel-config.php in a clear error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 - `phel config` now validates the effective configuration and reports problems in a dedicated "Validation" section: directories that must be relative, source/test directories that do not exist, no source directories configured, unknown optimization levels, and config values with the wrong type (#2600, #2601, #2602)
 - `phel doctor` now checks the project configuration: it fails on config errors and surfaces warnings as tips (#2603)
 
+### Changed
+
+- A broken `phel-config.php` (syntax error, evaluation error, or a non-`PhelConfig` return) now fails with a clear message that names the file and shows the expected shape, instead of a cryptic underlying error (#2604)
+
 ### Performance
 
 - Compile interop to native PHP: `php/->`, `php/::`, `php/new`, and `php/oset` emit direct expressions/statements instead of closure wrappers (#2524, #2525, #2526, #2532, #2536)

--- a/src/php/Config/ConfigLoadException.php
+++ b/src/php/Config/ConfigLoadException.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Config;
+
+use Error;
+use RuntimeException;
+use Throwable;
+
+use function is_string;
+use function realpath;
+use function sprintf;
+use function str_contains;
+
+/**
+ * Thrown when a project's `phel-config.php` cannot be loaded: it has a syntax
+ * error, raises an error while evaluating, or does not `return` a usable
+ * config value.
+ *
+ * Replaces the cryptic underlying failure (e.g. Gacela's "The PHP config file
+ * must return an array or a JsonSerializable object!") with a message that
+ * names the file and shows the expected shape.
+ */
+final class ConfigLoadException extends RuntimeException
+{
+    /**
+     * Wraps $error as a {@see ConfigLoadException} when it represents a failure
+     * to load $configPath; otherwise returns $error unchanged, so unrelated
+     * bootstrap failures keep their original type and message.
+     */
+    public static function wrapIfConfigError(Throwable $error, string $configPath): Throwable
+    {
+        if (!self::isConfigLoadError($error, $configPath)) {
+            return $error;
+        }
+
+        return new self(
+            sprintf(
+                "Failed to load %s: %s\n\n"
+                . "A phel-config.php must `return` a PhelConfig instance, for example:\n\n"
+                . "    <?php\n"
+                . "    declare(strict_types=1);\n"
+                . "    use Phel\\Config\\PhelConfig;\n"
+                . "    return new PhelConfig()->withSrcDirs(['src']);",
+                $configPath,
+                $error->getMessage(),
+            ),
+            previous: $error,
+        );
+    }
+
+    private static function isConfigLoadError(Throwable $error, string $configPath): bool
+    {
+        if (realpath($configPath) === false) {
+            return false;
+        }
+
+        // Gacela's reader rejects a non-array / non-JsonSerializable return.
+        if (str_contains($error->getMessage(), 'must return an array or a JsonSerializable')) {
+            return true;
+        }
+
+        // A PHP error (parse/type/...) raised while evaluating the config file.
+        return $error instanceof Error && self::originatesFrom($error, $configPath);
+    }
+
+    private static function originatesFrom(Throwable $error, string $configPath): bool
+    {
+        $target = realpath($configPath);
+        if ($target === false) {
+            return false;
+        }
+
+        if (realpath($error->getFile()) === $target) {
+            return true;
+        }
+
+        foreach ($error->getTrace() as $frame) {
+            $file = $frame['file'] ?? null;
+            if (is_string($file) && realpath($file) === $target) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -9,6 +9,7 @@ use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
 use Phar;
+use Phel\Config\ConfigLoadException;
 use Phel\Config\PhelConfig;
 use Phel\Config\ProjectLayout;
 use Phel\Filesystem\FilesystemFacade;
@@ -16,6 +17,7 @@ use Phel\Run\RunFacade;
 use Phel\Shared\PhelProjectDirectory;
 use Phel\Shared\ScalarCoercion;
 use RuntimeException;
+use Throwable;
 
 use function dirname;
 use function getcwd;
@@ -99,10 +101,16 @@ class Phel
             self::$autoDetectedConfig = self::detectProjectStructure($projectRootDir);
         }
 
-        Gacela::bootstrap($projectRootDir, self::configFn());
+        try {
+            Gacela::bootstrap($projectRootDir, self::configFn());
 
-        self::mergedConfigCacheInvalidator()->refreshIfStale();
-        self::mirrorPhelDirToEnv();
+            self::mergedConfigCacheInvalidator()->refreshIfStale();
+            // Forces the merged app config to materialize, so a broken
+            // phel-config.php fails here (inside the guard) rather than later.
+            self::mirrorPhelDirToEnv();
+        } catch (Throwable $throwable) {
+            throw ConfigLoadException::wrapIfConfigError($throwable, $configPath);
+        }
     }
 
     /**

--- a/tests/php/Integration/Bootstrap/ConfigLoadErrorTest.php
+++ b/tests/php/Integration/Bootstrap/ConfigLoadErrorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Bootstrap;
+
+use Gacela\Framework\Testing\ContainerFixture;
+use Phel\Config\ConfigLoadException;
+use Phel\Phel;
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function scandir;
+use function sys_get_temp_dir;
+use function unlink;
+
+/**
+ * End-to-end check that {@see Phel::bootstrap()} turns a broken
+ * `phel-config.php` into a friendly {@see ConfigLoadException} instead of a
+ * cryptic underlying error.
+ */
+final class ConfigLoadErrorTest extends TestCase
+{
+    use ContainerFixture;
+
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->resetContainer();
+        Phel::resetAutoDetectedConfig();
+        $this->dir = sys_get_temp_dir() . '/phel-badcfg-' . bin2hex(random_bytes(6));
+        mkdir($this->dir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        Phel::resetAutoDetectedConfig();
+        $this->removeDir($this->dir);
+        $this->cleanupContainerTempDirs();
+    }
+
+    public function test_bootstrap_wraps_a_non_config_return_value(): void
+    {
+        file_put_contents($this->dir . '/phel-config.php', "<?php\n\nreturn 'not a config';\n");
+
+        $this->expectException(ConfigLoadException::class);
+        $this->expectExceptionMessage('phel-config.php');
+
+        Phel::bootstrap($this->dir);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.') {
+                continue;
+            }
+
+            if ($entry === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $entry;
+            if (is_dir($path)) {
+                $this->removeDir($path);
+            } else {
+                @unlink($path);
+            }
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/php/Unit/Config/ConfigLoadExceptionTest.php
+++ b/tests/php/Unit/Config/ConfigLoadExceptionTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Config;
+
+use ParseError;
+use Phel\Config\ConfigLoadException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function bin2hex;
+use function file_put_contents;
+use function random_bytes;
+use function sys_get_temp_dir;
+
+final class ConfigLoadExceptionTest extends TestCase
+{
+    private const string GACELA_WRONG_TYPE = 'The PHP config file must return an array or a JsonSerializable object!';
+
+    private string $configPath;
+
+    protected function setUp(): void
+    {
+        $this->configPath = sys_get_temp_dir() . '/phel-config-' . bin2hex(random_bytes(6)) . '.php';
+        file_put_contents($this->configPath, "<?php\nreturn new \\Phel\\Config\\PhelConfig();\n");
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->configPath);
+    }
+
+    public function test_wraps_the_wrong_return_type_error(): void
+    {
+        $original = new RuntimeException(self::GACELA_WRONG_TYPE);
+
+        $wrapped = ConfigLoadException::wrapIfConfigError($original, $this->configPath);
+
+        self::assertInstanceOf(ConfigLoadException::class, $wrapped);
+        self::assertSame($original, $wrapped->getPrevious());
+        self::assertStringContainsString($this->configPath, $wrapped->getMessage());
+        self::assertStringContainsString('must `return` a PhelConfig', $wrapped->getMessage());
+    }
+
+    public function test_wraps_a_parse_error_originating_from_the_config_file(): void
+    {
+        $broken = sys_get_temp_dir() . '/phel-broken-' . bin2hex(random_bytes(6)) . '.php';
+        file_put_contents($broken, "<?php\nreturn new ;\n");
+
+        $caught = null;
+        try {
+            include $broken;
+        } catch (ParseError $parseError) {
+            $caught = $parseError;
+        }
+
+        try {
+            self::assertInstanceOf(ParseError::class, $caught);
+            $wrapped = ConfigLoadException::wrapIfConfigError($caught, $broken);
+
+            self::assertInstanceOf(ConfigLoadException::class, $wrapped);
+            self::assertStringContainsString($broken, $wrapped->getMessage());
+        } finally {
+            @unlink($broken);
+        }
+    }
+
+    public function test_returns_unrelated_errors_unchanged(): void
+    {
+        $original = new RuntimeException('something unrelated blew up');
+
+        self::assertSame($original, ConfigLoadException::wrapIfConfigError($original, $this->configPath));
+    }
+
+    public function test_does_not_wrap_when_the_config_path_does_not_exist(): void
+    {
+        // Even a config-shaped message is left alone when there is no file:
+        // the failure cannot be about a config that is not there.
+        $original = new RuntimeException(self::GACELA_WRONG_TYPE);
+
+        self::assertSame(
+            $original,
+            ConfigLoadException::wrapIfConfigError($original, '/no/such/phel-config.php'),
+        );
+    }
+}


### PR DESCRIPTION
## 🤔 Background

When a `phel-config.php` is broken, the failure today is cryptic: Gacela throws `RuntimeException: The PHP config file must return an array or a JsonSerializable object!`, or PHP throws a raw `ParseError`/`TypeError` — none of which name the file or say what a config should look like.

## 💡 Goal

Fail fast with an actionable message when the config file itself cannot be loaded (the one genuinely fatal config case), while leaving valid configs and unrelated bootstrap failures untouched.

## 🔖 Changes

- New `Phel\Config\ConfigLoadException` with a `wrapIfConfigError(Throwable, string $configPath)` factory.
- `Phel::bootstrap()` guards config loading: the config read is forced inside the guard (via `mirrorPhelDirToEnv`, which materializes the merged config), so a broken file fails there and is rewrapped.
- Detection is precise to avoid mislabeling unrelated errors:
  - Gacela's wrong-return-type message, **or**
  - a PHP `Error` (parse/type/…) whose origin (`getFile()` or stack trace) is the config file.
  
  Anything else is rethrown unchanged. Nothing is wrapped when the config file does not exist (zero-config/auto-detect path).
- The friendly message names the file, includes the original error, and shows the expected `return new PhelConfig()->withSrcDirs([...])` shape.
- Tests: `ConfigLoadExceptionTest` (wrong-return message, a real `ParseError` from including a broken file, unrelated-error passthrough, missing-file passthrough) and an end-to-end `ConfigLoadErrorTest` driving the real `Phel::bootstrap()` with a non-config return.

CHANGELOG updated under Unreleased → Changed.