### PR TITLE
chore(init): scaffold phel-config.php with declare(strict_types=1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - A broken `phel-config.php` (syntax error, evaluation error, or a non-`PhelConfig` return) now fails with a clear message that names the file and shows the expected shape, instead of a cryptic underlying error (#2604)
+- `phel init` now scaffolds `phel-config.php` with `declare(strict_types=1);`, matching the project's PHP conventions (#2605)
 
 ### Performance
 

--- a/src/php/Run/Domain/Init/ProjectTemplateGenerator.php
+++ b/src/php/Run/Domain/Init/ProjectTemplateGenerator.php
@@ -15,6 +15,8 @@ final class ProjectTemplateGenerator
         return <<<PHP
 <?php
 
+declare(strict_types=1);
+
 use Phel\\Config\\PhelConfig;
 use Phel\\Config\\ProjectLayout;
 

--- a/tests/php/Unit/Run/Domain/Init/ProjectTemplateGeneratorTest.php
+++ b/tests/php/Unit/Run/Domain/Init/ProjectTemplateGeneratorTest.php
@@ -21,6 +21,7 @@ final class ProjectTemplateGeneratorTest extends TestCase
     {
         $config = $this->generator->generateConfig('myapp\\main', ProjectLayout::Flat);
 
+        self::assertStringContainsString('declare(strict_types=1);', $config);
         self::assertStringContainsString('use Phel\\Config\\PhelConfig;', $config);
         self::assertStringContainsString('use Phel\\Config\\ProjectLayout;', $config);
         self::assertStringContainsString('PhelConfig::forProject(ProjectLayout::Flat)', $config);


### PR DESCRIPTION
## 🤔 Background

Every PHP file in the project starts with `declare(strict_types=1);` (it is even enforced by the coding standard), but the `phel-config.php` that `phel init` generates did not — so brand-new projects started off-convention.

## 💡 Goal

Make the scaffolded config match the project's own PHP conventions.

## 🔖 Changes

- `ProjectTemplateGenerator::generateConfig()` now emits `declare(strict_types=1);` right after the opening tag.
- Tests: assert the declaration is present; the generated file is lint-clean (the declaration is the first statement). Existing `InitCommandTest` assertions use substring checks, so they are unaffected.

CHANGELOG updated under Unreleased → Changed.