### PR TITLE
fix(cli): present config-load errors cleanly (no stack trace, exit 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- A broken `phel-config.php` (syntax error, evaluation error, or a non-`PhelConfig` return) now fails with a clear message that names the file and shows the expected shape, instead of a cryptic underlying error (#2604)
+- A broken `phel-config.php` (syntax error, evaluation error, or a non-`PhelConfig` return) now fails with a clear message that names the file and shows the expected shape — printed on its own and exiting 1, instead of a cryptic uncaught-exception stack trace (#2604, #2606)
 - `phel init` now scaffolds `phel-config.php` with `declare(strict_types=1);`, matching the project's PHP conventions (#2605)
 
 ### Performance

--- a/bin/phel
+++ b/bin/phel
@@ -8,6 +8,7 @@ if (function_exists('ini_set')) {
     @ini_set('memory_limit', '-1');
 }
 
+use Phel\Config\ConfigLoadException;
 use Phel\Console\ConsoleFacade;
 
 // NOTE: When packaged as a PHAR, the stub requires the PHAR's vendor/autoload.php first.
@@ -64,7 +65,15 @@ use Phel\Console\ConsoleFacade;
 
     // Phel classes are available either via the PHAR autoloader (in PHAR mode)
     // or the host Composer autoloader (source mode).
-    Phel::bootstrap($appRootDir);
+    try {
+        Phel::bootstrap($appRootDir);
+    } catch (ConfigLoadException $e) {
+        // A broken phel-config.php is a user error, not a Phel bug: print the
+        // actionable message on its own and exit cleanly, without the noise of
+        // an uncaught-exception stack trace.
+        fwrite(STDERR, $e->getMessage().PHP_EOL);
+        exit(1);
+    }
 
     // In PHAR mode, load the host project's Composer autoloader after Phel bootstrap.
     // This allows using PHP classes from the project's vendor dependencies.

--- a/tests/php/Integration/Phar/PharExecutionTest.php
+++ b/tests/php/Integration/Phar/PharExecutionTest.php
@@ -187,6 +187,26 @@ final class PharExecutionTest extends TestCase
         self::assertStringNotContainsString('phar://', $result['stdout']);
     }
 
+    public function test_phar_reports_a_broken_config_file_cleanly(): void
+    {
+        // A phel-config.php that does not return a PhelConfig must produce the
+        // actionable message and a clean exit 1 — not an uncaught-fatal dump.
+        file_put_contents(
+            $this->tempProjectDir . '/phel-config.php',
+            "<?php\n\nreturn 'not a config';\n",
+        );
+
+        $result = $this->runPhar(['config']);
+        $combined = $result['stdout'] . $result['stderr'];
+
+        self::assertSame(1, $result['exit'], 'a broken config must exit 1, not 255');
+        self::assertStringContainsString('phel-config.php', $combined);
+        self::assertStringContainsString('must `return` a PhelConfig', $combined);
+        // No raw PHP fatal / stack-trace noise.
+        self::assertStringNotContainsString('Uncaught', $combined);
+        self::assertStringNotContainsString('Stack trace', $combined);
+    }
+
     /**
      * @param list<string> $args
      *


### PR DESCRIPTION
## 🤔 Background

Full PHAR regression QA of the config-DX work surfaced this: #2604 added a friendly `ConfigLoadException`, but `bin/phel` calls `Phel::bootstrap()` *before* the Symfony console error handler is in place. So a broken `phel-config.php` escaped as an **uncaught PHP fatal** — a 30-line stack trace, the *cryptic* Gacela message shown first, the friendly text buried in the middle, and exit code 255.

## 💡 Goal

Make the friendly message actually land: print it on its own and exit cleanly.

## 🔖 Changes

- `bin/phel` wraps `Phel::bootstrap()` in a `try/catch (ConfigLoadException)`, writes just the actionable message to `STDERR`, and `exit(1)`.
- Only `ConfigLoadException` is caught — genuinely unexpected bootstrap errors keep their stack trace for debugging.
- Covers both PHAR and Composer installs, since both run through `bin/phel`.
- Test: new `PharExecutionTest` case asserts a broken config exits `1`, shows the actionable text, and contains no `Uncaught` / `Stack trace` noise.

Before: `PHP Fatal error: Uncaught RuntimeException: The PHP config file must return an array...` + full trace, exit 255.
After:
```
Failed to load /path/phel-config.php: The PHP config file must return an array or a JsonSerializable object!

A phel-config.php must `return` a PhelConfig instance, for example:
    ...
```
exit 1.

CHANGELOG: folded into the existing Unreleased → Changed entry.