### PR TITLE
fix(config): clarify that a config array is a valid phel-config.php return

### DIFF
--- a/src/php/Config/ConfigLoadException.php
+++ b/src/php/Config/ConfigLoadException.php
@@ -38,11 +38,13 @@ final class ConfigLoadException extends RuntimeException
         return new self(
             sprintf(
                 "Failed to load %s: %s\n\n"
-                . "A phel-config.php must `return` a PhelConfig instance, for example:\n\n"
+                . "A phel-config.php must `return` a PhelConfig instance (recommended) or a config array, for example:\n\n"
                 . "    <?php\n"
                 . "    declare(strict_types=1);\n"
                 . "    use Phel\\Config\\PhelConfig;\n"
-                . "    return new PhelConfig()->withSrcDirs(['src']);",
+                . "    return new PhelConfig()->withSrcDirs(['src']);\n\n"
+                . "    // or, equivalently, a plain array:\n"
+                . "    // return ['src-dirs' => ['src']];",
                 $configPath,
                 $error->getMessage(),
             ),

--- a/tests/php/Integration/Bootstrap/ConfigLoadErrorTest.php
+++ b/tests/php/Integration/Bootstrap/ConfigLoadErrorTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Bootstrap;
 
+use Gacela\Framework\Config\Config;
 use Gacela\Framework\Testing\ContainerFixture;
 use Phel\Config\ConfigLoadException;
+use Phel\Config\PhelConfig;
 use Phel\Phel;
 use PHPUnit\Framework\TestCase;
 
@@ -53,6 +55,17 @@ final class ConfigLoadErrorTest extends TestCase
         $this->expectExceptionMessage('phel-config.php');
 
         Phel::bootstrap($this->dir);
+    }
+
+    public function test_bootstrap_accepts_a_raw_array_config(): void
+    {
+        // A plain array is a valid config too (PhelConfig is recommended, not
+        // required): it must load and be readable, not raise a load error.
+        file_put_contents($this->dir . '/phel-config.php', "<?php\n\nreturn ['src-dirs' => ['custom-src']];\n");
+
+        Phel::bootstrap($this->dir);
+
+        self::assertSame(['custom-src'], Config::getInstance()->get(PhelConfig::SRC_DIRS));
     }
 
     private function removeDir(string $dir): void

--- a/tests/php/Unit/Config/ConfigLoadExceptionTest.php
+++ b/tests/php/Unit/Config/ConfigLoadExceptionTest.php
@@ -41,6 +41,8 @@ final class ConfigLoadExceptionTest extends TestCase
         self::assertSame($original, $wrapped->getPrevious());
         self::assertStringContainsString($this->configPath, $wrapped->getMessage());
         self::assertStringContainsString('must `return` a PhelConfig', $wrapped->getMessage());
+        // The raw-array form is equally valid, so the guidance must mention it.
+        self::assertStringContainsString('config array', $wrapped->getMessage());
     }
 
     public function test_wraps_a_parse_error_originating_from_the_config_file(): void


### PR DESCRIPTION
## 🤔 Background

The friendly config-load error (#2604) tells users a `phel-config.php` "must `return` a PhelConfig instance". But that overstates it: Gacela's config reader accepts a plain **array** just as well (`PhelConfig` implements `JsonSerializable`; an array is the other accepted shape). The type-mismatch diagnostics in #2602 exist precisely because raw-array configs are a supported form. So the message was misleading.

## 💡 Goal

Make the guidance accurate: `PhelConfig` is recommended, a config array is equally valid.

## 🔖 Changes

- Reworded `ConfigLoadException`: "must `return` a PhelConfig instance (recommended) or a config array", and the example now also shows the `return ['src-dirs' => ['src']]` form.
- Test: the message mentions the array form.
- Integration test: a raw-array `phel-config.php` loads via `Phel::bootstrap()` and its value is readable — i.e. arrays are not treated as a load error.

No CHANGELOG change: the existing Unreleased entry already says the error "shows the expected shape", which remains accurate.