### PR TITLE
fix(config): clean error for exceptions thrown from phel-config.php; run PharExecutionTest in CI

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -62,6 +62,12 @@ jobs:
           echo "PHAR size: $size bytes"
           test "$size" -lt 2097152  # 2 MiB budget
 
+      - name: Run the end-to-end PHAR test suite against the freshly built phar
+        # PharExecutionTest skips itself unless build/out/phel.phar exists, so it
+        # never runs in tests.yml. Run it here, where the phar was just built, to
+        # actually guard PHAR-only behaviour (e.g. the broken-config clean exit).
+        run: vendor/bin/phpunit --testsuite=integration --filter PharExecutionTest
+
       - name: Boot PHAR from a clean directory
         working-directory: /tmp
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- A broken `phel-config.php` (syntax error, evaluation error, or a return that is neither a `PhelConfig` instance nor a config array) now fails with a clear message that names the file and shows the expected shape, printed on its own and exiting 1, instead of a cryptic uncaught-exception stack trace (#2604, #2606, #2607)
+- A broken `phel-config.php` (syntax error, evaluation error, or a return that is neither a `PhelConfig` nor a config array) now fails with a clear message that names the file and shows the expected shape, printed on its own and exiting 1, instead of a cryptic uncaught-exception stack trace (#2604, #2606, #2607)
 - `phel init` now scaffolds `phel-config.php` with `declare(strict_types=1);`, matching the project's PHP conventions (#2605)
 
 ### Performance
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 - Short-circuit `Symbol` equality on identity, and skip the dynamic-scope check on global reads when no dynamic bindings are active (#2551, #2545)
 - Share one `static` slot for repeated literals (#2564), and splice captured nodes in the emitter with a prefix check instead of a per-call regex (#2565)
 - Speed up persistent data structures on hot paths: vector equality short-circuits on identity and walks chunk-aware (O(n)) (#2549), `dissoc`/`remove` skip the deep comparison on no-op (#2544), and hash-map iteration drops a redundant per-node copy (#2550)
-- Cut CLI startup: persist the compiled-code cache index and namespace index, writing once instead of per file (#2557, #2560), boot the REPL with only `phel.core` and lazy-load the rest (~34% faster to prompt) (#2559), lazy-load CLI commands per invocation (#2558), and ship a `phel.ini` from `phel doctor` to enable a persistent OPcache file cache, suppressed in PHAR runs where `php -c phar://…` cannot load it (#2556, #2599)
+- Cut CLI startup: persist the compiled-code cache index and namespace index, writing once instead of per file (#2557, #2560), boot the REPL with only `phel.core` and lazy-load the rest (~34% faster to prompt) (#2559), lazy-load CLI commands per invocation (#2558), and ship a `phel.ini` from `phel doctor` to enable a persistent OPcache file cache (#2556, #2599)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- A broken `phel-config.php` (syntax error, evaluation error, or a non-`PhelConfig` return) now fails with a clear message that names the file and shows the expected shape — printed on its own and exiting 1, instead of a cryptic uncaught-exception stack trace (#2604, #2606)
+- A broken `phel-config.php` (syntax error, evaluation error, or a return that is neither a `PhelConfig` instance nor a config array) now fails with a clear message that names the file and shows the expected shape, printed on its own and exiting 1, instead of a cryptic uncaught-exception stack trace (#2604, #2606, #2607)
 - `phel init` now scaffolds `phel-config.php` with `declare(strict_types=1);`, matching the project's PHP conventions (#2605)
 
 ### Performance
@@ -25,14 +25,14 @@ All notable changes to this project will be documented in this file.
 - Short-circuit `Symbol` equality on identity, and skip the dynamic-scope check on global reads when no dynamic bindings are active (#2551, #2545)
 - Share one `static` slot for repeated literals (#2564), and splice captured nodes in the emitter with a prefix check instead of a per-call regex (#2565)
 - Speed up persistent data structures on hot paths: vector equality short-circuits on identity and walks chunk-aware (O(n)) (#2549), `dissoc`/`remove` skip the deep comparison on no-op (#2544), and hash-map iteration drops a redundant per-node copy (#2550)
-- Cut CLI startup: persist the compiled-code cache index and namespace index, writing once instead of per file (#2557, #2560), boot the REPL with only `phel.core` and lazy-load the rest (~34% faster to prompt) (#2559), lazy-load CLI commands per invocation (#2558), and ship a `phel.ini` from `phel doctor` to enable a persistent OPcache file cache (#2556)
+- Cut CLI startup: persist the compiled-code cache index and namespace index, writing once instead of per file (#2557, #2560), boot the REPL with only `phel.core` and lazy-load the rest (~34% faster to prompt) (#2559), lazy-load CLI commands per invocation (#2558), and ship a `phel.ini` from `phel doctor` to enable a persistent OPcache file cache, suppressed in PHAR runs where `php -c phar://…` cannot load it (#2556, #2599)
 
 ### Fixed
 
-- Hashing a large persistent collection (vector, list, queue, lazy seq including chunked, hash/sorted set, or map) no longer throws a `TypeError` past ~13 elements: the rolling hash now wraps within a 32-bit range instead of overflowing to a float (#2567)
-- A persistent map or hash/sorted set containing a `NaN` key/element is equal to itself again: `equals` now short-circuits on object identity before the element walk
-- A `Cons` cell or sorted set whose hash legitimately computes to `0` now caches it instead of recomputing on every `hash()` call
-- The "not defined" error hint now also shows when the compiler appends a `Did you mean ...?` suggestion (a trailing period previously suppressed it)
+- Hashing a large persistent collection (vector, list, queue, lazy seq including chunked, hash/sorted set, or map) no longer throws a `TypeError` past ~13 elements: the rolling hash now wraps within a 32-bit range instead of overflowing to a float (#2567, #2585)
+- A persistent map or hash/sorted set containing a `NaN` key/element is equal to itself again: `equals` now short-circuits on object identity before the element walk (#2589)
+- A `Cons` cell or sorted set whose hash legitimately computes to `0` now caches it instead of recomputing on every `hash()` call (#2589)
+- The "not defined" error hint now also shows when the compiler appends a `Did you mean ...?` suggestion (a trailing period previously suppressed it) (#2523)
 
 ## [0.45.1](https://github.com/phel-lang/phel-lang/compare/v0.45.0...v0.45.1) - 2026-06-20
 

--- a/src/php/Config/ConfigLoadException.php
+++ b/src/php/Config/ConfigLoadException.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Config;
 
-use Error;
 use RuntimeException;
 use Throwable;
 
@@ -63,8 +62,10 @@ final class ConfigLoadException extends RuntimeException
             return true;
         }
 
-        // A PHP error (parse/type/...) raised while evaluating the config file.
-        return $error instanceof Error && self::originatesFrom($error, $configPath);
+        // Any error or exception raised while evaluating the config file: a
+        // parse/type error, or one the file throws itself (e.g. a guard that
+        // throws RuntimeException when a required env var is missing).
+        return self::originatesFrom($error, $configPath);
     }
 
     private static function originatesFrom(Throwable $error, string $configPath): bool

--- a/tests/php/Integration/Bootstrap/ConfigLoadErrorTest.php
+++ b/tests/php/Integration/Bootstrap/ConfigLoadErrorTest.php
@@ -68,6 +68,22 @@ final class ConfigLoadErrorTest extends TestCase
         self::assertSame(['custom-src'], Config::getInstance()->get(PhelConfig::SRC_DIRS));
     }
 
+    public function test_bootstrap_wraps_an_exception_thrown_from_the_config_file(): void
+    {
+        // A config file that throws (not a PHP Error, a deliberate exception)
+        // is an evaluation error and must become a friendly ConfigLoadException
+        // rather than an uncaught fatal with a stack trace.
+        file_put_contents(
+            $this->dir . '/phel-config.php',
+            "<?php\n\nthrow new \\RuntimeException('APP_KEY missing');\n",
+        );
+
+        $this->expectException(ConfigLoadException::class);
+        $this->expectExceptionMessage('phel-config.php');
+
+        Phel::bootstrap($this->dir);
+    }
+
     private function removeDir(string $dir): void
     {
         if (!is_dir($dir)) {

--- a/tests/php/Unit/Config/ConfigLoadExceptionTest.php
+++ b/tests/php/Unit/Config/ConfigLoadExceptionTest.php
@@ -68,6 +68,34 @@ final class ConfigLoadExceptionTest extends TestCase
         }
     }
 
+    public function test_wraps_an_exception_thrown_from_the_config_file(): void
+    {
+        // A config file may deliberately `throw` (e.g. a guard for a required
+        // env var). A thrown exception is an evaluation error too, so it must
+        // be wrapped, not surface as an uncaught fatal.
+        $broken = sys_get_temp_dir() . '/phel-throws-' . bin2hex(random_bytes(6)) . '.php';
+        file_put_contents($broken, "<?php\n\nthrow new \\RuntimeException('APP_KEY missing');\n");
+
+        $caught = null;
+        try {
+            include $broken;
+        } catch (RuntimeException $runtimeException) {
+            $caught = $runtimeException;
+        }
+
+        try {
+            self::assertInstanceOf(RuntimeException::class, $caught);
+            $wrapped = ConfigLoadException::wrapIfConfigError($caught, $broken);
+
+            self::assertInstanceOf(ConfigLoadException::class, $wrapped);
+            self::assertSame($caught, $wrapped->getPrevious());
+            self::assertStringContainsString($broken, $wrapped->getMessage());
+            self::assertStringContainsString('APP_KEY missing', $wrapped->getMessage());
+        } finally {
+            @unlink($broken);
+        }
+    }
+
     public function test_returns_unrelated_errors_unchanged(): void
     {
         $original = new RuntimeException('something unrelated blew up');


### PR DESCRIPTION
## 🤔 Background

Pre-release QA of the Unreleased changelog surfaced two gaps in the new "clean broken-config error" feature (#2604 / #2606 / #2607):

- A `phel-config.php` that deliberately `throw`s an exception (a normal pattern, e.g. guarding a required env var with `throw new RuntimeException('APP_KEY missing')`) escaped as an **uncaught PHP fatal with a stack trace and exit 255** — exactly the cryptic dump the feature is meant to replace. Only PHP `Error`s and Gacela's wrong-return message were being caught.
- `PharExecutionTest` (which guards PHAR-only behaviour, including the broken-config clean exit) **skips itself unless `build/out/phel.phar` exists**. `tests.yml` never builds the phar (so the test skips there), and `smoke.yml` only ran manual shell checks — so the suite ran in **no CI job at all**.

## 💡 Goal

Make the clean-error handling cover *any* exception raised while evaluating `phel-config.php`, and guarantee the PHAR end-to-end test actually runs in CI.

## 🔖 Changes

- **`fix(config)`**: broaden `ConfigLoadException::wrapIfConfigError` to wrap any `Throwable` that originates from the config file (was `instanceof Error` only). `originatesFrom()` already scopes the check, so unrelated bootstrap failures keep their original type. A thrown exception now produces the clean `Failed to load …` message, exits 1, and shows no stack trace.
  - Added regression coverage: a unit test (`ConfigLoadExceptionTest`) and an end-to-end bootstrap test (`ConfigLoadErrorTest`).
- **`chore(ci)`**: run `PharExecutionTest` in the `phar-smoke` job immediately after the phar is built, so PHAR-only behaviour (e.g. the broken-config clean exit) is actually exercised in CI.
- **`docs(changelog)`**: corrected the Unreleased "Changed" entry (a config *array* return is valid, #2607; removed an em-dash), added #2599 to the `phel.ini` note, and filled PR refs on the previously unnumbered Fixed bullets (#2585, #2589, #2523).

<!-- This PR fixes unreleased code, so the existing Unreleased "Changed" entry (#2604/#2606) now reads accurately and no new CHANGELOG entry is needed. -->
