### PR TITLE
fix(lsp): keep server alive when idle; fix empty documentSymbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ All notable changes to this project will be documented in this file.
 - Collection hash/equals correctness: hashing a large persistent collection (vector, list, queue, lazy seq including chunked, hash/sorted set, or map) no longer throws a `TypeError` past ~13 elements (the rolling hash wraps within a 32-bit range instead of overflowing to a float), a map or hash/sorted set containing a `NaN` key/element is equal to itself again (`equals` short-circuits on object identity), and a `Cons` cell or sorted set whose hash legitimately computes to `0` now caches it (#2567, #2585, #2589)
 - The "not defined" error hint now also shows when the compiler appends a `Did you mean ...?` suggestion (a trailing period previously suppressed it) (#2523)
 - `phel build` no longer reuses stale compiled output for a namespace whose source is unchanged but whose required namespace changed: the incremental cache now cascades a recompile to dependents, so an updated macro can no longer leave an outdated expansion baked into a dependent's compiled file (#2612)
+- `phel lsp` no longer shuts down when an editor sits idle: the message reader now distinguishes a read-timeout (a connected but quiet client) from end-of-stream, so the server stays up between requests instead of exiting after ~200ms of silence and forcing the editor to respawn it
+- `phel lsp` `textDocument/documentSymbol` now lists a file's definitions (it returned an empty list because the fallback indexed a single file path, but the project indexer only scans directories); symbols are extracted from the open buffer, so they also reflect unsaved edits
 
 ## [0.45.1](https://github.com/phel-lang/phel-lang/compare/v0.45.0...v0.45.1) - 2026-06-20
 

--- a/src/php/Api/ApiFacade.php
+++ b/src/php/Api/ApiFacade.php
@@ -79,6 +79,20 @@ final class ApiFacade extends AbstractFacade implements ApiFacadeInterface
     }
 
     /**
+     * Extract the top-level definitions from a single source buffer. Used for
+     * document symbols, where the in-memory (possibly unsaved) buffer is
+     * authoritative and the filesystem index may be stale or unavailable.
+     *
+     * @return list<Definition>
+     */
+    public function extractDefinitions(string $source, string $uri): array
+    {
+        return $this->getFactory()
+            ->createSymbolExtractor()
+            ->definitionsOf($source, $uri);
+    }
+
+    /**
      * Resolve a symbol to its defining site ("jump to definition").
      */
     public function resolveSymbol(ProjectIndex $index, string $namespace, string $symbol): ?Definition

--- a/src/php/Api/Application/SymbolExtractor.php
+++ b/src/php/Api/Application/SymbolExtractor.php
@@ -52,6 +52,16 @@ final readonly class SymbolExtractor
     ) {}
 
     /**
+     * Top-level definitions in a single source buffer (document symbols).
+     *
+     * @return list<Definition>
+     */
+    public function definitionsOf(string $source, string $uri): array
+    {
+        return $this->extract($source, $uri)['definitions'];
+    }
+
+    /**
      * @return array{
      *     namespace: string,
      *     definitions: list<Definition>,

--- a/src/php/Lsp/Application/Handler/DocumentSymbolHandler.php
+++ b/src/php/Lsp/Application/Handler/DocumentSymbolHandler.php
@@ -14,8 +14,6 @@ use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
 
-use function array_values;
-
 /**
  * Lists all top-level definitions in the open document. Uses the project
  * index when available; otherwise runs a single-file indexing pass so the
@@ -85,8 +83,10 @@ final readonly class DocumentSymbolHandler implements HandlerInterface
             return $defs;
         }
 
-        $index = $this->apiFacade->indexProject([$path]);
-
-        return array_values($index->definitions);
+        // No project index (or it has nothing for this file yet): extract from
+        // the open buffer. This reflects unsaved edits and avoids re-walking the
+        // filesystem — the project indexer only scans directories, so passing a
+        // single file path here would yield nothing.
+        return $this->apiFacade->extractDefinitions($document->text, $path);
     }
 }

--- a/src/php/Lsp/Application/Rpc/MessageReader.php
+++ b/src/php/Lsp/Application/Rpc/MessageReader.php
@@ -35,6 +35,9 @@ final class MessageReader
 
     private const int READ_TIMEOUT_MICRO = 200_000;
 
+    /** Sentinel: the read window elapsed before a header block arrived. */
+    private const int TIMED_OUT = -1;
+
     /**
      * @param resource $stream
      *
@@ -52,6 +55,14 @@ final class MessageReader
         $contentLength = $this->readHeaders($stream);
         if ($contentLength === null) {
             return null;
+        }
+
+        // No complete header block arrived within the read window. The client
+        // is simply idle (editors stay connected but quiet between requests),
+        // not gone, so return a heartbeat and let the caller poll again rather
+        // than mistaking the timeout for end-of-stream.
+        if ($contentLength === self::TIMED_OUT) {
+            return [];
         }
 
         if ($contentLength === 0) {
@@ -74,17 +85,36 @@ final class MessageReader
 
     /**
      * @param resource $stream
+     *
+     * @return int|null content length (>=0), {@see self::TIMED_OUT} when the
+     *                  read window elapsed before any data arrived, or null at
+     *                  end-of-stream
      */
     private function readHeaders($stream): ?int
     {
         $contentLength = null;
         $lines = 0;
+        $started = false;
 
         while ($lines < self::MAX_HEADER_LINES) {
             $line = fgets($stream);
             if ($line === false) {
-                return null;
+                // Distinguish a real EOF (client gone) from a read timeout
+                // (idle but still connected). A timeout before any byte of the
+                // block is a heartbeat; once a block has started we keep waiting
+                // for the rest so we never drop a partially read header.
+                if (feof($stream)) {
+                    return null;
+                }
+
+                if (!$started) {
+                    return self::TIMED_OUT;
+                }
+
+                continue;
             }
+
+            $started = true;
 
             $trimmed = trim($line);
             if ($trimmed === '') {

--- a/tests/php/Unit/Lsp/Application/Rpc/MessageReaderTest.php
+++ b/tests/php/Unit/Lsp/Application/Rpc/MessageReaderTest.php
@@ -8,9 +8,14 @@ use Phel\Lsp\Application\Rpc\MessageReader;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
+use function fclose;
 use function fopen;
 use function fwrite;
 use function rewind;
+use function stream_socket_pair;
+
+use const STREAM_PF_UNIX;
+use const STREAM_SOCK_STREAM;
 
 final class MessageReaderTest extends TestCase
 {
@@ -106,6 +111,71 @@ final class MessageReaderTest extends TestCase
 
         self::assertSame('one', $first['method'] ?? null);
         self::assertSame('two', $second['method'] ?? null);
+    }
+
+    public function test_it_returns_heartbeat_not_eof_when_an_idle_connection_times_out(): void
+    {
+        // A connected-but-idle client (the common editor case) must not be
+        // mistaken for a closed stream: read() returns [] (heartbeat), and a
+        // subsequent message on the same stream still parses.
+        [$server, $client] = $this->socketPair();
+
+        $reader = new MessageReader();
+
+        $idle = $reader->read($server);
+        self::assertSame([], $idle, 'idle timeout should be a heartbeat, not EOF');
+
+        fwrite($client, "Content-Length: 17\r\n\r\n{\"method\":\"ping\"}");
+        $message = $this->readUntilMessage($reader, $server);
+        self::assertSame(['method' => 'ping'], $message);
+
+        fclose($client);
+        fclose($server);
+    }
+
+    public function test_it_returns_null_when_the_client_closes_the_connection(): void
+    {
+        // A genuinely closed peer must still be reported as end-of-stream.
+        [$server, $client] = $this->socketPair();
+        fclose($client);
+
+        $reader = new MessageReader();
+        self::assertNull($reader->read($server));
+
+        fclose($server);
+    }
+
+    /**
+     * Poll past heartbeats until a framed message arrives.
+     *
+     * @param resource $stream
+     *
+     * @return array<string, mixed>|null
+     */
+    private function readUntilMessage(MessageReader $reader, $stream): ?array
+    {
+        for ($i = 0; $i < 50; ++$i) {
+            $message = $reader->read($stream);
+            if ($message === null || $message !== []) {
+                return $message;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * A blocking-but-idle stream pair: reading from one end times out (without
+     * EOF) until the other end writes, which `php://memory` cannot emulate.
+     *
+     * @return array{0: resource, 1: resource}
+     */
+    private function socketPair(): array
+    {
+        $pair = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+        self::assertNotFalse($pair);
+
+        return [$pair[0], $pair[1]];
     }
 
     /**


### PR DESCRIPTION
Two fixes that make `phel lsp` usable from a long-lived editor client (found while integration-testing the VS Code extension against a real `phel lsp` over stdio).

## 1. Server shuts down when the editor is idle

`MessageReader` sets a 200ms stream read timeout and treated `fgets()` returning `false` as end-of-stream, so `LspServer::serve` returned `0` and the server **exited ~200ms after any pause between messages** — i.e. the normal state of a connected editor that's waiting for the user. The client then has to respawn the server on every interaction.

`readHeaders()` now distinguishes a real EOF from a read timeout:
- timeout **before any header byte** → return a heartbeat (`[]` from `read()`) so the serve loop keeps polling;
- timeout **mid-block** → keep waiting, so a partially-read header is never dropped;
- `feof()` → still reported as end-of-stream (genuine client close).

Added socket-pair tests for the idle-timeout-then-message and client-close cases (`php://memory` can't emulate a non-EOF timeout, which is why the existing tests didn't catch this).

## 2. `textDocument/documentSymbol` always returned `[]`

`DocumentSymbolHandler`'s fallback called `indexProject([$path])` with a single **file** path, but `ProjectIndexer` only walks **directories** (`if (!is_dir($real)) continue;`), so it returned no definitions. It now extracts definitions from the open document buffer via a new `ApiFacade::extractDefinitions` (delegating purely to `SymbolExtractor::definitionsOf`), which also reflects unsaved edits.

## Verification

- End-to-end LSP harness over stdio (initialize → didOpen → completion/hover/definition/documentSymbol/formatting/rename/shutdown) **with realistic idle gaps**: was failing after diagnostics (server gone); now 19/19 capabilities pass, and `documentSymbol` lists the file's `defn`/`def` symbols.
- Full `unit,integration` suite green (4796 tests, 13897 assertions).
- `phpstan analyse --level=max` and `php-cs-fixer --dry-run` clean on the changed files (the facade-only-delegation rule is satisfied — the array access moved into `SymbolExtractor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)