### PR TITLE
feat(build): per-phase compile timing report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Project configuration validation: `phel config` reports problems in a dedicated "Validation" section (directories that must be relative, missing source/test directories, no source directories, unknown optimization levels, wrong-type values), and `phel doctor` checks the config too, failing on errors and surfacing warnings as tips (#2600, #2601, #2602, #2603)
+- `phel build --timing` prints per-phase compile wall-clock (lex/parse/read/analyze/emit) aggregated across all compiled namespaces, with each phase's share and a total — the repeatable, compile-only number to quote before/after a compiler-phase optimization. Pair with `--no-cache` for a full measurement; composes with `--report` (#2615)
 
 ### Changed
 

--- a/docs/internals/benchmarks.md
+++ b/docs/internals/benchmarks.md
@@ -40,6 +40,28 @@ composer bench-jit-tracing    # opcache on, tracing JIT
 
 See the [PHPBench docs](https://phpbench.readthedocs.io/) for advanced reporting.
 
+## Measuring compiler phases
+
+To quantify a compiler-phase change (lexer, parser, analyzer, emitter), build the project with `--timing`. It sums each phase's wall-clock across every compiled namespace. Pair it with `--no-cache` so the whole project recompiles and the numbers are comparable run to run:
+
+```bash
+./vendor/bin/phel build --no-cache --timing
+```
+
+```
+Compile-phase timing
+====================
+  lex             0.32 ms    0.0%
+  parse          86.68 ms    8.9%
+  read           27.07 ms    2.8%
+  analyze       395.82 ms   40.6%
+  emit          464.81 ms   47.7%
+  total         974.71 ms
+  (33 namespaces compiled)
+```
+
+Run it before and after a change and quote the before/after totals (and the affected phase's share) in the PR. This is compile-only — it never executes the built program, so the analyzer/emitter cost is isolated from runtime. `--timing` composes with `--report` (per-namespace sizes + build time). Without `--no-cache` only freshly compiled namespaces contribute; if everything is served from cache the report says so and tells you to re-run with `--no-cache`.
+
 ## Speeding up CLI runs with OPcache
 
 Phel compiles each `.phel` file to PHP and caches the result under the Phel cache dir (`.phel/cache/compiled/` by default). A warm `phel run` then just `require`s the cached PHP instead of recompiling. The remaining gap versus native PHP comes from PHP re-parsing those cached files on every process, because **OPcache is disabled on the CLI by default** (`opcache.enable_cli=0`).

--- a/src/php/Build/CLAUDE.md
+++ b/src/php/Build/CLAUDE.md
@@ -8,6 +8,7 @@ Compiles Phel projects to PHP: dependency resolution, caching, namespace extract
 - `getDependenciesForNamespace(array $dirs, array $ns)`: topologically sorted dependencies
 - `compileFile(src, dest)` / `evalFile(src)` / `compileProject(BuildOptions)`: compile to PHP (evalFile skips writing output)
 - `phel build --report` builds a `BuildReport` (`Domain/Compile/BuildReport` + `BuildReportEntry`) from the returned `CompiledFile[]` + build duration: namespace count, per-namespace compiled byte size (read from each target file), total size, fresh/cached counts. Pure VO with `toArray()`; the command renders it
+- `phel build --timing` installs `Infrastructure/Timing/PhaseTimingProfilerHook` as `Registry::$profilerHook` around `compileProject` (reset in `finally`) to sum the compiler's per-phase wall-clock (lex/parse/read/analyze/emit) across compiled namespaces, rendered as `Domain/Compile/PhaseTimingReport`. The hook's `wrapFn()` is a deliberate no-op — a build evaluates `def`/`defmacro` while compiling, so wrapping those fns in profiling proxies (what the runtime profiler does) would bake instrumentation into the emitted output. Pair with `--no-cache` for a full, comparable measurement
 - `clearCache(): string[]`: paths cleared from temp/cache dirs
 - `getHealthCheck()`: cache, output, source dir checks
 - `writeLocatedException` / `writeStackTrace` / `getOutputDirectory`: delegate to Command facade

--- a/src/php/Build/Domain/Compile/PhaseTimingReport.php
+++ b/src/php/Build/Domain/Compile/PhaseTimingReport.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Domain\Compile;
+
+use function array_filter;
+use function array_keys;
+use function array_sum;
+use function array_values;
+use function in_array;
+
+/**
+ * Per-phase compile wall-clock aggregated across every namespace compiled in a
+ * `phel build` run, surfaced by `phel build --timing`. It isolates the cost of
+ * each compiler phase (lex/parse/read/analyze/emit) so an optimization PR can
+ * quote a repeatable before/after number instead of eyeballing whole-build time.
+ */
+final readonly class PhaseTimingReport
+{
+    /** Canonical pipeline order; unknown phases are appended after these. */
+    private const array PHASE_ORDER = ['lex', 'parse', 'read', 'analyze', 'emit'];
+
+    /**
+     * @param array<string, float> $totalsMs    phase name => summed milliseconds
+     * @param int                  $sourceCount distinct sources (namespaces) that recorded a phase
+     */
+    private function __construct(
+        private array $totalsMs,
+        private int $sourceCount,
+    ) {}
+
+    /**
+     * @param array<string, float> $totalsMs
+     */
+    public static function fromTotals(array $totalsMs, int $sourceCount): self
+    {
+        return new self($totalsMs, $sourceCount);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->totalsMs === [];
+    }
+
+    public function totalMs(): float
+    {
+        return array_sum($this->totalsMs);
+    }
+
+    public function sourceCount(): int
+    {
+        return $this->sourceCount;
+    }
+
+    /**
+     * Per-phase rows in canonical pipeline order, each with its summed time and
+     * share of the overall compile time.
+     *
+     * @return list<array{phase: string, ms: float, share: float}>
+     */
+    public function phases(): array
+    {
+        $total = $this->totalMs();
+
+        $rows = [];
+        foreach ($this->orderedPhaseNames() as $phase) {
+            $ms = $this->totalsMs[$phase];
+            $rows[] = [
+                'phase' => $phase,
+                'ms' => $ms,
+                'share' => $total > 0.0 ? $ms / $total * 100.0 : 0.0,
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array{phases: array<string, float>, total_ms: float, namespaces: int}
+     */
+    public function toArray(): array
+    {
+        $phases = [];
+        foreach ($this->orderedPhaseNames() as $phase) {
+            $phases[$phase] = $this->totalsMs[$phase];
+        }
+
+        return [
+            'phases' => $phases,
+            'total_ms' => $this->totalMs(),
+            'namespaces' => $this->sourceCount,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function orderedPhaseNames(): array
+    {
+        $known = array_values(array_filter(
+            self::PHASE_ORDER,
+            fn(string $phase): bool => isset($this->totalsMs[$phase]),
+        ));
+
+        $extra = array_values(array_filter(
+            array_keys($this->totalsMs),
+            static fn(string $phase): bool => !in_array($phase, self::PHASE_ORDER, true),
+        ));
+
+        return [...$known, ...$extra];
+    }
+}

--- a/src/php/Build/Infrastructure/Command/BuildCommand.php
+++ b/src/php/Build/Infrastructure/Command/BuildCommand.php
@@ -10,6 +10,9 @@ use Phel\Build\BuildFacade;
 use Phel\Build\Domain\Compile\BuildOptions;
 use Phel\Build\Domain\Compile\BuildReport;
 use Phel\Build\Domain\Compile\CompiledFile;
+use Phel\Build\Domain\Compile\PhaseTimingReport;
+use Phel\Build\Infrastructure\Timing\PhaseTimingProfilerHook;
+use Phel\Lang\Registry;
 use Phel\Shared\Exceptions\CompilerException;
 use Phel\Shared\ResourceUsageFormatter;
 use Phel\Shared\ScalarCoercion;
@@ -37,6 +40,8 @@ final class BuildCommand extends Command
 
     private const string OPTION_REPORT = 'report';
 
+    private const string OPTION_TIMING = 'timing';
+
     protected function configure(): void
     {
         $this->setName('build')
@@ -62,6 +67,12 @@ HELP)
                 null,
                 InputOption::VALUE_NONE,
                 'Print a build report: namespace count, per-namespace compiled size, total size, and build time',
+            )
+            ->addOption(
+                self::OPTION_TIMING,
+                null,
+                InputOption::VALUE_NONE,
+                'Print per-phase compile timing (lex/parse/read/analyze/emit) aggregated across compiled namespaces; pair with --no-cache for a full, comparable measurement',
             );
     }
 
@@ -69,6 +80,13 @@ HELP)
     {
         $buildOptions = $this->getBuildOptions($input);
         $report = (bool) $input->getOption(self::OPTION_REPORT);
+
+        $timingHook = (bool) $input->getOption(self::OPTION_TIMING)
+            ? new PhaseTimingProfilerHook()
+            : null;
+        if ($timingHook instanceof PhaseTimingProfilerHook) {
+            Registry::$profilerHook = $timingHook;
+        }
 
         try {
             $startedAt = hrtime(true);
@@ -80,15 +98,44 @@ HELP)
             } else {
                 $this->printOutput($output, $compiledProject);
             }
+
+            if ($timingHook instanceof PhaseTimingProfilerHook) {
+                $this->printPhaseTiming($output, $timingHook->report());
+            }
         } catch (CompilerException $e) {
             $this->getFacade()->writeLocatedException($output, $e);
         } catch (Throwable $e) {
             $this->getFacade()->writeStackTrace($output, $e);
+        } finally {
+            Registry::$profilerHook = null;
         }
 
         $output->writeln(new ResourceUsageFormatter()->resourceUsageSinceStartOfRequest());
 
         return self::SUCCESS;
+    }
+
+    private function printPhaseTiming(OutputInterface $output, PhaseTimingReport $timing): void
+    {
+        $output->writeln('');
+        $output->writeln('Compile-phase timing');
+        $output->writeln('====================');
+
+        if ($timing->isEmpty()) {
+            $output->writeln('  No phases recorded — every namespace was served from cache. Re-run with --no-cache.');
+            return;
+        }
+
+        foreach ($timing->phases() as $row) {
+            $output->writeln(sprintf('  %-9s %10.2f ms  %5.1f%%', $row['phase'], $row['ms'], $row['share']));
+        }
+
+        $output->writeln(sprintf('  %-9s %10.2f ms', 'total', $timing->totalMs()));
+        $output->writeln(sprintf(
+            '  (%d namespace%s compiled)',
+            $timing->sourceCount(),
+            $timing->sourceCount() === 1 ? '' : 's',
+        ));
     }
 
     private function printReport(OutputInterface $output, BuildReport $report): void

--- a/src/php/Build/Infrastructure/Command/BuildCommand.php
+++ b/src/php/Build/Infrastructure/Command/BuildCommand.php
@@ -107,7 +107,9 @@ HELP)
         } catch (Throwable $e) {
             $this->getFacade()->writeStackTrace($output, $e);
         } finally {
-            Registry::$profilerHook = null;
+            if ($timingHook instanceof PhaseTimingProfilerHook) {
+                Registry::$profilerHook = null;
+            }
         }
 
         $output->writeln(new ResourceUsageFormatter()->resourceUsageSinceStartOfRequest());

--- a/src/php/Build/Infrastructure/Timing/PhaseTimingProfilerHook.php
+++ b/src/php/Build/Infrastructure/Timing/PhaseTimingProfilerHook.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Infrastructure\Timing;
+
+use Phel\Build\Domain\Compile\PhaseTimingReport;
+use Phel\Lang\AbstractFn;
+use Phel\Lang\ProfilerHookInterface;
+
+use function count;
+
+/**
+ * Profiler hook installed during `phel build --timing` to sum the compiler's
+ * per-phase wall-clock across every compiled namespace.
+ *
+ * Unlike the runtime profiler, {@see wrapFn()} is a deliberate no-op: a build
+ * evaluates `def`/`defmacro` forms while compiling, and wrapping those fns in
+ * profiling proxies would bake instrumentation into the build's registry and
+ * emitted output. Only {@see recordPhase()} carries signal here.
+ */
+final class PhaseTimingProfilerHook implements ProfilerHookInterface
+{
+    /** @var array<string, float> */
+    private array $totalsMs = [];
+
+    /** @var array<string, true> */
+    private array $sources = [];
+
+    public function wrapFn(AbstractFn $fn): AbstractFn
+    {
+        return $fn;
+    }
+
+    public function recordPhase(string $phase, string $source, float $elapsedMs): void
+    {
+        $this->totalsMs[$phase] = ($this->totalsMs[$phase] ?? 0.0) + $elapsedMs;
+        $this->sources[$source] = true;
+    }
+
+    public function report(): PhaseTimingReport
+    {
+        return PhaseTimingReport::fromTotals($this->totalsMs, count($this->sources));
+    }
+}

--- a/tests/php/Integration/Build/Command/BuildCommandTest.php
+++ b/tests/php/Integration/Build/Command/BuildCommandTest.php
@@ -186,6 +186,31 @@ TXT;
         self::assertStringContainsString('test-ns.hello', $text);
     }
 
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_timing_prints_per_phase_compile_breakdown(): void
+    {
+        DirectoryUtil::removeDir(__DIR__ . '/out');
+        $this->bootstrapGacela();
+
+        $output = new BufferedOutput();
+        $this->command->run(
+            new ArrayInput([
+                '--no-source-map' => true,
+                '--no-cache' => true,
+                '--timing' => true,
+            ]),
+            $output,
+        );
+        $text = $output->fetch();
+
+        self::assertStringContainsString('Compile-phase timing', $text);
+        self::assertMatchesRegularExpression('/lex\s+[\d.]+ ms\s+[\d.]+%/', $text);
+        self::assertMatchesRegularExpression('/analyze\s+[\d.]+ ms\s+[\d.]+%/', $text);
+        self::assertMatchesRegularExpression('/total\s+[\d.]+ ms/', $text);
+        self::assertMatchesRegularExpression('/\(\d+ namespaces? compiled\)/', $text);
+    }
+
     private function bootstrapGacela(): void
     {
         Phel::bootstrap(__DIR__);

--- a/tests/php/Unit/Build/Domain/Compile/PhaseTimingReportTest.php
+++ b/tests/php/Unit/Build/Domain/Compile/PhaseTimingReportTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Build\Domain\Compile;
+
+use Phel\Build\Domain\Compile\PhaseTimingReport;
+use PHPUnit\Framework\TestCase;
+
+use function array_column;
+
+final class PhaseTimingReportTest extends TestCase
+{
+    public function test_empty_report(): void
+    {
+        $report = PhaseTimingReport::fromTotals([], 0);
+
+        self::assertTrue($report->isEmpty());
+        self::assertSame(0.0, $report->totalMs());
+        self::assertSame([], $report->phases());
+        self::assertSame(0, $report->sourceCount());
+    }
+
+    public function test_total_ms_sums_all_phases(): void
+    {
+        $report = PhaseTimingReport::fromTotals(['analyze' => 10.0, 'lex' => 2.0, 'emit' => 8.0], 3);
+
+        self::assertFalse($report->isEmpty());
+        self::assertSame(20.0, $report->totalMs());
+        self::assertSame(3, $report->sourceCount());
+    }
+
+    public function test_phases_are_ordered_canonically_with_shares(): void
+    {
+        // Insertion order is deliberately scrambled; output must be lex -> emit.
+        $report = PhaseTimingReport::fromTotals(['emit' => 5.0, 'lex' => 5.0, 'analyze' => 10.0], 1);
+
+        $phases = $report->phases();
+
+        self::assertSame(['lex', 'analyze', 'emit'], array_column($phases, 'phase'));
+        self::assertEqualsWithDelta(25.0, $phases[0]['share'], 0.001);
+        self::assertEqualsWithDelta(50.0, $phases[1]['share'], 0.001);
+        self::assertEqualsWithDelta(25.0, $phases[2]['share'], 0.001);
+    }
+
+    public function test_unknown_phase_is_appended_after_known_phases(): void
+    {
+        $report = PhaseTimingReport::fromTotals(['custom' => 1.0, 'lex' => 1.0], 1);
+
+        self::assertSame(['lex', 'custom'], array_column($report->phases(), 'phase'));
+    }
+
+    public function test_to_array_is_ordered_and_stable(): void
+    {
+        $report = PhaseTimingReport::fromTotals(['emit' => 8.0, 'lex' => 2.0], 4);
+
+        self::assertSame([
+            'phases' => ['lex' => 2.0, 'emit' => 8.0],
+            'total_ms' => 10.0,
+            'namespaces' => 4,
+        ], $report->toArray());
+    }
+}

--- a/tests/php/Unit/Build/Infrastructure/Timing/PhaseTimingProfilerHookTest.php
+++ b/tests/php/Unit/Build/Infrastructure/Timing/PhaseTimingProfilerHookTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Build\Infrastructure\Timing;
+
+use Phel\Build\Infrastructure\Timing\PhaseTimingProfilerHook;
+use Phel\Lang\AbstractFn;
+use PHPUnit\Framework\TestCase;
+
+final class PhaseTimingProfilerHookTest extends TestCase
+{
+    public function test_record_phase_aggregates_across_sources(): void
+    {
+        $hook = new PhaseTimingProfilerHook();
+        $hook->recordPhase('lex', 'a.phel', 1.0);
+        $hook->recordPhase('analyze', 'a.phel', 4.0);
+        $hook->recordPhase('lex', 'b.phel', 2.0);
+
+        $report = $hook->report();
+
+        self::assertSame(7.0, $report->totalMs());
+        self::assertSame(2, $report->sourceCount());
+        self::assertSame([
+            'phases' => ['lex' => 3.0, 'analyze' => 4.0],
+            'total_ms' => 7.0,
+            'namespaces' => 2,
+        ], $report->toArray());
+    }
+
+    public function test_wrap_fn_is_a_noop(): void
+    {
+        // A build evaluates `def`/`defmacro` forms while compiling. Wrapping
+        // those fns in profiling proxies would bake instrumentation into the
+        // emitted output, so the build-timing hook must return the fn untouched.
+        $hook = new PhaseTimingProfilerHook();
+        $fn = $this->createStub(AbstractFn::class);
+
+        self::assertSame($fn, $hook->wrapFn($fn));
+    }
+
+    public function test_unused_hook_reports_empty(): void
+    {
+        self::assertTrue(new PhaseTimingProfilerHook()->report()->isEmpty());
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Whole-build time (`--report`) and single-run `phel profile` exist, but there was no compile-only, per-phase measurement at project-build granularity — the repeatable number needed to quantify compiler-phase work and unblock confident optimization (#2615).

## 💡 Goal

A single documented command that prints per-phase compile time aggregated across a project build, compile-only and parseable enough to quote in PRs.

## 🔖 Changes

- `phel build --timing` installs a `PhaseTimingProfilerHook` around `compileProject` (reset in `finally`) that sums per-phase wall-clock (lex/parse/read/analyze/emit) across compiled namespaces, rendered as a `PhaseTimingReport` with each phase's share + total. Pair with `--no-cache` for a full, comparable run; composes with `--report`.
- The hook reuses the existing `CodeCompiler` phase hooks, but its `wrapFn()` is a deliberate **no-op**: a build evaluates `def`/`defmacro` while compiling, so the runtime profiler's fn-wrapping would bake instrumentation into the emitted output — which is exactly why `ProfilerSession` could not simply be reused.
- Docs: `docs/internals/benchmarks.md` documents the before/after command. Real run on this repo: `analyze` 40.6% + `emit` 47.7% dominate the 33-namespace, ~975ms compile.

Closes #2615