### PR TITLE
fix(compiler): capture inliner-introduced shadows in nested IIFEs (#2622)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Opt-level-≥2 call inlining (#2586) emitted undefined-variable PHP when inlining a `^:pure` let-bodied `defn` whose body contains a nested call that lowers to an IIFE (`or`/`and`/`cond`): the renamed parameter/let shadow was not captured by the nested closure's `use(...)` clause, crashing at runtime. The inliner now threads introduced shadows onto the rebase environment so nested closures capture them (#2622)
+
 ### Added
 
 - Config validation in `phel config` and `phel doctor` (relative-path requirements, missing/empty source-test dirs, bad optimization levels, wrong types); `doctor` fails on errors and shows warnings as tips (#2600, #2601, #2602, #2603)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
@@ -136,8 +136,17 @@ final readonly class CallInliner
         // Pure args substitute straight into the body (folding-friendly);
         // impure or pure-but-multi-use args bind to a fresh gensym `let`
         // so they evaluate exactly once, left to right.
+        //
+        // Each binding's shadow is also registered as a local on the env
+        // threaded into the body rebase: those shadows are assigned ahead
+        // of the body, so any nested node that emits a closure (a `let`
+        // in expression context, an `or`/`and`/`cond` IIFE) must capture
+        // them in its `use(...)` clause. Leaving them off the env would
+        // make the closure capture the call-site locals only and read the
+        // shadow as an undefined variable (issue #2622).
         $bindings = [];
         $paramMap = [];
+        $rebaseEnv = $env;
         foreach ($params as $i => $param) {
             $arg = $args[$i];
             $name = $param->getName();
@@ -146,6 +155,7 @@ final readonly class CallInliner
                 $shadow = Symbol::gen($name . '_')->copyLocationFrom($param);
                 $bindings[] = new BindingNode($env, $param, $shadow, $arg, $callLocation);
                 $paramMap[$name] = new LocalVarNode($env, $shadow, $callLocation);
+                $rebaseEnv = $rebaseEnv->withMergedLocals([$shadow]);
 
                 continue;
             }
@@ -163,7 +173,7 @@ final readonly class CallInliner
 
         // `rebase` can still abort (returning `null`) if the body holds a
         // node type outside the whitelist or a non-parameter local.
-        $inlined = $this->rebase($ret, new RebaseContext($env, $bodyContext, $callLocation, $paramMap, true));
+        $inlined = $this->rebase($ret, new RebaseContext($rebaseEnv, $bodyContext, $callLocation, $paramMap, true));
         if (!$inlined instanceof AbstractNode) {
             return null;
         }
@@ -384,13 +394,20 @@ final readonly class CallInliner
             ? NodeEnvironment::CONTEXT_RETURN
             : $ctx->context;
 
+        // Like the parameter shadows in `tryInline`, each fresh let shadow
+        // is added to the env threaded into later inits and the body, so a
+        // nested closure (`let`/`or`/`and`/`cond` IIFE) captures it in its
+        // `use(...)` clause instead of reading it as undefined (#2622). An
+        // init only sees the shadows of the bindings preceding it, matching
+        // sequential `let` scoping.
         $paramMap = $ctx->paramMap;
+        $env = $ctx->env;
         $bindings = [];
         foreach ($node->getBindings() as $binding) {
             // Inits emit as expressions (`$shadow = <init>;`) and may
             // reference params or earlier bindings, so rebase them in
             // expression context with the substitutions accumulated so far.
-            $initCtx = new RebaseContext($ctx->env, NodeEnvironment::CONTEXT_EXPRESSION, $ctx->loc, $paramMap, true);
+            $initCtx = new RebaseContext($env, NodeEnvironment::CONTEXT_EXPRESSION, $ctx->loc, $paramMap, true);
             $init = $this->rebase($binding->getInitExpr(), $initCtx);
             if (!$init instanceof AbstractNode) {
                 return null;
@@ -399,9 +416,10 @@ final readonly class CallInliner
             $shadow = Symbol::gen($binding->getShadow()->getName() . '_')->copyLocationFrom($binding->getShadow());
             $bindings[] = new BindingNode($ctx->targetEnv(), $binding->getSymbol(), $shadow, $init, $ctx->loc);
             $paramMap[$binding->getShadow()->getName()] = new LocalVarNode($ctx->env, $shadow, $ctx->loc);
+            $env = $env->withMergedLocals([$shadow]);
         }
 
-        $bodyCtx = new RebaseContext($ctx->env, $bodyContext, $ctx->loc, $paramMap, true);
+        $bodyCtx = new RebaseContext($env, $bodyContext, $ctx->loc, $paramMap, true);
         $body = $this->rebase($node->getBodyExpr(), $bodyCtx);
         if (!$body instanceof AbstractNode) {
             return null;

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
@@ -146,7 +146,7 @@ final readonly class CallInliner
         // shadow as an undefined variable (issue #2622).
         $bindings = [];
         $paramMap = [];
-        $rebaseEnv = $env;
+        $scopeEnv = $env;
         foreach ($params as $i => $param) {
             $arg = $args[$i];
             $name = $param->getName();
@@ -155,7 +155,7 @@ final readonly class CallInliner
                 $shadow = Symbol::gen($name . '_')->copyLocationFrom($param);
                 $bindings[] = new BindingNode($env, $param, $shadow, $arg, $callLocation);
                 $paramMap[$name] = new LocalVarNode($env, $shadow, $callLocation);
-                $rebaseEnv = $rebaseEnv->withMergedLocals([$shadow]);
+                $scopeEnv = $scopeEnv->withMergedLocals([$shadow]);
 
                 continue;
             }
@@ -173,7 +173,7 @@ final readonly class CallInliner
 
         // `rebase` can still abort (returning `null`) if the body holds a
         // node type outside the whitelist or a non-parameter local.
-        $inlined = $this->rebase($ret, new RebaseContext($rebaseEnv, $bodyContext, $callLocation, $paramMap, true));
+        $inlined = $this->rebase($ret, new RebaseContext($scopeEnv, $bodyContext, $callLocation, $paramMap, true));
         if (!$inlined instanceof AbstractNode) {
             return null;
         }
@@ -401,13 +401,13 @@ final readonly class CallInliner
         // init only sees the shadows of the bindings preceding it, matching
         // sequential `let` scoping.
         $paramMap = $ctx->paramMap;
-        $env = $ctx->env;
+        $scopeEnv = $ctx->env;
         $bindings = [];
         foreach ($node->getBindings() as $binding) {
             // Inits emit as expressions (`$shadow = <init>;`) and may
             // reference params or earlier bindings, so rebase them in
             // expression context with the substitutions accumulated so far.
-            $initCtx = new RebaseContext($env, NodeEnvironment::CONTEXT_EXPRESSION, $ctx->loc, $paramMap, true);
+            $initCtx = new RebaseContext($scopeEnv, NodeEnvironment::CONTEXT_EXPRESSION, $ctx->loc, $paramMap, true);
             $init = $this->rebase($binding->getInitExpr(), $initCtx);
             if (!$init instanceof AbstractNode) {
                 return null;
@@ -416,10 +416,10 @@ final readonly class CallInliner
             $shadow = Symbol::gen($binding->getShadow()->getName() . '_')->copyLocationFrom($binding->getShadow());
             $bindings[] = new BindingNode($ctx->targetEnv(), $binding->getSymbol(), $shadow, $init, $ctx->loc);
             $paramMap[$binding->getShadow()->getName()] = new LocalVarNode($ctx->env, $shadow, $ctx->loc);
-            $env = $env->withMergedLocals([$shadow]);
+            $scopeEnv = $scopeEnv->withMergedLocals([$shadow]);
         }
 
-        $bodyCtx = new RebaseContext($env, $bodyContext, $ctx->loc, $paramMap, true);
+        $bodyCtx = new RebaseContext($scopeEnv, $bodyContext, $ctx->loc, $paramMap, true);
         $body = $this->rebase($node->getBodyExpr(), $bodyCtx);
         if (!$body instanceof AbstractNode) {
             return null;

--- a/tests/php/Integration/CallInlinerCaptureTest.php
+++ b/tests/php/Integration/CallInlinerCaptureTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompileOptions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * End-to-end guard for issue #2622: at optimization level 2 the
+ * {@see Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification\CallInliner}
+ * inlines a `^:pure` let-bodied `defn` whose body contains a nested call
+ * that lowers to an IIFE (`or`/`and`/`cond`). The renamed parameter shadow
+ * must be captured by that nested IIFE's `use(...)` clause; otherwise it
+ * reads as an undefined variable and arithmetic on the resulting `nil`
+ * crashes at runtime.
+ */
+final class CallInlinerCaptureTest extends TestCase
+{
+    private CompilerFacade $compilerFacade;
+
+    protected function setUp(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+        new BuildFacade()->compileFile(
+            __DIR__ . '/../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core'),
+        );
+        $this->compilerFacade = new CompilerFacade();
+    }
+
+    public function test_nested_iife_captures_renamed_param_shadow(): void
+    {
+        $opt2 = new CompileOptions()->setSource('inliner-capture')->setOptimizationLevel(2);
+
+        BuildFacade::enableBuildMode();
+        try {
+            $this->compilerFacade->compile($this->program(), $opt2);
+        } finally {
+            BuildFacade::disableBuildMode();
+        }
+
+        // A correctly-captured enemy resolves `(:type enemy)` to `:goblin`,
+        // finds `{:range 5}` in caster-spec and reports a hit at distance 5.
+        // A dropped capture would read `nil`, fall back to the default
+        // range and (in the reporter's case) crash on nil arithmetic.
+        $hit = $this->compilerFacade->eval(
+            '(call-site {:type :goblin :x 0 :y 0} 3.0 4.0)',
+            new CompileOptions()->setSource('inliner-capture-eval')->setOptimizationLevel(2),
+        );
+
+        self::assertEquals(Keyword::create('hit'), $hit);
+    }
+
+    private function program(): string
+    {
+        return <<<'PHEL'
+        (def caster-spec {:goblin {:range 5}})
+        (def attack-spec {})
+        (def default-attack-spec {:range 1})
+
+        (defn ^:pure attack-spec-of [enemy]
+          (or (get caster-spec (:type enemy))
+              (get attack-spec (:type enemy))
+              default-attack-spec))
+
+        (defn ^:pure in-attack-range? [enemy ^float px ^float py]
+          (let [dx (php/- px (:x enemy))
+                dy (php/- py (:y enemy))
+                r  (:range (attack-spec-of enemy))]
+            (php/<= (php/+ (php/* dx dx) (php/* dy dy)) (php/* r r))))
+
+        (defn call-site [enemy px py]
+          (if (in-attack-range? enemy px py) :hit :miss))
+        PHEL;
+    }
+}

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/CallInlinerTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/CallInlinerTest.php
@@ -195,6 +195,29 @@ final class CallInlinerTest extends TestCase
         self::assertNotSame('y_shadow', $binding->getShadow()->getName());
     }
 
+    public function test_rebased_nested_let_env_captures_introduced_shadows(): void
+    {
+        // (defn f [x] (let [y x] (let [w y] (+ w x)))) called with caller
+        // local z. `x` is used twice, so it binds to a fresh shadow. The
+        // inner let emits an IIFE in expression context, so its env must
+        // carry the rebased `x` shadow as a local — otherwise the closure's
+        // `use(...)` clause omits it and it reads as undefined (#2622).
+        $this->seedDefn('f', ['x'], $this->doubleNestedLetBody('x'));
+
+        $result = $this->inline('f', [new LocalVarNode($this->env, Symbol::create('z'))]);
+
+        self::assertInstanceOf(LetNode::class, $result);
+        $paramShadow = $result->getBindings()[0]->getShadow()->getName();
+
+        $deepest = $this->deepestLetNode($result);
+        $localNames = array_map(
+            static fn(Symbol $local): string => $local->getName(),
+            $deepest->getEnv()->getLocals(),
+        );
+
+        self::assertContains($paramShadow, $localNames);
+    }
+
     public function test_declines_impure_body(): void
     {
         // (defn log-it [x] (println x)) -> body is side-effecting
@@ -366,6 +389,59 @@ final class CallInlinerTest extends TestCase
         $let = new LetNode($this->env, [$binding], $letInner, false);
 
         return new DoNode($this->env, [], $let);
+    }
+
+    private function doubleNestedLetBody(string $param): DoNode
+    {
+        // (let [y <param>] (let [w y] (+ w <param>))) — <param> is used
+        // twice (the inner binding init and the sum), so it binds to a
+        // shadow, and the inner let nests inside the outer one.
+        $outerShadow = Symbol::create('y_shadow');
+        $innerShadow = Symbol::create('w_shadow');
+
+        $innerBinding = new BindingNode(
+            $this->env,
+            Symbol::create('w'),
+            $innerShadow,
+            new LocalVarNode($this->env, $outerShadow),
+        );
+
+        $innerBody = new DoNode($this->env, [], new CallNode(
+            $this->env,
+            new GlobalVarNode($this->env, CompilerConstants::PHEL_CORE_NAMESPACE, Symbol::create('+'), Phel::map()),
+            [
+                new LocalVarNode($this->env, $innerShadow),
+                new LocalVarNode($this->env, Symbol::create($param)),
+            ],
+        ));
+
+        $innerLet = new LetNode($this->env, [$innerBinding], $innerBody, false);
+
+        $outerBinding = new BindingNode(
+            $this->env,
+            Symbol::create('y'),
+            $outerShadow,
+            new LocalVarNode($this->env, Symbol::create($param)),
+        );
+
+        $outerLet = new LetNode(
+            $this->env,
+            [$outerBinding],
+            new DoNode($this->env, [], $innerLet),
+            false,
+        );
+
+        return new DoNode($this->env, [], $outerLet);
+    }
+
+    private function deepestLetNode(LetNode $node): LetNode
+    {
+        $body = $node->getBodyExpr();
+        if ($body instanceof DoNode) {
+            $body = $body->getRet();
+        }
+
+        return $body instanceof LetNode ? $this->deepestLetNode($body) : $node;
     }
 
     private function squareBody(string $param): DoNode


### PR DESCRIPTION
## 🤔 Background

The opt-level-≥2 call inliner (#2586) inlines a `^:pure` let-bodied `defn` by rebasing its analysed body onto the call site, renaming each parameter and `let` binding to a fresh gensym shadow at every use site. The rebaser threaded the **call-site environment verbatim** into the rebased body.

A nested node that emits a PHP closure — a `let` in expression context, or an `or`/`and`/`cond` IIFE — computes its `use(...)` capture clause from that environment's locals. Because the introduced shadows were never added to the environment, the closure captured the call-site locals only and read the renamed shadow as an **undefined variable**. In the reporter's case `nil` then flowed into arithmetic and crashed at runtime (`Arithmetic functions do not accept nil values`).

Closes #2622

## 💡 Goal

Make nested closures produced by the inliner capture the shadows the inliner introduces, so inlined `^:pure` let-bodied fns compile to correct PHP.

## 🔖 Changes

- `CallInliner::tryInline` and `CallInliner::rebaseLet` now register each introduced shadow (parameter shadow and `let`-binding shadow) as a local on the environment threaded into the body rebase. An init only sees the shadows of the bindings preceding it, matching sequential `let` scoping; the body sees them all. Nested closures therefore include the shadow in their `use(...)` clause instead of leaving it undefined.
- Unit test (`CallInlinerTest`): asserts the rebased nested `let`'s environment carries the introduced parameter shadow as a local.
- Integration test (`CallInlinerCaptureTest`): compiles the reporter's reproduction at optimization level 2 and evaluates it end-to-end, asserting the correct result (the buggy build returned the wrong value with an undefined-variable warning).
- `CHANGELOG.md`: `### Fixed` entry.

Both tests fail on `main` (undefined variable, wrong result) and pass with the fix.

The mandatory post-implementation refactor review surfaced no substantive changes: the fix is a minimal, two-site environment-threading change with no duplication, dead code, or naming drift to clean up.
