### PR TITLE
feat(run): report discarded pure value when 'phel compile' emits no PHP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- `phel compile` no longer prints nothing when a snippet folds to a discarded pure value (e.g. `(+ 1 2)` → `3`): stdout stays empty, but a note on stderr now reports the value the snippet reduces to and why no PHP was emitted
+
 ## [0.46.0](https://github.com/phel-lang/phel-lang/compare/v0.45.1...v0.46.0) - 2026-06-25
 
 ### Fixed

--- a/src/php/Compiler/Application/CodeCompiler.php
+++ b/src/php/Compiler/Application/CodeCompiler.php
@@ -156,7 +156,7 @@ final readonly class CodeCompiler implements CodeCompilerInterface
         ?ProfilerHookInterface $hook,
         string $source,
     ): void {
-        $node = $this->timed($hook, 'analyze', $source, fn(): AbstractNode => $this->analyze($readerResult));
+        $node = $this->timed($hook, 'analyze', $source, fn(): AbstractNode => $this->analyze($readerResult, $compileOptions));
         // We need to evaluate every statement because we may need it for macros.
         $this->timed($hook, 'emit', $source, fn() => $this->emitNode($node, $compileOptions));
     }
@@ -184,13 +184,15 @@ final readonly class CodeCompiler implements CodeCompilerInterface
     /**
      * @throws CompilerException
      */
-    private function analyze(ReaderResult $readerResult): AbstractNode
+    private function analyze(ReaderResult $readerResult, CompileOptions $compileOptions): AbstractNode
     {
+        $env = NodeEnvironment::empty();
+        if ($compileOptions->isEmitAsExpression()) {
+            $env = $env->withExpressionContext();
+        }
+
         try {
-            return $this->analyzer->analyze(
-                $readerResult->getAst(),
-                NodeEnvironment::empty(),
-            );
+            return $this->analyzer->analyze($readerResult->getAst(), $env);
         } catch (AnalyzerException $analyzerException) {
             throw new CompilerException($analyzerException, $readerResult->getCodeSnippet());
         }

--- a/src/php/Run/Application/CompileExecutor.php
+++ b/src/php/Run/Application/CompileExecutor.php
@@ -9,6 +9,8 @@ use Phel\Shared\Exceptions\CompilerException;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use Throwable;
 
+use function sprintf;
+
 /**
  * Compiles a Phel snippet to PHP without evaluating it.
  *
@@ -44,8 +46,14 @@ final readonly class CompileExecutor
             $options = new CompileOptions()
                 ->setEmitOnly(true)
                 ->setOptimizationLevel($this->optimizationLevel);
-            $result = $this->compilerFacade->compile($source, $options);
-            $stdout($result->getPhpCode());
+            $phpCode = $this->compilerFacade->compile($source, $options)->getPhpCode();
+
+            if (trim($phpCode) === '') {
+                $stderr($this->emptyOutputNote($source));
+                return true;
+            }
+
+            $stdout($phpCode);
             return true;
         } catch (CompilerException $e) {
             $nested = $e->getNestedException();
@@ -54,6 +62,38 @@ final readonly class CompileExecutor
         } catch (Throwable $e) {
             $stderr($e->getMessage() . "\n");
             return false;
+        }
+    }
+
+    /**
+     * A pure value in statement context emits no PHP (e.g. `(+ 1 2)` folds to
+     * `3`, which is then discarded). Re-compile in expression context — without
+     * evaluating — to recover the value so the note can name it instead of
+     * leaving the user staring at empty output.
+     */
+    private function emptyOutputNote(string $source): string
+    {
+        $value = $this->compileValueExpression($source);
+        $reason = 'a top-level expression with no binding or side effect emits no PHP';
+
+        if ($value === '') {
+            return sprintf("; no PHP emitted — %s.\n", $reason);
+        }
+
+        return sprintf("; no PHP emitted — this compiles to the value `%s`, which is discarded (%s).\n", $value, $reason);
+    }
+
+    private function compileValueExpression(string $source): string
+    {
+        try {
+            $options = new CompileOptions()
+                ->setEmitOnly(true)
+                ->setEmitAsExpression(true)
+                ->setOptimizationLevel($this->optimizationLevel);
+
+            return trim($this->compilerFacade->compile($source, $options)->getPhpCode());
+        } catch (Throwable) {
+            return '';
         }
     }
 }

--- a/src/php/Run/Infrastructure/Command/CompileCommand.php
+++ b/src/php/Run/Infrastructure/Command/CompileCommand.php
@@ -52,6 +52,10 @@ final class CompileCommand extends Command
             ->setHelp(<<<'HELP'
 Prints the PHP a snippet/file/stdin compiles to, without running it.
 
+A pure top-level value (e.g. <comment>(+ 1 2)</comment> folds to <comment>3</comment>) is discarded in
+statement context and emits no PHP; in that case a note on stderr
+reports the value the snippet reduces to, and stdout stays empty.
+
 <info>Examples:</info>
   <comment>phel compile '(+ 1 2)'</comment>      Compile an inline expression
   <comment>echo '(println "hi")' | phel compile -</comment>   Compile from stdin

--- a/src/php/Shared/CLAUDE.md
+++ b/src/php/Shared/CLAUDE.md
@@ -48,7 +48,7 @@ Stateless strategy-pattern printer (see `Printer/CLAUDE.md`); consumers instanti
 | `PhelProjectDirectory` | manages `.phel/` dir; static `ensure()`/`path()`/`resolve()`. Effective location: `PHEL_DIR` env → `withPhelDir()` override → `<projectRoot>/.phel` |
 | `VersionFinder` | pure version-string builder from explicit git inputs (no I/O); `getVersion()`. `LATEST_VERSION` const is bumped by `tools/release.sh` |
 | `VersionResolver` | gathers ambient version inputs (git working copy, Composer `InstalledVersions`, build-time `.phel-release.php`/`OFFICIAL_RELEASE`) and calls `VersionFinder`; `resolve()`. Console and Run consume directly, so neither owns version-detection wiring |
-| `CompileOptions` | source maps, emit-only mode, optimization levels |
+| `CompileOptions` | source maps, emit-only mode, optimization levels, `emitAsExpression` (analyse top-level forms in expression context so a folded pure value surfaces instead of being dropped — used by `phel compile`) |
 | `PhpAttributeRenderer` | renders `^{:php/attr …}` specs into PHP 8 attribute lines (`#[\ORM\Column(length: 255)]`). Accepts bare keyword (`:ORM/Entity`), single spec vector (`[:ORM/Column {:length 255}]`), or vector of specs. Consumed by `DefStructEmitter`/`DefInterfaceEmitter` + Interop export generator |
 | `Console/DeprecatedOptionWarner` | static `warn()` — one-line renamed-option deprecation notice to stderr (never corrupts machine-readable stdout like `phel config --json`) |
 | `Performance/OpcacheAdvisor` | pure `advise(...)` (caller passes ini flags) → `OpcacheAdvice` (`optimal`, `messages`); flags when OPcache won't persist the compiled-code cache across CLI runs |

--- a/src/php/Shared/CompileOptions.php
+++ b/src/php/Shared/CompileOptions.php
@@ -21,6 +21,8 @@ final class CompileOptions
 
     public const bool DEFAULT_EMIT_ONLY = false;
 
+    public const bool DEFAULT_EMIT_AS_EXPRESSION = false;
+
     /**
      * Roadmap of optimisation levels gated behind this option:
      *
@@ -44,6 +46,8 @@ final class CompileOptions
     private bool $isEnableSourceMaps = self::DEFAULT_ENABLE_SOURCE_MAPS;
 
     private bool $emitOnly = self::DEFAULT_EMIT_ONLY;
+
+    private bool $emitAsExpression = self::DEFAULT_EMIT_AS_EXPRESSION;
 
     private int $optimizationLevel = self::DEFAULT_OPTIMIZATION_LEVEL;
 
@@ -91,6 +95,25 @@ final class CompileOptions
     public function setEmitOnly(bool $emitOnly): self
     {
         $this->emitOnly = $emitOnly;
+
+        return $this;
+    }
+
+    /**
+     * Top-level forms compile in statement context by default, where a folded
+     * pure value (`(+ 1 2)` → `3`) emits no PHP. Enabling this analyses them in
+     * expression context instead, so the discarded value surfaces as a PHP
+     * expression — used by `phel compile` to report what an otherwise-empty
+     * snippet reduces to.
+     */
+    public function isEmitAsExpression(): bool
+    {
+        return $this->emitAsExpression;
+    }
+
+    public function setEmitAsExpression(bool $emitAsExpression): self
+    {
+        $this->emitAsExpression = $emitAsExpression;
 
         return $this;
     }

--- a/tests/php/Integration/Run/Command/Compile/CompileCommandTest.php
+++ b/tests/php/Integration/Run/Command/Compile/CompileCommandTest.php
@@ -44,12 +44,15 @@ final class CompileCommandTest extends AbstractTestCommand
     public function test_compile_folds_pure_arithmetic_to_literal(): void
     {
         $tester = new CommandTester(new CompileCommand());
-        $tester->execute(['source' => '(+ 1 2)']);
+        $tester->execute(['source' => '(+ 1 2)'], ['capture_stderr_separately' => true]);
 
-        // Folded literal is elided in statement context by `LiteralEmitter`,
-        // so no PHP statement reaches the output — the runtime call is gone.
+        // Folded literal is elided in statement context by `LiteralEmitter`, so
+        // no PHP statement reaches stdout; the discarded value is reported on
+        // stderr instead via an expression-context re-compile.
         $tester->assertCommandIsSuccessful();
         self::assertSame('', $tester->getDisplay());
+        self::assertStringContainsString('no PHP emitted', $tester->getErrorOutput());
+        self::assertStringContainsString('`3`', $tester->getErrorOutput());
     }
 
     public function test_compile_unbalanced_parentheses_fails(): void

--- a/tests/php/Unit/Run/Application/CompileExecutorTest.php
+++ b/tests/php/Unit/Run/Application/CompileExecutorTest.php
@@ -35,6 +35,43 @@ final class CompileExecutorTest extends TestCase
         self::assertSame(2, $this->capturedOptions->getOptimizationLevel());
     }
 
+    public function test_empty_output_reports_the_discarded_value_on_stderr(): void
+    {
+        $executor = new CompileExecutor($this->createValueFoldingCompilerFacade());
+
+        $out = '';
+        $err = '';
+        $ok = $executor->execute(
+            '(+ 1 2)',
+            static function (string $chunk) use (&$out): void {
+                $out .= $chunk;
+            },
+            static function (string $chunk) use (&$err): void {
+                $err .= $chunk;
+            },
+        );
+
+        self::assertTrue($ok);
+        self::assertSame('', $out, 'stdout stays clean when nothing compiles');
+        self::assertStringContainsString('no PHP emitted', $err);
+        self::assertStringContainsString('`3`', $err);
+    }
+
+    private function createValueFoldingCompilerFacade(): CompilerFacadeInterface
+    {
+        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade->method('hasBalancedParentheses')->willReturn(true);
+        $compilerFacade->method('compile')
+            ->willReturnCallback(static function (string $code, CompileOptions $options): EmitterResult {
+                // Statement context drops the folded literal; expression context surfaces it.
+                $php = $options->isEmitAsExpression() ? '3' : '';
+
+                return new EmitterResult(false, $php, '', '');
+            });
+
+        return $compilerFacade;
+    }
+
     private function createCapturingCompilerFacade(): CompilerFacadeInterface
     {
         $compilerFacade = $this->createMock(CompilerFacadeInterface::class);


### PR DESCRIPTION
## 🤔 Background

`phel compile '(+ 1 2)'` printed **nothing**, which looks like a bug. The cause: `CodeCompiler` analyses top-level forms in **statement context** (`NodeEnvironment::empty()`) — correct for compiling a `.phel` file, where a top-level pure value is genuinely dead code. The `+` call folds to the literal `3`, and `LiteralEmitter` elides a bare literal in statement context, so zero PHP reaches stdout.

Calls, operators, side effects and `def`s all still emit (`(php/+ 2 3)` → `(2 + 3);`); only forms that reduce to a discarded pure literal/local came out empty.

## 💡 Goal

Stop `phel compile` from silently emitting nothing. When a snippet compiles to no PHP, tell the user *what value it reduced to* and *why* — without evaluating anything (the command's "does not evaluate" contract must hold).

## 🔖 Changes

- **`Shared/CompileOptions`** — new `emitAsExpression` flag (plain bool; no Compiler import, stays a leaf).
- **`Compiler/Application/CodeCompiler`** — when the flag is set, top-level forms analyse in **expression context** (`withExpressionContext()`) so a folded pure value surfaces as a PHP expression. Inert when the flag is unset, so all existing compile paths are byte-identical.
- **`Run/Application/CompileExecutor`** — on empty output, recover the value via an emit-only expression-context **re-compile** (never an `eval`) and write a note to **stderr**; stdout stays clean, exit code stays `0`. The recompile is wrapped so any failure falls back to a generic note.
- **`CompileCommand`** help text documents the behaviour.
- **Tests** — new unit case (stdout empty + value reported on stderr); updated the integration test that previously asserted silent empty output.
- **`CHANGELOG.md`** `## Unreleased` + **`Shared/CLAUDE.md`** updated.

### Before / after

```
# before
$ phel compile '(+ 1 2)'
$                              # nothing

# after
$ phel compile '(+ 1 2)'
; no PHP emitted — this compiles to the value `3`, which is discarded
  (a top-level expression with no binding or side effect emits no PHP).   # → stderr
$ phel compile '(+ 1 2)' 2>/dev/null
$                              # stdout still clean for piping
```

Note: you see `3`, not `(1 + 2)` — Phel constant-folds `(+ 1 2)` at analysis regardless of context, so the *value* surfaces. Non-constant args keep their shape (`(php/+ 2 3)` → `(2 + 3)`).

## ✅ Verification

- `CompileExecutorTest` + `CompileCommandTest` green.
- Full **unit** suite (3850) and full **integration** suite green; the 435 exact-PHP-output fixtures are byte-identical (confirms statement-context emission is unchanged).
- `phpstan` (level 9) and `psalm` clean on changed files; cs-fixer reports nothing to fix.
