### PR TITLE
feat(test): faster phel test --parallel + clearer failure diffs (and testing DX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- `phel test` now renders the `+`/`-`/`~` structural diff for **any** same-shape collection that differs, not just collections with more than 3 entries: the common small-collection failure (`(= {:a 1 :b 2} {:a 1 :b 3})`, `[1 2 3]` vs `[1 2 4]`) now shows exactly what differs instead of two near-identical lines. Scalar pairs and mixed shapes keep the single-line summary
 - `phel compile` no longer prints nothing when a snippet folds to a discarded pure value (e.g. `(+ 1 2)` → `3`): stdout stays empty, but a note on stderr now reports the value the snippet reduces to and why no PHP was emitted
+
+### Performance
+
+- `phel test --parallel` workers no longer re-evaluate their full dependency closure (mostly the shared `phel.*` stdlib) on every namespace frame: each dependency is evaluated once per long-lived worker, as the serial runner already does. Removes the per-frame re-execution that made `--parallel=2` slower than serial and capped scaling; the speedup grows with the number of namespaces in a project
 
 ## [0.46.0](https://github.com/phel-lang/phel-lang/compare/v0.45.1...v0.46.0) - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Temp-file cleanup (`RealFilesystem::clearAll()`) no longer emits `unlink(...): No such file or directory` warnings when a tracked path was already removed by an earlier run (the file list is process-global static); it now skips missing paths. Surfaced as noise on every `phel test` / build run
+
 ### Changed
 
 - `phel compile` no longer prints nothing when a snippet folds to a discarded pure value (e.g. `(+ 1 2)` → `3`): stdout stays empty, but a note on stderr now reports the value the snippet reduces to and why no PHP was emitted

--- a/composer.json
+++ b/composer.json
@@ -103,9 +103,12 @@
         ],
         "test-compiler": "./vendor/bin/phpunit --testsuite=unit,integration --log-junit=data/log-junit.xml",
         "test-compiler:coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --testsuite=unit,integration --coverage-html=data/coverage-html --coverage-xml=data/coverage-xml --log-junit=data/coverage-xml/junit.xml",
+        "test-unit": "./vendor/bin/phpunit --testsuite=unit",
+        "test-integration": "./vendor/bin/phpunit --testsuite=integration",
         "test-agents": "./tools/validate-agents.sh",
         "test-tools": "./tools/bashunit tools/*-test.sh --simple",
         "test-core": "php -d memory_limit=256M ./bin/phel test",
+        "test-core:parallel": "php -d memory_limit=256M ./bin/phel test --parallel=auto",
         "test-quality": [
             "@csrun",
             "@psalm",

--- a/composer.json
+++ b/composer.json
@@ -96,10 +96,13 @@
         ],
         "test": "@test-all",
         "test-all": [
-            "@static-clear-cache",
             "@test-quality",
             "@test-compiler",
             "@test-core"
+        ],
+        "test-all:fresh": [
+            "@static-clear-cache",
+            "@test-all"
         ],
         "test-compiler": "./vendor/bin/phpunit --testsuite=unit,integration --log-junit=data/log-junit.xml",
         "test-compiler:coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --testsuite=unit,integration --coverage-html=data/coverage-html --coverage-xml=data/coverage-xml --log-junit=data/coverage-xml/junit.xml",

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -8,8 +8,9 @@
 4. [Macros](macros.md): `macroexpand`, quasiquote, auto-gensym.
 5. [Runtime](runtime.md): `Lang/`, persistent collections, `Registry`, `\Phel` facade.
 6. [Benchmarks](benchmarks.md): PHPBench setup.
-7. [FAQ](faq.md): grouped by reader.
-8. [CLI flag conventions](cli-flag-conventions.md): standard option names + short aliases.
+7. [Testing performance](testing-performance.md): suite timings, fast local workflows, parallelization.
+8. [FAQ](faq.md): grouped by reader.
+9. [CLI flag conventions](cli-flag-conventions.md): standard option names + short aliases.
 
 ## What to read for what
 
@@ -21,6 +22,7 @@
 | Build an editor / linter / tool | architecture, faq (tool builder) |
 | Compilation bug | compiler, faq (bug hunting) |
 | Profile | benchmarks |
+| Speed up the test loop | testing-performance |
 
 ## Adjacent
 

--- a/docs/internals/testing-performance.md
+++ b/docs/internals/testing-performance.md
@@ -1,0 +1,90 @@
+# Testing Performance &amp; DX
+
+How the test suites are wired, where the wall-clock goes, and the fast paths
+for local work. Numbers below are from a 10-core dev machine (June 2026) and
+are indicative, not a benchmark — re-measure before acting on them.
+
+## The three suites
+
+| Suite | Command | Count | Wall-clock | Parallel today |
+|-------|---------|-------|-----------|----------------|
+| PHPUnit `unit` | `composer test-unit` | 3850 tests | ~4 s | no (not needed) |
+| PHPUnit `integration` | `composer test-integration` | 984 tests | ~91 s | no |
+| Phel core | `composer test-core` | ~6100 assertions | ~93 s serial | opt-in (`--parallel`) |
+
+The full gate is `composer test` → `test-all`: clears static-analysis caches,
+then runs `test-quality` (cs-fixer, psalm, phpstan, rector), `test-compiler`
+(unit + integration), and `test-core`.
+
+## Where the time goes
+
+- **`unit` is already fast** (~1 ms/test). Leave it alone.
+- **`integration` is the bottleneck.** 421 `.test` fixtures (plus the other
+  integration cases) expand to 984 PHPUnit invocations via data providers, each
+  driving the full lexer → parser → analyzer → emitter pipeline, single-process
+  (~92 ms per invocation).
+- **`test-core` barely speeds up under `--parallel`.** Measured 93 s serial vs
+  79 s at `--parallel=auto` (8 workers) — only ~1.2×. Each subprocess worker
+  re-boots `phel.core` from scratch, so worker startup dominates over the
+  per-namespace work being distributed.
+
+## Fast local workflows
+
+You rarely need the whole gate while iterating:
+
+```bash
+composer test-unit                      # ~4 s — pure PHP logic
+composer test-integration               # compiler fixtures only
+composer test-core:parallel             # core lib across workers
+
+./bin/phel test --filter=<regex>        # one test by name
+./bin/phel test --ns="phel.http.*"      # one namespace glob
+./bin/phel test --last-failed           # re-run only last run's failures
+./bin/phel test --watch                 # re-run on .phel change
+./bin/phel test --slowest=10            # surface the slow tests
+```
+
+`phel test` already supports `--filter`, `--ns`, `--include`/`--exclude` tags,
+`--last-failed`, `--watch`, `--repeat`, `--seed`/`--random-order`, `--slowest`,
+multiple reporters, and `--coverage` — see `phel test --help`.
+
+## Proposed improvements (not yet adopted)
+
+### 1. Parallelize `integration` with paratest — ~4× win, but gated
+
+A spike with `brianium/paratest -p8` ran the suite in **~22 s vs ~91 s (4.1×)**.
+The bulk parallelizes cleanly, but 8 command-level E2E classes share
+filesystem / process / global-compiler state and fail under parallel workers:
+
+- `Api/AnalyzeCommandTest`
+- `Build/Command/BuildCommandTest`, `Build/Command/BuildCommandLoadE2ETest`
+- `Lint/LintCommandTest`
+- `Run/Command/Compile/CompileCommandTest`
+- `Run/Command/Eval/EvalCommandTest`
+- `Run/Command/Repl/ReplLazyBundledNamespaceTest`
+- `Run/Command/Test/TestCommandParallel/ParallelTestRunnerTest`
+
+Adopting paratest needs these isolated first — either a separate serial group
+(run them outside the parallel pass) or per-test temp-dir isolation so workers
+don't collide on shared paths. `RealFilesystem::$files` being a process-global
+static is the root of much of this coupling.
+
+### 2. Split the cache-clear out of the default gate
+
+`test-all` runs `static-clear-cache` (psalm + phpstan) on every invocation, so
+local full-gate runs always re-analyze cold. Psalm/PHPStan result caches are
+keyed on file content + config, so reuse is safe; clearing is only needed when
+you suspect a stale cache. Consider keeping the clear as a separate
+`test-all:fresh` (or CI-only) and letting the default reuse caches.
+
+### 3. Quiet the 98 PHPUnit notices in `unit`
+
+The unit suite reports 98 notices. They are noise that hides real signal in the
+summary line; worth triaging and resolving (or asserting against) so a clean
+run reads clean.
+
+### 4. Speed up `--parallel` worker startup for `test-core`
+
+The weak parallel speedup points at per-worker `phel.core` boot cost. Warming
+or sharing a compiled-core snapshot across workers would make `--parallel`
+worth defaulting on in CI and `test-core`.

--- a/docs/internals/testing-performance.md
+++ b/docs/internals/testing-performance.md
@@ -10,11 +10,16 @@ are indicative, not a benchmark — re-measure before acting on them.
 |-------|---------|-------|-----------|----------------|
 | PHPUnit `unit` | `composer test-unit` | 3850 tests | ~4 s | no (not needed) |
 | PHPUnit `integration` | `composer test-integration` | 984 tests | ~91 s | no |
-| Phel core | `composer test-core` | ~6100 assertions | ~93 s serial | opt-in (`--parallel`) |
+| Phel core | `composer test-core` | ~6100 tests | ~6 s warm serial | opt-in (`--parallel`) |
 
-The full gate is `composer test` → `test-all`: clears static-analysis caches,
-then runs `test-quality` (cs-fixer, psalm, phpstan, rector), `test-compiler`
-(unit + integration), and `test-core`.
+The full gate is `composer test` → `test-all`: `test-quality` (cs-fixer, psalm,
+phpstan, rector), `test-compiler` (unit + integration), and `test-core`. It
+reuses the psalm/phpstan result caches; `composer test-all:fresh` clears them
+first for a cold run.
+
+> `test-core` wall-clock swings with the compiled-PHP cache state: a cold first
+> run after a checkout pays the full compile, warm runs are several times
+> faster. Numbers below are warm.
 
 ## Where the time goes
 
@@ -23,10 +28,15 @@ then runs `test-quality` (cs-fixer, psalm, phpstan, rector), `test-compiler`
   integration cases) expand to 984 PHPUnit invocations via data providers, each
   driving the full lexer → parser → analyzer → emitter pipeline, single-process
   (~92 ms per invocation).
-- **`test-core` barely speeds up under `--parallel`.** Measured 93 s serial vs
-  79 s at `--parallel=auto` (8 workers) — only ~1.2×. Each subprocess worker
-  re-boots `phel.core` from scratch, so worker startup dominates over the
-  per-namespace work being distributed.
+- **`test-core --parallel` now reuses per-worker state.** Workers are
+  long-lived and used to re-evaluate their whole dependency closure (mostly the
+  shared `phel.*` stdlib) on every namespace frame — re-executing already-loaded
+  code dominated each frame, so `--parallel=2` was *slower* than serial and
+  4-vs-8 workers plateaued. Each dependency is now evaluated once per worker
+  (like the serial runner). Warm local figures: serial ~5.9 s, `--parallel=auto`
+  ~4.4 s before → ~3.9 s after. The relative win is modest on this small core
+  suite (real per-frame work is only ~20 ms) but grows with the number of
+  namespaces in a project, since the removed re-eval is fixed-cost per frame.
 
 ## Fast local workflows
 
@@ -48,13 +58,13 @@ composer test-core:parallel             # core lib across workers
 `--last-failed`, `--watch`, `--repeat`, `--seed`/`--random-order`, `--slowest`,
 multiple reporters, and `--coverage` — see `phel test --help`.
 
-## Proposed improvements (not yet adopted)
+## Remaining improvements (not yet adopted)
 
-### 1. Parallelize `integration` with paratest — ~4× win, but gated
+### 1. Parallelize `integration` with paratest — ~4× win, but gated on isolation
 
 A spike with `brianium/paratest -p8` ran the suite in **~22 s vs ~91 s (4.1×)**.
 The bulk parallelizes cleanly, but 8 command-level E2E classes share
-filesystem / process / global-compiler state and fail under parallel workers:
+filesystem / process / global-compiler state:
 
 - `Api/AnalyzeCommandTest`
 - `Build/Command/BuildCommandTest`, `Build/Command/BuildCommandLoadE2ETest`
@@ -64,27 +74,30 @@ filesystem / process / global-compiler state and fail under parallel workers:
 - `Run/Command/Repl/ReplLazyBundledNamespaceTest`
 - `Run/Command/Test/TestCommandParallel/ParallelTestRunnerTest`
 
-Adopting paratest needs these isolated first — either a separate serial group
-(run them outside the parallel pass) or per-test temp-dir isolation so workers
-don't collide on shared paths. `RealFilesystem::$files` being a process-global
-static is the root of much of this coupling.
+These can't simply be split into a serial group: tagging them `@group serial`
+and running just that group in one process **still fails** —
+`BuildCommandLoadE2ETest` has a latent inter-class isolation bug that the full
+random-order suite currently masks. Adopting paratest needs that real isolation
+work first (per-test temp-dir isolation; `RealFilesystem::$files` being a
+process-global static is the root of much of the coupling), so it is left as a
+dedicated follow-up.
 
-### 2. Split the cache-clear out of the default gate
+### 2. Drop CLI-opcache cost in `--parallel` workers
 
-`test-all` runs `static-clear-cache` (psalm + phpstan) on every invocation, so
-local full-gate runs always re-analyze cold. Psalm/PHPStan result caches are
-keyed on file content + config, so reuse is safe; clearing is only needed when
-you suspect a stale cache. Consider keeping the clear as a separate
-`test-all:fresh` (or CI-only) and letting the default reuse caches.
+With per-frame re-eval removed (see "Where the time goes"), the next parallel
+ceiling is that CLI opcache is off, so each worker re-parses every compiled
+`.php` it requires. A shared on-disk opcache file-cache across the worker pool
+(spawn workers with `-d opcache.enable_cli=1 -d opcache.file_cache=…`) would let
+worker N reuse what worker 1 compiled. Needs opcache-availability detection and
+cache lifecycle handling — its own change.
 
-### 3. Quiet the 98 PHPUnit notices in `unit`
+### 3. Convert passive mocks to stubs (the 98 `unit` notices)
 
-The unit suite reports 98 notices. They are noise that hides real signal in the
-summary line; worth triaging and resolving (or asserting against) so a clean
-run reads clean.
-
-### 4. Speed up `--parallel` worker startup for `test-core`
-
-The weak parallel speedup points at per-worker `phel.core` boot cost. Warming
-or sharing a compiled-core snapshot across workers would make `--parallel`
-worth defaulting on in CI and `test-core`.
+All 98 PHPUnit notices in the `unit` suite are one category: *"No expectations
+were configured for the mock object … use a test stub instead."* They come from
+`createMock()` used as a passive stub (no `->expects()`). The fix is mechanical
+but wide — `createMock(X::class)` → `createStub(X::class)` at the no-expectation
+sites across ~17 files (interfaces: `CompilerFacadeInterface`,
+`NamespaceExtractorInterface`, `BuildFacadeInterface`, `CommandFacadeInterface`,
+`PhelFnLoaderInterface`, `PrinterInterface`). Each site must be checked for an
+absent `->expects()` before converting, so it warrants its own focused PR.

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -481,16 +481,6 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
 ;; Collection diff (= failures)
 ;; --------------------------
 
-(def- diff-min-count
-  ;; Render a collection diff only when at least one side has more than this
-  ;; many entries, so small literals keep the original single-line summary.
-  3)
-
-(def- diff-min-readable-length
-  ;; Or when either side prints longer than this many characters; small
-  ;; collections of long values still benefit from a stacked diff.
-  80)
-
 (defn- sequential?
   "Returns true when `v` is a vector or a list: the two ordered shapes the diff renderer aligns by index."
   [v]
@@ -502,14 +492,6 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
   (or (and (map? a) (map? b))
       (and (set? a) (set? b))
       (and (sequential? a) (sequential? b))))
-
-(defn- diff-worth-rendering?
-  "Decides whether `expected` and `actual` are large enough to justify a block-style diff. Below the thresholds the existing summary line is more readable than the diff."
-  [expected actual]
-  (or (> (count expected) diff-min-count)
-      (> (count actual) diff-min-count)
-      (> (php/strlen (readable-str expected)) diff-min-readable-length)
-      (> (php/strlen (readable-str actual)) diff-min-readable-length)))
 
 (defn- print-diff-line [marker text]
   (println (str "    " marker " " text)))
@@ -587,10 +569,10 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
     (print-sequential-diff expected actual)))
 
 (defn- collection-diff-applicable?
-  "Returns true when a `=`/`not=` failure carries two same-shape collections big enough to benefit from a stacked diff."
+  "Returns true when a `=`/`not=` failure carries two same-shape collections that actually differ. Same-shape rules out scalar pairs (a `1`/`2` diff is noise); the `not=` check rules out a `not=` failure's equal pair, which would render an empty diff."
   [expected actual]
   (and (same-shape? expected actual)
-       (diff-worth-rendering? expected actual)))
+       (not= expected actual)))
 
 ;; --------------------------
 ;; String diff (= failures)

--- a/src/php/Filesystem/Infrastructure/RealFilesystem.php
+++ b/src/php/Filesystem/Infrastructure/RealFilesystem.php
@@ -35,7 +35,11 @@ final class RealFilesystem implements FilesystemInterface
     public function clearAll(): void
     {
         foreach (self::$files as $file) {
-            unlink($file);
+            // $files is process-global static, so a path may already be gone
+            // (cleared by another run or never written) — skip rather than warn.
+            if (file_exists($file)) {
+                unlink($file);
+            }
         }
 
         self::reset();

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -196,40 +196,11 @@ HELP)
             $nsPatterns = (array) $input->getOption(TestCommandOptionParser::OPT_NS);
             $namespacesInformation = new TestNamespacePruner()->prune($namespacesInformation, $nsPatterns);
 
-            // Suppress output during file loading phase and filter out integration test fixtures
-            $feedback->startLoading(count($namespacesInformation));
-            ob_start();
-            $filteredNamespaces = [];
-            /** @var list<array{0: NamespaceInformation, 1: Throwable}> $compileErrors */
-            $compileErrors = [];
-            foreach ($namespacesInformation as $info) {
-                $feedback->advance($info->getNamespace());
-
-                // Skip integration test fixture files - they are for PHPUnit tests only
-                if (str_contains($info->getFile(), 'tests/php/Integration/')) {
-                    continue;
-                }
-
-                if (str_contains($info->getFile(), 'tests/php/Benchmark/')) {
-                    continue;
-                }
-
-                try {
-                    $this->getFacade()->evalFile($info);
-                    $filteredNamespaces[] = $info;
-                } catch (Throwable $e) {
-                    if ($failFast) {
-                        ob_end_clean();
-                        $feedback->finishLoading();
-                        throw $e;
-                    }
-
-                    $compileErrors[] = [$info, $e];
-                }
-            }
-
-            ob_end_clean();
-            $feedback->finishLoading();
+            [$filteredNamespaces, $compileErrors] = $this->loadTestNamespaces(
+                $namespacesInformation,
+                $failFast,
+                $feedback,
+            );
 
             $this->reportCompileErrors($output, $compileErrors);
 
@@ -396,6 +367,56 @@ HELP)
         }
 
         $output->writeln($content);
+    }
+
+    /**
+     * Evaluates each discovered namespace, suppressing load-phase output and
+     * skipping PHPUnit-only fixtures. Returns the namespaces that compiled
+     * cleanly alongside the errors collected from the rest. With $failFast the
+     * first failure rethrows after restoring the output buffer and feedback.
+     *
+     * @param list<NamespaceInformation> $namespacesInformation
+     *
+     * @return array{0: list<NamespaceInformation>, 1: list<array{0: NamespaceInformation, 1: Throwable}>}
+     */
+    private function loadTestNamespaces(
+        array $namespacesInformation,
+        bool $failFast,
+        TestLoadingFeedback $feedback,
+    ): array {
+        $feedback->startLoading(count($namespacesInformation));
+        ob_start();
+        $filteredNamespaces = [];
+        $compileErrors = [];
+        foreach ($namespacesInformation as $info) {
+            $feedback->advance($info->getNamespace());
+            // These fixtures are PHPUnit-only; evaluating them as Phel namespaces is wrong.
+            if (str_contains($info->getFile(), 'tests/php/Integration/')) {
+                continue;
+            }
+
+            if (str_contains($info->getFile(), 'tests/php/Benchmark/')) {
+                continue;
+            }
+
+            try {
+                $this->getFacade()->evalFile($info);
+                $filteredNamespaces[] = $info;
+            } catch (Throwable $e) {
+                if ($failFast) {
+                    ob_end_clean();
+                    $feedback->finishLoading();
+                    throw $e;
+                }
+
+                $compileErrors[] = [$info, $e];
+            }
+        }
+
+        ob_end_clean();
+        $feedback->finishLoading();
+
+        return [$filteredNamespaces, $compileErrors];
     }
 
     /**

--- a/src/php/Run/Infrastructure/Command/TestWorkerCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestWorkerCommand.php
@@ -53,6 +53,9 @@ final class TestWorkerCommand extends Command
 
     public const string COMMAND_NAME = '_test-worker';
 
+    /** @var array<string, true> Dependency files already evaluated by this long-lived worker. */
+    private array $preloadedFiles = [];
+
     protected function configure(): void
     {
         $this->setName(self::COMMAND_NAME)
@@ -124,7 +127,18 @@ final class TestWorkerCommand extends Command
         }
 
         foreach ($this->getFacade()->getDependenciesFromPaths([$file]) as $info) {
+            // The worker lives for the whole run, so a dependency stays
+            // registered across frames; re-evaluating it (mostly the phel.*
+            // stdlib shared by every namespace) just re-executes it and
+            // dominated each frame. Eval each file once per worker, as the
+            // serial runner already does.
+            $depFile = $info->getFile();
+            if (isset($this->preloadedFiles[$depFile])) {
+                continue;
+            }
+
             $this->getFacade()->evalFile($info);
+            $this->preloadedFiles[$depFile] = true;
         }
     }
 

--- a/tests/phel/reporter-diff.phel
+++ b/tests/phel/reporter-diff.phel
@@ -2,9 +2,10 @@
   (:require phel.test :as t :refer [deftest is]))
 
 ;; Coverage for the unified-diff block emitted by the default reporter
-;; when an `=` failure compares two large collections of the same
-;; shape. The diff supplements the existing "Form / evaluated to / but
-;; is not" summary; small primitives keep the legacy single-line view.
+;; when an `=` failure compares two same-shape collections. The diff
+;; supplements the existing "Form / evaluated to / but is not" summary
+;; for any differing collection, regardless of size; scalar pairs and
+;; mixed shapes keep the single-line view.
 
 (defn- failure-event
   "Builds the synthetic `:failed` event a `=` assertion would produce
@@ -31,7 +32,7 @@
             :failures [(failure-event expected actual)]}))))
 
 ;; ---------------------------------------------------------------------------
-;; Threshold: small primitive failures keep the legacy single-line summary
+;; Scalar failures keep the single-line summary; collections always diff
 ;; ---------------------------------------------------------------------------
 
 (deftest test-small-primitive-failure-skips-diff-block
@@ -41,10 +42,12 @@
     (is (= 0 (php/preg_match "/Diff:/" out))
         "no Diff block for non-collection values")))
 
-(deftest test-tiny-vector-failure-skips-diff-block
+(deftest test-tiny-vector-failure-renders-diff-block
   (let [out (run-default-reporter [1 2] [3 4])]
-    (is (= 0 (php/preg_match "/Diff:/" out))
-        "vectors with 2 entries fall under the diff threshold")))
+    (is (php/preg_match "/Diff:/" out)
+        "even a 2-entry vector renders a diff when it differs")
+    (is (php/preg_match "/- \\[0\\] 1/" out) "differing index marked with -")
+    (is (php/preg_match "/\\+ \\[0\\] 3/" out) "differing index marked with +")))
 
 ;; ---------------------------------------------------------------------------
 ;; Map diff: + added, - removed, ~ changed (sorted by key)
@@ -131,15 +134,13 @@
         "no diff block for not= failures: the values are equal")))
 
 ;; ---------------------------------------------------------------------------
-;; Long-printed-but-small collections still trigger the diff
+;; Single-element collections still trigger the diff
 ;; ---------------------------------------------------------------------------
 
-(deftest test-long-printed-vector-triggers-diff-even-with-few-entries
-  (let [long-a "this is a fairly long string that pushes the readable length over the threshold"
-        long-b "another fairly long string that also pushes the readable length over the threshold"
-        out    (run-default-reporter [long-a] [long-b])]
+(deftest test-single-element-vector-triggers-diff
+  (let [out (run-default-reporter ["only-a"] ["only-b"])]
     (is (php/preg_match "/Diff:/" out)
-        "vector with one long element still renders as a diff block")))
+        "vector with one differing element renders a diff block")))
 
 ;; ---------------------------------------------------------------------------
 ;; Mixed-type keys do not break the diff sort

--- a/tests/php/Integration/Run/Command/Test/TestCommandParallel/ParallelTestRunnerTest.php
+++ b/tests/php/Integration/Run/Command/Test/TestCommandParallel/ParallelTestRunnerTest.php
@@ -37,6 +37,36 @@ final class ParallelTestRunnerTest extends TestCase
     }
 
     /**
+     * Each worker is long-lived and handles many namespaces across frames,
+     * reusing a dependency it evaluated for an earlier frame instead of
+     * re-evaluating it. Feed 2 workers several namespaces so a worker
+     * processes multiple frames, and assert every test still resolves and
+     * passes (Error: 0) — a regression guard for the per-worker dependency
+     * dedup: dropping a still-needed def would surface as a resolve error
+     * in a later frame.
+     */
+    public function test_worker_reuses_dependencies_across_frames_without_dropping_defs(): void
+    {
+        $project = $this->projectRoot();
+
+        [$status, $stdout] = $this->runPhel(
+            [
+                'test', '--parallel=2',
+                'tests/phel/walk.phel',
+                'tests/phel/test-framework.phel',
+                'tests/phel/reporter-diff.phel',
+                'tests/phel/reporters.phel',
+            ],
+            $project,
+        );
+
+        self::assertSame(0, $status, 'expected success exit, stdout was: ' . $stdout);
+        self::assertMatchesRegularExpression('/Failed:\s*0/', $stdout);
+        self::assertMatchesRegularExpression('/Error:\s*0/', $stdout);
+        self::assertMatchesRegularExpression('/Ran \d+ namespace\(s\) across 2 worker\(s\)/', $stdout);
+    }
+
+    /**
      * `--parallel=auto` resolves through CpuCountDetector and otherwise
      * follows the same pipeline; smoke-test that the resolved flow is
      * the same as an explicit worker count.

--- a/tests/php/Unit/Filesystem/Infrastructure/RealFilesystemTest.php
+++ b/tests/php/Unit/Filesystem/Infrastructure/RealFilesystemTest.php
@@ -6,6 +6,9 @@ namespace PhelTest\Unit\Filesystem\Infrastructure;
 
 use Phel\Filesystem\Infrastructure\RealFilesystem;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use const E_WARNING;
 
 final class RealFilesystemTest extends TestCase
 {
@@ -50,6 +53,31 @@ final class RealFilesystemTest extends TestCase
         self::assertFileExists($file);
 
         unlink($file);
+    }
+
+    public function test_clear_all_skips_already_removed_paths_without_warning(): void
+    {
+        $present = $this->createTempFile();
+        $alreadyGone = $this->createTempFile();
+        // Simulate a path a prior run already deleted: $files is process-global static.
+        unlink($alreadyGone);
+
+        $filesystem = new RealFilesystem();
+        $filesystem->addFile($alreadyGone);
+        $filesystem->addFile($present);
+
+        set_error_handler(static function (int $severity, string $message): bool {
+            throw new RuntimeException('Unexpected PHP warning: ' . $message);
+        }, E_WARNING);
+
+        try {
+            $filesystem->clearAll();
+        } finally {
+            restore_error_handler();
+        }
+
+        // No warning fired for the missing path, and present files were still cleaned.
+        self::assertFileDoesNotExist($present);
     }
 
     public function test_static_state_is_shared_across_instances(): void


### PR DESCRIPTION
## 🤔 Background

Improving the testing experience for **developers using Phel** (`phel test`) and for **contributors** (the internal suites). Measured the suites, fixed the high-confidence wins, documented the larger follow-ups.

## 💡 Goal

Make `phel test` faster and its failures clearer; tidy the internal test workflow.

## 🔖 Changes

**For Phel users**
- **perf(test):** `phel test --parallel` workers no longer re-evaluate the shared `phel.*` stdlib on every namespace frame (each dep is evaluated once per worker, like the serial runner). Fixes `--parallel=2` being slower than serial; the win grows with project size.
- **feat(test):** failures now show the `+`/`-`/`~` structural diff for *any* differing same-shape collection, not only large ones — small maps/vectors no longer print two near-identical lines with no diff. Scalars/mixed shapes keep the single-line summary.
- **fix(filesystem):** no more `unlink(...): No such file or directory` warnings on every `phel test` / build run.

**For contributors**
- **chore(composer):** add `test-unit`, `test-integration`, `test-core:parallel`; the default gate now reuses psalm/phpstan caches (cold clear moved to `test-all:fresh`).
- **ref(run):** extract `loadTestNamespaces()` from `TestCommand::execute()` (no behavior change).
- **docs(internals):** new `testing-performance.md` — timings, fast workflows, follow-ups.

**Documented follow-ups** (in `docs/internals/testing-performance.md`)
- paratest for `integration` (~4×) — blocked on real test-isolation bugs first.
- opcache file-cache for parallel workers.
- `createMock`→`createStub` for the 98 `unit` notices (~17 files).

## ✅ Verification

cs-fixer / psalm / phpstan / rector clean; `unit` 3851 pass, `core` 6100 pass (serial + `--parallel`), `ParallelTestRunnerTest` 9/9. New regression tests cover the cleanup fix and the per-worker dedup.
