### PR TITLE
perf(test): shared opcache file-cache for parallel test workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Performance
 
 - `phel test --parallel` workers no longer re-evaluate their full dependency closure (mostly the shared `phel.*` stdlib) on every namespace frame: each dependency is evaluated once per long-lived worker, as the serial runner already does. Removes the per-frame re-execution that made `--parallel=2` slower than serial and capped scaling; the speedup grows with the number of namespaces in a project
+- `phel test --parallel` workers now share an on-disk OPcache file cache, so each worker reuses the compiled `.php` opcode the first worker already parsed instead of re-parsing the whole stdlib closure itself. Enabled automatically when the Zend OPcache extension is available; a graceful no-op otherwise (#2628)
 
 ## [0.46.0](https://github.com/phel-lang/phel-lang/compare/v0.45.1...v0.46.0) - 2026-06-25
 

--- a/docs/internals/testing-performance.md
+++ b/docs/internals/testing-performance.md
@@ -82,14 +82,16 @@ work first (per-test temp-dir isolation; `RealFilesystem::$files` being a
 process-global static is the root of much of the coupling), so it is left as a
 dedicated follow-up.
 
-### 2. Drop CLI-opcache cost in `--parallel` workers
+### 2. Drop CLI-opcache cost in `--parallel` workers — adopted (#2628)
 
 With per-frame re-eval removed (see "Where the time goes"), the next parallel
-ceiling is that CLI opcache is off, so each worker re-parses every compiled
-`.php` it requires. A shared on-disk opcache file-cache across the worker pool
-(spawn workers with `-d opcache.enable_cli=1 -d opcache.file_cache=…`) would let
-worker N reuse what worker 1 compiled. Needs opcache-availability detection and
-cache lifecycle handling — its own change.
+ceiling was that CLI opcache is off, so each worker re-parsed every compiled
+`.php` it requires. Workers are now spawned with a shared on-disk opcache
+file-cache (`-d opcache.enable_cli=1 -d opcache.file_cache=<temp-dir>/opcache-workers`)
+so worker N reuses what worker 1 compiled. `RunFactory` enables it only when the
+Zend OPcache extension is loaded (a graceful no-op otherwise) and pre-creates the
+cache dir, which PHP requires to exist at startup. The serial path stays
+opcache-off by design.
 
 ### 3. Convert passive mocks to stubs (the 98 `unit` notices)
 

--- a/src/php/Run/Application/Test/ParallelTestOrchestrator.php
+++ b/src/php/Run/Application/Test/ParallelTestOrchestrator.php
@@ -42,9 +42,15 @@ final readonly class ParallelTestOrchestrator
      */
     private const int SELECT_TIMEOUT_MICROS = 100_000;
 
+    /**
+     * @param list<string> $opcacheFlags `-d` flags so every worker shares one
+     *                                   OPcache file cache; empty when OPcache
+     *                                   is unavailable
+     */
     public function __construct(
         private string $phpBinary,
         private string $phelBinary,
+        private array $opcacheFlags = [],
     ) {}
 
     /**
@@ -130,7 +136,7 @@ final readonly class ParallelTestOrchestrator
     {
         $workers = [];
         for ($i = 0; $i < $count; ++$i) {
-            $workers[] = TestWorkerHandle::spawn($this->phpBinary, $this->phelBinary);
+            $workers[] = TestWorkerHandle::spawn($this->phpBinary, $this->phelBinary, $this->opcacheFlags);
         }
 
         return $workers;

--- a/src/php/Run/Application/Test/TestWorkerHandle.php
+++ b/src/php/Run/Application/Test/TestWorkerHandle.php
@@ -54,9 +54,13 @@ final class TestWorkerHandle
         stream_set_blocking($this->stderr, false);
     }
 
-    public static function spawn(string $phpBinary, string $phelBinary): self
+    /**
+     * @param list<string> $opcacheFlags `-d` flags spliced before the script so
+     *                                   the pool shares one OPcache file cache
+     */
+    public static function spawn(string $phpBinary, string $phelBinary, array $opcacheFlags = []): self
     {
-        $cmd = [$phpBinary, $phelBinary, '_test-worker'];
+        $cmd = self::buildCommand($phpBinary, $phelBinary, $opcacheFlags);
 
         $pipes = [];
         $process = @proc_open(
@@ -74,6 +78,16 @@ final class TestWorkerHandle
         }
 
         return new self($process, $pipes);
+    }
+
+    /**
+     * @param list<string> $opcacheFlags
+     *
+     * @return list<string>
+     */
+    public static function buildCommand(string $phpBinary, string $phelBinary, array $opcacheFlags): array
+    {
+        return [$phpBinary, ...$opcacheFlags, $phelBinary, '_test-worker'];
     }
 
     /**

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -43,6 +43,7 @@ use Phel\Shared\Facade\ApiFacadeInterface;
 use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
 use Phel\Shared\Facade\CompilerFacadeInterface;
+use Phel\Shared\Performance\OpcacheWorkerFlags;
 use Phel\Shared\Printer\Printer;
 use Phel\Shared\Printer\PrinterInterface;
 use Phel\Shared\ScalarCoercion;
@@ -50,6 +51,8 @@ use Phel\Shared\VersionResolver;
 
 use function extension_loaded;
 use function is_array;
+use function is_dir;
+use function mkdir;
 
 /**
  * @extends AbstractFactory<RunConfig>
@@ -289,6 +292,7 @@ class RunFactory extends AbstractFactory
         return new ParallelTestOrchestrator(
             PHP_BINARY,
             $this->resolvePhelBinaryPath(),
+            $this->resolveOpcacheWorkerFlags(),
         );
     }
 
@@ -303,6 +307,31 @@ class RunFactory extends AbstractFactory
             $this->getCommandFacade(),
             new TestWatchLoop(new WatchFileScanner()),
         );
+    }
+
+    /**
+     * `-d` flags that point the whole worker pool at one on-disk OPcache file
+     * cache, so worker N reuses the compiled `.php` worker 1 already parsed.
+     * No-op when OPcache is unavailable or the cache dir cannot be prepared.
+     *
+     * @return list<string>
+     */
+    private function resolveOpcacheWorkerFlags(): array
+    {
+        if (!extension_loaded('Zend OPcache')) {
+            return [];
+        }
+
+        // opcache.file_cache must be an absolute, existing directory or PHP
+        // aborts at startup, so create it before any worker is spawned. It
+        // lives under the temp dir (not the compiled-code cache) so it survives
+        // `phel clear-cache` and keeps paying off across runs.
+        $cacheDir = $this->getFilesystemFacade()->getTempDir() . '/opcache-workers';
+        if (!is_dir($cacheDir) && !@mkdir($cacheDir, 0777, true) && !is_dir($cacheDir)) {
+            return [];
+        }
+
+        return OpcacheWorkerFlags::forFileCache(true, $cacheDir);
     }
 
     private function resolvePhelBinaryPath(): string

--- a/src/php/Shared/Performance/OpcacheWorkerFlags.php
+++ b/src/php/Shared/Performance/OpcacheWorkerFlags.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared\Performance;
+
+/**
+ * Builds the `-d` CLI flags that make a spawned PHP process share a compiled-code
+ * cache with its siblings through an on-disk OPcache file cache.
+ *
+ * Parallel test workers each `require` the same compiled `.php` stdlib; with CLI
+ * OPcache off (the default) every worker re-parses them. Pointing the pool at one
+ * file cache lets worker N reuse what worker 1 compiled.
+ *
+ * Pure: callers pass OPcache availability and the resolved cache dir so it stays
+ * trivially testable. Returns no flags (plain workers) when OPcache is absent or
+ * no cache dir is available — PHP aborts at startup if `opcache.file_cache` is an
+ * empty/missing path, so degrading is safer than emitting a half-set flag.
+ */
+final class OpcacheWorkerFlags
+{
+    /**
+     * @return list<string> `-d` flag pairs, or an empty list to spawn plain workers
+     */
+    public static function forFileCache(bool $opcacheLoaded, string $fileCacheDir): array
+    {
+        if (!$opcacheLoaded || $fileCacheDir === '') {
+            return [];
+        }
+
+        return ['-d', 'opcache.enable_cli=1', '-d', 'opcache.file_cache=' . $fileCacheDir];
+    }
+}

--- a/tests/php/Integration/Run/Command/Test/TestCommandParallel/ParallelTestRunnerTest.php
+++ b/tests/php/Integration/Run/Command/Test/TestCommandParallel/ParallelTestRunnerTest.php
@@ -4,14 +4,23 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Run\Command\Test\TestCommandParallel;
 
+use FilesystemIterator;
 use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
 
 use function dirname;
+use function extension_loaded;
 use function fclose;
+use function is_dir;
 use function is_resource;
 use function proc_close;
 use function proc_open;
+use function str_contains;
 use function stream_get_contents;
+use function sys_get_temp_dir;
+use function unlink;
 
 final class ParallelTestRunnerTest extends TestCase
 {
@@ -197,6 +206,83 @@ final class ParallelTestRunnerTest extends TestCase
         self::assertMatchesRegularExpression('/Passed:\s+\d+/', $stdout);
         self::assertMatchesRegularExpression('/Failed:\s+0/', $stdout);
         self::assertMatchesRegularExpression('/Total:\s+\d+/', $stdout);
+    }
+
+    /**
+     * With OPcache available, workers are spawned with a shared on-disk file
+     * cache so worker N reuses what worker 1 compiled. Prove the wired path
+     * actually persists opcode: after a parallel run the `opcache-workers`
+     * cache holds compiled `.bin` files. (OPcache writes each file once, so we
+     * assert the cache is populated rather than that it grew on every run.)
+     * Skips when OPcache is absent (the flags are a graceful no-op there).
+     */
+    public function test_parallel_run_populates_shared_opcache_file_cache(): void
+    {
+        if (!extension_loaded('Zend OPcache')) {
+            self::markTestSkipped('Zend OPcache is not loaded; worker file cache is intentionally skipped.');
+        }
+
+        // Start cold so a populated cache afterwards proves *this* run wrote it,
+        // not a leftover from an earlier run.
+        $this->clearWorkerOpcodeCache();
+
+        [$status, $stdout] = $this->runPhel(
+            ['test', '--parallel=2', 'tests/phel/walk.phel'],
+            $this->projectRoot(),
+        );
+
+        self::assertSame(0, $status, 'expected success exit, stdout was: ' . $stdout);
+        self::assertGreaterThan(
+            0,
+            $this->cachedOpcodeFileCount(),
+            'expected the parallel workers to persist compiled opcode under opcache-workers/',
+        );
+    }
+
+    private function cachedOpcodeFileCount(): int
+    {
+        $count = 0;
+        foreach ($this->workerOpcodeCacheFiles() as $file) {
+            ++$count;
+        }
+
+        return $count;
+    }
+
+    private function clearWorkerOpcodeCache(): void
+    {
+        foreach ($this->workerOpcodeCacheFiles() as $file) {
+            @unlink($file->getPathname());
+        }
+    }
+
+    /**
+     * Phel's default temp dir is <sys-temp>/phel/tmp and the worker cache hangs
+     * off it at .../opcache-workers; scan only Phel's own temp namespace
+     * (readable, narrow) for the persisted opcode files (.bin).
+     *
+     * @return iterable<SplFileInfo>
+     */
+    private function workerOpcodeCacheFiles(): iterable
+    {
+        $phelTempRoot = sys_get_temp_dir() . '/phel';
+        if (!is_dir($phelTempRoot)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($phelTempRoot, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::LEAVES_ONLY,
+        );
+
+        foreach ($iterator as $file) {
+            if ($file instanceof SplFileInfo
+                && $file->getExtension() === 'bin'
+                && str_contains($file->getPathname(), '/opcache-workers/')
+            ) {
+                yield $file;
+            }
+        }
     }
 
     /**

--- a/tests/php/Unit/Run/Application/Test/TestWorkerHandleTest.php
+++ b/tests/php/Unit/Run/Application/Test/TestWorkerHandleTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Application\Test;
+
+use Phel\Run\Application\Test\TestWorkerHandle;
+use PHPUnit\Framework\TestCase;
+
+final class TestWorkerHandleTest extends TestCase
+{
+    public function test_command_splices_opcache_flags_between_php_binary_and_script(): void
+    {
+        $cmd = TestWorkerHandle::buildCommand(
+            '/usr/bin/php',
+            '/app/bin/phel',
+            ['-d', 'opcache.enable_cli=1', '-d', 'opcache.file_cache=/var/phel/opcache-workers'],
+        );
+
+        // -d flags must precede the script so PHP applies them; the script and
+        // subcommand stay last so argv parsing is unchanged.
+        self::assertSame(
+            [
+                '/usr/bin/php',
+                '-d', 'opcache.enable_cli=1',
+                '-d', 'opcache.file_cache=/var/phel/opcache-workers',
+                '/app/bin/phel', '_test-worker',
+            ],
+            $cmd,
+        );
+    }
+
+    public function test_command_without_opcache_flags_is_the_plain_worker_invocation(): void
+    {
+        self::assertSame(
+            ['/usr/bin/php', '/app/bin/phel', '_test-worker'],
+            TestWorkerHandle::buildCommand('/usr/bin/php', '/app/bin/phel', []),
+        );
+    }
+}

--- a/tests/php/Unit/Shared/Performance/OpcacheWorkerFlagsTest.php
+++ b/tests/php/Unit/Shared/Performance/OpcacheWorkerFlagsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared\Performance;
+
+use Phel\Shared\Performance\OpcacheWorkerFlags;
+use PHPUnit\Framework\TestCase;
+
+final class OpcacheWorkerFlagsTest extends TestCase
+{
+    public function test_returns_enable_cli_and_file_cache_flags_when_opcache_is_loaded(): void
+    {
+        $flags = OpcacheWorkerFlags::forFileCache(true, '/var/phel/opcache-workers');
+
+        self::assertSame(
+            ['-d', 'opcache.enable_cli=1', '-d', 'opcache.file_cache=/var/phel/opcache-workers'],
+            $flags,
+        );
+    }
+
+    public function test_returns_no_flags_when_opcache_extension_is_absent(): void
+    {
+        self::assertSame([], OpcacheWorkerFlags::forFileCache(false, '/var/phel/opcache-workers'));
+    }
+
+    public function test_returns_no_flags_when_cache_dir_is_empty(): void
+    {
+        // No cache dir means the file_cache path would be empty, which makes
+        // PHP abort at startup; degrade to plain workers instead.
+        self::assertSame([], OpcacheWorkerFlags::forFileCache(true, ''));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Follow-up to #2625. `phel test --parallel` workers no longer re-eval the stdlib per frame, but CLI OPcache is off, so each worker still re-parses every compiled `.php` it requires — the next parallel ceiling.

## 💡 Goal

Let worker N reuse the opcode worker 1 already compiled, by pointing the whole pool at one shared on-disk OPcache file cache.

## 🔖 Changes

- Workers are spawned with `-d opcache.enable_cli=1 -d opcache.file_cache=<temp-dir>/opcache-workers`. Enabled only when the Zend OPcache extension is loaded; a graceful no-op otherwise (no flags, plain workers).
- `RunFactory` pre-creates the cache dir (PHP aborts at startup if `opcache.file_cache` is missing/relative) under the Phel temp dir, so it survives `phel clear-cache`.
- New pure `Phel\Shared\Performance\OpcacheWorkerFlags` assembles the flags (unit-tested); `TestWorkerHandle::buildCommand()` splices them before the script.
- Tests: unit coverage for flag assembly + command line; integration test proves a cold run repopulates the cache.

Final `ref` review (self + a focused reviewer pass) surfaced no changes to make.

Closes #2628