### PR TITLE
test: convert passive createMock() to createStub()

### DIFF
--- a/tests/php/Unit/Build/Application/CachedNamespaceExtractorTest.php
+++ b/tests/php/Unit/Build/Application/CachedNamespaceExtractorTest.php
@@ -53,7 +53,7 @@ final class CachedNamespaceExtractorTest extends TestCase
         file_put_contents($primaryPath, '(ns split\\ns)');
         file_put_contents($secondaryPath, '(in-ns split\\ns)');
 
-        $inner = $this->createMock(NamespaceExtractorInterface::class);
+        $inner = $this->createStub(NamespaceExtractorInterface::class);
         $inner->method('getNamespaceFromFile')->willReturnCallback(
             static fn(string $path): NamespaceInformation => str_ends_with($path, 'main.phel') ? $primaryInfo : $secondaryInfo,
         );
@@ -128,7 +128,7 @@ final class CachedNamespaceExtractorTest extends TestCase
         );
 
         $seenPaths = [];
-        $inner = $this->createMock(NamespaceExtractorInterface::class);
+        $inner = $this->createStub(NamespaceExtractorInterface::class);
         $inner->method('getNamespaceFromFile')->willReturnCallback(
             static function (string $path) use (&$seenPaths, $visibleInfo): NamespaceInformation {
                 $seenPaths[] = $path;
@@ -161,7 +161,7 @@ final class CachedNamespaceExtractorTest extends TestCase
 
         $goodInfo = new NamespaceInformation($goodPath, 'good\\ns', [], isPrimaryDefinition: true);
 
-        $inner = $this->createMock(NamespaceExtractorInterface::class);
+        $inner = $this->createStub(NamespaceExtractorInterface::class);
         $inner->method('getNamespaceFromFile')->willReturnCallback(
             static function (string $path) use ($goodInfo): NamespaceInformation {
                 if (str_ends_with($path, 'good.phel')) {

--- a/tests/php/Unit/Build/Application/FileCompilerTest.php
+++ b/tests/php/Unit/Build/Application/FileCompilerTest.php
@@ -63,7 +63,7 @@ final class FileCompilerTest extends TestCase
 
     private function createCapturingCompilerFacade(): CompilerFacadeInterface
     {
-        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade = $this->createStub(CompilerFacadeInterface::class);
         $compilerFacade->method('compile')
             ->willReturnCallback(function (string $code, CompileOptions $options): EmitterResult {
                 $this->capturedOptions = $options;

--- a/tests/php/Unit/Build/Application/FileEvaluatorTest.php
+++ b/tests/php/Unit/Build/Application/FileEvaluatorTest.php
@@ -53,7 +53,7 @@ final class FileEvaluatorTest extends TestCase
         $compilerFacade->expects($this->never())->method('compileForCache');
         $compilerFacade->expects($this->never())->method('eval');
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -86,7 +86,7 @@ final class FileEvaluatorTest extends TestCase
         $compilerFacade->expects($this->never())->method('compileForCache');
         $compilerFacade->expects($this->never())->method('eval');
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -121,7 +121,7 @@ final class FileEvaluatorTest extends TestCase
             ->method('compileForCache')
             ->willReturn(new EmitterResult(false, '$compiled = true;', '', ''));
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -153,7 +153,7 @@ final class FileEvaluatorTest extends TestCase
         $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
         $compilerFacade->expects($this->once())->method('eval');
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -180,7 +180,7 @@ final class FileEvaluatorTest extends TestCase
             ->method('compileForCache')
             ->willReturn(new EmitterResult(false, '$compiled = true;', '', ''));
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -204,11 +204,11 @@ final class FileEvaluatorTest extends TestCase
 
         $cache = new CompiledCodeCache($cacheDir);
 
-        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade = $this->createStub(CompilerFacadeInterface::class);
         $compilerFacade->method('compileForCache')
             ->willReturn(new EmitterResult(false, $compiledCode, '', ''));
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -241,7 +241,7 @@ final class FileEvaluatorTest extends TestCase
             ))
             ->willReturn(new EmitterResult(true, '$result = 123;', 'AAAA', $sourceFile));
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -267,7 +267,7 @@ final class FileEvaluatorTest extends TestCase
         $compilerFacade->expects($this->once())->method('eval');
         $compilerFacade->expects($this->never())->method('compileForCache');
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -303,7 +303,7 @@ final class FileEvaluatorTest extends TestCase
             ->method('compileForCache')
             ->willReturn(new EmitterResult(false, '$new = true;', '', ''));
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -326,11 +326,11 @@ final class FileEvaluatorTest extends TestCase
         $cache = new CompiledCodeCache($cacheDir);
         $cache->put($sourceFile, $namespace, md5($sourceCode), 'this is not valid php syntax {{{');
 
-        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade = $this->createStub(CompilerFacadeInterface::class);
         $compilerFacade->method('compileForCache')
             ->willReturn(new EmitterResult(false, '$result = 42;', '', ''));
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -354,7 +354,7 @@ final class FileEvaluatorTest extends TestCase
         $cache->put($sourceFile, $namespace, md5($sourceCode), 'throw new \\RuntimeException("User code error");');
 
         $compilerFacade = $this->createStub(CompilerFacadeInterface::class);
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -393,7 +393,7 @@ final class FileEvaluatorTest extends TestCase
         // analyzeNsForm path should NOT be used when env data is present
         $compilerFacade->expects($this->never())->method('lexString');
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -423,7 +423,7 @@ final class FileEvaluatorTest extends TestCase
         // lexString should be called as fallback (analyzeNsForm path)
         $compilerFacade->expects($this->once())->method('lexString');
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -458,7 +458,7 @@ final class FileEvaluatorTest extends TestCase
             ->with($namespace)
             ->willReturn($envData);
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -489,7 +489,7 @@ final class FileEvaluatorTest extends TestCase
             ->with($sourceCode, $sourceFile)
             ->willThrowException(new RuntimeException('lex failure'));
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -511,11 +511,11 @@ final class FileEvaluatorTest extends TestCase
         $cache = new CompiledCodeCache($cacheDir);
         $cache->put($sourceFile, $namespace, md5($sourceCode), '$result = 1;');
 
-        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade = $this->createStub(CompilerFacadeInterface::class);
         $compilerFacade->method('lexString')
             ->willThrowException(new RuntimeException('analysis failure'));
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -543,7 +543,7 @@ final class FileEvaluatorTest extends TestCase
         $tracker->expects($this->never())->method('registerDependencies');
 
         $compilerFacade = $this->createStub(CompilerFacadeInterface::class);
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -579,7 +579,7 @@ final class FileEvaluatorTest extends TestCase
         $compilerFacade->expects($this->exactly(2))->method('initializeGlobalEnvironment');
         $compilerFacade->expects($this->once())->method('restoreNamespaceEnvironmentData');
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -604,11 +604,11 @@ final class FileEvaluatorTest extends TestCase
             ->method('registerDependencies')
             ->with($sourceFile, $namespace, ['phel.core']);
 
-        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade = $this->createStub(CompilerFacadeInterface::class);
         $compilerFacade->method('compileForCache')
             ->willReturn(new EmitterResult(false, '$compiled = true;', '', ''));
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -631,7 +631,7 @@ final class FileEvaluatorTest extends TestCase
         $namespace = 'test\\namespace';
 
         $capturedOptions = null;
-        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade = $this->createStub(CompilerFacadeInterface::class);
         $compilerFacade->method('eval')
             ->willReturnCallback(static function (string $code, CompileOptions $options) use (&$capturedOptions): mixed {
                 $capturedOptions = $options;
@@ -639,7 +639,7 @@ final class FileEvaluatorTest extends TestCase
                 return null;
             });
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -677,7 +677,7 @@ final class FileEvaluatorTest extends TestCase
                 return new EmitterResult(false, '$level2 = true;', '', '');
             });
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );
@@ -726,7 +726,7 @@ final class FileEvaluatorTest extends TestCase
         $compilerFacade->expects($this->never())->method('compileForCache');
         $compilerFacade->expects($this->never())->method('eval');
 
-        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
         $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
             new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
         );

--- a/tests/php/Unit/Command/Domain/Exceptions/ExceptionArgsPrinterTest.php
+++ b/tests/php/Unit/Command/Domain/Exceptions/ExceptionArgsPrinterTest.php
@@ -82,7 +82,7 @@ final class ExceptionArgsPrinterTest extends TestCase
 
     private function stubPrinter(): PrinterInterface
     {
-        $printer = $this->createMock(PrinterInterface::class);
+        $printer = $this->createStub(PrinterInterface::class);
         $printer->method('print')->willReturnCallback(static fn($arg): string => $arg);
 
         return $printer;

--- a/tests/php/Unit/Internal/Domain/PhelFnNormalizerTest.php
+++ b/tests/php/Unit/Internal/Domain/PhelFnNormalizerTest.php
@@ -16,7 +16,7 @@ final class PhelFnNormalizerTest extends TestCase
 {
     public function test_no_functions_found(): void
     {
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([]);
 
         $normalizer = new PhelFnNormalizer($phelFnLoader, new PhelFnGroupKeyGenerator());
@@ -27,7 +27,7 @@ final class PhelFnNormalizerTest extends TestCase
 
     public function test_group_key_one_function(): void
     {
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
             'fn-name' => Phel::map(),
         ]);
@@ -51,7 +51,7 @@ final class PhelFnNormalizerTest extends TestCase
 
     public function test_group_key_functions_in_different_groups(): void
     {
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
             'fn-name-1' => Phel::map(),
             'fn-name-2' => Phel::map(),
@@ -84,7 +84,7 @@ final class PhelFnNormalizerTest extends TestCase
 
     public function test_group_key_functions_in_same_group_with_question_mark(): void
     {
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
             'fn-name' => Phel::map(),
             'fn-name?' => Phel::map(),
@@ -117,7 +117,7 @@ final class PhelFnNormalizerTest extends TestCase
 
     public function test_group_key_functions_in_same_group_with_minus(): void
     {
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
             'fn-name?' => Phel::map(),
             'fn-name-' => Phel::map(),
@@ -150,7 +150,7 @@ final class PhelFnNormalizerTest extends TestCase
 
     public function test_group_key_functions_in_same_group_with_upper_case(): void
     {
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
             'fn-name-' => Phel::map(),
             'FN-NAME' => Phel::map(),
@@ -188,7 +188,7 @@ final class PhelFnNormalizerTest extends TestCase
             true,
         );
 
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
             'privateSymbol' => $privateSymbol,
         ]);
@@ -202,7 +202,7 @@ final class PhelFnNormalizerTest extends TestCase
     {
         $symbol = Phel::map();
 
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
             '*build-mode*' => $symbol,
         ]);
@@ -231,7 +231,7 @@ final class PhelFnNormalizerTest extends TestCase
             'Constant for Not a Number (NAN) values.',
         );
 
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
             'NAN' => $symbol,
         ]);
@@ -263,7 +263,7 @@ final class PhelFnNormalizerTest extends TestCase
             "```phel\n(array & xs)\n```\nCreates a new Array.",
         );
 
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
             'array' => $symbol,
         ]);
@@ -295,7 +295,7 @@ final class PhelFnNormalizerTest extends TestCase
             "```phel\n(array & xs)\n```\nReturns a formatted string. See PHP's [sprintf](https://example.com) for more information.",
         );
 
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
             'format' => $symbol,
         ]);
@@ -327,7 +327,7 @@ final class PhelFnNormalizerTest extends TestCase
             'Use new-fn',
         );
 
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
             'old-fn' => $meta,
         ]);
@@ -364,7 +364,7 @@ final class PhelFnNormalizerTest extends TestCase
             ),
         );
 
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
             'fn-name' => $meta,
         ]);
@@ -409,7 +409,7 @@ final class PhelFnNormalizerTest extends TestCase
             ),
         );
 
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
             'fn-name' => $meta,
         ]);
@@ -431,7 +431,7 @@ final class PhelFnNormalizerTest extends TestCase
 
     public function test_normalize_native_symbol_doc_url(): void
     {
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
             'apply' => Phel::map(),
         ]);
@@ -466,7 +466,7 @@ final class PhelFnNormalizerTest extends TestCase
             "```phel\n(conj coll x)\n(conj coll x & xs)\n```\nReturns a new collection with elements added.",
         );
 
-        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader = $this->createStub(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
             'conj' => $symbol,
         ]);

--- a/tests/php/Unit/Run/Application/BundledNamespaceDetectorTest.php
+++ b/tests/php/Unit/Run/Application/BundledNamespaceDetectorTest.php
@@ -143,7 +143,7 @@ final class BundledNamespaceDetectorTest extends TestCase
      */
     private function createDetector(array $bundledNamespaces): BundledNamespaceDetector
     {
-        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade = $this->createStub(BuildFacadeInterface::class);
         $buildFacade->method('getNamespaceFromDirectories')->willReturn(
             array_map(
                 static fn(string $ns): NamespaceInformation => new NamespaceInformation('/' . $ns . '.phel', $ns, [], true),
@@ -151,7 +151,7 @@ final class BundledNamespaceDetectorTest extends TestCase
             ),
         );
 
-        $commandFacade = $this->createMock(CommandFacadeInterface::class);
+        $commandFacade = $this->createStub(CommandFacadeInterface::class);
         $commandFacade->method('getSourceDirectories')->willReturn([$this->tmpDir]);
         $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
 

--- a/tests/php/Unit/Run/Application/CompileExecutorTest.php
+++ b/tests/php/Unit/Run/Application/CompileExecutorTest.php
@@ -59,7 +59,7 @@ final class CompileExecutorTest extends TestCase
 
     private function createValueFoldingCompilerFacade(): CompilerFacadeInterface
     {
-        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade = $this->createStub(CompilerFacadeInterface::class);
         $compilerFacade->method('hasBalancedParentheses')->willReturn(true);
         $compilerFacade->method('compile')
             ->willReturnCallback(static function (string $code, CompileOptions $options): EmitterResult {
@@ -74,7 +74,7 @@ final class CompileExecutorTest extends TestCase
 
     private function createCapturingCompilerFacade(): CompilerFacadeInterface
     {
-        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade = $this->createStub(CompilerFacadeInterface::class);
         $compilerFacade->method('hasBalancedParentheses')->willReturn(true);
         $compilerFacade->method('compile')
             ->willReturnCallback(function (string $code, CompileOptions $options): EmitterResult {

--- a/tests/php/Unit/Run/Application/DataReadersLoaderTest.php
+++ b/tests/php/Unit/Run/Application/DataReadersLoaderTest.php
@@ -69,7 +69,7 @@ final class DataReadersLoaderTest extends TestCase
 
         $calls = [];
 
-        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade = $this->createStub(BuildFacadeInterface::class);
         $buildFacade->method('getDependenciesForNamespace')
             ->willReturnCallback(static function (array $dirs, array $ns) use (&$calls, $readerInfo): array {
                 $calls[] = ['deps', $ns];

--- a/tests/php/Unit/Run/Application/EvalExecutorTest.php
+++ b/tests/php/Unit/Run/Application/EvalExecutorTest.php
@@ -36,7 +36,7 @@ final class EvalExecutorTest extends TestCase
 
     private function createExecutor(int $optimizationLevel = 0): EvalExecutor
     {
-        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade = $this->createStub(CompilerFacadeInterface::class);
         $compilerFacade->method('hasBalancedParentheses')->willReturn(true);
         $compilerFacade->method('eval')
             ->willReturnCallback(function (string $code, CompileOptions $options): mixed {

--- a/tests/php/Unit/Run/Application/FileRunnerTest.php
+++ b/tests/php/Unit/Run/Application/FileRunnerTest.php
@@ -64,7 +64,7 @@ final class FileRunnerTest extends TestCase
         $coreInfo = new NamespaceInformation('/phel/core.phel', 'phel.core', [], true);
         $observedDirsArgs = [];
 
-        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade = $this->createStub(BuildFacadeInterface::class);
         $buildFacade->method('getNamespaceFromFile')->willReturn($scriptInfo);
         $buildFacade->method('getDependenciesForNamespace')->willReturnCallback(
             static function (array $dirs, array $ns) use (&$observedDirsArgs, $scriptInfo, $coreInfo): array {
@@ -76,7 +76,7 @@ final class FileRunnerTest extends TestCase
             new CompiledFile('', '', '', false),
         );
 
-        $commandFacade = $this->createMock(CommandFacadeInterface::class);
+        $commandFacade = $this->createStub(CommandFacadeInterface::class);
         $commandFacade->method('getSourceDirectories')->willReturn([$this->primarySrc]);
         $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
 
@@ -105,7 +105,7 @@ final class FileRunnerTest extends TestCase
         $observedDirsArgs = [];
         $namespaceFromFileCalls = [];
 
-        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade = $this->createStub(BuildFacadeInterface::class);
         $buildFacade->method('getNamespaceFromFile')->willReturnCallback(
             static function (string $path) use (&$namespaceFromFileCalls, $script, $helper, $scriptInfo, $helperInfo): NamespaceInformation {
                 $namespaceFromFileCalls[] = $path;
@@ -135,7 +135,7 @@ final class FileRunnerTest extends TestCase
             },
         );
 
-        $commandFacade = $this->createMock(CommandFacadeInterface::class);
+        $commandFacade = $this->createStub(CommandFacadeInterface::class);
         $commandFacade->method('getSourceDirectories')->willReturn([$this->primarySrc]);
         $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
 
@@ -168,7 +168,7 @@ final class FileRunnerTest extends TestCase
 
         $observedSeeds = [];
 
-        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade = $this->createStub(BuildFacadeInterface::class);
         $buildFacade->method('getNamespaceFromFile')->willReturn($scriptInfo);
         $buildFacade->method('getNamespaceFromDirectories')->willReturn([$asyncInfo]);
         $buildFacade->method('getDependenciesForNamespace')->willReturnCallback(
@@ -186,7 +186,7 @@ final class FileRunnerTest extends TestCase
             },
         );
 
-        $commandFacade = $this->createMock(CommandFacadeInterface::class);
+        $commandFacade = $this->createStub(CommandFacadeInterface::class);
         $commandFacade->method('getSourceDirectories')->willReturn([$this->primarySrc]);
         $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
 
@@ -212,7 +212,7 @@ final class FileRunnerTest extends TestCase
 
         $observedSeeds = [];
 
-        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade = $this->createStub(BuildFacadeInterface::class);
         $buildFacade->method('getNamespaceFromFile')->willReturn($scriptInfo);
         $buildFacade->method('getNamespaceFromDirectories')->willReturn([$testInfo]);
         $buildFacade->method('getDependenciesForNamespace')->willReturnCallback(
@@ -225,7 +225,7 @@ final class FileRunnerTest extends TestCase
             new CompiledFile('', '', '', false),
         );
 
-        $commandFacade = $this->createMock(CommandFacadeInterface::class);
+        $commandFacade = $this->createStub(CommandFacadeInterface::class);
         $commandFacade->method('getSourceDirectories')->willReturn([$this->primarySrc]);
         $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
 
@@ -247,7 +247,7 @@ final class FileRunnerTest extends TestCase
         $observedSeeds = [];
         $bundledDiscoveryCalls = 0;
 
-        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade = $this->createStub(BuildFacadeInterface::class);
         $buildFacade->method('getNamespaceFromFile')->willReturn($scriptInfo);
         $buildFacade->method('getNamespaceFromDirectories')->willReturnCallback(
             static function () use (&$bundledDiscoveryCalls): array {
@@ -265,7 +265,7 @@ final class FileRunnerTest extends TestCase
             new CompiledFile('', '', '', false),
         );
 
-        $commandFacade = $this->createMock(CommandFacadeInterface::class);
+        $commandFacade = $this->createStub(CommandFacadeInterface::class);
         $commandFacade->method('getSourceDirectories')->willReturn([$this->primarySrc]);
         $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
 
@@ -291,7 +291,7 @@ final class FileRunnerTest extends TestCase
         $subHelperInfo = new NamespaceInformation($subHelper, 'sub-helper', [], true);
         $coreInfo = new NamespaceInformation('/phel/core.phel', 'phel.core', [], true);
 
-        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade = $this->createStub(BuildFacadeInterface::class);
         $buildFacade->method('getNamespaceFromFile')->willReturnCallback(
             static fn(string $path): NamespaceInformation => match ($path) {
                 $script => $scriptInfo,
@@ -310,7 +310,7 @@ final class FileRunnerTest extends TestCase
             },
         );
 
-        $commandFacade = $this->createMock(CommandFacadeInterface::class);
+        $commandFacade = $this->createStub(CommandFacadeInterface::class);
         $commandFacade->method('getSourceDirectories')->willReturn([$this->primarySrc]);
         $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
 

--- a/tests/php/Unit/Run/Application/LazyBundledNamespaceResolverTest.php
+++ b/tests/php/Unit/Run/Application/LazyBundledNamespaceResolverTest.php
@@ -29,7 +29,7 @@ final class LazyBundledNamespaceResolverTest extends TestCase
         $jsonInfo = new NamespaceInformation('/phel/json.phel', 'phel.json', ['phel.core'], true);
 
         $evalled = [];
-        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade = $this->createStub(BuildFacadeInterface::class);
         $buildFacade->method('getDependenciesForNamespace')->willReturn([$coreInfo, $jsonInfo]);
         $buildFacade->method('evalFile')->willReturnCallback(
             static function (string $file) use (&$evalled): CompiledFile {
@@ -54,7 +54,7 @@ final class LazyBundledNamespaceResolverTest extends TestCase
         $jsonInfo = new NamespaceInformation('/phel/json.phel', 'phel.json', [], true);
 
         $observedSeeds = [];
-        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade = $this->createStub(BuildFacadeInterface::class);
         $buildFacade->method('getDependenciesForNamespace')->willReturnCallback(
             static function (array $dirs, array $seeds) use (&$observedSeeds, $jsonInfo): array {
                 $observedSeeds[] = $seeds;
@@ -95,7 +95,7 @@ final class LazyBundledNamespaceResolverTest extends TestCase
         $jsonInfo = new NamespaceInformation('/phel/json.phel', 'phel.json', [], true);
 
         $evalled = [];
-        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade = $this->createStub(BuildFacadeInterface::class);
         $buildFacade->method('getDependenciesForNamespace')->willReturn([$jsonInfo]);
         $buildFacade->method('evalFile')->willReturnCallback(
             static function (string $file) use (&$evalled): CompiledFile {

--- a/tests/php/Unit/Run/Application/NamespaceRunnerTest.php
+++ b/tests/php/Unit/Run/Application/NamespaceRunnerTest.php
@@ -16,7 +16,7 @@ final class NamespaceRunnerTest extends TestCase
     {
         $capturedNamespaces = [];
 
-        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade = $this->createStub(BuildFacadeInterface::class);
         $buildFacade->method('getDependenciesForNamespace')
             ->willReturnCallback(static function (array $dirs, array $ns) use (&$capturedNamespaces): array {
                 $capturedNamespaces = $ns;
@@ -25,7 +25,7 @@ final class NamespaceRunnerTest extends TestCase
         $buildFacade->method('evalFile')
             ->willReturn(new CompiledFile('', '', '', false));
 
-        $commandFacade = $this->createMock(CommandFacadeInterface::class);
+        $commandFacade = $this->createStub(CommandFacadeInterface::class);
         $commandFacade->method('getSourceDirectories')->willReturn([]);
         $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
 
@@ -48,7 +48,7 @@ final class NamespaceRunnerTest extends TestCase
     {
         $capturedNamespaces = [];
 
-        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade = $this->createStub(BuildFacadeInterface::class);
         $buildFacade->method('getDependenciesForNamespace')
             ->willReturnCallback(static function (array $dirs, array $ns) use (&$capturedNamespaces): array {
                 $capturedNamespaces = $ns;
@@ -57,7 +57,7 @@ final class NamespaceRunnerTest extends TestCase
         $buildFacade->method('evalFile')
             ->willReturn(new CompiledFile('', '', '', false));
 
-        $commandFacade = $this->createMock(CommandFacadeInterface::class);
+        $commandFacade = $this->createStub(CommandFacadeInterface::class);
         $commandFacade->method('getSourceDirectories')->willReturn([]);
         $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
 

--- a/tests/php/Unit/Run/Application/StructuredEvaluatorTest.php
+++ b/tests/php/Unit/Run/Application/StructuredEvaluatorTest.php
@@ -346,7 +346,7 @@ final class StructuredEvaluatorTest extends TestCase
      */
     private function compilerFacadeMock(): CompilerFacadeInterface
     {
-        $facade = $this->createMock(CompilerFacadeInterface::class);
+        $facade = $this->createStub(CompilerFacadeInterface::class);
         $facade->method('isGlobalEnvironmentInitialized')
             ->willReturnCallback(static fn(): bool => GlobalEnvironmentSingleton::isInitialized());
         $facade->method('getGlobalEnvironment')

--- a/tests/php/Unit/Run/Domain/Runner/NamespaceCollectorTest.php
+++ b/tests/php/Unit/Run/Domain/Runner/NamespaceCollectorTest.php
@@ -49,7 +49,7 @@ final class NamespaceCollectorTest extends TestCase
 
     public function test_appends_namespace_info_for_path_dropped_by_dependency_walk(): void
     {
-        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade = $this->createStub(BuildFacadeInterface::class);
         $commandFacade = $this->createStub(CommandFacadeInterface::class);
 
         $commandFacade->method('getSourceDirectories')->willReturn(['/src']);
@@ -72,7 +72,7 @@ final class NamespaceCollectorTest extends TestCase
 
     public function test_does_not_duplicate_namespace_info_resolved_by_dependency_walk(): void
     {
-        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade = $this->createStub(BuildFacadeInterface::class);
         $commandFacade = $this->createStub(CommandFacadeInterface::class);
 
         $commandFacade->method('getSourceDirectories')->willReturn(['/src']);


### PR DESCRIPTION
## 🤔 Background

The PHPUnit `unit` suite reported 98 notices, all the same category: *"No expectations were configured for the mock object … Consider refactoring to use a test stub instead."* They came from `createMock()` used as a passive stub (no `->expects()`).

## 💡 Goal

A clean unit-suite summary with 0 of these notices, without weakening any verifying mock.

## 🔖 Changes

- Converted 76 passive `createMock(X::class)` sites to `createStub(X::class)` across 14 test files.
- Converted a site **only** when its mock had no `->expects()` (single- or multi-line chain) before reassignment; mocks with any `->expects(...)` (incl. `self::never()`) were left as-is. 36 verifying `createMock` sites remain untouched.
- Unit-suite notices: **98 → 0**. Full `composer test` green (cs-fixer, psalm, phpstan, rector, all suites).
- Test-only change — no production code touched, so **no CHANGELOG entry** (deliberate).
- No final `ref` cleanup commit: the diff is mechanical 1:1 swaps with consistent idiom and no naming drift, nothing to tidy.

Closes #2629
