### PR TITLE
perf: auto-apply CLI opcache file_cache for warm runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Performance
+
+- `phel run`/`eval`/`repl` now auto-apply a persistent on-disk OPcache file cache so warm CLI invocations reuse compiled opcode instead of re-parsing every required `.php` (~30% faster warm startup). The CLI re-execs itself once via `pcntl_exec` (same PID, TTY, stdin, signals, and exit code) with `-d opcache.enable_cli=1 -d opcache.file_cache=<PHEL_DIR>/opcache`. No-op when OPcache or `pcntl` is unavailable, when `opcache.file_cache` is already set, or when `PHEL_NO_OPCACHE_REEXEC=1` opts out. The cache lives outside `phel clear-cache`'s blast radius
+
 ### Fixed
 
 - Temp-file cleanup (`RealFilesystem::clearAll()`) no longer emits `unlink(...): No such file or directory` warnings when a tracked path was already removed by an earlier run (the file list is process-global static); it now skips missing paths. Surfaced as noise on every `phel test` / build run

--- a/bin/phel
+++ b/bin/phel
@@ -10,6 +10,47 @@ if (function_exists('ini_set')) {
 
 use Phel\Config\ConfigLoadException;
 use Phel\Console\ConsoleFacade;
+use Phel\Shared\PhelProjectDirectory;
+use Phel\Shared\Performance\OpcacheReexec;
+
+/**
+ * Replace the current process with one that has an on-disk OPcache file cache,
+ * when it is safe and beneficial. The file_cache dir lives at `<PHEL_DIR>/opcache`,
+ * a sibling of the compiled-code cache so `phel clear-cache` never wipes it (PHP
+ * aborts at startup if the path is missing). The "already configured" guard in
+ * the decision is what stops the re-exec'd child from looping.
+ */
+function maybeReexecWithOpcacheFileCache(string $appRootDir): void
+{
+    $fileCacheDir = PhelProjectDirectory::path($appRootDir, 'opcache');
+    if (!is_dir($fileCacheDir) && !@mkdir($fileCacheDir, 0o755, true) && !is_dir($fileCacheDir)) {
+        return;
+    }
+
+    $decision = OpcacheReexec::decide(
+        opcacheLoaded: extension_loaded('Zend OPcache'),
+        fileCacheConfigured: (string) ini_get('opcache.file_cache') !== '',
+        optedOut: getenv('PHEL_NO_OPCACHE_REEXEC') !== false,
+        pcntlAvailable: function_exists('pcntl_exec'),
+        fileCacheDir: $fileCacheDir,
+    );
+
+    if (!$decision->shouldReexec) {
+        return;
+    }
+
+    $argv = $_SERVER['argv'] ?? [];
+    if (!is_array($argv) || $argv === []) {
+        return;
+    }
+
+    // argv[0] is the bin/phel script path; preserve the rest as user args. cwd
+    // is unchanged across the exec, so a relative script path still resolves.
+    $args = array_merge($decision->flags, array_values(array_map('strval', $argv)));
+
+    // If pcntl_exec returns at all it failed; fall through and run in-process.
+    @pcntl_exec(PHP_BINARY, $args);
+}
 
 // NOTE: When packaged as a PHAR, the stub requires the PHAR's vendor/autoload.php first.
 // The host project's autoloader is loaded after, allowing access to project dependencies.
@@ -62,6 +103,14 @@ use Phel\Console\ConsoleFacade;
         );
         exit(1);
     }
+
+    // Re-exec once with a persistent OPcache file cache so warm run/eval/repl
+    // reuse compiled opcode instead of re-parsing every required .php. These
+    // ini settings are startup-only, so the only way to apply them within this
+    // invocation is to replace the process image; pcntl_exec keeps the same PID,
+    // stdin/stdout/stderr + TTY, and signals, so the interactive REPL and exit
+    // codes survive transparently. Best-effort — any miss just runs in-process.
+    maybeReexecWithOpcacheFileCache($appRootDir);
 
     // Phel classes are available either via the PHAR autoloader (in PHAR mode)
     // or the host Composer autoloader (source mode).

--- a/src/php/Shared/CLAUDE.md
+++ b/src/php/Shared/CLAUDE.md
@@ -52,6 +52,8 @@ Stateless strategy-pattern printer (see `Printer/CLAUDE.md`); consumers instanti
 | `PhpAttributeRenderer` | renders `^{:php/attr …}` specs into PHP 8 attribute lines (`#[\ORM\Column(length: 255)]`). Accepts bare keyword (`:ORM/Entity`), single spec vector (`[:ORM/Column {:length 255}]`), or vector of specs. Consumed by `DefStructEmitter`/`DefInterfaceEmitter` + Interop export generator |
 | `Console/DeprecatedOptionWarner` | static `warn()` — one-line renamed-option deprecation notice to stderr (never corrupts machine-readable stdout like `phel config --json`) |
 | `Performance/OpcacheAdvisor` | pure `advise(...)` (caller passes ini flags) → `OpcacheAdvice` (`optimal`, `messages`); flags when OPcache won't persist the compiled-code cache across CLI runs |
+| `Performance/OpcacheWorkerFlags` | pure `forFileCache(loaded, dir)` → `-d opcache.enable_cli=1 -d opcache.file_cache=<dir>` flag pairs (or `[]`); shared by parallel test workers (`RunFactory`) and the CLI re-exec |
+| `Performance/OpcacheReexec` | pure `decide(...)` → `OpcacheReexecDecision` (`shouldReexec`, `flags`); whether `bin/phel` should `pcntl_exec` itself with a persistent file cache. Reuses `OpcacheWorkerFlags`; the actual exec is the thin edge in `bin/phel` |
 
 ## SourceMap (`SourceMap/`)
 

--- a/src/php/Shared/Performance/OpcacheReexec.php
+++ b/src/php/Shared/Performance/OpcacheReexec.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared\Performance;
+
+/**
+ * Decides whether the `phel` CLI should re-exec itself with a persistent
+ * OPcache file cache so warm `run`/`eval`/`repl` invocations reuse compiled
+ * opcode instead of re-parsing every required `.php`.
+ *
+ * `opcache.enable_cli` (PHP_INI_SYSTEM) and `opcache.file_cache` are
+ * startup-only — `ini_set()` cannot turn them on mid-process. The only way to
+ * auto-apply them within one invocation is to replace the process image with
+ * `pcntl_exec()`, which keeps the same PID, file descriptors (stdin/stdout/
+ * stderr + TTY), and signal disposition, so the interactive REPL, exit codes,
+ * and argv all survive transparently. A wrapping child (proc_open/passthru)
+ * would not, so we degrade rather than re-exec when `pcntl_exec` is missing.
+ *
+ * Pure: callers pass the runtime facts so the decision stays trivially
+ * testable; the actual exec lives at the CLI edge (`bin/phel`).
+ */
+final class OpcacheReexec
+{
+    public static function decide(
+        bool $opcacheLoaded,
+        bool $fileCacheConfigured,
+        bool $optedOut,
+        bool $pcntlAvailable,
+        string $fileCacheDir,
+    ): OpcacheReexecDecision {
+        // Already configured is also the loop guard: the re-exec'd child
+        // inherits the file_cache flag, so it falls through here and never
+        // re-execs again.
+        if ($optedOut || !$pcntlAvailable || $fileCacheConfigured) {
+            return new OpcacheReexecDecision(false, []);
+        }
+
+        $flags = OpcacheWorkerFlags::forFileCache($opcacheLoaded, $fileCacheDir);
+        if ($flags === []) {
+            return new OpcacheReexecDecision(false, []);
+        }
+
+        return new OpcacheReexecDecision(true, $flags);
+    }
+}

--- a/src/php/Shared/Performance/OpcacheReexecDecision.php
+++ b/src/php/Shared/Performance/OpcacheReexecDecision.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared\Performance;
+
+/**
+ * Outcome of {@see OpcacheReexec::decide()}: whether the CLI should replace its
+ * own process image to gain a persistent OPcache file cache, and the `-d` flags
+ * to apply when it does.
+ */
+final readonly class OpcacheReexecDecision
+{
+    /**
+     * @param list<string> $flags
+     */
+    public function __construct(
+        public bool $shouldReexec,
+        public array $flags,
+    ) {}
+}

--- a/tests/php/Integration/Run/Command/Run/OpcacheReexecTest.php
+++ b/tests/php/Integration/Run/Command/Run/OpcacheReexecTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Run\Command\Run;
+
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function dirname;
+use function escapeshellarg;
+use function exec;
+use function file_put_contents;
+use function implode;
+use function is_dir;
+use function mkdir;
+use function random_bytes;
+use function sprintf;
+use function sys_get_temp_dir;
+
+/**
+ * Drives the real `bin/phel` as a subprocess to prove the OPcache re-exec is
+ * correctness-preserving: a warm run with the feature on must match a run with
+ * it opted out, bit for bit on stdout and exit code. Speed is not asserted —
+ * the re-exec only ever needs to be transparent.
+ */
+final class OpcacheReexecTest extends TestCase
+{
+    private string $repoRoot;
+
+    private string $projectDir;
+
+    protected function setUp(): void
+    {
+        $this->repoRoot = dirname(__DIR__, 6);
+        $this->projectDir = sys_get_temp_dir() . '/phel-opcache-reexec-' . bin2hex(random_bytes(6));
+        mkdir($this->projectDir, 0o755, true);
+
+        mkdir($this->projectDir . '/vendor', 0o755, true);
+        file_put_contents(
+            $this->projectDir . '/vendor/autoload.php',
+            sprintf("<?php return require '%s/vendor/autoload.php';\n", $this->repoRoot),
+        );
+
+        file_put_contents(
+            $this->projectDir . '/main.phel',
+            "(ns local\\main)\n(println (+ 1 2 3))\n",
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->projectDir);
+    }
+
+    public function test_warm_run_with_opcache_reexec_matches_opted_out_run(): void
+    {
+        // Cold run primes the compiled-code cache and (when re-exec fires) the
+        // OPcache file cache, so the asserted run below is a genuine warm one.
+        $this->runPhel([]);
+
+        [$warmExit, $warmOut] = $this->runPhel([]);
+        [$optOutExit, $optOutOut] = $this->runPhel(['PHEL_NO_OPCACHE_REEXEC' => '1']);
+
+        self::assertSame(0, $warmExit);
+        self::assertSame($optOutExit, $warmExit);
+        self::assertSame($optOutOut, $warmOut);
+        self::assertStringContainsString('6', $warmOut);
+    }
+
+    /**
+     * @param array<string, string> $env
+     *
+     * @return array{0: int, 1: string} exit code and combined output
+     */
+    private function runPhel(array $env): array
+    {
+        $prefix = '';
+        foreach ($env as $name => $value) {
+            $prefix .= $name . '=' . escapeshellarg($value) . ' ';
+        }
+
+        $cmd = 'cd ' . escapeshellarg($this->projectDir)
+            . ' && ' . $prefix . 'php ' . escapeshellarg($this->repoRoot . '/bin/phel')
+            . ' run main.phel 2>&1';
+
+        exec($cmd, $output, $exitCode);
+
+        return [$exitCode, implode("\n", $output)];
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        exec('rm -rf ' . escapeshellarg($dir));
+    }
+}

--- a/tests/php/Unit/Shared/Performance/OpcacheReexecTest.php
+++ b/tests/php/Unit/Shared/Performance/OpcacheReexecTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared\Performance;
+
+use Phel\Shared\Performance\OpcacheReexec;
+use PHPUnit\Framework\TestCase;
+
+final class OpcacheReexecTest extends TestCase
+{
+    public function test_decides_to_reexec_with_file_cache_flags_when_everything_is_available(): void
+    {
+        $decision = OpcacheReexec::decide(
+            opcacheLoaded: true,
+            fileCacheConfigured: false,
+            optedOut: false,
+            pcntlAvailable: true,
+            fileCacheDir: '/var/phel/opcache',
+        );
+
+        self::assertTrue($decision->shouldReexec);
+        self::assertSame(
+            ['-d', 'opcache.enable_cli=1', '-d', 'opcache.file_cache=/var/phel/opcache'],
+            $decision->flags,
+        );
+    }
+
+    public function test_does_not_reexec_when_opcache_extension_is_absent(): void
+    {
+        $decision = OpcacheReexec::decide(
+            opcacheLoaded: false,
+            fileCacheConfigured: false,
+            optedOut: false,
+            pcntlAvailable: true,
+            fileCacheDir: '/var/phel/opcache',
+        );
+
+        self::assertFalse($decision->shouldReexec);
+        self::assertSame([], $decision->flags);
+    }
+
+    public function test_does_not_reexec_when_file_cache_is_already_configured(): void
+    {
+        // The re-exec'd child inherits the file_cache flag, so this is also the
+        // guard that prevents an infinite re-exec loop.
+        $decision = OpcacheReexec::decide(
+            opcacheLoaded: true,
+            fileCacheConfigured: true,
+            optedOut: false,
+            pcntlAvailable: true,
+            fileCacheDir: '/var/phel/opcache',
+        );
+
+        self::assertFalse($decision->shouldReexec);
+        self::assertSame([], $decision->flags);
+    }
+
+    public function test_does_not_reexec_when_opted_out(): void
+    {
+        $decision = OpcacheReexec::decide(
+            opcacheLoaded: true,
+            fileCacheConfigured: false,
+            optedOut: true,
+            pcntlAvailable: true,
+            fileCacheDir: '/var/phel/opcache',
+        );
+
+        self::assertFalse($decision->shouldReexec);
+        self::assertSame([], $decision->flags);
+    }
+
+    public function test_does_not_reexec_when_pcntl_is_unavailable(): void
+    {
+        // Without pcntl_exec there is no in-place process replacement, and a
+        // wrapping child would risk TTY/stdin/exit-code fidelity, so degrade.
+        $decision = OpcacheReexec::decide(
+            opcacheLoaded: true,
+            fileCacheConfigured: false,
+            optedOut: false,
+            pcntlAvailable: false,
+            fileCacheDir: '/var/phel/opcache',
+        );
+
+        self::assertFalse($decision->shouldReexec);
+        self::assertSame([], $decision->flags);
+    }
+
+    public function test_does_not_reexec_when_cache_dir_is_empty(): void
+    {
+        $decision = OpcacheReexec::decide(
+            opcacheLoaded: true,
+            fileCacheConfigured: false,
+            optedOut: false,
+            pcntlAvailable: true,
+            fileCacheDir: '',
+        );
+
+        self::assertFalse($decision->shouldReexec);
+        self::assertSame([], $decision->flags);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

CLI OPcache is off by default, so a warm `phel run`/`eval`/`repl` re-parses every compiled `.php` it requires. `opcache.enable_cli`/`opcache.file_cache` are startup-only — they cannot be turned on mid-process.

## 💡 Goal

Auto-apply an on-disk OPcache file cache so warm runs reuse compiled opcode (~30% faster warm startup), without regressing the interactive REPL or exit codes.

## 🔖 Changes

- `bin/phel` re-execs itself once via `pcntl_exec` (same PID, TTY, stdin, signals, exit code) with `-d opcache.enable_cli=1 -d opcache.file_cache=<PHEL_DIR>/opcache` (a sibling of the compiled-code cache, so `phel clear-cache` never wipes it).
- Pure decision in `Shared/Performance/OpcacheReexec` (reuses `OpcacheWorkerFlags`); the `already-configured` check doubles as the re-exec loop guard. Thin exec stays at the CLI edge.
- Re-exec covers `run`/`eval`/`repl` uniformly — `pcntl_exec` replaces the image in place, so the REPL keeps its TTY/stdin. No-op when OPcache or `pcntl` is missing, when `file_cache` is already set, or when `PHEL_NO_OPCACHE_REEXEC=1`.
- Unit tests for every decision branch; an integration test drives real `bin/phel` and asserts warm-run output/exit-code parity against an opted-out run.

Final `ref` review pass found no duplication/boundary/dead-code issues — no `ref` commit needed.

Closes #2632