### PR TITLE
fix(run): report source location + stack trace for runtime-lib errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `phel run` no longer discards the source location and stack trace when a runtime error is thrown from inside the runtime lib (e.g. `(+ x "boom")` → `Expected a number, got string`, `(/ 1 0)` → `Division by zero`): such errors used to print only the bare message because the throw site lives under `phel-lang/src`. They now surface the same filtered `.phel` stack trace as the REPL, mapping every Phel call site back to its source location. The fix is shared by `phel run`/`test`/`build`/`profile`/`export` (#2635)
 - Temp-file cleanup (`RealFilesystem::clearAll()`) no longer emits `unlink(...): No such file or directory` warnings when a tracked path was already removed by an earlier run (the file list is process-global static); it now skips missing paths. Surfaced as noise on every `phel test` / build run
 
 ### Changed

--- a/src/php/Command/Application/CommandExceptionWriter.php
+++ b/src/php/Command/Application/CommandExceptionWriter.php
@@ -36,15 +36,18 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
     {
         $cause = $e->getPrevious() ?? $e;
 
+        // When the throw site is the runtime lib (e.g. core `+`, `/`), its file
+        // is internal and maps to no user source, so the located `at` header is
+        // omitted; the Phel call sites still surface via the filtered trace.
         if (str_contains($cause->getFile(), 'phel-lang/src')) {
             $output->writeln($cause->getMessage());
         } else {
             $this->writeUserError($output, $cause);
+        }
 
-            $trace = $this->exceptionPrinter->getUserFacingTraceString($cause);
-            if ($trace !== '') {
-                $output->writeln(rtrim($trace));
-            }
+        $trace = $this->exceptionPrinter->getUserFacingTraceString($cause);
+        if ($trace !== '') {
+            $output->writeln(rtrim($trace));
         }
 
         $this->writeHint($output, $e);

--- a/tests/php/Integration/Run/Command/Run/Fixtures/runtime-lib-error-script.phel
+++ b/tests/php/Integration/Run/Command/Run/Fixtures/runtime-lib-error-script.phel
@@ -1,0 +1,9 @@
+(ns test\runtime-lib-error-script)
+
+(defn add-boom [x]
+  (+ x "boom"))
+
+(defn caller [x]
+  (add-boom x))
+
+(caller 1)

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -158,7 +158,7 @@ final class RunCommandTest extends AbstractTestCommand
         );
 
         // The error originates inside the runtime lib (core `+`), yet the user
-        // still needs the type, the Phel call site, and the filtered trace.
+        // still needs the message plus the Phel call sites from the filtered trace.
         self::assertStringContainsString('Expected a number, got string', $output);
         self::assertMatchesRegularExpression('~#\d+ .*\.phel:\d+ : \(test\\\\runtime-lib-error-script\\\\add-boom~', $output);
         self::assertMatchesRegularExpression('~#\d+ .*\.phel:\d+ : \(test\\\\runtime-lib-error-script\\\\caller~', $output);

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -151,6 +151,20 @@ final class RunCommandTest extends AbstractTestCommand
         self::assertMatchesRegularExpression('~\.\.\. \d+ internal frames?~', $output);
     }
 
+    public function test_runtime_lib_error_reports_phel_location_and_trace(): void
+    {
+        $output = $this->captureRunOutput(
+            __DIR__ . '/Fixtures/runtime-lib-error-script.phel',
+        );
+
+        // The error originates inside the runtime lib (core `+`), yet the user
+        // still needs the type, the Phel call site, and the filtered trace.
+        self::assertStringContainsString('Expected a number, got string', $output);
+        self::assertMatchesRegularExpression('~#\d+ .*\.phel:\d+ : \(test\\\\runtime-lib-error-script\\\\add-boom~', $output);
+        self::assertMatchesRegularExpression('~#\d+ .*\.phel:\d+ : \(test\\\\runtime-lib-error-script\\\\caller~', $output);
+        self::assertMatchesRegularExpression('~\.\.\. \d+ internal frames?~', $output);
+    }
+
     public function test_runtime_error_maps_phel_frames_on_repeated_run(): void
     {
         $scriptPath = __DIR__ . '/Fixtures/error-trace-script.phel';

--- a/tests/php/Unit/Command/Application/CommandExceptionWriterTest.php
+++ b/tests/php/Unit/Command/Application/CommandExceptionWriterTest.php
@@ -78,13 +78,20 @@ final class CommandExceptionWriterTest extends TestCase
         self::assertStringContainsString('rm -rf out /var/state/cache', $text);
     }
 
-    public function test_internal_phel_lang_source_does_not_invoke_extractor(): void
+    public function test_runtime_lib_error_skips_located_header_but_keeps_phel_trace(): void
     {
+        // A throw from inside the runtime lib has no user source for the `at`
+        // header, so the extractor is not consulted for it — yet the Phel call
+        // sites must still be surfaced via the filtered trace.
         $extractor = $this->createMock(FilePositionExtractorInterface::class);
         $extractor->expects(self::never())->method('getOriginal');
 
+        $printer = $this->createStub(ExceptionPrinterInterface::class);
+        $printer->method('getUserFacingTraceString')
+            ->willReturn("#3 /proj/src/main.phel:3 : (phel\\core\\+ 1 \"boom\")\n   ... 2 internal frames\n");
+
         $writer = new CommandExceptionWriter(
-            $this->createStub(ExceptionPrinterInterface::class),
+            $printer,
             $this->createStub(ErrorLogInterface::class),
             $extractor,
             'stale compiled output? try `rm -rf out /var/state/cache` and rebuild.',
@@ -94,10 +101,17 @@ final class CommandExceptionWriterTest extends TestCase
         $output = new BufferedOutput();
         $writer->writeStackTrace(
             $output,
-            $this->errorAt('internal', '/home/dev/phel-lang/src/php/Run/Foo.php', 99),
+            $this->errorAt('Expected a number, got string', '/home/dev/phel-lang/src/php/Lang/NumericCoercion.php', 40),
         );
 
-        self::assertSame("internal\n", $output->fetch());
+        $text = $output->fetch();
+
+        self::assertStringContainsString('Expected a number, got string', $text);
+        self::assertStringContainsString('#3 /proj/src/main.phel:3 : (phel\\core\\+ 1 "boom")', $text);
+        self::assertStringContainsString('... 2 internal frames', $text);
+        // No misleading `at <internal .php>` header pointing into the runtime lib.
+        self::assertStringNotContainsString('at /home/dev/phel-lang/src', $text);
+        self::assertStringNotContainsString('rm -rf out', $text);
     }
 
     public function test_writes_user_facing_trace_after_error_location(): void


### PR DESCRIPTION
## 🤔 Background

A runtime error thrown from inside the runtime lib (a core fn like `+` or `/`) during `phel run` printed only the bare message — no file, line, trace, or type. A type mismatch three calls deep gave the user nothing to locate it, while the REPL showed a full filtered trace for the same error.

Root cause: `CommandExceptionWriter::writeStackTrace()` short-circuited to a bare `getMessage()` whenever the throw site lived under `phel-lang/src`, suppressing the trace that still held the user's Phel call sites.

## 💡 Goal

Make `phel run` surface the Phel source location + usable stack trace for runtime-lib errors, reusing the existing `getUserFacingTraceString` machinery the other error paths already use (no parallel formatter).

## 🔖 Changes

- Emit the user-facing filtered trace unconditionally; only skip the located `at` header for internal throw sites (its file maps to no user source). Shared by `run`/`test`/`build`/`profile`/`export`.
- Integration + unit tests for the runtime-lib path; CHANGELOG entry.

Before: `Expected a number, got string`
After:
```
Expected a number, got string
   ... 2 internal frames
#3 .../boom.phel:3 : (phel\core\+ 1 "boom")
#4 .../boom.phel:6 : (boom\level-c 1)
   ... 21 internal frames
```

Closes #2635