### PR TITLE
fix(cli): use opcache.file_cache_only on re-exec to avoid OPcache startup-lock hang

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,8 @@ jobs:
   core-tests:
     name: Core tests on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
+    # Fail fast instead of hanging ~6h if a worker stalls on OPcache startup lock.
+    timeout-minutes: 8
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Requiring a non-existent user namespace now fails fast with `Cannot find namespace '…' required by '…'` instead of silently exiting 0 and surfacing later as a generic `Cannot resolve symbol`; framework `phel.*`/`clojure.*`, already-loaded, and PHP-interop `(:use …)` requires stay tolerated (#2636)
 - `phel run`/`test`/`build`/`profile`/`export` now surface the `.phel` source location and filtered stack trace for runtime errors thrown from the stdlib (e.g. `(/ 1 0)`), matching the REPL, instead of only the bare message (#2635)
 - No more spurious `unlink(...): No such file or directory` warnings on `phel test`/build when cleaning up a temp file an earlier run already removed
+- The CLI OPcache re-exec (#2632) now runs the warm child with `opcache.file_cache_only`, avoiding an intermittent multi-minute hang on some CI filesystems where allocating OPcache's shared-memory segment blocked on a startup lock; a re-exec-once breadcrumb also guarantees the re-exec can never loop
 
 ### Performance
 

--- a/bin/phel
+++ b/bin/phel
@@ -17,8 +17,8 @@ use Phel\Shared\Performance\OpcacheReexec;
  * Replace the current process with one that has an on-disk OPcache file cache,
  * when it is safe and beneficial. The file_cache dir lives at `<PHEL_DIR>/opcache`,
  * a sibling of the compiled-code cache so `phel clear-cache` never wipes it (PHP
- * aborts at startup if the path is missing). The "already configured" guard in
- * the decision is what stops the re-exec'd child from looping.
+ * aborts at startup if the path is missing). A re-exec-done breadcrumb in the
+ * environment stops the re-exec'd child from looping.
  */
 function maybeReexecWithOpcacheFileCache(string $appRootDir): void
 {
@@ -33,6 +33,7 @@ function maybeReexecWithOpcacheFileCache(string $appRootDir): void
         optedOut: getenv('PHEL_NO_OPCACHE_REEXEC') !== false,
         pcntlAvailable: function_exists('pcntl_exec'),
         fileCacheDir: $fileCacheDir,
+        reexecAlreadyDone: getenv(OpcacheReexec::REEXEC_DONE_ENV) !== false,
     );
 
     if (!$decision->shouldReexec) {
@@ -47,6 +48,10 @@ function maybeReexecWithOpcacheFileCache(string $appRootDir): void
     // argv[0] is the bin/phel script path; preserve the rest as user args. cwd
     // is unchanged across the exec, so a relative script path still resolves.
     $args = array_merge($decision->flags, array_values(array_map('strval', $argv)));
+
+    // Breadcrumb the child inherits so it can never re-exec again, even if it
+    // misreads opcache.file_cache back as empty on some build.
+    putenv(OpcacheReexec::REEXEC_DONE_ENV . '=1');
 
     // If pcntl_exec returns at all it failed; fall through and run in-process.
     @pcntl_exec(PHP_BINARY, $args);

--- a/src/php/Shared/Performance/OpcacheReexec.php
+++ b/src/php/Shared/Performance/OpcacheReexec.php
@@ -22,17 +22,26 @@ namespace Phel\Shared\Performance;
  */
 final class OpcacheReexec
 {
+    /**
+     * Set in the environment right before `pcntl_exec` so the re-exec'd child
+     * proves it is the second invocation without reading back an ini value.
+     * Its presence is an unconditional "never re-exec again", so a misread
+     * `opcache.file_cache` on any PHP/opcache build can never spin an exec loop.
+     */
+    public const string REEXEC_DONE_ENV = 'PHEL_OPCACHE_REEXEC_DONE';
+
     public static function decide(
         bool $opcacheLoaded,
         bool $fileCacheConfigured,
         bool $optedOut,
         bool $pcntlAvailable,
         string $fileCacheDir,
+        bool $reexecAlreadyDone = false,
     ): OpcacheReexecDecision {
-        // Already configured is also the loop guard: the re-exec'd child
-        // inherits the file_cache flag, so it falls through here and never
-        // re-execs again.
-        if ($optedOut || !$pcntlAvailable || $fileCacheConfigured) {
+        // file_cache already set is one loop guard (the child inherits the
+        // flag); the breadcrumb is the belt-and-suspenders one that holds even
+        // if a build fails to read that flag back.
+        if ($optedOut || !$pcntlAvailable || $fileCacheConfigured || $reexecAlreadyDone) {
             return new OpcacheReexecDecision(false, []);
         }
 
@@ -40,6 +49,16 @@ final class OpcacheReexec
         if ($flags === []) {
             return new OpcacheReexecDecision(false, []);
         }
+
+        // file_cache_only skips OPcache's shared-memory segment (and its
+        // /tmp/.ZendSem.* semaphore) while keeping the on-disk opcode cache that
+        // gives the warm-start win. A short-lived CLI process never reuses SHM
+        // across invocations, and allocating it can block on a semaphore lock
+        // during startup on some CI filesystems — dropping it removes that hang
+        // with no loss of cache benefit. Scoped to the CLI re-exec; parallel
+        // test workers keep SHM.
+        $flags[] = '-d';
+        $flags[] = 'opcache.file_cache_only=1';
 
         return new OpcacheReexecDecision(true, $flags);
     }

--- a/tests/php/Unit/Shared/Performance/OpcacheReexecTest.php
+++ b/tests/php/Unit/Shared/Performance/OpcacheReexecTest.php
@@ -20,10 +20,34 @@ final class OpcacheReexecTest extends TestCase
         );
 
         self::assertTrue($decision->shouldReexec);
+        // file_cache_only is appended for the CLI re-exec to skip the OPcache
+        // SHM segment (a startup-lock hang risk) while keeping the disk cache.
         self::assertSame(
-            ['-d', 'opcache.enable_cli=1', '-d', 'opcache.file_cache=/var/phel/opcache'],
+            [
+                '-d', 'opcache.enable_cli=1',
+                '-d', 'opcache.file_cache=/var/phel/opcache',
+                '-d', 'opcache.file_cache_only=1',
+            ],
             $decision->flags,
         );
+    }
+
+    public function test_does_not_reexec_when_breadcrumb_marks_it_already_done(): void
+    {
+        // The re-exec'd child inherits PHEL_OPCACHE_REEXEC_DONE; this guard holds
+        // even if it misreads opcache.file_cache back as empty, so the exec can
+        // never loop regardless of the PHP/opcache build.
+        $decision = OpcacheReexec::decide(
+            opcacheLoaded: true,
+            fileCacheConfigured: false,
+            optedOut: false,
+            pcntlAvailable: true,
+            fileCacheDir: '/var/phel/opcache',
+            reexecAlreadyDone: true,
+        );
+
+        self::assertFalse($decision->shouldReexec);
+        self::assertSame([], $decision->flags);
     }
 
     public function test_does_not_reexec_when_opcache_extension_is_absent(): void


### PR DESCRIPTION
## 🤔 Background

Since #2632, `bin/phel` re-execs itself once via `pcntl_exec` with `opcache.enable_cli=1` + `opcache.file_cache=<PHEL_DIR>/opcache` so warm `run`/`eval`/`repl`/`test` reuse compiled opcode. Turning OPcache on also allocates a **shared-memory segment** guarded by a `/tmp/.ZendSem.*` semaphore.

The CI job "Core tests on PHP 8.4" hung silently for 17+ minutes on two runs of a recent PR, then passed in 77s when re-run on a fresh runner. The identical code on PHP 8.5 never hung (8.5 always-loads OPcache via a different startup path). The serial `composer test-core` spawns no test workers and reads no stdin, so the only subprocess in play is this self-re-exec.

The most likely mechanism is a blocking advisory-lock wait (`fcntl F_SETLKW`) during the re-exec'd child's OPcache **SHM** startup on that runner's filesystem (cf. php-src #11609/#11336) — intermittent and infra-dependent, which is why it could not be reproduced locally across ~9 cold full-suite runs on PHP 8.4 Linux.

## 💡 Goal

Make the CLI re-exec unable to hang, without losing the #2632 warm-start win.

## 🔖 Changes

- **`opcache.file_cache_only=1` on the CLI re-exec** (`OpcacheReexec::decide`): a short-lived CLI process never reuses the SHM segment across invocations, so we keep the on-disk opcode cache (and its speedup) but skip the SHM segment and its semaphore — removing the suspected startup-lock hang. Scoped to the CLI re-exec only; `phel test --parallel` workers (#2628) keep SHM unchanged.
- **Re-exec-once breadcrumb** `PHEL_OPCACHE_REEXEC_DONE`: set via `putenv()` immediately before `pcntl_exec`; `decide()` treats its presence as an unconditional "never re-exec again". This removes the entire infinite-loop class even on a hypothetical build where `ini_get('opcache.file_cache')` reads back empty.
- Updated `OpcacheReexecTest` (asserts the appended flag; new breadcrumb-guard case) and the `## Unreleased` CHANGELOG `### Fixed` entry.

No warm-benefit regression — direct A/B (flags passed as the child receives them): plain `file_cache` ~0.20-0.24s vs `file_cache_only=1` ~0.18-0.19s (equal-or-faster). `composer test-quality`, the full unit suite, the integration transparency test, and `composer test-core` all pass with no hang.

### Suggested follow-up (separate, protected path)

`.github/workflows/tests.yml` is protected so it is **not** touched here. Recommend adding a fail-fast backstop to the `core-tests` job (normally ~75s) so any future hang fails in minutes instead of stalling the runner:

```diff
   core-tests:
     name: Core tests on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
+    timeout-minutes: 8
```
