### PR TITLE
fix(build): emit (load ...) stdlib secondaries when compiled-code cache is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - `phel run`/`test`/`build`/`profile`/`export` now surface the `.phel` source location and filtered stack trace for runtime errors thrown from the stdlib (e.g. `(/ 1 0)`), matching the REPL, instead of only the bare message (#2635)
 - No more spurious `unlink(...): No such file or directory` warnings on `phel test`/build when cleaning up a temp file an earlier run already removed
 - The CLI OPcache re-exec (#2632) now runs the warm child with `opcache.file_cache_only`, avoiding an intermittent multi-minute hang on some CI filesystems where allocating OPcache's shared-memory segment blocked on a startup lock; a re-exec-once breadcrumb also guarantees the re-exec can never loop
+- `phel build` with the compiled-code cache disabled now still emits the `(load ...)` secondaries (`out/phel/core/*.php`) next to their primary, so a self-contained PHAR no longer fatals with `Cannot locate core/… for (load ...)` on first load; the harvester falls back to the build-time compiled output when there is no cache to copy from (#2648)
 
 ### Performance
 

--- a/src/php/Build/Application/FileEvaluator.php
+++ b/src/php/Build/Application/FileEvaluator.php
@@ -9,6 +9,7 @@ use Phel\Build\BuildFacade;
 use Phel\Build\Domain\Cache\CompiledCodeCacheInterface;
 use Phel\Build\Domain\Cache\DependencyTrackerInterface;
 use Phel\Build\Domain\Compile\CompiledFile;
+use Phel\Build\Domain\Compile\CompiledSecondaryStore;
 use Phel\Build\Domain\Extractor\FirstFormExtractor;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
@@ -44,6 +45,7 @@ final class FileEvaluator
         private readonly FirstFormExtractor $firstFormExtractor = new FirstFormExtractor(),
         private readonly ?DependencyTrackerInterface $dependencyTracker = null,
         private readonly int $optimizationLevel = CompileOptions::DEFAULT_OPTIMIZATION_LEVEL,
+        private readonly ?CompiledSecondaryStore $compiledSecondaryStore = null,
     ) {}
 
     /**
@@ -149,6 +151,22 @@ final class FileEvaluator
             ->setSource($src)
             ->setIsEnabledSourceMaps(true)
             ->setOptimizationLevel($this->optimizationLevel);
+
+        // With no persistent cache there is nowhere for the harvester to pick up
+        // a built `(load ...)` secondary. During a build, capture the compiled
+        // PHP here — the one point the registry is warm in the right order — so
+        // the harvester can still emit `out/<ns>/*.php`. `compileForCache()`
+        // evaluates each form as it emits (so later forms still resolve) and
+        // produces the same cache-mode output (forward-decl guards + inline
+        // source map) the harvester would otherwise copy from the cache. The
+        // "<?php\n" prefix mirrors CompiledCodeCache::put, so the harvested file
+        // is byte-identical whether it came from the cache or from here.
+        if ($this->compiledSecondaryStore instanceof CompiledSecondaryStore && BuildFacade::isBuildMode()) {
+            $result = $this->compilerFacade->compileForCache($code, $options);
+            $this->compiledSecondaryStore->put($src, "<?php\n" . $result->getCodeWithSourceMap());
+
+            return new CompiledFile($src, '', $namespace);
+        }
 
         $this->compilerFacade->eval($code, $options);
 

--- a/src/php/Build/Application/ProjectCompiler.php
+++ b/src/php/Build/Application/ProjectCompiler.php
@@ -41,7 +41,7 @@ final readonly class ProjectCompiler
         private CommandFacadeInterface $commandFacade,
         private EntryPointPhpFileInterface $entryPointPhpFile,
         private BuildConfigInterface $config,
-        private ?SecondaryFileHarvester $secondaryFileHarvester = null,
+        private SecondaryFileHarvester $secondaryFileHarvester,
     ) {
         $this->targetPathResolver = new CompiledTargetPathResolver($compilerFacade);
     }
@@ -160,10 +160,6 @@ final readonly class ProjectCompiler
      */
     private function harvestSecondaries(array $namespaceInformation, string $dest, array $srcDirectories): void
     {
-        if (!$this->secondaryFileHarvester instanceof SecondaryFileHarvester) {
-            return;
-        }
-
         foreach ($namespaceInformation as $info) {
             if ($info->isPrimaryDefinition()) {
                 continue;

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -16,6 +16,7 @@ use Phel\Build\Application\NamespaceExtractor;
 use Phel\Build\Application\ProjectCompiler;
 use Phel\Build\Domain\Cache\NamespaceCacheInterface;
 use Phel\Build\Domain\Cache\ScanIndexCacheInterface;
+use Phel\Build\Domain\Compile\CompiledSecondaryStore;
 use Phel\Build\Domain\Compile\CompiledTargetPathResolver;
 use Phel\Build\Domain\Compile\FileCompilerInterface;
 use Phel\Build\Domain\Compile\Output\EntryPointPhpFile;
@@ -88,6 +89,7 @@ final class BuildFactory extends AbstractFactory
                 $this->createFirstFormExtractor(),
                 $this->createDependencyTracker(),
                 $this->getConfig()->getOptimizationLevel(),
+                $this->createCompiledSecondaryStore(),
             ),
         );
         return $evaluator;
@@ -155,18 +157,28 @@ final class BuildFactory extends AbstractFactory
         return $facade;
     }
 
-    private function createSecondaryFileHarvester(): ?SecondaryFileHarvester
+    private function createSecondaryFileHarvester(): SecondaryFileHarvester
     {
-        $compiledCodeCache = $this->createCompiledCodeCache();
-        if (!$compiledCodeCache instanceof CompiledCodeCache) {
-            return null;
-        }
-
+        // Always present: with the compiled-code cache off it falls back to the
+        // in-memory store the evaluator fills, so secondaries are still emitted.
         return new SecondaryFileHarvester(
-            $compiledCodeCache,
             new CompiledTargetPathResolver($this->getCompilerFacade()),
             $this->createFileIo(),
+            $this->createCompiledSecondaryStore(),
+            $this->createCompiledCodeCache(),
         );
+    }
+
+    private function createCompiledSecondaryStore(): CompiledSecondaryStore
+    {
+        // Shared singleton: the FileEvaluator writes built secondaries into it
+        // and the harvester drains it within the same build process.
+        /** @var CompiledSecondaryStore $store */
+        $store = $this->singleton(
+            CompiledSecondaryStore::class,
+            static fn(): CompiledSecondaryStore => new CompiledSecondaryStore(),
+        );
+        return $store;
     }
 
     private function createCompiledCodeCache(): ?CompiledCodeCache

--- a/src/php/Build/CLAUDE.md
+++ b/src/php/Build/CLAUDE.md
@@ -36,7 +36,8 @@ Compiles Phel projects to PHP: namespace extraction, dependency ordering, and ca
 | `Domain/Extractor/TopologicalNamespaceSorter` | Dependency-order compilation |
 | `Domain/Compile/BuildReport` + `BuildReportEntry` | `--report` VO (`toArray()`); command renders it |
 | `Domain/Compile/PhaseTimingReport` | `--timing` per-phase wall-clock report |
-| `Domain/Compile/SecondaryFileHarvester` | Harvests cached `.php` siblings into the build output tree |
+| `Domain/Compile/SecondaryFileHarvester` | Writes `(in-ns ...)` secondary `.php` siblings into the build output tree; takes them from the compiled-code cache, else from `CompiledSecondaryStore` (so a cache-off build still emits them) |
+| `Domain/Compile/CompiledSecondaryStore` | In-memory hand-off of build-time-compiled secondaries from `FileEvaluator` to `SecondaryFileHarvester` when the compiled-code cache is off |
 | `Infrastructure/Cache/CompiledCodeCache` | Compiled-code cache policy orchestrator |
 | `Infrastructure/Cache/PhpScanIndexCache` / `NullScanIndexCache` | Persisted dir-scan index |
 | `Infrastructure/Cache/PhpNamespaceCache` / `NullNamespaceCache` | Namespace-extraction cache |

--- a/src/php/Build/Domain/Compile/CompiledSecondaryStore.php
+++ b/src/php/Build/Domain/Compile/CompiledSecondaryStore.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Domain\Compile;
+
+/**
+ * In-memory hand-off of compiled `(in-ns ...)` secondaries from the build-time
+ * `(load ...)` evaluation to the {@see SecondaryFileHarvester}.
+ *
+ * Secondaries must be compiled while the primary's `(load ...)` runs, because
+ * that is the only point the registry is warm in the right order (recompiling
+ * one standalone afterwards re-runs macro expansion against a partial registry
+ * and fails). When the persistent compiled-code cache is on, that cached `.php`
+ * is what the harvester copies. With the cache off there is nowhere to keep the
+ * compiled output, so this store holds it for the duration of the build instead
+ * — keeping every `out/phel/core/*.php` sibling without a fragile recompile.
+ */
+final class CompiledSecondaryStore
+{
+    /** @var array<string, string> source path => compiled PHP (with preamble) */
+    private array $compiledBySource = [];
+
+    public function put(string $sourcePath, string $phpCode): void
+    {
+        $this->compiledBySource[$sourcePath] = $phpCode;
+    }
+
+    public function get(string $sourcePath): ?string
+    {
+        return $this->compiledBySource[$sourcePath] ?? null;
+    }
+}

--- a/src/php/Build/Domain/Compile/SecondaryFileHarvester.php
+++ b/src/php/Build/Domain/Compile/SecondaryFileHarvester.php
@@ -18,21 +18,30 @@ use function mkdir;
 use function sprintf;
 
 /**
- * Copies a compiled `(in-ns ...)` secondary from the compile cache into
- * the build output directory.
+ * Writes a compiled `(in-ns ...)` secondary into the build output directory.
  *
- * Primary files compile directly through `FileCompiler`. Secondaries
- * are pulled in by the primary's `(load ...)` at build-time evaluation,
- * which leaves a cached `.php` in `CompiledCodeCache`. This class
- * relocates that cached output into the public build tree so a deployed
- * artifact ships a sibling `.php` for every `(in-ns ...)` file.
+ * Primary files compile directly through `FileCompiler`. Secondaries are pulled
+ * in by the primary's `(load ...)` at build-time evaluation; that run compiles
+ * each one against a warm registry. This class lands the resulting `.php` next
+ * to the primary so a deployed artifact (e.g. a self-contained PHAR) ships a
+ * sibling for every `(in-ns ...)` file and can `(load ...)` it without the
+ * `.phel` sources or a runtime compiler.
+ *
+ * It never recompiles a secondary standalone — that re-runs macro expansion
+ * against a partially-ready registry and fails. It takes the build-time output
+ * from the compiled-code cache when enabled, else from the in-memory
+ * {@see CompiledSecondaryStore} the evaluator fills during the same build. With
+ * the cache off and no store a build emitted the primary `out/phel/core.php`
+ * but none of its `out/phel/core/*.php` secondaries, so the bundle fataled with
+ * "Cannot locate core/… for (load ...)" on first load.
  */
 final readonly class SecondaryFileHarvester
 {
     public function __construct(
-        private CompiledCodeCacheInterface $compiledCodeCache,
         private CompiledTargetPathResolver $targetPathResolver,
         private FileIoInterface $fileIo,
+        private CompiledSecondaryStore $compiledSecondaryStore,
+        private ?CompiledCodeCacheInterface $compiledCodeCache = null,
     ) {}
 
     /**
@@ -42,22 +51,34 @@ final readonly class SecondaryFileHarvester
     {
         $sourceFile = $secondary->getFile();
         $sourceCode = $this->fileIo->getContents($sourceFile);
-        $cachedPath = $this->compiledCodeCache->get($sourceFile, md5($sourceCode));
 
-        if ($cachedPath === null) {
-            // The primary didn't (load ...) this secondary during the build.
-            // Compile cache may have been disabled or the secondary is
-            // orphaned — nothing to copy, the build still succeeds.
+        $phpCode = $this->compiledPhp($sourceFile, $sourceCode);
+        if ($phpCode === null) {
+            // The primary never (load ...)ed this secondary during the build
+            // (e.g. an orphaned file) — nothing to emit, the build still
+            // succeeds.
             return;
         }
 
         $targetPath = $destDir . '/' . $this->targetPathResolver->resolve($secondary, $sourceDirectories);
         $this->ensureDir(dirname($targetPath));
-        $this->fileIo->putContents($targetPath, $this->fileIo->getContents($cachedPath));
+        $this->fileIo->putContents($targetPath, $phpCode);
         $this->fileIo->putContents(
             SourceMapSiblings::sourceFile($targetPath),
             $sourceCode,
         );
+    }
+
+    private function compiledPhp(string $sourceFile, string $sourceCode): ?string
+    {
+        if ($this->compiledCodeCache instanceof CompiledCodeCacheInterface) {
+            $cachedPath = $this->compiledCodeCache->get($sourceFile, md5($sourceCode));
+            if ($cachedPath !== null) {
+                return $this->fileIo->getContents($cachedPath);
+            }
+        }
+
+        return $this->compiledSecondaryStore->get($sourceFile);
     }
 
     private function ensureDir(string $dir): void

--- a/tests/php/Integration/Build/Command/BuildCommandLoadNoCompiledCacheE2ETest.php
+++ b/tests/php/Integration/Build/Command/BuildCommandLoadNoCompiledCacheE2ETest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Build\Command;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use Phel\Build\Infrastructure\Command\BuildCommand;
+use PhelTest\Integration\Util\DirectoryUtil;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\StreamOutput;
+
+use function dirname;
+use function escapeshellarg;
+use function fopen;
+use function is_dir;
+use function rename;
+use function shell_exec;
+use function sprintf;
+use function stream_get_contents;
+use function trim;
+use function var_export;
+
+/**
+ * Regression for #2648: with the compiled-code cache off, a `phel build` must
+ * still emit the `(load ...)` secondaries next to their primary. The harvester
+ * used to copy them out of that cache, so disabling the cache silently dropped
+ * every secondary and the bundle fataled with "Cannot locate … for (load ...)"
+ * the moment the primary loaded.
+ *
+ * Uses the same `src-load-e2e` fixture as {@see BuildCommandLoadE2ETest}, only
+ * with `withEnableCompiledCodeCache(false)`.
+ */
+final class BuildCommandLoadNoCompiledCacheE2ETest extends TestCase
+{
+    private const string DEST_DIR = __DIR__ . '/out-load-e2e-no-cache';
+
+    private const string SRC_DIR = __DIR__ . '/src-load-e2e';
+
+    public static function tearDownAfterClass(): void
+    {
+        DirectoryUtil::removeDir(self::DEST_DIR);
+        self::restoreSrcDir();
+        DirectoryUtil::removeDir(sys_get_temp_dir() . '/phel');
+    }
+
+    protected function setUp(): void
+    {
+        DirectoryUtil::removeDir(self::DEST_DIR);
+        self::restoreSrcDir();
+        DirectoryUtil::removeDir(sys_get_temp_dir() . '/phel');
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_build_emits_loaded_secondaries_without_the_compiled_code_cache(): void
+    {
+        $this->runBuild();
+
+        self::assertFileExists(self::DEST_DIR . '/loade2e/core.php');
+        self::assertFileExists(self::DEST_DIR . '/loade2e/core/util.php');
+        self::assertFileExists(self::DEST_DIR . '/loade2e/core/greet.php');
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_built_artifact_runs_without_the_source_tree(): void
+    {
+        $this->runBuild();
+        $this->hideSrcDir();
+
+        $runner = $this->writeRunner();
+        $output = trim((string) shell_exec('php ' . escapeshellarg($runner) . ' 2>&1'));
+
+        self::assertStringContainsString('>> Hello, world!', $output);
+    }
+
+    private function writeRunner(): string
+    {
+        $runner = self::DEST_DIR . '/run.php';
+        $autoload = dirname(__DIR__, 5) . '/vendor/autoload.php';
+        $compiled = self::DEST_DIR . '/loade2e/core.php';
+
+        $code = sprintf(
+            "<?php declare(strict_types=1);\nrequire_once %s;\nrequire_once %s;\n",
+            var_export($autoload, true),
+            var_export($compiled, true),
+        );
+        file_put_contents($runner, $code);
+
+        return $runner;
+    }
+
+    private function runBuild(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addAppConfig('phel-config-load-e2e-no-compiled-cache.php');
+        });
+
+        ob_start();
+        $output = new StreamOutput(fopen('php://memory', 'w+') ?: throw new RuntimeException('Cannot open memory stream'));
+        $exit = new BuildCommand()->run(new ArrayInput(['--no-source-map' => true]), $output);
+        ob_end_clean();
+
+        if ($exit !== 0) {
+            rewind($output->getStream());
+            self::fail('Build command failed (exit=' . $exit . "):\n" . stream_get_contents($output->getStream()));
+        }
+    }
+
+    private function hideSrcDir(): void
+    {
+        if (is_dir(self::SRC_DIR)) {
+            rename(self::SRC_DIR, self::SRC_DIR . '.bak');
+        }
+    }
+
+    private static function restoreSrcDir(): void
+    {
+        if (is_dir(self::SRC_DIR . '.bak')) {
+            rename(self::SRC_DIR . '.bak', self::SRC_DIR);
+        }
+    }
+}

--- a/tests/php/Integration/Build/Command/phel-config-load-e2e-no-compiled-cache.php
+++ b/tests/php/Integration/Build/Command/phel-config-load-e2e-no-compiled-cache.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Phel\Config\PhelConfig;
+
+// Same project as phel-config-load-e2e.php but with the compiled-code cache
+// off, the configuration that made a downstream build drop its `(load ...)`
+// secondaries (#2648).
+return new PhelConfig()
+    ->withSrcDirs([__DIR__ . '/src-load-e2e'])
+    ->withVendorDir('')
+    ->withMainPhelNamespace('loade2e\core')
+    ->withMainPhpPath('out-load-e2e-no-cache/main.php')
+    ->withBuildDestDir('out-load-e2e-no-cache')
+    ->withEnableCompiledCodeCache(false)
+    ->withIgnoreWhenBuilding([]);


### PR DESCRIPTION
## 🤔 Background

Since 0.46 `phel.core` is split into `(load ...)`-ed submodules (`core/meta`, `core/math`, …). A **downstream** `phel build` compiles `out/phel/core.php` but, when the compiled-code cache is disabled, emits **none** of its `(load ...)` secondaries to `out/phel/core/*.php`. A self-contained PHAR bundling only `out/` + `vendor/` (no `.phel` sources, no classpath) then ships `core.php` without its siblings and **fatals on first load** with `Cannot locate core/… for (load ...)`. Reported from bundling [phel-doom](https://github.com/Chemaclass/phel-doom) on 0.46. Closes #2648.

Root cause: `SecondaryFileHarvester` only ever **copied** secondaries out of the compiled-code cache, and `BuildFactory::createSecondaryFileHarvester()` returned `null` (a complete no-op) when that cache was off — so every secondary was silently dropped. Even with the cache on, a missing/stale cache entry skipped a secondary.

The secondaries *are* compiled during the primary's build-time `(load ...)` — the one point the registry is warm in the right order. With the cache off, `FileEvaluator` previously just `eval`'d that code and threw the compiled PHP away.

## 💡 Goal

A `phel build` must always emit a `.php` sibling for every `(load ...)` secondary, with or without the compiled-code cache, so a self-contained bundle loads. Without recompiling a secondary standalone — that re-runs macro expansion against a partially-ready registry and fails (`condp` etc.).

## 🔖 Changes

- New `CompiledSecondaryStore` — an in-memory hand-off of build-time-compiled secondaries from `FileEvaluator` to `SecondaryFileHarvester`.
- `FileEvaluator`: in the no-cache branch, during a build, compile via `compileForCache` (which evaluates each form as it emits, so later forms still resolve) and stash the result in the store. Output is byte-identical (modulo gensym numbering) to what the cache would hold.
- `SecondaryFileHarvester`: take the compiled secondary from the compiled-code cache when present, else from the store. Always emit it.
- `BuildFactory`: always create the harvester (never `null`); share the store singleton with the evaluator.
- `ProjectCompiler`: the harvester is now required (drops the nullable + guard).
- Regression test `BuildCommandLoadNoCompiledCacheE2ETest` (compiled-code cache **off**): asserts the `(load ...)` secondaries are emitted and the built artifact runs with the source tree hidden. Verified it **fails on `main`** (missing `core/util.php`; runtime fatal) and passes here.
- CHANGELOG `## Unreleased` + Build module `CLAUDE.md`.

`composer test-quality` (cs-fixer, psalm, phpstan L9, rector, config) green; full unit suite green; the existing `BuildCommandLoadE2ETest` (cache on) still passes.
