### PR TITLE
docs(init): add composer install to next-steps output

### DIFF
--- a/src/php/Run/Infrastructure/Command/InitCommand.php
+++ b/src/php/Run/Infrastructure/Command/InitCommand.php
@@ -418,6 +418,7 @@ HELP)
         $output->writeln('Next steps:');
 
         $step = 1;
+        $output->writeln(sprintf('  %d. Install dependencies: <comment>composer install</comment>', $step++));
         $output->writeln(sprintf('  %d. Run your code:  <comment>./vendor/bin/phel run %s</comment>', $step++, $mainFilename));
         if (!$noTests) {
             $output->writeln(sprintf('  %d. Run the tests: <comment>./vendor/bin/phel test</comment>', $step++));


### PR DESCRIPTION
## 🤔 Background

phel init prints steps referencing ./vendor/bin/phel, but users haven't run composer install yet.

## 💡 Goal

Add composer install as step 1 so new users don't hit "command not found."

## 🔖 Changes

- Added "Install dependencies: composer install" as step 1 in printNextSteps()