### PR TITLE
fix(compiler): rank did-you-mean suggestions by relevance not raw edit distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- "Did you mean" suggestions now rank by relevance instead of raw edit distance: a typed symbol that is an in-order subsequence of a candidate is preferred (so `prn` suggests `print`/`printf`/`println` rather than `or`/`pop`/`put`), distance ties break on shared prefix, and a good longer match is no longer cut off by the fixed distance ceiling (#2637)
 - Requiring a non-existent user namespace now fails fast with `Cannot find namespace '…' required by '…'` instead of silently exiting 0 and surfacing later as a generic `Cannot resolve symbol`; framework `phel.*`/`clojure.*`, already-loaded, and PHP-interop `(:use …)` requires stay tolerated (#2636)
 - `phel run`/`test`/`build`/`profile`/`export` now surface the `.phel` source location and filtered stack trace for runtime errors thrown from the stdlib (e.g. `(/ 1 0)`), matching the REPL, instead of only the bare message (#2635)
 - No more spurious `unlink(...): No such file or directory` warnings on `phel test`/build when cleaning up a temp file an earlier run already removed

--- a/src/php/Compiler/Domain/Analyzer/SymbolSuggestionProvider.php
+++ b/src/php/Compiler/Domain/Analyzer/SymbolSuggestionProvider.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Analyzer;
 
+use function array_map;
+use function array_slice;
+use function intdiv;
 use function levenshtein;
+use function max;
+use function min;
+use function strcmp;
 use function strlen;
 use function usort;
 
@@ -20,37 +26,76 @@ final class SymbolSuggestionProvider
      * @param string        $undefinedSymbol  The symbol that could not be resolved
      * @param array<string> $availableSymbols List of available symbols to search through
      *
-     * @return array<string> List of suggested symbols, sorted by similarity
+     * @return array<string> List of suggested symbols, most relevant first
      */
     public function findSimilar(string $undefinedSymbol, array $availableSymbols): array
     {
-        $suggestions = [];
-
+        $scored = [];
         foreach ($availableSymbols as $candidate) {
-            $distance = $this->calculateDistance($undefinedSymbol, $candidate);
-
-            if ($distance <= self::MAX_EDIT_DISTANCE && $distance > 0) {
-                $suggestions[] = [
-                    'symbol' => $candidate,
-                    'distance' => $distance,
-                ];
+            $score = $this->score($undefinedSymbol, $candidate);
+            if ($score !== null) {
+                $scored[] = $score;
             }
         }
 
-        usort($suggestions, static fn(array $a, array $b): int => $a['distance'] <=> $b['distance']);
+        usort($scored, $this->byRelevance(...));
 
-        $result = [];
-        $count = 0;
-        foreach ($suggestions as $suggestion) {
-            if ($count >= self::MAX_SUGGESTIONS) {
-                break;
-            }
+        return array_map(
+            static fn(array $score): string => $score['symbol'],
+            array_slice($scored, 0, self::MAX_SUGGESTIONS),
+        );
+    }
 
-            $result[] = $suggestion['symbol'];
-            ++$count;
+    /**
+     * Scores a candidate against the typed symbol, or returns `null` when the
+     * candidate is too dissimilar to suggest.
+     *
+     * @return array{symbol: string, subsequence: int, prefix: int, distance: int}|null
+     */
+    private function score(string $undefinedSymbol, string $candidate): ?array
+    {
+        $distance = $this->calculateDistance($undefinedSymbol, $candidate);
+        if ($distance === 0) {
+            // The candidate is the symbol itself; never suggest it.
+            return null;
         }
 
-        return $result;
+        $maxLength = max(strlen($undefinedSymbol), strlen($candidate));
+        $isSubsequence = $this->isSubsequence($undefinedSymbol, $candidate);
+
+        // Small absolute edits always qualify. Longer candidates that contain
+        // the typed symbol as an in-order subsequence (e.g. `prn` in `println`,
+        // distance 4) qualify under a length-scaled bound, so a good long match
+        // is not cut off by the fixed distance ceiling.
+        $accepted = $distance <= self::MAX_EDIT_DISTANCE
+            || ($isSubsequence && $distance <= intdiv($maxLength + 1, 2));
+        if (!$accepted) {
+            return null;
+        }
+
+        return [
+            'symbol' => $candidate,
+            'subsequence' => $isSubsequence ? 0 : 1,
+            'prefix' => $this->commonPrefixLength($undefinedSymbol, $candidate),
+            'distance' => $distance,
+        ];
+    }
+
+    /**
+     * Orders by, in priority: subsequence match (the typed symbol is an in-order
+     * fragment of the candidate, e.g. `prn` in `print`), then longer shared
+     * prefix, then smaller edit distance, then alphabetically for a stable,
+     * deterministic result.
+     *
+     * @param array{symbol: string, subsequence: int, prefix: int, distance: int} $a
+     * @param array{symbol: string, subsequence: int, prefix: int, distance: int} $b
+     */
+    private function byRelevance(array $a, array $b): int
+    {
+        return $a['subsequence'] <=> $b['subsequence']
+            ?: $b['prefix'] <=> $a['prefix']
+            ?: $a['distance'] <=> $b['distance']
+            ?: strcmp($a['symbol'], $b['symbol']);
     }
 
     private function calculateDistance(string $undefinedSymbol, string $candidate): int
@@ -63,5 +108,36 @@ final class SymbolSuggestionProvider
         }
 
         return levenshtein($undefinedSymbol, $candidate);
+    }
+
+    /**
+     * Whether every character of `$needle` appears in `$haystack` in order
+     * (not necessarily contiguously). `prn` is a subsequence of `println`.
+     */
+    private function isSubsequence(string $needle, string $haystack): bool
+    {
+        $needleLength = strlen($needle);
+        $haystackLength = strlen($haystack);
+
+        $i = 0;
+        for ($j = 0; $i < $needleLength && $j < $haystackLength; ++$j) {
+            if ($needle[$i] === $haystack[$j]) {
+                ++$i;
+            }
+        }
+
+        return $i === $needleLength;
+    }
+
+    private function commonPrefixLength(string $a, string $b): int
+    {
+        $limit = min(strlen($a), strlen($b));
+
+        $length = 0;
+        while ($length < $limit && $a[$length] === $b[$length]) {
+            ++$length;
+        }
+
+        return $length;
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SymbolSuggestionProviderTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SymbolSuggestionProviderTest.php
@@ -103,4 +103,39 @@ final class SymbolSuggestionProviderTest extends TestCase
 
         self::assertSame([], $suggestions);
     }
+
+    public function test_find_similar_prefers_print_family_over_unrelated_short_words(): void
+    {
+        // Regression for #2637: `prn` used to surface `or`/`pop`/`put` (all
+        // levenshtein distance 2) while `print`/`println` were absent.
+        $availableSymbols = ['or', 'pop', 'put', 'print', 'println', 'printf', 'map'];
+
+        $suggestions = $this->provider->findSimilar('prn', $availableSymbols);
+
+        self::assertSame('print', $suggestions[0]);
+        self::assertContains('println', $suggestions);
+        self::assertNotContains('or', $suggestions);
+        self::assertNotContains('pop', $suggestions);
+        self::assertNotContains('put', $suggestions);
+    }
+
+    public function test_find_similar_includes_longer_subsequence_beyond_fixed_distance(): void
+    {
+        // `prn` -> `println` is levenshtein distance 4 (> MAX_EDIT_DISTANCE),
+        // but `prn` is an in-order subsequence of `println`, so a length-scaled
+        // bound keeps the good long match instead of dropping it.
+        $suggestions = $this->provider->findSimilar('prn', ['println']);
+
+        self::assertSame(['println'], $suggestions);
+    }
+
+    public function test_find_similar_breaks_distance_ties_by_shared_prefix(): void
+    {
+        // `ab` is a subsequence of both `yab` and `abx` at the same distance (1);
+        // `abx` shares the leading prefix `ab` while `yab` shares none, so `abx`
+        // ranks first regardless of input order.
+        $suggestions = $this->provider->findSimilar('ab', ['yab', 'abx']);
+
+        self::assertSame('abx', $suggestions[0]);
+    }
 }


### PR DESCRIPTION
## 🤔 Background

"Did you mean" suggestions for an unresolved symbol were ordered by raw levenshtein distance alone. That had two visible failure modes for Clojure muscle-memory typos:

- Several unrelated short words tie at the same distance and the tie breaks arbitrarily.
- A closer *longer* match exceeds the fixed distance ceiling (`MAX_EDIT_DISTANCE = 3`) and is dropped entirely.

```
$ phel eval '(prn "x")'
[PHEL001] Cannot resolve symbol 'prn'. Did you mean 'or', 'pop', or 'put'?
```

`levenshtein("prn","print") = 2` ties with `or`/`pop`/`put` (also 2), and `println` = 4 is over the ceiling, so the genuinely useful suggestions never appear.

## 💡 Goal

Surface the relevant suggestions first, so `prn` proposes `print`/`printf`/`println`.

## 🔖 Changes

- `SymbolSuggestionProvider` now ranks candidates by, in priority: in-order **subsequence** match (the typed symbol is a fragment of the candidate, e.g. `prn` in `print`), then longer shared **prefix**, then smaller edit **distance**, then alphabetically for a stable, deterministic result.
- A subsequence match also qualifies under a **length-scaled** distance bound (`ceil(maxLen / 2)`), so a good longer candidate (`println` for `prn`) is no longer cut off by the fixed ceiling. Small absolute edits still qualify as before.
- Added unit tests for the `prn` regression, the length-scaled subsequence acceptance, and the prefix tie-break. All existing suggestion tests stay green.

After:

```
$ phel eval '(prn "x")'
[PHEL001] Cannot resolve symbol 'prn'. Did you mean 'print', 'printf', or 'println'?
```

CHANGELOG updated under `## Unreleased`.

Closes #2637