### PR TITLE
fix(run): don't leak compiled temp path on not-callable error; fire hint for scalars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Invoking a non-function value (e.g. `(def x 5)` then `(x 1 2)`) now shows only the `.phel` source location and an actionable `hint:` instead of leaking the internal compiled temp path (`__phel_<hash>.php`): the not-callable hint also fires for PHP's scalar wording (`Value of type int is not callable`, not only `Object of type …`), and the ephemeral eval temp file is no longer printed as a `(compiled: …)` clause (persistent `out/` build artifacts still are, to help diagnose stale builds) (#2638)
 - "Did you mean" suggestions now rank by relevance instead of raw edit distance: a typed symbol that is an in-order subsequence of a candidate is preferred (so `prn` suggests `print`/`printf`/`println` rather than `or`/`pop`/`put`), distance ties break on shared prefix, and a good longer match is no longer cut off by the fixed distance ceiling (#2637)
 - Requiring a non-existent user namespace now fails fast with `Cannot find namespace '…' required by '…'` instead of silently exiting 0 and surfacing later as a generic `Cannot resolve symbol`; framework `phel.*`/`clojure.*`, already-loaded, and PHP-interop `(:use …)` requires stay tolerated (#2636)
 - `phel run`/`test`/`build`/`profile`/`export` now surface the `.phel` source location and filtered stack trace for runtime errors thrown from the stdlib (e.g. `(/ 1 0)`), matching the REPL, instead of only the bare message (#2635)

--- a/src/php/Command/Application/CommandExceptionWriter.php
+++ b/src/php/Command/Application/CommandExceptionWriter.php
@@ -103,6 +103,15 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
         $output->writeln($cause->getMessage());
 
         if ($position->filename() !== $file) {
+            // An ephemeral eval temp file (`__phel_<hash>.php`) is an internal
+            // artifact with no meaning to a Phel user, so only show the resolved
+            // source. A persistent build artifact (`out/phel/…`) still names its
+            // compiled file, which is useful when diagnosing a stale build.
+            if ($this->isEphemeralCompiledFile($file)) {
+                $output->writeln(sprintf('  at %s:%d', $position->filename(), $position->line()));
+                return;
+            }
+
             $output->writeln(sprintf(
                 '  at %s:%d (compiled: %s:%d)',
                 $position->filename(),
@@ -117,5 +126,15 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
         if (str_ends_with($file, '.php')) {
             $output->writeln('  hint: ' . $this->staleOutputHint);
         }
+    }
+
+    /**
+     * Whether the compiled file is an ephemeral eval temp file (named
+     * `__phel_<hash>.php` by the evaluator), as opposed to a persistent build
+     * artifact under `out/`.
+     */
+    private function isEphemeralCompiledFile(string $file): bool
+    {
+        return str_starts_with(basename($file), '__phel');
     }
 }

--- a/src/php/Shared/Exceptions/Hint/NotCallableHint.php
+++ b/src/php/Shared/Exceptions/Hint/NotCallableHint.php
@@ -43,7 +43,10 @@ final class NotCallableHint implements ExceptionHintInterface
 
     private function extractType(string $message): ?string
     {
-        if (preg_match('/Object of type ([\\w\\\\]+) is not callable/', $message, $m) === 1) {
+        // PHP phrases invoking a non-callable as "Object of type X ..." when X is
+        // an object and "Value of type X ..." when X is a scalar (int, string, …),
+        // so match both so e.g. `((def x 5) ...) (x 1)` still surfaces a hint.
+        if (preg_match('/(?:Object|Value) of type ([\\w\\\\]+) is not callable/', $message, $m) === 1) {
             return $m[1];
         }
 

--- a/tests/php/Unit/Command/Application/CommandExceptionWriterTest.php
+++ b/tests/php/Unit/Command/Application/CommandExceptionWriterTest.php
@@ -51,6 +51,35 @@ final class CommandExceptionWriterTest extends TestCase
         self::assertStringNotContainsString('KeepGeneratedTempFiles', $text);
     }
 
+    public function test_suppresses_compiled_temp_path_for_ephemeral_eval_file(): void
+    {
+        // An eval temp file (`__phel_<hash>.php`) is an internal artifact; only
+        // the resolved Phel source should be shown, never the temp path (#2638).
+        $compiledPath = '/private/var/folders/T/phel/tmp/__phel_abc123.php';
+        $compiledLine = 4;
+
+        $extractor = $this->createStub(FilePositionExtractorInterface::class);
+        $extractor->method('getOriginal')->willReturn(new FilePosition('/proj/03-not-fn.phel', 3));
+
+        $writer = new CommandExceptionWriter(
+            $this->createStub(ExceptionPrinterInterface::class),
+            $this->createStub(ErrorLogInterface::class),
+            $extractor,
+            'stale hint',
+            new ExceptionHintResolver([]),
+        );
+
+        $output = new BufferedOutput();
+        $writer->writeStackTrace($output, $this->errorAt('Value of type int is not callable', $compiledPath, $compiledLine));
+
+        $text = $output->fetch();
+
+        self::assertStringContainsString('Value of type int is not callable', $text);
+        self::assertStringContainsString('at /proj/03-not-fn.phel:3', $text);
+        self::assertStringNotContainsString('compiled:', $text);
+        self::assertStringNotContainsString('__phel_abc123.php', $text);
+    }
+
     public function test_emits_stale_output_hint_when_source_map_missing(): void
     {
         $compiledPath = '/proj/out/phel/http.php';

--- a/tests/php/Unit/Shared/Exceptions/Hint/NotCallableHintTest.php
+++ b/tests/php/Unit/Shared/Exceptions/Hint/NotCallableHintTest.php
@@ -43,4 +43,16 @@ final class NotCallableHintTest extends TestCase
 
         self::assertStringContainsString("'App\\Custom\\Thing'", $hint->hint($e));
     }
+
+    public function test_applies_to_scalar_value_not_callable_message(): void
+    {
+        // PHP phrases a non-callable scalar as "Value of type int is not
+        // callable" (e.g. `(def x 5)` then `(x 1)`); the hint must fire here too.
+        $hint = new NotCallableHint();
+        $e = new Error('Value of type int is not callable');
+
+        self::assertTrue($hint->appliesTo($e));
+        self::assertStringContainsString("'int'", $hint->hint($e));
+        self::assertStringContainsString('first', $hint->hint($e));
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Invoking a non-function value via `phel run` produced a developer-hostile error:

```
$ phel run 03-not-fn.phel    # (def x 5) then (x 1 2)
Value of type int is not callable
  at .../03-not-fn.phel:3 (compiled: /private/var/.../T/phel/tmp/__phel_<hash>.php:4)
   ... 21 internal frames
```

Two problems: it leaks an internal compiled temp path that means nothing to a Phel user, and no actionable `hint:` fires — `NotCallableHint` only matched PHP's *object* wording (`Object of type X is not callable`), while PHP phrases a non-callable **scalar** as `Value of type int is not callable`.

## 💡 Goal

Show only the `.phel` location plus an actionable hint, matching the clean `[PHEL…]` errors that analyze-time validations already give.

## 🔖 Changes

- `NotCallableHint` now matches both `Object of type X …` and `Value of type X …`, so the hint fires for scalars (`int`, `string`, …) too.
- `CommandExceptionWriter` suppresses the `(compiled: …)` clause when the compiled file is an ephemeral eval temp file (`__phel_<hash>.php`); persistent `out/` build artifacts still show it (useful when diagnosing a stale build).
- Unit tests for both: scalar `Value of type int …` hint, and ephemeral-temp-path suppression.

After:

```
Value of type int is not callable
  at .../03-not-fn.phel:3
   ... 21 internal frames
hint: value of type 'int' is not a function. Drop the parens, or use an accessor like (first), (nth), or (get).
```

CHANGELOG updated under `## Unreleased`.

Closes #2638