### PR TITLE
fix(bootstrap): resolve project root from CWD, not the binary location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- A global or PHAR `phel` install now resolves the project root from the working directory (walking up to the nearest `phel-config.php`) instead of the binary's location, so `phel config`/`doctor` read the local config and see the project's source/test dirs from any project directory (#2640)
 - `phel.router/compiled-router` now compiles routes that carry a `:handler` function (every real route, and the macro's own docstring `:example`), instead of failing with `literal not supported: …AbstractFn` (#2663)
 - `phel build` at an optimization level above 0 now ships the full `(load ...)` secondaries (e.g. `phel.core`'s `core/meta.php`) instead of a broken artifact that fataled with `Cannot locate core/… for (load ...)` on first load (#2631)
 - `defn`/`defmacro` (and their `-` variants) with a non-symbol name (e.g. `(defn 123 [x] x)`) now fail with a clean `[PHEL005]` error naming the offending type, instead of crashing with an internal PHP error that leaked core internals (#2639)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- A global or PHAR `phel` install now resolves the project root from the working directory (walking up to the nearest `phel-config.php`) instead of the binary's location, so `phel config`/`doctor` read the local config and see the project's source/test dirs from any project directory (#2640)
+- A global or PHAR `phel` install now resolves the project root from the working directory (walking up to the nearest project root — a `phel-config.php` or installed `vendor/`) instead of the binary's location, so `phel config`/`doctor` read the local config and see the project's source/test dirs from any project directory (#2640)
 - `phel.router/compiled-router` now compiles routes that carry a `:handler` function (every real route, and the macro's own docstring `:example`), instead of failing with `literal not supported: …AbstractFn` (#2663)
 - `phel build` at an optimization level above 0 now ships the full `(load ...)` secondaries (e.g. `phel.core`'s `core/meta.php`) instead of a broken artifact that fataled with `Cannot locate core/… for (load ...)` on first load (#2631)
 - `defn`/`defmacro` (and their `-` variants) with a non-symbol name (e.g. `(defn 123 [x] x)`) now fail with a clean `[PHEL005]` error naming the offending type, instead of crashing with an internal PHP error that leaked core internals (#2639)

--- a/bin/phel
+++ b/bin/phel
@@ -115,7 +115,7 @@ function maybeReexecWithOpcacheFileCache(string $appRootDir): void
     }
 
     // Anchor the project root to the working directory (walk up to the nearest
-    // phel-config.php), independent of where the binary/autoloader live, so a
+    // project root), independent of where the binary/autoloader live, so a
     // global or PHAR install reads the user's project — not the binary dir.
     $appRootDir = ProjectRootResolver::resolveFromCwd($cwd);
 

--- a/bin/phel
+++ b/bin/phel
@@ -11,6 +11,7 @@ if (function_exists('ini_set')) {
 use Phel\Config\ConfigLoadException;
 use Phel\Console\ConsoleFacade;
 use Phel\Shared\PhelProjectDirectory;
+use Phel\Shared\ProjectRootResolver;
 use Phel\Shared\Performance\OpcacheReexec;
 
 /**
@@ -62,19 +63,24 @@ function maybeReexecWithOpcacheFileCache(string $appRootDir): void
 (static function (): void {
     $runningInPhar = \Phar::running() !== '';
 
+    // getcwd() only returns false in pathological cases (e.g. the working dir was
+    // deleted under us); __DIR__ is a last-resort anchor so we never pass false on.
+    $cwd = getcwd() ?: __DIR__;
+
     if ($runningInPhar) {
         // We're inside phel.phar. Autoload is already in place (from the stub).
-        // For app root, prefer the current working directory (the user's project).
-        $appRootDir = getcwd() ?: __DIR__;
+        $autoloadFound = true;
     } else {
-        // Source checkout: find and load the host Composer autoloader.
-        $appRootDir = (static function (): ?string {
-            $dir = getcwd();
+        // Source checkout / Composer install: find and load the host autoloader.
+        // Its location is NOT the project root — a global install loads classes
+        // from ~/.composer/vendor while the user's project is elsewhere (#2640).
+        $autoloadFound = (static function () use ($cwd): bool {
+            $dir = $cwd;
             while (is_dir($dir)) {
                 $autoload = $dir.'/vendor/autoload.php';
                 if (is_file($autoload)) {
                     require_once $autoload;
-                    return $dir;
+                    return true;
                 }
                 $parent = dirname($dir);
                 if ($parent === $dir) {
@@ -84,22 +90,21 @@ function maybeReexecWithOpcacheFileCache(string $appRootDir): void
             }
 
             foreach ([
-                         [__DIR__, '/../vendor/autoload.php'],
-                         [__DIR__, '/../../vendor/autoload.php'],
-                         [__DIR__, '/../../../autoload.php'],
-                     ] as $files) {
-                $file = sprintf('%s%s', ...$files);
+                         __DIR__.'/../vendor/autoload.php',
+                         __DIR__.'/../../vendor/autoload.php',
+                         __DIR__.'/../../../autoload.php',
+                     ] as $file) {
                 if (is_file($file)) {
                     require_once $file;
-                    return $files[0];
+                    return true;
                 }
             }
 
-            return null;
+            return false;
         })();
     }
 
-    if ($appRootDir === null) {
+    if (!$autoloadFound) {
         fwrite(
             STDERR,
             'You must set up the project dependencies, run the following commands:'.PHP_EOL.
@@ -108,6 +113,11 @@ function maybeReexecWithOpcacheFileCache(string $appRootDir): void
         );
         exit(1);
     }
+
+    // Anchor the project root to the working directory (walk up to the nearest
+    // phel-config.php), independent of where the binary/autoloader live, so a
+    // global or PHAR install reads the user's project — not the binary dir.
+    $appRootDir = ProjectRootResolver::resolveFromCwd($cwd);
 
     // Re-exec once with a persistent OPcache file cache so warm run/eval/repl
     // reuse compiled opcode instead of re-parsing every required .php. These

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -15,6 +15,7 @@ use Phel\Config\ProjectLayout;
 use Phel\Filesystem\FilesystemFacade;
 use Phel\Run\RunFacade;
 use Phel\Shared\PhelProjectDirectory;
+use Phel\Shared\ProjectRootResolver;
 use Phel\Shared\ScalarCoercion;
 use RuntimeException;
 use Throwable;
@@ -261,9 +262,10 @@ class Phel
             throw new RuntimeException('Unable to determine current working directory.');
         }
 
-        // Check CWD first
-        if (file_exists($cwd . '/' . self::PHEL_CONFIG_FILE_NAME)) {
-            return $cwd;
+        // Prefer the user's project: walk up from CWD to the nearest phel-config.php.
+        $root = ProjectRootResolver::resolveFromCwd($cwd);
+        if (file_exists($root . '/' . self::PHEL_CONFIG_FILE_NAME)) {
+            return $root;
         }
 
         // Check PHAR's directory

--- a/src/php/Shared/ProjectRootResolver.php
+++ b/src/php/Shared/ProjectRootResolver.php
@@ -15,18 +15,28 @@ use function is_file;
  * launcher walks up to find — outside the user's project. Anchoring the root to
  * that location makes `phel config`/`doctor` read the wrong `phel-config.php`
  * and check the wrong source/test dirs (#2640). Instead we anchor to the
- * working directory: walk up from it to the nearest `phel-config.php`, and fall
- * back to the working directory itself (where zero-config auto-detection runs).
+ * working directory: walk up from it to the nearest project root, and fall back
+ * to the working directory itself (where zero-config auto-detection runs).
+ *
+ * A directory is a project root if it holds a `phel-config.php` (a configured
+ * project, possibly without a local `vendor/` — the #2640 case) or an installed
+ * `vendor/autoload.php`. The latter boundary stops the walk from escaping a
+ * zero-config project nested inside another (e.g. an example project that lives
+ * inside this repo) and climbing into the parent's `phel-config.php`.
  */
 final class ProjectRootResolver
 {
     private const string CONFIG_FILE_NAME = 'phel-config.php';
 
+    private const string AUTOLOAD_PATH = 'vendor/autoload.php';
+
     public static function resolveFromCwd(string $cwd): string
     {
         $dir = $cwd;
         while (true) {
-            if (is_file($dir . '/' . self::CONFIG_FILE_NAME)) {
+            if (is_file($dir . '/' . self::CONFIG_FILE_NAME)
+                || is_file($dir . '/' . self::AUTOLOAD_PATH)
+            ) {
                 return $dir;
             }
 

--- a/src/php/Shared/ProjectRootResolver.php
+++ b/src/php/Shared/ProjectRootResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared;
+
+use function dirname;
+use function is_file;
+
+/**
+ * Discovers the project root for a CLI invocation independently of where the
+ * `phel` binary (and its autoloader) live.
+ *
+ * A global Composer or PHAR install puts the binary — and the autoloader the
+ * launcher walks up to find — outside the user's project. Anchoring the root to
+ * that location makes `phel config`/`doctor` read the wrong `phel-config.php`
+ * and check the wrong source/test dirs (#2640). Instead we anchor to the
+ * working directory: walk up from it to the nearest `phel-config.php`, and fall
+ * back to the working directory itself (where zero-config auto-detection runs).
+ */
+final class ProjectRootResolver
+{
+    private const string CONFIG_FILE_NAME = 'phel-config.php';
+
+    public static function resolveFromCwd(string $cwd): string
+    {
+        $dir = $cwd;
+        while (true) {
+            if (is_file($dir . '/' . self::CONFIG_FILE_NAME)) {
+                return $dir;
+            }
+
+            $parent = dirname($dir);
+            if ($parent === $dir) {
+                return $cwd;
+            }
+
+            $dir = $parent;
+        }
+    }
+}

--- a/tests/php/Integration/Bootstrap/ProjectRootResolutionTest.php
+++ b/tests/php/Integration/Bootstrap/ProjectRootResolutionTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Bootstrap;
+
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function dirname;
+use function implode;
+use function mkdir;
+use function proc_close;
+use function proc_open;
+use function random_bytes;
+use function realpath;
+use function stream_get_contents;
+use function sys_get_temp_dir;
+
+/**
+ * Runs the source `bin/phel` against a temp project that has its own
+ * `phel-config.php` but NO local `vendor/` — the shape of a global/PHAR
+ * install. Before #2640 the launcher anchored the project root to the
+ * autoloader it walked up to (the phel-lang checkout's own `vendor/`), so
+ * `phel config` reported the binary's directory instead of the user's project.
+ */
+final class ProjectRootResolutionTest extends TestCase
+{
+    private string $binPath;
+
+    private string $projectDir;
+
+    protected function setUp(): void
+    {
+        $repoRoot = dirname(__DIR__, 4);
+        $this->binPath = $repoRoot . '/bin/phel';
+
+        $this->projectDir = realpath(sys_get_temp_dir())
+            . '/phel-root-' . bin2hex(random_bytes(6));
+        mkdir($this->projectDir . '/src', 0755, true);
+        file_put_contents(
+            $this->projectDir . '/phel-config.php',
+            "<?php\n\nreturn (new \\Phel\\Config\\PhelConfig())->withSrcDirs(['src']);\n",
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->projectDir . '/phel-config.php');
+        @rmdir($this->projectDir . '/src');
+        @rmdir($this->projectDir);
+    }
+
+    public function test_config_reports_the_cwd_project_root_not_the_binary_dir(): void
+    {
+        $result = $this->runPhelInDir($this->projectDir, ['config']);
+
+        self::assertSame(0, $result['exit'], $result['stderr']);
+        self::assertStringContainsString(
+            ' - project root: ' . $this->projectDir,
+            $result['stdout'],
+            'project root must be the CWD project, not the binary/autoloader directory',
+        );
+    }
+
+    public function test_walks_up_to_the_project_root_from_a_subdirectory(): void
+    {
+        $subdir = $this->projectDir . '/src';
+        $result = $this->runPhelInDir($subdir, ['config']);
+
+        self::assertSame(0, $result['exit'], $result['stderr']);
+        self::assertStringContainsString(
+            ' - project root: ' . $this->projectDir,
+            $result['stdout'],
+            'running from a subdirectory must resolve up to the nearest phel-config.php',
+        );
+    }
+
+    /**
+     * @param list<string> $args
+     *
+     * @return array{exit: int, stdout: string, stderr: string}
+     */
+    private function runPhelInDir(string $cwd, array $args): array
+    {
+        $cmd = implode(' ', [
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($this->binPath),
+            ...array_map(escapeshellarg(...), $args),
+        ]);
+
+        $proc = proc_open($cmd, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, $cwd);
+        self::assertIsResource($proc, 'proc_open failed');
+
+        $stdout = stream_get_contents($pipes[1]) ?: '';
+        $stderr = stream_get_contents($pipes[2]) ?: '';
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($proc);
+
+        return ['exit' => $exit, 'stdout' => $stdout, 'stderr' => $stderr];
+    }
+}

--- a/tests/php/Integration/Phar/PharExecutionTest.php
+++ b/tests/php/Integration/Phar/PharExecutionTest.php
@@ -177,6 +177,44 @@ final class PharExecutionTest extends TestCase
         self::assertStringContainsString('6', $result['stdout']);
     }
 
+    public function test_phar_config_reports_the_cwd_project_root_not_the_phar_dir(): void
+    {
+        // Regression #2640: a PHAR must root at the user's project (the CWD),
+        // not the directory the phar/binary lives in.
+        file_put_contents(
+            $this->tempProjectDir . '/phel-config.php',
+            "<?php\n\nreturn (new \\Phel\\Config\\PhelConfig())->withSrcDirs(['src']);\n",
+        );
+
+        $result = $this->runPhar(['config']);
+
+        self::assertSame(0, $result['exit'], $result['stderr']);
+        self::assertStringContainsString(
+            ' - project root: ' . realpath($this->tempProjectDir),
+            $result['stdout'],
+            'PHAR must root at the CWD project, not the phar/binary location',
+        );
+    }
+
+    public function test_phar_config_walks_up_to_the_project_root_from_a_subdirectory(): void
+    {
+        file_put_contents(
+            $this->tempProjectDir . '/phel-config.php',
+            "<?php\n\nreturn (new \\Phel\\Config\\PhelConfig())->withSrcDirs(['src']);\n",
+        );
+        $subdir = $this->tempProjectDir . '/src';
+        mkdir($subdir, 0755, true);
+
+        $result = $this->runPharInDir($subdir, ['config']);
+
+        self::assertSame(0, $result['exit'], $result['stderr']);
+        self::assertStringContainsString(
+            ' - project root: ' . realpath($this->tempProjectDir),
+            $result['stdout'],
+            'running a PHAR from a subdirectory must resolve up to the nearest phel-config.php',
+        );
+    }
+
     public function test_phar_doctor_does_not_point_to_an_unusable_phar_ini(): void
     {
         // Regression: `phel doctor`'s OPcache tip must not suggest

--- a/tests/php/Unit/Shared/ProjectRootResolverTest.php
+++ b/tests/php/Unit/Shared/ProjectRootResolverTest.php
@@ -26,6 +26,8 @@ final class ProjectRootResolverTest extends TestCase
     {
         @unlink($this->root . '/phel-config.php');
         @unlink($this->root . '/a/phel-config.php');
+        @unlink($this->root . '/a/vendor/autoload.php');
+        @rmdir($this->root . '/a/vendor');
         @rmdir($this->root . '/a/b');
         @rmdir($this->root . '/a');
         @rmdir($this->root);
@@ -63,6 +65,21 @@ final class ProjectRootResolverTest extends TestCase
         mkdir($deep, 0755, true);
 
         self::assertSame($nearer, ProjectRootResolver::resolveFromCwd($deep));
+    }
+
+    public function test_stops_at_an_installed_vendor_dir_without_escaping_to_a_parent_config(): void
+    {
+        // The ancestor is a configured project; the nested dir is a zero-config
+        // project with its own installed vendor/ (e.g. an example inside this
+        // repo). The walk must stop at the nested dir, not climb to the parent.
+        $this->writeConfig($this->root);
+        $nested = $this->root . '/a';
+        mkdir($nested . '/vendor', 0755, true);
+        file_put_contents($nested . '/vendor/autoload.php', "<?php\n");
+        $deep = $nested . '/b';
+        mkdir($deep, 0755, true);
+
+        self::assertSame($nested, ProjectRootResolver::resolveFromCwd($deep));
     }
 
     public function test_walk_terminates_at_the_filesystem_root(): void

--- a/tests/php/Unit/Shared/ProjectRootResolverTest.php
+++ b/tests/php/Unit/Shared/ProjectRootResolverTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared;
+
+use Phel\Shared\ProjectRootResolver;
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function mkdir;
+use function random_bytes;
+use function sys_get_temp_dir;
+
+final class ProjectRootResolverTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/phel-root-' . bin2hex(random_bytes(6));
+        mkdir($this->root, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->root . '/phel-config.php');
+        @unlink($this->root . '/a/phel-config.php');
+        @rmdir($this->root . '/a/b');
+        @rmdir($this->root . '/a');
+        @rmdir($this->root);
+    }
+
+    public function test_returns_cwd_when_it_holds_the_config(): void
+    {
+        $this->writeConfig($this->root);
+
+        self::assertSame($this->root, ProjectRootResolver::resolveFromCwd($this->root));
+    }
+
+    public function test_walks_up_to_the_nearest_config_from_a_subdirectory(): void
+    {
+        $this->writeConfig($this->root);
+        $deep = $this->root . '/a/b';
+        mkdir($deep, 0755, true);
+
+        self::assertSame($this->root, ProjectRootResolver::resolveFromCwd($deep));
+    }
+
+    public function test_falls_back_to_cwd_when_no_config_is_found(): void
+    {
+        // No phel-config.php anywhere up the tree from this fresh temp dir.
+        self::assertSame($this->root, ProjectRootResolver::resolveFromCwd($this->root));
+    }
+
+    public function test_prefers_the_nearest_config_over_an_ancestor(): void
+    {
+        $this->writeConfig($this->root);
+        $nearer = $this->root . '/a';
+        mkdir($nearer, 0755, true);
+        $this->writeConfig($nearer);
+        $deep = $nearer . '/b';
+        mkdir($deep, 0755, true);
+
+        self::assertSame($nearer, ProjectRootResolver::resolveFromCwd($deep));
+    }
+
+    public function test_walk_terminates_at_the_filesystem_root(): void
+    {
+        // No phel-config.php at '/', so the walk must hit the dirname('/') === '/'
+        // guard and return cwd instead of looping forever.
+        self::assertSame('/', ProjectRootResolver::resolveFromCwd('/'));
+    }
+
+    private function writeConfig(string $dir): void
+    {
+        file_put_contents($dir . '/phel-config.php', "<?php\n\nreturn null;\n");
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Running a standalone `phel` whose binary lives **outside** the project (a PHAR, or a global `composer global require` install) resolved the project root to the **binary's directory** instead of the user's project. `bin/phel` walked up from the CWD looking for `vendor/autoload.php` and used *that* directory as the project root — but a global install's autoloader is `~/.composer/vendor/...`, nowhere near the user's project. When the project had no local `vendor/` the walk fell through to a `__DIR__`-relative autoloader and anchored the root at the binary dir.

Result, from a real project dir:

```
$ phel config
 - project root: <BIN_DIR>        # wrong — should be the CWD project
 - phel-config.php: not found     # false: it exists in the CWD
$ phel doctor
 - TIP Source directory 'src' does not exist   # false after `phel init`
```

`vendor/bin/phel` worked only because the binary happens to live inside the project, so the autoloader dir == project root.

Closes #2640

## 💡 Goal

Resolve the project root from the **working directory**, independent of where the binary/autoloader live, so `phel config`/`doctor` (and every config consumer) read the local `phel-config.php` and see the project's source/test dirs from any project directory — for PHAR, global, and vendor installs alike.

## 🔖 Changes

- **`src/php/Shared/ProjectRootResolver.php`** (new) — pure, stateless `resolveFromCwd(string $cwd): string`: walk up from the CWD to the nearest `phel-config.php`; fall back to the CWD (where zero-config auto-detection runs). Anchored on `phel-config.php` only — **not** `composer.json`, which would wrongly resolve a Phel sub-project to its monorepo root.
- **`bin/phel`** — separated the two concerns the launcher had conflated: autoloader discovery (still walks up / falls back to *load classes*) vs. project-root discovery (now `ProjectRootResolver::resolveFromCwd($cwd)`, independent of the autoloader location). `getcwd()` is read once.
- **`src/php/Phel.php`** — `resolvePharProjectRoot()` delegates its CWD step to the resolver (so PHAR runs also walk up), preserving the existing PHAR-dir and CWD fallbacks.
- **Tests**
  - `tests/php/Unit/Shared/ProjectRootResolverTest.php` — CWD-holds-config, walk-up from a subdir, nearest-wins, no-config fallback, filesystem-root walk termination.
  - `tests/php/Integration/Bootstrap/ProjectRootResolutionTest.php` — execs the **source** `bin/phel config` from a temp project that has `phel-config.php` + `src/` but **no local `vendor/`** (the global-install shape). Verified to fail before the fix with `project root: <repo>/bin`; passes after. Also covers running from a subdirectory.
- **`CHANGELOG.md`** — `### Fixed` entry under `## Unreleased`.

### No behavior change for normal installs

`Phel::run($projectRootDir, …)` (library API) never invokes the resolver — the caller's explicit root is passed through. A `vendor/bin/phel` install whose CWD holds `phel-config.php` resolves to the same CWD as before. `composer test` / source-checkout dev are unaffected.

### Review / refactor pass

An independent review pass (correctness, regressions, edge cases, module placement) surfaced three actionable items, all applied within the feature commit: dedupe the double `getcwd()` call, comment the pathological `getcwd() === false` fallback, and add the filesystem-root walk-termination test. It confirmed no regression for the library API or vendor installs, and agreed `phel-config.php`-only is the correct anchor. A final re-review found nothing further, so there is no separate `ref(...)` commit.

Full `composer test` gate is green (static analysis + compiler + 6114 core tests).
