### PR TITLE
fix(config): reject a null-returning phel-config.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - A global or PHAR `phel` install now resolves the project root from the working directory (walking up to the nearest project root — a `phel-config.php` or installed `vendor/`) instead of the binary's location, so `phel config`/`doctor` read the local config and see the project's source/test dirs from any project directory (#2640)
+- A `phel-config.php` that evaluates to `null` (a forgotten or typo'd `return`) is now rejected with an actionable error naming the file and the expected shape, instead of being silently treated as an empty config and falling back to defaults (#2642)
 - `phel.router/compiled-router` now compiles routes that carry a `:handler` function (every real route, and the macro's own docstring `:example`), instead of failing with `literal not supported: …AbstractFn` (#2663)
 - `phel build` at an optimization level above 0 now ships the full `(load ...)` secondaries (e.g. `phel.core`'s `core/meta.php`) instead of a broken artifact that fataled with `Cannot locate core/… for (load ...)` on first load (#2631)
 - `defn`/`defmacro` (and their `-` variants) with a non-symbol name (e.g. `(defn 123 [x] x)`) now fail with a clean `[PHEL005]` error naming the offending type, instead of crashing with an internal PHP error that leaked core internals (#2639)

--- a/src/php/Config/CLAUDE.md
+++ b/src/php/Config/CLAUDE.md
@@ -12,6 +12,7 @@ Pure data/model layer defining configuration structure for Phel projects. Leaf m
 | `ProjectLayout.php` | Backed enum: `Flat` / `Nested` / `Root` |
 | `PhelConfigValidator.php` | Validates src/test/vendor dirs; backs `PhelConfig::validate()` |
 | `ConfigLoadException.php` | `wrapIfConfigError()` rethrows errors originating from `phel-config.php` |
+| `StrictPhpConfigReader.php` | Gacela `ConfigReaderInterface` that rejects a `null`-returning `phel-config.php` instead of silently coercing to `[]`; wired in `Phel::configFn()` |
 
 ## PhelConfig API
 

--- a/src/php/Config/StrictPhpConfigReader.php
+++ b/src/php/Config/StrictPhpConfigReader.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Config;
+
+use Gacela\Framework\Config\ConfigReaderInterface;
+use JsonSerializable;
+use RuntimeException;
+
+use function file_exists;
+use function is_array;
+use function pathinfo;
+
+use const PATHINFO_EXTENSION;
+
+/**
+ * Like Gacela's PhpConfigReader, except a `phel-config.php` that evaluates to
+ * `null` is rejected instead of silently coerced to an empty config. Gacela's
+ * own reader maps a null return to `[]`, so a config that returns nothing
+ * usable — a forgotten or typo'd `return` — would apply zero settings with no
+ * error, the exact silent misconfiguration #2642 reports.
+ *
+ * Every other shape keeps Gacela's contract: a JsonSerializable (e.g.
+ * {@see PhelConfig}) or a plain array is accepted, and any non-array throws the
+ * same message PhpConfigReader uses — so {@see ConfigLoadException::wrapIfConfigError()}
+ * upgrades it to a file-named, actionable error.
+ */
+final class StrictPhpConfigReader implements ConfigReaderInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function read(string $absolutePath): array
+    {
+        if (pathinfo($absolutePath, PATHINFO_EXTENSION) !== 'php' || !file_exists($absolutePath)) {
+            return [];
+        }
+
+        /**
+         * @psalm-suppress UnresolvableInclude
+         *
+         * @var mixed $content
+         */
+        $content = include $absolutePath;
+
+        if ($content instanceof JsonSerializable) {
+            /** @var array<string, mixed> $serialized */
+            $serialized = $content->jsonSerialize();
+
+            return $serialized;
+        }
+
+        if (is_array($content)) {
+            /** @var array<string, mixed> $content */
+            return $content;
+        }
+
+        throw new RuntimeException('The PHP config file must return an array or a JsonSerializable object!');
+    }
+}

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -12,6 +12,7 @@ use Phar;
 use Phel\Config\ConfigLoadException;
 use Phel\Config\PhelConfig;
 use Phel\Config\ProjectLayout;
+use Phel\Config\StrictPhpConfigReader;
 use Phel\Filesystem\FilesystemFacade;
 use Phel\Run\RunFacade;
 use Phel\Shared\PhelProjectDirectory;
@@ -185,8 +186,14 @@ class Phel
                 // Register the auto-detected config as inline config
                 $config->addAppConfigKeyValues($autoConfig->jsonSerialize());
             } else {
-                // Normal config file loading
-                $config->addAppConfig(self::PHEL_CONFIG_FILE_NAME, self::PHEL_CONFIG_LOCAL_FILE_NAME);
+                // Normal config file loading. The strict reader rejects a
+                // null-returning phel-config.php instead of letting Gacela
+                // silently treat it as an empty config (#2642).
+                $config->addAppConfig(
+                    self::PHEL_CONFIG_FILE_NAME,
+                    self::PHEL_CONFIG_LOCAL_FILE_NAME,
+                    new StrictPhpConfigReader(),
+                );
             }
         };
     }

--- a/tests/php/Integration/Bootstrap/ConfigLoadErrorTest.php
+++ b/tests/php/Integration/Bootstrap/ConfigLoadErrorTest.php
@@ -57,6 +57,20 @@ final class ConfigLoadErrorTest extends TestCase
         Phel::bootstrap($this->dir);
     }
 
+    public function test_bootstrap_wraps_a_null_return_value(): void
+    {
+        // Gacela's reader would coerce `return null;` to an empty config and
+        // boot silently; the strict reader turns it into a friendly
+        // ConfigLoadException so a forgotten/typo'd return is not invisibly
+        // ignored.
+        file_put_contents($this->dir . '/phel-config.php', "<?php\n\nreturn null;\n");
+
+        $this->expectException(ConfigLoadException::class);
+        $this->expectExceptionMessage('phel-config.php');
+
+        Phel::bootstrap($this->dir);
+    }
+
     public function test_bootstrap_accepts_a_raw_array_config(): void
     {
         // A plain array is a valid config too (PhelConfig is recommended, not

--- a/tests/php/Unit/Config/StrictPhpConfigReaderTest.php
+++ b/tests/php/Unit/Config/StrictPhpConfigReaderTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Config;
+
+use Phel\Config\PhelConfig;
+use Phel\Config\StrictPhpConfigReader;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function bin2hex;
+use function file_put_contents;
+use function random_bytes;
+use function sys_get_temp_dir;
+
+final class StrictPhpConfigReaderTest extends TestCase
+{
+    private string $path;
+
+    protected function setUp(): void
+    {
+        $this->path = sys_get_temp_dir() . '/phel-strict-' . bin2hex(random_bytes(6)) . '.php';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->path);
+    }
+
+    public function test_reads_a_plain_array_config(): void
+    {
+        file_put_contents($this->path, "<?php\nreturn ['src-dirs' => ['custom-src']];\n");
+
+        self::assertSame(['src-dirs' => ['custom-src']], new StrictPhpConfigReader()->read($this->path));
+    }
+
+    public function test_reads_a_phel_config_instance_via_json_serialize(): void
+    {
+        file_put_contents($this->path, "<?php\nreturn new \\Phel\\Config\\PhelConfig()->withSrcDirs(['app']);\n");
+
+        $values = new StrictPhpConfigReader()->read($this->path);
+
+        self::assertSame(['app'], $values[PhelConfig::SRC_DIRS]);
+    }
+
+    public function test_rejects_a_null_return_instead_of_coercing_to_empty(): void
+    {
+        // Gacela's PhpConfigReader maps `return null;` to `[]`; the strict
+        // reader must refuse it so a forgotten/typo'd return is not silently
+        // dropped (the #2642 regression).
+        file_put_contents($this->path, "<?php\nreturn null;\n");
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must return an array or a JsonSerializable');
+
+        new StrictPhpConfigReader()->read($this->path);
+    }
+
+    public function test_still_rejects_a_scalar_return(): void
+    {
+        file_put_contents($this->path, "<?php\nreturn 'nope';\n");
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must return an array or a JsonSerializable');
+
+        new StrictPhpConfigReader()->read($this->path);
+    }
+
+    public function test_returns_empty_for_a_missing_file(): void
+    {
+        self::assertSame([], new StrictPhpConfigReader()->read('/no/such/phel-config.php'));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

A `phel-config.php` that evaluates to `null` (a forgotten or typo'd `return`) was silently dropped: Gacela's `PhpConfigReader` maps a `null` return to `[]`, so `phel config` reported the file as "found" yet applied zero settings — the silent misconfiguration #2642 describes. (Scalar/object returns and a missing `return` already error.)

## 💡 Goal

Make an unusable `phel-config.php` fail loudly with an actionable, file-named error instead of falling back to defaults.

## 🔖 Changes

- New `StrictPhpConfigReader` (wired in `Phel::configFn()`): accepts an array or `JsonSerializable` (e.g. `PhelConfig`), but lets a `null` return fall through to the canonical wrong-type error that `ConfigLoadException` upgrades to a friendly, file-named message. Runs only on real file reads, so Gacela's merged-config cache still skips it (no perf regression).
- Unit test for the reader + an end-to-end bootstrap regression in `ConfigLoadErrorTest`.
- Mandatory refactor pass: no code changes — the reader is already minimal and the Gacela-contract mirror is intentional (its `PhpConfigReader` is `final`).

Closes #2642