### PR TITLE
feat(lsp): signature help for plain Phel function calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- LSP signature help (`textDocument/signatureHelp`) now covers plain Phel function calls like `(map f xs)` — showing each arity, its parameter names, and the docstring — instead of only `php/...` interop calls (#2643)
+
 ### Changed
 
 - `phel test` now shows a `+`/`-`/`~` structural diff for any same-shape collection that differs (previously only for collections with more than 3 entries); scalars and mixed shapes keep the single-line summary

--- a/src/php/Api/ApiFacade.php
+++ b/src/php/Api/ApiFacade.php
@@ -168,4 +168,17 @@ final class ApiFacade extends AbstractFacade implements ApiFacadeInterface
             ->createPhpInteropDocResolver()
             ->signatureAt($source, $line, $col);
     }
+
+    /**
+     * LSP SignatureHelp payload for the plain Phel function call enclosing the
+     * cursor, or null when not applicable.
+     *
+     * @return array{signatures: list<array{label: string, parameters: list<array{label: string}>, documentation?: string}>, activeSignature: int, activeParameter: int}|null
+     */
+    public function phelSignatureAt(string $source, int $line, int $col, string $currentNs = 'user'): ?array
+    {
+        return $this->getFactory()
+            ->createPhelSignatureResolver()
+            ->signatureAt($source, $line, $col, $currentNs);
+    }
 }

--- a/src/php/Api/ApiFactory.php
+++ b/src/php/Api/ApiFactory.php
@@ -12,6 +12,7 @@ use Phel\Api\Application\CompletionDocFormatter;
 use Phel\Api\Application\CompletionDocResolver;
 use Phel\Api\Application\PhelFnGroupKeyGenerator;
 use Phel\Api\Application\PhelFnNormalizer;
+use Phel\Api\Application\PhelSignatureResolver;
 use Phel\Api\Application\PhpInteropCompleter;
 use Phel\Api\Application\PhpInteropDocResolver;
 use Phel\Api\Application\PointCompleter;
@@ -113,6 +114,11 @@ final class ApiFactory extends AbstractFactory
     public function createPhpInteropDocResolver(): PhpInteropDocResolver
     {
         return new PhpInteropDocResolver();
+    }
+
+    public function createPhelSignatureResolver(): PhelSignatureResolver
+    {
+        return new PhelSignatureResolver($this->createSymbolMetadataFinder());
     }
 
     public function createApiDaemon(ApiFacade $facade): ApiDaemon

--- a/src/php/Api/Application/PhelSignatureResolver.php
+++ b/src/php/Api/Application/PhelSignatureResolver.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use Phel\Api\Domain\SymbolMetadataFinderInterface;
+use Phel\Api\Transfer\PhelFunction;
+
+use function array_slice;
+use function count;
+use function in_array;
+use function max;
+use function min;
+use function str_starts_with;
+use function strlen;
+use function strpos;
+use function substr;
+
+/**
+ * LSP SignatureHelp for the plain Phel function call enclosing the cursor
+ * (e.g. `(map f xs)`) — the complement to
+ * {@see PhpInteropDocResolver::signatureAt()}, which only covers `php/...`
+ * interop calls. Returns null when the cursor is not inside a resolvable Phel
+ * call, so the handler can fall through.
+ */
+final readonly class PhelSignatureResolver
+{
+    public function __construct(
+        private SymbolMetadataFinderInterface $finder,
+    ) {}
+
+    /**
+     * @return array{signatures: list<array{label: string, parameters: list<array{label: string}>, documentation?: string}>, activeSignature: int, activeParameter: int}|null
+     */
+    public function signatureAt(string $source, int $line, int $col, string $currentNs = 'user'): ?array
+    {
+        $before = CursorText::before($source, $line, $col);
+        $open = CursorText::openParenPositions($before);
+        if ($open === []) {
+            return null;
+        }
+
+        [$tokens, $endsOpen] = $this->tokenize(substr($before, $open[count($open) - 1] + 1));
+        if ($tokens === []) {
+            return null;
+        }
+
+        $head = $tokens[0];
+        // `php/...` calls belong to PhpInteropDocResolver; defer so this resolver
+        // never shadows interop signature help.
+        if ($head === '' || str_starts_with($head, 'php/')) {
+            return null;
+        }
+
+        $fn = $this->finder->find($head, $currentNs);
+        if (!$fn instanceof PhelFunction) {
+            return null;
+        }
+
+        $arities = $fn->signatures;
+        if ($arities === []) {
+            return null;
+        }
+
+        // tokens = [head, arg0, arg1, ...]: drop the head; a half-typed final
+        // token (no trailing space) is the arg the caret sits on, not a new one.
+        $activeParameter = max(0, count($tokens) - 1 - ($endsOpen ? 1 : 0));
+
+        return $this->response($arities, $fn->doc, $activeParameter);
+    }
+
+    /**
+     * @param non-empty-list<string> $arities
+     *
+     * @return array{signatures: list<array{label: string, parameters: list<array{label: string}>, documentation?: string}>, activeSignature: int, activeParameter: int}
+     */
+    private function response(array $arities, string $doc, int $activeParameter): array
+    {
+        $signatures = [];
+        foreach ($arities as $signature) {
+            $information = [
+                'label' => $signature,
+                'parameters' => $this->parameterInformation($this->parameters($signature)),
+            ];
+            if ($doc !== '') {
+                $information['documentation'] = $doc;
+            }
+
+            $signatures[] = $information;
+        }
+
+        $activeSignature = $this->bestArity($signatures, $activeParameter);
+        $paramCount = count($signatures[$activeSignature]['parameters']);
+
+        return [
+            'signatures' => $signatures,
+            'activeSignature' => $activeSignature,
+            'activeParameter' => $paramCount === 0 ? 0 : min($activeParameter, $paramCount - 1),
+        ];
+    }
+
+    /**
+     * Pick the arity whose parameters can hold the active argument: the
+     * smallest signature with more parameters than the active index, falling
+     * back to the largest (variadic) arity when the caret is past them all.
+     *
+     * @param non-empty-list<array{label: string, parameters: list<array{label: string}>, documentation?: string}> $signatures
+     */
+    private function bestArity(array $signatures, int $activeParameter): int
+    {
+        $covering = null;
+        $coveringCount = 0;
+        $largest = 0;
+        $largestCount = -1;
+
+        foreach ($signatures as $index => $signature) {
+            $count = count($signature['parameters']);
+            if ($count > $largestCount) {
+                $largest = $index;
+                $largestCount = $count;
+            }
+
+            if ($count > $activeParameter && ($covering === null || $count < $coveringCount)) {
+                $covering = $index;
+                $coveringCount = $count;
+            }
+        }
+
+        return $covering ?? $largest;
+    }
+
+    /**
+     * Parameter names of a signature string like `(map f coll & colls)`,
+     * keeping a destructured `[a b]` / `{:keys [a]}` parameter whole and
+     * dropping the variadic `&` marker (it labels no single argument).
+     *
+     * @return list<string>
+     */
+    private function parameters(string $signature): array
+    {
+        $inner = $signature;
+        if (str_starts_with($inner, '(')) {
+            $inner = substr($inner, 1);
+        }
+
+        if ($inner !== '' && str_ends_with($inner, ')')) {
+            $inner = substr($inner, 0, -1);
+        }
+
+        [$tokens] = $this->tokenize($inner);
+
+        // tokens = [name, param0, ...]: drop the function name, then the marker.
+        $params = [];
+        foreach (array_slice($tokens, 1) as $token) {
+            if ($token !== '&') {
+                $params[] = $token;
+            }
+        }
+
+        return $params;
+    }
+
+    /**
+     * @param list<string> $parameters
+     *
+     * @return list<array{label: string}>
+     */
+    private function parameterInformation(array $parameters): array
+    {
+        $information = [];
+        foreach ($parameters as $parameter) {
+            $information[] = ['label' => $parameter];
+        }
+
+        return $information;
+    }
+
+    /**
+     * Like {@see PhpFormTokenizer::topLevel()} but also balances `[]`/`{}` so a
+     * collection-literal argument stays one token; the shared tokenizer tracks
+     * only `()` because the interop chains it serves never nest Phel literals.
+     *
+     * @return array{0: list<string>, 1: bool} the tokens, and whether the slice
+     *                                         ends mid-token (the caret is still inside the last token)
+     */
+    private function tokenize(string $content): array
+    {
+        $length = strlen($content);
+        $tokens = [];
+        $current = '';
+        $depth = 0;
+        $inString = false;
+        $i = 0;
+
+        while ($i < $length) {
+            $char = $content[$i];
+
+            if ($inString) {
+                $current .= $char;
+                if ($char === '\\' && $i + 1 < $length) {
+                    $current .= $content[$i + 1];
+                    $i += 2;
+                    continue;
+                }
+
+                if ($char === '"') {
+                    $inString = false;
+                }
+
+                ++$i;
+                continue;
+            }
+
+            if ($char === '"') {
+                $inString = true;
+                $current .= $char;
+                ++$i;
+                continue;
+            }
+
+            if ($char === ';' && $depth === 0) {
+                if ($current !== '') {
+                    $tokens[] = $current;
+                    $current = '';
+                }
+
+                $newline = strpos($content, "\n", $i);
+                if ($newline === false) {
+                    return [$tokens, false];
+                }
+
+                $i = $newline + 1;
+                continue;
+            }
+
+            if ($depth === 0 && in_array($char, [' ', "\t", "\n", "\r", ','], true)) {
+                if ($current !== '') {
+                    $tokens[] = $current;
+                    $current = '';
+                }
+
+                ++$i;
+                continue;
+            }
+
+            if (in_array($char, ['(', '[', '{'], true)) {
+                ++$depth;
+            } elseif ((in_array($char, [')', ']', '}'], true)) && $depth > 0) {
+                --$depth;
+            }
+
+            $current .= $char;
+            ++$i;
+        }
+
+        $endsOpen = $current !== '';
+        if ($endsOpen) {
+            $tokens[] = $current;
+        }
+
+        return [$tokens, $endsOpen];
+    }
+}

--- a/src/php/Api/Application/PhelSignatureResolver.php
+++ b/src/php/Api/Application/PhelSignatureResolver.php
@@ -9,12 +9,9 @@ use Phel\Api\Transfer\PhelFunction;
 
 use function array_slice;
 use function count;
-use function in_array;
 use function max;
 use function min;
 use function str_starts_with;
-use function strlen;
-use function strpos;
 use function substr;
 
 /**
@@ -28,6 +25,7 @@ final readonly class PhelSignatureResolver
 {
     public function __construct(
         private SymbolMetadataFinderInterface $finder,
+        private PhpFormTokenizer $tokenizer = new PhpFormTokenizer(),
     ) {}
 
     /**
@@ -41,7 +39,10 @@ final readonly class PhelSignatureResolver
             return null;
         }
 
-        [$tokens, $endsOpen] = $this->tokenize(substr($before, $open[count($open) - 1] + 1));
+        [$tokens, $endsOpen] = $this->tokenizer->topLevel(
+            substr($before, $open[count($open) - 1] + 1),
+            balanceCollectionLiterals: true,
+        );
         if ($tokens === []) {
             return null;
         }
@@ -148,7 +149,7 @@ final readonly class PhelSignatureResolver
             $inner = substr($inner, 0, -1);
         }
 
-        [$tokens] = $this->tokenize($inner);
+        [$tokens] = $this->tokenizer->topLevel($inner, balanceCollectionLiterals: true);
 
         // tokens = [name, param0, ...]: drop the function name, then the marker.
         $params = [];
@@ -174,91 +175,5 @@ final readonly class PhelSignatureResolver
         }
 
         return $information;
-    }
-
-    /**
-     * Like {@see PhpFormTokenizer::topLevel()} but also balances `[]`/`{}` so a
-     * collection-literal argument stays one token; the shared tokenizer tracks
-     * only `()` because the interop chains it serves never nest Phel literals.
-     *
-     * @return array{0: list<string>, 1: bool} the tokens, and whether the slice
-     *                                         ends mid-token (the caret is still inside the last token)
-     */
-    private function tokenize(string $content): array
-    {
-        $length = strlen($content);
-        $tokens = [];
-        $current = '';
-        $depth = 0;
-        $inString = false;
-        $i = 0;
-
-        while ($i < $length) {
-            $char = $content[$i];
-
-            if ($inString) {
-                $current .= $char;
-                if ($char === '\\' && $i + 1 < $length) {
-                    $current .= $content[$i + 1];
-                    $i += 2;
-                    continue;
-                }
-
-                if ($char === '"') {
-                    $inString = false;
-                }
-
-                ++$i;
-                continue;
-            }
-
-            if ($char === '"') {
-                $inString = true;
-                $current .= $char;
-                ++$i;
-                continue;
-            }
-
-            if ($char === ';' && $depth === 0) {
-                if ($current !== '') {
-                    $tokens[] = $current;
-                    $current = '';
-                }
-
-                $newline = strpos($content, "\n", $i);
-                if ($newline === false) {
-                    return [$tokens, false];
-                }
-
-                $i = $newline + 1;
-                continue;
-            }
-
-            if ($depth === 0 && in_array($char, [' ', "\t", "\n", "\r", ','], true)) {
-                if ($current !== '') {
-                    $tokens[] = $current;
-                    $current = '';
-                }
-
-                ++$i;
-                continue;
-            }
-
-            if (in_array($char, ['(', '[', '{'], true)) {
-                ++$depth;
-            } elseif ((in_array($char, [')', ']', '}'], true)) && $depth > 0) {
-                --$depth;
-            }
-
-            $current .= $char;
-            ++$i;
-        }
-
-        $endsOpen = $current !== '';
-        if ($endsOpen) {
-            $tokens[] = $current;
-        }
-
-        return [$tokens, $endsOpen];
     }
 }

--- a/src/php/Api/Application/PhpFormTokenizer.php
+++ b/src/php/Api/Application/PhpFormTokenizer.php
@@ -13,6 +13,9 @@ use function strpos;
  * keeping nested `(...)` forms whole and skipping string literals and `;`
  * comments. Commas count as whitespace (Clojure-aligned). Shared by the interop
  * resolvers, which need to walk a `php/->` chain or a `let` binding lexically.
+ *
+ * Pass `$balanceCollectionLiterals` to also keep `[...]`/`{...}` whole, so a
+ * vector/map argument counts as one token (used by Phel-call signature help).
  */
 final class PhpFormTokenizer
 {
@@ -21,8 +24,10 @@ final class PhpFormTokenizer
      *                                         ends mid-token (the caret is still inside the last token rather than
      *                                         past it)
      */
-    public function topLevel(string $content): array
+    public function topLevel(string $content, bool $balanceCollectionLiterals = false): array
     {
+        $opening = $balanceCollectionLiterals ? ['(', '[', '{'] : ['('];
+        $closing = $balanceCollectionLiterals ? [')', ']', '}'] : [')'];
         $length = strlen($content);
         $tokens = [];
         $current = '';
@@ -81,9 +86,9 @@ final class PhpFormTokenizer
                 continue;
             }
 
-            if ($char === '(') {
+            if (in_array($char, $opening, true)) {
                 ++$depth;
-            } elseif ($char === ')' && $depth > 0) {
+            } elseif ($depth > 0 && in_array($char, $closing, true)) {
                 --$depth;
             }
 

--- a/src/php/Api/CLAUDE.md
+++ b/src/php/Api/CLAUDE.md
@@ -18,6 +18,7 @@ REPL autocompletion, function introspection/docs, and user-code semantic analysi
 | `completeAtPoint(source, line, col, ProjectIndex)` | Completion at cursor; returns PHP-interop completions in a `php/`-interop position, else Phel completions |
 | `phpInteropHoverAt(source, line, col): ?string` | Reflected hover markdown for PHP interop |
 | `phpInteropSignatureAt(source, line, col): ?array` | LSP signature help for PHP interop |
+| `phelSignatureAt(source, line, col, currentNs = 'user'): ?array` | LSP signature help for a plain Phel function call (`PhelSignatureResolver`) |
 | `createApiDaemon(): ApiDaemon` | Long-running JSON-RPC daemon |
 
 Project-level transfers: `ProjectIndex`, `Definition`, `Location`, `Completion`, `Diagnostic`, `PhelFunction`.

--- a/src/php/Lsp/Application/Handler/SignatureHelpHandler.php
+++ b/src/php/Lsp/Application/Handler/SignatureHelpHandler.php
@@ -11,10 +11,10 @@ use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
 
 /**
- * Handles `textDocument/signatureHelp` for PHP-interop calls: shows the
- * signature of the constructor / method being called inside `(php/new ...)`,
- * `(php/-> recv (method ...))`, or `(php/:: Class (method ...))`. Returns null
- * for any other position.
+ * Handles `textDocument/signatureHelp`. PHP-interop calls resolve first —
+ * `(php/new ...)`, `(php/-> recv (method ...))`, `(php/:: Class (method ...))` —
+ * then plain Phel function calls like `(map f xs)` fall back to the symbol's
+ * documented arities. Returns null when the cursor is over neither.
  */
 final readonly class SignatureHelpHandler implements HandlerInterface
 {
@@ -51,6 +51,7 @@ final readonly class SignatureHelpHandler implements HandlerInterface
 
         [$line, $col] = $document->oneBasedLineCol($position);
 
-        return $this->apiFacade->phpInteropSignatureAt($document->text, $line, $col);
+        return $this->apiFacade->phpInteropSignatureAt($document->text, $line, $col)
+            ?? $this->apiFacade->phelSignatureAt($document->text, $line, $col);
     }
 }

--- a/src/php/Lsp/CLAUDE.md
+++ b/src/php/Lsp/CLAUDE.md
@@ -46,4 +46,4 @@ Language Server Protocol v3.17 over stdio (JSON-RPC 2.0, `Content-Length` framin
 - `DocumentStore` is authoritative for open-file content.
 - Diagnostics are cooperatively debounced: callers check `DiagnosticPublisher::shouldPublish()` before `publish()`; `publishNow()` skips debounce (used on didSave).
 - Converters in `Application/Convert/` must stay pure (no Facade state) so they remain unit-testable.
-- PHP interop (completion/hover/signatureHelp) resolves through the Api facade (`phpInteropHoverAt`, `phpInteropSignatureAt`, `completeAtPoint`). `CompletionHandler`/`HoverHandler` try interop first, then fall back to Phel symbols; `SignatureHelpHandler` is interop-only.
+- PHP interop (completion/hover/signatureHelp) resolves through the Api facade (`phpInteropHoverAt`, `phpInteropSignatureAt`, `completeAtPoint`). `CompletionHandler`/`HoverHandler`/`SignatureHelpHandler` try interop first, then fall back to Phel symbols — signature help reads the symbol's documented arities via `phelSignatureAt`.

--- a/tests/php/Integration/Lsp/PhpInteropLspTest.php
+++ b/tests/php/Integration/Lsp/PhpInteropLspTest.php
@@ -218,6 +218,43 @@ final class PhpInteropLspTest extends TestCase
 
     #[PreserveGlobalState(false)]
     #[RunInSeparateProcess]
+    public function test_signature_help_for_a_phel_core_function(): void
+    {
+        $uri = 'file:///x.phel';
+        $source = '(map )';
+        $session = $this->sessionWith($uri, $source);
+
+        // Cursor inside the argument list of the plain Phel call (no interop).
+        $result = $this->signatureHelp()->handle(
+            $this->params($uri, line: 0, character: 5),
+            $session,
+        );
+
+        self::assertIsArray($result);
+        $signature = $result['signatures'][$result['activeSignature']];
+        self::assertStringContainsString('map', (string) $signature['label']);
+        self::assertNotEmpty($signature['parameters']);
+        self::assertSame(0, $result['activeParameter']);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_signature_help_returns_null_outside_a_call(): void
+    {
+        $uri = 'file:///x.phel';
+        $source = 'map';
+        $session = $this->sessionWith($uri, $source);
+
+        $result = $this->signatureHelp()->handle(
+            $this->params($uri, line: 0, character: 3),
+            $session,
+        );
+
+        self::assertNull($result);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function test_completion_falls_back_to_phel_for_plain_code(): void
     {
         $uri = 'file:///x.phel';

--- a/tests/php/Unit/Api/Application/PhelSignatureResolverTest.php
+++ b/tests/php/Unit/Api/Application/PhelSignatureResolverTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\PhelSignatureResolver;
+use Phel\Api\Domain\SymbolMetadataFinderInterface;
+use Phel\Api\Transfer\PhelFunction;
+use PHPUnit\Framework\TestCase;
+
+use function strlen;
+
+final class PhelSignatureResolverTest extends TestCase
+{
+    public function test_returns_signature_for_a_phel_call(): void
+    {
+        $help = $this->resolverFor($this->mapFn())->signatureAt(...$this->cursorAfter('(map '));
+
+        self::assertNotNull($help);
+        self::assertSame('(map f coll)', $help['signatures'][$help['activeSignature']]['label']);
+        self::assertSame(
+            [['label' => 'f'], ['label' => 'coll']],
+            $help['signatures'][0]['parameters'],
+        );
+        self::assertSame(0, $help['activeParameter']);
+    }
+
+    public function test_exposes_every_arity_as_a_signature(): void
+    {
+        $help = $this->resolverFor($this->mapFn())->signatureAt(...$this->cursorAfter('(map '));
+
+        self::assertNotNull($help);
+        self::assertCount(2, $help['signatures']);
+        self::assertSame('(map f coll & colls)', $help['signatures'][1]['label']);
+    }
+
+    public function test_active_parameter_tracks_the_argument_index(): void
+    {
+        $help = $this->resolverFor($this->mapFn())->signatureAt(...$this->cursorAfter('(map inc '));
+
+        self::assertNotNull($help);
+        self::assertSame(1, $help['activeParameter']);
+    }
+
+    public function test_selects_the_arity_that_covers_the_active_argument(): void
+    {
+        // Fourth argument (index 3): the fixed (map f coll) arity cannot hold it,
+        // so the variadic arity is chosen and the index clamps to its last param.
+        $help = $this->resolverFor($this->mapFn())->signatureAt(...$this->cursorAfter('(map f a b '));
+
+        self::assertNotNull($help);
+        self::assertSame(1, $help['activeSignature']);
+        self::assertSame(2, $help['activeParameter']);
+    }
+
+    public function test_attaches_the_docstring_as_documentation(): void
+    {
+        $help = $this->resolverFor($this->mapFn())->signatureAt(...$this->cursorAfter('(map '));
+
+        self::assertNotNull($help);
+        self::assertSame('Maps f over coll.', $help['signatures'][0]['documentation'] ?? null);
+    }
+
+    public function test_keeps_a_destructured_parameter_whole(): void
+    {
+        $fn = new PhelFunction('user', 'handle', '', ['(handle [a b] c)'], '');
+
+        $help = $this->resolverFor($fn)->signatureAt(...$this->cursorAfter('(handle '));
+
+        self::assertNotNull($help);
+        self::assertSame(
+            [['label' => '[a b]'], ['label' => 'c']],
+            $help['signatures'][0]['parameters'],
+        );
+    }
+
+    public function test_counts_a_collection_literal_argument_as_one(): void
+    {
+        $fn = new PhelFunction('phel.core', 'reduce', '', ['(reduce f coll)'], '');
+
+        // The vector is a single argument; the caret sits on the second arg.
+        $help = $this->resolverFor($fn)->signatureAt(...$this->cursorAfter('(reduce [1 2 3] '));
+
+        self::assertNotNull($help);
+        self::assertSame(1, $help['activeParameter']);
+    }
+
+    public function test_returns_null_when_not_inside_a_call(): void
+    {
+        self::assertNull($this->resolverFor($this->mapFn())->signatureAt(...$this->cursorAfter('map ')));
+    }
+
+    public function test_returns_null_for_a_php_interop_head(): void
+    {
+        // php/... calls are the PhpInteropDocResolver's job; the Phel resolver
+        // must defer so it does not shadow interop signature help.
+        self::assertNull($this->resolverFor($this->mapFn())->signatureAt(...$this->cursorAfter('(php/new ')));
+    }
+
+    public function test_returns_null_when_the_symbol_is_unknown(): void
+    {
+        self::assertNull($this->resolverFor(null)->signatureAt(...$this->cursorAfter('(unknown ')));
+    }
+
+    public function test_returns_null_when_the_function_has_no_signatures(): void
+    {
+        $fn = new PhelFunction('user', 'x', '', [], '');
+
+        self::assertNull($this->resolverFor($fn)->signatureAt(...$this->cursorAfter('(x ')));
+    }
+
+    private function resolverFor(?PhelFunction $fn): PhelSignatureResolver
+    {
+        $finder = $this->createStub(SymbolMetadataFinderInterface::class);
+        $finder->method('find')->willReturn($fn);
+
+        return new PhelSignatureResolver($finder);
+    }
+
+    private function mapFn(): PhelFunction
+    {
+        return new PhelFunction(
+            'phel.core',
+            'map',
+            'Maps f over coll.',
+            ['(map f coll)', '(map f coll & colls)'],
+            '',
+        );
+    }
+
+    /**
+     * Place the caret at the end of $source (line 1), mirroring how an editor
+     * requests signature help while the argument list is still open.
+     *
+     * @return array{0: string, 1: int, 2: int}
+     */
+    private function cursorAfter(string $source): array
+    {
+        return [$source, 1, strlen($source) + 1];
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`SignatureHelpHandler` was interop-only: it showed signatures for `(php/new ...)` / `(php/-> ...)` / `(php/:: ...)` but nothing for plain Phel calls like `(map f xs)`, so editors offered no arity / parameter / doc help for Phel functions (#2643).

## 💡 Goal

Show signature help — each arity, its parameter names, the docstring, and the active parameter — for plain Phel function calls too.

## 🔖 Changes

- New `PhelSignatureResolver` (Api): finds the Phel call enclosing the cursor, resolves the head via `ApiFacade::findSymbolMetadata()`, and builds the LSP SignatureHelp from the symbol's documented arities — picking the arity that fits the current argument and clamping the active parameter.
- `SignatureHelpHandler` now tries interop first, then this Phel fallback; interop behaviour is unchanged.
- Unit tests for the resolver + end-to-end LSP tests (real `map`, and the no-call case).
- Refactor: dropped a duplicated tokenizer for an opt-in flag on the shared `PhpFormTokenizer` (interop tokenizing stays byte-identical).

Closes #2643