### PR TITLE
feat(nrepl): surface *1/*2/*3 value history in eval responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - LSP signature help (`textDocument/signatureHelp`) now covers plain Phel function calls like `(map f xs)` — showing each arity, its parameter names, and the docstring — instead of only `php/...` interop calls (#2643)
+- nREPL eval responses now carry `*1`/`*2`/`*3` value history (the last three results) per session, so clients like Calva and Conjure can show recent values instead of only the last one (#2644)
 
 ### Changed
 

--- a/src/php/Nrepl/Application/Op/EvalResultResponder.php
+++ b/src/php/Nrepl/Application/Op/EvalResultResponder.php
@@ -52,11 +52,7 @@ final readonly class EvalResultResponder
             $session = $this->sessionFor($request);
             $session?->recordValue($result->value);
 
-            $responses[] = OpResponse::forRequest($request, [
-                'ns' => $session instanceof Session ? $session->namespace() : 'user',
-                'value' => $this->printer->print($result->value),
-            ]);
-
+            $responses[] = OpResponse::forRequest($request, $this->successPayload($session, $result->value));
             $responses[] = OpResponse::done($request);
 
             return $responses;
@@ -83,6 +79,26 @@ final readonly class EvalResultResponder
         return $request->session !== null
             ? $this->sessions->get($request->session)
             : null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function successPayload(?Session $session, mixed $value): array
+    {
+        $payload = [
+            'ns' => $session instanceof Session ? $session->namespace() : 'user',
+            'value' => $this->printer->print($value),
+        ];
+
+        // *1/*2/*3 exist only within a session; a session-less eval has no history.
+        if ($session instanceof Session) {
+            $payload['*1'] = $this->printer->print($session->value(1));
+            $payload['*2'] = $this->printer->print($session->value(2));
+            $payload['*3'] = $this->printer->print($session->value(3));
+        }
+
+        return $payload;
     }
 
     private function errorFrame(

--- a/src/php/Nrepl/CLAUDE.md
+++ b/src/php/Nrepl/CLAUDE.md
@@ -43,5 +43,5 @@ nREPL protocol server: bencode-over-TCP for editor tooling (Cursive, Calva, CIDE
 - Client loop uses PHP Fibers (one per connection via `ClientFiberPool`, cooperative suspend).
 - Eval always via RunFacade — no inline compilation.
 - `LookupOp` resolves namespace: explicit param, else session, else `"user"`.
-- `Session` tracks id, namespace, last value (`*1/*2/*3` history is future work; only single last value kept).
+- `Session` tracks id, namespace, and a 3-deep value ring (`value(1..3)`; `lastValue()` is `value(1)`). `EvalResultResponder` surfaces it as `*1`/`*2`/`*3` in each successful eval response (session-scoped; absent for session-less evals). `*e` stays REPL-only.
 - `NreplSocketServer::run(int $maxIterations = 0)` bounds test runs; `0` = unbounded.

--- a/src/php/Nrepl/Domain/Session/Session.php
+++ b/src/php/Nrepl/Domain/Session/Session.php
@@ -4,14 +4,19 @@ declare(strict_types=1);
 
 namespace Phel\Nrepl\Domain\Session;
 
+use function array_slice;
+
 /**
- * Mutable state for a single nREPL session: tracks the current namespace
- * scope and the most recently evaluated value (the future basis for *1/*2/*3
- * history; for now only the single last value is kept).
+ * Mutable state for a single nREPL session: the current namespace scope and a
+ * small ring of the most recently evaluated values, surfaced to clients as
+ * `*1`/`*2`/`*3`.
  */
 final class Session
 {
-    private mixed $lastValue = null;
+    private const int HISTORY_SIZE = 3;
+
+    /** @var list<mixed> the last few evaluated values, newest first */
+    private array $valueHistory = [];
 
     public function __construct(
         public readonly string $id,
@@ -35,18 +40,28 @@ final class Session
     }
 
     /**
-     * The value of the most recent successful evaluation in this session.
+     * The value of the most recent successful evaluation (`*1`), or null.
      */
     public function lastValue(): mixed
     {
-        return $this->lastValue;
+        return $this->value(1);
     }
 
     /**
-     * Remember the latest evaluated value as the session's last value.
+     * The value $position evaluations ago — 1 is the most recent (`*1`) through
+     * 3 (`*3`) — or null when the session has not produced that many yet.
+     */
+    public function value(int $position): mixed
+    {
+        return $this->valueHistory[$position - 1] ?? null;
+    }
+
+    /**
+     * Record the latest evaluated value, rotating the `*1`/`*2`/`*3` history
+     * and dropping anything older than the most recent {@see HISTORY_SIZE}.
      */
     public function recordValue(mixed $value): void
     {
-        $this->lastValue = $value;
+        $this->valueHistory = array_slice([$value, ...$this->valueHistory], 0, self::HISTORY_SIZE);
     }
 }

--- a/tests/php/Unit/Nrepl/Application/Op/EvalResultResponderTest.php
+++ b/tests/php/Unit/Nrepl/Application/Op/EvalResultResponderTest.php
@@ -52,6 +52,42 @@ final class EvalResultResponderTest extends TestCase
         self::assertSame('user', $responses[0]->payload['ns']);
     }
 
+    public function test_success_surfaces_value_history_in_metadata(): void
+    {
+        $printer = $this->createStub(PrinterInterface::class);
+        $printer->method('print')->willReturnCallback(static fn(mixed $v): string => (string) $v);
+
+        $registry = new SessionRegistry();
+        $session = $registry->create();
+        $responder = new EvalResultResponder($printer, $registry);
+
+        $responder->respond(new OpRequest('eval', 'r1', $session->id, []), EvalResult::success(1), 'fallback');
+        $responder->respond(new OpRequest('eval', 'r2', $session->id, []), EvalResult::success(2), 'fallback');
+
+        $responses = $responder->respond(new OpRequest('eval', 'r3', $session->id, []), EvalResult::success(3), 'fallback');
+
+        $payload = $responses[0]->payload;
+        self::assertSame('3', $payload['*1']);
+        self::assertSame('2', $payload['*2']);
+        self::assertSame('1', $payload['*3']);
+    }
+
+    public function test_no_history_keys_without_a_session(): void
+    {
+        $printer = $this->createStub(PrinterInterface::class);
+        $printer->method('print')->willReturn('nil');
+
+        $responder = new EvalResultResponder($printer, new SessionRegistry());
+
+        $responses = $responder->respond(
+            new OpRequest('eval', null, null, []),
+            EvalResult::success(null),
+            'fallback',
+        );
+
+        self::assertArrayNotHasKey('*1', $responses[0]->payload);
+    }
+
     public function test_success_prepends_out_frame_when_output_present(): void
     {
         $printer = $this->createStub(PrinterInterface::class);

--- a/tests/php/Unit/Nrepl/Domain/Op/EvalOpTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/EvalOpTest.php
@@ -37,6 +37,7 @@ final class EvalOpTest extends TestCase
         self::assertCount(2, $responses);
         self::assertSame('3', $responses[0]->payload['value']);
         self::assertSame('user', $responses[0]->payload['ns']);
+        self::assertSame('3', $responses[0]->payload['*1']);
         self::assertContains('done', $responses[1]->payload['status']);
         self::assertSame(3, $session->lastValue());
     }

--- a/tests/php/Unit/Nrepl/Domain/Session/SessionRegistryTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Session/SessionRegistryTest.php
@@ -64,4 +64,28 @@ final class SessionRegistryTest extends TestCase
         self::assertSame('phel.core', $session->namespace());
         self::assertSame(42, $session->lastValue());
     }
+
+    public function test_session_keeps_a_ring_of_the_last_three_values(): void
+    {
+        $session = new SessionRegistry()->create();
+
+        self::assertNull($session->value(1));
+
+        $session->recordValue('a');
+        self::assertSame('a', $session->value(1));
+        self::assertNull($session->value(2));
+
+        $session->recordValue('b');
+        self::assertSame('b', $session->value(1));
+        self::assertSame('a', $session->value(2));
+
+        $session->recordValue('c');
+        self::assertSame(['c', 'b', 'a'], [$session->value(1), $session->value(2), $session->value(3)]);
+
+        // A fourth value rotates the oldest ('a') out of the ring.
+        $session->recordValue('d');
+        self::assertSame(['d', 'c', 'b'], [$session->value(1), $session->value(2), $session->value(3)]);
+        self::assertNull($session->value(4));
+        self::assertSame('d', $session->lastValue());
+    }
 }


### PR DESCRIPTION
## 🤔 Background

An nREPL `Session` kept only a single `lastValue`, so clients (Calva, Conjure) could not read value history across evals — only the last result (#2644).

## 💡 Goal

Give each session the last three results and surface them to clients as `*1`/`*2`/`*3`.

## 🔖 Changes

- `Session` now keeps a 3-deep value ring (`value(1..3)`; `lastValue()` = `value(1)`) instead of a single field.
- `EvalResultResponder` includes `*1`/`*2`/`*3` in each successful eval response — session-scoped, absent for session-less evals. `*e` stays REPL-only, per the issue.
- Unit tests for the ring and the response metadata, plus an op-path assertion in `EvalOpTest`.
- Refactor pass: no separate changes — response-building was extracted into `successPayload()` as part of the feature and the ring is self-contained.

Closes #2644