### PR TITLE
feat(repl): show :example in (doc sym) output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- The REPL `(doc sym)` now prints the function's `:example` under an `Example:` heading, alongside its signature and description (#2645)
 - `phel test` now shows a `+`/`-`/`~` structural diff for any same-shape collection that differs (previously only for collections with more than 3 entries); scalars and mixed shapes keep the single-line summary
 - `phel compile` now prints to stderr the value a snippet folds to when it emits no PHP (e.g. `(+ 1 2)` → `3`) (#2624)
 - `phel init` now scaffolds `phel-config.php` at `->withOptimizationLevel(2)`, so new projects get inlined arithmetic/bit ops and elided nil-guards by default; the runtime default stays `0` for existing projects (#2631)

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -76,9 +76,13 @@
     (when meta
       (let [doc        (or (get meta :doc) "")
             deprecated (get meta :deprecated)
-            message    (if deprecated
+            example    (get meta :example)
+            with-dep   (if deprecated
                          (str doc (if (= doc "") "" "\n") "DEPRECATED: " deprecated)
-                         doc)]
+                         doc)
+            message    (if example
+                         (str with-dep "\n\nExample:\n" example)
+                         with-dep)]
         (clean-doc message)))))
 
 (defmacro doc

--- a/tests/php/Integration/Run/Command/Repl/ReplCommandTestTrait.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplCommandTestTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Run\Command\Repl;
+
+use Gacela\Framework\Gacela;
+use Phel\Command\Application\TextExceptionPrinter;
+use Phel\Command\Domain\ErrorLogInterface;
+use Phel\Command\Domain\Exceptions\ExceptionArgsPrinter;
+use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractor;
+use Phel\Command\Infrastructure\SourceMapExtractor;
+use Phel\Run\Domain\Repl\ReplCommandIoInterface;
+use Phel\Run\RunFactory;
+use Phel\Shared\ColorStyle;
+use Phel\Shared\ColorStyleInterface;
+use Phel\Shared\Munge;
+use Phel\Shared\Printer\Printer;
+use Phel\Shared\Printer\PrinterInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Shared REPL-command test wiring: a capturing {@see ReplTestIo} and a
+ * {@see RunFactory} override that routes REPL output through it.
+ *
+ * @psalm-require-extends TestCase
+ *
+ * @phpstan-require-extends TestCase
+ */
+trait ReplCommandTestTrait
+{
+    private function createReplTestIo(): ReplTestIo
+    {
+        $exceptionPrinter = new TextExceptionPrinter(
+            new ExceptionArgsPrinter(Printer::readable()),
+            ColorStyle::noStyles(),
+            new Munge(),
+            new FilePositionExtractor(new SourceMapExtractor()),
+            $this->createStub(ErrorLogInterface::class),
+        );
+
+        return new ReplTestIo($exceptionPrinter);
+    }
+
+    private function prepareRunFactory(ReplCommandIoInterface $io): void
+    {
+        Gacela::overrideExistingResolvedClass(
+            RunFactory::class,
+            new class($io) extends RunFactory {
+                public function __construct(private readonly ReplCommandIoInterface $io) {}
+
+                public function createColorStyle(): ColorStyleInterface
+                {
+                    return ColorStyle::noStyles();
+                }
+
+                public function createPrinter(): PrinterInterface
+                {
+                    return Printer::nonReadable();
+                }
+
+                public function createReplCommandIo(): ReplCommandIoInterface
+                {
+                    return $this->io;
+                }
+            },
+        );
+    }
+}

--- a/tests/php/Integration/Run/Command/Repl/ReplDocTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplDocTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Run\Command\Repl;
+
+use Gacela\Framework\Gacela;
+use Override;
+use Phel\Command\Application\TextExceptionPrinter;
+use Phel\Command\Domain\ErrorLogInterface;
+use Phel\Command\Domain\Exceptions\ExceptionArgsPrinter;
+use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractor;
+use Phel\Command\Infrastructure\SourceMapExtractor;
+use Phel\Run\Domain\Repl\ReplCommandIoInterface;
+use Phel\Run\Infrastructure\Command\ReplCommand;
+use Phel\Run\RunFactory;
+use Phel\Shared\ColorStyle;
+use Phel\Shared\ColorStyleInterface;
+use Phel\Shared\Munge;
+use Phel\Shared\Printer\Printer;
+use Phel\Shared\Printer\PrinterInterface;
+use PhelTest\Integration\Run\Command\AbstractTestCommand;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use Symfony\Component\Console\Input\InputInterface;
+
+final class ReplDocTest extends AbstractTestCommand
+{
+    private string $previousCwd = '';
+
+    private string $tempDir = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->previousCwd = getcwd() ?: '';
+        $this->tempDir = $this->containerTempDir();
+        chdir($this->tempDir);
+        Gacela::bootstrap($this->tempDir);
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        chdir($this->previousCwd);
+        $this->cleanupContainerTempDirs();
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function test_doc_prints_signature_description_and_example(): void
+    {
+        $io = $this->createReplTestIo();
+        $io->setInputs(
+            new InputLine('user:1> ', '(defn add-two "Adds 2 to x." {:example "(add-two 5)"} [x] (+ x 2))'),
+            new InputLine('user:2> ', '(doc add-two)'),
+            new InputLine('user:3> ', 'exit'),
+        );
+        $this->prepareRunFactory($io);
+
+        // `doc` prints via `println`, which writes to stdout rather than the
+        // REPL IO buffer, so capture both streams.
+        ob_start();
+        new ReplCommand()->run(
+            $this->createStub(InputInterface::class),
+            $this->stubOutput(),
+        );
+        $output = $io->getOutputString() . ob_get_clean();
+        self::assertStringContainsString('(add-two x)', $output);
+        self::assertStringContainsString('Adds 2 to x.', $output);
+        // The :example metadata is now rendered under its own heading (#2645).
+        self::assertStringContainsString("Example:\n(add-two 5)", $output);
+    }
+
+    private function createReplTestIo(): ReplTestIo
+    {
+        $exceptionPrinter = new TextExceptionPrinter(
+            new ExceptionArgsPrinter(Printer::readable()),
+            ColorStyle::noStyles(),
+            new Munge(),
+            new FilePositionExtractor(new SourceMapExtractor()),
+            $this->createStub(ErrorLogInterface::class),
+        );
+
+        return new ReplTestIo($exceptionPrinter);
+    }
+
+    private function prepareRunFactory(ReplCommandIoInterface $io): void
+    {
+        Gacela::overrideExistingResolvedClass(
+            RunFactory::class,
+            new class($io) extends RunFactory {
+                public function __construct(private readonly ReplCommandIoInterface $io) {}
+
+                public function createColorStyle(): ColorStyleInterface
+                {
+                    return ColorStyle::noStyles();
+                }
+
+                public function createPrinter(): PrinterInterface
+                {
+                    return Printer::nonReadable();
+                }
+
+                public function createReplCommandIo(): ReplCommandIoInterface
+                {
+                    return $this->io;
+                }
+            },
+        );
+    }
+}

--- a/tests/php/Integration/Run/Command/Repl/ReplDocTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplDocTest.php
@@ -6,19 +6,7 @@ namespace PhelTest\Integration\Run\Command\Repl;
 
 use Gacela\Framework\Gacela;
 use Override;
-use Phel\Command\Application\TextExceptionPrinter;
-use Phel\Command\Domain\ErrorLogInterface;
-use Phel\Command\Domain\Exceptions\ExceptionArgsPrinter;
-use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractor;
-use Phel\Command\Infrastructure\SourceMapExtractor;
-use Phel\Run\Domain\Repl\ReplCommandIoInterface;
 use Phel\Run\Infrastructure\Command\ReplCommand;
-use Phel\Run\RunFactory;
-use Phel\Shared\ColorStyle;
-use Phel\Shared\ColorStyleInterface;
-use Phel\Shared\Munge;
-use Phel\Shared\Printer\Printer;
-use Phel\Shared\Printer\PrinterInterface;
 use PhelTest\Integration\Run\Command\AbstractTestCommand;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
@@ -26,6 +14,8 @@ use Symfony\Component\Console\Input\InputInterface;
 
 final class ReplDocTest extends AbstractTestCommand
 {
+    use ReplCommandTestTrait;
+
     private string $previousCwd = '';
 
     private string $tempDir = '';
@@ -70,43 +60,5 @@ final class ReplDocTest extends AbstractTestCommand
         self::assertStringContainsString('Adds 2 to x.', $output);
         // The :example metadata is now rendered under its own heading (#2645).
         self::assertStringContainsString("Example:\n(add-two 5)", $output);
-    }
-
-    private function createReplTestIo(): ReplTestIo
-    {
-        $exceptionPrinter = new TextExceptionPrinter(
-            new ExceptionArgsPrinter(Printer::readable()),
-            ColorStyle::noStyles(),
-            new Munge(),
-            new FilePositionExtractor(new SourceMapExtractor()),
-            $this->createStub(ErrorLogInterface::class),
-        );
-
-        return new ReplTestIo($exceptionPrinter);
-    }
-
-    private function prepareRunFactory(ReplCommandIoInterface $io): void
-    {
-        Gacela::overrideExistingResolvedClass(
-            RunFactory::class,
-            new class($io) extends RunFactory {
-                public function __construct(private readonly ReplCommandIoInterface $io) {}
-
-                public function createColorStyle(): ColorStyleInterface
-                {
-                    return ColorStyle::noStyles();
-                }
-
-                public function createPrinter(): PrinterInterface
-                {
-                    return Printer::nonReadable();
-                }
-
-                public function createReplCommandIo(): ReplCommandIoInterface
-                {
-                    return $this->io;
-                }
-            },
-        );
     }
 }

--- a/tests/php/Integration/Run/Command/Repl/ReplHistoryVarsTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplHistoryVarsTest.php
@@ -6,19 +6,7 @@ namespace PhelTest\Integration\Run\Command\Repl;
 
 use Gacela\Framework\Gacela;
 use Override;
-use Phel\Command\Application\TextExceptionPrinter;
-use Phel\Command\Domain\ErrorLogInterface;
-use Phel\Command\Domain\Exceptions\ExceptionArgsPrinter;
-use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractor;
-use Phel\Command\Infrastructure\SourceMapExtractor;
-use Phel\Run\Domain\Repl\ReplCommandIoInterface;
 use Phel\Run\Infrastructure\Command\ReplCommand;
-use Phel\Run\RunFactory;
-use Phel\Shared\ColorStyle;
-use Phel\Shared\ColorStyleInterface;
-use Phel\Shared\Munge;
-use Phel\Shared\Printer\Printer;
-use Phel\Shared\Printer\PrinterInterface;
 use PhelTest\Integration\Run\Command\AbstractTestCommand;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
@@ -26,6 +14,8 @@ use Symfony\Component\Console\Input\InputInterface;
 
 final class ReplHistoryVarsTest extends AbstractTestCommand
 {
+    use ReplCommandTestTrait;
+
     private string $previousCwd = '';
 
     private string $tempDir = '';
@@ -114,43 +104,5 @@ final class ReplHistoryVarsTest extends AbstractTestCommand
 
         $output = $io->getOutputString();
         self::assertStringContainsString('boom', $output, 'getMessage() on *e returns boom');
-    }
-
-    private function createReplTestIo(): ReplTestIo
-    {
-        $exceptionPrinter = new TextExceptionPrinter(
-            new ExceptionArgsPrinter(Printer::readable()),
-            ColorStyle::noStyles(),
-            new Munge(),
-            new FilePositionExtractor(new SourceMapExtractor()),
-            $this->createStub(ErrorLogInterface::class),
-        );
-
-        return new ReplTestIo($exceptionPrinter);
-    }
-
-    private function prepareRunFactory(ReplCommandIoInterface $io): void
-    {
-        Gacela::overrideExistingResolvedClass(
-            RunFactory::class,
-            new class($io) extends RunFactory {
-                public function __construct(private readonly ReplCommandIoInterface $io) {}
-
-                public function createColorStyle(): ColorStyleInterface
-                {
-                    return ColorStyle::noStyles();
-                }
-
-                public function createPrinter(): PrinterInterface
-                {
-                    return Printer::nonReadable();
-                }
-
-                public function createReplCommandIo(): ReplCommandIoInterface
-                {
-                    return $this->io;
-                }
-            },
-        );
     }
 }

--- a/tests/php/Integration/Run/Command/Repl/ReplTestCommand.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplTestCommand.php
@@ -6,19 +6,7 @@ namespace PhelTest\Integration\Run\Command\Repl;
 
 use Generator;
 use Override;
-use Phel\Command\Application\TextExceptionPrinter;
-use Phel\Command\Domain\ErrorLogInterface;
-use Phel\Command\Domain\Exceptions\ExceptionArgsPrinter;
-use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractor;
-use Phel\Command\Infrastructure\SourceMapExtractor;
-use Phel\Run\Domain\Repl\ReplCommandIoInterface;
 use Phel\Run\Infrastructure\Command\ReplCommand;
-use Phel\Run\RunFactory;
-use Phel\Shared\ColorStyle;
-use Phel\Shared\ColorStyleInterface;
-use Phel\Shared\Munge;
-use Phel\Shared\Printer\Printer;
-use Phel\Shared\Printer\PrinterInterface;
 use PhelTest\Integration\Run\Command\AbstractTestCommand;
 use PHPUnit\Framework\Attributes\DataProvider;
 use RecursiveDirectoryIterator;
@@ -29,6 +17,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class ReplTestCommand extends AbstractTestCommand
 {
+    use ReplCommandTestTrait;
+
     private string $previousCwd = '';
 
     public function __construct()
@@ -158,41 +148,4 @@ final class ReplTestCommand extends AbstractTestCommand
         return $inputs;
     }
 
-    private function createReplTestIo(): ReplTestIo
-    {
-        $exceptionPrinter = new TextExceptionPrinter(
-            new ExceptionArgsPrinter(Printer::readable()),
-            ColorStyle::noStyles(),
-            new Munge(),
-            new FilePositionExtractor(new SourceMapExtractor()),
-            $this->createStub(ErrorLogInterface::class),
-        );
-
-        return new ReplTestIo($exceptionPrinter);
-    }
-
-    private function prepareRunFactory(ReplCommandIoInterface $io): void
-    {
-        Gacela::overrideExistingResolvedClass(
-            RunFactory::class,
-            new class($io) extends RunFactory {
-                public function __construct(private readonly ReplCommandIoInterface $io) {}
-
-                public function createColorStyle(): ColorStyleInterface
-                {
-                    return ColorStyle::noStyles();
-                }
-
-                public function createPrinter(): PrinterInterface
-                {
-                    return Printer::nonReadable();
-                }
-
-                public function createReplCommandIo(): ReplCommandIoInterface
-                {
-                    return $this->io;
-                }
-            },
-        );
-    }
 }


### PR DESCRIPTION
## 🤔 Background

The REPL `(doc sym)` printed a symbol's signature and description but dropped its `:example` metadata, so you could not see a usage example without leaving the session (#2645).

## 💡 Goal

Show the `:example` in `(doc sym)` output, alongside the signature and description.

## 🔖 Changes

- `find-doc` (in `repl.phel`) now appends the symbol's `:example` under an `Example:` heading; a symbol without an example is unchanged.
- New `ReplDocTest` proving the example renders — it captures `println` stdout, which the REPL IO buffer does not hold.
- Refactor: extracted the duplicated `createReplTestIo()` / `prepareRunFactory()` REPL test wiring into `ReplCommandTestTrait`, shared by the doc test and its siblings.

Closes #2645