### PR TITLE
docs(cli): point to editor setup guides for lsp/nrepl

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -36,6 +36,14 @@ enable tab-completion (see the [README](../README.md#enable-shell-completion-opt
 | `test` `t` | Run the test suite (all tests, or the files/namespaces you pass) |
 | `watch` | Watch Phel files and reload changed namespaces on change |
 
+## Editor setup
+
+`phel lsp` (Language Server, stdio) and `phel nrepl` (default `127.0.0.1:7888`) plug
+Phel into your editor. Per-editor setup lives on the website:
+
+- **LSP** — VS Code, Emacs (eglot / lsp-mode), Vim / Neovim (coc.nvim / vim-lsp): [Editor support](https://phel-lang.org/documentation/tooling/editor-support/)
+- **nREPL** — Calva, Conjure: [REPL / nREPL](https://phel-lang.org/documentation/tooling/repl/)
+
 ## compile vs eval vs run vs build
 
 These four overlap; pick by what you want back:


### PR DESCRIPTION
## 🤔 Background

The CLI reference lists `phel lsp` and `phel nrepl` but had no setup pointer. Per `docs/README.md`, user-facing editor / REPL guides live on phel-lang.org, not in this repo (#2646).

## 💡 Goal

Make editor setup discoverable from the CLI reference without duplicating the website's guides.

## 🔖 Changes

- Add a short "Editor setup" section to `docs/cli-reference.md` (next to the `lsp`/`nrepl` rows) linking the website's editor-support and REPL/nREPL pages.

Resolved as a pointer rather than a new `docs/editor-setup.md`, to respect the `docs/README.md` policy that user-facing editor/REPL guides live on phel-lang.org.

Closes #2646