### PR TITLE
fix(test): run --parallel correctly from the distributed PHAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `phel test --parallel` now works from the distributed PHAR: the long-lived worker no longer re-evaluates bundled namespaces it already loaded, which under a PHAR re-nulled core fns (`map`/`seq`/`nil?`) and failed every worker with "__invoke() on null" (0 tests run); serial runs were unaffected (#2672)
 - Global/PHAR `phel` resolves the project root from the working directory (nearest `phel-config.php` or `vendor/`), not the binary location, so `phel config`/`doctor` read the local config from anywhere (#2640)
 - `phel-config.php` returning `null` is now rejected with a clear error, not silently treated as empty config (#2642)
 - `phel.router/compiled-router` now compiles routes carrying a `:handler` function (#2663)

--- a/src/php/Run/Infrastructure/Command/TestWorkerCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestWorkerCommand.php
@@ -6,6 +6,7 @@ namespace Phel\Run\Infrastructure\Command;
 
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
+use Phel\Lang\Registry;
 use Phel\Run\Application\Test\FrameKey;
 use Phel\Run\Application\Test\WorkerFrame;
 use Phel\Run\Application\Test\WorkRequest;
@@ -26,6 +27,7 @@ use function is_string;
 use function ob_get_clean;
 use function ob_start;
 use function sprintf;
+use function str_replace;
 
 /**
  * Hidden subcommand: parallel-test worker. One process per pool slot,
@@ -127,13 +129,18 @@ final class TestWorkerCommand extends Command
         }
 
         foreach ($this->getFacade()->getDependenciesFromPaths([$file]) as $info) {
-            // The worker lives for the whole run, so a dependency stays
-            // registered across frames; re-evaluating it (mostly the phel.*
-            // stdlib shared by every namespace) just re-executes it and
-            // dominated each frame. Eval each file once per worker, as the
-            // serial runner already does.
+            // The worker is long-lived: eval each dependency file once across all frames.
             $depFile = $info->getFile();
             if (isset($this->preloadedFiles[$depFile])) {
+                continue;
+            }
+
+            // Skip namespaces already loaded at bootstrap (loadPhelNamespaces brings in
+            // the whole bundled phel.* stdlib). Re-evaluating a precompiled sibling (PHAR)
+            // re-runs its primary, which re-nulls forward-declared defs (map/seq/nil?)
+            // that its require_once secondaries then won't restore — a null callable. (#2672)
+            if (Registry::getInstance()->hasNamespace(str_replace('-', '_', $info->getNamespace()))) {
+                $this->preloadedFiles[$depFile] = true;
                 continue;
             }
 

--- a/tools/release-lib.sh
+++ b/tools/release-lib.sh
@@ -542,15 +542,73 @@ qa_smoke_test_phar() {
         rm -f "$step_out" "$step_err"
     }
 
+    _qa_expect_err() {
+        local label="$1"; local pattern="$2"; shift 2
+        step_out=$(mktemp); step_err=$(mktemp)
+        ( cd "$tmp_dir" && "$@" ) >"$step_out" 2>"$step_err"
+        step_rc=$?
+        if [[ $step_rc -eq 0 ]]; then
+            log_err "QA [$label] expected a non-zero exit but the command succeeded"
+            failures=$((failures + 1))
+        elif grep -qE 'PHP (Warning|Fatal|Parse) ' "$step_err"; then
+            log_err "QA [$label] leaked a raw PHP diagnostic instead of a clean Phel error:"
+            grep -E 'PHP (Warning|Fatal|Parse) ' "$step_err" | head -3 >&2
+            failures=$((failures + 1))
+        elif ! grep -qiE "$pattern" "$step_err" "$step_out"; then
+            log_err "QA [$label] error output did not match /$pattern/"
+            sed -n '1,20p' "$step_err" >&2
+            failures=$((failures + 1))
+        else
+            log_ok "QA [$label]"
+        fi
+        rm -f "$step_out" "$step_err"
+    }
+
+    # Core CLI surface: every batch command must run clean against the built PHAR.
     _qa_expect "version" "v${expected_version}" php phel.phar --version
-    _qa_run    "init"        php phel.phar init --force
-    _qa_expect "run"         "Hello, Phel!" php phel.phar run src/main.phel
-    _qa_expect "test"        "Passed: 2"   php phel.phar test
-    _qa_run    "format"      php phel.phar format --dry-run src/
-    _qa_run    "build"       php phel.phar build
-    _qa_run    "doctor"      php phel.phar doctor
-    _qa_run    "lint"        php phel.phar lint src
-    _qa_run    "doc"         php phel.phar doc map
+    _qa_run    "init" php phel.phar init --force
+    _qa_run    "init-opt-level-2" grep -q "withOptimizationLevel(2)" phel-config.php
+    _qa_expect "run" "Hello, Phel!" php phel.phar run src/main.phel
+    _qa_expect "eval" "3" php phel.phar eval "(+ 1 2)"
+    _qa_run    "compile" php phel.phar compile "(+ 1 2)"
+    _qa_expect "test" "Passed: 2" php phel.phar test
+    _qa_run    "test-parallel" php phel.phar test --parallel 2
+    _qa_run    "format" php phel.phar format --dry-run src/
+    _qa_run    "build" php phel.phar build
+    _qa_run    "lint" php phel.phar lint src
+    _qa_run    "analyze" php phel.phar analyze src/main.phel
+    _qa_run    "index" php phel.phar index src
+    _qa_run    "export" php phel.phar export
+    _qa_run    "ns" php phel.phar ns
+    _qa_run    "config" php phel.phar config
+    _qa_run    "doctor" php phel.phar doctor
+    _qa_run    "cache-clear" php phel.phar cache:clear
+    _qa_run    "doc" php phel.phar doc map
+
+    # Editor / long-running commands: confirm each loads via --help without booting a server.
+    _qa_run    "repl-help" php phel.phar repl --help
+    _qa_run    "nrepl-help" php phel.phar nrepl --help
+    _qa_run    "lsp-help" php phel.phar lsp --help
+    _qa_run    "watch-help" php phel.phar watch --help
+    _qa_run    "api-daemon-help" php phel.phar api-daemon --help
+    _qa_run    "profile-help" php phel.phar profile --help
+    _qa_run    "agent-install-help" php phel.phar agent-install --help
+
+    # Project root resolves from CWD, so config works from a nested subdirectory.
+    mkdir -p "$tmp_dir/sub/dir"
+    _qa_run    "config-from-subdir" bash -c "cd '$tmp_dir/sub/dir' && php '$tmp_dir/phel.phar' config"
+
+    # Error paths must surface a clean Phel diagnostic, never a raw PHP crash.
+    _qa_expect_err "err-divide-by-zero" "ivision" php phel.phar eval "(/ 1 0)"
+    _qa_expect_err "err-non-symbol-defn" "symbol|PHEL" php phel.phar eval "(defn 123 [x] x)"
+    _qa_expect_err "err-not-callable" "callable|hint" php phel.phar eval "(let [x 5] (x 1 2))"
+    _qa_expect_err "err-unknown-symbol" "resolve|did you mean" php phel.phar eval "(prnn 1)"
+
+    # A phel-config.php returning null must be rejected, not silently treated as empty.
+    cp "$tmp_dir/phel-config.php" "$tmp_dir/phel-config.php.bak"
+    printf '<?php\n\ndeclare(strict_types=1);\n\nreturn null;\n' > "$tmp_dir/phel-config.php"
+    _qa_expect_err "reject-null-config" "array|JsonSerializable" php phel.phar config
+    mv "$tmp_dir/phel-config.php.bak" "$tmp_dir/phel-config.php"
 
     rm -rf "$tmp_dir"
 


### PR DESCRIPTION
## 🤔 Background

`phel test --parallel` was completely broken in the distributed PHAR (all versions, incl. v0.46.0): every worker failed with `Call to a member function __invoke() on null` and ran 0 tests. Serial was fine. Surfaced by a new release-time QA smoke check that runs the full CLI surface against the built PHAR.

## 💡 Goal

Make `phel test --parallel` work from the PHAR, and guard it so it can't regress unnoticed.

## 🔖 Changes

- The long-lived test worker no longer re-evaluates bundled namespaces it already loaded at bootstrap. Re-running a precompiled-sibling primary inside a PHAR re-nulled forward-declared core defs (`map`/`seq`/`nil?`) that the `require_once` secondaries didn't restore → null callable. Skips namespaces already registered after `loadPhelNamespaces`.
- Expanded `qa_smoke_test_phar` to exercise every CLI command + error paths against the built PHAR (the check that caught this).
- Deeper hardening (idempotent precompiled-sibling load) tracked in #2673.

Closes #2672