### PR TITLE
test(phar): guard `phel test --parallel` from the distributed PHAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- `phel test --parallel` now works from the distributed PHAR: the long-lived worker no longer re-evaluates bundled namespaces it already loaded, which under a PHAR re-nulled core fns (`map`/`seq`/`nil?`) and failed every worker with "__invoke() on null" (0 tests run); serial runs were unaffected (#2672)
+- `phel test --parallel` now works from the distributed PHAR; the long-lived worker no longer re-evaluates already-loaded bundled namespaces (serial runs were unaffected) (#2672)
 - Global/PHAR `phel` resolves the project root from the working directory (nearest `phel-config.php` or `vendor/`), not the binary location, so `phel config`/`doctor` read the local config from anywhere (#2640)
 - `phel-config.php` returning `null` is now rejected with a clear error, not silently treated as empty config (#2642)
 - `phel.router/compiled-router` now compiles routes carrying a `:handler` function (#2663)

--- a/src/php/Run/Infrastructure/Command/TestWorkerCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestWorkerCommand.php
@@ -135,10 +135,7 @@ final class TestWorkerCommand extends Command
                 continue;
             }
 
-            // Skip namespaces already loaded at bootstrap (loadPhelNamespaces brings in
-            // the whole bundled phel.* stdlib). Re-evaluating a precompiled sibling (PHAR)
-            // re-runs its primary, which re-nulls forward-declared defs (map/seq/nil?)
-            // that its require_once secondaries then won't restore — a null callable. (#2672)
+            // Skip already-loaded bundled ns: re-evaluating one re-nulls its forward-declared defs under a PHAR (#2672).
             if (Registry::getInstance()->hasNamespace(str_replace('-', '_', $info->getNamespace()))) {
                 $this->preloadedFiles[$depFile] = true;
                 continue;

--- a/tests/php/Integration/Phar/PharExecutionTest.php
+++ b/tests/php/Integration/Phar/PharExecutionTest.php
@@ -145,6 +145,51 @@ final class PharExecutionTest extends TestCase
         );
     }
 
+    public function test_phar_test_parallel_runs_without_re_nulling_bundled_core(): void
+    {
+        // Regression #2672: from the PHAR the long-lived parallel worker
+        // re-evaluated bundled phel.core, re-nulling its forward-declared defs
+        // (map/seq/nil?) — every worker died "__invoke() on null", 0 tests.
+        $projectDir = $this->tempProjectDir . '/fresh-parallel';
+        mkdir($projectDir, 0755, true);
+
+        $init = $this->runPharInDir($projectDir, ['init', '--no-interaction']);
+        self::assertSame(
+            0,
+            $init['exit'],
+            sprintf("phel init failed.\nstdout:\n%s\nstderr:\n%s", $init['stdout'], $init['stderr']),
+        );
+
+        $test = $this->runPharInDir($projectDir, ['test', '--parallel=2']);
+        $combined = $test['stdout'] . $test['stderr'];
+
+        self::assertSame(
+            0,
+            $test['exit'],
+            sprintf(
+                "phel test --parallel from PHAR must pass.\nstdout:\n%s\nstderr:\n%s",
+                $test['stdout'],
+                $test['stderr'],
+            ),
+        );
+        self::assertStringNotContainsString(
+            '__invoke() on null',
+            $combined,
+            'a worker re-evaluating bundled phel.core would re-null map/seq/nil? (#2672)',
+        );
+        self::assertMatchesRegularExpression(
+            '/across 2 parallel worker\(s\)/',
+            $test['stdout'],
+            'must fan out to workers, not silently fall back to serial',
+        );
+        self::assertMatchesRegularExpression(
+            '/Passed:\s+[1-9]/',
+            $test['stdout'],
+            'workers must actually run tests, not report 0 (the #2672 symptom)',
+        );
+        self::assertMatchesRegularExpression('/Error:\s+0/', $test['stdout']);
+    }
+
     public function test_phar_ships_shell_completion_scripts(): void
     {
         // Regression: the PHAR build must not exclude Symfony's

--- a/tools/release-lib.sh
+++ b/tools/release-lib.sh
@@ -550,9 +550,9 @@ qa_smoke_test_phar() {
         if [[ $step_rc -eq 0 ]]; then
             log_err "QA [$label] expected a non-zero exit but the command succeeded"
             failures=$((failures + 1))
-        elif grep -qE 'PHP (Warning|Fatal|Parse) ' "$step_err"; then
+        elif grep -qE 'PHP (Warning|Fatal|Parse|Deprecated) ' "$step_err"; then
             log_err "QA [$label] leaked a raw PHP diagnostic instead of a clean Phel error:"
-            grep -E 'PHP (Warning|Fatal|Parse) ' "$step_err" | head -3 >&2
+            grep -E 'PHP (Warning|Fatal|Parse|Deprecated) ' "$step_err" | head -3 >&2
             failures=$((failures + 1))
         elif ! grep -qiE "$pattern" "$step_err" "$step_out"; then
             log_err "QA [$label] error output did not match /$pattern/"
@@ -572,7 +572,7 @@ qa_smoke_test_phar() {
     _qa_expect "eval" "3" php phel.phar eval "(+ 1 2)"
     _qa_run    "compile" php phel.phar compile "(+ 1 2)"
     _qa_expect "test" "Passed: 2" php phel.phar test
-    _qa_run    "test-parallel" php phel.phar test --parallel 2
+    _qa_expect "test-parallel" "Passed: +[1-9]" php phel.phar test --parallel 2
     _qa_run    "format" php phel.phar format --dry-run src/
     _qa_run    "build" php phel.phar build
     _qa_run    "lint" php phel.phar lint src


### PR DESCRIPTION
## 🤔 Background

#2674 fixed `phel test --parallel` crashing from the distributed PHAR, but the bug only reproduces inside a PHAR (precompiled stdlib siblings). The source-tree parallel tests pass with or without the fix, so CI couldn't catch a revert.

## 💡 Goal

Add a real regression guard for the #2672 fix, plus two small review follow-ups.

## 🔖 Changes

- `PharExecutionTest`: new case runs `init` + `test --parallel=2` against the built phar and asserts workers fan out, tests actually run, and the `__invoke() on null` crash is gone. Runs in CI's phar-smoke job; self-skips when no phar is built. Verified RED when the guard is reverted.
- Collapse the worker skip-guard comment to one WHY line; trim the CHANGELOG entry.
- Release QA smoke: assert `test --parallel` reports `Passed:` (not just exit 0), and flag `PHP Deprecated` on error paths.

Related to #2672