### PR TITLE
fix(build): make precompiled-sibling re-eval idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - `phel test --parallel` no longer intermittently fails from the distributed PHAR: a namespace whose worker hits a transient load error is re-run on a fresh worker (up to twice) before the error surfaces, so a rare race can't red the whole run; genuine test failures are never retried, and serial runs were always unaffected (#2672)
+- Re-evaluating an already-loaded bundled namespace (a precompiled `.php` sibling shipped in the PHAR) no longer nulls its forward-declared defs (`map`/`seq`/`nil?`): the primary is loaded with `require_once`, so a second load can't reset them to null and crash a later call with `__invoke() on null` (#2673)
 - Global/PHAR `phel` resolves the project root from the working directory (nearest `phel-config.php` or `vendor/`), not the binary location, so `phel config`/`doctor` read the local config from anywhere (#2640)
 - `phel-config.php` returning `null` is now rejected with a clear error, not silently treated as empty config (#2642)
 - `phel.router/compiled-router` now compiles routes carrying a `:handler` function (#2663)

--- a/src/php/Build/Application/FileEvaluator.php
+++ b/src/php/Build/Application/FileEvaluator.php
@@ -76,8 +76,13 @@ final class FileEvaluator
         $precompiledSibling = $this->precompiledSiblingPath($src);
         if ($precompiledSibling !== null) {
             $this->compilerFacade->initializeGlobalEnvironment();
+            // #2673: `require_once`, not `require` — a bundled primary
+            // forward-declares defs (`map`/`seq`/`nil?`) as null and restores
+            // them via `require_once` secondaries. A second plain `require`
+            // re-nulls the forward decls while the secondaries no-op, leaving
+            // them null. Loading the primary once per process keeps them.
             /** @psalm-suppress UnresolvableInclude */
-            require $precompiledSibling;
+            require_once $precompiledSibling;
 
             return new CompiledFile($src, $precompiledSibling, $namespace);
         }
@@ -184,7 +189,7 @@ final class FileEvaluator
      * `.phel`/`.cljc` source (the stdlib bundled in the PHAR), or null when
      * none applies.
      *
-     * When present, the sibling is `require`d directly, skipping the
+     * When present, the sibling is `require_once`d directly, skipping the
      * lex/parse/analyze/emit pipeline and the compiled-code cache entirely:
      * running the compiled file registers every definition (with macro meta)
      * in the runtime registry, which is all the analyzer needs to resolve

--- a/src/php/Build/Application/FileEvaluator.php
+++ b/src/php/Build/Application/FileEvaluator.php
@@ -76,11 +76,9 @@ final class FileEvaluator
         $precompiledSibling = $this->precompiledSiblingPath($src);
         if ($precompiledSibling !== null) {
             $this->compilerFacade->initializeGlobalEnvironment();
-            // #2673: `require_once`, not `require` — a bundled primary
-            // forward-declares defs (`map`/`seq`/`nil?`) as null and restores
-            // them via `require_once` secondaries. A second plain `require`
-            // re-nulls the forward decls while the secondaries no-op, leaving
-            // them null. Loading the primary once per process keeps them.
+            // #2673: `require_once`, not `require` — the primary forward-declares
+            // defs (`map`/`seq`/`nil?`) as null and refills them via `require_once`
+            // secondaries; a second plain `require` re-nulls them while the secondaries no-op.
             /** @psalm-suppress UnresolvableInclude */
             require_once $precompiledSibling;
 

--- a/src/php/Build/CLAUDE.md
+++ b/src/php/Build/CLAUDE.md
@@ -72,7 +72,7 @@ Compiles Phel projects to PHP: namespace extraction, dependency ordering, and ca
 
 ### Precompiled-sibling fast path
 
-- Before the compiled-code cache, `FileEvaluator::evalFile` checks for a `phel build`-style `<name>.php` next to the `<name>.phel`/`.cljc` source (detected via the `BuiltFilePreamble` marker). If present it `require`s it directly and returns — skipping the whole pipeline and the cache.
+- Before the compiled-code cache, `FileEvaluator::evalFile` checks for a `phel build`-style `<name>.php` next to the `<name>.phel`/`.cljc` source (detected via the `BuiltFilePreamble` marker). If present it `require_once`s it directly and returns — skipping the whole pipeline and the cache. `require_once` (not `require`) keeps a re-`evalFile` idempotent: a second load must not re-run the primary and re-null its forward-declared defs (#2673).
 - This is how the PHAR ships `phel.core` precompiled (siblings added by `build/build-phar.php::addPrecompiledStdlibSiblings`): running the compiled file populates the runtime registry (defs + macro meta), which is all the analyzer needs to resolve those symbols when later compiling user code. Inert when no sibling exists (plain source / composer checkouts).
 - A namespace may only be bundled together with its full transitive `(:require ...)` closure, since FILE-mode output `require_once`s its dependency siblings directly — `phel.core` qualifies because it is self-contained.
 - The fast path (and the emitted `(load ...)` `.php` preference) is disabled while `*build-mode*` is on, so `phel build` recompiles + harvests the stdlib into its output tree instead of short-circuiting to the bundle. `PhelSourceLoader::load` preserves an outer build mode so it stays on across every `(load ...)` of a build.

--- a/tests/php/Unit/Build/Application/FileEvaluatorTest.php
+++ b/tests/php/Unit/Build/Application/FileEvaluatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Build\Application;
 
+use Phel;
 use Phel\Build\Application\FileEvaluator;
 use Phel\Build\BuildFacade;
 use Phel\Build\Domain\Cache\DependencyTrackerInterface;
@@ -11,6 +12,7 @@ use Phel\Build\Domain\Extractor\FirstFormExtractor;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
 use Phel\Compiler\Domain\Emitter\EmitterResult;
+use Phel\Lang\Registry;
 use Phel\Shared\CompileOptions;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use Phel\Shared\NamespaceInformation;
@@ -18,6 +20,8 @@ use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
+
+use function sprintf;
 
 final class FileEvaluatorTest extends TestCase
 {
@@ -100,6 +104,50 @@ final class FileEvaluatorTest extends TestCase
         self::assertTrue($GLOBALS['phel_precompiled_sibling_ran'] ?? false);
 
         unset($GLOBALS['phel_precompiled_sibling_ran']);
+    }
+
+    public function test_re_eval_of_precompiled_sibling_keeps_forward_declared_def(): void
+    {
+        // #2673: a bundled primary forward-declares a def as null, then a
+        // `require_once` secondary registers the real value. A second evalFile
+        // must not re-run the primary and re-null the def (`map`/`seq`/`nil?`
+        // in phel.core). This is the exact shape only the PHAR ships.
+        $namespace = 'test\\precompiled_idempotent_2673';
+        $defName = 'the-fn';
+
+        $sourceFile = $this->tempDir . '/core.phel';
+        file_put_contents($sourceFile, '(ns test\\precompiled_idempotent_2673)');
+
+        // The secondary is pulled in with `require_once`, so it runs once per
+        // process — mirroring a compiled `(load ...)` secondary.
+        $this->writePrecompiledDef(
+            $this->tempDir . '/core-secondary.php',
+            $namespace,
+            $defName,
+            "static fn () => 'real'",
+        );
+
+        $this->writePrecompiledDef(
+            $this->tempDir . '/core.php',
+            $namespace,
+            $defName,
+            'null',
+            "require_once __DIR__ . '/core-secondary.php';\n",
+        );
+
+        $compilerFacade = $this->createStub(CompilerFacadeInterface::class);
+        $namespaceExtractor = $this->createStub(NamespaceExtractorInterface::class);
+        $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
+            new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
+        );
+
+        $evaluator = new FileEvaluator($compilerFacade, $namespaceExtractor);
+        $evaluator->evalFile($sourceFile);
+        $evaluator->evalFile($sourceFile);
+
+        $def = Registry::getInstance()->getDefinition($namespace, $defName);
+        self::assertNotNull($def, 'Re-evaluating a precompiled sibling must not null a forward-declared def');
+        self::assertSame('real', $def());
     }
 
     public function test_eval_file_ignores_precompiled_sibling_during_build(): void
@@ -738,6 +786,31 @@ final class FileEvaluatorTest extends TestCase
             optimizationLevel: 0,
         );
         $evaluator->evalFile($sourceFile);
+    }
+
+    /**
+     * Writes a precompiled `.php` sibling that registers one def via
+     * `\Phel::addDefinition`, mirroring the shape the PHAR bundles.
+     */
+    private function writePrecompiledDef(
+        string $path,
+        string $namespace,
+        string $defName,
+        string $valueExpr,
+        string $trailer = '',
+    ): void {
+        file_put_contents(
+            $path,
+            "<?php declare(strict_types=1);\n"
+            . sprintf(
+                "%s::addDefinition(%s, %s, %s);\n",
+                '\\' . Phel::class,
+                var_export($namespace, true),
+                var_export($defName, true),
+                $valueExpr,
+            )
+            . $trailer,
+        );
     }
 
     private function removeDir(string $dir): void

--- a/tests/php/Unit/Build/Application/FileEvaluatorTest.php
+++ b/tests/php/Unit/Build/Application/FileEvaluatorTest.php
@@ -148,6 +148,8 @@ final class FileEvaluatorTest extends TestCase
         $def = Registry::getInstance()->getDefinition($namespace, $defName);
         self::assertNotNull($def, 'Re-evaluating a precompiled sibling must not null a forward-declared def');
         self::assertSame('real', $def());
+
+        Registry::getInstance()->removeNamespace($namespace);
     }
 
     public function test_eval_file_ignores_precompiled_sibling_during_build(): void


### PR DESCRIPTION
## 🤔 Background

Re-evaluating an already-loaded **bundled** namespace (a precompiled `.php` sibling shipped in the PHAR, e.g. `phel.core`) nulled its forward-declared defs (`map`/`seq`/`nil?`): the primary was loaded with plain `require`, so a second `evalFile` re-ran it and reset those defs to `null`, while its `(load ...)` secondaries — compiled to `require_once` — no-op'd and never re-registered the real values. A later call then crashed with `Call to a member function __invoke() on null`. This is the root cause behind #2672 (previously patched only defensively in the test worker).

## 💡 Goal

Make a re-`evalFile` of a bundled namespace idempotent — it must never leave a registered def nulled.

## 🔖 Changes

- `FileEvaluator` loads the precompiled primary with `require_once`, not `require`, so a second load is a no-op and the first load's real defs survive.
- Deterministic unit test reproducing the exact precompiled-sibling shape (red on `require`, green on `require_once`); PHAR-mode symptom already covered by `PharExecutionTest::test_phar_test_parallel_runs_without_re_nulling_bundled_core`.
- Synced `Build/CLAUDE.md` + CHANGELOG.

Closes #2673