### PR TITLE
fix(build): exclude example run-artifacts from the PHAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- The distributed PHAR no longer bundles example templates' local build artifacts. `phel init --template` sources were shipped with any `.phel/` cache and installed `vendor/` a maintainer left behind from running an example locally, which inflated a release PHAR from ~2 MB to ~14 MB; only the template sources ship now (#2678)
+
 ## [0.47.0](https://github.com/phel-lang/phel-lang/compare/v0.46.0...v0.47.0) - 2026-07-01
 
 ### Added

--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -544,6 +544,15 @@ final class PharBuilder
 
             $absolute = $fileInfo->getPathname();
             $relative = ltrim(str_replace('\\', '/', substr($absolute, \strlen($this->root))), '/');
+
+            // Ship template SOURCES only. Running an example locally leaves
+            // gitignored build junk behind (`.phel/` opcache+compiled cache,
+            // an installed `vendor/`); bundling it verbatim ballooned the
+            // release from ~2 MB to ~14 MB (#2678).
+            if ($this->isExampleBuildArtifact($relative)) {
+                continue;
+            }
+
             $phar->addFile($absolute, $relative);
             ++$this->stats['files_added'];
 
@@ -552,6 +561,22 @@ final class PharBuilder
                 $this->stats['total_size'] += $size;
             }
         }
+    }
+
+    /**
+     * A path inside an example template that is a local build artifact rather
+     * than a shipped source: the `.phel/` cache/opcache dir or an installed
+     * `vendor/`. Users regenerate both with `composer install` + first run.
+     */
+    private function isExampleBuildArtifact(string $relative): bool
+    {
+        foreach (explode('/', $relative) as $segment) {
+            if ($segment === '.phel' || $segment === 'vendor') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
## 🤔 Background

The distributed `phel.phar` for [v0.47.0](https://github.com/phel-lang/phel-lang/releases/tag/v0.47.0) shipped at **~14 MB** — prior releases were ~1.98 MB. Root cause: `build-phar.php`'s `addExampleTemplates()` walks `resources/agents/examples/` and `addFile()`s **every file with no filtering**, unlike the main tree walk (`addFiles()`), which applies `$excludeDirs`/`$excludeFiles` and a default-deny for hidden dirs.

It was written unfiltered on purpose — templates need `composer.json`/`README.md` that the main filter strips. But that also lets local run-artifacts through: a maintainer who had run a bundled example locally leaves gitignored junk behind — `.phel/` (opcache + compiled cache, ~15 MB per example) and an installed `vendor/` (~4.4 MB per example). Three examples × that ≈ the missing ~12 MB.

Not a code regression: the function was always unfiltered. It only bit once the example dirs accumulated local junk. CI builds from a clean `git clone` (tracked files only), so the 2.25 MiB smoke budget never saw it.

## 💡 Goal

Make the PHAR build robust to local working-tree state: ship example **template sources only**, never a developer's local caches or installed dependencies — regardless of what junk sits in `resources/agents/examples/` at build time.

## 🔖 Changes

- `addExampleTemplates()` skips any path with a `.phel` or `vendor` segment via a new `isExampleBuildArtifact()` helper; template sources (`.phel`, `phel-config.php`, `src/`, `tests/`, `composer.json`, `README.md`, `.gitignore`) still ship.
- CHANGELOG: Unreleased → Fixed entry.

Verified: rebuilt `OFFICIAL_RELEASE=true build/phar.sh` → **2.0 MB**, `0` example junk files, `phel init --template todo-app` scaffolds a runnable project, `phel --version` → `Phel v0.47.0`. The slim 2.0 MB artifact has already been re-uploaded to the v0.47.0 release, replacing the bloated one.

