### PR TITLE
fix(test): show --parallel=auto in the test command help example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - The distributed PHAR no longer bundles example templates' local build artifacts. `phel init --template` sources were shipped with any `.phel/` cache and installed `vendor/` a maintainer left behind from running an example locally, which inflated a release PHAR from ~2 MB to ~14 MB; only the template sources ship now (#2678)
+- `phel test --help` now shows `--parallel=auto` in its example; the bare `--parallel` it printed before errors, because the option requires a value (an integer, `auto`, or `max`) (#2679)
 
 ## [0.47.0](https://github.com/phel-lang/phel-lang/compare/v0.46.0...v0.47.0) - 2026-07-01
 

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -58,7 +58,7 @@ Runs the test suite (all tests by default, or the files/namespaces you pass).
 
 <info>Examples:</info>
   <comment>phel test</comment>                     Run every test
-  <comment>phel test --filter=greet --parallel</comment>   Filter by name, run in parallel
+  <comment>phel test --filter=greet --parallel=auto</comment>   Filter by name, run in parallel
 HELP)
             ->addArgument(
                 TestCommandOptionParser::ARG_PATHS,


### PR DESCRIPTION
## 🤔 Background

`phel test --help` printed this example:

```
phel test --filter=greet --parallel   Filter by name, run in parallel
```

But `--parallel` is declared `InputOption::VALUE_REQUIRED` (it takes an integer worker count, `auto`, or `max`). Copy-pasting the example errors:

```
The "--parallel" option requires a value.
```

Surfaced while validating the v0.47.0 release notes from the PHAR.

## 💡 Goal

Make the built-in example copy-pasteable.

## 🔖 Changes

- Help example → `phel test --filter=greet --parallel=auto`.
- CHANGELOG: Unreleased → Fixed entry.

Docs-only; no behavior change (`--parallel` stays value-required, as its long option description already documents). Verified `phel test --help` renders the new example and `phel test --parallel=auto` runs.
