### PR TITLE
feat(core): add reduce-kv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `reduce-kv`: reduce an associative collection with `(f acc key value)`, vector indices as keys, `reduced` short-circuit supported (#2680)
+
 ### Fixed
 
 - The distributed PHAR no longer bundles example templates' local build artifacts. `phel init --template` sources were shipped with any `.phel/` cache and installed `vendor/` a maintainer left behind from running an example locally, which inflated a release PHAR from ~2 MB to ~14 MB; only the template sources ship now (#2678)

--- a/src/phel/core/transducers.phel
+++ b/src/phel/core/transducers.phel
@@ -70,6 +70,21 @@
         (php/-> acc (deref)))
     (throw (php/new InvalidArgumentException "expected 2 or 3 arguments in reduce"))))
 
+(defn reduce-kv
+  "Reduces an associative collection by applying `f` to the accumulator, key and value of each entry, starting with `init`. Vectors use the index as key. Respects early termination via `(reduced val)`."
+  {:example "(reduce-kv (fn [m k v] (assoc m v k)) {} {:a 1 :b 2}) ; => {1 :a, 2 :b}"
+   :see-also ["reduce" "update-keys" "update-vals" "reduced"]}
+  [f init coll]
+  (let [acc  (php/new Volatile init)
+        done (php/new Volatile false)]
+    (dofor [[k v] :pairs coll :while (not (php/-> done (deref)))]
+      (let [result (f (php/-> acc (deref)) k v)]
+        (if (reduced? result)
+          (do (php/-> acc (reset (php/-> result (deref))))
+              (php/-> done (reset true)))
+          (php/-> acc (reset result)))))
+    (php/-> acc (deref))))
+
 (defn completing
   "Takes a reducing function `f` of 2 args and returns a fn suitable for transduce by adding a 1-arity (completion) that calls `cf` (default: identity)."
   {:see-also ["transduce"]}

--- a/tests/phel/core/transducers.phel
+++ b/tests/phel/core/transducers.phel
@@ -28,6 +28,27 @@
   (is (= 10 (reduce + [1 2 3 4])) "reduce without init")
   (is (= 10 (reduce + 0 [1 2 3 4])) "reduce with init"))
 
+(deftest test-reduce-kv-map
+  (is (= {1 :a 2 :b} (reduce-kv (fn [m k v] (assoc m v k)) {} {:a 1 :b 2}))
+      "reduce-kv inverts a map")
+  (is (= 6 (reduce-kv (fn [acc _ v] (+ acc v)) 0 {:a 1 :b 2 :c 3}))
+      "reduce-kv sums map values"))
+
+(deftest test-reduce-kv-vector
+  (is (= [[0 :a] [1 :b] [2 :c]]
+         (reduce-kv (fn [acc i v] (conj acc [i v])) [] [:a :b :c]))
+      "reduce-kv passes vector indices as keys"))
+
+(deftest test-reduce-kv-empty
+  (is (= :init (reduce-kv (fn [acc k v] (assoc acc k v)) :init {}))
+      "reduce-kv returns init on empty map")
+  (is (= 0 (reduce-kv (fn [acc _ v] (+ acc v)) 0 []))
+      "reduce-kv returns init on empty vector"))
+
+(deftest test-reduce-kv-reduced
+  (is (= [:a] (reduce-kv (fn [acc k _] (reduced [k])) :init {:a 1 :b 2}))
+      "reduce-kv stops early on reduced and unwraps it"))
+
 (deftest test-completing
   (let [f (completing +)]
     (is (= 0 (f)) "0-arity calls f")


### PR DESCRIPTION
## 🤔 Background

`reduce-kv` is the most-used missing Clojure staple in `phel\core`. Map-heavy code currently reduces over `(pairs m)` and destructures each entry, which is slower and noisier.

Closes #2680

## 💡 Goal

Add `reduce-kv` matching Clojure semantics: reduce an associative collection with `(f acc key value)`.

## 🔖 Changes

- Add `reduce-kv` to `src/phel/core/transducers.phel` next to `reduce`, following its `dofor` + `Volatile` pattern, including `(reduced val)` short-circuit support
- Vectors pass the index as key
- Tests in `tests/phel/core/transducers.phel`: map inversion, value sum, vector indices, empty collections (init passthrough), early termination via `reduced`
- CHANGELOG entry under Unreleased