### PR TITLE
feat(core): add gcd and lcm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `gcd` and `lcm`: greatest common divisor and least common multiple for integers (#2686)
+
 ### Fixed
 
 - The distributed PHAR no longer bundles example templates' local build artifacts. `phel init --template` sources were shipped with any `.phel/` cache and installed `vendor/` a maintainer left behind from running an example locally, which inflated a release PHAR from ~2 MB to ~14 MB; only the template sources ship now (#2678)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -360,6 +360,29 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
     (throw (php/new InvalidArgumentException
                     (str "abs expects a number, got " (type x))))))
 
+(defn gcd
+  "Returns the greatest common divisor of `a` and `b`, computed with the
+  Euclidean algorithm. The result is always non-negative; `(gcd 0 0)` is `0`."
+  {:example "(gcd 12 18) ; => 6\n(gcd -12 18) ; => 6"
+   :see-also ["lcm" "mod" "abs"]}
+  [a b]
+  (loop [x (abs a)
+         y (abs b)]
+    (if (zero? y)
+      x
+      (recur y (mod x y)))))
+
+(defn lcm
+  "Returns the least common multiple of `a` and `b`. The result is always
+  non-negative; when either argument is zero the result is `0`."
+  {:example "(lcm 4 6) ; => 12\n(lcm -4 6) ; => 12"
+   :see-also ["gcd" "abs"]}
+  [a b]
+  (if (or (zero? a) (zero? b))
+    0
+    ;; divide before multiplying to reduce overflow
+    (abs (* (quot a (gcd a b)) b))))
+
 (defn int
   "Coerces `x` to an integer. `Ratio` and `BigDecimal` values truncate
    toward zero (`(int 1/10)` is `0`, `(int -1.1M)` is `-1`); `BigInt`

--- a/tests/phel/core/math-operation.phel
+++ b/tests/phel/core/math-operation.phel
@@ -86,6 +86,28 @@
   (let [huge (php/:: \Phel\Lang\BigInt (fromString "100000000000000000000"))]
     (is (bigint? (quot huge 3)) "quot stays BigInt when result overflows int")))
 
+(deftest test-gcd
+  (is (= 6 (gcd 12 18)) "(gcd 12 18)")
+  (is (= 1 (gcd 7 13)) "(gcd 7 13) of coprimes is 1")
+  (is (= 0 (gcd 0 0)) "(gcd 0 0)")
+  (is (= 5 (gcd 0 5)) "(gcd 0 5) is the other operand")
+  (is (= 5 (gcd 5 0)) "(gcd 5 0) is the other operand")
+  (is (= 6 (gcd -12 18)) "(gcd -12 18) is non-negative")
+  (is (= 6 (gcd 12 -18)) "(gcd 12 -18) is non-negative")
+  (is (= 6 (gcd -12 -18)) "(gcd -12 -18) is non-negative")
+  (is (true? (int? (gcd 12 18))) "gcd result stays an int"))
+
+(deftest test-lcm
+  (is (= 12 (lcm 4 6)) "(lcm 4 6)")
+  (is (= 21 (lcm 3 7)) "(lcm 3 7) of coprimes")
+  (is (= 0 (lcm 4 0)) "(lcm 4 0)")
+  (is (= 0 (lcm 0 4)) "(lcm 0 4)")
+  (is (= 0 (lcm 0 0)) "(lcm 0 0)")
+  (is (= 12 (lcm -4 6)) "(lcm -4 6) is non-negative")
+  (is (= 12 (lcm 4 -6)) "(lcm 4 -6) is non-negative")
+  (is (= 12 (lcm -4 -6)) "(lcm -4 -6) is non-negative")
+  (is (true? (int? (lcm 4 6))) "lcm result stays an int"))
+
 (deftest test-**
   (is (= 8 (** 2 3)) "2 ** 3"))
 


### PR DESCRIPTION
## 🤔 Background

Closes #2686

Phel core has no `gcd` or `lcm`, and PHP offers no native equivalents, so users migrating from Clojure-adjacent ecosystems have to hand-roll both. This fills that basic library gap.

## 💡 Goal

Add `gcd` and `lcm` to `phel\core` with Clojure-aligned semantics: results are always non-negative integers, zero and negative inputs are handled.

## 🔖 Changes

- `gcd`: Euclidean algorithm via `loop`/`recur` over `mod`, operating on `abs` of both operands; `(gcd 0 0)` is `0`, `(gcd x 0)` is `|x|`
- `lcm`: short-circuits to `0` when either operand is zero, otherwise `(abs (* (quot a (gcd a b)) b))` — dividing before multiplying to reduce overflow, using `quot` to keep integer results
- Both carry `:doc`, `:example`, and `:see-also` metadata, matching neighboring math fns
- Tests in `tests/phel/core/math-operation.phel` covering basics, coprimes, zero operands, negative operands (non-negative results), and `int?` of results
- CHANGELOG entry under `## Unreleased` → `### Added`
