### PR TITLE
feat(core): add trampoline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `trampoline`: stack-safe mutual recursion by bouncing returned thunks (#2682)
+
 ### Fixed
 
 - The distributed PHAR no longer bundles example templates' local build artifacts. `phel init --template` sources were shipped with any `.phel/` cache and installed `vendor/` a maintainer left behind from running an example locally, which inflated a release PHAR from ~2 MB to ~14 MB; only the template sources ship now (#2678)

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -144,6 +144,19 @@
                                  arg)))))]
         (apply f patched)))))
 
+(defn trampoline
+  "Calls `f` with any supplied `args`. While the return value is a function, calls it with no arguments and repeats; returns the first non-function value. Use it for stack-safe mutual recursion: have the functions return a zero-argument function wrapping the next call instead of calling it directly. Only Phel functions bounce — keywords and collections, although callable, are returned as-is. To return a function as the final value, wrap it in a collection and unwrap it after `trampoline` returns."
+  {:example (str
+             "(defn my-even? [n] (if (zero? n) true (fn [] (my-odd? (dec n)))))" php/PHP_EOL
+             "(defn my-odd? [n] (if (zero? n) false (fn [] (my-even? (dec n)))))" php/PHP_EOL
+             "(trampoline my-even? 10000) ; => true")
+   :see-also ["loop" "recur" "fn?"]}
+  [f & args]
+  (loop [ret (apply f args)]
+    (if (fn? ret)
+      (recur (ret))
+      ret)))
+
 (defn memoize
   "Returns a memoized version of the function `f`. The memoized function caches the return value for each set of arguments."
   {:example (str

--- a/tests/phel/core/function-operation.phel
+++ b/tests/phel/core/function-operation.phel
@@ -142,6 +142,35 @@
     (is (= 7 (f 3 4)) "different multi-arg call")
     (is (= 2 (deref counter)) "two executions")))
 
+(deftest test-trampoline-direct-value
+  (is (= 3 (trampoline + 1 2)) "non-function return comes back unchanged")
+  (is (nil? (trampoline (fn [] nil))) "nil return is not bounced"))
+
+(deftest test-trampoline-one-bounce
+  (is (= 42 (trampoline (fn [x] (fn [] (inc x))) 41))
+      "returned thunk is called once and its value returned"))
+
+(deftest test-trampoline-args-passed-through
+  (is (= [1 2 3] (trampoline (fn [& xs] xs) 1 2 3))
+      "all initial args reach f"))
+
+(deftest test-trampoline-mutual-recursion
+  (letfn [(my-even? [n] (if (zero? n) true (fn [] (my-odd? (dec n)))))
+          (my-odd? [n] (if (zero? n) false (fn [] (my-even? (dec n)))))]
+    ;; 10000 bounces would overflow the PHP call stack without trampoline
+    (is (true? (trampoline my-even? 10000)) "my-even? 10000 bounces to true")
+    (is (false? (trampoline my-odd? 10000)) "my-odd? 10000 bounces to false")))
+
+(deftest test-trampoline-callables-not-reinvoked
+  (is (= :done (trampoline (fn [] :done))) "keyword return is not treated as a thunk")
+  (is (= {:a 1} (trampoline (fn [] {:a 1}))) "map return is not treated as a thunk")
+  (is (= [1 2] (trampoline (fn [] [1 2]))) "vector return is not treated as a thunk"))
+
+(deftest test-trampoline-function-as-final-value
+  (let [wrapped (trampoline (fn [] [inc]))]
+    (is (fn? (first wrapped)) "wrapping in a collection returns the function itself")
+    (is (= 2 ((first wrapped) 1)) "unwrapped function still works")))
+
 (def memoize-meta-counter (atom 0))
 
 (defn ^:memoize memoize-meta-add [a b]


### PR DESCRIPTION
## 🤔 Background

Closes #2682

PHP's call stack is shallow, so mutually recursive functions overflow quickly. `loop`/`recur` only covers self-recursion; there was no stack-safe answer for mutual recursion. `trampoline` is the standard Clojure solution.

## 💡 Goal

Add `trampoline` to `phel\core` with Clojure semantics: `(trampoline f & args)` calls `f` with `args`; while the return value is a function, it keeps calling it with no arguments; otherwise it returns the value.

## 🔖 Changes

- Add `trampoline` to `src/phel/core/fns-sets.phel` with `:doc`, `:example`, and `:see-also` (`loop`, `recur`, `fn?`). Re-invocation uses `fn?`, so keywords and collections — although callable — are returned as-is, matching Clojure. The `:doc` documents the caveat: to return a function as the final value, wrap it in a collection.
- Tests in `tests/phel/core/function-operation.phel`: direct value, one bounce, args pass-through, deep mutual recursion (`my-even?`/`my-odd?` at 10000 — a depth that overflows the PHP stack without trampolining), keyword/map/vector returns not re-invoked, and the wrap-in-collection escape hatch.
- CHANGELOG entry under `## Unreleased` → `### Added`.