### PR TITLE
feat(core): add reductions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `reductions`: sequence of intermediate reduce values, with and without init (#2681)
+
 ### Fixed
 
 - The distributed PHAR no longer bundles example templates' local build artifacts. `phel init --template` sources were shipped with any `.phel/` cache and installed `vendor/` a maintainer left behind from running an example locally, which inflated a release PHAR from ~2 MB to ~14 MB; only the template sources ship now (#2678)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -959,6 +959,25 @@ With one argument returns an infinite lazy sequence of calls to f."
   [f x]
   (lazy-seq-from-generator (php/:: Seq (iterate f x))))
 
+(defn reductions
+  "Returns a lazy sequence of the intermediate values of the reduction (as per reduce) of coll by f, starting with init when supplied."
+  {:example "(reductions + [1 2 3 4]) ; => @[1 3 6 10]\n(reductions + 0 [1 2 3 4]) ; => @[0 1 3 6 10]"
+   :see-also ["reduce" "iterate"]}
+  ([f coll]
+   (lazy-seq
+     (let [s (seq coll)]
+       (if s
+         (reductions f (first s) (rest s))
+         [(f)]))))
+  ([f init coll]
+   (if (reduced? init)
+     [(unreduced init)]
+     (cons init
+           (lazy-seq
+             (let [s (seq coll)]
+               (when s
+                 (reductions f (f init (first s)) (rest s)))))))))
+
 (defn iterator-seq
   "Returns a lazy sequence over a PHP `Traversable` (Iterator, Generator, IteratorAggregate, ...), pulling one element at a time. Unlike the eager coercion that materialises a `Traversable` via `iterator_to_array`, this streams a large or infinite source (DB cursor, stream reader, paginated API), so `take`/`map`/`filter` only pull what they consume."
   {:example "(take 3 (iterator-seq (php/new \\ArrayIterator (php/array 1 2 3 4 5)))) ; => @[1 2 3]"

--- a/tests/phel/core/infinite-seqs.phel
+++ b/tests/phel/core/infinite-seqs.phel
@@ -72,6 +72,12 @@
   (is (= [1 2 4 8] (take 4 (iterate (fn [x] (* 2 x)) 1)))
       "(take 4 (iterate (fn [x] (* 2 x)) 1))"))
 
+(deftest test-reductions-infinite
+  (is (= [1 3 6 10 15] (take 5 (reductions + (iterate inc 1))))
+      "(take 5 (reductions + (iterate inc 1)))")
+  (is (false? (realized? (reductions + (iterate inc 1))))
+      "reductions over an infinite source is unrealized until accessed"))
+
 (deftest test-doall-with-lazy-sequence-from-iterate
   (is (= [1 2 3 4 5] (doall (take 5 (iterate inc 1))))
       "doall should realize lazy sequence and return vector"))

--- a/tests/phel/core/sequence-functions.phel
+++ b/tests/phel/core/sequence-functions.phel
@@ -59,6 +59,16 @@
   (is (= 6 (reduce + (for [x :in (hash-set 1 2 3)] x))) "reduce without init on set vector")
   (is (= 0 (reduce + [])) "reduce without init on empty vector with +"))
 
+(deftest test-reductions
+  (is (= [1 3 6 10] (reductions + [1 2 3 4])) "reductions without init")
+  (is (= [0 1 3 6 10] (reductions + 0 [1 2 3 4])) "reductions with init")
+  (is (= [0] (reductions + [])) "reductions without init on empty coll yields [(f)]")
+  (is (= [5] (reductions + 5 [])) "reductions with init on empty coll yields [init]")
+  (is (= [7] (reductions + [7])) "reductions without init on single-element coll")
+  (is (= ["" "a" "ab" "abc"] (reductions str "" ["a" "b" "c"])) "reductions accumulates strings")
+  (is (= [1 3 6 6] (reductions (fn [acc x] (if (>= acc 6) (reduced acc) (+ acc x))) [1 2 3 4 5]))
+      "reductions stops at a reduced value"))
+
 ;; =============================================================================
 ;; Path Navigation (assoc-in, update-in, dissoc-in)
 ;; =============================================================================


### PR DESCRIPTION
## 🤔 Background

Streaming/accumulator patterns (running totals, cumulative state) currently need a hand-rolled `loop` with an explicit accumulator vector. `reductions` is the idiomatic Clojure one-liner for this.

Closes #2681

## 💡 Goal

Add `reductions` to `phel\core`, matching Clojure semantics:

```phel
(reductions + [1 2 3 4])   # => @[1 3 6 10]
(reductions + 0 [1 2 3 4]) # => @[0 1 3 6 10]
```

## 🔖 Changes

- Add `reductions` to `src/phel/core/seq-fns.phel` next to the other lazy sequence generators (`iterate`, `cycle`), with `:doc`, `:example`, and `:see-also` metadata
- Fully lazy (built on `lazy-seq`), so it works over infinite sources: `(take 5 (reductions + (iterate inc 1)))` => `@[1 3 6 10 15]`
- Clojure-aligned edge cases: `(reductions f [])` => `[(f)]`, `(reductions f init [])` => `[init]`, and `(reduced val)` short-circuits the sequence
- Tests in `tests/phel/core/sequence-functions.phel` (both arities, empty coll, single element, string accumulation, `reduced`) and `tests/phel/core/infinite-seqs.phel` (infinite source, unrealized until accessed)
- CHANGELOG entry under `## Unreleased` / `### Added`