### PR TITLE
feat(core): add subvec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `subvec`: persistent vector slice with start/end bounds checking (#2683)
+
 ### Fixed
 
 - The distributed PHAR no longer bundles example templates' local build artifacts. `phel init --template` sources were shipped with any `.phel/` cache and installed `vendor/` a maintainer left behind from running an example locally, which inflated a release PHAR from ~2 MB to ~14 MB; only the template sources ship now (#2678)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1,6 +1,7 @@
 (in-ns phel.core)
 
 (use InvalidArgumentException)
+(use OutOfBoundsException)
 (use Phel)
 (use Phel.Lang.Eduction)
 (use Phel.Lang.Collections.HashSet.PersistentHashSetInterface)
@@ -26,7 +27,7 @@
 ;;   - Core higher-order seq fns: `map`, `filter`, `remove`, `keep`,
 ;;     `keep-indexed`, `map-indexed`, `mapcat`.
 ;;   - Slicing: `take`, `take-last`, `take-while`, `take-nth`, `drop`,
-;;     `drop-last`, `drop-while`, `last`, `butlast`, `slice`.
+;;     `drop-last`, `drop-while`, `last`, `butlast`, `slice`, `subvec`.
 ;;   - Generation: `iterate`, `cycle`, `repeat`, `repeatedly`, `lazy-seq`,
 ;;     `lazy-cat`, `concat`, `cat`, `interpose`, `interleave`, `sequence`.
 ;;   - Shaping: `partition`, `partition-by`, `partition-all`, `split-at`,
@@ -248,6 +249,20 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
     (php-array? coll) (php/array_slice coll offset length)
     (php/instanceof coll SliceInterface) (php/-> coll (slice offset length))
     (throw (php/new InvalidArgumentException "Cannot slice"))))
+
+(defn subvec
+  "Returns a persistent vector of the items in `v` from `start` (inclusive) to `end` (exclusive). `end` defaults to `(count v)`. The result shares structure with `v`. Throws an OutOfBoundsException when `start` or `end` is out of range or `start` is greater than `end`."
+  {:example "(subvec [1 2 3 4 5] 1 3) ; => [2 3]\n(subvec [1 2 3 4 5] 2) ; => [3 4 5]"
+   :see-also ["slice" "take" "drop"]}
+  ([v start] (subvec v start (count v)))
+  ([v start end]
+   (when-not (php/instanceof v PersistentVectorInterface)
+     (throw (php/new InvalidArgumentException (str "Cannot subvec on type " (type v)))))
+   (let [cnt (count v)]
+     (when (or (< start 0) (> end cnt) (> start end))
+       (throw (php/new OutOfBoundsException
+                       (str "subvec bounds [" start ", " end ") out of range for vector of count " cnt))))
+     (php/-> v (slice start (php/- end start))))))
 
 (defn set
   "Coerces a collection to a set. Returns a set containing the distinct elements of `coll`. For creating sets from arguments, use `hash-set`."

--- a/tests/phel/core/sequence-operation.phel
+++ b/tests/phel/core/sequence-operation.phel
@@ -259,6 +259,24 @@
   (is (= [3 4] (slice [1 2 3 4] 2)) "slice on vector")
   (is (= [3] (slice [1 2 3 4] 2 1)) "slice with length on vector"))
 
+(deftest test-subvec
+  (is (= [2 3] (subvec [1 2 3 4 5] 1 3)) "subvec with start and end")
+  (is (= [3 4 5] (subvec [1 2 3 4 5] 2)) "subvec with default end")
+  (is (= [] (subvec [1 2 3] 1 1)) "empty slice when start equals end")
+  (is (= [] (subvec [1 2 3] 3)) "empty slice when start equals count")
+  (is (= [1 2 3] (subvec [1 2 3] 0 3)) "full slice")
+  (is (= [] (subvec [] 0 0)) "full slice of empty vector")
+  (is (vector? (subvec [1 2 3] 0 2)) "subvec returns a vector")
+  (is (thrown? \OutOfBoundsException (subvec [1 2 3] -1)) "negative start throws")
+  (is (thrown? \OutOfBoundsException (subvec [1 2 3] 0 4)) "end beyond count throws")
+  (is (thrown? \OutOfBoundsException (subvec [1 2 3] 4)) "start beyond count throws")
+  (is (thrown? \OutOfBoundsException (subvec [1 2 3] 2 1)) "start greater than end throws")
+  (is (thrown? \InvalidArgumentException (subvec '(1 2 3) 0)) "subvec on a list throws")
+  (let [v   [1 2 3 4 5]
+        sub (subvec v 1 3)]
+    (is (= [2 3] sub) "subvec slices the vector")
+    (is (= [1 2 3 4 5] v) "original vector is unchanged")))
+
 (deftest test-get
   (is (= "b" (get (php/array "a" "b" "c") 1)) "get on php array")
   (is (= "b" (get ["a" "b" "c"] 1)) "get on vector")


### PR DESCRIPTION
## 🤔 Background

Closes #2683

Slicing a vector today means `(take (- end start) (drop start v))`, which walks and rebuilds the whole vector, or `slice`, which uses offset/length semantics instead of Clojure's start/end. Phel already has the efficient machinery: `AbstractPersistentVector::slice()` dispatches to `sliceNormalized()`, which returns a `SubVector` — an O(1) structural-sharing view over the source vector.

## 💡 Goal

Add `subvec` to `phel\core` with Clojure argument semantics: `(subvec v start)` / `(subvec v start end)` returns a persistent vector of the items from `start` (inclusive) to `end` (exclusive, defaults to `(count v)`), with bounds validation that throws on out-of-range indices.

## 🔖 Changes

- Add `subvec` to `src/phel/core/seq-fns.phel` (next to `slice`): a thin wrapper over the existing PHP-level `slice`, so the result is an O(1) `SubVector` view sharing structure with the source — no new PHP machinery needed
- Throws `OutOfBoundsException` (the same exception `nth` uses for index errors) when `start < 0`, `end > (count v)`, or `start > end`, with the offending bounds and vector count in the message
- Throws `InvalidArgumentException` when the argument is not a persistent vector
- `:doc`, `:example`, and `:see-also` (`slice`, `take`, `drop`) metadata included
- Tests in `tests/phel/core/sequence-operation.phel`: 2-arity, 3-arity, empty slice (`start == end`, `start == count`), full slice, empty vector, result is a vector, all out-of-bounds cases, non-vector input, and source-vector immutability
- CHANGELOG entry under `## Unreleased` / `### Added`
