### PR TITLE
feat(core): add arity and variadic? (#2685)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `arity` and `variadic?`: function reflection helpers for required parameter count and variadic detection (#2685)
+
 ### Fixed
 
 - The distributed PHAR no longer bundles example templates' local build artifacts. `phel init --template` sources were shipped with any `.phel/` cache and installed `vendor/` a maintainer left behind from running an example locally, which inflated a release PHAR from ~2 MB to ~14 MB; only the template sources ship now (#2678)

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -5,9 +5,9 @@
 ;;   1. Set algebra: `union`, `intersection`, `difference`,
 ;;      `symmetric-difference`, `subset?`, `superset?`.
 ;;   2. Function combinators and collection helpers: `constantly`,
-;;      `complement`, `some-fn`, `juxt`, `partial`, `fnil`, `memoize`,
-;;      `memoize-lru`, `tree-seq`, `flatten`, `merge-with`, `update-keys`,
-;;      `update-vals`, etc.
+;;      `complement`, `arity`, `variadic?`, `some-fn`, `juxt`, `partial`,
+;;      `fnil`, `memoize`, `memoize-lru`, `tree-seq`, `flatten`,
+;;      `merge-with`, `update-keys`, `update-vals`, etc.
 
 ;; -------------
 ;; Set operation
@@ -98,6 +98,26 @@
   "Returns a function that takes the same arguments as `f` and returns the opposite truth value."
   [f]
   #(not (apply f %&)))
+
+;; Phel fns compile to invokable objects or plain PHP closures; the
+;; `__invoke` signature is the single reflection point covering both.
+(defn- fn-reflection
+  [f]
+  (php/new \ReflectionMethod f "__invoke"))
+
+(defn arity
+  "Returns the number of required parameters of the function `f`. For a variadic function this is the number of parameters before `&`. A multi-arity function compiles to a single variadic dispatch, so it reports `0`."
+  {:example "(arity inc) ; => 1\n(arity assoc) ; => 3"
+   :see-also ["variadic?" "apply" "partial"]}
+  [f]
+  (php/-> (fn-reflection f) (getNumberOfRequiredParameters)))
+
+(defn variadic?
+  "Returns true if the function `f` accepts a variable number of arguments. A multi-arity function compiles to a single variadic dispatch, so it always reports `true`."
+  {:example "(variadic? +) ; => true\n(variadic? inc) ; => false"
+   :see-also ["arity" "apply"]}
+  [f]
+  (php/-> (fn-reflection f) (isVariadic)))
 
 (defn some-fn
   "Takes a variadic set of predicates and returns a function `f` that, when called with any number of arguments, returns the first logical true value produced by applying any of the composing predicates to any of its arguments, and `false` when none match. The returned function short-circuits on the first truthy result: arguments after it are not inspected, and predicates after it are not tried. Predicates are consulted in the order supplied; for a given predicate, arguments are consulted left-to-right."

--- a/tests/phel/core/function-operation.phel
+++ b/tests/phel/core/function-operation.phel
@@ -12,6 +12,37 @@
 (deftest test-complement
   (is (false? ((complement and) true true)) "complement of and"))
 
+(deftest test-arity-fixed
+  (is (= 1 (arity inc)) "arity of one-parameter core fn")
+  (is (= 0 (arity (fn [] 1))) "arity of zero-parameter fn")
+  (is (= 3 (arity (fn [a b c] a))) "arity of anonymous three-parameter fn")
+  (is (= 2 (arity |(+ $1 $2))) "arity of short fn literal"))
+
+(deftest test-arity-variadic
+  (is (= 3 (arity assoc)) "variadic fn reports required parameters before &")
+  (is (= 0 (arity +)) "fully variadic fn reports zero required parameters")
+  (is (= 1 (arity (fn [x & xs] x))) "anonymous variadic fn reports required parameters"))
+
+(deftest test-arity-multi-arity
+  ;; Multi-arity fns compile to a single variadic `__invoke` dispatch,
+  ;; so they report the dispatch signature: arity 0 and variadic? true.
+  (let [f (fn multi ([x] x) ([x y] y))]
+    (is (= 0 (arity f)) "multi-arity fn reports the variadic dispatch arity")
+    (is (true? (variadic? f)) "multi-arity fn reports the variadic dispatch")))
+
+(deftest test-variadic?
+  (is (true? (variadic? +)) "+ accepts variadic args")
+  (is (true? (variadic? assoc)) "assoc accepts variadic args")
+  (is (false? (variadic? inc)) "inc is not variadic")
+  (is (false? (variadic? (fn [a b] a))) "fixed-arity anonymous fn is not variadic")
+  (is (false? (variadic? |(+ $1 $2))) "short fn literal is not variadic")
+  (is (true? (variadic? (fn [x & xs] x))) "anonymous variadic fn is variadic"))
+
+(deftest test-arity-php-callable
+  (let [upper (php/callable \strtoupper)]
+    (is (= 1 (arity upper)) "php/callable closure reports the PHP signature")
+    (is (false? (variadic? upper)) "php/callable closure is not variadic")))
+
 (deftest test-some-fn-single-pred
   (is (true? ((some-fn even?) 2)) "some-fn with one pred, single truthy arg")
   (is (false? ((some-fn even?) 1)) "some-fn with one pred, single falsy arg")


### PR DESCRIPTION
## 🤔 Background

Closes #2685

Higher-order and framework code (dispatchers, middleware, test utilities, mock libraries) needs to ask "how many arguments does this function take?" — there was no clean way to do that in Phel.

## 💡 Goal

Add function-reflection helpers to `phel\core`:

- `(arity f)` — number of required parameters of `f`; for variadic fns, the count of parameters before `&` (`(arity assoc)` => `3`).
- `(variadic? f)` — true when `f` accepts a variable number of arguments (`(variadic? +)` => `true`).

Placed in `phel\core` (rather than `phel\reflect`) so they are usable without a `require`, next to their natural neighbors `complement`, `partial`, and `apply` in the "Function operation" section of `fns-sets.phel`.

## 🔖 Changes

- `src/phel/core/fns-sets.phel`: `arity` and `variadic?`, both implemented via a shared private `fn-reflection` helper (`ReflectionMethod` on `__invoke`). Phel fns compile either to invokable objects extending `AbstractFn` or to plain PHP closures, and closures also expose an `__invoke` signature, so this single reflection point covers named fns, anonymous fns, `|(...)` literals, and `php/callable` values.
- **Multi-arity contract** (documented in the docstrings and asserted in tests): multi-arity fns compile to a single variadic `__invoke(...$args)` dispatch, so they report `(arity f)` => `0` and `(variadic? f)` => `true`.
- `tests/phel/core/function-operation.phel`: tests for fixed-arity core and anonymous fns, variadic fns (`+`, `assoc`, `[x & xs]`), the multi-arity dispatch contract, `|(+ $1 $2)` short fn literals, and `php/callable` closures.
- `CHANGELOG.md`: entry under `## Unreleased` / `### Added`.