### PR TITLE
feat(pprint): add inspect (#2688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - `reduce-kv`: reduce an associative collection with `(f acc key value)`, vector indices as keys, `reduced` short-circuit supported (#2680)
 - `gcd` and `lcm`: greatest common divisor and least common multiple for integers (#2686)
+- `inspect`: pretty-prints a value (colored on TTY) and returns it unchanged for pipeline debugging (#2688)
 
 ### Fixed
 

--- a/src/phel/pprint.phel
+++ b/src/phel/pprint.phel
@@ -8,92 +8,124 @@
   [x]
   (php/-> (php/:: Printer (readable)) (print x)))
 
+(defn- render-value
+  "Prints `x` with the given printer (plain or colored)."
+  [printer x]
+  (php/-> printer (print x)))
+
 (defn- pp-str
-  "Pretty-prints `form` to a string with the given indent level and max width."
-  [form indent width]
+  "Pretty-prints `form` to a string with the given indent level and max width.
+  Width is always measured on the plain readable output; `printer` only affects
+  how leaves are rendered (ANSI codes would inflate the measured length)."
+  [form indent width printer]
   (let [t         (type form)
         available (- width indent)
         flat      (print-value form)]
     (cond
       (= t :vector)
       (if (<= (count flat) available)
-        flat
+        (render-value printer form)
         (let [prefix       "["
               suffix       "]"
               inner-indent (+ indent 1)
               pad          (php/str_repeat " " inner-indent)
-              parts        (for [x :in form] (pp-str x inner-indent width))]
+              parts        (for [x :in form] (pp-str x inner-indent width printer))]
           (str prefix
                (php/implode (str "\n" pad) (apply php-indexed-array parts))
                suffix)))
 
       (= t :list)
       (if (<= (count flat) available)
-        flat
+        (render-value printer form)
         (let [prefix       "("
               suffix       ")"
               inner-indent (+ indent 1)
               pad          (php/str_repeat " " inner-indent)
-              parts        (for [x :in form] (pp-str x inner-indent width))]
+              parts        (for [x :in form] (pp-str x inner-indent width printer))]
           (str prefix
                (php/implode (str "\n" pad) (apply php-indexed-array parts))
                suffix)))
 
       (= t :hash-map)
       (if (<= (count flat) available)
-        flat
+        (render-value printer form)
         (let [prefix       "{"
               suffix       "}"
               inner-indent (+ indent 1)
               pad          (php/str_repeat " " inner-indent)
               pairs        (for [[k v] :pairs form]
                              (let [kstr (print-value k)]
-                               (str kstr " " (pp-str v (+ inner-indent (count kstr) 1) width))))
+                               (str (render-value printer k) " "
+                                    (pp-str v (+ inner-indent (count kstr) 1) width printer))))
               joined       (php/implode (str "\n" pad) (apply php-indexed-array pairs))]
           (str prefix joined suffix)))
 
       (= t :set)
       (if (<= (count flat) available)
-        flat
+        (render-value printer form)
         (let [prefix       "#{"
               suffix       "}"
               inner-indent (+ indent 2)
               pad          (php/str_repeat " " inner-indent)
-              parts        (for [x :in form] (pp-str x inner-indent width))]
+              parts        (for [x :in form] (pp-str x inner-indent width printer))]
           (str prefix
                (php/implode (str "\n" pad) (apply php-indexed-array parts))
                suffix)))
 
       (= t :struct)
       (if (<= (count flat) available)
-        flat
+        (render-value printer form)
         (let [prefix       "{"
               suffix       "}"
               inner-indent (+ indent 1)
               pad          (php/str_repeat " " inner-indent)
               pairs        (for [[k v] :pairs form]
                              (let [kstr (print-value k)]
-                               (str kstr " " (pp-str v (+ inner-indent (count kstr) 1) width))))
+                               (str (render-value printer k) " "
+                                    (pp-str v (+ inner-indent (count kstr) 1) width printer))))
               joined       (php/implode (str "\n" pad) (apply php-indexed-array pairs))]
           (str prefix joined suffix)))
 
-      flat)))
+      (render-value printer form))))
 
 (defn pprint-str
   "Pretty-prints `form` to a string with optional `width` (default 72)."
   {:doc "Pretty-print a data structure to a string with line breaks and indentation."
-   :see-also ["pprint"]
+   :see-also ["pprint" "inspect"]
    :example "(pprint-str {:a [1 2 3] :b {:c 4 :d 5}})"}
   [form & [width]]
   (let [w (or width *default-width*)]
-    (pp-str form 0 w)))
+    (pp-str form 0 w (php/:: Printer (readable)))))
 
 (defn pprint
   "Pretty-prints `form` to stdout with optional `width` (default 72)."
   {:doc "Pretty-print a data structure to stdout with line breaks and indentation."
-   :see-also ["pprint-str"]
+   :see-also ["pprint-str" "inspect"]
    :example "(pprint {:a [1 2 3] :b {:c 4 :d 5}})"}
   [form & [width]]
   (php/print (pprint-str form width))
   (php/print "\n")
   nil)
+
+(defn- color-output?
+  "True when stdout is an interactive terminal.
+  Output buffering means the text is being captured, not shown on a terminal."
+  []
+  (and (zero? (php/ob_get_level))
+       (php/defined "STDOUT")
+       (php/function_exists "stream_isatty")
+       (php/stream_isatty php/STDOUT)))
+
+(defn inspect
+  "Pretty-prints `x` to stdout (colored on a TTY) and returns `x` unchanged."
+  {:doc "Pretty-print a value for humans (colored when stdout is a terminal) and return it unchanged, so it can be dropped into threading pipelines."
+   :see-also ["pprint" "pprint-str" "tap>"]
+   :example "(-> {:a [1 2 3]} inspect (get :a))"}
+  [x & [width]]
+  (let [w       (or width *default-width*)
+        printer (if (color-output?)
+                  (php/:: Printer (readableWithColor))
+                  (php/:: Printer (readable)))]
+    (php/print (pp-str x 0 w printer))
+    (php/print "\n")
+    x))

--- a/tests/phel/pprint.phel
+++ b/tests/phel/pprint.phel
@@ -1,6 +1,6 @@
 (ns phel-test.pprint
   (:require phel.test :refer [deftest is])
-  (:require phel.pprint :refer [pprint-str]))
+  (:require phel.pprint :refer [pprint-str inspect]))
 
 ;; ---------------------------
 ;; Scalar values (no wrapping)
@@ -68,3 +68,34 @@
   (is (= "[]" (pprint-str [])) "empty vector")
   (is (= "{}" (pprint-str {})) "empty map")
   (is (= "()" (pprint-str '())) "empty list"))
+
+;; --------------------------------
+;; Inspect
+;; --------------------------------
+
+(deftest test-inspect-returns-argument
+  (let [returned (atom :unset)
+        _        (with-output-buffer (reset! returned (inspect {:a [1 2 3]})))]
+    (is (= {:a [1 2 3]} (deref returned)) "inspect returns a map unchanged"))
+  (let [returned (atom :unset)
+        _        (with-output-buffer (reset! returned (inspect [1 2 3])))]
+    (is (= [1 2 3] (deref returned)) "inspect returns a vector unchanged"))
+  (let [returned (atom :unset)
+        _        (with-output-buffer (reset! returned (inspect nil)))]
+    (is (nil? (deref returned)) "inspect returns nil unchanged")))
+
+(deftest test-inspect-output-plain-when-captured
+  (let [output (with-output-buffer (inspect {:a 1}))]
+    (is (= "{:a 1}\n" output) "captured output is the plain pretty print")
+    (is (not (str-contains? output (php/chr 27))) "no ANSI escape codes when not on a TTY")))
+
+(deftest test-inspect-output-wraps-wide-values
+  (let [output (with-output-buffer (inspect [:alpha :beta :gamma] 10))]
+    (is (str-contains? output "\n :beta") "wide value wraps like pprint")
+    (is (= "[:alpha\n :beta\n :gamma]\n" output) "wrapped layout matches pprint-str plus newline")))
+
+(deftest test-inspect-threading-pipeline
+  (let [returned (atom :unset)
+        _        (with-output-buffer
+                   (reset! returned (-> {:a 1} inspect (get :a) inspect inc)))]
+    (is (= 2 (deref returned)) "inspect composes in threading pipelines")))


### PR DESCRIPTION
## 🤔 Background

Closes #2688

`pprint` exists but is plain, and `print-str` flattens everything onto one line. There was no ergonomic front-door for "show me this value nicely" during development — especially one that can be dropped into the middle of a threading pipeline without changing its result.

## 💡 Goal

Add `inspect`: a human-first pretty-printer that prints a value (colored when stdout is a terminal, plain otherwise) and returns the value unchanged, so `(-> x inspect transform)` composes.

## 🔖 Changes

- `inspect` lives in `phel\pprint` (not `phel\core`): pprint depends on core, so core requiring pprint would be circular. The issue allows either home.
- Colors reuse the existing `Printer::readableWithColor()` infrastructure (the same one `phel\repl`'s `print-colorful` uses), so struct names and PHP object classes are already annotated by the readable printer's type printers.
- Color is enabled only when `stream_isatty(STDOUT)` is true and no output buffering is active — captured output (tests, `with-output-buffer`, pipes) stays plain.
- `pp-str` now takes the rendering printer as a parameter while still measuring line widths on the plain readable output, so ANSI escape codes never inflate the wrap/indent math. `pprint-str`/`pprint` behavior is unchanged.
- Tests: return-value passthrough (map/vector/nil), plain output without ANSI codes when captured, wrapped layout for wide values, and threading-pipeline composition.
- CHANGELOG entry under Unreleased/Added.
