### PR TITLE
feat(test): add html coverage report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - `arity` and `variadic?`: function reflection helpers for required parameter count and variadic detection (#2685)
 - `inspect`: pretty-prints a value (colored on TTY) and returns it unchanged for pipeline debugging (#2688)
 - `with-open`: scoped resource cleanup macro; closes bound resources in reverse order even on exception (#2684)
+- `phel test --coverage=html`: self-contained HTML coverage report with line-colored .phel sources (#2692)
 
 ### Fixed
 

--- a/src/php/Run/Application/Test/Coverage/CoverageReport.php
+++ b/src/php/Run/Application/Test/Coverage/CoverageReport.php
@@ -67,6 +67,11 @@ final readonly class CoverageReport
         return $this->files;
     }
 
+    public function driverName(): string
+    {
+        return $this->driver;
+    }
+
     public function toText(): string
     {
         if ($this->files === []) {

--- a/src/php/Run/Application/Test/Coverage/HtmlCoverageRenderer.php
+++ b/src/php/Run/Application/Test/Coverage/HtmlCoverageRenderer.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application\Test\Coverage;
+
+use function basename;
+use function count;
+use function explode;
+use function file_get_contents;
+use function htmlspecialchars;
+use function implode;
+use function is_file;
+use function preg_replace;
+use function sha1;
+use function sprintf;
+use function str_ends_with;
+use function substr;
+
+use const ENT_QUOTES;
+
+/**
+ * Renders a {@see CoverageReport} as a self-contained static HTML report:
+ * an index page with per-file percentages plus one page per source file with
+ * line-colored code. Inline CSS only, so the output works offline and as a
+ * CI artifact.
+ */
+final readonly class HtmlCoverageRenderer
+{
+    private const string CSS = <<<'CSS'
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2rem auto; max-width: 60rem; padding: 0 1rem; color: #1f2328; }
+        h1 { font-size: 1.4rem; }
+        h1 code { font-size: 1.1rem; }
+        a { color: #0969da; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        table.summary { border-collapse: collapse; width: 100%; }
+        table.summary th, table.summary td { border: 1px solid #d1d9e0; padding: 0.4rem 0.6rem; text-align: left; }
+        table.summary td.num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+        table.summary tr.total td { font-weight: 600; background: #f6f8fa; }
+        .bar { background: #eceff2; border-radius: 3px; width: 8rem; height: 0.6rem; display: inline-block; vertical-align: middle; margin-right: 0.5rem; }
+        .bar span { background: #1a7f37; border-radius: 3px; height: 100%; display: block; }
+        table.source { border-collapse: collapse; width: 100%; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.85rem; }
+        table.source td { padding: 0 0.6rem; white-space: pre-wrap; }
+        table.source td.ln { text-align: right; color: #59636e; user-select: none; border-right: 1px solid #d1d9e0; width: 1%; }
+        tr.covered td { background: #dafbe1; }
+        tr.covered td.ln { background: #aceebb; }
+        tr.uncovered td { background: #ffebe9; }
+        tr.uncovered td.ln { background: #ffcecb; }
+        tr.neutral td.code { color: #8b949e; }
+        .meta { color: #59636e; font-size: 0.85rem; }
+        CSS;
+
+    /**
+     * @return array<string, string> page filename => full HTML document
+     */
+    public function render(CoverageReport $report): array
+    {
+        $pages = ['index.html' => $this->renderIndex($report)];
+        foreach ($report->files() as $file) {
+            $pages[$this->pageName($file->filename)] = $this->renderFilePage($file);
+        }
+
+        return $pages;
+    }
+
+    public function pageName(string $filename): string
+    {
+        $safeBasename = (string) preg_replace('/[^A-Za-z0-9._-]+/', '-', basename($filename));
+
+        // The hash disambiguates equal basenames from different directories.
+        return sprintf('%s.%s.html', $safeBasename, substr(sha1($filename), 0, 8));
+    }
+
+    private function renderIndex(CoverageReport $report): string
+    {
+        if ($report->files() === []) {
+            $body = '<p>No project source files were executed.</p>';
+
+            return $this->document('Phel Coverage', $report, $body);
+        }
+
+        $rows = [];
+        foreach ($report->files() as $file) {
+            $rows[] = sprintf(
+                '<tr><td><a href="%s">%s</a></td><td class="num">%s %.1f%%</td><td class="num">%d/%d</td></tr>',
+                $this->escape($this->pageName($file->filename)),
+                $this->escape($file->filename),
+                $this->coverageBar($file->percentage()),
+                $file->percentage(),
+                $file->coveredCount(),
+                $file->coverableCount(),
+            );
+        }
+
+        $rows[] = sprintf(
+            '<tr class="total"><td>Total</td><td class="num">%s %.1f%%</td><td class="num">%d/%d</td></tr>',
+            $this->coverageBar($report->totalPercentage()),
+            $report->totalPercentage(),
+            $report->totalCovered(),
+            $report->totalCoverable(),
+        );
+
+        $body = '<table class="summary"><thead><tr><th>File</th><th>Coverage</th><th>Lines</th></tr></thead><tbody>'
+            . implode('', $rows)
+            . '</tbody></table>';
+
+        return $this->document('Phel Coverage', $report, $body);
+    }
+
+    private function renderFilePage(CoverageFile $file): string
+    {
+        $title = sprintf('%s — Phel Coverage', $file->filename);
+        $header = sprintf(
+            '<p class="meta"><a href="index.html">&larr; Index</a> &middot; %s %.1f%% &middot; %d/%d lines</p>',
+            $this->coverageBar($file->percentage()),
+            $file->percentage(),
+            $file->coveredCount(),
+            $file->coverableCount(),
+        );
+
+        $source = is_file($file->filename) ? file_get_contents($file->filename) : false;
+        if ($source === false) {
+            return $this->documentWithHeading(
+                $title,
+                $file->filename,
+                $header . '<p>Source file is not readable.</p>',
+            );
+        }
+
+        if (str_ends_with($source, "\n")) {
+            $source = substr($source, 0, -1);
+        }
+
+        $hits = $file->lineHits();
+        $rows = [];
+        foreach (explode("\n", $source) as $index => $line) {
+            $lineNumber = $index + 1;
+            $class = 'neutral';
+            if (isset($hits[$lineNumber])) {
+                $class = $hits[$lineNumber] ? 'covered' : 'uncovered';
+            }
+
+            $rows[] = sprintf(
+                '<tr class="%s"><td class="ln">%d</td><td class="code">%s</td></tr>',
+                $class,
+                $lineNumber,
+                $this->escape($line),
+            );
+        }
+
+        $body = $header . '<table class="source"><tbody>' . implode('', $rows) . '</tbody></table>';
+
+        return $this->documentWithHeading($title, $file->filename, $body);
+    }
+
+    private function document(string $title, CoverageReport $report, string $body): string
+    {
+        $heading = sprintf(
+            '<h1>Phel Coverage <span class="meta">(%s, %d files)</span></h1>',
+            $this->escape($report->driverName()),
+            count($report->files()),
+        );
+
+        return $this->htmlDocument($title, $heading . $body);
+    }
+
+    private function documentWithHeading(string $title, string $filename, string $body): string
+    {
+        $heading = sprintf('<h1><code>%s</code></h1>', $this->escape($filename));
+
+        return $this->htmlDocument($title, $heading . $body);
+    }
+
+    private function htmlDocument(string $title, string $body): string
+    {
+        return sprintf(
+            "<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n"
+            . "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+            . "<title>%s</title>\n<style>\n%s\n</style>\n</head>\n<body>\n%s\n</body>\n</html>\n",
+            $this->escape($title),
+            self::CSS,
+            $body,
+        );
+    }
+
+    private function coverageBar(float $percentage): string
+    {
+        return sprintf('<span class="bar"><span style="width:%.1f%%"></span></span>', $percentage);
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES);
+    }
+}

--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -33,7 +33,7 @@ Version comes from `Shared\VersionResolver` directly — Run does **not** depend
 ## Structure
 
 - `Infrastructure/Command/`: 10 user-facing Symfony commands (incl. `config` — dumps effective merged config) + 1 hidden `_test-worker` (`TestWorkerCommand`).
-- `Application/Test/Coverage/`: `CoverageDriver`, `CoverageAggregator`, `CoverageReport`, `CoverageFile`.
+- `Application/Test/Coverage/`: `CoverageDriver`, `CoverageAggregator`, `CoverageReport`, `CoverageFile`, `HtmlCoverageRenderer`.
 - `Runtime/PhelSourceLoader`: cached-PHP boot entry.
 
 ## Key Constraints
@@ -45,7 +45,7 @@ Version comes from `Shared\VersionResolver` directly — Run does **not** depend
 - **Bundled namespace lazy loading**: `BundledNamespaces` lists every `phel.*` module. `NamespaceLoader` (REPL/eval/lint/lsp/nrepl/watch startup) eagerly seeds only the startup ns + `phel.core`; others load lazily. It registers `LazyBundledNamespaceResolver` (implements Compiler's `BundledNamespaceResolverInterface`) on the global env; `SymbolResolver` invokes it when a fully qualified `phel.*` ref (`phel.json/encode`) hits an unloaded bundle — loads on demand, then retries (no "not defined"). `(require ...)` already loads via dependency resolution.
 - **File dedup**: `NamespaceFileTracker` (process-wide static) dedupes evaluated files across eager startup and lazy loads. `NamespaceLoader::reset()` clears it.
 - **Script bundles**: `FileRunner` uses `BundledNamespaceDetector` to seed only bundles referenced via fully qualified form (`phel.json/encode`) or Clojure-compatible requires (`clojure.test` → `phel.test`), avoiding cold-start cost for scripts that don't reach bundled modules.
-- **Coverage**: `phel test --coverage[=text|clover]` wraps the serial test eval with the driver, maps raw PHP line coverage to `.phel` via `CommandFacade::getCompiledFileLineMap`, filters to project source dirs. Coverage **forces serial execution** (parallel workers can't merge).
+- **Coverage**: `phel test --coverage[=text|clover|html]` wraps the serial test eval with the driver, maps raw PHP line coverage to `.phel` via `CommandFacade::getCompiledFileLineMap`, filters to project source dirs. Coverage **forces serial execution** (parallel workers can't merge). `html` writes a self-contained static report (`HtmlCoverageRenderer`) to `var/coverage/` by default; override the directory with `html:<dir>` or `--coverage-output`.
 - **Parallel testing**: `ParallelTestOrchestrator` spawns a `phel _test-worker` subprocess pool, one ns per length-prefixed JSON work frame; per-ns output is buffered and flushed in input order. `CpuCountDetector` honours `PHEL_TEST_WORKERS`, falls back to `nproc`/`sysctl`/`/proc/cpuinfo`, caps at 8.
 - **Watch testing**: `runTestWatchLoop` (`phel test --watch`) polls project src/test dirs for `.phel`/`phel-config.php` mtime changes every 500ms, re-invoking `$runTests` as a subprocess per change.
 - **Completion unaffected by lazy load**: the Api completer builds its catalog from `ApiConfig::allNamespaces()`, not from what the REPL loaded.

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -9,6 +9,7 @@ use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Run\Application\Test\Coverage\CoverageDriver;
 use Phel\Run\Application\Test\Coverage\CoverageReport;
+use Phel\Run\Application\Test\Coverage\HtmlCoverageRenderer;
 use Phel\Run\Domain\Test\TestCommandOptions;
 use Phel\Run\Domain\Test\TestNamespacePruner;
 use Phel\Run\RunFacade;
@@ -27,9 +28,13 @@ use Throwable;
 use function count;
 use function file_put_contents;
 use function is_array;
+use function is_dir;
 use function is_string;
+use function mkdir;
 use function sprintf;
+use function strpos;
 use function strtolower;
+use function substr;
 use function time;
 
 /**
@@ -45,6 +50,8 @@ final class TestCommand extends Command
     private const string OPT_COVERAGE = 'coverage';
 
     private const string OPT_COVERAGE_OUTPUT = 'coverage-output';
+
+    private const string DEFAULT_HTML_COVERAGE_DIR = 'var/coverage';
 
     protected function configure(): void
     {
@@ -166,14 +173,14 @@ HELP)
                 self::OPT_COVERAGE,
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Collect line coverage (via pcov or xdebug) mapped back to .phel sources. Value is the format: "text" (default) or "clover".',
+                'Collect line coverage (via pcov or xdebug) mapped back to .phel sources. Value is the format: "text" (default), "clover", or "html". "html" writes a static report to var/coverage/ (override with "html:<dir>").',
                 false,
-                ['text', 'clover'],
+                ['text', 'clover', 'html'],
             )->addOption(
                 self::OPT_COVERAGE_OUTPUT,
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Write the coverage report to a file instead of stdout (use with --coverage=clover for CI).',
+                'Write the coverage report to a file instead of stdout (use with --coverage=clover for CI). With --coverage=html the value is the report directory.',
             );
     }
 
@@ -355,7 +362,20 @@ HELP)
         string $format,
         mixed $outputPath,
     ): void {
-        $format = $format === '' ? 'text' : strtolower($format);
+        // "html:<dir>" carries the report directory in the format value itself.
+        $colonPos = strpos($format, ':');
+        $formatSuffix = $colonPos === false ? '' : substr($format, $colonPos + 1);
+        $format = strtolower($colonPos === false ? $format : substr($format, 0, $colonPos));
+        $format = $format === '' ? 'text' : $format;
+
+        if ($format === 'html') {
+            $directory = $formatSuffix !== ''
+                ? $formatSuffix
+                : ((is_string($outputPath) && $outputPath !== '') ? $outputPath : self::DEFAULT_HTML_COVERAGE_DIR);
+            $this->writeHtmlCoverage($output, $report, $directory);
+            return;
+        }
+
         $content = $format === 'clover'
             ? $report->toClover(time())
             : $report->toText();
@@ -367,6 +387,20 @@ HELP)
         }
 
         $output->writeln($content);
+    }
+
+    private function writeHtmlCoverage(OutputInterface $output, CoverageReport $report, string $directory): void
+    {
+        if (!is_dir($directory) && !mkdir($directory, 0o755, true) && !is_dir($directory)) {
+            $output->writeln(sprintf('<error>Cannot create coverage report directory %s</error>', $directory));
+            return;
+        }
+
+        foreach (new HtmlCoverageRenderer()->render($report) as $pageName => $html) {
+            file_put_contents($directory . '/' . $pageName, $html);
+        }
+
+        $output->writeln(sprintf('HTML coverage report written to %s', $directory . '/index.html'));
     }
 
     /**

--- a/tests/php/Integration/Run/Command/Test/TestCommandCoverage/TestCommandCoverageTest.php
+++ b/tests/php/Integration/Run/Command/Test/TestCommandCoverage/TestCommandCoverageTest.php
@@ -13,6 +13,7 @@ use function escapeshellarg;
 use function exec;
 use function file_get_contents;
 use function file_put_contents;
+use function glob;
 use function implode;
 use function mkdir;
 use function random_bytes;
@@ -89,6 +90,34 @@ final class TestCommandCoverageTest extends TestCase
         $xml = simplexml_load_string((string) file_get_contents($cloverPath));
         self::assertNotFalse($xml, 'clover output is well-formed XML');
         self::assertStringContainsString('calc.phel', (string) file_get_contents($cloverPath));
+    }
+
+    public function test_html_coverage_writes_report_to_default_directory(): void
+    {
+        [, $output] = $this->runPhelTest(['--coverage=html']);
+        $this->skipIfNoDriver($output);
+
+        $indexPath = $this->projectDir . '/var/coverage/index.html';
+        self::assertStringContainsString('HTML coverage report written to var/coverage/index.html', $output);
+        self::assertFileExists($indexPath);
+
+        $index = (string) file_get_contents($indexPath);
+        self::assertStringContainsString('calc.phel', $index);
+        self::assertMatchesRegularExpression('/\d+\.\d%/', $index);
+        self::assertStringNotContainsString('http://', $index);
+        self::assertStringNotContainsString('https://', $index);
+    }
+
+    public function test_html_coverage_supports_custom_directory_suffix(): void
+    {
+        [, $output] = $this->runPhelTest(['--coverage=html:report/cov']);
+        $this->skipIfNoDriver($output);
+
+        self::assertFileExists($this->projectDir . '/report/cov/index.html');
+        $filePages = glob($this->projectDir . '/report/cov/calc.phel.*.html');
+        self::assertNotFalse($filePages);
+        self::assertCount(1, $filePages);
+        self::assertStringContainsString('class="covered"', (string) file_get_contents($filePages[0]));
     }
 
     private function skipIfNoDriver(string $output): void

--- a/tests/php/Unit/Run/Application/Test/Coverage/HtmlCoverageRendererTest.php
+++ b/tests/php/Unit/Run/Application/Test/Coverage/HtmlCoverageRendererTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Application\Test\Coverage;
+
+use Override;
+use Phel\Run\Application\Test\Coverage\CoverageFile;
+use Phel\Run\Application\Test\Coverage\CoverageReport;
+use Phel\Run\Application\Test\Coverage\HtmlCoverageRenderer;
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function escapeshellarg;
+use function exec;
+use function file_put_contents;
+use function mkdir;
+use function random_bytes;
+use function sys_get_temp_dir;
+
+final class HtmlCoverageRendererTest extends TestCase
+{
+    private string $sourceDir;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->sourceDir = sys_get_temp_dir() . '/phel-html-coverage-' . bin2hex(random_bytes(8));
+        mkdir($this->sourceDir, 0o755, true);
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        exec('rm -rf ' . escapeshellarg($this->sourceDir));
+    }
+
+    public function test_index_lists_files_with_percentages_and_links(): void
+    {
+        $calc = $this->writeSource('calc.phel', "(ns app.calc)\n(defn add [a b]\n  (+ a b))\n");
+        $util = $this->writeSource('util.phel', "(ns app.util)\n(def answer 42)\n");
+        $renderer = new HtmlCoverageRenderer();
+
+        $pages = $renderer->render(new CoverageReport([
+            new CoverageFile($calc, [2 => true, 3 => false]),
+            new CoverageFile($util, [2 => true]),
+        ], 'pcov'));
+
+        $index = $pages['index.html'];
+        self::assertStringContainsString('calc.phel', $index);
+        self::assertStringContainsString('util.phel', $index);
+        self::assertStringContainsString('50.0%', $index); // calc: 1 of 2
+        self::assertStringContainsString('100.0%', $index); // util: 1 of 1
+        self::assertStringContainsString('66.7%', $index); // total: 2 of 3
+        self::assertStringContainsString('pcov', $index);
+        self::assertStringContainsString('href="' . $renderer->pageName($calc) . '"', $index);
+        self::assertArrayHasKey($renderer->pageName($calc), $pages);
+        self::assertArrayHasKey($renderer->pageName($util), $pages);
+    }
+
+    public function test_file_page_marks_covered_uncovered_and_neutral_lines(): void
+    {
+        $calc = $this->writeSource('calc.phel', "(ns app.calc)\n(defn add [a b]\n  (+ a b))\n");
+        $renderer = new HtmlCoverageRenderer();
+
+        $pages = $renderer->render(new CoverageReport([
+            new CoverageFile($calc, [2 => true, 3 => false]),
+        ], 'pcov'));
+        $filePage = $pages[$renderer->pageName($calc)];
+
+        self::assertStringContainsString(
+            '<tr class="neutral"><td class="ln">1</td><td class="code">(ns app.calc)</td></tr>',
+            $filePage,
+        );
+        self::assertStringContainsString(
+            '<tr class="covered"><td class="ln">2</td><td class="code">(defn add [a b]</td></tr>',
+            $filePage,
+        );
+        self::assertStringContainsString(
+            '<tr class="uncovered"><td class="ln">3</td><td class="code">  (+ a b))</td></tr>',
+            $filePage,
+        );
+        self::assertStringContainsString('<a href="index.html">', $filePage);
+    }
+
+    public function test_file_page_escapes_html_in_source(): void
+    {
+        $file = $this->writeSource('markup.phel', "(def snippet \"<b>bold & bad</b>\")\n");
+        $renderer = new HtmlCoverageRenderer();
+
+        $pages = $renderer->render(new CoverageReport([
+            new CoverageFile($file, [1 => true]),
+        ], 'pcov'));
+        $filePage = $pages[$renderer->pageName($file)];
+
+        self::assertStringNotContainsString('<b>', $filePage);
+        self::assertStringContainsString('&lt;b&gt;bold &amp; bad&lt;/b&gt;', $filePage);
+    }
+
+    public function test_output_is_self_contained(): void
+    {
+        $calc = $this->writeSource('calc.phel', "(ns app.calc)\n(defn add [a b]\n  (+ a b))\n");
+
+        $pages = new HtmlCoverageRenderer()->render(new CoverageReport([
+            new CoverageFile($calc, [2 => true, 3 => false]),
+        ], 'pcov'));
+
+        foreach ($pages as $pageName => $html) {
+            self::assertStringNotContainsString('http://', $html, $pageName . ' must not reference external resources');
+            self::assertStringNotContainsString('https://', $html, $pageName . ' must not reference external resources');
+            self::assertStringContainsString('<style>', $html, $pageName . ' must inline its CSS');
+        }
+    }
+
+    public function test_page_names_disambiguate_equal_basenames(): void
+    {
+        $renderer = new HtmlCoverageRenderer();
+
+        self::assertNotSame(
+            $renderer->pageName('/proj/src/calc.phel'),
+            $renderer->pageName('/proj/src/nested/calc.phel'),
+        );
+        self::assertStringStartsWith('calc.phel.', $renderer->pageName('/proj/src/calc.phel'));
+    }
+
+    public function test_index_when_no_files_were_executed(): void
+    {
+        $pages = new HtmlCoverageRenderer()->render(new CoverageReport([], 'xdebug'));
+
+        self::assertCount(1, $pages);
+        self::assertStringContainsString('No project source files were executed.', $pages['index.html']);
+    }
+
+    public function test_file_page_when_source_is_not_readable(): void
+    {
+        $missing = $this->sourceDir . '/deleted.phel';
+        $renderer = new HtmlCoverageRenderer();
+
+        $pages = $renderer->render(new CoverageReport([
+            new CoverageFile($missing, [1 => true]),
+        ], 'pcov'));
+
+        self::assertStringContainsString('Source file is not readable.', $pages[$renderer->pageName($missing)]);
+    }
+
+    private function writeSource(string $basename, string $code): string
+    {
+        $path = $this->sourceDir . '/' . $basename;
+        file_put_contents($path, $code);
+
+        return $path;
+    }
+}

--- a/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
+++ b/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
@@ -138,7 +138,7 @@ final class TestCommandOptionsWiringTest extends TestCase
     {
         $tester = new CommandCompletionTester(new TestCommand());
 
-        self::assertSame(['text', 'clover'], $tester->complete(['--coverage', '']));
+        self::assertSame(['text', 'clover', 'html'], $tester->complete(['--coverage', '']));
     }
 
     public function test_reporter_option_completes_builtins(): void


### PR DESCRIPTION
## 🤔 Background

Closes #2692

`phel test --coverage` supports `text` and `clover` formats, both mapping PHP line coverage back to `.phel` sources (#2433). Clover serves CI, but there is no human-browsable report to inspect coverage gaps visually.

## 💡 Goal

Add `html` as a third coverage format: `phel test --coverage=html` writes a self-contained static HTML report with an index of per-file coverage percentages and one page per source file with line-colored code (covered green, uncovered red, non-executable dimmed).

## 🔖 Changes

- New `HtmlCoverageRenderer` in `Run/Application/Test/Coverage/`: pure rendering layer over the existing `CoverageReport`/`CoverageFile` data model (same per-line data that feeds the clover output — no new measurement). Returns a page-name → HTML map; the command writes the files.
- `--coverage=html` writes to `var/coverage/` by default; the directory can be overridden with `--coverage=html:<dir>` (per the issue syntax) or the existing `--coverage-output` option.
- Output is fully self-contained: inline CSS only, no CDN or external requests, so it works offline and as a CI artifact. Source code is HTML-escaped; equal basenames from different directories get disambiguated page names.
- `CoverageReport::driverName()` accessor so the index can show which driver (pcov/xdebug) produced the data.
- Help text and shell completion now list `html`; `src/php/Run/CLAUDE.md` updated.
- Tests: `HtmlCoverageRendererTest` (index listing, line classes, HTML escaping, self-containment, page-name disambiguation, empty report, unreadable source) plus two end-to-end cases in `TestCommandCoverageTest` (default dir and `html:<dir>` suffix; skip without pcov/xdebug like the existing coverage tests).
- CHANGELOG entry under Unreleased / Added.
