### PR TITLE
feat(export): derive stub types from :tag metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - `inspect`: pretty-prints a value (colored on TTY) and returns it unchanged for pipeline debugging (#2688)
 - `with-open`: scoped resource cleanup macro; closes bound resources in reverse order even on exception (#2684)
 - `phel test --coverage=html`: self-contained HTML coverage report with line-colored .phel sources (#2692)
+- `phel export` stubs now carry native parameter/return types and `@param`/`@return` docblocks derived from `:tag` metadata (#2695)
 
 ### Fixed
 

--- a/src/php/Interop/CLAUDE.md
+++ b/src/php/Interop/CLAUDE.md
@@ -35,6 +35,6 @@ Generates PHP wrapper classes for Phel functions marked `^{:export true}`, so PH
 - Only `^{:export true}` fns are exported.
 - Export target directory is wiped and regenerated each run.
 - Phel ns → PHP: hyphens become CamelCase (`my-lib` → `MyLib`); generated method names camelCase the fn name (`my-fn` → `myFn`).
-- `CompiledPhpMethodBuilder` reflects the compiled fn class's `BOUND_TO` constant + `__invoke` signature; do not bypass — params/return type/ns come from there.
+- `CompiledPhpMethodBuilder` reflects the compiled fn class's `BOUND_TO` constant + `__invoke` signature; do not bypass — params/return type/ns come from there. Native param/return types (compiled from `:tag`) are mirrored into the wrapper signature plus an `@param`/`@return` docblock; multi-arity fns reflect an untyped `__invoke(...$args)`, so their `@return` comes from the return `:tag` that `FunctionToExport` carries from the definition metadata. Fns without any type info keep a docblock-free `mixed` wrapper.
 - `^{:php/attr [...]}` on an exported `defn` is threaded through `FunctionToExport` and rendered via `Phel\Shared\PhpAttributeRenderer` as PHP 8 attributes above the wrapper method (e.g. `#[\…\Route('/p')]`).
 - `PhelCallerTrait` caches resolved definitions in a process-wide static keyed by `namespace::definitionName`, never invalidated. Safe for CLI / per-request FPM; a wrapper keeps calling the originally resolved definition if the runtime redefines it mid-process.

--- a/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
+++ b/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
@@ -17,6 +17,8 @@ use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
 use Phel\Shared\NamespaceInformation;
 
+use function is_string;
+
 final readonly class FunctionsToExportFinder implements FunctionsToExportFinderInterface
 {
     /**
@@ -95,6 +97,7 @@ final readonly class FunctionsToExportFinder implements FunctionsToExportFinderI
                     $functionsToExport[$ns][] = new FunctionToExport(
                         $fn,
                         $meta->find(Keyword::create('attr', 'php')),
+                        $this->returnTag($meta),
                     );
                 }
             }
@@ -121,5 +124,18 @@ final readonly class FunctionsToExportFinder implements FunctionsToExportFinderI
     private function isExport(PersistentMapInterface $meta): bool
     {
         return (bool) ($meta[Keyword::create('export')] ?? false);
+    }
+
+    /**
+     * The compiler stores the fn's return-type `:tag` (declared or inferred) as a
+     * plain string in the definition metadata.
+     *
+     * @param PersistentMapInterface<mixed, mixed> $meta
+     */
+    private function returnTag(PersistentMapInterface $meta): ?string
+    {
+        $tag = $meta->find(Keyword::create('tag'));
+
+        return is_string($tag) && $tag !== '' ? $tag : null;
     }
 }

--- a/src/php/Interop/Domain/Generator/Builder/CompiledPhpMethodBuilder.php
+++ b/src/php/Interop/Domain/Generator/Builder/CompiledPhpMethodBuilder.php
@@ -10,9 +10,11 @@ use Phel\Shared\ScalarCoercion;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionParameter;
+use ReflectionType;
 
 use function array_map;
 use function implode;
+use function sprintf;
 
 final readonly class CompiledPhpMethodBuilder
 {
@@ -25,10 +27,11 @@ final readonly class CompiledPhpMethodBuilder
      *
      * The compiled Phel function is a class whose `BOUND_TO` constant holds its
      * fully qualified Phel name; reflection on its `__invoke` method provides the
-     * parameter list and return type. These are rendered into the method template,
-     * replacing the `$ATTRIBUTES$`, `$METHOD_NAME$`, `$ARGS$`, `$RETURN_TYPE$`,
-     * `$PHEL_NAMESPACE$` and `$PHEL_FUNCTION_NAME$` tokens, so the generated method
-     * delegates to `self::callPhel(...)` at runtime.
+     * parameter list and return type (the `:tag` metadata is compiled into that
+     * signature). These are rendered into the method template, replacing the
+     * `$DOC_BLOCK$`, `$ATTRIBUTES$`, `$METHOD_NAME$`, `$SIGNATURE_ARGS$`, `$ARGS$`,
+     * `$RETURN_TYPE$`, `$PHEL_NAMESPACE$` and `$PHEL_FUNCTION_NAME$` tokens, so the
+     * generated method delegates to `self::callPhel(...)` at runtime.
      */
     public function build(string $phelNs, FunctionToExport $functionToExport): string
     {
@@ -39,19 +42,23 @@ final readonly class CompiledPhpMethodBuilder
         $refInvoke = $ref->getMethod('__invoke');
 
         return str_replace([
+            '$DOC_BLOCK$',
             '$ATTRIBUTES$',
             '$METHOD_NAME$',
-            '$ARGS$',
+            '$SIGNATURE_ARGS$',
             '$RETURN_TYPE$',
             '$PHEL_NAMESPACE$',
             '$PHEL_FUNCTION_NAME$',
+            '$ARGS$',
         ], [
+            $this->buildDocBlock($refInvoke, $functionToExport->returnTag()),
             $this->buildAttributes($functionToExport),
             $this->buildMethodName($boundTo),
-            $this->buildArgs($refInvoke),
+            $this->buildSignatureArgs($refInvoke),
             $this->buildReturnType($refInvoke),
             str_replace(['_', '\\'], ['-', '\\\\'], $phelNs),
             $this->buildPhelFunctionName($boundTo),
+            $this->buildArgs($refInvoke),
         ], $this->methodTemplate());
     }
 
@@ -100,6 +107,73 @@ final readonly class CompiledPhpMethodBuilder
         return implode(', ', $args);
     }
 
+    private function buildSignatureArgs(ReflectionMethod $refInvoke): string
+    {
+        $args = array_map(
+            static function (ReflectionParameter $p): string {
+                $type = $p->getType();
+                $typePrefix = $type instanceof ReflectionType ? $type->__toString() . ' ' : '';
+                $variadic = $p->isVariadic() ? '...' : '';
+
+                return $typePrefix . $variadic . '$' . $p->getName();
+            },
+            $refInvoke->getParameters(),
+        );
+
+        return implode(', ', $args);
+    }
+
+    /**
+     * Renders an indented `@param`/`@return` docblock for the wrapper method, or ''
+     * when no type information exists (so untyped fns keep their previous output).
+     */
+    private function buildDocBlock(ReflectionMethod $refInvoke, ?string $returnTag): string
+    {
+        $docLines = [];
+        $knowsAnyType = false;
+
+        foreach ($refInvoke->getParameters() as $param) {
+            $paramType = $this->typeToString($param->getType());
+            $knowsAnyType = $knowsAnyType || $paramType !== 'mixed';
+            $variadicPrefix = $param->isVariadic() ? '...' : '';
+            $docLines[] = sprintf('@param %s %s$%s', $paramType, $variadicPrefix, $param->getName());
+        }
+
+        $returnDocType = $this->returnDocType($refInvoke, $returnTag);
+        $knowsAnyType = $knowsAnyType || $returnDocType !== 'mixed';
+
+        if (!$knowsAnyType) {
+            return '';
+        }
+
+        $docLines[] = '@return ' . $returnDocType;
+
+        return "    /**\n"
+            . implode('', array_map(
+                static fn(string $line): string => '     * ' . $line . "\n",
+                $docLines,
+            ))
+            . "     */\n";
+    }
+
+    private function returnDocType(ReflectionMethod $refInvoke, ?string $returnTag): string
+    {
+        $reflected = $this->typeToString($refInvoke->getReturnType());
+
+        // Multi-arity fns compile to an untyped `__invoke(...$args)`; their return
+        // `:tag` survives only in the definition metadata.
+        if ($reflected === 'mixed' && $returnTag !== null) {
+            return $returnTag;
+        }
+
+        return $reflected;
+    }
+
+    private function typeToString(?ReflectionType $type): string
+    {
+        return $type instanceof ReflectionType ? (string) $type : 'mixed';
+    }
+
     private function buildPhelFunctionName(string $boundTo): string
     {
         $suffix = strrchr($boundTo, '\\');
@@ -141,7 +215,7 @@ final readonly class CompiledPhpMethodBuilder
     {
         return <<<'TXT'
 
-$ATTRIBUTES$    public static function $METHOD_NAME$($ARGS$)$RETURN_TYPE$
+$DOC_BLOCK$$ATTRIBUTES$    public static function $METHOD_NAME$($SIGNATURE_ARGS$)$RETURN_TYPE$
     {
         return self::callPhel('$PHEL_NAMESPACE$', '$PHEL_FUNCTION_NAME$', $ARGS$);
     }

--- a/src/php/Interop/Domain/ReadModel/FunctionToExport.php
+++ b/src/php/Interop/Domain/ReadModel/FunctionToExport.php
@@ -9,12 +9,15 @@ use Phel\Lang\FnInterface;
 final readonly class FunctionToExport
 {
     /**
-     * @param mixed $attributes the `:php/attr` metadata spec (a vector of
-     *                          attribute specs), or null when none is present
+     * @param mixed       $attributes the `:php/attr` metadata spec (a vector of
+     *                                attribute specs), or null when none is present
+     * @param string|null $returnTag  the return-type `:tag` string from the definition
+     *                                metadata, or null when the fn is untagged
      */
     public function __construct(
         private FnInterface $fn,
         private mixed $attributes = null,
+        private ?string $returnTag = null,
     ) {}
 
     public function fn(): FnInterface
@@ -25,5 +28,10 @@ final readonly class FunctionToExport
     public function attributes(): mixed
     {
         return $this->attributes;
+    }
+
+    public function returnTag(): ?string
+    {
+        return $this->returnTag;
     }
 }

--- a/tests/php/Integration/Interop/Command/Export/ExportCommandTest.php
+++ b/tests/php/Integration/Interop/Command/Export/ExportCommandTest.php
@@ -54,6 +54,29 @@ final class ExportCommandTest extends TestCase
         $adder = (string) file_get_contents(__DIR__ . '/PhelGenerated/TestCmdExportMultiple/Adder.php');
         self::assertStringContainsString("#[\\My\\Routing\\Route('/add')]", $adder);
         self::assertSame(5, Adder::adder3(2, 3));
+
+        // `:tag` metadata becomes native parameter/return types plus a docblock
+        $expectedTypedAdder = <<<'TXT'
+    /**
+     * @param int $a
+     * @param int $b
+     * @return int
+     */
+    public static function typedAdder(int $a, int $b): int
+TXT;
+        self::assertStringContainsString($expectedTypedAdder, $adder);
+        self::assertSame(5, Adder::typedAdder(2, 3));
+
+        // multi-arity fns stay natively untyped but keep the return :tag in the docblock
+        $expectedMultiAdder = <<<'TXT'
+    /**
+     * @param mixed ...$args
+     * @return int
+     */
+    public static function multiAdder(...$args): mixed
+TXT;
+        self::assertStringContainsString($expectedMultiAdder, $adder);
+        self::assertSame(7, Adder::multiAdder(3, 4));
     }
 
     private function stubOutput(): OutputInterface

--- a/tests/php/Integration/Interop/Command/Export/src/test-cmd-export-multiple/adder.phel
+++ b/tests/php/Integration/Interop/Command/Export/src/test-cmd-export-multiple/adder.phel
@@ -15,3 +15,13 @@
    :php/attr [[:My.Routing/Route "/add"]]}
   [a b]
   (php/+ a b))
+
+(defn ^int typed-adder
+  {:export true}
+  [^int a ^int b]
+  (php/+ a b))
+
+(defn ^int multi-adder
+  {:export true}
+  ([^int a] a)
+  ([^int a ^int b] (php/+ a b)))

--- a/tests/php/Unit/Interop/Generator/CompiledPhpMethodBuilderTest.php
+++ b/tests/php/Unit/Interop/Generator/CompiledPhpMethodBuilderTest.php
@@ -86,6 +86,106 @@ final class CompiledPhpMethodBuilderTest extends TestCase
         self::assertStringContainsString(': mixed', $result);
     }
 
+    public function test_renders_typed_params_in_signature_and_docblock(): void
+    {
+        $functionToExport = new FunctionToExport(new class() implements FnInterface {
+            public const BOUND_TO = 'test_ns\\typed_params';
+
+            public function __invoke(int $a, ?string $b): int
+            {
+                return $a;
+            }
+        });
+
+        $result = $this->methodBuilder->build('test_ns', $functionToExport);
+
+        self::assertStringContainsString('public static function typedParams(int $a, ?string $b): int', $result);
+        self::assertStringContainsString(" * @param int \$a\n", $result);
+        self::assertStringContainsString(" * @param ?string \$b\n", $result);
+        self::assertStringContainsString(" * @return int\n", $result);
+        self::assertStringContainsString("callPhel('test-ns', 'typed-params', \$a, \$b)", $result);
+    }
+
+    public function test_renders_typed_variadic_param(): void
+    {
+        $functionToExport = new FunctionToExport(new class() implements FnInterface {
+            public const BOUND_TO = 'test_ns\\typed_variadic';
+
+            public function __invoke(string $glue, int ...$nums): string
+            {
+                return $glue . implode($glue, $nums);
+            }
+        });
+
+        $result = $this->methodBuilder->build('test_ns', $functionToExport);
+
+        self::assertStringContainsString('public static function typedVariadic(string $glue, int ...$nums): string', $result);
+        self::assertStringContainsString(' * @param int ...$nums', $result);
+        self::assertStringContainsString("callPhel('test-ns', 'typed-variadic', \$glue, ...\$nums)", $result);
+    }
+
+    public function test_skips_docblock_when_no_type_information_exists(): void
+    {
+        $functionToExport = new FunctionToExport(new class() implements FnInterface {
+            public const BOUND_TO = 'test_ns\\untyped';
+
+            public function __invoke($a, ...$rest)
+            {
+                return $a;
+            }
+        });
+
+        $result = $this->methodBuilder->build('test_ns', $functionToExport);
+
+        self::assertStringNotContainsString('/**', $result);
+        self::assertStringContainsString('public static function untyped($a, ...$rest): mixed', $result);
+    }
+
+    public function test_return_tag_from_meta_fills_docblock_for_untyped_invoke(): void
+    {
+        // multi-arity fns compile to an untyped `__invoke(...$args)`; the return
+        // :tag survives only in the definition metadata
+        $functionToExport = new FunctionToExport(
+            new class() implements FnInterface {
+                public const BOUND_TO = 'test_ns\\multi_arity';
+
+                public function __invoke(...$args)
+                {
+                    return $args[0] ?? null;
+                }
+            },
+            null,
+            'int',
+        );
+
+        $result = $this->methodBuilder->build('test_ns', $functionToExport);
+
+        self::assertStringContainsString('public static function multiArity(...$args): mixed', $result);
+        self::assertStringContainsString(' * @param mixed ...$args', $result);
+        self::assertStringContainsString(' * @return int', $result);
+    }
+
+    public function test_native_return_type_wins_over_return_tag_in_docblock(): void
+    {
+        $functionToExport = new FunctionToExport(
+            new class() implements FnInterface {
+                public const BOUND_TO = 'test_ns\\native_return';
+
+                public function __invoke(): string
+                {
+                    return '';
+                }
+            },
+            null,
+            'string',
+        );
+
+        $result = $this->methodBuilder->build('test_ns', $functionToExport);
+
+        self::assertStringContainsString(' * @return string', $result);
+        self::assertStringContainsString('(): string', $result);
+    }
+
     public function test_renders_php_attributes_above_method(): void
     {
         $typeFactory = TypeFactory::getInstance();

--- a/tests/php/Unit/Interop/Generator/WrapperGeneratorTest.php
+++ b/tests/php/Unit/Interop/Generator/WrapperGeneratorTest.php
@@ -47,7 +47,12 @@ final class FileNameExample
 {
     use PhelCallerTrait;
 
-    public static function phelFunctionExample($a, ...$b): int|float
+    /**
+     * @param int $a
+     * @param int ...$b
+     * @return int|float
+     */
+    public static function phelFunctionExample(int $a, int ...$b): int|float
     {
         return self::callPhel('custom-namespace\\file-name-example', 'phel-function-example', $a, ...$b);
     }


### PR DESCRIPTION
## 🤔 Background

Closes #2695

`phel export` generates PHP wrapper classes for fns tagged `{:export true}`, and typed-defn `:tag` metadata is already compiled into each fn's `__invoke` signature — but the generated stubs dropped the parameter types entirely and carried no docblocks, so PHP callers of Phel code lost static analysis at the boundary.

## 💡 Goal

Make exported stubs carry the type information that `:tag` metadata already provides, so PHPStan/Psalm can analyze PHP code that calls into Phel.

## 🔖 Changes

- `CompiledPhpMethodBuilder` now mirrors the compiled `__invoke`'s native parameter types (which the compiler derives from `:tag`, declared or inferred) into the wrapper signature, e.g. `typedAdder(int $a, int $b): int` instead of `typedAdder($a, $b): int`.
- Every wrapper method with any type information gets a `@param`/`@return` docblock; unknown slots are documented as `mixed`. Fns with no type information at all keep their previous docblock-free `mixed` output byte for byte.
- Multi-arity fns compile to an untyped `__invoke(...$args)`, so their return `:tag` is now threaded from the definition metadata through `FunctionToExport` (new `returnTag` field, read by `FunctionsToExportFinder`) into the docblock: the wrapper stays natively `(...$args): mixed` but documents `@return int`.
- Unit tests for typed/nullable/variadic params, the no-type-info skip, and the meta-tag fallback; the export integration test now exports typed and multi-arity fixture fns and asserts the exact generated signature + docblock (no test in the suite shells out to PHPStan, so the assertion is on stub content).
- CHANGELOG entry under Unreleased/Added; Interop module notes updated.

**v1 scope / follow-ups:**

- Per-arity `@phpstan-*` annotations for multi-arity fns (today: widest variadic signature + `@return` from the shared return `:tag`; per-param tags of individual arities are compile-time-only metadata and not available at export time).
- Generic docblock types like `list<int>` or `array<string, mixed>`: `:tag` values are currently limited to PHP-native type strings, so there is nothing richer to translate yet; once tags can express element types, the docblock (not the native signature) is where they should land.
