### PR TITLE
feat(core): add dbg macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - `with-open`: scoped resource cleanup macro; closes bound resources in reverse order even on exception (#2684)
 - `phel test --coverage=html`: self-contained HTML coverage report with line-colored .phel sources (#2692)
 - `phel export` stubs now carry native parameter/return types and `@param`/`@return` docblocks derived from `:tag` metadata (#2695)
+- `dbg`: debug macro printing `[file:line] form => value` to stderr and returning the value (#2687)
 
 ### Fixed
 

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -3,10 +3,12 @@
 (use InvalidArgumentException)
 (use Phel)
 (use Phel.Lang.Seq)
+(use Phel.Lang.SourceLocationInterface)
 (use Phel.Shared.Printer.Printer)
 
 ;; I/O: stdout/formatting (`print`, `println`, `pr`, `prn`, `print-str`,
-;; `format`, `printf`, `with-output-buffer`); file helpers (`slurp`, `spit`,
+;; `format`, `printf`, `with-output-buffer`); stderr debugging (`dbg`,
+;; `dbg-write`); file helpers (`slurp`, `spit`,
 ;; `line-seq`, `file-seq`, `read-file-lazy`, `csv-seq`, `with-open`); and regex helpers
 ;; (`re-pattern`, `re-seq`, `re-find`, `re-matches`). Everything here touches
 ;; the outside world — pure code belongs elsewhere.
@@ -63,6 +65,38 @@
   [fmt & xs]
   (apply php/printf fmt xs)
   nil)
+
+(defn dbg-write
+  "Writes `message` to the standard error stream. Output primitive behind the `dbg` macro; redefine it with `with-redefs` to capture debug output in tests."
+  {:example "(dbg-write \"debug line\\n\")"
+   :see-also ["dbg"]}
+  [message]
+  ;; fopen instead of the STDERR constant: STDERR only exists in the CLI SAPI.
+  (let [stderr-handle (php/fopen "php://stderr" "w")]
+    (php/fwrite stderr-handle message)
+    (php/fclose stderr-handle))
+  nil)
+
+(defn- dbg-location-str [form]
+  (if (php/instanceof form SourceLocationInterface)
+    (let [start-loc (php/-> form (getStartLocation))]
+      (if start-loc
+        (str (php/-> start-loc (getFile)) ":" (php/-> start-loc (getLine)))
+        "unknown"))
+    "unknown"))
+
+(defmacro dbg
+  "Prints `[file:line] form => value` to the standard error stream and returns the value unchanged, so it can wrap any subexpression without restructuring code. With no argument prints just `[file:line]` as a reached-here marker and returns nil."
+  {:example "(defn area [w h] (* (dbg w) h))\n(area 3 4) ; stderr: [src/main.phel:12] w => 3"
+   :see-also ["tap>" "println" "dbg-write"]}
+  ([]
+   `(dbg-write ~(str "[" (dbg-location-str &form) "]\n")))
+  ([expr]
+   `(let [value# ~expr]
+      (dbg-write (str ~(str "[" (dbg-location-str &form) "] " (print-str expr) " => ")
+                      (print-str value#)
+                      "\n"))
+      value#)))
 
 ;; ---------------
 ;; File operations

--- a/tests/phel/core/print-operation.phel
+++ b/tests/phel/core/print-operation.phel
@@ -1,5 +1,6 @@
 (ns phel-test.core.print-operation
-  (:require phel.test :refer [deftest is]))
+  (:require phel.test :refer [deftest is])
+  (:require phel.string :as s))
 
 (deftest test-str
   (is (= "" (str)) "str with no arg")
@@ -68,3 +69,33 @@
 
 (deftest test-printf
   (is (output? "hello\nworld" (printf "%s\n%s" "hello" "world")) "printf hello\\nworld"))
+
+(deftest test-dbg-returns-value
+  (with-redefs [dbg-write (fn [_] nil)]
+    (is (= 3 (dbg (+ 1 2))) "dbg returns the evaluated value")
+    (is (nil? (dbg nil)) "dbg passes nil through")
+    (is (nil? (dbg)) "zero-arg dbg returns nil")))
+
+(deftest test-dbg-evaluates-expr-once
+  (with-redefs [dbg-write (fn [_] nil)]
+    (let [eval-count (atom 0)]
+      (is (= 1 (dbg (swap! eval-count inc))) "returns the side-effecting expr value")
+      (is (= 1 (deref eval-count)) "expr is evaluated exactly once"))))
+
+(deftest test-dbg-output-format
+  (let [captured (atom nil)]
+    (with-redefs [dbg-write (fn [message] (reset! captured message) nil)]
+      (dbg (+ 1 2)))
+    (let [message (deref captured)]
+      (is (= true (s/starts-with? message "[")) "dbg output starts with the location prefix")
+      (is (= true (s/contains? message "print-operation.phel:")) "dbg output contains the source file")
+      (is (= true (s/contains? message "(+ 1 2) => 3")) "dbg output contains form and value")
+      (is (= true (s/ends-with? message "\n")) "dbg output ends with a newline"))))
+
+(deftest test-dbg-zero-arg-prints-location-marker
+  (let [captured (atom nil)]
+    (with-redefs [dbg-write (fn [message] (reset! captured message) nil)]
+      (dbg))
+    (let [message (deref captured)]
+      (is (= true (s/contains? message "print-operation.phel:")) "marker contains the source file")
+      (is (= true (s/ends-with? message "]\n")) "marker is just the bracketed location"))))


### PR DESCRIPTION
## 🤔 Background

Closes #2687

The current debugging story is `println`/`tap>`, neither of which shows *where* a print came from or *what expression* produced the value. Rust's `dbg!` solves this with a wrap-look-unwrap macro that prints location, source form, and value while returning the value unchanged.

## 💡 Goal

Add a `dbg` macro to `phel\core` that prints `[file:line] form => value` to stderr and returns the value, so any subexpression can be wrapped without restructuring code.

## 🔖 Changes

- `dbg` macro in `src/phel/core/io.phel` (Print operation section, next to `print-str`/`printf` — it is a printing tool, unlike the tap registry in `tap.phel`):
  - `(dbg expr)` prints `[file:line] <source form> => <printed value>` to stderr and returns the value. The expression is evaluated exactly once (bound to an auto-gensym in the expansion).
  - `(dbg)` prints just `[file:line]` as a reached-here marker and returns nil.
  - `file:line` comes from the start location of `&form` (the implicit call-form parameter every `defmacro` receives), read the same way `phel.test`'s `is` reports assertion locations. Forms without a location (e.g. programmatically built) print `[unknown]`; REPL input prints the reader's honest `[string:1]`.
  - Form and value are rendered with `print-str`, matching the issue example (`w => 3`).
- `dbg-write`, a small public output primitive that writes to stderr via `php/fopen "php://stderr"` (the `STDERR` constant only exists in the CLI SAPI). Public so the macro expansion resolves in user namespaces and so tests (or users) can capture debug output with `with-redefs`.
- Tests in `tests/phel/core/print-operation.phel`: value passthrough (incl. nil and zero-arg), single evaluation of a side-effecting expression, output format (location prefix, source file, `form => value`, trailing newline), and the zero-arg location marker — output captured by redefining `dbg-write`, since `output?` only buffers stdout.
- CHANGELOG entry under `## Unreleased` / `### Added`.
