### PR TITLE
fix(core): truncate subvec indices toward zero like Clojure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - `gcd` and `lcm`: greatest common divisor and least common multiple for integers (#2686)
 - `trampoline`: stack-safe mutual recursion by bouncing returned thunks (#2682)
 - `reductions`: sequence of intermediate reduce values, with and without init (#2681)
-- `subvec`: persistent vector slice with start/end bounds checking (#2683)
+- `subvec`: persistent vector slice with start/end bounds checking; non-integer indices truncate toward zero and `NaN` counts as `0`, matching Clojure (#2683)
 - `arity` and `variadic?`: function reflection helpers for required parameter count and variadic detection (#2685)
 - `inspect`: pretty-prints a value (colored on TTY) and returns it unchanged for pipeline debugging (#2688)
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -19,7 +19,10 @@
 (use Phel.Lang.Equalizer)
 (use Phel.Lang.Hasher)
 (use Phel.Lang.NumericOperations)
+(use Phel.Lang.BigDecimal)
+(use Phel.Lang.BigInt)
 (use Phel.Lang.PushInterface)
+(use Phel.Lang.Ratio)
 (use Phel.Lang.Seq)
 (use Phel.Lang.SliceInterface)
 
@@ -250,14 +253,22 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
     (php/instanceof coll SliceInterface) (php/-> coll (slice offset length))
     (throw (php/new InvalidArgumentException "Cannot slice"))))
 
-;; Clojure truncates subvec indices toward zero (NaN counts as 0); core `int`
-;; is not defined yet at this load point, so coerce with PHP primitives.
+;; Clojure's subvec runs indices through RT.intCast: numbers truncate toward
+;; zero, NaN counts as 0, ±Inf collapses to int min/max (then fails bounds),
+;; and non-numbers throw. Core `int` is not defined yet at this load point,
+;; so coerce with PHP primitives.
 (defn- subvec-index [x]
   (cond
-    (php/is_int x)    x
-    (php/is_float x)  (if (php/is_nan x) 0 (php/intval x))
-    (php/is_object x) (php/-> x (toInt))
-    true              (php/intval x)))
+    (php/is_int x)   x
+    (php/is_float x) (cond
+                       (php/is_nan x)      0
+                       (php/is_infinite x) (if (php/< x 0) php/PHP_INT_MIN php/PHP_INT_MAX)
+                       true                (php/intval x))
+    (or (php/instanceof x Ratio)
+        (php/instanceof x BigInt)
+        (php/instanceof x BigDecimal)) (php/-> x (toInt))
+    true (throw (php/new InvalidArgumentException
+                         (str "subvec index must be a number, got " (type x))))))
 
 (defn subvec
   "Returns a persistent vector of the items in `v` from `start` (inclusive) to `end` (exclusive). `end` defaults to `(count v)`. Non-integer indices truncate toward zero and `NaN` counts as `0`, matching Clojure. The result shares structure with `v`. Throws an OutOfBoundsException when `start` or `end` is out of range or `start` is greater than `end`."

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -250,15 +250,26 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
     (php/instanceof coll SliceInterface) (php/-> coll (slice offset length))
     (throw (php/new InvalidArgumentException "Cannot slice"))))
 
+;; Clojure truncates subvec indices toward zero (NaN counts as 0); core `int`
+;; is not defined yet at this load point, so coerce with PHP primitives.
+(defn- subvec-index [x]
+  (cond
+    (php/is_int x)    x
+    (php/is_float x)  (if (php/is_nan x) 0 (php/intval x))
+    (php/is_object x) (php/-> x (toInt))
+    true              (php/intval x)))
+
 (defn subvec
-  "Returns a persistent vector of the items in `v` from `start` (inclusive) to `end` (exclusive). `end` defaults to `(count v)`. The result shares structure with `v`. Throws an OutOfBoundsException when `start` or `end` is out of range or `start` is greater than `end`."
+  "Returns a persistent vector of the items in `v` from `start` (inclusive) to `end` (exclusive). `end` defaults to `(count v)`. Non-integer indices truncate toward zero and `NaN` counts as `0`, matching Clojure. The result shares structure with `v`. Throws an OutOfBoundsException when `start` or `end` is out of range or `start` is greater than `end`."
   {:example "(subvec [1 2 3 4 5] 1 3) ; => [2 3]\n(subvec [1 2 3 4 5] 2) ; => [3 4 5]"
    :see-also ["slice" "take" "drop"]}
   ([v start] (subvec v start (count v)))
   ([v start end]
    (when-not (php/instanceof v PersistentVectorInterface)
      (throw (php/new InvalidArgumentException (str "Cannot subvec on type " (type v)))))
-   (let [cnt (count v)]
+   (let [cnt   (count v)
+         start (subvec-index start)
+         end   (subvec-index end)]
      (when (or (< start 0) (> end cnt) (> start end))
        (throw (php/new OutOfBoundsException
                        (str "subvec bounds [" start ", " end ") out of range for vector of count " cnt))))

--- a/tests/phel/core/sequence-operation.phel
+++ b/tests/phel/core/sequence-operation.phel
@@ -272,6 +272,11 @@
   (is (thrown? \OutOfBoundsException (subvec [1 2 3] 4)) "start beyond count throws")
   (is (thrown? \OutOfBoundsException (subvec [1 2 3] 2 1)) "start greater than end throws")
   (is (thrown? \InvalidArgumentException (subvec '(1 2 3) 0)) "subvec on a list throws")
+  (is (= [] (subvec [0 1 2] ##NaN ##NaN)) "NaN indices count as 0")
+  (is (= [0 1 2] (subvec [0 1 2] ##NaN 3)) "NaN start counts as 0")
+  (is (= [] (subvec [0 1 2] 0 ##NaN)) "NaN end counts as 0")
+  (is (= [2] (subvec [0 1 2] 2.72 3.14)) "float indices truncate toward zero")
+  (is (= [0] (subvec [0 1 2] 1/2 4/3)) "ratio indices truncate toward zero")
   (let [v   [1 2 3 4 5]
         sub (subvec v 1 3)]
     (is (= [2 3] sub) "subvec slices the vector")

--- a/tests/phel/core/sequence-operation.phel
+++ b/tests/phel/core/sequence-operation.phel
@@ -277,6 +277,15 @@
   (is (= [] (subvec [0 1 2] 0 ##NaN)) "NaN end counts as 0")
   (is (= [2] (subvec [0 1 2] 2.72 3.14)) "float indices truncate toward zero")
   (is (= [0] (subvec [0 1 2] 1/2 4/3)) "ratio indices truncate toward zero")
+  (is (thrown? \InvalidArgumentException (subvec [] nil 0)) "nil start throws")
+  (is (thrown? \InvalidArgumentException (subvec [0 1 2] 1 nil)) "nil end throws")
+  (is (thrown? \InvalidArgumentException (subvec [0 1 2] :a 2)) "keyword start throws")
+  (is (thrown? \InvalidArgumentException (subvec [0 1 2] 1 :b)) "keyword end throws")
+  (is (thrown? \InvalidArgumentException (subvec [0 1 2] 'c 'd)) "symbol indices throw")
+  (is (thrown? \InvalidArgumentException (subvec [0 1 2] "a" "b")) "string indices throw")
+  (is (thrown? \InvalidArgumentException (subvec [0 1 2] [] {})) "collection indices throw")
+  (is (thrown? \OutOfBoundsException (subvec [0 1 2 3] ##-Inf 4)) "negative infinity start is out of bounds")
+  (is (thrown? \OutOfBoundsException (subvec [0 1 2 3] 0 ##Inf)) "positive infinity end is out of bounds")
   (let [v   [1 2 3 4 5]
         sub (subvec v 1 3)]
     (is (= [2 3] sub) "subvec slices the vector")


### PR DESCRIPTION
## 🤔 Background

The clojure-test-suite required check turned red on main after #2702: `subvec` passed raw indices to the typed PHP `slice()` method, so `(subvec [0 1 2] NaN NaN)`, float indices like `2.72`, and ratio indices like `1/2` threw `TypeError` instead of matching Clojure, which truncates indices toward zero (with NaN counting as 0).

Relates to #2683.

## 💡 Goal

Restore Clojure-aligned index semantics and turn the clojure-test-suite check green again.

## 🔖 Changes

- `subvec` coerces `start`/`end` through a private `subvec-index` helper before validation: ints pass through, `NaN` becomes 0, floats truncate via `intval`, `Ratio`/`BigInt`/`BigDecimal` truncate via their `toInt` — implemented with PHP primitives because core `int` is not yet loaded at seq-fns load order
- Tests for the exact suite cases: `NaN`/`NaN`, `NaN`/3, 0/`NaN`, `2.72`/`3.14`, `1/2`/`4/3`
- CHANGELOG bullet for #2683 extended with the truncation semantics