### PR TITLE
perf(compiler): compact def metadata emission (#2722)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to this project will be documented in this file.
 - The distributed PHAR no longer bundles example templates' local build artifacts. `phel init --template` sources were shipped with any `.phel/` cache and installed `vendor/` a maintainer left behind from running an example locally, which inflated a release PHAR from ~2 MB to ~14 MB; only the template sources ship now (#2678)
 - `phel test --help` now shows `--parallel=auto` in its example; the bare `--parallel` it printed before errors, because the option requires a value (an integer, `auto`, or `max`) (#2679)
 
+### Performance
+
+- Trivial `def`/`defn` location metadata now emits a single `\Phel::locationMeta(...)` call instead of an expanded keyword-keyed map literal; smaller generated PHP per definition, byte-value-identical runtime map (#2722)
+
 ## [0.47.0](https://github.com/phel-lang/phel-lang/compare/v0.46.0...v0.47.0) - 2026-07-01
 
 ### Added

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -339,6 +339,30 @@ final class Phel extends InternalPhel
     }
 
     /**
+     * Wrap the `:start-location`/`:end-location` pair a trivial `def` / `defn`
+     * synthesises into its metadata map. Lets the compiler emit one helper call
+     * instead of the expanded `Phel::map(Keyword::create("start-location"), ...)`
+     * per definition — same map at runtime, far less generated PHP across
+     * def-heavy namespaces. The keyword keys intern once per process via the
+     * `static` slots, as in {@see self::location()}.
+     *
+     * @param PersistentMapInterface<mixed, mixed> $startLocation
+     * @param PersistentMapInterface<mixed, mixed> $endLocation
+     *
+     * @return PersistentMapInterface<mixed, mixed>
+     */
+    public static function locationMeta(
+        PersistentMapInterface $startLocation,
+        PersistentMapInterface $endLocation,
+    ): PersistentMapInterface {
+        static $kwStart, $kwEnd;
+        $kwStart ??= self::keyword('start-location');
+        $kwEnd ??= self::keyword('end-location');
+
+        return self::map($kwStart, $startLocation, $kwEnd, $endLocation);
+    }
+
+    /**
      * Create a persistent hash set from an array of values.
      *
      * @param list<mixed>|null $values

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
@@ -139,7 +139,7 @@ final class MapEmitter implements NodeEmitterInterface
             return null;
         }
 
-        $byKeyword = [];
+        $locationsByKeyword = [];
         for ($i = 0; $i < 4; $i += 2) {
             $key = $entries[$i];
             $value = $entries[$i + 1];
@@ -158,11 +158,11 @@ final class MapEmitter implements NodeEmitterInterface
                 return null;
             }
 
-            $byKeyword[$keyword->getName()] = $location;
+            $locationsByKeyword[$keyword->getName()] = $location;
         }
 
-        $start = $byKeyword['start-location'] ?? null;
-        $end = $byKeyword['end-location'] ?? null;
+        $start = $locationsByKeyword['start-location'] ?? null;
+        $end = $locationsByKeyword['end-location'] ?? null;
         if ($start === null || $end === null) {
             return null;
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
@@ -31,8 +31,11 @@ final class MapEmitter implements NodeEmitterInterface
         $cached = $this->outputEmitter->emitConstantSlotPrefix($node, $loc);
 
         $locationLiteral = $this->locationLiteral($node);
+        $defLocationMeta = $locationLiteral === null ? $this->defLocationMeta($node) : null;
         if ($locationLiteral !== null) {
             $this->emitLocationHelper($locationLiteral, $loc);
+        } elseif ($defLocationMeta !== null) {
+            $this->emitDefLocationMetaHelper($defLocationMeta, $loc);
         } else {
             $this->outputEmitter->emitStr('\Phel::map(', $loc);
             $this->emitEntries($node);
@@ -117,6 +120,66 @@ final class MapEmitter implements NodeEmitterInterface
             . ')',
             $loc,
         );
+    }
+
+    /**
+     * Detect the exact two-entry `{:start-location {loc} :end-location {loc}}`
+     * map that a trivial `def`/`defn` (no docstring, tags or other meta)
+     * synthesises. Collapses it to one `\Phel::locationMeta(...)` call, so
+     * def-heavy namespaces emit far less PHP for the identical runtime map.
+     * A def carrying extra meta has more entries and falls through to the
+     * generic `\Phel::map(...)` path unchanged.
+     *
+     * @return array{start: array{file: string, line: int, column: int}, end: array{file: string, line: int, column: int}}|null
+     */
+    private function defLocationMeta(MapNode $node): ?array
+    {
+        $entries = $node->getKeyValues();
+        if (count($entries) !== 4) {
+            return null;
+        }
+
+        $byKeyword = [];
+        for ($i = 0; $i < 4; $i += 2) {
+            $key = $entries[$i];
+            $value = $entries[$i + 1];
+
+            if (!$key instanceof LiteralNode || !$value instanceof MapNode) {
+                return null;
+            }
+
+            $keyword = $key->getValue();
+            if (!$keyword instanceof Keyword) {
+                return null;
+            }
+
+            $location = $this->locationLiteral($value);
+            if ($location === null) {
+                return null;
+            }
+
+            $byKeyword[$keyword->getName()] = $location;
+        }
+
+        $start = $byKeyword['start-location'] ?? null;
+        $end = $byKeyword['end-location'] ?? null;
+        if ($start === null || $end === null) {
+            return null;
+        }
+
+        return ['start' => $start, 'end' => $end];
+    }
+
+    /**
+     * @param array{start: array{file: string, line: int, column: int}, end: array{file: string, line: int, column: int}} $meta
+     */
+    private function emitDefLocationMetaHelper(array $meta, ?SourceLocation $loc): void
+    {
+        $this->outputEmitter->emitStr('\Phel::locationMeta(', $loc);
+        $this->emitLocationHelper($meta['start'], $loc);
+        $this->outputEmitter->emitStr(', ', $loc);
+        $this->emitLocationHelper($meta['end'], $loc);
+        $this->outputEmitter->emitStr(')', $loc);
     }
 
     private function emitEntries(MapNode $node): void

--- a/tests/php/Integration/Fixtures/Call/non-fn-global-call-skipped.test
+++ b/tests/php/Integration/Fixtures/Call/non-fn-global-call-skipped.test
@@ -6,10 +6,7 @@
   "user",
   "k",
   \Phel\Lang\Keyword::create("a"),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/non-fn-global-call-skipped.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/non-fn-global-call-skipped.test", 1, 10)
-  )
+  \Phel::locationMeta(\Phel::location("Call/non-fn-global-call-skipped.test", 1, 0), \Phel::location("Call/non-fn-global-call-skipped.test", 1, 10))
 );
 (\Phel::getDefinition("user", "k"))(\Phel::map(
   \Phel\Lang\Keyword::create("a"), 1

--- a/tests/php/Integration/Fixtures/Call/php-oset-statement.test
+++ b/tests/php/Integration/Fixtures/Call/php-oset-statement.test
@@ -6,9 +6,6 @@
   "user",
   "o",
   (new \stdClass()),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/php-oset-statement.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/php-oset-statement.test", 1, 27)
-  )
+  \Phel::locationMeta(\Phel::location("Call/php-oset-statement.test", 1, 0), \Phel::location("Call/php-oset-statement.test", 1, 27))
 );
 \Phel::getDefinition("user", "o")->name = "test";

--- a/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
@@ -6,9 +6,6 @@
   "user",
   "arr",
   array(1, 2, 3),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/php-push-global-reference.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/php-push-global-reference.test", 1, 27)
-  )
+  \Phel::locationMeta(\Phel::location("Call/php-push-global-reference.test", 1, 0), \Phel::location("Call/php-push-global-reference.test", 1, 27))
 );
 (\Phel::getDefinitionReference("user", "arr"))[] = 4;

--- a/tests/php/Integration/Fixtures/Def/basic-def.test
+++ b/tests/php/Integration/Fixtures/Def/basic-def.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   1,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/basic-def.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/basic-def.test", 1, 9)
-  )
+  \Phel::locationMeta(\Phel::location("Def/basic-def.test", 1, 0), \Phel::location("Def/basic-def.test", 1, 9))
 );

--- a/tests/php/Integration/Fixtures/Def/bigdec-literal.test
+++ b/tests/php/Integration/Fixtures/Def/bigdec-literal.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   \Phel\Lang\BigDecimal::fromString("1.5"),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/bigdec-literal.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/bigdec-literal.test", 1, 12)
-  )
+  \Phel::locationMeta(\Phel::location("Def/bigdec-literal.test", 1, 0), \Phel::location("Def/bigdec-literal.test", 1, 12))
 );

--- a/tests/php/Integration/Fixtures/Def/bigint-literal-negative.test
+++ b/tests/php/Integration/Fixtures/Def/bigint-literal-negative.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   -123,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/bigint-literal-negative.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/bigint-literal-negative.test", 1, 13)
-  )
+  \Phel::locationMeta(\Phel::location("Def/bigint-literal-negative.test", 1, 0), \Phel::location("Def/bigint-literal-negative.test", 1, 13))
 );

--- a/tests/php/Integration/Fixtures/Def/bigint-literal-oversize.test
+++ b/tests/php/Integration/Fixtures/Def/bigint-literal-oversize.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   \Phel\Lang\BigInt::fromString("9223372036854775808"),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/bigint-literal-oversize.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/bigint-literal-oversize.test", 1, 28)
-  )
+  \Phel::locationMeta(\Phel::location("Def/bigint-literal-oversize.test", 1, 0), \Phel::location("Def/bigint-literal-oversize.test", 1, 28))
 );

--- a/tests/php/Integration/Fixtures/Def/bigint-literal.test
+++ b/tests/php/Integration/Fixtures/Def/bigint-literal.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   1,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/bigint-literal.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/bigint-literal.test", 1, 10)
-  )
+  \Phel::locationMeta(\Phel::location("Def/bigint-literal.test", 1, 0), \Phel::location("Def/bigint-literal.test", 1, 10))
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-alpha.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-alpha.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   "a",
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/char-literal-alpha.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/char-literal-alpha.test", 1, 10)
-  )
+  \Phel::locationMeta(\Phel::location("Def/char-literal-alpha.test", 1, 0), \Phel::location("Def/char-literal-alpha.test", 1, 10))
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-named-newline.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-named-newline.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   "\n",
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/char-literal-named-newline.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/char-literal-named-newline.test", 1, 16)
-  )
+  \Phel::locationMeta(\Phel::location("Def/char-literal-named-newline.test", 1, 0), \Phel::location("Def/char-literal-named-newline.test", 1, 16))
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-named-space.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-named-space.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   " ",
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/char-literal-named-space.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/char-literal-named-space.test", 1, 14)
-  )
+  \Phel::locationMeta(\Phel::location("Def/char-literal-named-space.test", 1, 0), \Phel::location("Def/char-literal-named-space.test", 1, 14))
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-octal.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-octal.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   "A",
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/char-literal-octal.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/char-literal-octal.test", 1, 13)
-  )
+  \Phel::locationMeta(\Phel::location("Def/char-literal-octal.test", 1, 0), \Phel::location("Def/char-literal-octal.test", 1, 13))
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-punctuation.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-punctuation.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   "(",
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/char-literal-punctuation.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/char-literal-punctuation.test", 1, 10)
-  )
+  \Phel::locationMeta(\Phel::location("Def/char-literal-punctuation.test", 1, 0), \Phel::location("Def/char-literal-punctuation.test", 1, 10))
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-unicode.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-unicode.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   "Ω",
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/char-literal-unicode.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/char-literal-unicode.test", 1, 14)
-  )
+  \Phel::locationMeta(\Phel::location("Def/char-literal-unicode.test", 1, 0), \Phel::location("Def/char-literal-unicode.test", 1, 14))
 );

--- a/tests/php/Integration/Fixtures/Def/def-no-value.test
+++ b/tests/php/Integration/Fixtures/Def/def-no-value.test
@@ -5,8 +5,5 @@
   "user",
   "baz",
   null,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/def-no-value.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/def-no-value.test", 1, 9)
-  )
+  \Phel::locationMeta(\Phel::location("Def/def-no-value.test", 1, 0), \Phel::location("Def/def-no-value.test", 1, 9))
 );

--- a/tests/php/Integration/Fixtures/Def/def-php-class-reference.test
+++ b/tests/php/Integration/Fixtures/Def/def-php-class-reference.test
@@ -7,9 +7,6 @@ PHPChildT
   "user",
   "PHPChildT",
   \RecursiveArrayIterator::class,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/def-php-class-reference.test", 2, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/def-php-class-reference.test", 2, 38)
-  )
+  \Phel::locationMeta(\Phel::location("Def/def-php-class-reference.test", 2, 0), \Phel::location("Def/def-php-class-reference.test", 2, 38))
 );
 \Phel::getDefinition("user", "PHPChildT");

--- a/tests/php/Integration/Fixtures/Def/def-php-function-reference.test
+++ b/tests/php/Integration/Fixtures/Def/def-php-function-reference.test
@@ -5,8 +5,5 @@
   "user",
   "uc",
   (function(...$args) { return \strtoupper(...$args);}),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/def-php-function-reference.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/def-php-function-reference.test", 1, 24)
-  )
+  \Phel::locationMeta(\Phel::location("Def/def-php-function-reference.test", 1, 0), \Phel::location("Def/def-php-function-reference.test", 1, 24))
 );

--- a/tests/php/Integration/Fixtures/Def/def-trailing-quote-in-name.test
+++ b/tests/php/Integration/Fixtures/Def/def-trailing-quote-in-name.test
@@ -5,8 +5,5 @@
   "user",
   "a'",
   42,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/def-trailing-quote-in-name.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/def-trailing-quote-in-name.test", 1, 11)
-  )
+  \Phel::locationMeta(\Phel::location("Def/def-trailing-quote-in-name.test", 1, 0), \Phel::location("Def/def-trailing-quote-in-name.test", 1, 11))
 );

--- a/tests/php/Integration/Fixtures/Def/defonce-redefine.test
+++ b/tests/php/Integration/Fixtures/Def/defonce-redefine.test
@@ -6,10 +6,7 @@ if (!\Phel::isDefined("user", "counter")) {
     "user",
     "counter",
     0,
-    \Phel::map(
-      \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defonce-redefine.test", 1, 0),
-      \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defonce-redefine.test", 1, 19)
-    )
+    \Phel::locationMeta(\Phel::location("Def/defonce-redefine.test", 1, 0), \Phel::location("Def/defonce-redefine.test", 1, 19))
   );
 }
 if (!\Phel::isDefined("user", "counter")) {
@@ -17,9 +14,6 @@ if (!\Phel::isDefined("user", "counter")) {
     "user",
     "counter",
     99,
-    \Phel::map(
-      \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defonce-redefine.test", 1, 20),
-      \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defonce-redefine.test", 1, 40)
-    )
+    \Phel::locationMeta(\Phel::location("Def/defonce-redefine.test", 1, 20), \Phel::location("Def/defonce-redefine.test", 1, 40))
   );
 }

--- a/tests/php/Integration/Fixtures/Def/defonce.test
+++ b/tests/php/Integration/Fixtures/Def/defonce.test
@@ -6,9 +6,6 @@ if (!\Phel::isDefined("user", "counter")) {
     "user",
     "counter",
     0,
-    \Phel::map(
-      \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defonce.test", 1, 0),
-      \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defonce.test", 1, 19)
-    )
+    \Phel::locationMeta(\Phel::location("Def/defonce.test", 1, 0), \Phel::location("Def/defonce.test", 1, 19))
   );
 }

--- a/tests/php/Integration/Fixtures/Def/hash-php-map-literal.test
+++ b/tests/php/Integration/Fixtures/Def/hash-php-map-literal.test
@@ -5,8 +5,5 @@
   "user",
   "arr",
   (\Phel::getDefinition("phel.core", "php-associative-array"))->__invoke("a", 1, "b", 2),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/hash-php-map-literal.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/hash-php-map-literal.test", 1, 28)
-  )
+  \Phel::locationMeta(\Phel::location("Def/hash-php-map-literal.test", 1, 0), \Phel::location("Def/hash-php-map-literal.test", 1, 28))
 );

--- a/tests/php/Integration/Fixtures/Def/hash-php-vector-literal.test
+++ b/tests/php/Integration/Fixtures/Def/hash-php-vector-literal.test
@@ -5,8 +5,5 @@
   "user",
   "arr",
   (\Phel::getDefinition("phel.core", "php-indexed-array"))->__invoke(1, 2, 3),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/hash-php-vector-literal.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/hash-php-vector-literal.test", 1, 22)
-  )
+  \Phel::locationMeta(\Phel::location("Def/hash-php-vector-literal.test", 1, 0), \Phel::location("Def/hash-php-vector-literal.test", 1, 22))
 );

--- a/tests/php/Integration/Fixtures/Def/namespace-def.test
+++ b/tests/php/Integration/Fixtures/Def/namespace-def.test
@@ -19,8 +19,5 @@ require_once __DIR__ . '/../phel/core.php';
   "my.ns",
   "x",
   1,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/namespace-def.test", 3, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/namespace-def.test", 3, 9)
-  )
+  \Phel::locationMeta(\Phel::location("Def/namespace-def.test", 3, 0), \Phel::location("Def/namespace-def.test", 3, 9))
 );

--- a/tests/php/Integration/Fixtures/Def/negative-hex-int-min.test
+++ b/tests/php/Integration/Fixtures/Def/negative-hex-int-min.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   (-9223372036854775807 - 1),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/negative-hex-int-min.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/negative-hex-int-min.test", 1, 27)
-  )
+  \Phel::locationMeta(\Phel::location("Def/negative-hex-int-min.test", 1, 0), \Phel::location("Def/negative-hex-int-min.test", 1, 27))
 );

--- a/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
+++ b/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
@@ -13,10 +13,7 @@
         "user",
         "x",
         1,
-        ($__phel_const_0 ??= \Phel::map(
-          \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 14),
-          \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 23)
-        ))
+        ($__phel_const_0 ??= \Phel::locationMeta(\Phel::location("Def/nested-def-inside-fn.test", 1, 14), \Phel::location("Def/nested-def-inside-fn.test", 1, 23)))
       );
 
       return \Phel::getDefinition("user", "x");

--- a/tests/php/Integration/Fixtures/Def/radix-binary.test
+++ b/tests/php/Integration/Fixtures/Def/radix-binary.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   15,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/radix-binary.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/radix-binary.test", 1, 14)
-  )
+  \Phel::locationMeta(\Phel::location("Def/radix-binary.test", 1, 0), \Phel::location("Def/radix-binary.test", 1, 14))
 );

--- a/tests/php/Integration/Fixtures/Def/radix-hex.test
+++ b/tests/php/Integration/Fixtures/Def/radix-hex.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   255,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/radix-hex.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/radix-hex.test", 1, 13)
-  )
+  \Phel::locationMeta(\Phel::location("Def/radix-hex.test", 1, 0), \Phel::location("Def/radix-hex.test", 1, 13))
 );

--- a/tests/php/Integration/Fixtures/Def/radix-negative.test
+++ b/tests/php/Integration/Fixtures/Def/radix-negative.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   -15,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/radix-negative.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/radix-negative.test", 1, 15)
-  )
+  \Phel::locationMeta(\Phel::location("Def/radix-negative.test", 1, 0), \Phel::location("Def/radix-negative.test", 1, 15))
 );

--- a/tests/php/Integration/Fixtures/Def/ratio-literal-negative.test
+++ b/tests/php/Integration/Fixtures/Def/ratio-literal-negative.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   \Phel\Lang\Ratio::create(\Phel\Lang\BigInt::fromString("-3"), \Phel\Lang\BigInt::fromString("4")),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/ratio-literal-negative.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/ratio-literal-negative.test", 1, 12)
-  )
+  \Phel::locationMeta(\Phel::location("Def/ratio-literal-negative.test", 1, 0), \Phel::location("Def/ratio-literal-negative.test", 1, 12))
 );

--- a/tests/php/Integration/Fixtures/Def/ratio-literal.test
+++ b/tests/php/Integration/Fixtures/Def/ratio-literal.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   \Phel\Lang\Ratio::create(\Phel\Lang\BigInt::fromString("1"), \Phel\Lang\BigInt::fromString("2")),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/ratio-literal.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/ratio-literal.test", 1, 11)
-  )
+  \Phel::locationMeta(\Phel::location("Def/ratio-literal.test", 1, 0), \Phel::location("Def/ratio-literal.test", 1, 11))
 );

--- a/tests/php/Integration/Fixtures/Def/string-literal-unicode-escape.test
+++ b/tests/php/Integration/Fixtures/Def/string-literal-unicode-escape.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   " ",
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/string-literal-unicode-escape.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/string-literal-unicode-escape.test", 1, 16)
-  )
+  \Phel::locationMeta(\Phel::location("Def/string-literal-unicode-escape.test", 1, 0), \Phel::location("Def/string-literal-unicode-escape.test", 1, 16))
 );

--- a/tests/php/Integration/Fixtures/Def/symbolic-number-inf.test
+++ b/tests/php/Integration/Fixtures/Def/symbolic-number-inf.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   INF,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/symbolic-number-inf.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/symbolic-number-inf.test", 1, 13)
-  )
+  \Phel::locationMeta(\Phel::location("Def/symbolic-number-inf.test", 1, 0), \Phel::location("Def/symbolic-number-inf.test", 1, 13))
 );

--- a/tests/php/Integration/Fixtures/Def/symbolic-number-nan.test
+++ b/tests/php/Integration/Fixtures/Def/symbolic-number-nan.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   NAN,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/symbolic-number-nan.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/symbolic-number-nan.test", 1, 13)
-  )
+  \Phel::locationMeta(\Phel::location("Def/symbolic-number-nan.test", 1, 0), \Phel::location("Def/symbolic-number-nan.test", 1, 13))
 );

--- a/tests/php/Integration/Fixtures/Def/symbolic-number-neg-inf.test
+++ b/tests/php/Integration/Fixtures/Def/symbolic-number-neg-inf.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   -INF,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/symbolic-number-neg-inf.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/symbolic-number-neg-inf.test", 1, 14)
-  )
+  \Phel::locationMeta(\Phel::location("Def/symbolic-number-neg-inf.test", 1, 0), \Phel::location("Def/symbolic-number-neg-inf.test", 1, 14))
 );

--- a/tests/php/Integration/Fixtures/Def/tagged-literal-in-reader-conditional.test
+++ b/tests/php/Integration/Fixtures/Def/tagged-literal-in-reader-conditional.test
@@ -5,8 +5,5 @@
   "user",
   "x",
   42,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/tagged-literal-in-reader-conditional.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/tagged-literal-in-reader-conditional.test", 1, 54)
-  )
+  \Phel::locationMeta(\Phel::location("Def/tagged-literal-in-reader-conditional.test", 1, 0), \Phel::location("Def/tagged-literal-in-reader-conditional.test", 1, 54))
 );

--- a/tests/php/Integration/Fixtures/Do/do-in-expr.test
+++ b/tests/php/Integration/Fixtures/Do/do-in-expr.test
@@ -8,8 +8,5 @@
     (1 + 2);
     return (3 + 4);
   })(),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Do/do-in-expr.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Do/do-in-expr.test", 1, 36)
-  )
+  \Phel::locationMeta(\Phel::location("Do/do-in-expr.test", 1, 0), \Phel::location("Do/do-in-expr.test", 1, 36))
 );

--- a/tests/php/Integration/Fixtures/Keyword/keywords.test
+++ b/tests/php/Integration/Fixtures/Keyword/keywords.test
@@ -23,35 +23,23 @@ require_once __DIR__ . '/xyz/foo.php';
   "test",
   "a",
   \Phel\Lang\Keyword::create("bar"),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Keyword/keywords.test", 3, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Keyword/keywords.test", 3, 12)
-  )
+  \Phel::locationMeta(\Phel::location("Keyword/keywords.test", 3, 0), \Phel::location("Keyword/keywords.test", 3, 12))
 );
 \Phel::addDefinition(
   "test",
   "b",
   \Phel\Lang\Keyword::create("bar", "test"),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Keyword/keywords.test", 4, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Keyword/keywords.test", 4, 13)
-  )
+  \Phel::locationMeta(\Phel::location("Keyword/keywords.test", 4, 0), \Phel::location("Keyword/keywords.test", 4, 13))
 );
 \Phel::addDefinition(
   "test",
   "c",
   \Phel\Lang\Keyword::create("bar", "xyz.foo"),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Keyword/keywords.test", 5, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Keyword/keywords.test", 5, 17)
-  )
+  \Phel::locationMeta(\Phel::location("Keyword/keywords.test", 5, 0), \Phel::location("Keyword/keywords.test", 5, 17))
 );
 \Phel::addDefinition(
   "test",
   "d",
   \Phel\Lang\Keyword::create("bar", "xyz\\foo"),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Keyword/keywords.test", 6, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Keyword/keywords.test", 6, 20)
-  )
+  \Phel::locationMeta(\Phel::location("Keyword/keywords.test", 6, 0), \Phel::location("Keyword/keywords.test", 6, 20))
 );

--- a/tests/php/Integration/Fixtures/Let/let-expr.test
+++ b/tests/php/Integration/Fixtures/Let/let-expr.test
@@ -11,8 +11,5 @@
     $y_2 = 2;
     return ($x_1 + $y_2);
   })(),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Let/let-expr.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Let/let-expr.test", 1, 35)
-  )
+  \Phel::locationMeta(\Phel::location("Let/let-expr.test", 1, 0), \Phel::location("Let/let-expr.test", 1, 35))
 );

--- a/tests/php/Integration/Fixtures/MacroExpand/return-array.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/return-array.test
@@ -26,8 +26,5 @@
   "user",
   "y",
   [0 => 1, 1 => 2, 2 => [0 => 3, 1 => 4]],
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("MacroExpand/return-array.test", 3, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("MacroExpand/return-array.test", 3, 13)
-  )
+  \Phel::locationMeta(\Phel::location("MacroExpand/return-array.test", 3, 0), \Phel::location("MacroExpand/return-array.test", 3, 13))
 );

--- a/tests/php/Integration/Fixtures/Ns/require-multiple.test
+++ b/tests/php/Integration/Fixtures/Ns/require-multiple.test
@@ -26,17 +26,11 @@ require_once __DIR__ . '/xyz/core2.php';
   "test",
   "kw",
   \Phel\Lang\Keyword::create("f1", "xyz.core"),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Ns/require-multiple.test", 6, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Ns/require-multiple.test", 6, 15)
-  )
+  \Phel::locationMeta(\Phel::location("Ns/require-multiple.test", 6, 0), \Phel::location("Ns/require-multiple.test", 6, 15))
 );
 \Phel::addDefinition(
   "test",
   "kw2",
   \Phel\Lang\Keyword::create("f3", "xyz.core2"),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Ns/require-multiple.test", 7, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Ns/require-multiple.test", 7, 17)
-  )
+  \Phel::locationMeta(\Phel::location("Ns/require-multiple.test", 7, 0), \Phel::location("Ns/require-multiple.test", 7, 17))
 );

--- a/tests/php/Integration/Fixtures/Ns/require-vector-multiple.test
+++ b/tests/php/Integration/Fixtures/Ns/require-vector-multiple.test
@@ -26,17 +26,11 @@ require_once __DIR__ . '/xyz/core2.php';
   "test",
   "kw",
   \Phel\Lang\Keyword::create("f1", "xyz.core"),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Ns/require-vector-multiple.test", 6, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Ns/require-vector-multiple.test", 6, 15)
-  )
+  \Phel::locationMeta(\Phel::location("Ns/require-vector-multiple.test", 6, 0), \Phel::location("Ns/require-vector-multiple.test", 6, 15))
 );
 \Phel::addDefinition(
   "test",
   "kw2",
   \Phel\Lang\Keyword::create("f3", "xyz.core2"),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Ns/require-vector-multiple.test", 7, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Ns/require-vector-multiple.test", 7, 17)
-  )
+  \Phel::locationMeta(\Phel::location("Ns/require-vector-multiple.test", 7, 0), \Phel::location("Ns/require-vector-multiple.test", 7, 17))
 );

--- a/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
+++ b/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
@@ -6,9 +6,6 @@
   "user",
   "a",
   (new \stdClass()),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("PhpObjectSet/set-class-property.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("PhpObjectSet/set-class-property.test", 1, 27)
-  )
+  \Phel::locationMeta(\Phel::location("PhpObjectSet/set-class-property.test", 1, 0), \Phel::location("PhpObjectSet/set-class-property.test", 1, 27))
 );
 \Phel::getDefinition("user", "a")->name = "test";

--- a/tests/php/Integration/Fixtures/SetVar/set-var.test
+++ b/tests/php/Integration/Fixtures/SetVar/set-var.test
@@ -6,10 +6,7 @@
   "user",
   "x",
   1,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("SetVar/set-var.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("SetVar/set-var.test", 1, 9)
-  )
+  \Phel::locationMeta(\Phel::location("SetVar/set-var.test", 1, 0), \Phel::location("SetVar/set-var.test", 1, 9))
 );
 \Phel::setVar(
   "user",

--- a/tests/php/Integration/Fixtures/Try/try-catch-finally-expr-throw.test
+++ b/tests/php/Integration/Fixtures/Try/try-catch-finally-expr-throw.test
@@ -16,8 +16,5 @@
       (3 + 3);
     }
   })(),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Try/try-catch-finally-expr-throw.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Try/try-catch-finally-expr-throw.test", 4, 27)
-  )
+  \Phel::locationMeta(\Phel::location("Try/try-catch-finally-expr-throw.test", 1, 0), \Phel::location("Try/try-catch-finally-expr-throw.test", 4, 27))
 );

--- a/tests/php/Integration/Fixtures/Try/try-catch-finally-expr.test
+++ b/tests/php/Integration/Fixtures/Try/try-catch-finally-expr.test
@@ -16,8 +16,5 @@
       (3 + 3);
     }
   })(),
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Try/try-catch-finally-expr.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Try/try-catch-finally-expr.test", 4, 27)
-  )
+  \Phel::locationMeta(\Phel::location("Try/try-catch-finally-expr.test", 1, 0), \Phel::location("Try/try-catch-finally-expr.test", 4, 27))
 );

--- a/tests/php/Integration/Fixtures/VarQuote/var-quote-emits-get-var.test
+++ b/tests/php/Integration/Fixtures/VarQuote/var-quote-emits-get-var.test
@@ -6,9 +6,6 @@
   "user",
   "x",
   1,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("VarQuote/var-quote-emits-get-var.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("VarQuote/var-quote-emits-get-var.test", 1, 9)
-  )
+  \Phel::locationMeta(\Phel::location("VarQuote/var-quote-emits-get-var.test", 1, 0), \Phel::location("VarQuote/var-quote-emits-get-var.test", 1, 9))
 );
 \Phel\Lang\Registry::getInstance()->getVar("user", "x");

--- a/tests/php/Integration/Fixtures/VarQuote/var-special-form.test
+++ b/tests/php/Integration/Fixtures/VarQuote/var-special-form.test
@@ -6,9 +6,6 @@
   "user",
   "x",
   1,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("VarQuote/var-special-form.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("VarQuote/var-special-form.test", 1, 9)
-  )
+  \Phel::locationMeta(\Phel::location("VarQuote/var-special-form.test", 1, 0), \Phel::location("VarQuote/var-special-form.test", 1, 9))
 );
 \Phel\Lang\Registry::getInstance()->getVar("user", "x");

--- a/tests/php/Unit/Phel/PhelConstructorsTest.php
+++ b/tests/php/Unit/Phel/PhelConstructorsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Phel;
 
 use Phel;
+use Phel\Lang\Keyword;
 use PHPUnit\Framework\TestCase;
 
 final class PhelConstructorsTest extends TestCase
@@ -61,5 +62,29 @@ final class PhelConstructorsTest extends TestCase
     {
         $set = Phel::set(null);
         self::assertSame([], $set->toPhpArray());
+    }
+
+    /**
+     * The compiler emits `Phel::locationMeta(...)` in place of the expanded
+     * `Phel::map(:start-location ..., :end-location ...)` def metadata, so the
+     * resulting map must be value-identical to the hand-built one.
+     */
+    public function test_location_meta_equals_expanded_def_metadata(): void
+    {
+        $start = Phel::location('example.phel', 1, 0);
+        $end = Phel::location('example.phel', 2, 5);
+
+        $expected = Phel::map(
+            Keyword::create('start-location'),
+            $start,
+            Keyword::create('end-location'),
+            $end,
+        );
+
+        $actual = Phel::locationMeta($start, $end);
+
+        self::assertTrue($actual->equals($expected));
+        self::assertTrue($start->equals($actual[Keyword::create('start-location')]));
+        self::assertTrue($end->equals($actual[Keyword::create('end-location')]));
     }
 }


### PR DESCRIPTION
## 🤔 Background

Every `def` emitted an expanded `\Phel::map(Keyword::create("start-location"), ..., Keyword::create("end-location"), ...)` metadata literal, even for trivial definitions whose meta is location-only.

## 💡 Goal

Shrink generated PHP for def-heavy namespaces while keeping the runtime metadata map byte-value-identical. Closes #2722.

## 🔖 Changes

- Add `\Phel::locationMeta(start, end)` runtime helper (interns the two location keywords once per process).
- `MapEmitter` collapses the exact two-entry `{:start-location {loc} :end-location {loc}}` shape to `\Phel::locationMeta(\Phel::location(...), \Phel::location(...))`; defs with extra meta are unchanged.
- Regenerate 47 integration fixtures; unit test asserts the collapsed map equals the expanded one.