### PR TITLE
feat(compiler): intern equal collection literals (#2720)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 ### Performance
 
 - Trivial `def`/`defn` location metadata now emits a single `\Phel::locationMeta(...)` call instead of an expanded keyword-keyed map literal; smaller generated PHP per definition, byte-value-identical runtime map (#2722)
+- Equal collection literals (`[1 2 3]`, `{:a 1}`, sets) repeated in a function body now share a single cached constant slot instead of allocating one per occurrence, shrinking emitted PHP (#2720)
 
 ## [0.47.0](https://github.com/phel-lang/phel-lang/compare/v0.46.0...v0.47.0) - 2026-07-01
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/ConstantScope.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/ConstantScope.php
@@ -238,13 +238,13 @@ final class ConstantScope
     {
         $digest = '';
         for ($i = 0, $length = count($keyValues); $i < $length; $i += 2) {
-            $keyKey = $this->valueKey($keyValues[$i]);
-            $valueKey = $this->valueKey($keyValues[$i + 1]);
-            if ($keyKey === null || $valueKey === null) {
+            $keyChildKey = $this->valueKey($keyValues[$i]);
+            $valueChildKey = $this->valueKey($keyValues[$i + 1]);
+            if ($keyChildKey === null || $valueChildKey === null) {
                 return null;
             }
 
-            $digest .= $this->lengthPrefixedKey($keyKey) . '=>' . $this->lengthPrefixedKey($valueKey);
+            $digest .= $this->lengthPrefixedKey($keyChildKey) . '=>' . $this->lengthPrefixedKey($valueChildKey);
         }
 
         return 'map:[' . $digest . ']';

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/ConstantScope.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/ConstantScope.php
@@ -6,13 +6,19 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\Cache;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
+use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 use Phel\Lang\Keyword;
 use SplObjectStorage;
 
+use function count;
 use function is_bool;
 use function is_float;
 use function is_int;
+use function is_nan;
 use function is_string;
+use function strlen;
 use function var_export;
 
 /**
@@ -28,13 +34,14 @@ use function var_export;
  * Counters and lookups are independent so the emitter can render distinct
  * `static $__phel_const_*` and `static $__phel_call_*` declarations.
  *
- * Constant slots dedup cacheable scalar/keyword literals **by value**: since
- * keywords are interned singletons (and scalars immutable), every occurrence
- * of the same value collapses to a single shared slot — one `??=` guard and
- * one `use (&...)` capture entry. Collection literals stay identity-keyed
- * (their construction is not a cheap interned singleton). The per-node map
- * still points every collapsed node at the shared slot, so the emitter
- * resolves slots by node as before and never references an uncaptured slot.
+ * Constant slots dedup cacheable literals **by value**: scalars/keywords key
+ * on their value, and pure collection literals key on a structural digest of
+ * their contents, so every occurrence of the same literal collapses to a
+ * single shared slot — one `??=` guard and one `use (&...)` capture entry.
+ * Both colliding sites emit the identical literal but share the variable, so
+ * only the first evaluation allocates. The per-node map still points every
+ * collapsed node at the shared slot, so the emitter resolves slots by node as
+ * before and never references an uncaptured slot.
  */
 final class ConstantScope
 {
@@ -71,11 +78,11 @@ final class ConstantScope
 
         $valueKey = $this->valueKey($node);
         if ($valueKey !== null) {
-            // Cacheable scalar/keyword literal: dedup by value. Reuse the
-            // shared slot if this value was already reserved, otherwise
-            // allocate one. Either way the per-node map records the shared
-            // slot so `lookup($node)` resolves every occurrence to it and the
-            // emitter never references an uncaptured slot.
+            // Cacheable scalar/keyword/collection literal: dedup by value.
+            // Reuse the shared slot if this value was already reserved,
+            // otherwise allocate one. Either way the per-node map records the
+            // shared slot so `lookup($node)` resolves every occurrence to it
+            // and the emitter never references an uncaptured slot.
             $slot = $this->valueSlots[$valueKey] ??= $this->nextConstId++;
             $this->constSlots[$node] = $slot;
 
@@ -130,13 +137,28 @@ final class ConstantScope
     }
 
     /**
-     * Stable value key for a cacheable scalar/keyword literal, or `null` for
-     * any node that must stay identity-keyed (collections, symbols, numeric
-     * value types, etc.). Type-tagged so `1` (int) and `"1"` (string) never
-     * collide, and keywords never collide with a same-named string.
+     * Stable value key for a cacheable literal, or `null` for any node that
+     * must stay identity-keyed (symbols, calls, numeric value types, etc.).
+     * Scalars/keywords key on their value; pure collection literals key on a
+     * structural digest of their contents (each child recursed through the
+     * same method). Type-tagged so `1` (int) and `"1"` (string) never collide,
+     * keywords never collide with a same-named string, and the `vec:`/`set:`/
+     * `map:` prefixes keep the collection shapes disjoint.
      */
     private function valueKey(AbstractNode $node): ?string
     {
+        if ($node instanceof VectorNode) {
+            return $this->collectionValueKey('vec', $node->getArgs());
+        }
+
+        if ($node instanceof SetNode) {
+            return $this->collectionValueKey('set', $node->getValues());
+        }
+
+        if ($node instanceof MapNode) {
+            return $this->mapValueKey($node->getKeyValues());
+        }
+
         if (!$node instanceof LiteralNode) {
             return null;
         }
@@ -159,7 +181,13 @@ final class ConstantScope
         }
 
         if (is_float($value)) {
-            // `var_export` round-trips a float deterministically (NAN/INF
+            // NaN != NaN, so two NaN literals must stay distinct instances;
+            // interning would alias them and flip collection equality to true.
+            if (is_nan($value)) {
+                return null;
+            }
+
+            // `var_export` round-trips a float deterministically (INF
             // included), so distinct floats never share a slot key.
             return 'float:' . var_export($value, true);
         }
@@ -173,5 +201,63 @@ final class ConstantScope
         }
 
         return null;
+    }
+
+    /**
+     * Structural key for a `VectorNode`/`SetNode`. Returns `null` — so the
+     * whole literal stays identity-keyed — if any element is not itself
+     * value-keyable (e.g. a call or local): sharing a slot only holds when
+     * the literal reconstructs the same value on every evaluation.
+     *
+     * @param list<AbstractNode> $children
+     */
+    private function collectionValueKey(string $prefix, array $children): ?string
+    {
+        $digest = '';
+        foreach ($children as $child) {
+            $childKey = $this->valueKey($child);
+            if ($childKey === null) {
+                return null;
+            }
+
+            $digest .= $this->lengthPrefixedKey($childKey);
+        }
+
+        return $prefix . ':[' . $digest . ']';
+    }
+
+    /**
+     * Structural key for a `MapNode`. `getKeyValues()` is a flat
+     * `[k, v, k, v, …]` list in literal order; each entry keys on both its
+     * key and value digest. Bails to `null` like {@see collectionValueKey}
+     * when any key or value is not value-keyable.
+     *
+     * @param array<int, AbstractNode> $keyValues
+     */
+    private function mapValueKey(array $keyValues): ?string
+    {
+        $digest = '';
+        for ($i = 0, $length = count($keyValues); $i < $length; $i += 2) {
+            $keyKey = $this->valueKey($keyValues[$i]);
+            $valueKey = $this->valueKey($keyValues[$i + 1]);
+            if ($keyKey === null || $valueKey === null) {
+                return null;
+            }
+
+            $digest .= $this->lengthPrefixedKey($keyKey) . '=>' . $this->lengthPrefixedKey($valueKey);
+        }
+
+        return 'map:[' . $digest . ']';
+    }
+
+    /**
+     * Length-prefix a child key so concatenated digests are unambiguous.
+     * A raw comma-join would let a crafted string element forge the digest
+     * of a differently-shaped literal (e.g. `["a,str:b"]` vs `["a" "b"]`),
+     * collapsing two distinct values onto one slot and corrupting it.
+     */
+    private function lengthPrefixedKey(string $childKey): string
+    {
+        return strlen($childKey) . ':' . $childKey;
     }
 }

--- a/tests/php/Integration/Fixtures/ConstantHoisting/collection-repeated-interned-shares-slot.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/collection-repeated-interned-shares-slot.test
@@ -2,11 +2,11 @@
 (fn [b] (if b [1 2] [1 2]))
 --PHP--
 (function($b) {
-  static $__phel_const_0, $__phel_const_1;
+  static $__phel_const_0;
   if (($__truthy = $b) !== null && $__truthy !== false) {
     return ($__phel_const_0 ??= \Phel::vector([1, 2]));
   } else {
-    return ($__phel_const_1 ??= \Phel::vector([1, 2]));
+    return ($__phel_const_0 ??= \Phel::vector([1, 2]));
   }
 
 });

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/BodyConstantScannerTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/BodyConstantScannerTest.php
@@ -88,8 +88,10 @@ final class BodyConstantScannerTest extends TestCase
 
     public function test_descends_into_if_branches(): void
     {
+        // Distinct literals so the assertion isolates descent-into-both-arms
+        // from the value-interning that collapses equal literals to one slot.
         $thenVec = $this->pureVector();
-        $elseVec = $this->pureVector();
+        $elseVec = $this->pureVector(4);
         $if = new IfNode(
             NodeEnvironment::empty(),
             new LiteralNode(NodeEnvironment::empty(), true),
@@ -106,8 +108,10 @@ final class BodyConstantScannerTest extends TestCase
 
     public function test_descends_into_let_bindings_and_body(): void
     {
+        // Distinct literals so the assertion isolates descent-into-both from
+        // the value-interning that collapses equal literals to one slot.
         $initVec = $this->pureVector();
-        $bodyVec = $this->pureVector();
+        $bodyVec = $this->pureVector(4);
         $let = new LetNode(
             NodeEnvironment::empty(),
             [
@@ -163,12 +167,12 @@ final class BodyConstantScannerTest extends TestCase
         self::assertSame(1, $scope->count());
     }
 
-    private function pureVector(): VectorNode
+    private function pureVector(int $start = 1): VectorNode
     {
         return new VectorNode(NodeEnvironment::empty(), [
-            new LiteralNode(NodeEnvironment::empty(), 1),
-            new LiteralNode(NodeEnvironment::empty(), 2),
-            new LiteralNode(NodeEnvironment::empty(), 3),
+            new LiteralNode(NodeEnvironment::empty(), $start),
+            new LiteralNode(NodeEnvironment::empty(), $start + 1),
+            new LiteralNode(NodeEnvironment::empty(), $start + 2),
         ]);
     }
 }

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/ConstantScopeTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/ConstantScopeTest.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\ConstantHoisting;
 
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
+use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\ConstantScope;
 use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
 use PHPUnit\Framework\TestCase;
 
 final class ConstantScopeTest extends TestCase
@@ -114,18 +118,174 @@ final class ConstantScopeTest extends TestCase
         self::assertSame(2, $scope->count());
     }
 
-    public function test_collection_literals_stay_identity_keyed(): void
+    public function test_structurally_equal_collections_share_one_slot(): void
     {
         $scope = new ConstantScope();
         $first = new VectorNode(NodeEnvironment::empty(), [
             new LiteralNode(NodeEnvironment::empty(), 1),
+            new LiteralNode(NodeEnvironment::empty(), 2),
         ]);
         $second = new VectorNode(NodeEnvironment::empty(), [
             new LiteralNode(NodeEnvironment::empty(), 1),
+            new LiteralNode(NodeEnvironment::empty(), 2),
+        ]);
+
+        self::assertSame(0, $scope->reserve($first));
+        self::assertSame(0, $scope->reserve($second));
+        self::assertSame(0, $scope->lookup($first));
+        self::assertSame(0, $scope->lookup($second));
+        self::assertSame(1, $scope->count());
+    }
+
+    public function test_structurally_equal_maps_share_one_slot(): void
+    {
+        $scope = new ConstantScope();
+        $first = new MapNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), Keyword::create('a')),
+            new LiteralNode(NodeEnvironment::empty(), 1),
+        ]);
+        $second = new MapNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), Keyword::create('a')),
+            new LiteralNode(NodeEnvironment::empty(), 1),
+        ]);
+
+        self::assertSame(0, $scope->reserve($first));
+        self::assertSame(0, $scope->reserve($second));
+        self::assertSame(1, $scope->count());
+    }
+
+    public function test_nested_structurally_equal_collections_share_one_slot(): void
+    {
+        $scope = new ConstantScope();
+        $first = new VectorNode(NodeEnvironment::empty(), [
+            new VectorNode(NodeEnvironment::empty(), [
+                new LiteralNode(NodeEnvironment::empty(), 1),
+            ]),
+        ]);
+        $second = new VectorNode(NodeEnvironment::empty(), [
+            new VectorNode(NodeEnvironment::empty(), [
+                new LiteralNode(NodeEnvironment::empty(), 1),
+            ]),
+        ]);
+
+        self::assertSame(0, $scope->reserve($first));
+        self::assertSame(0, $scope->reserve($second));
+        self::assertSame(1, $scope->count());
+    }
+
+    public function test_same_elements_in_different_collection_shapes_do_not_collide(): void
+    {
+        $scope = new ConstantScope();
+        $vector = new VectorNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 1),
+        ]);
+        $set = new SetNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 1),
+        ]);
+
+        self::assertSame(0, $scope->reserve($vector));
+        self::assertSame(1, $scope->reserve($set));
+        self::assertSame(2, $scope->count());
+    }
+
+    public function test_collection_with_non_literal_child_stays_identity_keyed(): void
+    {
+        $scope = new ConstantScope();
+        $first = new VectorNode(NodeEnvironment::empty(), [
+            new LocalVarNode(NodeEnvironment::empty(), Symbol::create('x')),
+        ]);
+        $second = new VectorNode(NodeEnvironment::empty(), [
+            new LocalVarNode(NodeEnvironment::empty(), Symbol::create('x')),
         ]);
 
         self::assertSame(0, $scope->reserve($first));
         self::assertSame(1, $scope->reserve($second));
         self::assertSame(2, $scope->count());
+    }
+
+    public function test_string_element_cannot_forge_a_colliding_collection_key(): void
+    {
+        // `["a,str:b"]` (one string) and `["a" "b"]` (two strings) would share
+        // a raw comma-joined digest; length-prefixing keeps them on distinct
+        // slots so neither corrupts the other's cached value.
+        $scope = new ConstantScope();
+        $forged = new VectorNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 'a,str:b'),
+        ]);
+        $twoStrings = new VectorNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 'a'),
+            new LiteralNode(NodeEnvironment::empty(), 'b'),
+        ]);
+
+        self::assertSame(0, $scope->reserve($forged));
+        self::assertSame(1, $scope->reserve($twoStrings));
+        self::assertSame(2, $scope->count());
+    }
+
+    public function test_nan_float_literal_is_not_value_keyed(): void
+    {
+        // NaN != NaN, so two NaN literals must never collapse onto one slot.
+        $scope = new ConstantScope();
+        $first = new LiteralNode(NodeEnvironment::empty(), NAN);
+        $second = new LiteralNode(NodeEnvironment::empty(), NAN);
+
+        self::assertSame(0, $scope->reserve($first));
+        self::assertSame(1, $scope->reserve($second));
+        self::assertSame(2, $scope->count());
+    }
+
+    public function test_vector_containing_nan_is_not_interned(): void
+    {
+        // A NaN child bails the whole literal to identity-keying, so two
+        // `["a" ##NaN]` vectors stay distinct instances and compare unequal.
+        $scope = new ConstantScope();
+        $first = new VectorNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 'a'),
+            new LiteralNode(NodeEnvironment::empty(), NAN),
+        ]);
+        $second = new VectorNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 'a'),
+            new LiteralNode(NodeEnvironment::empty(), NAN),
+        ]);
+
+        self::assertSame(0, $scope->reserve($first));
+        self::assertSame(1, $scope->reserve($second));
+        self::assertSame(2, $scope->count());
+    }
+
+    public function test_set_containing_nan_is_not_interned(): void
+    {
+        $scope = new ConstantScope();
+        $first = new SetNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 1.0),
+            new LiteralNode(NodeEnvironment::empty(), NAN),
+        ]);
+        $second = new SetNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 1.0),
+            new LiteralNode(NodeEnvironment::empty(), NAN),
+        ]);
+
+        self::assertSame(0, $scope->reserve($first));
+        self::assertSame(1, $scope->reserve($second));
+        self::assertSame(2, $scope->count());
+    }
+
+    public function test_finite_float_collection_still_shares_one_slot(): void
+    {
+        // Only NaN bails; a finite float keeps interning, proving the guard is
+        // NaN-specific and not a blanket opt-out for float-bearing literals.
+        $scope = new ConstantScope();
+        $first = new VectorNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 'a'),
+            new LiteralNode(NodeEnvironment::empty(), 1.5),
+        ]);
+        $second = new VectorNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 'a'),
+            new LiteralNode(NodeEnvironment::empty(), 1.5),
+        ]);
+
+        self::assertSame(0, $scope->reserve($first));
+        self::assertSame(0, $scope->reserve($second));
+        self::assertSame(1, $scope->count());
     }
 }


### PR DESCRIPTION
## 🤔 Background

Collection literals in the per-fn constant cache were identity-keyed: an identical `[1 2 3]` appearing twice in one fn body got two separate `static $__phel_const_N` slots (scalars/keywords were already value-deduped).

## 💡 Goal

Intern equal pure collection literals onto one shared slot — smaller emitted PHP and one fewer allocation per duplicated literal.

## 🔖 Changes

- `ConstantScope::valueKey()` now builds a structural, type-prefixed (`vec:`/`set:`/`map:`) key for pure `VectorNode`/`SetNode`/`MapNode`, recursing per child; any non-value-keyable child (call, local) bails to identity-keying.
- Child keys are length-prefixed so a crafted string element can't forge another shape's key and corrupt a shared slot.
- Unit tests (interning + both guards), updated integration fixture, CHANGELOG. Refactor commit had one rename (avoids a local shadowing the method name); no behavior change.

Closes #2720
