### PR TITLE
perf(compiler): fold extra def metadata into locationMeta (#2722)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file.
 
 ### Performance
 
-- `def`/`defn` location metadata now emits a single `\Phel::locationMeta(...)` call instead of an expanded keyword-keyed map literal; any further metadata (`:doc`, `:private`, `:tag`, …) folds in as trailing arguments, so docstring-heavy namespaces shrink too. Byte-value-identical runtime map (#2722)
+- `def`/`defn` location metadata now emits a single `\Phel::locationMeta(...)` call instead of an expanded keyword-keyed map literal; any further metadata (`:doc`, `:private`, `:tag`, …) folds in as trailing arguments, so docstring-heavy namespaces shrink too. The runtime metadata map stays value-equal — same keys/values (`=`, hash); only its iteration order changes, which Phel maps do not guarantee (#2722, #2725)
 - Equal collection literals (`[1 2 3]`, `{:a 1}`, sets) repeated in a function body now share a single cached constant slot instead of allocating one per occurrence, shrinking emitted PHP (#2720)
 
 ## [0.47.0](https://github.com/phel-lang/phel-lang/compare/v0.46.0...v0.47.0) - 2026-07-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file.
 
 ### Performance
 
-- Trivial `def`/`defn` location metadata now emits a single `\Phel::locationMeta(...)` call instead of an expanded keyword-keyed map literal; smaller generated PHP per definition, byte-value-identical runtime map (#2722)
+- `def`/`defn` location metadata now emits a single `\Phel::locationMeta(...)` call instead of an expanded keyword-keyed map literal; any further metadata (`:doc`, `:private`, `:tag`, …) folds in as trailing arguments, so docstring-heavy namespaces shrink too. Byte-value-identical runtime map (#2722)
 - Equal collection literals (`[1 2 3]`, `{:a 1}`, sets) repeated in a function body now share a single cached constant slot instead of allocating one per occurrence, shrinking emitted PHP (#2720)
 
 ## [0.47.0](https://github.com/phel-lang/phel-lang/compare/v0.46.0...v0.47.0) - 2026-07-01

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -339,12 +339,17 @@ final class Phel extends InternalPhel
     }
 
     /**
-     * Wrap the `:start-location`/`:end-location` pair a trivial `def` / `defn`
+     * Wrap the `:start-location`/`:end-location` pair a `def` / `defn`
      * synthesises into its metadata map. Lets the compiler emit one helper call
      * instead of the expanded `Phel::map(Keyword::create("start-location"), ...)`
      * per definition — same map at runtime, far less generated PHP across
      * def-heavy namespaces. The keyword keys intern once per process via the
      * `static` slots, as in {@see self::location()}.
+     *
+     * `$extraKeyValues` carries any remaining metadata a definition declares
+     * (`:doc`, `:private`, `:tag`, …) as flat key/value pairs. Map value is
+     * key-order independent, so folding the location keys ahead of the extras
+     * yields the identical runtime map the expanded literal produced.
      *
      * @param PersistentMapInterface<mixed, mixed> $startLocation
      * @param PersistentMapInterface<mixed, mixed> $endLocation
@@ -354,12 +359,13 @@ final class Phel extends InternalPhel
     public static function locationMeta(
         PersistentMapInterface $startLocation,
         PersistentMapInterface $endLocation,
+        mixed ...$extraKeyValues,
     ): PersistentMapInterface {
         static $kwStart, $kwEnd;
         $kwStart ??= self::keyword('start-location');
         $kwEnd ??= self::keyword('end-location');
 
-        return self::map($kwStart, $startLocation, $kwEnd, $endLocation);
+        return self::map($kwStart, $startLocation, $kwEnd, $endLocation, ...$extraKeyValues);
     }
 
     /**

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -342,14 +342,17 @@ final class Phel extends InternalPhel
      * Wrap the `:start-location`/`:end-location` pair a `def` / `defn`
      * synthesises into its metadata map. Lets the compiler emit one helper call
      * instead of the expanded `Phel::map(Keyword::create("start-location"), ...)`
-     * per definition — same map at runtime, far less generated PHP across
-     * def-heavy namespaces. The keyword keys intern once per process via the
-     * `static` slots, as in {@see self::location()}.
+     * per definition — value-equal map at runtime, far less generated PHP
+     * across def-heavy namespaces. The keyword keys intern once per process via
+     * the `static` slots, as in {@see self::location()}.
      *
      * `$extraKeyValues` carries any remaining metadata a definition declares
-     * (`:doc`, `:private`, `:tag`, …) as flat key/value pairs. Map value is
-     * key-order independent, so folding the location keys ahead of the extras
-     * yields the identical runtime map the expanded literal produced.
+     * (`:doc`, `:private`, `:tag`, …) as flat key/value pairs. Map value and
+     * hash are key-order independent, so folding the location keys ahead of the
+     * extras yields a runtime map value-equal to the expanded literal (equal
+     * keys/values, equal hash). Only iteration/print order shifts (locations
+     * enumerate first) — immaterial, as Phel maps are unordered and every
+     * metadata consumer reads by key, never by order.
      *
      * @param PersistentMapInterface<mixed, mixed> $startLocation
      * @param PersistentMapInterface<mixed, mixed> $endLocation

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
@@ -123,42 +123,44 @@ final class MapEmitter implements NodeEmitterInterface
     }
 
     /**
-     * Detect the exact two-entry `{:start-location {loc} :end-location {loc}}`
-     * map that a trivial `def`/`defn` (no docstring, tags or other meta)
-     * synthesises. Collapses it to one `\Phel::locationMeta(...)` call, so
-     * def-heavy namespaces emit far less PHP for the identical runtime map.
-     * A def carrying extra meta has more entries and falls through to the
-     * generic `\Phel::map(...)` path unchanged.
+     * Detect a `def`/`defn` metadata map that carries both location-shaped
+     * `:start-location` and `:end-location` entries, and collapse it to one
+     * `\Phel::locationMeta(...)` call so def-heavy namespaces emit far less
+     * PHP for the identical runtime map. Any further metadata (`:doc`,
+     * `:private`, `:tag`, …) rides along as trailing key/value arguments;
+     * map value is key-order independent, so the runtime map is unchanged.
+     * Maps missing either location entry fall through to the generic
+     * `\Phel::map(...)` path.
      *
-     * @return array{start: array{file: string, line: int, column: int}, end: array{file: string, line: int, column: int}}|null
+     * @return array{start: array{file: string, line: int, column: int}, end: array{file: string, line: int, column: int}, extras: list<array{AbstractNode, AbstractNode}>}|null
      */
     private function defLocationMeta(MapNode $node): ?array
     {
         $entries = $node->getKeyValues();
-        if (count($entries) !== 4) {
+        $entryCount = count($entries);
+        if ($entryCount < 4 || $entryCount % 2 !== 0) {
             return null;
         }
 
         $locationsByKeyword = [];
-        for ($i = 0; $i < 4; $i += 2) {
+        $extras = [];
+        for ($i = 0; $i < $entryCount; $i += 2) {
             $key = $entries[$i];
             $value = $entries[$i + 1];
 
-            if (!$key instanceof LiteralNode || !$value instanceof MapNode) {
-                return null;
+            $keyword = $key instanceof LiteralNode ? $key->getValue() : null;
+            $name = $keyword instanceof Keyword ? $keyword->getName() : null;
+            $location = $value instanceof MapNode ? $this->locationLiteral($value) : null;
+
+            if ($location !== null
+                && ($name === 'start-location' || $name === 'end-location')
+                && !isset($locationsByKeyword[$name])
+            ) {
+                $locationsByKeyword[$name] = $location;
+                continue;
             }
 
-            $keyword = $key->getValue();
-            if (!$keyword instanceof Keyword) {
-                return null;
-            }
-
-            $location = $this->locationLiteral($value);
-            if ($location === null) {
-                return null;
-            }
-
-            $locationsByKeyword[$keyword->getName()] = $location;
+            $extras[] = [$key, $value];
         }
 
         $start = $locationsByKeyword['start-location'] ?? null;
@@ -167,11 +169,11 @@ final class MapEmitter implements NodeEmitterInterface
             return null;
         }
 
-        return ['start' => $start, 'end' => $end];
+        return ['start' => $start, 'end' => $end, 'extras' => $extras];
     }
 
     /**
-     * @param array{start: array{file: string, line: int, column: int}, end: array{file: string, line: int, column: int}} $meta
+     * @param array{start: array{file: string, line: int, column: int}, end: array{file: string, line: int, column: int}, extras: list<array{AbstractNode, AbstractNode}>} $meta
      */
     private function emitDefLocationMetaHelper(array $meta, ?SourceLocation $loc): void
     {
@@ -179,6 +181,14 @@ final class MapEmitter implements NodeEmitterInterface
         $this->emitLocationHelper($meta['start'], $loc);
         $this->outputEmitter->emitStr(', ', $loc);
         $this->emitLocationHelper($meta['end'], $loc);
+
+        foreach ($meta['extras'] as [$key, $value]) {
+            $this->outputEmitter->emitStr(', ', $loc);
+            $this->outputEmitter->emitNode($key);
+            $this->outputEmitter->emitStr(', ', $loc);
+            $this->outputEmitter->emitNode($value);
+        }
+
         $this->outputEmitter->emitStr(')', $loc);
     }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
@@ -126,11 +126,12 @@ final class MapEmitter implements NodeEmitterInterface
      * Detect a `def`/`defn` metadata map that carries both location-shaped
      * `:start-location` and `:end-location` entries, and collapse it to one
      * `\Phel::locationMeta(...)` call so def-heavy namespaces emit far less
-     * PHP for the identical runtime map. Any further metadata (`:doc`,
+     * PHP for a value-equal runtime map. Any further metadata (`:doc`,
      * `:private`, `:tag`, …) rides along as trailing key/value arguments;
-     * map value is key-order independent, so the runtime map is unchanged.
-     * Maps missing either location entry fall through to the generic
-     * `\Phel::map(...)` path.
+     * map value and hash are key-order independent, so the runtime map stays
+     * value-equal (only its iteration order shifts, which is immaterial —
+     * Phel maps are unordered and metadata is read by key). Maps missing
+     * either location entry fall through to the generic `\Phel::map(...)` path.
      *
      * @return array{start: array{file: string, line: int, column: int}, end: array{file: string, line: int, column: int}, extras: list<array{AbstractNode, AbstractNode}>}|null
      */

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
@@ -179,17 +179,42 @@ final class MapEmitter implements NodeEmitterInterface
     private function emitDefLocationMetaHelper(array $meta, ?SourceLocation $loc): void
     {
         $this->outputEmitter->emitStr('\Phel::locationMeta(', $loc);
-        $this->emitLocationHelper($meta['start'], $loc);
-        $this->outputEmitter->emitStr(', ', $loc);
-        $this->emitLocationHelper($meta['end'], $loc);
 
-        foreach ($meta['extras'] as [$key, $value]) {
+        // A location-only meta map is short enough to stay on one line;
+        // extra metadata (docstrings, arglists, …) wraps one arg per line so
+        // the generated PHP and its integration fixtures stay diff-readable.
+        if ($meta['extras'] === []) {
+            $this->emitLocationHelper($meta['start'], $loc);
             $this->outputEmitter->emitStr(', ', $loc);
+            $this->emitLocationHelper($meta['end'], $loc);
+            $this->outputEmitter->emitStr(')', $loc);
+
+            return;
+        }
+
+        $this->outputEmitter->increaseIndentLevel();
+        $this->outputEmitter->emitLine();
+
+        $this->emitLocationHelper($meta['start'], $loc);
+        $this->outputEmitter->emitStr(',', $loc);
+        $this->outputEmitter->emitLine();
+        $this->emitLocationHelper($meta['end'], $loc);
+        $this->outputEmitter->emitStr(',', $loc);
+        $this->outputEmitter->emitLine();
+
+        $lastIndex = count($meta['extras']) - 1;
+        foreach ($meta['extras'] as $index => [$key, $value]) {
             $this->outputEmitter->emitNode($key);
             $this->outputEmitter->emitStr(', ', $loc);
             $this->outputEmitter->emitNode($value);
+            if ($index < $lastIndex) {
+                $this->outputEmitter->emitStr(',', $loc);
+            }
+
+            $this->outputEmitter->emitLine();
         }
 
+        $this->outputEmitter->decreaseIndentLevel();
         $this->outputEmitter->emitStr(')', $loc);
     }
 

--- a/tests/php/Integration/Fixtures/Call/apply-fixed-arity-direct.test
+++ b/tests/php/Integration/Fixtures/Call/apply-fixed-arity-direct.test
@@ -13,6 +13,13 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, $b, $c);
     }
   },
-  \Phel::locationMeta(\Phel::location("Call/apply-fixed-arity-direct.test", 1, 0), \Phel::location("Call/apply-fixed-arity-direct.test", 1, 29), \Phel\Lang\Keyword::create("doc"), "```phel\n(add3 a b c)\n```\n", "min-arity", 3, "is-variadic", false, "arglists", "[a b c]")
+  \Phel::locationMeta(
+    \Phel::location("Call/apply-fixed-arity-direct.test", 1, 0),
+    \Phel::location("Call/apply-fixed-arity-direct.test", 1, 29),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add3 a b c)\n```\n",
+    "min-arity", 3,
+    "is-variadic", false,
+    "arglists", "[a b c]"
+  )
 );
 (\Phel::getDefinition("user", "add3"))->__invoke(1, 2, 3);

--- a/tests/php/Integration/Fixtures/Call/apply-fixed-arity-direct.test
+++ b/tests/php/Integration/Fixtures/Call/apply-fixed-arity-direct.test
@@ -13,13 +13,6 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, $b, $c);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(add3 a b c)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/apply-fixed-arity-direct.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/apply-fixed-arity-direct.test", 1, 29),
-    "min-arity", 3,
-    "is-variadic", false,
-    "arglists", "[a b c]"
-  )
+  \Phel::locationMeta(\Phel::location("Call/apply-fixed-arity-direct.test", 1, 0), \Phel::location("Call/apply-fixed-arity-direct.test", 1, 29), \Phel\Lang\Keyword::create("doc"), "```phel\n(add3 a b c)\n```\n", "min-arity", 3, "is-variadic", false, "arglists", "[a b c]")
 );
 (\Phel::getDefinition("user", "add3"))->__invoke(1, 2, 3);

--- a/tests/php/Integration/Fixtures/Call/global-call.test
+++ b/tests/php/Integration/Fixtures/Call/global-call.test
@@ -13,12 +13,6 @@
       return 1;
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/global-call.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/global-call.test", 1, 18),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]"
-  )
+  \Phel::locationMeta(\Phel::location("Call/global-call.test", 1, 0), \Phel::location("Call/global-call.test", 1, 18), "min-arity", 1, "is-variadic", false, "arglists", "[x]")
 );
 (\Phel::getDefinition("user", "x"))->__invoke(1);

--- a/tests/php/Integration/Fixtures/Call/global-call.test
+++ b/tests/php/Integration/Fixtures/Call/global-call.test
@@ -13,6 +13,12 @@
       return 1;
     }
   },
-  \Phel::locationMeta(\Phel::location("Call/global-call.test", 1, 0), \Phel::location("Call/global-call.test", 1, 18), "min-arity", 1, "is-variadic", false, "arglists", "[x]")
+  \Phel::locationMeta(
+    \Phel::location("Call/global-call.test", 1, 0),
+    \Phel::location("Call/global-call.test", 1, 18),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
 );
 (\Phel::getDefinition("user", "x"))->__invoke(1);

--- a/tests/php/Integration/Fixtures/Call/php-fn-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-fn-reference.test
@@ -13,12 +13,6 @@
       return ($f)(...\Phel\Lang\Seq::toApplyArguments($xs));
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/php-fn-reference.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/php-fn-reference.test", 1, 44),
-    "min-arity", 2,
-    "is-variadic", false,
-    "arglists", "[f xs]"
-  )
+  \Phel::locationMeta(\Phel::location("Call/php-fn-reference.test", 1, 0), \Phel::location("Call/php-fn-reference.test", 1, 44), "min-arity", 2, "is-variadic", false, "arglists", "[f xs]")
 );
 (\Phel::getDefinition("user", "custom-reduce"))->__invoke((function(...$args) { return array(...$args);}), \Phel::vector([1, 2, 3]));

--- a/tests/php/Integration/Fixtures/Call/php-fn-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-fn-reference.test
@@ -13,6 +13,12 @@
       return ($f)(...\Phel\Lang\Seq::toApplyArguments($xs));
     }
   },
-  \Phel::locationMeta(\Phel::location("Call/php-fn-reference.test", 1, 0), \Phel::location("Call/php-fn-reference.test", 1, 44), "min-arity", 2, "is-variadic", false, "arglists", "[f xs]")
+  \Phel::locationMeta(
+    \Phel::location("Call/php-fn-reference.test", 1, 0),
+    \Phel::location("Call/php-fn-reference.test", 1, 44),
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[f xs]"
+  )
 );
 (\Phel::getDefinition("user", "custom-reduce"))->__invoke((function(...$args) { return array(...$args);}), \Phel::vector([1, 2, 3]));

--- a/tests/php/Integration/Fixtures/Call/self-call-direct.test
+++ b/tests/php/Integration/Fixtures/Call/self-call-direct.test
@@ -11,12 +11,5 @@
       return $this($n);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/self-call-direct.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/self-call-direct.test", 1, 22),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[n]"
-  )
+  \Phel::locationMeta(\Phel::location("Call/self-call-direct.test", 1, 0), \Phel::location("Call/self-call-direct.test", 1, 22), \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[n]")
 );

--- a/tests/php/Integration/Fixtures/Call/self-call-direct.test
+++ b/tests/php/Integration/Fixtures/Call/self-call-direct.test
@@ -11,5 +11,12 @@
       return $this($n);
     }
   },
-  \Phel::locationMeta(\Phel::location("Call/self-call-direct.test", 1, 0), \Phel::location("Call/self-call-direct.test", 1, 22), \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[n]")
+  \Phel::locationMeta(
+    \Phel::location("Call/self-call-direct.test", 1, 0),
+    \Phel::location("Call/self-call-direct.test", 1, 22),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[n]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Call/self-call-with-if.test
+++ b/tests/php/Integration/Fixtures/Call/self-call-with-if.test
@@ -12,12 +12,5 @@
 
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/self-call-with-if.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/self-call-with-if.test", 1, 52),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[n]"
-  )
+  \Phel::locationMeta(\Phel::location("Call/self-call-with-if.test", 1, 0), \Phel::location("Call/self-call-with-if.test", 1, 52), \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[n]")
 );

--- a/tests/php/Integration/Fixtures/Call/self-call-with-if.test
+++ b/tests/php/Integration/Fixtures/Call/self-call-with-if.test
@@ -12,5 +12,12 @@
 
     }
   },
-  \Phel::locationMeta(\Phel::location("Call/self-call-with-if.test", 1, 0), \Phel::location("Call/self-call-with-if.test", 1, 52), \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[n]")
+  \Phel::locationMeta(
+    \Phel::location("Call/self-call-with-if.test", 1, 0),
+    \Phel::location("Call/self-call-with-if.test", 1, 52),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[n]"
+  )
 );

--- a/tests/php/Integration/Fixtures/ConstantHoisting/map-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/map-in-fn-body.test
@@ -15,11 +15,5 @@
       ));
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 27),
-    "min-arity", 0,
-    "is-variadic", false,
-    "arglists", "[]"
-  )
+  \Phel::locationMeta(\Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 0), \Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 27), "min-arity", 0, "is-variadic", false, "arglists", "[]")
 );

--- a/tests/php/Integration/Fixtures/ConstantHoisting/map-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/map-in-fn-body.test
@@ -15,5 +15,11 @@
       ));
     }
   },
-  \Phel::locationMeta(\Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 0), \Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 27), "min-arity", 0, "is-variadic", false, "arglists", "[]")
+  \Phel::locationMeta(
+    \Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 0),
+    \Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 27),
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
 );

--- a/tests/php/Integration/Fixtures/ConstantHoisting/multiple-pure-literals.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/multiple-pure-literals.test
@@ -18,5 +18,11 @@
 
     }
   },
-  \Phel::locationMeta(\Phel::location("ConstantHoisting/multiple-pure-literals.test", 1, 0), \Phel::location("ConstantHoisting/multiple-pure-literals.test", 2, 22), "min-arity", 1, "is-variadic", false, "arglists", "[b]")
+  \Phel::locationMeta(
+    \Phel::location("ConstantHoisting/multiple-pure-literals.test", 1, 0),
+    \Phel::location("ConstantHoisting/multiple-pure-literals.test", 2, 22),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[b]"
+  )
 );

--- a/tests/php/Integration/Fixtures/ConstantHoisting/multiple-pure-literals.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/multiple-pure-literals.test
@@ -18,11 +18,5 @@
 
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("ConstantHoisting/multiple-pure-literals.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("ConstantHoisting/multiple-pure-literals.test", 2, 22),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[b]"
-  )
+  \Phel::locationMeta(\Phel::location("ConstantHoisting/multiple-pure-literals.test", 1, 0), \Phel::location("ConstantHoisting/multiple-pure-literals.test", 2, 22), "min-arity", 1, "is-variadic", false, "arglists", "[b]")
 );

--- a/tests/php/Integration/Fixtures/ConstantHoisting/set-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/set-in-fn-body.test
@@ -12,5 +12,11 @@
       return ($__phel_const_0 ??= \Phel::set([1, 2, 3]));
     }
   },
-  \Phel::locationMeta(\Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 0), \Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 24), "min-arity", 0, "is-variadic", false, "arglists", "[]")
+  \Phel::locationMeta(
+    \Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 0),
+    \Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 24),
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
 );

--- a/tests/php/Integration/Fixtures/ConstantHoisting/set-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/set-in-fn-body.test
@@ -12,11 +12,5 @@
       return ($__phel_const_0 ??= \Phel::set([1, 2, 3]));
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 24),
-    "min-arity", 0,
-    "is-variadic", false,
-    "arglists", "[]"
-  )
+  \Phel::locationMeta(\Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 0), \Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 24), "min-arity", 0, "is-variadic", false, "arglists", "[]")
 );

--- a/tests/php/Integration/Fixtures/ConstantHoisting/vector-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/vector-in-fn-body.test
@@ -12,5 +12,11 @@
       return ($__phel_const_0 ??= \Phel::vector([1, 2, 3]));
     }
   },
-  \Phel::locationMeta(\Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 0), \Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 23), "min-arity", 0, "is-variadic", false, "arglists", "[]")
+  \Phel::locationMeta(
+    \Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 0),
+    \Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 23),
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
 );

--- a/tests/php/Integration/Fixtures/ConstantHoisting/vector-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/vector-in-fn-body.test
@@ -12,11 +12,5 @@
       return ($__phel_const_0 ??= \Phel::vector([1, 2, 3]));
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 23),
-    "min-arity", 0,
-    "is-variadic", false,
-    "arglists", "[]"
-  )
+  \Phel::locationMeta(\Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 0), \Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 23), "min-arity", 0, "is-variadic", false, "arglists", "[]")
 );

--- a/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
@@ -41,14 +41,7 @@ interface IPlayer {
 
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/definterface-instance-of.test", 3, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/definterface-instance-of.test", 5, 31),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[p]"
-  )
+  \Phel::locationMeta(\Phel::location("Def/definterface-instance-of.test", 3, 0), \Phel::location("Def/definterface-instance-of.test", 5, 31), \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs", "min-arity", 1, "is-variadic", false, "arglists", "[p]")
 );
 
 \Phel::addDefinition(
@@ -69,13 +62,6 @@ interface IPlayer {
 
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/definterface-instance-of.test", 3, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/definterface-instance-of.test", 5, 31),
-    "min-arity", 3,
-    "is-variadic", false,
-    "arglists", "[p me you]"
-  )
+  \Phel::locationMeta(\Phel::location("Def/definterface-instance-of.test", 3, 0), \Phel::location("Def/definterface-instance-of.test", 5, 31), \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n", "min-arity", 3, "is-variadic", false, "arglists", "[p me you]")
 );
 ("foo" instanceof \interface_instance\IPlayer);

--- a/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
@@ -41,7 +41,14 @@ interface IPlayer {
 
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/definterface-instance-of.test", 3, 0), \Phel::location("Def/definterface-instance-of.test", 5, 31), \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs", "min-arity", 1, "is-variadic", false, "arglists", "[p]")
+  \Phel::locationMeta(
+    \Phel::location("Def/definterface-instance-of.test", 3, 0),
+    \Phel::location("Def/definterface-instance-of.test", 5, 31),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[p]"
+  )
 );
 
 \Phel::addDefinition(
@@ -62,6 +69,13 @@ interface IPlayer {
 
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/definterface-instance-of.test", 3, 0), \Phel::location("Def/definterface-instance-of.test", 5, 31), \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n", "min-arity", 3, "is-variadic", false, "arglists", "[p me you]")
+  \Phel::locationMeta(
+    \Phel::location("Def/definterface-instance-of.test", 3, 0),
+    \Phel::location("Def/definterface-instance-of.test", 5, 31),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n",
+    "min-arity", 3,
+    "is-variadic", false,
+    "arglists", "[p me you]"
+  )
 );
 ("foo" instanceof \interface_instance\IPlayer);

--- a/tests/php/Integration/Fixtures/Def/definterface.test
+++ b/tests/php/Integration/Fixtures/Def/definterface.test
@@ -39,14 +39,7 @@ interface IPlayer {
 
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/definterface.test", 3, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/definterface.test", 5, 31),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[p]"
-  )
+  \Phel::locationMeta(\Phel::location("Def/definterface.test", 3, 0), \Phel::location("Def/definterface.test", 5, 31), \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs", "min-arity", 1, "is-variadic", false, "arglists", "[p]")
 );
 
 \Phel::addDefinition(
@@ -67,12 +60,5 @@ interface IPlayer {
 
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/definterface.test", 3, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/definterface.test", 5, 31),
-    "min-arity", 3,
-    "is-variadic", false,
-    "arglists", "[p me you]"
-  )
+  \Phel::locationMeta(\Phel::location("Def/definterface.test", 3, 0), \Phel::location("Def/definterface.test", 5, 31), \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n", "min-arity", 3, "is-variadic", false, "arglists", "[p me you]")
 );

--- a/tests/php/Integration/Fixtures/Def/definterface.test
+++ b/tests/php/Integration/Fixtures/Def/definterface.test
@@ -39,7 +39,14 @@ interface IPlayer {
 
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/definterface.test", 3, 0), \Phel::location("Def/definterface.test", 5, 31), \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs", "min-arity", 1, "is-variadic", false, "arglists", "[p]")
+  \Phel::locationMeta(
+    \Phel::location("Def/definterface.test", 3, 0),
+    \Phel::location("Def/definterface.test", 5, 31),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[p]"
+  )
 );
 
 \Phel::addDefinition(
@@ -60,5 +67,12 @@ interface IPlayer {
 
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/definterface.test", 3, 0), \Phel::location("Def/definterface.test", 5, 31), \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n", "min-arity", 3, "is-variadic", false, "arglists", "[p me you]")
+  \Phel::locationMeta(
+    \Phel::location("Def/definterface.test", 3, 0),
+    \Phel::location("Def/definterface.test", 5, 31),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n",
+    "min-arity", 3,
+    "is-variadic", false,
+    "arglists", "[p me you]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/defmacro-skips-type-inference.test
+++ b/tests/php/Integration/Fixtures/Def/defmacro-skips-type-inference.test
@@ -12,13 +12,5 @@
       return (\Phel::getDefinition("phel.core", "list"))(...\Phel\Lang\Seq::toApplyArguments(($__phel_call_0 ??= \Phel::getDefinition("phel.core", "concat"))->__invoke(($__phel_call_1 ??= \Phel::getDefinition("phel.core", "list"))->__invoke((\Phel\Lang\Symbol::create("php/+"))), ($__phel_call_2 ??= \Phel::getDefinition("phel.core", "list"))->__invoke($x), ($__phel_call_3 ??= \Phel::getDefinition("phel.core", "list"))->__invoke(1))));
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("macro"), true,
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(plus1 x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defmacro-skips-type-inference.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defmacro-skips-type-inference.test", 1, 34),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]"
-  )
+  \Phel::locationMeta(\Phel::location("Def/defmacro-skips-type-inference.test", 1, 0), \Phel::location("Def/defmacro-skips-type-inference.test", 1, 34), \Phel\Lang\Keyword::create("macro"), true, \Phel\Lang\Keyword::create("doc"), "```phel\n(plus1 x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
 );

--- a/tests/php/Integration/Fixtures/Def/defmacro-skips-type-inference.test
+++ b/tests/php/Integration/Fixtures/Def/defmacro-skips-type-inference.test
@@ -12,5 +12,13 @@
       return (\Phel::getDefinition("phel.core", "list"))(...\Phel\Lang\Seq::toApplyArguments(($__phel_call_0 ??= \Phel::getDefinition("phel.core", "concat"))->__invoke(($__phel_call_1 ??= \Phel::getDefinition("phel.core", "list"))->__invoke((\Phel\Lang\Symbol::create("php/+"))), ($__phel_call_2 ??= \Phel::getDefinition("phel.core", "list"))->__invoke($x), ($__phel_call_3 ??= \Phel::getDefinition("phel.core", "list"))->__invoke(1))));
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/defmacro-skips-type-inference.test", 1, 0), \Phel::location("Def/defmacro-skips-type-inference.test", 1, 34), \Phel\Lang\Keyword::create("macro"), true, \Phel\Lang\Keyword::create("doc"), "```phel\n(plus1 x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
+  \Phel::locationMeta(
+    \Phel::location("Def/defmacro-skips-type-inference.test", 1, 0),
+    \Phel::location("Def/defmacro-skips-type-inference.test", 1, 34),
+    \Phel\Lang\Keyword::create("macro"), true,
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(plus1 x)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/defn-inferred-param-tag.test
+++ b/tests/php/Integration/Fixtures/Def/defn-inferred-param-tag.test
@@ -11,13 +11,5 @@
       return ($x + 1);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(add1 x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-inferred-param-tag.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-inferred-param-tag.test", 1, 27),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]",
-    \Phel\Lang\Keyword::create("tag"), "int"
-  )
+  \Phel::locationMeta(\Phel::location("Def/defn-inferred-param-tag.test", 1, 0), \Phel::location("Def/defn-inferred-param-tag.test", 1, 27), \Phel\Lang\Keyword::create("doc"), "```phel\n(add1 x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]", \Phel\Lang\Keyword::create("tag"), "int")
 );

--- a/tests/php/Integration/Fixtures/Def/defn-inferred-param-tag.test
+++ b/tests/php/Integration/Fixtures/Def/defn-inferred-param-tag.test
@@ -11,5 +11,13 @@
       return ($x + 1);
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/defn-inferred-param-tag.test", 1, 0), \Phel::location("Def/defn-inferred-param-tag.test", 1, 27), \Phel\Lang\Keyword::create("doc"), "```phel\n(add1 x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]", \Phel\Lang\Keyword::create("tag"), "int")
+  \Phel::locationMeta(
+    \Phel::location("Def/defn-inferred-param-tag.test", 1, 0),
+    \Phel::location("Def/defn-inferred-param-tag.test", 1, 27),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add1 x)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/defn-meta.test
+++ b/tests/php/Integration/Fixtures/Def/defn-meta.test
@@ -11,13 +11,5 @@
       return $x;
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("export"), true,
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(identity x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-meta.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-meta.test", 1, 36),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]"
-  )
+  \Phel::locationMeta(\Phel::location("Def/defn-meta.test", 1, 0), \Phel::location("Def/defn-meta.test", 1, 36), \Phel\Lang\Keyword::create("export"), true, \Phel\Lang\Keyword::create("doc"), "```phel\n(identity x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
 );

--- a/tests/php/Integration/Fixtures/Def/defn-meta.test
+++ b/tests/php/Integration/Fixtures/Def/defn-meta.test
@@ -11,5 +11,13 @@
       return $x;
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/defn-meta.test", 1, 0), \Phel::location("Def/defn-meta.test", 1, 36), \Phel\Lang\Keyword::create("export"), true, \Phel\Lang\Keyword::create("doc"), "```phel\n(identity x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
+  \Phel::locationMeta(
+    \Phel::location("Def/defn-meta.test", 1, 0),
+    \Phel::location("Def/defn-meta.test", 1, 36),
+    \Phel\Lang\Keyword::create("export"), true,
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(identity x)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/defn-multi-arity-infers-return.test
+++ b/tests/php/Integration/Fixtures/Def/defn-multi-arity-infers-return.test
@@ -26,13 +26,5 @@
       };
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(poly a)\n(poly a b)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-multi-arity-infers-return.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-multi-arity-infers-return.test", 1, 49),
-    "min-arity", 1,
-    "is-variadic", false,
-    "max-arity", 2,
-    "arglists", "([a] [a b])"
-  )
+  \Phel::locationMeta(\Phel::location("Def/defn-multi-arity-infers-return.test", 1, 0), \Phel::location("Def/defn-multi-arity-infers-return.test", 1, 49), \Phel\Lang\Keyword::create("doc"), "```phel\n(poly a)\n(poly a b)\n```\n", "min-arity", 1, "is-variadic", false, "max-arity", 2, "arglists", "([a] [a b])")
 );

--- a/tests/php/Integration/Fixtures/Def/defn-multi-arity-infers-return.test
+++ b/tests/php/Integration/Fixtures/Def/defn-multi-arity-infers-return.test
@@ -26,5 +26,13 @@
       };
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/defn-multi-arity-infers-return.test", 1, 0), \Phel::location("Def/defn-multi-arity-infers-return.test", 1, 49), \Phel\Lang\Keyword::create("doc"), "```phel\n(poly a)\n(poly a b)\n```\n", "min-arity", 1, "is-variadic", false, "max-arity", 2, "arglists", "([a] [a b])")
+  \Phel::locationMeta(
+    \Phel::location("Def/defn-multi-arity-infers-return.test", 1, 0),
+    \Phel::location("Def/defn-multi-arity-infers-return.test", 1, 49),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(poly a)\n(poly a b)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "max-arity", 2,
+    "arglists", "([a] [a b])"
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/defn-no-params-infers-return.test
+++ b/tests/php/Integration/Fixtures/Def/defn-no-params-infers-return.test
@@ -11,13 +11,5 @@
       return (1 + 1);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(two)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-no-params-infers-return.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-no-params-infers-return.test", 1, 25),
-    "min-arity", 0,
-    "is-variadic", false,
-    "arglists", "[]",
-    \Phel\Lang\Keyword::create("tag"), "int"
-  )
+  \Phel::locationMeta(\Phel::location("Def/defn-no-params-infers-return.test", 1, 0), \Phel::location("Def/defn-no-params-infers-return.test", 1, 25), \Phel\Lang\Keyword::create("doc"), "```phel\n(two)\n```\n", "min-arity", 0, "is-variadic", false, "arglists", "[]", \Phel\Lang\Keyword::create("tag"), "int")
 );

--- a/tests/php/Integration/Fixtures/Def/defn-no-params-infers-return.test
+++ b/tests/php/Integration/Fixtures/Def/defn-no-params-infers-return.test
@@ -11,5 +11,13 @@
       return (1 + 1);
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/defn-no-params-infers-return.test", 1, 0), \Phel::location("Def/defn-no-params-infers-return.test", 1, 25), \Phel\Lang\Keyword::create("doc"), "```phel\n(two)\n```\n", "min-arity", 0, "is-variadic", false, "arglists", "[]", \Phel\Lang\Keyword::create("tag"), "int")
+  \Phel::locationMeta(
+    \Phel::location("Def/defn-no-params-infers-return.test", 1, 0),
+    \Phel::location("Def/defn-no-params-infers-return.test", 1, 25),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(two)\n```\n",
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/defn-rand-range-fully-inferred.test
+++ b/tests/php/Integration/Fixtures/Def/defn-rand-range-fully-inferred.test
@@ -13,5 +13,12 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($lo, ($__phel_call_1 ??= \Phel::getDefinition("phel.core", "rand-int"))->__invoke(($hi - $lo)));
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/defn-rand-range-fully-inferred.test", 1, 0), \Phel::location("Def/defn-rand-range-fully-inferred.test", 2, 30), \Phel\Lang\Keyword::create("doc"), "```phel\n(rand-range lo hi)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[lo hi]")
+  \Phel::locationMeta(
+    \Phel::location("Def/defn-rand-range-fully-inferred.test", 1, 0),
+    \Phel::location("Def/defn-rand-range-fully-inferred.test", 2, 30),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(rand-range lo hi)\n```\n",
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[lo hi]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/defn-rand-range-fully-inferred.test
+++ b/tests/php/Integration/Fixtures/Def/defn-rand-range-fully-inferred.test
@@ -13,12 +13,5 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($lo, ($__phel_call_1 ??= \Phel::getDefinition("phel.core", "rand-int"))->__invoke(($hi - $lo)));
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(rand-range lo hi)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-rand-range-fully-inferred.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-rand-range-fully-inferred.test", 2, 30),
-    "min-arity", 2,
-    "is-variadic", false,
-    "arglists", "[lo hi]"
-  )
+  \Phel::locationMeta(\Phel::location("Def/defn-rand-range-fully-inferred.test", 1, 0), \Phel::location("Def/defn-rand-range-fully-inferred.test", 2, 30), \Phel\Lang\Keyword::create("doc"), "```phel\n(rand-range lo hi)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[lo hi]")
 );

--- a/tests/php/Integration/Fixtures/Def/defn-return-from-grafted-params.test
+++ b/tests/php/Integration/Fixtures/Def/defn-return-from-grafted-params.test
@@ -11,13 +11,5 @@
       return (($a + $b) + 0);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(add2 a b)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-return-from-grafted-params.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-return-from-grafted-params.test", 1, 39),
-    "min-arity", 2,
-    "is-variadic", false,
-    "arglists", "[a b]",
-    \Phel\Lang\Keyword::create("tag"), "int"
-  )
+  \Phel::locationMeta(\Phel::location("Def/defn-return-from-grafted-params.test", 1, 0), \Phel::location("Def/defn-return-from-grafted-params.test", 1, 39), \Phel\Lang\Keyword::create("doc"), "```phel\n(add2 a b)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[a b]", \Phel\Lang\Keyword::create("tag"), "int")
 );

--- a/tests/php/Integration/Fixtures/Def/defn-return-from-grafted-params.test
+++ b/tests/php/Integration/Fixtures/Def/defn-return-from-grafted-params.test
@@ -11,5 +11,13 @@
       return (($a + $b) + 0);
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/defn-return-from-grafted-params.test", 1, 0), \Phel::location("Def/defn-return-from-grafted-params.test", 1, 39), \Phel\Lang\Keyword::create("doc"), "```phel\n(add2 a b)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[a b]", \Phel\Lang\Keyword::create("tag"), "int")
+  \Phel::locationMeta(
+    \Phel::location("Def/defn-return-from-grafted-params.test", 1, 0),
+    \Phel::location("Def/defn-return-from-grafted-params.test", 1, 39),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add2 a b)\n```\n",
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[a b]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/defn-return-type-name.test
+++ b/tests/php/Integration/Fixtures/Def/defn-return-type-name.test
@@ -11,13 +11,5 @@
       return ($x + $y);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("tag"), "int",
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(add x y)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-return-type-name.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-return-type-name.test", 1, 43),
-    "min-arity", 2,
-    "is-variadic", false,
-    "arglists", "[x y]"
-  )
+  \Phel::locationMeta(\Phel::location("Def/defn-return-type-name.test", 1, 0), \Phel::location("Def/defn-return-type-name.test", 1, 43), \Phel\Lang\Keyword::create("tag"), "int", \Phel\Lang\Keyword::create("doc"), "```phel\n(add x y)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[x y]")
 );

--- a/tests/php/Integration/Fixtures/Def/defn-return-type-name.test
+++ b/tests/php/Integration/Fixtures/Def/defn-return-type-name.test
@@ -11,5 +11,13 @@
       return ($x + $y);
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/defn-return-type-name.test", 1, 0), \Phel::location("Def/defn-return-type-name.test", 1, 43), \Phel\Lang\Keyword::create("tag"), "int", \Phel\Lang\Keyword::create("doc"), "```phel\n(add x y)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[x y]")
+  \Phel::locationMeta(
+    \Phel::location("Def/defn-return-type-name.test", 1, 0),
+    \Phel::location("Def/defn-return-type-name.test", 1, 43),
+    \Phel\Lang\Keyword::create("tag"), "int",
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add x y)\n```\n",
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[x y]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/defn-typed-params.test
+++ b/tests/php/Integration/Fixtures/Def/defn-typed-params.test
@@ -11,13 +11,5 @@
       return ($x + $y);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(add x y)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-typed-params.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-typed-params.test", 1, 56),
-    "min-arity", 2,
-    "is-variadic", false,
-    "arglists", "[x y]",
-    \Phel\Lang\Keyword::create("tag"), "int"
-  )
+  \Phel::locationMeta(\Phel::location("Def/defn-typed-params.test", 1, 0), \Phel::location("Def/defn-typed-params.test", 1, 56), \Phel\Lang\Keyword::create("doc"), "```phel\n(add x y)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[x y]", \Phel\Lang\Keyword::create("tag"), "int")
 );

--- a/tests/php/Integration/Fixtures/Def/defn-typed-params.test
+++ b/tests/php/Integration/Fixtures/Def/defn-typed-params.test
@@ -11,5 +11,13 @@
       return ($x + $y);
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/defn-typed-params.test", 1, 0), \Phel::location("Def/defn-typed-params.test", 1, 56), \Phel\Lang\Keyword::create("doc"), "```phel\n(add x y)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[x y]", \Phel\Lang\Keyword::create("tag"), "int")
+  \Phel::locationMeta(
+    \Phel::location("Def/defn-typed-params.test", 1, 0),
+    \Phel::location("Def/defn-typed-params.test", 1, 56),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add x y)\n```\n",
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[x y]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/defn-untagged-param-infers-return.test
+++ b/tests/php/Integration/Fixtures/Def/defn-untagged-param-infers-return.test
@@ -11,13 +11,5 @@
       return (1 + 1);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(const-two x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-untagged-param-infers-return.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-untagged-param-infers-return.test", 1, 32),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]",
-    \Phel\Lang\Keyword::create("tag"), "int"
-  )
+  \Phel::locationMeta(\Phel::location("Def/defn-untagged-param-infers-return.test", 1, 0), \Phel::location("Def/defn-untagged-param-infers-return.test", 1, 32), \Phel\Lang\Keyword::create("doc"), "```phel\n(const-two x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]", \Phel\Lang\Keyword::create("tag"), "int")
 );

--- a/tests/php/Integration/Fixtures/Def/defn-untagged-param-infers-return.test
+++ b/tests/php/Integration/Fixtures/Def/defn-untagged-param-infers-return.test
@@ -11,5 +11,13 @@
       return (1 + 1);
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/defn-untagged-param-infers-return.test", 1, 0), \Phel::location("Def/defn-untagged-param-infers-return.test", 1, 32), \Phel\Lang\Keyword::create("doc"), "```phel\n(const-two x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]", \Phel\Lang\Keyword::create("tag"), "int")
+  \Phel::locationMeta(
+    \Phel::location("Def/defn-untagged-param-infers-return.test", 1, 0),
+    \Phel::location("Def/defn-untagged-param-infers-return.test", 1, 32),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(const-two x)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/defstruct-inside-fn-body.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-inside-fn-body.test
@@ -29,11 +29,5 @@
 
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defstruct-inside-fn-body.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defstruct-inside-fn-body.test", 3, 33),
-    "min-arity", 0,
-    "is-variadic", false,
-    "arglists", "[]"
-  )
+  \Phel::locationMeta(\Phel::location("Def/defstruct-inside-fn-body.test", 1, 0), \Phel::location("Def/defstruct-inside-fn-body.test", 3, 33), "min-arity", 0, "is-variadic", false, "arglists", "[]")
 );

--- a/tests/php/Integration/Fixtures/Def/defstruct-inside-fn-body.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-inside-fn-body.test
@@ -29,5 +29,11 @@
 
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/defstruct-inside-fn-body.test", 1, 0), \Phel::location("Def/defstruct-inside-fn-body.test", 3, 33), "min-arity", 0, "is-variadic", false, "arglists", "[]")
+  \Phel::locationMeta(
+    \Phel::location("Def/defstruct-inside-fn-body.test", 1, 0),
+    \Phel::location("Def/defstruct-inside-fn-body.test", 3, 33),
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/doc-def.test
@@ -5,5 +5,9 @@
   "user",
   "x",
   1,
-  \Phel::locationMeta(\Phel::location("Def/doc-def.test", 1, 0), \Phel::location("Def/doc-def.test", 1, 21), \Phel\Lang\Keyword::create("doc"), "my number")
+  \Phel::locationMeta(
+    \Phel::location("Def/doc-def.test", 1, 0),
+    \Phel::location("Def/doc-def.test", 1, 21),
+    \Phel\Lang\Keyword::create("doc"), "my number"
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/doc-def.test
@@ -5,9 +5,5 @@
   "user",
   "x",
   1,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "my number",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/doc-def.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/doc-def.test", 1, 21)
-  )
+  \Phel::locationMeta(\Phel::location("Def/doc-def.test", 1, 0), \Phel::location("Def/doc-def.test", 1, 21), \Phel\Lang\Keyword::create("doc"), "my number")
 );

--- a/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
+++ b/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
@@ -19,5 +19,11 @@
       return \Phel::getDefinition("user", "x");
     }
   },
-  \Phel::locationMeta(\Phel::location("Def/nested-def-inside-fn.test", 1, 0), \Phel::location("Def/nested-def-inside-fn.test", 1, 27), "min-arity", 0, "is-variadic", false, "arglists", "[]")
+  \Phel::locationMeta(
+    \Phel::location("Def/nested-def-inside-fn.test", 1, 0),
+    \Phel::location("Def/nested-def-inside-fn.test", 1, 27),
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
+++ b/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
@@ -19,11 +19,5 @@
       return \Phel::getDefinition("user", "x");
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 27),
-    "min-arity", 0,
-    "is-variadic", false,
-    "arglists", "[]"
-  )
+  \Phel::locationMeta(\Phel::location("Def/nested-def-inside-fn.test", 1, 0), \Phel::location("Def/nested-def-inside-fn.test", 1, 27), "min-arity", 0, "is-variadic", false, "arglists", "[]")
 );

--- a/tests/php/Integration/Fixtures/Def/private-def-meta.test
+++ b/tests/php/Integration/Fixtures/Def/private-def-meta.test
@@ -5,10 +5,5 @@
   "user",
   "x",
   1,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("private"), true,
-    \Phel\Lang\Keyword::create("export"), true,
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/private-def-meta.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/private-def-meta.test", 1, 38)
-  )
+  \Phel::locationMeta(\Phel::location("Def/private-def-meta.test", 1, 0), \Phel::location("Def/private-def-meta.test", 1, 38), \Phel\Lang\Keyword::create("private"), true, \Phel\Lang\Keyword::create("export"), true)
 );

--- a/tests/php/Integration/Fixtures/Def/private-def-meta.test
+++ b/tests/php/Integration/Fixtures/Def/private-def-meta.test
@@ -5,5 +5,10 @@
   "user",
   "x",
   1,
-  \Phel::locationMeta(\Phel::location("Def/private-def-meta.test", 1, 0), \Phel::location("Def/private-def-meta.test", 1, 38), \Phel\Lang\Keyword::create("private"), true, \Phel\Lang\Keyword::create("export"), true)
+  \Phel::locationMeta(
+    \Phel::location("Def/private-def-meta.test", 1, 0),
+    \Phel::location("Def/private-def-meta.test", 1, 38),
+    \Phel\Lang\Keyword::create("private"), true,
+    \Phel\Lang\Keyword::create("export"), true
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/private-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-def.test
@@ -5,5 +5,9 @@
   "user",
   "x",
   1,
-  \Phel::locationMeta(\Phel::location("Def/private-def.test", 1, 0), \Phel::location("Def/private-def.test", 1, 18), \Phel\Lang\Keyword::create("private"), true)
+  \Phel::locationMeta(
+    \Phel::location("Def/private-def.test", 1, 0),
+    \Phel::location("Def/private-def.test", 1, 18),
+    \Phel\Lang\Keyword::create("private"), true
+  )
 );

--- a/tests/php/Integration/Fixtures/Def/private-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-def.test
@@ -5,9 +5,5 @@
   "user",
   "x",
   1,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("private"), true,
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/private-def.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/private-def.test", 1, 18)
-  )
+  \Phel::locationMeta(\Phel::location("Def/private-def.test", 1, 0), \Phel::location("Def/private-def.test", 1, 18), \Phel\Lang\Keyword::create("private"), true)
 );

--- a/tests/php/Integration/Fixtures/Def/private-doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-doc-def.test
@@ -5,10 +5,5 @@
   "user",
   "x",
   1,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("private"), true,
-    \Phel\Lang\Keyword::create("doc"), "my number",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/private-doc-def.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/private-doc-def.test", 1, 42)
-  )
+  \Phel::locationMeta(\Phel::location("Def/private-doc-def.test", 1, 0), \Phel::location("Def/private-doc-def.test", 1, 42), \Phel\Lang\Keyword::create("private"), true, \Phel\Lang\Keyword::create("doc"), "my number")
 );

--- a/tests/php/Integration/Fixtures/Def/private-doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-doc-def.test
@@ -5,5 +5,10 @@
   "user",
   "x",
   1,
-  \Phel::locationMeta(\Phel::location("Def/private-doc-def.test", 1, 0), \Phel::location("Def/private-doc-def.test", 1, 42), \Phel\Lang\Keyword::create("private"), true, \Phel\Lang\Keyword::create("doc"), "my number")
+  \Phel::locationMeta(
+    \Phel::location("Def/private-doc-def.test", 1, 0),
+    \Phel::location("Def/private-doc-def.test", 1, 42),
+    \Phel\Lang\Keyword::create("private"), true,
+    \Phel\Lang\Keyword::create("doc"), "my number"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq-nil-stays-untagged.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq-nil-stays-untagged.test
@@ -13,12 +13,5 @@
 
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(nil-check x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/defn-infer-phel-core-eq-nil-stays-untagged.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/defn-infer-phel-core-eq-nil-stays-untagged.test", 1, 39),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/defn-infer-phel-core-eq-nil-stays-untagged.test", 1, 0), \Phel::location("Fn/defn-infer-phel-core-eq-nil-stays-untagged.test", 1, 39), \Phel\Lang\Keyword::create("doc"), "```phel\n(nil-check x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
 );

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq-nil-stays-untagged.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq-nil-stays-untagged.test
@@ -13,5 +13,12 @@
 
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/defn-infer-phel-core-eq-nil-stays-untagged.test", 1, 0), \Phel::location("Fn/defn-infer-phel-core-eq-nil-stays-untagged.test", 1, 39), \Phel\Lang\Keyword::create("doc"), "```phel\n(nil-check x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/defn-infer-phel-core-eq-nil-stays-untagged.test", 1, 0),
+    \Phel::location("Fn/defn-infer-phel-core-eq-nil-stays-untagged.test", 1, 39),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(nil-check x)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq.test
@@ -12,12 +12,5 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "="))->__invoke($x, 5);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(is-five? x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 27),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 0), \Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 27), \Phel\Lang\Keyword::create("doc"), "```phel\n(is-five? x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
 );

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq.test
@@ -12,5 +12,12 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "="))->__invoke($x, 5);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 0), \Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 27), \Phel\Lang\Keyword::create("doc"), "```phel\n(is-five? x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 0),
+    \Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 27),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(is-five? x)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-gte.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-gte.test
@@ -11,13 +11,5 @@
       return ($x >= 0.5);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(at-least-half? x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 36),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]",
-    \Phel\Lang\Keyword::create("tag"), "bool"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 0), \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 36), \Phel\Lang\Keyword::create("doc"), "```phel\n(at-least-half? x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]", \Phel\Lang\Keyword::create("tag"), "bool")
 );

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-gte.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-gte.test
@@ -11,5 +11,13 @@
       return ($x >= 0.5);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 0), \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 36), \Phel\Lang\Keyword::create("doc"), "```phel\n(at-least-half? x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]", \Phel\Lang\Keyword::create("tag"), "bool")
+  \Phel::locationMeta(
+    \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 0),
+    \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 36),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(at-least-half? x)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]",
+    \Phel\Lang\Keyword::create("tag"), "bool"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-bigint-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-bigint-bails.test
@@ -12,12 +12,5 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, \Phel\Lang\BigInt::fromString("99999999999999999999"));
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(plus-big a)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 47),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[a]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 0), \Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 47), \Phel\Lang\Keyword::create("doc"), "```phel\n(plus-big a)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[a]")
 );

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-bigint-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-bigint-bails.test
@@ -12,5 +12,12 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, \Phel\Lang\BigInt::fromString("99999999999999999999"));
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 0), \Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 47), \Phel\Lang\Keyword::create("doc"), "```phel\n(plus-big a)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[a]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 0),
+    \Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 47),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(plus-big a)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[a]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-float.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-float.test
@@ -11,5 +11,12 @@
       return ($a + 1.1);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 0), \Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 37), \Phel\Lang\Keyword::create("doc"), "```phel\n(inc-by-one-tenth a)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[a]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 0),
+    \Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 37),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(inc-by-one-tenth a)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[a]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-float.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-float.test
@@ -11,12 +11,5 @@
       return ($a + 1.1);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(inc-by-one-tenth a)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 37),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[a]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 0), \Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 37), \Phel\Lang\Keyword::create("doc"), "```phel\n(inc-by-one-tenth a)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[a]")
 );

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-without-literal-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-without-literal-bails.test
@@ -12,5 +12,12 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, $b);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 0), \Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 24), \Phel\Lang\Keyword::create("doc"), "```phel\n(add a b)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[a b]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 0),
+    \Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 24),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add a b)\n```\n",
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[a b]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-without-literal-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-without-literal-bails.test
@@ -12,12 +12,5 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, $b);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(add a b)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 24),
-    "min-arity", 2,
-    "is-variadic", false,
-    "arglists", "[a b]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 0), \Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 24), \Phel\Lang\Keyword::create("doc"), "```phel\n(add a b)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[a b]")
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
@@ -12,5 +12,12 @@
 
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 0), \Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 82), \Phel\Lang\Keyword::create("doc"), "```phel\n(fib n)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[n]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 0),
+    \Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 82),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(fib n)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[n]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
@@ -12,12 +12,5 @@
 
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(fib n)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 82),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[n]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 0), \Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 82), \Phel\Lang\Keyword::create("doc"), "```phel\n(fib n)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[n]")
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-explicit-wins.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-explicit-wins.test
@@ -12,7 +12,15 @@
       return ($a * 2);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 0), \Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 40), \Phel\Lang\Keyword::create("tag"), "int", \Phel\Lang\Keyword::create("doc"), "```phel\n(produce a)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[a]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 0),
+    \Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 40),
+    \Phel\Lang\Keyword::create("tag"), "int",
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(produce a)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[a]"
+  )
 );
 (function(int $x): bool {
   static $__phel_call_0;

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-explicit-wins.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-explicit-wins.test
@@ -12,15 +12,7 @@
       return ($a * 2);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("tag"), "int",
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(produce a)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 40),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[a]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 0), \Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 40), \Phel\Lang\Keyword::create("tag"), "int", \Phel\Lang\Keyword::create("doc"), "```phel\n(produce a)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[a]")
 );
 (function(int $x): bool {
   static $__phel_call_0;

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-inferred-callee.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-inferred-callee.test
@@ -12,15 +12,7 @@
       return is_int($x);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(check x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 31),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]",
-    \Phel\Lang\Keyword::create("tag"), "bool"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 0), \Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 31), \Phel\Lang\Keyword::create("doc"), "```phel\n(check x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]", \Phel\Lang\Keyword::create("tag"), "bool")
 );
 (function($x): bool {
   static $__phel_call_0;

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-inferred-callee.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-inferred-callee.test
@@ -12,7 +12,15 @@
       return is_int($x);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 0), \Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 31), \Phel\Lang\Keyword::create("doc"), "```phel\n(check x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]", \Phel\Lang\Keyword::create("tag"), "bool")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 0),
+    \Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 31),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(check x)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]",
+    \Phel\Lang\Keyword::create("tag"), "bool"
+  )
 );
 (function($x): bool {
   static $__phel_call_0;

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-tagged.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-tagged.test
@@ -12,7 +12,15 @@
       return ($a + $b);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 0), \Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 43), \Phel\Lang\Keyword::create("tag"), "int", \Phel\Lang\Keyword::create("doc"), "```phel\n(sum a b)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[a b]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 0),
+    \Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 43),
+    \Phel\Lang\Keyword::create("tag"), "int",
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(sum a b)\n```\n",
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[a b]"
+  )
 );
 (function(int $x): int {
   static $__phel_call_0;

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-tagged.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-tagged.test
@@ -12,15 +12,7 @@
       return ($a + $b);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("tag"), "int",
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(sum a b)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 43),
-    "min-arity", 2,
-    "is-variadic", false,
-    "arglists", "[a b]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 0), \Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 43), \Phel\Lang\Keyword::create("tag"), "int", \Phel\Lang\Keyword::create("doc"), "```phel\n(sum a b)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[a b]")
 );
 (function(int $x): int {
   static $__phel_call_0;

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-untagged.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-untagged.test
@@ -12,15 +12,7 @@
       return ($a + $b);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(add a b)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 38),
-    "min-arity", 2,
-    "is-variadic", false,
-    "arglists", "[a b]",
-    \Phel\Lang\Keyword::create("tag"), "int"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 0), \Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 38), \Phel\Lang\Keyword::create("doc"), "```phel\n(add a b)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[a b]", \Phel\Lang\Keyword::create("tag"), "int")
 );
 (function(int $x): int {
   static $__phel_call_0;

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-untagged.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-untagged.test
@@ -12,7 +12,15 @@
       return ($a + $b);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 0), \Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 38), \Phel\Lang\Keyword::create("doc"), "```phel\n(add a b)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[a b]", \Phel\Lang\Keyword::create("tag"), "int")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 0),
+    \Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 38),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add a b)\n```\n",
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[a b]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
 );
 (function(int $x): int {
   static $__phel_call_0;

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-propagates.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-propagates.test
@@ -12,7 +12,15 @@
       return ($a + $b);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 0), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 43), \Phel\Lang\Keyword::create("tag"), "int", \Phel\Lang\Keyword::create("doc"), "```phel\n(sum a b)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[a b]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 0),
+    \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 43),
+    \Phel\Lang\Keyword::create("tag"), "int",
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(sum a b)\n```\n",
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[a b]"
+  )
 );
 \Phel::addDefinition(
   "user",
@@ -25,5 +33,13 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("user", "sum"))->__invoke($x, $y);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 0), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 31), \Phel\Lang\Keyword::create("doc"), "```phel\n(add-pair x y)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[x y]", \Phel\Lang\Keyword::create("tag"), "int")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 0),
+    \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 31),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add-pair x y)\n```\n",
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[x y]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-propagates.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-propagates.test
@@ -12,15 +12,7 @@
       return ($a + $b);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("tag"), "int",
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(sum a b)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 43),
-    "min-arity", 2,
-    "is-variadic", false,
-    "arglists", "[a b]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 0), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 43), \Phel\Lang\Keyword::create("tag"), "int", \Phel\Lang\Keyword::create("doc"), "```phel\n(sum a b)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[a b]")
 );
 \Phel::addDefinition(
   "user",
@@ -33,13 +25,5 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("user", "sum"))->__invoke($x, $y);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(add-pair x y)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 31),
-    "min-arity", 2,
-    "is-variadic", false,
-    "arglists", "[x y]",
-    \Phel\Lang\Keyword::create("tag"), "int"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 0), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 31), \Phel\Lang\Keyword::create("doc"), "```phel\n(add-pair x y)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[x y]", \Phel\Lang\Keyword::create("tag"), "int")
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-fqn.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-fqn.test
@@ -12,7 +12,14 @@
       return $s;
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 0), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 42), \Phel\Lang\Keyword::create("doc"), "```phel\n(typed s)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[s]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 0),
+    \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 42),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(typed s)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[s]"
+  )
 );
 \Phel::addDefinition(
   "user",
@@ -25,5 +32,12 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("user", "typed"))->__invoke($x);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 0), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 27), \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 0),
+    \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 27),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-fqn.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-fqn.test
@@ -12,14 +12,7 @@
       return $s;
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(typed s)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 42),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[s]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 0), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 42), \Phel\Lang\Keyword::create("doc"), "```phel\n(typed s)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[s]")
 );
 \Phel::addDefinition(
   "user",
@@ -32,12 +25,5 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("user", "typed"))->__invoke($x);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 27),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 0), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 27), \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-nullable.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-nullable.test
@@ -12,14 +12,7 @@
       return $a;
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(maybe a)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 24),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[a]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 0), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 24), \Phel\Lang\Keyword::create("doc"), "```phel\n(maybe a)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[a]")
 );
 \Phel::addDefinition(
   "user",
@@ -32,12 +25,5 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("user", "maybe"))->__invoke($x);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 27),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 0), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 27), \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-nullable.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-nullable.test
@@ -12,7 +12,14 @@
       return $a;
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 0), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 24), \Phel\Lang\Keyword::create("doc"), "```phel\n(maybe a)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[a]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 0),
+    \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 24),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(maybe a)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[a]"
+  )
 );
 \Phel::addDefinition(
   "user",
@@ -25,5 +32,12 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("user", "maybe"))->__invoke($x);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 0), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 27), \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 0),
+    \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 27),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-union.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-union.test
@@ -12,7 +12,14 @@
       return $a;
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 0), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 33), \Phel\Lang\Keyword::create("doc"), "```phel\n(either a)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[a]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 0),
+    \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 33),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(either a)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[a]"
+  )
 );
 \Phel::addDefinition(
   "user",
@@ -25,5 +32,12 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("user", "either"))->__invoke($x);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 0), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 28), \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 0),
+    \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 28),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-union.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-union.test
@@ -12,14 +12,7 @@
       return $a;
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(either a)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 33),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[a]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 0), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 33), \Phel\Lang\Keyword::create("doc"), "```phel\n(either a)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[a]")
 );
 \Phel::addDefinition(
   "user",
@@ -32,12 +25,5 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("user", "either"))->__invoke($x);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 28),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 0), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 28), \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-bails-on-bigint-literal.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-bails-on-bigint-literal.test
@@ -12,13 +12,5 @@
       return random_int(0, ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($x, \Phel\Lang\BigInt::fromString("99999999999999999999")));
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 64),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]",
-    \Phel\Lang\Keyword::create("tag"), "int"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 0), \Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 64), \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]", \Phel\Lang\Keyword::create("tag"), "int")
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-bails-on-bigint-literal.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-bails-on-bigint-literal.test
@@ -12,5 +12,13 @@
       return random_int(0, ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($x, \Phel\Lang\BigInt::fromString("99999999999999999999")));
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 0), \Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 64), \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]", \Phel\Lang\Keyword::create("tag"), "int")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 0),
+    \Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 64),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-int-stable.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-int-stable.test
@@ -11,5 +11,13 @@
       return random_int(0, ($x + $y));
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 0), \Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 48), \Phel\Lang\Keyword::create("doc"), "```phel\n(add-pair x y)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[x y]", \Phel\Lang\Keyword::create("tag"), "int")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 0),
+    \Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 48),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add-pair x y)\n```\n",
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[x y]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-int-stable.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-int-stable.test
@@ -11,13 +11,5 @@
       return random_int(0, ($x + $y));
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(add-pair x y)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 48),
-    "min-arity", 2,
-    "is-variadic", false,
-    "arglists", "[x y]",
-    \Phel\Lang\Keyword::create("tag"), "int"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 0), \Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 48), \Phel\Lang\Keyword::create("doc"), "```phel\n(add-pair x y)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[x y]", \Phel\Lang\Keyword::create("tag"), "int")
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-bails-on-disagreement.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-bails-on-disagreement.test
@@ -11,13 +11,5 @@
       return ($a . random_int(0, $a));
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(weird a)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 47),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[a]",
-    \Phel\Lang\Keyword::create("tag"), "string"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 0), \Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 47), \Phel\Lang\Keyword::create("doc"), "```phel\n(weird a)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[a]", \Phel\Lang\Keyword::create("tag"), "string")
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-bails-on-disagreement.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-bails-on-disagreement.test
@@ -11,5 +11,13 @@
       return ($a . random_int(0, $a));
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 0), \Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 47), \Phel\Lang\Keyword::create("doc"), "```phel\n(weird a)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[a]", \Phel\Lang\Keyword::create("tag"), "string")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 0),
+    \Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 47),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(weird a)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[a]",
+    \Phel\Lang\Keyword::create("tag"), "string"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-numeric.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-numeric.test
@@ -11,13 +11,5 @@
       return random_int(0, ($hi - $lo));
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(rrange lo hi)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 54),
-    "min-arity", 2,
-    "is-variadic", false,
-    "arglists", "[lo hi]",
-    \Phel\Lang\Keyword::create("tag"), "int"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 0), \Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 54), \Phel\Lang\Keyword::create("doc"), "```phel\n(rrange lo hi)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[lo hi]", \Phel\Lang\Keyword::create("tag"), "int")
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-numeric.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-numeric.test
@@ -11,5 +11,13 @@
       return random_int(0, ($hi - $lo));
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 0), \Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 54), \Phel\Lang\Keyword::create("doc"), "```phel\n(rrange lo hi)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[lo hi]", \Phel\Lang\Keyword::create("tag"), "int")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 0),
+    \Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 54),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(rrange lo hi)\n```\n",
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[lo hi]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-recursion-cycle.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-recursion-cycle.test
@@ -11,5 +11,13 @@
       return random_int(0, $this(($n - 1)));
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 0), \Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 51), \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[n]", \Phel\Lang\Keyword::create("tag"), "int")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 0),
+    \Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 51),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[n]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-recursion-cycle.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-recursion-cycle.test
@@ -11,13 +11,5 @@
       return random_int(0, $this(($n - 1)));
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 51),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[n]",
-    \Phel\Lang\Keyword::create("tag"), "int"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 0), \Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 51), \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[n]", \Phel\Lang\Keyword::create("tag"), "int")
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-phel-core-plus.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-phel-core-plus.test
@@ -12,12 +12,5 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, 1);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(inc-by-one a)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 29),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[a]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 0), \Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 29), \Phel\Lang\Keyword::create("doc"), "```phel\n(inc-by-one a)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[a]")
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-phel-core-plus.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-phel-core-plus.test
@@ -12,5 +12,12 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, 1);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 0), \Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 29), \Phel\Lang\Keyword::create("doc"), "```phel\n(inc-by-one a)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[a]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 0),
+    \Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 29),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(inc-by-one a)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[a]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-count-arg.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-count-arg.test
@@ -11,13 +11,5 @@
       return count($xs);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(size xs)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-php-count-arg.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-php-count-arg.test", 1, 31),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[xs]",
-    \Phel\Lang\Keyword::create("tag"), "int"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-php-count-arg.test", 1, 0), \Phel::location("Fn/fn-infer-php-count-arg.test", 1, 31), \Phel\Lang\Keyword::create("doc"), "```phel\n(size xs)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[xs]", \Phel\Lang\Keyword::create("tag"), "int")
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-count-arg.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-count-arg.test
@@ -11,5 +11,13 @@
       return count($xs);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-php-count-arg.test", 1, 0), \Phel::location("Fn/fn-infer-php-count-arg.test", 1, 31), \Phel\Lang\Keyword::create("doc"), "```phel\n(size xs)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[xs]", \Phel\Lang\Keyword::create("tag"), "int")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-php-count-arg.test", 1, 0),
+    \Phel::location("Fn/fn-infer-php-count-arg.test", 1, 31),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(size xs)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[xs]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-intdiv-args.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-intdiv-args.test
@@ -11,5 +11,13 @@
       return intdiv($a, $b);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 0), \Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 33), \Phel\Lang\Keyword::create("doc"), "```phel\n(div a b)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[a b]", \Phel\Lang\Keyword::create("tag"), "int")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 0),
+    \Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 33),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(div a b)\n```\n",
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[a b]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-intdiv-args.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-intdiv-args.test
@@ -11,13 +11,5 @@
       return intdiv($a, $b);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(div a b)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 33),
-    "min-arity", 2,
-    "is-variadic", false,
-    "arglists", "[a b]",
-    \Phel\Lang\Keyword::create("tag"), "int"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 0), \Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 33), \Phel\Lang\Keyword::create("doc"), "```phel\n(div a b)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[a b]", \Phel\Lang\Keyword::create("tag"), "int")
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-random-int-arg.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-random-int-arg.test
@@ -11,5 +11,13 @@
       return random_int(0, $hi);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 0), \Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 40), \Phel\Lang\Keyword::create("doc"), "```phel\n(rrange hi)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[hi]", \Phel\Lang\Keyword::create("tag"), "int")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 0),
+    \Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 40),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(rrange hi)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[hi]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-random-int-arg.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-random-int-arg.test
@@ -11,13 +11,5 @@
       return random_int(0, $hi);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(rrange hi)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 40),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[hi]",
-    \Phel\Lang\Keyword::create("tag"), "int"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 0), \Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 40), \Phel\Lang\Keyword::create("doc"), "```phel\n(rrange hi)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[hi]", \Phel\Lang\Keyword::create("tag"), "int")
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-mixed-branches-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-mixed-branches-bails.test
@@ -13,13 +13,6 @@
 
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(mixed x flag)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 57),
-    "min-arity", 2,
-    "is-variadic", false,
-    "arglists", "[x flag]"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 0), \Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 57), \Phel\Lang\Keyword::create("doc"), "```phel\n(mixed x flag)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[x flag]")
 );
 (\Phel::getDefinition("user", "mixed"))->__invoke("x", false);

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-mixed-branches-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-mixed-branches-bails.test
@@ -13,6 +13,13 @@
 
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 0), \Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 57), \Phel\Lang\Keyword::create("doc"), "```phel\n(mixed x flag)\n```\n", "min-arity", 2, "is-variadic", false, "arglists", "[x flag]")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 0),
+    \Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 57),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(mixed x flag)\n```\n",
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[x flag]"
+  )
 );
 (\Phel::getDefinition("user", "mixed"))->__invoke("x", false);

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-numeric.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-numeric.test
@@ -12,14 +12,6 @@
       return ($x + 1);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(add1 x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-param-infer-numeric.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-param-infer-numeric.test", 1, 27),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]",
-    \Phel\Lang\Keyword::create("tag"), "int"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-param-infer-numeric.test", 1, 0), \Phel::location("Fn/fn-param-infer-numeric.test", 1, 27), \Phel\Lang\Keyword::create("doc"), "```phel\n(add1 x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]", \Phel\Lang\Keyword::create("tag"), "int")
 );
 (\Phel::getDefinition("user", "add1"))->__invoke(42);

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-numeric.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-numeric.test
@@ -12,6 +12,14 @@
       return ($x + 1);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-param-infer-numeric.test", 1, 0), \Phel::location("Fn/fn-param-infer-numeric.test", 1, 27), \Phel\Lang\Keyword::create("doc"), "```phel\n(add1 x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]", \Phel\Lang\Keyword::create("tag"), "int")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-param-infer-numeric.test", 1, 0),
+    \Phel::location("Fn/fn-param-infer-numeric.test", 1, 27),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add1 x)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]",
+    \Phel\Lang\Keyword::create("tag"), "int"
+  )
 );
 (\Phel::getDefinition("user", "add1"))->__invoke(42);

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-string.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-string.test
@@ -12,6 +12,14 @@
       return ("hi " . $x);
     }
   },
-  \Phel::locationMeta(\Phel::location("Fn/fn-param-infer-string.test", 1, 0), \Phel::location("Fn/fn-param-infer-string.test", 1, 32), \Phel\Lang\Keyword::create("doc"), "```phel\n(greet x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]", \Phel\Lang\Keyword::create("tag"), "string")
+  \Phel::locationMeta(
+    \Phel::location("Fn/fn-param-infer-string.test", 1, 0),
+    \Phel::location("Fn/fn-param-infer-string.test", 1, 32),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(greet x)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]",
+    \Phel\Lang\Keyword::create("tag"), "string"
+  )
 );
 (\Phel::getDefinition("user", "greet"))->__invoke("world");

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-string.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-string.test
@@ -12,14 +12,6 @@
       return ("hi " . $x);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(greet x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-param-infer-string.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-param-infer-string.test", 1, 32),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]",
-    \Phel\Lang\Keyword::create("tag"), "string"
-  )
+  \Phel::locationMeta(\Phel::location("Fn/fn-param-infer-string.test", 1, 0), \Phel::location("Fn/fn-param-infer-string.test", 1, 32), \Phel\Lang\Keyword::create("doc"), "```phel\n(greet x)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[x]", \Phel\Lang\Keyword::create("tag"), "string")
 );
 (\Phel::getDefinition("user", "greet"))->__invoke("world");

--- a/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
@@ -19,11 +19,5 @@
       })();
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Foreach/foreach-expr.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Foreach/foreach-expr.test", 3, 18),
-    "min-arity", 0,
-    "is-variadic", false,
-    "arglists", "[]"
-  )
+  \Phel::locationMeta(\Phel::location("Foreach/foreach-expr.test", 1, 0), \Phel::location("Foreach/foreach-expr.test", 3, 18), "min-arity", 0, "is-variadic", false, "arglists", "[]")
 );

--- a/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
@@ -19,5 +19,11 @@
       })();
     }
   },
-  \Phel::locationMeta(\Phel::location("Foreach/foreach-expr.test", 1, 0), \Phel::location("Foreach/foreach-expr.test", 3, 18), "min-arity", 0, "is-variadic", false, "arglists", "[]")
+  \Phel::locationMeta(
+    \Phel::location("Foreach/foreach-expr.test", 1, 0),
+    \Phel::location("Foreach/foreach-expr.test", 3, 18),
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Foreach/foreach-tagged-array-param-skips-adapter.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-tagged-array-param-skips-adapter.test
@@ -17,12 +17,5 @@
       })();
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(process arr)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 59),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[arr]"
-  )
+  \Phel::locationMeta(\Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 0), \Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 59), \Phel\Lang\Keyword::create("doc"), "```phel\n(process arr)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[arr]")
 );

--- a/tests/php/Integration/Fixtures/Foreach/foreach-tagged-array-param-skips-adapter.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-tagged-array-param-skips-adapter.test
@@ -17,5 +17,12 @@
       })();
     }
   },
-  \Phel::locationMeta(\Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 0), \Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 59), \Phel\Lang\Keyword::create("doc"), "```phel\n(process arr)\n```\n", "min-arity", 1, "is-variadic", false, "arglists", "[arr]")
+  \Phel::locationMeta(
+    \Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 0),
+    \Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 59),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(process arr)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[arr]"
+  )
 );

--- a/tests/php/Integration/Fixtures/MacroExpand/defmacro-env-form.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/defmacro-env-form.test
@@ -13,13 +13,5 @@
 
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("macro"), true,
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(ns-present?)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("MacroExpand/defmacro-env-form.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("MacroExpand/defmacro-env-form.test", 1, 52),
-    "min-arity", 0,
-    "is-variadic", false,
-    "arglists", "[]"
-  )
+  \Phel::locationMeta(\Phel::location("MacroExpand/defmacro-env-form.test", 1, 0), \Phel::location("MacroExpand/defmacro-env-form.test", 1, 52), \Phel\Lang\Keyword::create("macro"), true, \Phel\Lang\Keyword::create("doc"), "```phel\n(ns-present?)\n```\n", "min-arity", 0, "is-variadic", false, "arglists", "[]")
 );

--- a/tests/php/Integration/Fixtures/MacroExpand/defmacro-env-form.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/defmacro-env-form.test
@@ -13,5 +13,13 @@
 
     }
   },
-  \Phel::locationMeta(\Phel::location("MacroExpand/defmacro-env-form.test", 1, 0), \Phel::location("MacroExpand/defmacro-env-form.test", 1, 52), \Phel\Lang\Keyword::create("macro"), true, \Phel\Lang\Keyword::create("doc"), "```phel\n(ns-present?)\n```\n", "min-arity", 0, "is-variadic", false, "arglists", "[]")
+  \Phel::locationMeta(
+    \Phel::location("MacroExpand/defmacro-env-form.test", 1, 0),
+    \Phel::location("MacroExpand/defmacro-env-form.test", 1, 52),
+    \Phel\Lang\Keyword::create("macro"), true,
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(ns-present?)\n```\n",
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
 );

--- a/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
@@ -17,13 +17,6 @@
       ]);
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("macro"), true,
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("MacroExpand/macro-expand.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("MacroExpand/macro-expand.test", 1, 38),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[n]"
-  )
+  \Phel::locationMeta(\Phel::location("MacroExpand/macro-expand.test", 1, 0), \Phel::location("MacroExpand/macro-expand.test", 1, 38), \Phel\Lang\Keyword::create("macro"), true, "min-arity", 1, "is-variadic", false, "arglists", "[n]")
 );
 (1 + 1);

--- a/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
@@ -17,6 +17,13 @@
       ]);
     }
   },
-  \Phel::locationMeta(\Phel::location("MacroExpand/macro-expand.test", 1, 0), \Phel::location("MacroExpand/macro-expand.test", 1, 38), \Phel\Lang\Keyword::create("macro"), true, "min-arity", 1, "is-variadic", false, "arglists", "[n]")
+  \Phel::locationMeta(
+    \Phel::location("MacroExpand/macro-expand.test", 1, 0),
+    \Phel::location("MacroExpand/macro-expand.test", 1, 38),
+    \Phel\Lang\Keyword::create("macro"), true,
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[n]"
+  )
 );
 (1 + 1);

--- a/tests/php/Integration/Fixtures/MacroExpand/return-array.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/return-array.test
@@ -13,14 +13,7 @@
       return array(1, 2, array(3, 4));
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("macro"), true,
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("MacroExpand/return-array.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("MacroExpand/return-array.test", 1, 55),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]"
-  )
+  \Phel::locationMeta(\Phel::location("MacroExpand/return-array.test", 1, 0), \Phel::location("MacroExpand/return-array.test", 1, 55), \Phel\Lang\Keyword::create("macro"), true, "min-arity", 1, "is-variadic", false, "arglists", "[x]")
 );
 \Phel::addDefinition(
   "user",

--- a/tests/php/Integration/Fixtures/MacroExpand/return-array.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/return-array.test
@@ -13,7 +13,14 @@
       return array(1, 2, array(3, 4));
     }
   },
-  \Phel::locationMeta(\Phel::location("MacroExpand/return-array.test", 1, 0), \Phel::location("MacroExpand/return-array.test", 1, 55), \Phel\Lang\Keyword::create("macro"), true, "min-arity", 1, "is-variadic", false, "arglists", "[x]")
+  \Phel::locationMeta(
+    \Phel::location("MacroExpand/return-array.test", 1, 0),
+    \Phel::location("MacroExpand/return-array.test", 1, 55),
+    \Phel\Lang\Keyword::create("macro"), true,
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
 );
 \Phel::addDefinition(
   "user",

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -24,11 +24,7 @@ require_once __DIR__ . '/my_namespace/core.php';
   "hello_world",
   "x",
   10,
-  \Phel::map(
-    \Phel\Lang\Keyword::create("private"), true,
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Ns/munge-ns.test", 5, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Ns/munge-ns.test", 5, 19)
-  )
+  \Phel::locationMeta(\Phel::location("Ns/munge-ns.test", 5, 0), \Phel::location("Ns/munge-ns.test", 5, 19), \Phel\Lang\Keyword::create("private"), true)
 );
 if (!class_exists('hello_world\abc')) {
 final class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
@@ -55,14 +51,7 @@ final class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
       return (new \hello_world\abc($a));
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(abc a)\n```\nCreates a new abc struct.",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Ns/munge-ns.test", 7, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Ns/munge-ns.test", 7, 19),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[a]"
-  )
+  \Phel::locationMeta(\Phel::location("Ns/munge-ns.test", 7, 0), \Phel::location("Ns/munge-ns.test", 7, 19), \Phel\Lang\Keyword::create("doc"), "```phel\n(abc a)\n```\nCreates a new abc struct.", "min-arity", 1, "is-variadic", false, "arglists", "[a]")
 );
 
 (\Phel::getDefinition("phel.core", "swap!"))->__invoke(\Phel::getDefinition("phel.core", "*type-tag-registry*"), \Phel::getDefinition("phel.core", "assoc"), \Phel::getDefinition("hello_world", "abc"), "hello_world\\abc");
@@ -76,12 +65,5 @@ final class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
       return is_a($x, "hello_world\\abc");
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(abc? x)\n```\nChecks if `x` is an instance of the abc struct.",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Ns/munge-ns.test", 7, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Ns/munge-ns.test", 7, 19),
-    "min-arity", 1,
-    "is-variadic", false,
-    "arglists", "[x]"
-  )
+  \Phel::locationMeta(\Phel::location("Ns/munge-ns.test", 7, 0), \Phel::location("Ns/munge-ns.test", 7, 19), \Phel\Lang\Keyword::create("doc"), "```phel\n(abc? x)\n```\nChecks if `x` is an instance of the abc struct.", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
 );

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -24,7 +24,11 @@ require_once __DIR__ . '/my_namespace/core.php';
   "hello_world",
   "x",
   10,
-  \Phel::locationMeta(\Phel::location("Ns/munge-ns.test", 5, 0), \Phel::location("Ns/munge-ns.test", 5, 19), \Phel\Lang\Keyword::create("private"), true)
+  \Phel::locationMeta(
+    \Phel::location("Ns/munge-ns.test", 5, 0),
+    \Phel::location("Ns/munge-ns.test", 5, 19),
+    \Phel\Lang\Keyword::create("private"), true
+  )
 );
 if (!class_exists('hello_world\abc')) {
 final class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
@@ -51,7 +55,14 @@ final class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
       return (new \hello_world\abc($a));
     }
   },
-  \Phel::locationMeta(\Phel::location("Ns/munge-ns.test", 7, 0), \Phel::location("Ns/munge-ns.test", 7, 19), \Phel\Lang\Keyword::create("doc"), "```phel\n(abc a)\n```\nCreates a new abc struct.", "min-arity", 1, "is-variadic", false, "arglists", "[a]")
+  \Phel::locationMeta(
+    \Phel::location("Ns/munge-ns.test", 7, 0),
+    \Phel::location("Ns/munge-ns.test", 7, 19),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(abc a)\n```\nCreates a new abc struct.",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[a]"
+  )
 );
 
 (\Phel::getDefinition("phel.core", "swap!"))->__invoke(\Phel::getDefinition("phel.core", "*type-tag-registry*"), \Phel::getDefinition("phel.core", "assoc"), \Phel::getDefinition("hello_world", "abc"), "hello_world\\abc");
@@ -65,5 +76,12 @@ final class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
       return is_a($x, "hello_world\\abc");
     }
   },
-  \Phel::locationMeta(\Phel::location("Ns/munge-ns.test", 7, 0), \Phel::location("Ns/munge-ns.test", 7, 19), \Phel\Lang\Keyword::create("doc"), "```phel\n(abc? x)\n```\nChecks if `x` is an instance of the abc struct.", "min-arity", 1, "is-variadic", false, "arglists", "[x]")
+  \Phel::locationMeta(
+    \Phel::location("Ns/munge-ns.test", 7, 0),
+    \Phel::location("Ns/munge-ns.test", 7, 19),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(abc? x)\n```\nChecks if `x` is an instance of the abc struct.",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Try/throw-expr.test
+++ b/tests/php/Integration/Fixtures/Try/throw-expr.test
@@ -14,11 +14,5 @@
       return $e_1;
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Try/throw-expr.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Try/throw-expr.test", 1, 56),
-    "min-arity", 0,
-    "is-variadic", false,
-    "arglists", "[]"
-  )
+  \Phel::locationMeta(\Phel::location("Try/throw-expr.test", 1, 0), \Phel::location("Try/throw-expr.test", 1, 56), "min-arity", 0, "is-variadic", false, "arglists", "[]")
 );

--- a/tests/php/Integration/Fixtures/Try/throw-expr.test
+++ b/tests/php/Integration/Fixtures/Try/throw-expr.test
@@ -14,5 +14,11 @@
       return $e_1;
     }
   },
-  \Phel::locationMeta(\Phel::location("Try/throw-expr.test", 1, 0), \Phel::location("Try/throw-expr.test", 1, 56), "min-arity", 0, "is-variadic", false, "arglists", "[]")
+  \Phel::locationMeta(
+    \Phel::location("Try/throw-expr.test", 1, 0),
+    \Phel::location("Try/throw-expr.test", 1, 56),
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Yield/yield-array.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-array.test
@@ -19,12 +19,5 @@
       })();
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_array)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Yield/yield-array.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Yield/yield-array.test", 3, 26),
-    "min-arity", 0,
-    "is-variadic", false,
-    "arglists", "[]"
-  )
+  \Phel::locationMeta(\Phel::location("Yield/yield-array.test", 1, 0), \Phel::location("Yield/yield-array.test", 3, 26), \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_array)\n```\n", "min-arity", 0, "is-variadic", false, "arglists", "[]")
 );

--- a/tests/php/Integration/Fixtures/Yield/yield-array.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-array.test
@@ -19,5 +19,12 @@
       })();
     }
   },
-  \Phel::locationMeta(\Phel::location("Yield/yield-array.test", 1, 0), \Phel::location("Yield/yield-array.test", 3, 26), \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_array)\n```\n", "min-arity", 0, "is-variadic", false, "arglists", "[]")
+  \Phel::locationMeta(
+    \Phel::location("Yield/yield-array.test", 1, 0),
+    \Phel::location("Yield/yield-array.test", 3, 26),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_array)\n```\n",
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Yield/yield-doseq-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-doseq-str.test
@@ -19,12 +19,5 @@
       })();
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_str)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Yield/yield-doseq-str.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Yield/yield-doseq-str.test", 3, 23),
-    "min-arity", 0,
-    "is-variadic", false,
-    "arglists", "[]"
-  )
+  \Phel::locationMeta(\Phel::location("Yield/yield-doseq-str.test", 1, 0), \Phel::location("Yield/yield-doseq-str.test", 3, 23), \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_str)\n```\n", "min-arity", 0, "is-variadic", false, "arglists", "[]")
 );

--- a/tests/php/Integration/Fixtures/Yield/yield-doseq-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-doseq-str.test
@@ -19,5 +19,12 @@
       })();
     }
   },
-  \Phel::locationMeta(\Phel::location("Yield/yield-doseq-str.test", 1, 0), \Phel::location("Yield/yield-doseq-str.test", 3, 23), \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_str)\n```\n", "min-arity", 0, "is-variadic", false, "arglists", "[]")
+  \Phel::locationMeta(
+    \Phel::location("Yield/yield-doseq-str.test", 1, 0),
+    \Phel::location("Yield/yield-doseq-str.test", 3, 23),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_str)\n```\n",
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Yield/yield-return-context.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-return-context.test
@@ -14,5 +14,12 @@
       yield 2;
     }
   },
-  \Phel::locationMeta(\Phel::location("Yield/yield-return-context.test", 1, 0), \Phel::location("Yield/yield-return-context.test", 3, 18), \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_no_return)\n```\n", "min-arity", 0, "is-variadic", false, "arglists", "[]")
+  \Phel::locationMeta(
+    \Phel::location("Yield/yield-return-context.test", 1, 0),
+    \Phel::location("Yield/yield-return-context.test", 3, 18),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_no_return)\n```\n",
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
 );

--- a/tests/php/Integration/Fixtures/Yield/yield-return-context.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-return-context.test
@@ -14,12 +14,5 @@
       yield 2;
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_no_return)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Yield/yield-return-context.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Yield/yield-return-context.test", 3, 18),
-    "min-arity", 0,
-    "is-variadic", false,
-    "arglists", "[]"
-  )
+  \Phel::locationMeta(\Phel::location("Yield/yield-return-context.test", 1, 0), \Phel::location("Yield/yield-return-context.test", 3, 18), \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_no_return)\n```\n", "min-arity", 0, "is-variadic", false, "arglists", "[]")
 );

--- a/tests/php/Integration/Fixtures/Yield/yield-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-str.test
@@ -19,12 +19,5 @@
       })();
     }
   },
-  \Phel::map(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_str)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Yield/yield-str.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Yield/yield-str.test", 3, 23),
-    "min-arity", 0,
-    "is-variadic", false,
-    "arglists", "[]"
-  )
+  \Phel::locationMeta(\Phel::location("Yield/yield-str.test", 1, 0), \Phel::location("Yield/yield-str.test", 3, 23), \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_str)\n```\n", "min-arity", 0, "is-variadic", false, "arglists", "[]")
 );

--- a/tests/php/Integration/Fixtures/Yield/yield-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-str.test
@@ -19,5 +19,12 @@
       })();
     }
   },
-  \Phel::locationMeta(\Phel::location("Yield/yield-str.test", 1, 0), \Phel::location("Yield/yield-str.test", 3, 23), \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_str)\n```\n", "min-arity", 0, "is-variadic", false, "arglists", "[]")
+  \Phel::locationMeta(
+    \Phel::location("Yield/yield-str.test", 1, 0),
+    \Phel::location("Yield/yield-str.test", 3, 23),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_str)\n```\n",
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
 );

--- a/tests/php/Unit/Phel/PhelConstructorsTest.php
+++ b/tests/php/Unit/Phel/PhelConstructorsTest.php
@@ -87,4 +87,40 @@ final class PhelConstructorsTest extends TestCase
         self::assertTrue($start->equals($actual[Keyword::create('start-location')]));
         self::assertTrue($end->equals($actual[Keyword::create('end-location')]));
     }
+
+    /**
+     * A definition carrying extra metadata (`:doc`, `:private`, …) folds those
+     * pairs in as trailing arguments; the map is key-order independent, so it
+     * must still equal the expanded literal the compiler used to emit.
+     */
+    public function test_location_meta_with_extra_metadata_equals_expanded(): void
+    {
+        $start = Phel::location('example.phel', 1, 0);
+        $end = Phel::location('example.phel', 2, 5);
+
+        $expected = Phel::map(
+            Keyword::create('doc'),
+            'greets someone',
+            Keyword::create('private'),
+            true,
+            Keyword::create('start-location'),
+            $start,
+            Keyword::create('end-location'),
+            $end,
+        );
+
+        $actual = Phel::locationMeta(
+            $start,
+            $end,
+            Keyword::create('doc'),
+            'greets someone',
+            Keyword::create('private'),
+            true,
+        );
+
+        self::assertTrue($actual->equals($expected));
+        self::assertSame('greets someone', $actual[Keyword::create('doc')]);
+        self::assertTrue($actual[Keyword::create('private')]);
+        self::assertTrue($start->equals($actual[Keyword::create('start-location')]));
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Follow-up to #2723 (merged). That PR compacted metadata only for *trivial* defs (location-only). Definitions carrying a docstring, `:private`, `:tag` or arity-reflection meta still emitted the expanded `\Phel::map(...)` literal — which covers most of `phel\core`.

## 💡 Goal

Extend the compaction to those defs too, keeping the runtime metadata map value-equal. Relates to #2722.

## 🔖 Changes

- `\Phel::locationMeta(start, end, ...$extraKeyValues)` is now variadic; extra metadata pairs fold in after the two locations.
- `MapEmitter::defLocationMeta` collapses any def-meta map carrying both location-shaped `:start-location` + `:end-location` entries, forwarding the remaining key/values as trailing arguments to `locationMeta`.
- Extras wrap **one argument per line** (location-only maps stay single-line), so the generated PHP and the fixtures remain diff-readable and debuggable.
- Regenerated 65 integration fixtures; unit test covers the extra-metadata case.

## 📉 Impact — generated PHP, branch vs `main`

Compiled with `phel compile`:

| source | bytes | lines |
|---|---|---|
| `core/math.phel` | 105,265 → 98,704 (**−6.2%**) | 2,325 → 2,325 |
| `core/seq-fns.phel` | 180,967 → 172,624 (**−4.6%**) | 3,803 → 3,803 |
| 3-def sample (docstring + `:private` + plain) | 1,509 → 1,266 (**−16.1%**) | 48 → 48 |

Line count matches `main` — the multi-line layout is preserved. The byte win comes from dropping the two `\Phel\Lang\Keyword::create("start-location")` / `"end-location")` interns and the `\Phel::map(...)` wrapper per def; the runtime win (two fewer keyword interns at load) is the same regardless of line formatting.

## ✅ Verification

- `phpunit --testsuite=unit,integration`: **unit + 1020 integration pass**, 0 fail. `phel test` core: **6232 pass**, 0 fail. phpstan level 9 + psalm clean.
- Runtime map is **value-equal**, not byte-identical: value, `equals` and `hash` are key-order independent (confirmed by reverting the two source files and diffing). Folding the locations to the front only changes the metadata map's *iteration/print* order, which Phel maps do not guarantee and which no consumer relies on — every reader (`phel\core` tests, `Api`, `Interop`) accesses metadata by key or `=`. Adversarial review also cleared duplicate-key, foreign-location-value and non-def map-literal edge cases (all stay value-equal, no invalid PHP).
- Docstrings/CHANGELOG tightened from the earlier "byte-value-identical" wording to "value-equal" to match what actually holds.

## 🎨 Resolved: line formatting

The draft asked whether to keep multi-line formatting for docstring-rich defs. **Kept multi-line** — generated PHP is read when debugging compiled output and reviewed in fixtures, and whitespace is free at PHP load time. Only location-only maps (no extras) stay on a single line, matching #2723.
