### PR TITLE
fix(compiler): typed-vector get returns nil on out-of-range/non-int key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 - Distributed PHAR no longer bundles example templates' build artifacts — `phel init --template` shipped any leftover `.phel/` cache and `vendor/`, bloating a release PHAR from ~2 MB to ~14 MB; only template sources ship now (#2678)
 - `phel test --help` now shows `--parallel=auto` in its example; the bare `--parallel` it printed before errors, since the option needs a value (an integer, `auto`, or `max`) (#2679)
+- `get` on a `:tag`-typed vector with an out-of-range or non-integer key now returns `nil` (or the supplied default), matching runtime `get`, instead of throwing — the compiler no longer lowers it to an unguarded `$v->get()` (#2712)
 
 ### Performance
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -10,7 +10,6 @@ use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Lang\AbstractFn;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
-use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\FnInterface;
 
 use function count;
@@ -87,12 +86,11 @@ final readonly class CallSpecialization
     }
 
     /**
-     * `(get coll k)` with two args, where the analyser has tagged the
-     * target as either `PersistentVectorInterface` or
-     * `PersistentMapInterface`. The runtime `phel.core/get` body walks
-     * a `cond` chain covering nil, set, seq, and the generic
-     * `php/aget` fallback; for a typed indexed access every branch
-     * collapses to a single method call on the target collection.
+     * `(get map k)` with two args, where the analyser has tagged the
+     * target as `PersistentMapInterface`. The runtime `phel.core/get`
+     * body walks a `cond` chain covering nil, set, seq, and the generic
+     * `php/aget` fallback; for a typed map lookup every branch collapses
+     * to the nil-safe `find` method call.
      */
     public static function isTypedGetAccess(CallNode $node): bool
     {
@@ -103,6 +101,15 @@ final readonly class CallSpecialization
      * Returns the PHP method name to call on the target collection for
      * a `(get coll k)` call the emitter can specialise, or `null` when
      * the call is not a typed get-access.
+     *
+     * A tagged VECTOR `get` is deliberately NOT specialised here: unlike
+     * the map's nil-safe `find`, `PersistentVector::get(int)` throws when
+     * the index is out of range and TypeErrors on a non-int key, whereas
+     * runtime `phel.core/get` returns nil for both (it guards non-int keys
+     * and out-of-range access). Delegating vector `get` to the runtime
+     * keeps those semantics; `nth` remains the specialised O(1) accessor.
+     * A correct fast vector `get` (int-check + bounds guard with single
+     * evaluation of the key) is left as follow-up.
      */
     public static function typedGetAccessMethod(CallNode $node): ?string
     {
@@ -116,7 +123,6 @@ final readonly class CallSpecialization
         }
 
         return match (TagNormalizer::ofLocalVar($args[0])) {
-            PersistentVectorInterface::class => 'get',
             PersistentMapInterface::class => 'find',
             default => null,
         };

--- a/tests/php/Integration/Fixtures/Call/get-on-persistent-vector-local.test
+++ b/tests/php/Integration/Fixtures/Call/get-on-persistent-vector-local.test
@@ -2,5 +2,6 @@
 (fn [^"\\Phel\\Lang\\Collections\\Vector\\PersistentVectorInterface" v ^int i] (get v i))
 --PHP--
 (function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v, int $i) {
-  return ($v->get($i));
+  static $__phel_call_0;
+  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "get"))->__invoke($v, $i);
 });


### PR DESCRIPTION
## 🤔 Background

While investigating #2712 (widen type inference to reach the native fast paths), the emitter's typed-vector `get` specialization turned out to be a latent correctness bug. A `:tag`-typed `PersistentVector` `(get v k)` lowered to `$v->get($k)`:

- out-of-range index → **throws** `IndexOutOfBoundsException`;
- non-integer key → **TypeError** (`get(int)` rejects e.g. a keyword).

Runtime `phel.core/get` returns `nil` for both (it guards non-int keys and out-of-range access before `php/aget`). So a compiled typed-vector `get` silently diverged from documented `get` semantics.

## 💡 Goal

Make typed-vector `get` behave like runtime `get`.

## 🔖 Changes

- `CallSpecialization::typedGetAccessMethod` no longer specializes `get` on a `PersistentVectorInterface`-tagged target — it delegates to the runtime (nil-safe) instead of the throwing `$v->get()`.
- Unchanged: the nil-safe map `find` path, and the already bounds-guarded `nth`/`count`/`first`/`second`/`last` vector specializations. `nth` remains the specialized O(1) vector accessor.
- Regenerated `get-on-persistent-vector-local.test`.
- CHANGELOG under `## Unreleased`.

## ✅ Verification

- Specialized-vs-dynamic matrix (`get`/`nth`/`count`/`first`/`last`, in-bounds/OOB/default/non-int, vector + map): OOB `get` now returns `nil` (was a throw); every other op already matched.
- `phpunit --testsuite=unit,integration`: **4970 pass**, 0 fail. `phel test` core: **6232 pass**, 0 fail. phpstan level 9 clean.

## Note on the rest of #2712

The issue's headline ask — *infer* collection types so unannotated `let`-bound vector/map literals hit these specializations automatically — was implemented on a spike and benchmarked branch-vs-`main`. It showed **no measurable runtime win** (within noise, below the issue's own ">5% is real" bar) in any config tested: no-opcache, opcache warm, and `opcache.jit=tracing`. Runtime collection-op dispatch is already cheap (short cond chains with `php/aget` fast paths + a cheap registry lookup), so replacing it with a direct method call saves ~nothing; the "15–30% overhead" the issue cites applies to numeric ops, which the existing scalar inference (#2627) already captures.

So only this correctness fix ships here. #2712 is left open for a call on whether the collection inference is worth pursuing (e.g. as a prerequisite to #2714, if that proves a win).
