### PR TITLE
test: lock lazy-seq force-once contract

### DIFF
--- a/tests/phel/core/sequence-operation.phel
+++ b/tests/phel/core/sequence-operation.phel
@@ -489,6 +489,21 @@
   (is (= '() (concat nil nil)) "concat two nil")
   (is (= [1 2 3 4 5 6] (concat [1 2 3] nil [4 5 6])) "concat vectors and nil"))
 
+(deftest test-lazy-seq-force-once
+  ;; A side-effecting step fn in a lazy pipeline must realize exactly once per
+  ;; cell, even when the same seq is walked multiple times (Clojure force-once).
+  (let [calls (atom 0)
+        s     (map (fn [x] (swap! calls inc) (* x 10)) [1 2 3 4 5])]
+    (is (= 150 (reduce + 0 s)) "first full walk sums mapped values")
+    (is (= 150 (reduce + 0 s)) "second full walk returns the cached values")
+    (is (= 5 @calls) "step fn fires once per element across both walks, not per walk"))
+  (let [fires (atom 0)
+        one   (lazy-seq (swap! fires inc) (cons 42 nil))]
+    (first one)
+    (first one)
+    (first one)
+    (is (= 1 @fires) "single-cell lazy-seq realizes its thunk exactly once")))
+
 (deftest test-compact
   (is (= [1 2 3] (compact [1 nil 2 nil 3])) "compact removes nil by default")
   (is (= [1 2 3] (compact [1 0 2 false 3] 0 false)) "compact removes specified values")


### PR DESCRIPTION
## 🤔 Background

#2713 proposed adding force-once memoization to lazy sequences, suspecting the producing thunk re-runs on every traversal (O(passes)). Investigation shows the behavior **already exists**:

- `LazySeq::realize()` runs the thunk once, clears `$this->fn`, and caches `$this->realized`; later derefs return the cache.
- `ChunkedSeq` wraps its tail in `MemoizedThunk` (force-once).
- `Cons` holds a concrete head + lazy tail — no recomputation.

Empirically (side-effecting step fn, counting invocations):

| case | fires | verdict |
|---|---|---|
| single-cell lazy-seq, 3× `first` | **1** | memoized |
| finite `map` pipeline walked 2× | **5** (not 10) | memoized |
| infinite `map`/`take` 5, walked 2× | **6** (not 10) | memoized (+1 = `iterate` lookahead) |

Already covered by PHP unit tests: `LazySeqTest::test_caches_realized_values` and the realize-once assertion. No correctness bug, no runtime work needed.

## 💡 Goal

Lock the force-once contract at the **Phel language surface** (the `map` + `lazy-seq` macro + `reduce` wiring), not just the `LazySeq` class, so a future regression in core seq plumbing is caught.

## 🔖 Changes

- Add `test-lazy-seq-force-once` to `tests/phel/core/sequence-operation.phel`: a side-effecting step fn in a `map`/`reduce` pipeline realizes each cell exactly once across repeated walks (asserts 5, would read 10 if re-forced); a single-cell `lazy-seq` runs its thunk once across repeated `first` (asserts 1, would read 3).

Test-only, no behavior change — no CHANGELOG entry. Refs #2713.
