### PR TITLE
perf(compiler): infer let/loop binding types for argument-independent PHP built-ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 
 ### Performance
 
+- `let`/`loop` bindings whose init calls a pure PHP built-in with a fixed primitive return type (`php/cos`, `php/sqrt`, `php/ord`, `php/implode`, and ~35 more trig/math/string/`ctype_*` functions) now infer that type, so arithmetic, comparison, and string ops on the binding emit native PHP operators instead of runtime dispatch — matching what already happened when the call was written inline as an operand. Argument-typed functions (`pow`, `str_replace`, `json_encode`) stay excluded so no wrong tag is stamped (#2712)
 - `def`/`defn` location metadata emits a single `\Phel::locationMeta(...)` call instead of an expanded keyword-keyed map; extra metadata (`:doc`, `:private`, `:tag`, …) folds in as trailing args, so docstring-heavy namespaces shrink too. Runtime map stays value-equal (#2722, #2725)
 - Equal collection literals (`[1 2 3]`, `{:a 1}`, sets) repeated in a function body share one cached constant slot instead of one per occurrence, shrinking emitted PHP (#2720)
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PurePhpFunctionReturnTypes.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PurePhpFunctionReturnTypes.php
@@ -16,22 +16,60 @@ namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
  * with a stable signature across supported PHP versions; anything whose
  * return type depends on its arguments or runtime mode stays out so the
  * inferrers never stamp the wrong tag.
+ *
+ * Stricter than the emitter's {@see \Phel\Compiler\Domain\Emitter\OutputEmitter\KnownPhpFunctionReturnTypes}:
+ * that table may over-widen an operand to make a native operator fire (it
+ * tags `pow`/`str_replace`/`json_encode`), because the emitter only needs
+ * the operator, not the exact type. A tag written here PERSISTS on the
+ * binding and feeds later inference (equality, collection access), so only
+ * functions whose result is exactly one primitive on every non-throwing
+ * input belong here. Deliberately absent despite being in the emitter table:
+ * `pow` (`int|float`), `str_replace` (`string|array`), `hex2bin`/`json_encode`
+ * (`string|false`), `abs`/`min`/`max` (argument-typed).
  */
 final class PurePhpFunctionReturnTypes
 {
     /** @var array<string, string> */
     private const array RETURN_TYPES = [
+        // int
         'strlen' => 'int',
-        'intval' => 'int',
         'mb_strlen' => 'int',
         'count' => 'int',
-        'random_int' => 'int',
+        'intval' => 'int',
         'intdiv' => 'int',
+        'ord' => 'int',
+        'crc32' => 'int',
+        'random_int' => 'int',
+        'mt_rand' => 'int',
+        'rand' => 'int',
+
+        // float — PHP `floor`/`ceil`/`round` return float, not int (`gettype(floor(3.7)) === "double"`).
         'floatval' => 'float',
         'doubleval' => 'float',
         'floor' => 'float',
         'ceil' => 'float',
         'round' => 'float',
+        'sqrt' => 'float',
+        'exp' => 'float',
+        'log' => 'float',
+        'log10' => 'float',
+        'log2' => 'float',
+        'cos' => 'float',
+        'sin' => 'float',
+        'tan' => 'float',
+        'acos' => 'float',
+        'asin' => 'float',
+        'atan' => 'float',
+        'atan2' => 'float',
+        'fmod' => 'float',
+        'fdiv' => 'float',
+        'hypot' => 'float',
+        'deg2rad' => 'float',
+        'rad2deg' => 'float',
+        'pi' => 'float',
+        'lcg_value' => 'float',
+
+        // bool
         'boolval' => 'bool',
         'is_int' => 'bool',
         'is_integer' => 'bool',
@@ -45,16 +83,37 @@ final class PurePhpFunctionReturnTypes
         'is_object' => 'bool',
         'is_callable' => 'bool',
         'is_numeric' => 'bool',
+        'is_iterable' => 'bool',
+        'is_countable' => 'bool',
+        'array_key_exists' => 'bool',
+        'in_array' => 'bool',
+        'ctype_alpha' => 'bool',
+        'ctype_digit' => 'bool',
+        'ctype_alnum' => 'bool',
+        'ctype_space' => 'bool',
+
+        // string
         'strval' => 'string',
+        'gettype' => 'string',
+        'sprintf' => 'string',
         'strtolower' => 'string',
         'strtoupper' => 'string',
         'mb_strtolower' => 'string',
         'mb_strtoupper' => 'string',
+        'ucfirst' => 'string',
+        'ucwords' => 'string',
+        'lcfirst' => 'string',
         'trim' => 'string',
         'ltrim' => 'string',
         'rtrim' => 'string',
-        'sprintf' => 'string',
-        'gettype' => 'string',
+        'str_repeat' => 'string',
+        'str_pad' => 'string',
+        'substr' => 'string',
+        'chr' => 'string',
+        'implode' => 'string',
+        'join' => 'string',
+        'bin2hex' => 'string',
+        'base64_encode' => 'string',
     ];
 
     private function __construct() {}

--- a/tests/php/Integration/Fixtures/Call/str-inferred-string-locals-folds-to-concat.test
+++ b/tests/php/Integration/Fixtures/Call/str-inferred-string-locals-folds-to-concat.test
@@ -1,6 +1,6 @@
 --PHEL--
 (fn [^string a ^string b] (str "[" a b "]"))
 --PHP--
-(function(string $a, string $b) {
+(function(string $a, string $b): string {
   return ("[" . $a . $b . "]");
 });

--- a/tests/php/Integration/Fixtures/Def/defstruct-php-magic-methods.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-php-magic-methods.test
@@ -24,7 +24,7 @@ final class counter extends \Phel\Lang\Collections\Struct\AbstractPersistentStru
     return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($x, $n);
   }
 
-  public function __toString() {
+  public function __toString(): string {
     $n = $this->n;
     static $__phel_call_0;
     $this_2 = $this;

--- a/tests/php/Integration/Fixtures/Inline/str.test
+++ b/tests/php/Integration/Fixtures/Inline/str.test
@@ -6,10 +6,10 @@
 --PHP--
 (function(string $a) {
   return "";
-});(function(string $a) {
+});(function(string $a): string {
   return ($a);
-});(function(string $a, string $b) {
+});(function(string $a, string $b): string {
   return ($a . $b);
-});(function(string $a, string $b, string $c) {
+});(function(string $a, string $b, string $c): string {
   return ($a . $b . $c);
 });

--- a/tests/php/Integration/Fixtures/Let/let-php-implode-native-concat.test
+++ b/tests/php/Integration/Fixtures/Let/let-php-implode-native-concat.test
@@ -1,0 +1,8 @@
+--PHEL--
+(fn [xs] (let [s (php/implode "," xs)] (php/. s "!")))
+--PHP--
+(function($xs): string {
+  /** @var string $s_1 */
+  $s_1 = implode(",", $xs);
+  return ($s_1 . "!");
+});

--- a/tests/php/Integration/Fixtures/Let/let-php-ord-native-add.test
+++ b/tests/php/Integration/Fixtures/Let/let-php-ord-native-add.test
@@ -1,0 +1,8 @@
+--PHEL--
+(fn [s] (let [o (php/ord s)] (+ o 1)))
+--PHP--
+(function($s) {
+  /** @var int $o_1 */
+  $o_1 = ord($s);
+  return ($o_1 + 1);
+});

--- a/tests/php/Integration/Fixtures/Let/let-php-pow-bails.test
+++ b/tests/php/Integration/Fixtures/Let/let-php-pow-bails.test
@@ -1,0 +1,8 @@
+--PHEL--
+(fn [^int x] (let [p (php/pow x 2)] (+ p 1)))
+--PHP--
+(function(int $x) {
+  static $__phel_call_0;
+  $p_1 = pow($x, 2);
+  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($p_1, 1);
+});

--- a/tests/php/Integration/Fixtures/Let/let-php-sqrt-native-mul.test
+++ b/tests/php/Integration/Fixtures/Let/let-php-sqrt-native-mul.test
@@ -1,0 +1,8 @@
+--PHEL--
+(fn [^float x] (let [s (php/sqrt x)] (* s 2.0)))
+--PHP--
+(function(float $x) {
+  /** @var float $s_1 */
+  $s_1 = sqrt($x);
+  return ($s_1 * 2.0);
+});

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/SpecialForm/PurePhpFunctionReturnTypesTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/SpecialForm/PurePhpFunctionReturnTypesTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PurePhpFunctionReturnTypes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the table's contract: only functions whose result is exactly one
+ * primitive on every non-throwing input may be listed, because a tag read
+ * from here is grafted onto a binding and propagates through later
+ * inference. Argument-typed or `false`-on-error functions must stay out even
+ * when the looser emitter table lists them.
+ */
+final class PurePhpFunctionReturnTypesTest extends TestCase
+{
+    public function test_int_returning_functions(): void
+    {
+        foreach (['strlen', 'count', 'intval', 'intdiv', 'ord', 'crc32', 'random_int', 'mt_rand', 'rand'] as $fn) {
+            self::assertSame('int', PurePhpFunctionReturnTypes::returnTypeOf($fn), $fn);
+        }
+    }
+
+    public function test_float_returning_functions(): void
+    {
+        foreach (['floor', 'ceil', 'round', 'sqrt', 'exp', 'log', 'cos', 'sin', 'tan', 'atan2', 'fmod', 'fdiv', 'hypot', 'pi', 'lcg_value'] as $fn) {
+            self::assertSame('float', PurePhpFunctionReturnTypes::returnTypeOf($fn), $fn);
+        }
+    }
+
+    public function test_bool_returning_functions(): void
+    {
+        foreach (['is_int', 'is_string', 'is_iterable', 'is_countable', 'array_key_exists', 'in_array', 'ctype_alpha', 'ctype_digit'] as $fn) {
+            self::assertSame('bool', PurePhpFunctionReturnTypes::returnTypeOf($fn), $fn);
+        }
+    }
+
+    public function test_string_returning_functions(): void
+    {
+        foreach (['strval', 'sprintf', 'str_repeat', 'str_pad', 'substr', 'chr', 'implode', 'join', 'bin2hex', 'base64_encode'] as $fn) {
+            self::assertSame('string', PurePhpFunctionReturnTypes::returnTypeOf($fn), $fn);
+        }
+    }
+
+    /**
+     * These live in the emitter's KnownPhpFunctionReturnTypes (which only
+     * needs the operator to be right) but must NOT be tagged by the analyzer:
+     * their return type depends on the argument or falls back to `false`.
+     */
+    public function test_argument_dependent_functions_are_excluded(): void
+    {
+        foreach (['pow', 'str_replace', 'hex2bin', 'json_encode', 'abs', 'min', 'max'] as $fn) {
+            self::assertNull(PurePhpFunctionReturnTypes::returnTypeOf($fn), $fn);
+        }
+    }
+
+    public function test_unknown_function_returns_null(): void
+    {
+        self::assertNull(PurePhpFunctionReturnTypes::returnTypeOf('some_unlisted_fn'));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Phel's analyzer already infers primitive `:tag` types for `let`/`loop` bindings (issue #2712 tracks widening this). It reads `PurePhpFunctionReturnTypes` to type a binding whose init is a PHP built-in. That table was a **strict subset** of the emitter's `KnownPhpFunctionReturnTypes`, so the *same* call specialized as a direct arithmetic operand but fell back to runtime dispatch once its result was let-bound:

```phel
(fn [^float x] (+ (php/cos x) 1.0))          ; native:   (cos($x) + 1.0)
(fn [^float x] (let [c (php/cos x)] (+ c 1.0))) ; before: (+)->__invoke($c_1, 1.0)   ← dispatch
```

`cos`, `sqrt`, `ord`, `implode`, and ~35 other fixed-return built-ins the emitter already trusts were simply missing from the analyzer table.

## 💡 Goal

Give `let`/`loop` binding inference the same PHP-built-in knowledge the emitter has, so the binding inherits the type and native arithmetic / comparison / concat fires — with **zero emitter change** (the specialization seam already reads the binding's inferred tag).

## 🔖 Changes

- **`PurePhpFunctionReturnTypes`**: add the argument-independent, single-primitive-return built-ins present in the emitter table but missing here — trig/math → `float` (`cos sin tan a* sqrt exp log* fmod fdiv hypot deg2rad rad2deg pi lcg_value`), `ord`/`crc32`/`mt_rand`/`rand` → `int`, `ctype_*`/`in_array`/`array_key_exists`/`is_iterable`/`is_countable` → `bool`, `chr`/`implode`/`join`/`str_repeat`/`str_pad`/`substr`/`ucfirst`/`ucwords`/`lcfirst`/`bin2hex`/`base64_encode` → `string`.
- **Deliberately excluded** despite being in the emitter table: `pow` (`int|float`), `str_replace` (`string|array`), `hex2bin`/`json_encode` (`string|false`), `abs`/`min`/`max` (argument-typed). A tag written here **persists on the binding** and feeds later inference (equality, collection access), so it must be exact — unlike the emitter table, which only needs the operator to be right. Class docblock now spells this contract out.
- **Fixtures** (`tests/php/Integration/Fixtures/Let/`): `let-php-sqrt-native-mul`, `let-php-ord-native-add`, `let-php-implode-native-concat` prove the new native emission; `let-php-pow-bails` locks the exclusion (still dynamic dispatch).
- **Unit test** `PurePhpFunctionReturnTypesTest`: pins the table contract, incl. that the excluded argument-typed functions return `null`.

Result — the same `(let [c (php/cos x)] (+ c 1.0))` now emits `($c_1 + 1.0)`.

## Notes

First slice of #2712 (the PHP-built-in path). The complementary "infer through `fn`" work — propagating a called user/global fn's inferred `:tag` return type into let bindings and operands — is a separate follow-up. Refs #2712.

`phpstan` L9 + `psalm` L1 clean; full `unit` suite (3966) and the `Let/` integration fixtures green. (The 4 local `TestCommandCoverageTest` failures are pre-existing and environmental — they need `xdebug.mode=coverage`, unrelated to this change.)

### Bonus: return-type inference chain

The table is shared with `ReturnTypeInferrer`, so widening it also improves fn/return inference. Adding `implode` types the multi-arg tail of phel.core `str` (`(php/implode "" parts)`); all branches of `str` then agree on `string`, so `str` infers `:tag string` — which correctly flows a `: string` return declaration onto fns and struct methods whose tail is a `str` call. Three existing fixtures are updated to observe this (`str` concat fold, `str` inlining, defstruct `__toString(): string`). `__invoke` returning `(+ x n)` stays untyped (numeric overflow promotion) and zero-arg `(str)` folding to a literal `""` keeps no return tag — both verified.

> Note: analyzing `phel.core` from source is what surfaces this; a stale local compiled-core cache can mask it (CI compiles clean). Verified with a clean cache via `paratest` — full integration suite green apart from the pre-existing `xdebug.mode` coverage tests.
