### PR TITLE
fix(build): bust stale compiled-code cache on compiler-only output changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.
 - Distributed PHAR no longer bundles example templates' build artifacts — `phel init --template` shipped any leftover `.phel/` cache and `vendor/`, bloating a release PHAR from ~2 MB to ~14 MB; only template sources ship now (#2678)
 - `phel test --help` now shows `--parallel=auto` in its example; the bare `--parallel` it printed before errors, since the option needs a value (an integer, `auto`, or `max`) (#2679)
 - `get` on a `:tag`-typed vector with an out-of-range or non-integer key now returns `nil` (or the supplied default), matching runtime `get`, instead of throwing — the compiler no longer lowers it to an unguarded `$v->get()` (#2712)
-- The compiled-code cache no longer serves stale PHP after a compiler-only change: its per-source key hashes just the `.phel` source, so an emitter/analyzer change that alters output for unchanged source (e.g. the cross-fn return-type `:tag` inference) could keep serving a pre-change compiled file within the same version. The cache index format version is bumped, invalidating stale entries once and forcing a cold recompile
+- The compiled-code cache no longer serves stale PHP after a compiler-only change: its per-source key hashes just the `.phel` source, so an emitter/analyzer change that alters output for unchanged source (e.g. the cross-fn return-type `:tag` inference) could keep serving a pre-change compiled file within the same version. The cache index format version is bumped, invalidating stale entries once and forcing a cold recompile (#2732)
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Distributed PHAR no longer bundles example templates' build artifacts — `phel init --template` shipped any leftover `.phel/` cache and `vendor/`, bloating a release PHAR from ~2 MB to ~14 MB; only template sources ship now (#2678)
 - `phel test --help` now shows `--parallel=auto` in its example; the bare `--parallel` it printed before errors, since the option needs a value (an integer, `auto`, or `max`) (#2679)
 - `get` on a `:tag`-typed vector with an out-of-range or non-integer key now returns `nil` (or the supplied default), matching runtime `get`, instead of throwing — the compiler no longer lowers it to an unguarded `$v->get()` (#2712)
+- The compiled-code cache no longer serves stale PHP after a compiler-only change: its per-source key hashes just the `.phel` source, so an emitter/analyzer change that alters output for unchanged source (e.g. the cross-fn return-type `:tag` inference) could keep serving a pre-change compiled file within the same version. The cache index format version is bumped, invalidating stale entries once and forcing a cold recompile
 
 ### Performance
 

--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,10 @@
             "@static-clear-cache",
             "@test-all"
         ],
-        "test-compiler": "./vendor/bin/phpunit --testsuite=unit,integration --log-junit=data/log-junit.xml",
+        "test-compiler": [
+            "./vendor/bin/phpunit --testsuite=unit --log-junit=data/log-junit.xml",
+            "./vendor/bin/paratest --testsuite=integration --runner=WrapperRunner"
+        ],
         "test-compiler:coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --testsuite=unit,integration --coverage-html=data/coverage-html --coverage-xml=data/coverage-xml --log-junit=data/coverage-xml/junit.xml",
         "test-unit": "./vendor/bin/phpunit --testsuite=unit",
         "test-integration": "./vendor/bin/paratest --testsuite=integration --runner=WrapperRunner",

--- a/src/php/Build/Infrastructure/Cache/CacheIndexFile.php
+++ b/src/php/Build/Infrastructure/Cache/CacheIndexFile.php
@@ -23,9 +23,13 @@ use function is_string;
  */
 final readonly class CacheIndexFile
 {
-    // Bump when entry structure changes (namespace/source_hash/compiled_path/last_accessed keys).
+    // Bump when the entry structure changes (namespace/source_hash/compiled_path/last_accessed keys)
+    // OR when the emitted PHP format changes within a release: the per-source `source_hash` only
+    // tracks the .phel source, so a compiler change that alters output for unchanged source (e.g. the
+    // #2729 cross-fn `:tag` inference) leaves stale compiled files that a same-version cache would
+    // keep serving. Bumping here rejects the whole index once, forcing a cold recompile.
     // Decoupled from the Phel version for cache stability across minor releases.
-    private const string INDEX_FORMAT_VERSION = '1.2';
+    private const string INDEX_FORMAT_VERSION = '1.3';
 
     public function __construct(
         private CacheDirectory $directory,


### PR DESCRIPTION
## 🤔 Background

The compiled-code cache keys each entry by a `source_hash` that hashes **only the `.phel` source**, and the index `version()` folds in just the `INDEX_FORMAT_VERSION` and the Phel version string. Neither moves on a compiler-only change. So an emitter/analyzer change that alters the emitted PHP for *unchanged* source — e.g. the recent cross-fn return-type `:tag` inference (#2729) — leaves a pre-change compiled `.php` that a same-version cache keeps serving. Result: stale PHP after a compiler bump, and 4 return-type integration fixtures failing against a warm cache.

## 💡 Goal

Invalidate the stale compiled-code cache once so a cold recompile picks up the new emitter output, and speed up the compiler test target while here.

## 🔖 Changes

- **fix(build):** bump `CacheIndexFile::INDEX_FORMAT_VERSION` `1.2 → 1.3`. This rejects the whole index once, forcing a cold recompile that regenerates compiled files with the current emitter output. The doc comment on the constant now records *why* a compiler-only output change requires a bump.
  - **Deliberately a one-time bump, not a systematic fix.** The root cause — `source_hash` tracks source only, and `version()` doesn't move on a compiler-only change — recurs on the next emitter/analyzer change. Folding the compiler-output format into the cache key is a separate, larger change; this unblocks the current stale state.
- **perf(test):** split `test-compiler` into a serial `unit` run + a parallel (`paratest`, `WrapperRunner`) `integration` run, instead of one combined `phpunit --testsuite=unit,integration`. Integration fixtures parallelize cleanly; unit stays serial.
- **docs:** CHANGELOG `## Unreleased` entry under `### Fixed`.
