### PR TITLE
fix: degrade disk caches gracefully in read-only environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `phel` no longer fatals in read-only environments (e.g. the NixOS build sandbox): Gacela's file cache, the build caches (compiled-code, namespace, dependency-graph, scan-index), and the intermediate cache now degrade to in-memory/disabled variants when the cache dir cannot be created, and `phel doc` inside a PHAR falls back to the system temp dir when the working directory is unwritable — `phel --help`, `doc`, `eval`, and the REPL all work from an unwritable project root (nixpkgs 0.47.0 `versionCheckHook` failure)
 - Distributed PHAR no longer bundles example templates' build artifacts — `phel init --template` shipped any leftover `.phel/` cache and `vendor/`, bloating a release PHAR from ~2 MB to ~14 MB; only template sources ship now (#2678)
 - `phel test --help` now shows `--parallel=auto` in its example; the bare `--parallel` it printed before errors, since the option needs a value (an integer, `auto`, or `max`) (#2679)
 - `get` on a `:tag`-typed vector with an out-of-range or non-integer key now returns `nil` (or the supplied default), matching runtime `get`, instead of throwing — the compiler no longer lowers it to an unguarded `$v->get()` (#2712)

--- a/src/php/Api/Infrastructure/PhelFunctionRuntimeLoader.php
+++ b/src/php/Api/Infrastructure/PhelFunctionRuntimeLoader.php
@@ -141,14 +141,20 @@ final readonly class PhelFunctionRuntimeLoader
         // and keeps the generated file out of the (possibly read-only) package
         // tree. Inside a PHAR sys_get_temp_dir() is fine too, but the cwd keeps
         // the generated namespace resolvable against the project's own sources.
-        $baseDir = Phar::running() !== '' ? $this->currentWorkingDir() : sys_get_temp_dir();
+        // An unwritable cwd (read-only sandbox) falls back to sys temp.
+        $baseDirs = Phar::running() !== ''
+            ? [$this->currentWorkingDir(), sys_get_temp_dir()]
+            : [sys_get_temp_dir()];
 
-        $tempDir = $baseDir . '/.phel_temp_' . uniqid('', true);
-        if (!mkdir($tempDir, 0755, true) && !is_dir($tempDir)) {
-            throw new RuntimeException(sprintf('Unable to create temporary directory at "%s".', $tempDir));
+        $suffix = '/.phel_temp_' . uniqid('', true);
+        foreach ($baseDirs as $baseDir) {
+            $tempDir = $baseDir . $suffix;
+            if (@mkdir($tempDir, 0755, true) || is_dir($tempDir)) {
+                return $tempDir . '/doc.phel';
+            }
         }
 
-        return $tempDir . '/doc.phel';
+        throw new RuntimeException(sprintf('Unable to create temporary directory at "%s%s".', end($baseDirs), $suffix));
     }
 
     private function currentWorkingDir(): string

--- a/src/php/Build/BuildConfig.php
+++ b/src/php/Build/BuildConfig.php
@@ -10,6 +10,7 @@ use Phel\Config\PhelConfig;
 use Phel\Shared\CompileOptions;
 use Phel\Shared\PhelProjectDirectory;
 use Phel\Shared\ScalarCoercion;
+use Phel\Shared\WritableCacheDir;
 
 use function is_string;
 
@@ -60,12 +61,14 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
 
     public function isNamespaceCacheEnabled(): bool
     {
-        return (bool) $this->get(PhelConfig::ENABLE_NAMESPACE_CACHE, true);
+        return (bool) $this->get(PhelConfig::ENABLE_NAMESPACE_CACHE, true)
+            && WritableCacheDir::isUsable($this->getCacheDir());
     }
 
     public function isCompiledCodeCacheEnabled(): bool
     {
-        return (bool) $this->get(PhelConfig::ENABLE_COMPILED_CODE_CACHE, true);
+        return (bool) $this->get(PhelConfig::ENABLE_COMPILED_CODE_CACHE, true)
+            && WritableCacheDir::isUsable($this->getCacheDir());
     }
 
     public function getTempDir(): string

--- a/src/php/Compiler/CompilerConfig.php
+++ b/src/php/Compiler/CompilerConfig.php
@@ -8,6 +8,7 @@ use Gacela\Framework\AbstractConfig;
 use Phel\Config\PhelConfig;
 use Phel\Shared\PhelProjectDirectory;
 use Phel\Shared\ScalarCoercion;
+use Phel\Shared\WritableCacheDir;
 
 use function is_string;
 
@@ -25,7 +26,8 @@ final class CompilerConfig extends AbstractConfig
 
     public function isIntermediateCacheEnabled(): bool
     {
-        return (bool) $this->get(PhelConfig::ENABLE_INTERMEDIATE_CACHE, false);
+        return (bool) $this->get(PhelConfig::ENABLE_INTERMEDIATE_CACHE, false)
+            && WritableCacheDir::isUsable($this->getCacheDir());
     }
 
     /**

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -18,6 +18,7 @@ use Phel\Run\RunFacade;
 use Phel\Shared\PhelProjectDirectory;
 use Phel\Shared\ProjectRootResolver;
 use Phel\Shared\ScalarCoercion;
+use Phel\Shared\WritableCacheDir;
 use RuntimeException;
 use Throwable;
 
@@ -104,9 +105,12 @@ class Phel
         }
 
         try {
-            Gacela::bootstrap($projectRootDir, self::configFn());
+            Gacela::bootstrap($projectRootDir, self::configFn($projectRootDir));
 
-            self::mergedConfigCacheInvalidator()->refreshIfStale();
+            if (self::isFileCacheUsable($projectRootDir)) {
+                self::mergedConfigCacheInvalidator()->refreshIfStale();
+            }
+
             // Forces the merged app config to materialize, so a broken
             // phel-config.php fails here (inside the guard) rather than later.
             self::mirrorPhelDirToEnv();
@@ -176,10 +180,18 @@ class Phel
     /**
      * @return Closure(GacelaConfig):void
      */
-    public static function configFn(): callable
+    public static function configFn(?string $projectRootDir = null): callable
     {
-        return static function (GacelaConfig $config): void {
-            $config->enableFileCache(self::FILE_CACHE_DIR);
+        $rootDir = $projectRootDir ?? (getcwd() ?: '');
+
+        return static function (GacelaConfig $config) use ($rootDir): void {
+            // In read-only environments (e.g. the NixOS build sandbox, where
+            // cwd is `/` and there is no writable HOME) Gacela's file cache
+            // would fatal on `mkdir`. Fall back to its in-memory cache instead.
+            if (self::isFileCacheUsable($rootDir)) {
+                $config->enableFileCache(self::FILE_CACHE_DIR);
+            }
+
             // If we have auto-detected config (no phel-config.php exists), use it
             $autoConfig = self::getAutoDetectedConfig();
             if ($autoConfig instanceof PhelConfig) {
@@ -204,6 +216,24 @@ class Phel
     public static function resetAutoDetectedConfig(): void
     {
         self::$autoDetectedConfig = null;
+    }
+
+    /**
+     * Whether Gacela's file cache can actually write to disk. Gacela throws an
+     * uncaught RuntimeException when the cache dir cannot be created, which
+     * turned `phel --help` into a fatal in sandboxed/read-only environments
+     * (e.g. the NixOS build sandbox, where the resolved root is `/`).
+     *
+     * A `GACELA_CACHE_DIR` env override is trusted as-is: the user explicitly
+     * chose that dir, so a failure there should stay loud.
+     */
+    private static function isFileCacheUsable(string $projectRootDir): bool
+    {
+        if (getenv('GACELA_CACHE_DIR') !== false) {
+            return true;
+        }
+
+        return WritableCacheDir::isUsable($projectRootDir . '/' . self::FILE_CACHE_DIR);
     }
 
     /**

--- a/src/php/Shared/CLAUDE.md
+++ b/src/php/Shared/CLAUDE.md
@@ -46,6 +46,7 @@ Stateless strategy-pattern printer (see `Printer/CLAUDE.md`); consumers instanti
 | `ScalarCoercion` | coerce config `mixed`→scalar with default: static `toString()`, `toInt()`, `toFloat()`, `toStringList()` |
 | `ResourceUsageFormatter` | `resourceUsageSinceStartOfRequest()` → "Time: HH:MM:SS.mmm, Memory: X.XX MB" |
 | `PhelProjectDirectory` | manages `.phel/` dir; static `ensure()`/`path()`/`resolve()`. Effective location: `PHEL_DIR` env → `withPhelDir()` override → `<projectRoot>/.phel` |
+| `WritableCacheDir` | static `isUsable(dir)` (memoized; `reset()` for tests) — can the cache dir be written to (creates it when missing)? Gates every disk cache (Gacela file cache in `Phel::bootstrap`, Build's compiled-code/namespace caches, Compiler's intermediate cache) so read-only sandboxes (NixOS build) degrade to in-memory instead of fataling |
 | `VersionFinder` | pure version-string builder from explicit git inputs (no I/O); `getVersion()`. `LATEST_VERSION` const is bumped by `tools/release.sh` |
 | `VersionResolver` | gathers ambient version inputs (git working copy, Composer `InstalledVersions`, build-time `.phel-release.php`/`OFFICIAL_RELEASE`) and calls `VersionFinder`; `resolve()`. Console and Run consume directly, so neither owns version-detection wiring |
 | `CompiledSourceHash` | static `of(code, optLevel)` → compiled-code cache key (mixes `\|O{level}` when level>0, plain `md5` at 0). Shared so Build's `FileEvaluator` writer and `SecondaryFileHarvester` reader key identically |

--- a/src/php/Shared/WritableCacheDir.php
+++ b/src/php/Shared/WritableCacheDir.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared;
+
+use function is_dir;
+use function is_writable;
+use function mkdir;
+
+/**
+ * Answers whether a cache directory can actually be written to, creating it
+ * when possible. Disk caches must degrade to their in-memory/null variants
+ * instead of fataling in read-only environments (e.g. the NixOS build
+ * sandbox, where the resolved project root is `/` and there is no writable
+ * HOME) — Gacela's FileCache and the build caches all throw an uncaught
+ * RuntimeException on a failed `mkdir`.
+ */
+final class WritableCacheDir
+{
+    /** @var array<string, bool> */
+    private static array $usableByDir = [];
+
+    public static function isUsable(string $dir): bool
+    {
+        return self::$usableByDir[$dir] ??= self::check($dir);
+    }
+
+    /**
+     * Reset the memoized results (useful for testing).
+     */
+    public static function reset(): void
+    {
+        self::$usableByDir = [];
+    }
+
+    private static function check(string $dir): bool
+    {
+        if ($dir === '') {
+            return false;
+        }
+
+        if (is_dir($dir)) {
+            return is_writable($dir);
+        }
+
+        // Creating the dir here is not a side effect to avoid: it is the same
+        // dir the gated cache would create lazily on its first write.
+        return @mkdir($dir, 0o777, true) || is_dir($dir);
+    }
+}

--- a/tests/php/Integration/Bootstrap/ReadOnlyProjectRootTest.php
+++ b/tests/php/Integration/Bootstrap/ReadOnlyProjectRootTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Bootstrap;
+
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function chmod;
+use function dirname;
+use function escapeshellarg;
+use function implode;
+use function mkdir;
+use function proc_close;
+use function proc_open;
+use function random_bytes;
+use function realpath;
+use function rmdir;
+use function stream_get_contents;
+use function sys_get_temp_dir;
+
+use const PHP_BINARY;
+
+/**
+ * Runs the source `bin/phel` from a read-only working directory with no HOME,
+ * the shape of the NixOS build sandbox where the resolved project root is not
+ * writable. Before this guard existed Gacela's file cache (and the build
+ * dependency-graph cache) fataled on `mkdir`, which broke the nixpkgs
+ * `versionCheckHook` (`phel --help`).
+ */
+final class ReadOnlyProjectRootTest extends TestCase
+{
+    private string $binPath;
+
+    private string $readOnlyDir;
+
+    protected function setUp(): void
+    {
+        $repoRoot = dirname(__DIR__, 4);
+        $this->binPath = $repoRoot . '/bin/phel';
+
+        $this->readOnlyDir = realpath(sys_get_temp_dir())
+            . '/phel-readonly-' . bin2hex(random_bytes(6));
+        mkdir($this->readOnlyDir, 0755, true);
+        chmod($this->readOnlyDir, 0555);
+
+        if (@mkdir($this->readOnlyDir . '/probe')) {
+            @rmdir($this->readOnlyDir . '/probe');
+            self::markTestSkipped('chmod has no effect (running as root?)');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        @chmod($this->readOnlyDir, 0755);
+        @rmdir($this->readOnlyDir);
+    }
+
+    public function test_help_prints_the_version_from_a_read_only_cwd(): void
+    {
+        $result = $this->runPhelInReadOnlyDir(['--help']);
+
+        self::assertSame(0, $result['exit'], $result['stderr']);
+        self::assertStringContainsString('Phel v', $result['stdout']);
+        self::assertStringNotContainsString('was not created', $result['stderr']);
+    }
+
+    public function test_doc_works_from_a_read_only_cwd(): void
+    {
+        $result = $this->runPhelInReadOnlyDir(['doc', 'map']);
+
+        self::assertSame(0, $result['exit'], $result['stderr']);
+        self::assertStringContainsString('map', $result['stdout']);
+        self::assertStringNotContainsString('was not created', $result['stderr']);
+    }
+
+    public function test_eval_works_from_a_read_only_cwd(): void
+    {
+        $result = $this->runPhelInReadOnlyDir(['eval', '(+ 40 2)']);
+
+        self::assertSame(0, $result['exit'], $result['stderr']);
+        self::assertStringContainsString('42', $result['stdout']);
+    }
+
+    /**
+     * @param list<string> $args
+     *
+     * @return array{exit: int, stdout: string, stderr: string}
+     */
+    private function runPhelInReadOnlyDir(array $args): array
+    {
+        $cmd = implode(' ', [
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($this->binPath),
+            ...array_map(escapeshellarg(...), $args),
+        ]);
+
+        // No HOME mirrors the sandbox; keep PATH + TMPDIR so PHP still works.
+        $env = array_diff_key(getenv(), ['HOME' => '']);
+
+        $proc = proc_open($cmd, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, $this->readOnlyDir, $env);
+        self::assertIsResource($proc, 'proc_open failed');
+
+        $stdout = stream_get_contents($pipes[1]) ?: '';
+        $stderr = stream_get_contents($pipes[2]) ?: '';
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($proc);
+
+        return ['exit' => $exit, 'stdout' => $stdout, 'stderr' => $stderr];
+    }
+}

--- a/tests/php/Unit/Shared/WritableCacheDirTest.php
+++ b/tests/php/Unit/Shared/WritableCacheDirTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared;
+
+use Phel\Shared\WritableCacheDir;
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function chmod;
+use function is_writable;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function sys_get_temp_dir;
+
+final class WritableCacheDirTest extends TestCase
+{
+    private string $baseDir;
+
+    protected function setUp(): void
+    {
+        WritableCacheDir::reset();
+        $this->baseDir = sys_get_temp_dir() . '/phel-writable-' . bin2hex(random_bytes(6));
+        mkdir($this->baseDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        WritableCacheDir::reset();
+        @chmod($this->baseDir, 0755);
+        @rmdir($this->baseDir . '/nested/cache');
+        @rmdir($this->baseDir . '/nested');
+        @rmdir($this->baseDir);
+    }
+
+    public function test_existing_writable_dir_is_usable(): void
+    {
+        self::assertTrue(WritableCacheDir::isUsable($this->baseDir));
+    }
+
+    public function test_missing_dir_under_writable_parent_is_created_and_usable(): void
+    {
+        $dir = $this->baseDir . '/nested/cache';
+
+        self::assertTrue(WritableCacheDir::isUsable($dir));
+        self::assertDirectoryExists($dir);
+    }
+
+    public function test_dir_under_read_only_parent_is_not_usable(): void
+    {
+        chmod($this->baseDir, 0555);
+        if (is_writable($this->baseDir . '/probe') || @mkdir($this->baseDir . '/probe')) {
+            @rmdir($this->baseDir . '/probe');
+            self::markTestSkipped('chmod has no effect (running as root?)');
+        }
+
+        self::assertFalse(WritableCacheDir::isUsable($this->baseDir . '/nested/cache'));
+        self::assertDirectoryDoesNotExist($this->baseDir . '/nested/cache');
+    }
+
+    public function test_read_only_existing_dir_is_not_usable(): void
+    {
+        chmod($this->baseDir, 0555);
+        if (@mkdir($this->baseDir . '/probe')) {
+            @rmdir($this->baseDir . '/probe');
+            self::markTestSkipped('chmod has no effect (running as root?)');
+        }
+
+        self::assertFalse(WritableCacheDir::isUsable($this->baseDir));
+    }
+
+    public function test_empty_dir_is_not_usable(): void
+    {
+        self::assertFalse(WritableCacheDir::isUsable(''));
+    }
+
+    public function test_result_is_memoized_until_reset(): void
+    {
+        $dir = $this->baseDir . '/nested/cache';
+        self::assertTrue(WritableCacheDir::isUsable($dir));
+
+        rmdir($dir);
+        rmdir($this->baseDir . '/nested');
+        self::assertTrue(WritableCacheDir::isUsable($dir), 'memoized answer survives dir removal');
+
+        WritableCacheDir::reset();
+        self::assertTrue(WritableCacheDir::isUsable($dir), 're-created after reset');
+        self::assertDirectoryExists($dir);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

The nixpkgs auto-update of phel 0.45.1 → 0.47.0 [failed](https://nixpkgs-update-logs.nix-community.org/phel/2026-07-12.log): in the NixOS build sandbox the resolved project root is `/` (read-only, no writable HOME), so Gacela's file cache fataled during bootstrap with `Uncaught RuntimeException: Directory "//.phel/cache" was not created`. Even `phel --help` died, which broke the nixpkgs `versionCheckHook`.

`phel doc` had two more independent fatals in the same environment: the Build dependency-graph cache (Gacela `FileCache`, same uncaught mkdir throw) and, in PHAR mode, the generated-doc temp dir being created under the (unwritable) cwd.

## 💡 Goal

`phel` never fatals because a cache directory cannot be created. Disk caches degrade to their in-memory/disabled variants; the CLI works end-to-end from an unwritable project root so the next release packages cleanly on NixOS.

## 🔖 Changes

- New `Phel\Shared\WritableCacheDir` pure utility: `isUsable(dir)` — is the cache dir writable (creating it when missing, memoized per dir).
- `Phel::bootstrap`/`configFn`: enable Gacela's file cache (and run the merged-config invalidator) only when `.phel/cache` is usable; otherwise Gacela's in-memory cache takes over. An explicit `GACELA_CACHE_DIR` override is trusted as-is and stays loud on failure.
- `BuildConfig::isNamespaceCacheEnabled/isCompiledCodeCacheEnabled` and `CompilerConfig::isIntermediateCacheEnabled` now also require a usable cache dir — gates the compiled-code, dependency-graph, namespace, and scan-index caches plus the intermediate cache without touching their call sites.
- `phel doc` in PHAR mode falls back to `sys_get_temp_dir()` when the cwd is unwritable.
- Tests: `WritableCacheDirTest` (unit) and `ReadOnlyProjectRootTest` (integration — runs `bin/phel --help`/`doc`/`eval` from a chmod-0555 cwd with no HOME).

Verified manually from a read-only cwd with HOME unset: `--help`, `--version`, `list`, `config`, `doc map`, `eval`, and the REPL all exit 0, for both `bin/phel` and the built PHAR. A deliberately unwritable `TEMP_DIR` still fails loud — compilation genuinely needs it, and the system temp dir is writable in the Nix sandbox.

Fixes the nixpkgs 0.47.0 update failure.