### PR TITLE
fix: harden CLI for read-only and minimal environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `phel format` no longer aborts with an uncaught exception when the scanned tree contains an unreadable directory (skips it), and reports an error instead of silently succeeding when a reformatted file cannot be written back
+- `phel test --coverage` and `phel profile --output` now report an error instead of printing success when the report file cannot be written; `phel run --debug` warns once and keeps running when the debug log location is unwritable (it looped silent failed writes before)
+- Read-only friendliness: the temp-dir and error-log writers no longer emit raw PHP warnings on failure (the clear error/stderr message remains), and `symfony/polyfill-mbstring` is now an explicit dependency so minimal PHP builds without `ext-mbstring` keep working
 - `phel` no longer fatals in read-only environments (e.g. the NixOS build sandbox): Gacela's file cache, the build caches (compiled-code, namespace, dependency-graph, scan-index), and the intermediate cache now degrade to in-memory/disabled variants when the cache dir cannot be created, and `phel doc` inside a PHAR falls back to the system temp dir when the working directory is unwritable — `phel --help`, `doc`, `eval`, and the REPL all work from an unwritable project root (nixpkgs 0.47.0 `versionCheckHook` failure)
 - Distributed PHAR no longer bundles example templates' build artifacts — `phel init --template` shipped any leftover `.phel/` cache and `vendor/`, bloating a release PHAR from ~2 MB to ~14 MB; only template sources ship now (#2678)
 - `phel test --help` now shows `--parallel=auto` in its example; the bare `--parallel` it printed before errors, since the option needs a value (an integer, `auto`, or `max`) (#2679)

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "amphp/amp": "^3.1",
         "gacela-project/gacela": "^1.15",
         "symfony/console": "^6.0|^7.0|^8.0",
+        "symfony/polyfill-mbstring": "^1.30",
         "symfony/routing": "^7.3|^8.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc56b112af98298bb58ff7a9a732424b",
+    "content-hash": "e77857af50c438a6eed1befdf28d0cdf",
     "packages": [
         {
             "name": "amphp/amp",
@@ -788,16 +788,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -849,7 +849,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -869,7 +869,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php85",

--- a/src/php/Command/Infrastructure/ErrorLog.php
+++ b/src/php/Command/Infrastructure/ErrorLog.php
@@ -19,7 +19,9 @@ final readonly class ErrorLog implements ErrorLogInterface
     {
         $this->ensureParentDirectory();
 
-        file_put_contents(
+        // Best-effort: the error already reaches stderr; a read-only log
+        // location must not turn error reporting itself into a warning.
+        @file_put_contents(
             $this->filepath,
             $text . PHP_EOL,
             FILE_APPEND | LOCK_EX,

--- a/src/php/Compiler/Infrastructure/Service/DebugLineTap.php
+++ b/src/php/Compiler/Infrastructure/Service/DebugLineTap.php
@@ -33,14 +33,18 @@ final class DebugLineTap
     /** @var array<string, string|null> */
     private array $phelSourceCache = [];
 
+    private bool $logWritable = true;
+
     private function __construct(
         private readonly string $logPath,
         private readonly ?string $phelFileFilter = null,
     ) {
         $this->lastFlushTime = microtime(true);
         $this->writeHeader();
-        register_tick_function($this->onTick(...));
-        register_shutdown_function($this->flush(...));
+        if ($this->logWritable) {
+            register_tick_function($this->onTick(...));
+            register_shutdown_function($this->flush(...));
+        }
     }
 
     public static function enable(?string $phelFileFilter = null, string $logPath = './phel-debug.log'): void
@@ -70,6 +74,10 @@ final class DebugLineTap
 
     private function onTick(): void
     {
+        if (!$this->logWritable) {
+            return;
+        }
+
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
         if ($trace === []) {
             return;
@@ -114,7 +122,10 @@ final class DebugLineTap
             return;
         }
 
-        file_put_contents($this->logPath, implode('', $this->buffer), FILE_APPEND | LOCK_EX);
+        if (@file_put_contents($this->logPath, implode('', $this->buffer), FILE_APPEND | LOCK_EX) === false) {
+            $this->disableLogging('flush');
+        }
+
         $this->buffer = [];
         $this->lastFlushTime = microtime(true);
     }
@@ -147,7 +158,25 @@ final class DebugLineTap
         }
 
         $header .= "=======================================================\n\n";
-        file_put_contents($this->logPath, $header);
+        if (@file_put_contents($this->logPath, $header) === false) {
+            $this->disableLogging('open');
+        }
+    }
+
+    /**
+     * The tap runs from a tick function, so a persistently unwritable log
+     * (e.g. read-only cwd) must warn once and stop tracing instead of
+     * retrying the failed write on every tick until shutdown.
+     */
+    private function disableLogging(string $stage): void
+    {
+        $this->logWritable = false;
+        $this->buffer = [];
+        @fwrite(STDERR, sprintf(
+            "phel: debug trace disabled, cannot %s log file %s\n",
+            $stage,
+            $this->logPath,
+        ));
     }
 
     private function getSource(string $file, int $line): string

--- a/src/php/Filesystem/Application/TempDirFinder.php
+++ b/src/php/Filesystem/Application/TempDirFinder.php
@@ -74,7 +74,9 @@ final class TempDirFinder
         }
 
         $oldUmask = umask(0);
-        if (!mkdir($tempDir, 0777, true) && !is_dir($tempDir)) {
+        // Suppressed: the thrown FileException is the user-facing signal; the
+        // raw PHP warning would just duplicate it as noise above the error.
+        if (!@mkdir($tempDir, 0777, true) && !is_dir($tempDir)) {
             throw FileException::canNotCreateDirectory($tempDir);
         }
 

--- a/src/php/Formatter/Application/PhelPathFilter.php
+++ b/src/php/Formatter/Application/PhelPathFilter.php
@@ -54,9 +54,12 @@ final class PhelPathFilter implements PathFilterInterface
      */
     private function createRecursiveIterator(string $path): RecursiveIteratorIterator
     {
+        // CATCH_GET_CHILD skips unreadable subdirectories instead of aborting
+        // the whole format run with an uncaught UnexpectedValueException.
         return new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::SKIP_DOTS),
             RecursiveIteratorIterator::LEAVES_ONLY,
+            RecursiveIteratorIterator::CATCH_GET_CHILD,
         );
     }
 

--- a/src/php/Formatter/Infrastructure/IO/SystemFileIo.php
+++ b/src/php/Formatter/Infrastructure/IO/SystemFileIo.php
@@ -39,6 +39,8 @@ final class SystemFileIo implements FileIoInterface
 
     public function putContents(string $filename, string $data): void
     {
-        file_put_contents($filename, $data);
+        if (@file_put_contents($filename, $data) === false) {
+            throw new RuntimeException(sprintf('Unable to write file "%s".', $filename));
+        }
     }
 }

--- a/src/php/Profile/Infrastructure/Command/ProfileCommand.php
+++ b/src/php/Profile/Infrastructure/Command/ProfileCommand.php
@@ -178,7 +178,12 @@ HELP)
 
         $json = $this->getFacade()->renderJson($report);
         if ($writeToFile) {
-            file_put_contents($outputFile, $json);
+            if (@file_put_contents($outputFile, $json) === false) {
+                $output->writeln(sprintf('<error>Cannot write JSON report to %s</error>', $outputFile));
+
+                return;
+            }
+
             $output->writeln(sprintf('<info>JSON report written to %s</info>', $outputFile));
 
             return;

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -381,7 +381,11 @@ HELP)
             : $report->toText();
 
         if (is_string($outputPath) && $outputPath !== '') {
-            file_put_contents($outputPath, $content);
+            if (@file_put_contents($outputPath, $content) === false) {
+                $output->writeln(sprintf('<error>Cannot write coverage report to %s</error>', $outputPath));
+                return;
+            }
+
             $output->writeln(sprintf('Coverage report written to %s', $outputPath));
             return;
         }
@@ -397,7 +401,10 @@ HELP)
         }
 
         foreach (new HtmlCoverageRenderer()->render($report) as $pageName => $html) {
-            file_put_contents($directory . '/' . $pageName, $html);
+            if (@file_put_contents($directory . '/' . $pageName, $html) === false) {
+                $output->writeln(sprintf('<error>Cannot write coverage page %s</error>', $directory . '/' . $pageName));
+                return;
+            }
         }
 
         $output->writeln(sprintf('HTML coverage report written to %s', $directory . '/index.html'));

--- a/tests/php/Unit/Formatter/Application/PhelPathFilterTest.php
+++ b/tests/php/Unit/Formatter/Application/PhelPathFilterTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Formatter\Application;
+
+use Phel\Formatter\Application\PhelPathFilter;
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function chmod;
+use function file_put_contents;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function sys_get_temp_dir;
+use function unlink;
+
+final class PhelPathFilterTest extends TestCase
+{
+    private string $baseDir;
+
+    protected function setUp(): void
+    {
+        $this->baseDir = sys_get_temp_dir() . '/phel-path-filter-' . bin2hex(random_bytes(6));
+        mkdir($this->baseDir . '/readable', 0755, true);
+        mkdir($this->baseDir . '/unreadable', 0755, true);
+        file_put_contents($this->baseDir . '/readable/a.phel', '(ns a)');
+        file_put_contents($this->baseDir . '/unreadable/hidden.phel', '(ns hidden)');
+        chmod($this->baseDir . '/unreadable', 0000);
+    }
+
+    protected function tearDown(): void
+    {
+        @chmod($this->baseDir . '/unreadable', 0755);
+        @unlink($this->baseDir . '/unreadable/hidden.phel');
+        @unlink($this->baseDir . '/readable/a.phel');
+        @rmdir($this->baseDir . '/unreadable');
+        @rmdir($this->baseDir . '/readable');
+        @rmdir($this->baseDir);
+    }
+
+    public function test_unreadable_subdirectory_is_skipped_not_fatal(): void
+    {
+        if (is_readable($this->baseDir . '/unreadable')) {
+            self::markTestSkipped('chmod has no effect (running as root?)');
+        }
+
+        $paths = new PhelPathFilter()->filterPaths([$this->baseDir]);
+
+        self::assertSame([$this->baseDir . '/readable/a.phel'], $paths);
+    }
+}

--- a/tests/php/Unit/Formatter/Infrastructure/IO/SystemFileIoTest.php
+++ b/tests/php/Unit/Formatter/Infrastructure/IO/SystemFileIoTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Formatter\Infrastructure\IO;
+
+use Phel\Formatter\Infrastructure\IO\SystemFileIo;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function bin2hex;
+use function chmod;
+use function file_get_contents;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function sys_get_temp_dir;
+use function unlink;
+
+final class SystemFileIoTest extends TestCase
+{
+    private string $baseDir;
+
+    protected function setUp(): void
+    {
+        $this->baseDir = sys_get_temp_dir() . '/phel-file-io-' . bin2hex(random_bytes(6));
+        mkdir($this->baseDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        @chmod($this->baseDir, 0755);
+        @unlink($this->baseDir . '/out.phel');
+        @rmdir($this->baseDir);
+    }
+
+    public function test_put_contents_writes_the_file(): void
+    {
+        new SystemFileIo()->putContents($this->baseDir . '/out.phel', '(ns out)');
+
+        self::assertSame('(ns out)', file_get_contents($this->baseDir . '/out.phel'));
+    }
+
+    public function test_put_contents_throws_when_target_is_not_writable(): void
+    {
+        chmod($this->baseDir, 0555);
+        if (@file_put_contents($this->baseDir . '/probe', 'x') !== false) {
+            @unlink($this->baseDir . '/probe');
+            self::markTestSkipped('chmod has no effect (running as root?)');
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to write file');
+
+        new SystemFileIo()->putContents($this->baseDir . '/out.phel', '(ns out)');
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Follow-up to #2735 (the NixOS build-sandbox fatal). A full audit of every CLI command's filesystem writes and environment assumptions — plus the actual nixpkgs derivation (`php.buildComposerProject2` + release tarball + `versionCheckHook`) — surfaced a second tier of issues: not sandbox-fatal, but crashes or silent failures in read-only / minimal environments.

Audit results that needed **no** change, verified empirically: version resolution prints a clean `Phel v0.47.0` from a no-git release tarball with the `git` binary absent (all git shell-outs are `@exec` + `2>/dev/null`); `--help`, `--version`, `list`, `config`, `doc`, `eval`, REPL all exit 0 from a read-only cwd with no HOME; readline/pcntl/opcache/proc_open absences are guarded; `composer.lock` is committed as nixpkgs requires.

## 💡 Goal

Every failure in a constrained environment is either gracefully absorbed (best-effort logging, skippable directories) or reported honestly — never an uncaught exception, never a false success message, never raw PHP warning noise.

## 🔖 Changes

- **`phel format`**: unreadable subdirectory in the scanned tree no longer aborts the run with an uncaught `RecursiveDirectoryIterator` exception (`CATCH_GET_CHILD`); unwritable target file now throws a clear "Unable to write file" error instead of silently pretending the file was formatted.
- **`phel test --coverage`** (text/clover/html) and **`phel profile --output`**: unwritable report path now prints `<error>` and skips the success message (both printed success with no file before).
- **`phel run --debug`**: unwritable `phel-debug.log` warns once on stderr, disables the trace, and the program keeps running (before: one silent failed `file_put_contents` per tick until shutdown).
- **Error log + temp dir**: `ErrorLog` appends are best-effort (the error already reaches stderr); `TempDirFinder` mkdir no longer emits a raw PHP warning above its own clear `FileException`.
- **Packaging**: `symfony/polyfill-mbstring` is now an explicit dependency — the lexer's UTF-8 column tracking calls `mb_strlen`, previously satisfied only transitively via symfony/console.
- Tests: `PhelPathFilterTest` (unreadable-subdir skip) and `SystemFileIoTest` (write-failure throw), both root-safe via chmod-probe skips.

All suites green locally: unit 3998, integration 1040 (14 skips environmental: no pcov + no local PHAR), core 6279 assertions, phpstan/psalm/cs-fixer/rector clean.