### PR TITLE
feat(core): add every-pred function combinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `every-pred`: complement of `some-fn`; returns a predicate that is true only when every composing predicate is logical true for every argument, short-circuiting on the first false and returning a strict boolean
+
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `every-pred`: complement of `some-fn`; returns a predicate that is true only when every composing predicate is logical true for every argument, short-circuiting on the first false and returning a strict boolean
+- `every-pred`: complement of `some-fn`; returns a predicate that is true only when every composing predicate is logical true for every argument, short-circuiting on the first false and returning a strict boolean (#2738)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -5,8 +5,8 @@
 ;;   1. Set algebra: `union`, `intersection`, `difference`,
 ;;      `symmetric-difference`, `subset?`, `superset?`.
 ;;   2. Function combinators and collection helpers: `constantly`,
-;;      `complement`, `arity`, `variadic?`, `some-fn`, `juxt`, `partial`,
-;;      `fnil`, `memoize`, `memoize-lru`, `tree-seq`, `flatten`,
+;;      `complement`, `arity`, `variadic?`, `some-fn`, `every-pred`, `juxt`,
+;;      `partial`, `fnil`, `memoize`, `memoize-lru`, `tree-seq`, `flatten`,
 ;;      `merge-with`, `update-keys`, `update-vals`, etc.
 
 ;; -------------
@@ -129,6 +129,17 @@
    (let [preds (cons p ps)]
      (fn [& args]
        (or (some (fn [pred] (some pred args)) preds) false)))))
+
+(defn every-pred
+  "Takes a variadic set of predicates and returns a function `f` that, when called with any number of arguments, returns `true` if every composing predicate returns a logical true value against every argument, and `false` otherwise. The returned function short-circuits on the first logical false result: arguments after it are not inspected, and predicates after it are not tried. Predicates are consulted in the order supplied; for a given predicate, arguments are consulted left-to-right. With no arguments the returned function returns `true`."
+  {:example "((every-pred even? pos?) 2 4 6) ; => true\n((every-pred even? pos?) 2 -4) ; => false"
+   :see-also ["some-fn" "complement" "every?" "not-every?"]}
+  ([]
+   (throw (php/new \InvalidArgumentException "every-pred expects at least one predicate")))
+  ([p & ps]
+   (let [preds (cons p ps)]
+     (fn [& args]
+       (every? (fn [pred] (every? pred args)) preds)))))
 
 (defn juxt
   "Takes a list of functions and returns a new function that is the juxtaposition of those functions."

--- a/tests/phel/core/function-operation.phel
+++ b/tests/phel/core/function-operation.phel
@@ -87,6 +87,50 @@
     (is (= [[:p1 :a] [:p1 :match] [:p2 :a] [:p2 :match]] (deref log))
         "some-fn tries each pred on all args before advancing")))
 
+(deftest test-every-pred-single-pred
+  (is (true? ((every-pred even?) 2)) "every-pred with one pred, single truthy arg")
+  (is (false? ((every-pred even?) 1)) "every-pred with one pred, single falsy arg")
+  (is (true? ((every-pred even?) 2 4 6)) "every-pred with one pred, all args truthy")
+  (is (false? ((every-pred even?) 2 3)) "every-pred with one pred, one arg falsy")
+  (is (true? ((every-pred even?))) "every-pred with one pred, zero args returns true"))
+
+(deftest test-every-pred-multiple-preds
+  (is (true? ((every-pred pos? even?) 2)) "every-pred true when all preds match")
+  (is (false? ((every-pred pos? even?) 1)) "every-pred false when second pred fails")
+  (is (false? ((every-pred pos? even?) -2)) "every-pred false when first pred fails")
+  (is (true? ((every-pred pos? even?) 2 4 6)) "every-pred true when all preds match all args")
+  (is (false? ((every-pred pos? even?) 2 3)) "every-pred false when a pred fails one arg"))
+
+(deftest test-every-pred-zero-arity-throws-at-runtime
+  (is (thrown? \InvalidArgumentException (every-pred))
+      "every-pred with no predicates compiles and throws at runtime"))
+
+(deftest test-every-pred-returns-boolean
+  (is (true? ((every-pred (fn [_] 5)) 1)) "every-pred coerces truthy value to true")
+  (is (false? ((every-pred (fn [_] nil)) 1)) "every-pred coerces falsy value to false"))
+
+(deftest test-every-pred-short-circuits-preds
+  (let [calls (atom 0)
+        p1    (fn [x] (swap! calls inc) (even? x))
+        p2    (fn [_] (throw (php/new \Exception "should not be called")))]
+    (is (false? ((every-pred p1 p2) 3)) "every-pred short-circuits on first false pred")
+    (is (= 1 (deref calls)) "second pred was not invoked")))
+
+(deftest test-every-pred-short-circuits-args
+  (let [calls (atom 0)
+        p     (fn [x] (swap! calls inc) (even? x))]
+    (is (false? ((every-pred p) 2 4 5 6)) "every-pred short-circuits on first falsy arg")
+    (is (= 3 (deref calls)) "pred only called until first falsy result")))
+
+(deftest test-every-pred-pred-order
+  ;; All preds are tried on all args before moving to next pred
+  (let [log (atom [])
+        p1  (fn [x] (swap! log push [:p1 x]) true)
+        p2  (fn [x] (swap! log push [:p2 x]) true)]
+    ((every-pred p1 p2) :a :b)
+    (is (= [[:p1 :a] [:p1 :b] [:p2 :a] [:p2 :b]] (deref log))
+        "every-pred tries each pred on all args before advancing")))
+
 (deftest test-juxt
   (is (= [2 1] ((juxt second first) [1 2])) "juxt"))
 


### PR DESCRIPTION
## 🤔 Background

Phel already ships `some-fn` (returns the first logical-true value of any predicate against any argument), but its natural dual `every-pred` was missing. The gap is visible even in the `fns-sets.phel` module header comment, which lists the combinator family without it. Clojure exposes both as a pair, and `every-pred` is the idiomatic way to compose a conjunction of predicates for `filter`/`remove`/guards, e.g. `(filter (every-pred pos? even?) xs)`.

## 💡 Goal

Restore parity with `some-fn` by adding `every-pred`, matching Clojure semantics and the existing house style/tests exactly.

## 🔖 Changes

- Add `every-pred` to `src/phel/core/fns-sets.phel`, placed right after `some-fn`:
  - Variadic predicates; returns a function that is `true` only when **every** composing predicate is logical true against **every** argument, else `false`.
  - Short-circuits on the first logical-false result (predicates left-to-right, args left-to-right).
  - Returns a strict boolean; with no call arguments the returned function returns `true` (vacuous truth), matching Clojure.
  - Zero predicates throws `\InvalidArgumentException`, mirroring `some-fn`.
  - Full `:doc` / `:example` / `:see-also` metadata; module header comment updated to list it.
- Add tests in `tests/phel/core/function-operation.phel` mirroring the `some-fn` suite: single/multiple predicates, zero-arity throw, boolean coercion, short-circuit over predicates and over arguments, and predicate/argument evaluation order.
- Add a `## Unreleased` → `### Added` CHANGELOG entry.

Full core suite green locally: 6297 passed, 0 failed.