### PR TITLE
feat(core): add mapv and filterv eager vector variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `every-pred`: complement of `some-fn`; returns a predicate that is true only when every composing predicate is logical true for every argument, short-circuiting on the first false and returning a strict boolean (#2738)
-- `mapv` and `filterv`: eager vector-returning variants of the lazy `map` and `filter`
+- `mapv` and `filterv`: eager vector-returning variants of the lazy `map` and `filter` (#2739)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `every-pred`: complement of `some-fn`; returns a predicate that is true only when every composing predicate is logical true for every argument, short-circuiting on the first false and returning a strict boolean (#2738)
+- `mapv` and `filterv`: eager vector-returning variants of the lazy `map` and `filter`
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -565,6 +565,20 @@ Creates intermediate maps if they don't exist."
         (copy-meta coll result))
     (throw (php/new InvalidArgumentException "filter expects 1 or 2 arguments"))))
 
+(defn mapv
+  "Returns a vector consisting of the result of applying `f` to the set of first items of each coll, followed by applying `f` to the set of second items in each coll, until any one of the colls is exhausted. Like `map`, but eager and returns a vector rather than a lazy sequence."
+  {:example "(mapv inc [1 2 3]) ; => [2 3 4]"
+   :see-also ["map" "filterv" "vec"]}
+  [f coll & colls]
+  (vec (apply map f coll colls)))
+
+(defn filterv
+  "Returns a vector of the items in `coll` for which `(pred item)` returns a logical true value. Like `filter`, but eager and returns a vector rather than a lazy sequence."
+  {:example "(filterv even? [1 2 3 4 5 6]) ; => [2 4 6]"
+   :see-also ["filter" "mapv" "remove" "vec"]}
+  [pred coll]
+  (vec (filter pred coll)))
+
 (defn remove
   "Returns a lazy sequence of elements where predicate returns false. Opposite of filter. When called with pred only, returns a transducer."
   {:example "(remove even? [1 2 3 4 5 6]) ; => @[1 3 5]"

--- a/tests/phel/core/sequence-functions.phel
+++ b/tests/phel/core/sequence-functions.phel
@@ -24,6 +24,20 @@
 (deftest test-map-empty-element
   (is (= [] (map #(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
 
+(deftest test-mapv
+  (is (= [2 3 4] (mapv inc [1 2 3])) "mapv applies f eagerly")
+  (is (vector? (mapv inc [1 2 3])) "mapv returns a vector")
+  (is (= [11 22 33] (mapv + [1 2 3] [10 20 30])) "mapv with multiple collections")
+  (is (= [11 22] (mapv + [1 2 10] [10 20])) "mapv stops at the shortest collection")
+  (is (= [[:a 1]] (mapv identity {:a 1})) "mapv over a map yields entries")
+  (is (= [] (mapv inc [])) "mapv on empty collection returns empty vector"))
+
+(deftest test-filterv
+  (is (= [2 4 6] (filterv even? [1 2 3 4 5 6])) "filterv keeps matching items")
+  (is (vector? (filterv even? [1 2 3 4])) "filterv returns a vector")
+  (is (= [] (filterv pos? [])) "filterv on empty collection returns empty vector")
+  (is (= [] (filterv pos? [-1 -2])) "filterv with no matches returns empty vector"))
+
 (deftest test-mapcat
   (is (= [1 2 3 4 5 6] (mapcat reverse [[3 2 1] [6 5 4]])) "mapcat")
   (is (= [] (mapcat identity [])) "mapcat on empty vector"))


### PR DESCRIPTION
## 🤔 Background

Phel's `map` and `filter` are **lazy** (they return a `LazySeq`). Clojure ships eager, vector-returning counterparts `mapv` and `filterv` for the very common case where you want a concrete vector back immediately: predictable evaluation, no wrapper, ready for indexed access. Both were missing from Phel.

## 💡 Goal

Add `mapv` and `filterv` with Clojure-aligned semantics, so `(mapv f coll)` / `(filterv pred coll)` are available instead of hand-writing `(vec (map ...))` / `(vec (filter ...))`.

## 🔖 Changes

- `mapv` (`src/phel/core/seq-fns.phel`): eager, vector-returning `map`. Delegates to `map` then realizes with `vec`, so it inherits `map`'s exact semantics — multiple collections (stops at the shortest), and map inputs yielding `[k v]` entries. Signature `[f coll & colls]` (requires at least one collection, matching Clojure — no transducer/zero-coll arity).
- `filterv` (`src/phel/core/seq-fns.phel`): eager, vector-returning `filter`, signature `[pred coll]`.
- Tests in `tests/phel/core/sequence-functions.phel`: values, vector-ness (`vector?`), multi-collection + shortest-collection, map-entry inputs, and empty/no-match cases.
- `## Unreleased` CHANGELOG entry.

Full core suite green locally: 6307 passed, 0 failed.