### PR TITLE
feat(core): add qualified-symbol?, qualified-keyword?, qualified-ident? predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - `every-pred`: complement of `some-fn`; returns a predicate that is true only when every composing predicate is logical true for every argument, short-circuiting on the first false and returning a strict boolean (#2738)
 - `mapv` and `filterv`: eager vector-returning variants of the lazy `map` and `filter` (#2739)
-- `qualified-symbol?`, `qualified-keyword?`, and `qualified-ident?`: predicates for namespaced symbols/keywords, completing the ident-predicate family alongside the existing `simple-*` variants
+- `qualified-symbol?`, `qualified-keyword?`, and `qualified-ident?`: predicates for namespaced symbols/keywords, completing the ident-predicate family alongside the existing `simple-*` variants (#2740)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - `every-pred`: complement of `some-fn`; returns a predicate that is true only when every composing predicate is logical true for every argument, short-circuiting on the first false and returning a strict boolean (#2738)
 - `mapv` and `filterv`: eager vector-returning variants of the lazy `map` and `filter` (#2739)
+- `qualified-symbol?`, `qualified-keyword?`, and `qualified-ident?`: predicates for namespaced symbols/keywords, completing the ident-predicate family alongside the existing `simple-*` variants
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -266,6 +266,27 @@
   [x]
   (or (simple-symbol? x) (simple-keyword? x)))
 
+(defn qualified-symbol?
+  "Returns true if `x` is a symbol with a namespace."
+  {:example "(qualified-symbol? 'foo/bar) ; => true\n(qualified-symbol? 'a) ; => false"
+   :see-also ["symbol?" "simple-symbol?" "qualified-ident?"]}
+  [x]
+  (and (symbol? x) (some? (php/-> x (getNamespace)))))
+
+(defn qualified-keyword?
+  "Returns true if `x` is a keyword with a namespace."
+  {:example "(qualified-keyword? :foo/bar) ; => true\n(qualified-keyword? :a) ; => false"
+   :see-also ["keyword?" "simple-keyword?" "qualified-ident?"]}
+  [x]
+  (and (keyword? x) (some? (php/-> x (getNamespace)))))
+
+(defn qualified-ident?
+  "Returns true if `x` is a symbol or keyword with a namespace."
+  {:example "(qualified-ident? 'foo/bar) ; => true\n(qualified-ident? :a) ; => false"
+   :see-also ["qualified-symbol?" "qualified-keyword?" "ident?"]}
+  [x]
+  (or (qualified-symbol? x) (qualified-keyword? x)))
+
 (def ^:private special-symbols
   "The set of symbols that name Phel special forms, including the
   syntactic markers `&`, `catch`, and `finally` recognised by `fn`,

--- a/tests/phel/core/type-operation.phel
+++ b/tests/phel/core/type-operation.phel
@@ -263,6 +263,28 @@
   (is (false? (simple-ident? "test")) "simple-ident? on string")
   (is (false? (simple-ident? nil)) "simple-ident? on nil"))
 
+(deftest test-qualified-symbol?
+  (is (true? (qualified-symbol? 'foo/bar)) "qualified-symbol? on namespaced symbol")
+  (is (false? (qualified-symbol? 'x)) "qualified-symbol? on simple symbol")
+  (is (false? (qualified-symbol? :foo/bar)) "qualified-symbol? on namespaced keyword")
+  (is (false? (qualified-symbol? 42)) "qualified-symbol? on integer")
+  (is (false? (qualified-symbol? nil)) "qualified-symbol? on nil"))
+
+(deftest test-qualified-keyword?
+  (is (true? (qualified-keyword? :foo/bar)) "qualified-keyword? on namespaced keyword")
+  (is (false? (qualified-keyword? :test)) "qualified-keyword? on simple keyword")
+  (is (false? (qualified-keyword? 'foo/bar)) "qualified-keyword? on namespaced symbol")
+  (is (false? (qualified-keyword? "test")) "qualified-keyword? on string")
+  (is (false? (qualified-keyword? nil)) "qualified-keyword? on nil"))
+
+(deftest test-qualified-ident?
+  (is (true? (qualified-ident? 'foo/bar)) "qualified-ident? on namespaced symbol")
+  (is (true? (qualified-ident? :foo/bar)) "qualified-ident? on namespaced keyword")
+  (is (false? (qualified-ident? 'x)) "qualified-ident? on simple symbol")
+  (is (false? (qualified-ident? :test)) "qualified-ident? on simple keyword")
+  (is (false? (qualified-ident? 42)) "qualified-ident? on integer")
+  (is (false? (qualified-ident? nil)) "qualified-ident? on nil"))
+
 (deftest test-special-symbol?
   (is (true? (special-symbol? 'def)) "special-symbol? on def")
   (is (true? (special-symbol? 'fn)) "special-symbol? on fn")


### PR DESCRIPTION
## 🤔 Background

Phel already ships the `simple-symbol?` / `simple-keyword?` / `simple-ident?` predicates (true for **un-namespaced** idents) plus the umbrella `ident?`. Their Clojure counterparts for the **namespaced** case — `qualified-symbol?`, `qualified-keyword?`, `qualified-ident?` — were missing, leaving the family asymmetric.

## 💡 Goal

Complete the ident-predicate family so both halves (simple/qualified) exist, matching Clojure.

## 🔖 Changes

- `src/phel/core/predicates.phel`, placed right after `simple-ident?`:
  - `qualified-symbol?` — `(and (symbol? x) (some? (php/-> x (getNamespace))))`
  - `qualified-keyword?` — same for keywords
  - `qualified-ident?` — `(or (qualified-symbol? x) (qualified-keyword? x))`
  - Mirrors the exact shape of the existing `simple-*` predicates (which use `(nil? (getNamespace))`); the qualified variants invert that with `some?`.
- Tests in `tests/phel/core/type-operation.phel` mirroring the `simple-*` test blocks: namespaced true; simple/cross-type/`nil` false.
- `## Unreleased` CHANGELOG entry.

Full core suite green locally: 6323 passed, 0 failed.