### PR TITLE
feat(core): add unsigned-bit-shift-right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - `every-pred`: complement of `some-fn`; returns a predicate that is true only when every composing predicate is logical true for every argument, short-circuiting on the first false and returning a strict boolean (#2738)
 - `mapv` and `filterv`: eager vector-returning variants of the lazy `map` and `filter` (#2739)
+- `unsigned-bit-shift-right`: logical right shift that zero-fills the vacated high bits instead of sign-extending, completing the bit-shift family
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - `every-pred`: complement of `some-fn`; returns a predicate that is true only when every composing predicate is logical true for every argument, short-circuiting on the first false and returning a strict boolean (#2738)
 - `mapv` and `filterv`: eager vector-returning variants of the lazy `map` and `filter` (#2739)
-- `unsigned-bit-shift-right`: logical right shift that zero-fills the vacated high bits instead of sign-extending, completing the bit-shift family
+- `unsigned-bit-shift-right`: logical right shift that zero-fills the vacated high bits instead of sign-extending, completing the bit-shift family (#2742)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -88,6 +88,18 @@
   (assert-non-nil x n)
   (php/>> x n))
 
+(defn unsigned-bit-shift-right
+  "Bitwise shift right without sign extension: the vacated high bits are filled with zeros rather than copies of the sign bit. Unlike `bit-shift-right`, `(unsigned-bit-shift-right -1 10)` is a large positive number, not `-1`."
+  {:example "(unsigned-bit-shift-right -1 10) ; => 18014398509481983"
+   :see-also ["bit-shift-right" "bit-shift-left"]}
+  [x n]
+  (assert-non-nil x n)
+  ;; A right shift by 0 would make the mask `PHP_INT_MAX >> -1`, which PHP
+  ;; rejects as a negative shift; the value is already unchanged in that case.
+  (if (php/=== 0 n)
+    x
+    (php/& (php/>> x n) (php/>> php/PHP_INT_MAX (php/- n 1)))))
+
 (defn bit-set
   "Returns the integer `x` with the bit at index `n` (0-based, least significant first) set to 1."
   {:example "(bit-set 0 2) ; => 4"

--- a/tests/phel/core/bitwise-operation.phel
+++ b/tests/phel/core/bitwise-operation.phel
@@ -30,6 +30,15 @@
   (is (= 0b0001 (bit-shift-right 0b1101 3)) "bit-shift-right 3")
   (is (= 0b0000 (bit-shift-right 0b1101 4)) "bit-shift-right 4"))
 
+(deftest test-unsigned-bit-shift-right
+  (is (= 0b1101 (unsigned-bit-shift-right 0b1101 0)) "unsigned-bit-shift-right 0 is a no-op")
+  (is (= 0b0110 (unsigned-bit-shift-right 0b1101 1)) "unsigned-bit-shift-right on a positive value matches bit-shift-right")
+  (is (= 0b0001 (unsigned-bit-shift-right 0b1101 3)) "unsigned-bit-shift-right 3")
+  (is (= 18014398509481983 (unsigned-bit-shift-right -1 10))
+      "unsigned-bit-shift-right zero-fills the sign bits instead of extending them")
+  (is (= -1 (bit-shift-right -1 10))
+      "bit-shift-right sign-extends, unlike unsigned-bit-shift-right"))
+
 (deftest test-bit-set
   (is (= 0b1111 (bit-set 0b1011 2)) "bit-set at pos 2")
   (is (= 0b1011 (bit-set 0b1011 0)) "bit-set at pos 0"))
@@ -51,6 +60,8 @@
   (is (thrown? \InvalidArgumentException (bit-not nil)) "(bit-not nil)")
   (is (thrown? \InvalidArgumentException (bit-shift-left nil 1)) "(bit-shift-left nil 1)")
   (is (thrown? \InvalidArgumentException (bit-shift-right nil 1)) "(bit-shift-right nil 1)")
+  (is (thrown? \InvalidArgumentException (unsigned-bit-shift-right nil 1)) "(unsigned-bit-shift-right nil 1)")
+  (is (thrown? \InvalidArgumentException (unsigned-bit-shift-right 1 nil)) "(unsigned-bit-shift-right 1 nil)")
   (is (thrown? \InvalidArgumentException (bit-set nil 1)) "(bit-set nil 1)")
   (is (thrown? \InvalidArgumentException (bit-clear nil 1)) "(bit-clear nil 1)")
   (is (thrown? \InvalidArgumentException (bit-flip nil 1)) "(bit-flip nil 1)")


### PR DESCRIPTION
## 🤔 Background

Phel ships `bit-and/or/xor/not`, `bit-shift-left`, and `bit-shift-right`, but not Clojure's `unsigned-bit-shift-right`. PHP's `>>` is an **arithmetic** shift (it copies the sign bit), so there was no built-in way to do a **logical** right shift that zero-fills the high bits. The `clojure-test-suite` specs this function (`unsigned_bit_shift_right.cljc`).

## 💡 Goal

Complete the bit-shift family with a Clojure-aligned `unsigned-bit-shift-right`.

## 🔖 Changes

- `unsigned-bit-shift-right` in `src/phel/core/math.phel`, right after `bit-shift-right`:
  - `(unsigned-bit-shift-right x n)` → `(x >> n) & (PHP_INT_MAX >> (n - 1))`; the mask clears the sign-extended high bits so they read as zero.
  - `n = 0` short-circuits to `x` (the mask expression would otherwise be `PHP_INT_MAX >> -1`, which PHP rejects as a negative shift).
  - `assert-non-nil` guard mirrors `bit-shift-right`, so `nil` arguments throw `InvalidArgumentException`.
- Tests in `tests/phel/core/bitwise-operation.phel`: no-op at 0, positive values match `bit-shift-right`, the sign-bit case `(unsigned-bit-shift-right -1 10) => 18014398509481983` contrasted with `(bit-shift-right -1 10) => -1`, and `nil` arguments throwing.

Matches the `clojure-test-suite` `unsigned_bit_shift_right.cljc` cases (throws on `nil`; `(-1, 10) => 18014398509481983`). Full core suite green locally: 6314 passed, 0 failed.