### PR TITLE
feat(core): add bit-and-not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - `every-pred`: complement of `some-fn`; returns a predicate that is true only when every composing predicate is logical true for every argument, short-circuiting on the first false and returning a strict boolean (#2738)
 - `mapv` and `filterv`: eager vector-returning variants of the lazy `map` and `filter` (#2739)
 - `unsigned-bit-shift-right`: logical right shift that zero-fills the vacated high bits instead of sign-extending, completing the bit-shift family (#2742)
-- `bit-and-not`: bitwise `and` with the complement of each subsequent argument (`x & ~y`)
+- `bit-and-not`: bitwise `and` with the complement of each subsequent argument (`x & ~y`) (#2744)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - `every-pred`: complement of `some-fn`; returns a predicate that is true only when every composing predicate is logical true for every argument, short-circuiting on the first false and returning a strict boolean (#2738)
 - `mapv` and `filterv`: eager vector-returning variants of the lazy `map` and `filter` (#2739)
 - `unsigned-bit-shift-right`: logical right shift that zero-fills the vacated high bits instead of sign-extending, completing the bit-shift family (#2742)
+- `bit-and-not`: bitwise `and` with the complement of each subsequent argument (`x & ~y`)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -100,6 +100,15 @@
     x
     (php/& (php/>> x n) (php/>> php/PHP_INT_MAX (php/- n 1)))))
 
+(defn bit-and-not
+  "Bitwise `and` with the complement of each subsequent argument: `(bit-and-not x y)` is `x & ~y`. Additional arguments are folded in left to right, clearing every bit that is set in any of them."
+  {:example "(bit-and-not 0xFF 0x0F) ; => 240"
+   :see-also ["bit-and" "bit-not" "bit-or"]}
+  [x y & args]
+  (let [all (concat [x y] args)]
+    (assert-non-nil-coll all)
+    (reduce (fn [acc v] (php/& acc (php/~ v))) x (rest all))))
+
 (defn bit-set
   "Returns the integer `x` with the bit at index `n` (0-based, least significant first) set to 1."
   {:example "(bit-set 0 2) ; => 4"

--- a/tests/phel/core/bitwise-operation.phel
+++ b/tests/phel/core/bitwise-operation.phel
@@ -16,6 +16,13 @@
 (deftest test-bit-not
   (is (= -8 (bit-not 0b0111)) "bit-not"))
 
+(deftest test-bit-and-not
+  (is (= 0b0100 (bit-and-not 0b1100 0b1001)) "bit-and-not clears bits set in the second operand")
+  (is (= 8 (bit-and-not 12 4)) "bit-and-not 12 4")
+  (is (= 240 (bit-and-not 0xFF 0x0F)) "bit-and-not masks off the low nibble")
+  (is (= 0 (bit-and-not 0xFF 0xFF)) "bit-and-not of a value with itself is zero")
+  (is (= 0b1000 (bit-and-not 0b1110 0b0100 0b0010)) "bit-and-not folds extra args left to right"))
+
 (deftest test-bit-shift-left
   (is (= 0b1101 (bit-shift-left 0b1101 0)) "bit-shift-left 0")
   (is (= 0b11010 (bit-shift-left 0b1101 1)) "bit-shift-left 1")
@@ -62,6 +69,8 @@
   (is (thrown? \InvalidArgumentException (bit-shift-right nil 1)) "(bit-shift-right nil 1)")
   (is (thrown? \InvalidArgumentException (unsigned-bit-shift-right nil 1)) "(unsigned-bit-shift-right nil 1)")
   (is (thrown? \InvalidArgumentException (unsigned-bit-shift-right 1 nil)) "(unsigned-bit-shift-right 1 nil)")
+  (is (thrown? \InvalidArgumentException (bit-and-not nil 1)) "(bit-and-not nil 1)")
+  (is (thrown? \InvalidArgumentException (bit-and-not 1 nil)) "(bit-and-not 1 nil)")
   (is (thrown? \InvalidArgumentException (bit-set nil 1)) "(bit-set nil 1)")
   (is (thrown? \InvalidArgumentException (bit-clear nil 1)) "(bit-clear nil 1)")
   (is (thrown? \InvalidArgumentException (bit-flip nil 1)) "(bit-flip nil 1)")


### PR DESCRIPTION
## 🤔 Background

Phel has `bit-and/or/xor/not`, the shifts, and the single-bit helpers, but not Clojure's `bit-and-not` — the common idiom for clearing a mask of bits (`x & ~y`). The `clojure-test-suite` specs it (`bit_and_not.cljc`).

## 💡 Goal

Add `bit-and-not` with Clojure-aligned, variadic semantics.

## 🔖 Changes

- `bit-and-not` in `src/phel/core/math.phel`, after `unsigned-bit-shift-right`:
  - `(bit-and-not x y)` => `x & ~y`; extra args fold in left to right (`x & ~y & ~z …`), clearing every bit set in any subsequent argument.
  - Variadic `[x y & args]`, matching Clojure and the reduce style of `bit-and`/`bit-or`/`bit-xor`; `assert-non-nil-coll` makes `nil` arguments throw `InvalidArgumentException`.
- Tests in `tests/phel/core/bitwise-operation.phel`: two-operand clear, the suite values `(12,4)=>8` and `(0xFF,0x0F)=>240`, self-clear `(0xFF,0xFF)=>0`, three-arg fold, and `nil` throwing.

Matches the `clojure-test-suite` `bit_and_not.cljc` cases. Full core suite green locally: 6321 passed, 0 failed.