### PR TITLE
feat(core): add rational? predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - `mapv` and `filterv`: eager vector-returning variants of the lazy `map` and `filter` (#2739)
 - `unsigned-bit-shift-right`: logical right shift that zero-fills the vacated high bits instead of sign-extending, completing the bit-shift family (#2742)
 - `bit-and-not`: bitwise `and` with the complement of each subsequent argument (`x & ~y`) (#2744)
-- `rational?`: predicate for rational numbers (integers, `Ratio`, and `BigDecimal`; floats are not rational)
+- `rational?`: predicate for rational numbers (integers, `Ratio`, and `BigDecimal`; floats are not rational) (#2745)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - `mapv` and `filterv`: eager vector-returning variants of the lazy `map` and `filter` (#2739)
 - `unsigned-bit-shift-right`: logical right shift that zero-fills the vacated high bits instead of sign-extending, completing the bit-shift family (#2742)
 - `bit-and-not`: bitwise `and` with the complement of each subsequent argument (`x & ~y`) (#2744)
+- `rational?`: predicate for rational numbers (integers, `Ratio`, and `BigDecimal`; floats are not rational)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -204,6 +204,13 @@
   [x]
   (float? x))
 
+(defn rational?
+  "Returns true if `x` is a rational number: an integer (`int` or `BigInt`), a `Ratio`, or a `BigDecimal`. Floating-point numbers (including `##Inf`, `##-Inf`, and `##NaN`) are not rational."
+  {:example "(rational? 1/2) ; => true\n(rational? 1.0) ; => false"
+   :see-also ["ratio?" "number?" "integer?"]}
+  [x]
+  (and (number? x) (not (float? x))))
+
 (defn string?
   "Returns true if `x` is a string, false otherwise."
   {:example "(string? \"a\") ; => true\n(string? :a) ; => false"

--- a/tests/phel/core/type-operation.phel
+++ b/tests/phel/core/type-operation.phel
@@ -351,6 +351,34 @@
        nil
        "1/2"))
 
+(deftest test-rational?
+  (are [x] (true? (rational? x))
+       0
+       1
+       -1
+       (bigint "0")
+       (bigint "100000000000000000000000")
+       0.0M
+       1.0M
+       -1.0M
+       1/2
+       -1/2)
+  (are [x] (false? (rational? x))
+       0.0
+       1.0
+       -1.0
+       ##Inf
+       ##-Inf
+       ##NaN
+       nil
+       true
+       false
+       "1"
+       :a
+       'a
+       [1]
+       {:a 1}))
+
 (deftest test-bigint?
   (is (true? (bigint? (php/:: \Phel\Lang\BigInt (fromString "100000000000000000000000"))))
       "bigint? on a BigInt value")


### PR DESCRIPTION
## 🤔 Background

Phel has `number?`, `ratio?`, `integer?`, `float?`/`double?`, but not Clojure's `rational?`. The `clojure-test-suite` specs it (`rational_qmark.cljc`).

## 💡 Goal

Add `rational?` with Clojure-aligned semantics.

## 🔖 Changes

- `rational?` in `src/phel/core/predicates.phel`, after `double?`:
  - `(and (number? x) (not (float? x)))` — true for integers (`int`/`BigInt`), `Ratio`, and `BigDecimal`; false for floats, `##Inf`/`##-Inf`/`##NaN`, and all non-numbers.
- Tests in `tests/phel/core/type-operation.phel` covering every category from the suite: ints, `BigInt`, `BigDecimal` (`1.0M`), `Ratio`, versus floats/infinities/`NaN`/`nil`/booleans/strings/keywords/symbols/collections.

Matches the `clojure-test-suite` `rational_qmark.cljc` cases (including the perhaps-surprising `(rational? 1.0M) => true`). Full core suite green locally: 6345 passed, 0 failed.