### PR TITLE
feat(core): add while macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - `unsigned-bit-shift-right`: logical right shift that zero-fills the vacated high bits instead of sign-extending, completing the bit-shift family (#2742)
 - `bit-and-not`: bitwise `and` with the complement of each subsequent argument (`x & ~y`) (#2744)
 - `rational?`: predicate for rational numbers (integers, `Ratio`, and `BigDecimal`; floats are not rational) (#2745)
+- `while`: macro that repeatedly evaluates its body for side effects while a test stays logical true
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - `unsigned-bit-shift-right`: logical right shift that zero-fills the vacated high bits instead of sign-extending, completing the bit-shift family (#2742)
 - `bit-and-not`: bitwise `and` with the complement of each subsequent argument (`x & ~y`) (#2744)
 - `rational?`: predicate for rational numbers (integers, `Ratio`, and `BigDecimal`; floats are not rational) (#2745)
-- `while`: macro that repeatedly evaluates its body for side effects while a test stays logical true
+- `while`: macro that repeatedly evaluates its body for side effects while a test stays logical true (#2746)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/src/phel/core/loops.phel
+++ b/src/phel/core/loops.phel
@@ -21,3 +21,13 @@
     `(let [~n-sym ~n]
        (doseq [~binding :range [0 ~n-sym]]
          ~@body))))
+
+(defmacro while
+  "Repeatedly evaluates `body` (for side effects) as long as `test` is logical true. Returns nil."
+  {:example "(while (pos? @counter) (swap! counter dec))"
+   :see-also ["dotimes" "loop" "doseq"]}
+  [test & body]
+  `(loop []
+     (when ~test
+       ~@body
+       (recur))))

--- a/tests/phel/core/loop-recur.phel
+++ b/tests/phel/core/loop-recur.phel
@@ -44,3 +44,17 @@
          (loop [a 1 b 2 n 0]
            (if (>= n 3) [a b] (recur b a (inc n)))))
       "swapping recur args reads the pre-recur values"))
+
+(deftest test-while-runs-until-test-is-false
+  (let [n   (atom 3)
+        log (atom [])]
+    (while (pos? @n)
+           (swap! log conj @n)
+           (swap! n dec))
+    (is (= [3 2 1] @log) "while runs the body until the test becomes false")
+    (is (= 0 @n) "while stops as soon as the test is false")))
+
+(deftest test-while-skips-body-when-test-is-false
+  (let [ran (atom false)]
+    (is (nil? (while false (reset! ran true))) "while returns nil")
+    (is (false? @ran) "while never runs the body when the test starts false")))


### PR DESCRIPTION
## 🤔 Background

Phel has `dotimes`, `doseq`, `for`/`dofor`, and `loop`/`recur`, but not Clojure's `while` — the idiomatic way to repeat a side-effecting body until a condition goes false (e.g. draining an atom, polling until ready).

## 💡 Goal

Add the `while` macro with Clojure-aligned semantics.

## 🔖 Changes

- `while` in `src/phel/core/loops.phel`, after `dotimes`:
  - `(while test & body)` expands to `(loop [] (when test body… (recur)))`.
  - Evaluates `body` for side effects while `test` is logical true; returns `nil`. Skips the body entirely when `test` starts false.
  - No local bindings are introduced into the expansion (the `loop` vector is empty), so no gensym/hygiene shims are needed.
- Tests in `tests/phel/core/loop-recur.phel`: an atom-draining loop records `[3 2 1]` and lands at `0`; a false test runs the body zero times and returns `nil`.

Not part of the `clojure-test-suite`, but matches Clojure's `while`. Full core suite green locally: 6349 passed, 0 failed.