### PR TITLE
feat(core): add compare-and-set!, swap-vals!, reset-vals!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 - `bit-and-not`: bitwise `and` with the complement of each subsequent argument (`x & ~y`) (#2744)
 - `rational?`: predicate for rational numbers (integers, `Ratio`, and `BigDecimal`; floats are not rational) (#2745)
 - `while`: macro that repeatedly evaluates its body for side effects while a test stays logical true (#2746)
-- `compare-and-set!`, `swap-vals!`, and `reset-vals!`: complete the atom API — conditional identity-based swap, and swap/reset variants returning `[old new]`
+- `compare-and-set!`, `swap-vals!`, and `reset-vals!`: complete the atom API — conditional identity-based swap, and swap/reset variants returning `[old new]` (#2747)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - `bit-and-not`: bitwise `and` with the complement of each subsequent argument (`x & ~y`) (#2744)
 - `rational?`: predicate for rational numbers (integers, `Ratio`, and `BigDecimal`; floats are not rational) (#2745)
 - `while`: macro that repeatedly evaluates its body for side effects while a test stays logical true (#2746)
+- `compare-and-set!`, `swap-vals!`, and `reset-vals!`: complete the atom API — conditional identity-based swap, and swap/reset variants returning `[old new]`
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -98,6 +98,38 @@ Returns the new value after the swap."
                   (apply f current args))]
     (reset! variable next)))
 
+(defn compare-and-set!
+  "Atomically sets the value of the atom `variable` to `new-value` if and only if its current value is identical (via `identical?`) to `old-value`. Returns true when the swap happened, false otherwise."
+  {:example "(def a (atom 1))\n(compare-and-set! a 1 2) ; => true\n(compare-and-set! a 1 3) ; => false"
+   :see-also ["atom" "reset!" "swap!"]}
+  [variable old-value new-value]
+  (if (identical? (deref variable) old-value)
+    (do (reset! variable new-value) true)
+    false))
+
+(defn reset-vals!
+  "Sets the value of the atom `variable` to `new-value`. Returns a vector `[old-value new-value]` of the values before and after the reset."
+  {:example "(def a (atom 1))\n(reset-vals! a 2) ; => [1 2]"
+   :see-also ["reset!" "swap-vals!"]}
+  [variable new-value]
+  (let [old (deref variable)]
+    (reset! variable new-value)
+    [old new-value]))
+
+(defn swap-vals!
+  "Atomically swaps the value of the atom `variable` to `(apply f current-value args)`. Returns a vector `[old-value new-value]` of the values before and after the swap."
+  {:example "(def a (atom 1))\n(swap-vals! a inc) ; => [1 2]"
+   :see-also ["swap!" "reset-vals!"]}
+  [variable f & args]
+  (let [old  (deref variable)
+        next (case (count args)
+               0 (f old)
+               1 (f old (first args))
+               2 (f old (first args) (second args))
+               (apply f old args))]
+    (reset! variable next)
+    [old next]))
+
 (defn add-watch
   "Adds a watch function to a variable. The watch fn is called when the variable changes with four arguments: key, ref, old-value, new-value."
   {:example "(add-watch my-var :logger (fn [key ref old new] (println old \"->\" new)))"

--- a/tests/phel/core/watches-validators.phel
+++ b/tests/phel/core/watches-validators.phel
@@ -16,6 +16,26 @@
     (is (= 17 (swap! a + 3 4)) "swap! with extra args returns new value")
     (is (= 17 @a) "swap! with extra args stores the new value")))
 
+(deftest test-compare-and-set!
+  (let [a (atom 1)]
+    (is (true? (compare-and-set! a 1 2)) "compare-and-set! succeeds when the current value matches")
+    (is (= 2 @a) "compare-and-set! stores the new value on success")
+    (is (false? (compare-and-set! a 1 3)) "compare-and-set! fails when the current value does not match")
+    (is (= 2 @a) "compare-and-set! leaves the value unchanged on failure")))
+
+(deftest test-reset-vals!
+  (let [a (atom 1)]
+    (is (= [1 2] (reset-vals! a 2)) "reset-vals! returns [old new]")
+    (is (= 2 @a) "reset-vals! stores the new value")))
+
+(deftest test-swap-vals!
+  (let [a (atom 1)]
+    (is (= [1 2] (swap-vals! a inc)) "swap-vals! returns [old new]")
+    (is (= 2 @a) "swap-vals! stores the new value"))
+  (let [a (atom 10)]
+    (is (= [10 17] (swap-vals! a + 3 4)) "swap-vals! with extra args returns [old new]")
+    (is (= 17 @a) "swap-vals! with extra args stores the new value")))
+
 ;; --- Watches ---
 
 (deftest test-add-watch-fires-on-swap


### PR DESCRIPTION
## 🤔 Background

Phel's atom API has `atom`, `deref`, `reset!`, `swap!`, `add-watch`, but is missing Clojure's `compare-and-set!` and the `*-vals!` variants that return both the old and new value. These are the idiomatic tools for conditional updates and for reading the value an atom held just before a change.

## 💡 Goal

Complete the atom API with Clojure-aligned `compare-and-set!`, `swap-vals!`, and `reset-vals!`.

## 🔖 Changes

In `src/phel/core/atoms.phel`, after `swap!`:

- `compare-and-set!` — `(compare-and-set! a old new)` sets the atom to `new` iff its current value is `identical?` to `old` (reference/`===` semantics, matching Clojure), returns `true`/`false`. On success it goes through `reset!`, so watches and validators fire exactly as they do for a normal set.
- `reset-vals!` — like `reset!`, but returns `[old new]`.
- `swap-vals!` — like `swap!` (same arity fast-paths for 0/1/2 extra args), but returns `[old new]`.

Tests in `tests/phel/core/watches-validators.phel`: `compare-and-set!` success/failure and value-unchanged-on-failure; `reset-vals!` and `swap-vals!` return `[old new]` and store the new value, including the extra-args path.

Full core suite green locally: 6359 passed, 0 failed.