### PR TITLE
feat(core): add println-str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - `rational?`: predicate for rational numbers (integers, `Ratio`, and `BigDecimal`; floats are not rational) (#2745)
 - `while`: macro that repeatedly evaluates its body for side effects while a test stays logical true (#2746)
 - `compare-and-set!`, `swap-vals!`, and `reset-vals!`: complete the atom API — conditional identity-based swap, and swap/reset variants returning `[old new]` (#2747)
+- `println-str`: like `println` but returns the string (with trailing newline) instead of writing to output
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 - `rational?`: predicate for rational numbers (integers, `Ratio`, and `BigDecimal`; floats are not rational) (#2745)
 - `while`: macro that repeatedly evaluates its body for side effects while a test stays logical true (#2746)
 - `compare-and-set!`, `swap-vals!`, and `reset-vals!`: complete the atom API — conditional identity-based swap, and swap/reset variants returning `[old new]` (#2747)
-- `println-str`: like `println` but returns the string (with trailing newline) instead of writing to output
+- `println-str`: like `println` but returns the string (with trailing newline) instead of writing to output (#2748)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -55,6 +55,13 @@
   (php/print "\n")
   nil)
 
+(defn println-str
+  "Same as `println`, but instead of writing to an output stream the resulting string is returned, with a trailing newline."
+  {:example "(println-str \"a\" \"b\") ; => \"a b\\n\""
+   :see-also ["print-str" "println"]}
+  [& xs]
+  (str (apply print-str xs) "\n"))
+
 (defn format
   "Returns a formatted string. See PHP's [sprintf](https://www.php.net/manual/en/function.sprintf.php) for more information."
   [fmt & xs]

--- a/tests/phel/core/print-operation.phel
+++ b/tests/phel/core/print-operation.phel
@@ -46,6 +46,12 @@
   (is (= "false" (print-str false)) "print-str on false")
   (is (= "nil" (print-str nil)) "print-str on nil"))
 
+(deftest test-println-str
+  (is (= "\n" (println-str)) "println-str with no args is just a newline")
+  (is (= "a b\n" (println-str "a" "b")) "println-str joins args and appends a newline")
+  (is (= "[a b]\n" (println-str ["a" "b"])) "println-str on a collection")
+  (is (= "nil\n" (println-str nil)) "println-str on nil"))
+
 (deftest test-print
   (is (output? "hello\nworld" (print "hello\nworld")) "print hello\\nworld"))
 


### PR DESCRIPTION
## 🤔 Background

Phel has `print-str` (returns what `print` would emit) but not Clojure's `println-str`. The `clojure-test-suite` specs it (`println_str.cljc`).

## 💡 Goal

Add `println-str`, the string-returning counterpart of `println`.

## 🔖 Changes

- `println-str` in `src/phel/core/io.phel`, after `println`:
  - `(str (apply print-str xs) "\n")` — same non-readable rendering as `print-str`, with a trailing newline; `(println-str)` returns just `"\n"`.
- Tests in `tests/phel/core/print-operation.phel`: no-args newline, joined args, a collection, and `nil`.

Matches the `clojure-test-suite` `println_str.cljc` cases. Full core suite green locally: 6363 passed, 0 failed.

Note: the readable siblings `pr-str`/`prn-str` are intentionally not included here — they require a distinct character type Phel lacks (tracked in #2743).