### PR TITLE
feat(core): add distinct? predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - `while`: macro that repeatedly evaluates its body for side effects while a test stays logical true (#2746)
 - `compare-and-set!`, `swap-vals!`, and `reset-vals!`: complete the atom API — conditional identity-based swap, and swap/reset variants returning `[old new]` (#2747)
 - `println-str`: like `println` but returns the string (with trailing newline) instead of writing to output (#2748)
+- `distinct?`: predicate returning true when no two of its arguments are `=`
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 - `while`: macro that repeatedly evaluates its body for side effects while a test stays logical true (#2746)
 - `compare-and-set!`, `swap-vals!`, and `reset-vals!`: complete the atom API — conditional identity-based swap, and swap/reset variants returning `[old new]` (#2747)
 - `println-str`: like `println` but returns the string (with trailing newline) instead of writing to output (#2748)
-- `distinct?`: predicate returning true when no two of its arguments are `=`
+- `distinct?`: predicate returning true when no two of its arguments are `=` (#2749)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -682,6 +682,14 @@ Creates intermediate maps if they don't exist."
             (copy-meta coll result))))
     (throw (php/new InvalidArgumentException "distinct expects 0 or 1 arguments"))))
 
+(defn distinct?
+  "Returns true if no two of the arguments are `=`. Requires at least one argument."
+  {:example "(distinct? 1 2 3) ; => true\n(distinct? 1 2 1) ; => false"
+   :see-also ["distinct" "=" "set"]}
+  [x & more]
+  (let [all (cons x more)]
+    (= (count all) (count (distinct all)))))
+
 (defn reverse
   "Reverses the order of the elements in the given sequence."
   {:example "(reverse [1 2 3 4]) ; => [4 3 2 1]"

--- a/tests/phel/core/sequence-functions.phel
+++ b/tests/phel/core/sequence-functions.phel
@@ -275,6 +275,14 @@
   (is (= [1 2 3] (distinct [1 1 2 3 2 2 3 1])) "distinct: array")
   (is (= [1 2 3] (distinct (php/array 1 1 2 3 2 2 3 1))) "distinct: php array"))
 
+(deftest test-distinct?
+  (is (true? (distinct? 1)) "distinct? of a single argument")
+  (is (true? (distinct? 1 2 3)) "distinct? when all arguments differ")
+  (is (false? (distinct? 1 2 1)) "distinct? when two arguments are equal")
+  (is (false? (distinct? :a :a)) "distinct? on repeated keywords")
+  (is (false? (distinct? [1 2] [1 2])) "distinct? compares by value, not identity")
+  (is (true? (distinct? [1 2] [1 3])) "distinct? on value-distinct collections"))
+
 (deftest test-dedupe
   (is (= [1 2 3 2 1] (dedupe [1 1 2 3 3 2 1 1])) "dedupe removes consecutive duplicates")
   (is (= [] (dedupe [])) "dedupe empty"))


### PR DESCRIPTION
## 🤔 Background

Phel has `distinct` (dedupe a sequence) but not Clojure's `distinct?` — the predicate that answers "are these arguments all different?".

## 💡 Goal

Add `distinct?` with Clojure-aligned semantics.

## 🔖 Changes

- `distinct?` in `src/phel/core/seq-fns.phel`, right after `distinct` (it depends on `distinct`, which loads after `predicates`):
  - `[x & more]` — requires at least one argument; returns true when no two arguments are `=`. Uses value equality via `distinct`, so `(distinct? [1 2] [1 2])` is `false`.
- Tests in `tests/phel/core/sequence-functions.phel`: single arg, all-different, a repeated value, repeated keywords, and value-equal vs value-distinct collections.

Full core suite green locally: 6369 passed, 0 failed.