### PR TITLE
feat(core): add bounded-count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - `compare-and-set!`, `swap-vals!`, and `reset-vals!`: complete the atom API — conditional identity-based swap, and swap/reset variants returning `[old new]` (#2747)
 - `println-str`: like `println` but returns the string (with trailing newline) instead of writing to output (#2748)
 - `distinct?`: predicate returning true when no two of its arguments are `=` (#2749)
+- `bounded-count`: count a collection, walking at most `n` elements of a non-`counted?` sequence
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 - `compare-and-set!`, `swap-vals!`, and `reset-vals!`: complete the atom API — conditional identity-based swap, and swap/reset variants returning `[old new]` (#2747)
 - `println-str`: like `println` but returns the string (with trailing newline) instead of writing to output (#2748)
 - `distinct?`: predicate returning true when no two of its arguments are `=` (#2749)
-- `bounded-count`: count a collection, walking at most `n` elements of a non-`counted?` sequence
+- `bounded-count`: count a collection, walking at most `n` elements of a non-`counted?` sequence (#2750)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -690,6 +690,19 @@ Creates intermediate maps if they don't exist."
   (let [all (cons x more)]
     (= (count all) (count (distinct all)))))
 
+(defn bounded-count
+  "Returns the number of items in `coll`, but counts at most `n` when `coll` is not `counted?`. If `coll` is `counted?` (its size is known in O(1)) the full `count` is returned, which may exceed `n`; otherwise the sequence is walked at most `n` steps."
+  {:example "(bounded-count 3 [1 2 3 4 5]) ; => 5\n(bounded-count 3 (map inc (range 100))) ; => 3"
+   :see-also ["count" "counted?" "take"]}
+  [n coll]
+  (if (counted? coll)
+    (count coll)
+    (loop [i 0
+           s (seq coll)]
+      (if (and s (php/< i n))
+        (recur (php/+ i 1) (next s))
+        i))))
+
 (defn reverse
   "Reverses the order of the elements in the given sequence."
   {:example "(reverse [1 2 3 4]) ; => [4 3 2 1]"

--- a/tests/phel/core/sequence-functions.phel
+++ b/tests/phel/core/sequence-functions.phel
@@ -283,6 +283,13 @@
   (is (false? (distinct? [1 2] [1 2])) "distinct? compares by value, not identity")
   (is (true? (distinct? [1 2] [1 3])) "distinct? on value-distinct collections"))
 
+(deftest test-bounded-count
+  (is (= 5 (bounded-count 3 [1 2 3 4 5])) "bounded-count returns the full count of a counted collection")
+  (is (= 3 (bounded-count 3 (map inc (range 100)))) "bounded-count caps a lazy sequence at n")
+  (is (= 4 (bounded-count 10 (map inc (range 4)))) "bounded-count returns the real length when shorter than n")
+  (is (= 0 (bounded-count 3 [])) "bounded-count of an empty collection is 0")
+  (is (= 0 (bounded-count 3 nil)) "bounded-count of nil is 0"))
+
 (deftest test-dedupe
   (is (= [1 2 3 2 1] (dedupe [1 1 2 3 3 2 1 1])) "dedupe removes consecutive duplicates")
   (is (= [] (dedupe [])) "dedupe empty"))


### PR DESCRIPTION
## 🤔 Background

Clojure's `bounded-count` counts a collection but avoids walking an entire (possibly infinite/expensive) lazy sequence: for a `counted?` collection it returns the O(1) count, otherwise it walks at most `n` elements. Phel had no such helper.

## 💡 Goal

Add `bounded-count` with Clojure-aligned semantics.

## 🔖 Changes

- `bounded-count` in `src/phel/core/seq-fns.phel`, after `distinct?`:
  - `(bounded-count n coll)` — returns `(count coll)` when `coll` is `counted?` (may exceed `n`); otherwise walks the seq at most `n` steps and returns how many it saw. `nil` counts as `0`.
  - Uses the `php/+` primitive for the index rather than `inc`, since `inc` (in `math`) loads after `seq-fns`.
- Tests in `tests/phel/core/sequence-functions.phel`: counted collection returns full length, a lazy seq is capped at `n`, a shorter-than-`n` lazy seq returns its real length, and empty/`nil` return `0`.

Full core suite green locally: 6374 passed, 0 failed.