### PR TITLE
feat(core): add splitv-at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 - `println-str`: like `println` but returns the string (with trailing newline) instead of writing to output (#2748)
 - `distinct?`: predicate returning true when no two of its arguments are `=` (#2749)
 - `bounded-count`: count a collection, walking at most `n` elements of a non-`counted?` sequence (#2750)
-- `splitv-at`: eager vector-returning variant of `split-at`
+- `splitv-at`: eager vector-returning variant of `split-at` (#2751)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - `println-str`: like `println` but returns the string (with trailing newline) instead of writing to output (#2748)
 - `distinct?`: predicate returning true when no two of its arguments are `=` (#2749)
 - `bounded-count`: count a collection, walking at most `n` elements of a non-`counted?` sequence (#2750)
+- `splitv-at`: eager vector-returning variant of `split-at`
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1302,6 +1302,13 @@ If map has duplicated values, some keys will be ignored."
   [n coll]
   [(take n coll) (drop n coll)])
 
+(defn splitv-at
+  "Returns a vector `[(vec (take n coll)) (vec (drop n coll))]`. Like `split-at`, but eagerly returns vectors rather than lazy sequences."
+  {:example "(splitv-at 2 [1 2 3 4 5]) ; => [[1 2] [3 4 5]]"
+   :see-also ["split-at" "mapv" "filterv"]}
+  [n coll]
+  [(vec (take n coll)) (vec (drop n coll))])
+
 (defn split-with
   "Returns a vector of `[(take-while pred coll) (drop-while pred coll)]`."
   {:example "(split-with #(< % 4) [1 2 3 4 5 6]) ; => [@[1 2 3] @[4 5 6]]"

--- a/tests/phel/core/sequence-functions.phel
+++ b/tests/phel/core/sequence-functions.phel
@@ -587,6 +587,14 @@
   (is (= [[1 2] [3 4 5]] (split-at 2 [1 2 3 4 5])) "split-at")
   (is (= [[1 2] []] (split-at 3 [1 2])) "split-at empty"))
 
+(deftest test-splitv-at
+  (is (= [[1 2] [3 4 5]] (splitv-at 2 [1 2 3 4 5])) "splitv-at splits at n")
+  (is (vector? (first (splitv-at 2 [1 2 3 4 5]))) "splitv-at returns a vector for the first half")
+  (is (vector? (get (splitv-at 2 [1 2 3 4 5]) 1)) "splitv-at returns a vector for the second half")
+  (is (= [[] [1 2 3]] (splitv-at 0 [1 2 3])) "splitv-at 0 puts everything in the second half")
+  (is (= [[1 2] []] (splitv-at 9 [1 2])) "splitv-at past the end leaves an empty second half")
+  (is (= [[] []] (splitv-at 2 [])) "splitv-at on an empty collection"))
+
 (deftest test-split-with
   (is (= [[1 2 3] [4 5]] (split-with (partial >= 3) [1 2 3 4 5])) "split-with"))
 


### PR DESCRIPTION
## 🤔 Background

Clojure 1.12 added `splitv-at`, the eager, vector-returning counterpart of `split-at` (whose halves are lazy sequences). It complements the `mapv`/`filterv` family already being added to Phel.

## 💡 Goal

Add `splitv-at`.

## 🔖 Changes

- `splitv-at` in `src/phel/core/seq-fns.phel`, after `split-at`:
  - `(splitv-at n coll)` => `[(vec (take n coll)) (vec (drop n coll))]` — both halves are concrete vectors.
- Tests in `tests/phel/core/sequence-functions.phel`: the split value, both halves are `vector?`, `n = 0`, `n` past the end, and an empty collection.

Full core suite green locally: 6380 passed, 0 failed.