### PR TITLE
feat(core): add map-invert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
 - `bounded-count`: count a collection, walking at most `n` elements of a non-`counted?` sequence (#2750)
 - `splitv-at`: eager vector-returning variant of `split-at` (#2751)
 
+- `map-invert`: returns a map with keys and values swapped
+
 ### Changed
 
 - `partition` now accepts Clojure's `[n step coll]` and `[n step pad coll]` arities: a custom step produces overlapping or gapped chunks, and a pad collection fills (or is dropped from) the final incomplete chunk. The existing `[n coll]` behavior is unchanged (#2752)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 - `bounded-count`: count a collection, walking at most `n` elements of a non-`counted?` sequence (#2750)
 - `splitv-at`: eager vector-returning variant of `split-at` (#2751)
 
-- `map-invert`: returns a map with keys and values swapped
+- `map-invert`: returns a map with keys and values swapped (#2753)
 
 ### Changed
 

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -336,3 +336,13 @@ Without arguments, uses a default cache size of 128 entries."
    (for [[k v] :pairs m
          :reduce [acc (transient {})]]
      (assoc! acc k (f v)))))
+
+(defn map-invert
+  "Returns a map with the keys and values of `m` swapped. When several keys share a value, the one visited last in iteration order wins."
+  {:example "(map-invert {:a 1 :b 2}) ; => {1 :a, 2 :b}"
+   :see-also ["update-keys" "update-vals" "select-keys"]}
+  [m]
+  (persistent
+   (for [[k v] :pairs m
+         :reduce [acc (transient {})]]
+     (assoc! acc v k))))

--- a/tests/phel/core/utility-functions.phel
+++ b/tests/phel/core/utility-functions.phel
@@ -38,6 +38,12 @@
   (is (= {:a "1" :b "2"} (update-vals {:a 1 :b 2} str)) "update-vals with str")
   (is (= {} (update-vals {} identity)) "update-vals on empty map"))
 
+(deftest test-map-invert
+  (is (= {1 :a 2 :b} (map-invert {:a 1 :b 2})) "map-invert swaps keys and values")
+  (is (= {:a 1 :b 2} (map-invert (map-invert {:a 1 :b 2}))) "map-invert round-trips a 1:1 map")
+  (is (= {} (map-invert {})) "map-invert on an empty map")
+  (is (= {10 "x"} (map-invert {"x" 10})) "map-invert with string keys"))
+
 ;; --- Safe parsing ---
 
 (deftest test-parse-long


### PR DESCRIPTION
## 🤔 Background

Clojure's `clojure.set/map-invert` swaps a map's keys and values. Phel had `update-keys`/`update-vals` but no key/value inversion, so callers hand-rolled a reduce.

## 💡 Goal

Add `map-invert`.

## 🔖 Changes

- `map-invert` in `src/phel/core/fns-sets.phel`, next to `update-keys`/`update-vals` (same transient `for … :reduce` idiom):
  - `(map-invert m)` returns a map with keys and values swapped; when several keys share a value, the last one in iteration order wins.
- Tests in `tests/phel/core/utility-functions.phel`: basic swap, round-trip of a 1:1 map, empty map, and string keys.

Full core suite green locally: 6393 passed, 0 failed.