### PR TITLE
feat(core): add infinite? as alias for inf?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - `splitv-at`: eager vector-returning variant of `split-at` (#2751)
 
 - `map-invert`: returns a map with keys and values swapped (#2753)
+- `infinite?`: alias for `inf?`, matching Clojure's naming
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 - `splitv-at`: eager vector-returning variant of `split-at` (#2751)
 
 - `map-invert`: returns a map with keys and values swapped (#2753)
-- `infinite?`: alias for `inf?`, matching Clojure's naming
+- `infinite?`: alias for `inf?`, matching Clojure's naming (#2754)
 
 ### Changed
 

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -366,9 +366,16 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 (defn inf?
   "Checks if `x` is infinite."
   {:example "(inf? php/INF) ; => true"
-   :see-also ["nan?"]}
+   :see-also ["nan?" "infinite?"]}
   [x]
   (php/is_infinite x))
+
+(defn infinite?
+  "Checks if `x` is positive or negative infinity. Alias for `inf?`, matching Clojure's `infinite?` naming."
+  {:example "(infinite? php/INF) ; => true\n(infinite? 1.0) ; => false"
+   :see-also ["inf?" "nan?"]}
+  [x]
+  (inf? x))
 
 (defn abs
   "Returns the absolute value of `x`.

--- a/tests/phel/core/math-operation.phel
+++ b/tests/phel/core/math-operation.phel
@@ -191,6 +191,12 @@
   (is (= ##Inf php/INF) "##Inf equals php/INF")
   (is (true? (neg? ##-Inf)) "##-Inf is negative"))
 
+(deftest test-infinite?
+  (is (true? (infinite? ##Inf)) "infinite? on positive infinity")
+  (is (true? (infinite? ##-Inf)) "infinite? on negative infinity")
+  (is (false? (infinite? 1.0)) "infinite? on a finite float")
+  (is (false? (infinite? 42)) "infinite? on an integer"))
+
 (deftest test-min
   (is (= 1 (min 1 2 3)) "(min 1 2 3)")
   (is (= "x" (min "x")) "min with a single non-numeric argument returns it unchanged")


### PR DESCRIPTION
## 🤔 Background

Phel exposes `inf?` for the infinity check. Clojure names it `infinite?`. Phel already carries Clojure-naming aliases in the same spirit (`NaN?` for `nan?`, `double?` for `float?`), but `infinite?` was missing.

## 💡 Goal

Add `infinite?` as a Clojure-named alias of `inf?`.

## 🔖 Changes

- `infinite?` in `src/phel/core/math.phel`, right after `inf?`, delegating to it; `inf?`'s `:see-also` now cross-links `infinite?`.
- Tests in `tests/phel/core/math-operation.phel`: `##Inf`, `##-Inf`, a finite float, and an integer.

Full core suite green locally: 6397 passed, 0 failed.