### PR TITLE
feat(core): add clojure.set relational helpers select, project, rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 
 - `map-invert`: returns a map with keys and values swapped (#2753)
 - `infinite?`: alias for `inf?`, matching Clojure's naming (#2754)
+- `select`, `project`, and `rename`: `clojure.set`-style relational helpers over sets (filter to a set; keep only some keys; rename keys)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 
 - `map-invert`: returns a map with keys and values swapped (#2753)
 - `infinite?`: alias for `inf?`, matching Clojure's naming (#2754)
-- `select`, `project`, and `rename`: `clojure.set`-style relational helpers over sets (filter to a set; keep only some keys; rename keys)
+- `select`, `project`, and `rename`: `clojure.set`-style relational helpers over sets (filter to a set; keep only some keys; rename keys) (#2755)
 
 ### Changed
 

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -3,7 +3,8 @@
 ;; Two loosely-related groups, kept together because both build higher-level
 ;; abstractions over the seq/set primitives in core.phel:
 ;;   1. Set algebra: `union`, `intersection`, `difference`,
-;;      `symmetric-difference`, `subset?`, `superset?`.
+;;      `symmetric-difference`, `subset?`, `superset?`, and the relational
+;;      helpers `select`, `project`, `rename`.
 ;;   2. Function combinators and collection helpers: `constantly`,
 ;;      `complement`, `arity`, `variadic?`, `some-fn`, `every-pred`, `juxt`,
 ;;      `partial`, `fnil`, `memoize`, `memoize-lru`, `tree-seq`, `flatten`,
@@ -74,6 +75,27 @@
   {:example "(superset? (hash-set 1 2 3) (hash-set 1 2)) ; => true"}
   [s1 s2]
   (subset? s2 s1))
+
+(defn select
+  "Returns a set of the elements of `xset` for which `(pred element)` is logical true."
+  {:example "(select even? (hash-set 1 2 3 4)) ; => (hash-set 2 4)"
+   :see-also ["filter" "project"]}
+  [pred xset]
+  (set (filter pred xset)))
+
+(defn project
+  "Returns a set of maps, keeping only the keys in `ks` from each map in the relation `xrel`."
+  {:example "(project (hash-set {:a 1 :b 2}) [:a]) ; => (hash-set {:a 1})"
+   :see-also ["select-keys" "rename" "select"]}
+  [xrel ks]
+  (set (map (fn [m] (select-keys m ks)) xrel)))
+
+(defn rename
+  "Returns a set of maps like the relation `xrel`, with the keys of each map renamed according to `kmap` (a map of old-key to new-key)."
+  {:example "(rename (hash-set {:a 1 :b 2}) {:a :x}) ; => (hash-set {:x 1 :b 2})"
+   :see-also ["rename-keys" "project"]}
+  [xrel kmap]
+  (set (map (fn [m] (rename-keys m kmap)) xrel)))
 
 ;; ------------------
 ;; Function operation

--- a/tests/phel/core/set-operation.phel
+++ b/tests/phel/core/set-operation.phel
@@ -36,6 +36,20 @@
   (is (= false (superset? (hash-set 1 2) (hash-set 1 2 3))) "subset is not superset")
   (is (= false (superset? (hash-set 1 2 3) (hash-set 4))) "disjoint is not superset"))
 
+(deftest test-select
+  (is (= (hash-set 2 4) (select even? (hash-set 1 2 3 4))) "select keeps matching elements as a set")
+  (is (= (hash-set) (select even? (hash-set 1 3 5))) "select with no matches is empty")
+  (is (= (hash-set) (select even? (hash-set))) "select on an empty set"))
+
+(deftest test-project
+  (is (= (hash-set {:a 1}) (project (hash-set {:a 1 :b 2}) [:a])) "project keeps only the requested keys")
+  (is (= (hash-set {:a 1} {:a 4}) (project (hash-set {:a 1 :b 2} {:a 4 :b 5}) [:a])) "project over a relation")
+  (is (= (hash-set {}) (project (hash-set {:a 1}) [])) "project with no keys yields empty maps"))
+
+(deftest test-rename
+  (is (= (hash-set {:x 1 :b 2}) (rename (hash-set {:a 1 :b 2}) {:a :x})) "rename renames matching keys")
+  (is (= (hash-set {:a 1}) (rename (hash-set {:a 1}) {:z :y})) "rename ignores keys that are absent"))
+
 (deftest test-disj
   (is (= (hash-set 1 2 3) (disj (hash-set 1 2 3))) "disj with no keys is a no-op")
   (is (= (hash-set 1 3) (disj (hash-set 1 2 3) 2)) "disj removes a single key")


### PR DESCRIPTION
## 🤔 Background

Phel's set algebra (`union`, `intersection`, `difference`, `symmetric-difference`, `subset?`, `superset?`) mirrors `clojure.set`, but the relational helpers `select`, `project`, and `rename` were missing.

## 💡 Goal

Add the three clean relational helpers, Clojure-aligned.

## 🔖 Changes

In `src/phel/core/fns-sets.phel`, in the Set-operation section after `superset?`:

- `select` — `(select pred xset)` returns the subset of `xset` for which `pred` is logical true (a set, unlike lazy `filter`).
- `project` — `(project xrel ks)` returns a set of maps, each reduced to the keys in `ks` (via `select-keys`).
- `rename` — `(rename xrel kmap)` returns a set of maps with keys renamed per `kmap` (via the existing `rename-keys`).

Tests in `tests/phel/core/set-operation.phel` cover matches/no-matches/empty for `select`, single/multi/empty-key `project`, and present/absent-key `rename`. (`index` and `join` are left out: `join` already exists in Phel, and `index` is a heavier relational primitive.)

Full core suite green locally: 6405 passed, 0 failed.