### PR TITLE
feat(core): add clojure.set index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file.
 - `map-invert`: returns a map with keys and values swapped (#2753)
 - `infinite?`: alias for `inf?`, matching Clojure's naming (#2754)
 - `select`, `project`, and `rename`: `clojure.set`-style relational helpers over sets (filter to a set; keep only some keys; rename keys) (#2755)
-- `index`: `clojure.set`-style grouping of a relation into a map keyed by selected columns
+- `index`: `clojure.set`-style grouping of a relation into a map keyed by selected columns (#2756)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - `map-invert`: returns a map with keys and values swapped (#2753)
 - `infinite?`: alias for `inf?`, matching Clojure's naming (#2754)
 - `select`, `project`, and `rename`: `clojure.set`-style relational helpers over sets (filter to a set; keep only some keys; rename keys) (#2755)
+- `index`: `clojure.set`-style grouping of a relation into a map keyed by selected columns
 
 ### Changed
 

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -4,7 +4,7 @@
 ;; abstractions over the seq/set primitives in core.phel:
 ;;   1. Set algebra: `union`, `intersection`, `difference`,
 ;;      `symmetric-difference`, `subset?`, `superset?`, and the relational
-;;      helpers `select`, `project`, `rename`.
+;;      helpers `select`, `project`, `rename`, `index`.
 ;;   2. Function combinators and collection helpers: `constantly`,
 ;;      `complement`, `arity`, `variadic?`, `some-fn`, `every-pred`, `juxt`,
 ;;      `partial`, `fnil`, `memoize`, `memoize-lru`, `tree-seq`, `flatten`,
@@ -96,6 +96,18 @@
    :see-also ["rename-keys" "project"]}
   [xrel kmap]
   (set (map (fn [m] (rename-keys m kmap)) xrel)))
+
+(defn index
+  "Returns a map that groups the maps in the relation `xrel` by their values for the keys in `ks`. Each key is `(select-keys map ks)` and each value is the set of maps sharing those key-values."
+  {:example "(index (hash-set {:name \"a\" :dept 1} {:name \"b\" :dept 1}) [:dept]) ; => {{:dept 1} (hash-set {:name \"a\" :dept 1} {:name \"b\" :dept 1})}"
+   :see-also ["project" "select" "group-by"]}
+  [xrel ks]
+  (reduce
+   (fn [m x]
+     (let [ik (select-keys x ks)]
+       (assoc m ik (conj (get m ik (hash-set)) x))))
+   {}
+   xrel))
 
 ;; ------------------
 ;; Function operation

--- a/tests/phel/core/set-operation.phel
+++ b/tests/phel/core/set-operation.phel
@@ -50,6 +50,16 @@
   (is (= (hash-set {:x 1 :b 2}) (rename (hash-set {:a 1 :b 2}) {:a :x})) "rename renames matching keys")
   (is (= (hash-set {:a 1}) (rename (hash-set {:a 1}) {:z :y})) "rename ignores keys that are absent"))
 
+(deftest test-index
+  (let [rel (hash-set {:name "a" :dept 1} {:name "b" :dept 1} {:name "c" :dept 2})
+        idx (index rel [:dept])]
+    (is (= 2 (count (keys idx))) "index has one entry per distinct key-map")
+    (is (= 2 (count (get idx {:dept 1}))) "index groups all maps sharing the key-values")
+    (is (= (hash-set {:name "c" :dept 2}) (get idx {:dept 2})) "index value is the set of matching maps"))
+  (is (= {} (index (hash-set) [:a])) "index of an empty relation is an empty map")
+  (is (= {{} (hash-set {:a 1} {:a 2})} (index (hash-set {:a 1} {:a 2}) []))
+      "index with no keys groups everything under the empty map"))
+
 (deftest test-disj
   (is (= (hash-set 1 2 3) (disj (hash-set 1 2 3))) "disj with no keys is a no-op")
   (is (= (hash-set 1 3) (disj (hash-set 1 2 3) 2)) "disj removes a single key")


### PR DESCRIPTION
## 🤔 Background

Following `select`/`project`/`rename` (#2755), `index` is the remaining broadly-useful `clojure.set` relational helper Phel lacked. It builds a lookup from a relation (set of maps) — handy for joins and grouping.

## 💡 Goal

Add `index`, Clojure-aligned.

## 🔖 Changes

- `index` in `src/phel/core/fns-sets.phel`, after `rename`:
  - `(index xrel ks)` returns a map from `(select-keys map ks)` to the set of maps in `xrel` sharing those key-values.
- Tests in `tests/phel/core/set-operation.phel`: grouping several maps by a key (entry count, group contents), an empty relation, and the empty-`ks` case (everything under `{}`).

`join` is intentionally not added: Phel already binds `join` (string join). `index`/`select`/`project`/`rename` cover the relational set. Full core suite green locally: 6410 passed, 0 failed.