### PR TITLE
feat(core): support step arity in partition-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- `partition-all` now accepts Clojure's `[n step coll]` arity for overlapping or gapped chunks that keep the incomplete tail
 - `partition` now accepts Clojure's `[n step coll]` and `[n step pad coll]` arities: a custom step produces overlapping or gapped chunks, and a pad collection fills (or is dropped from) the final incomplete chunk. The existing `[n coll]` behavior is unchanged (#2752)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- `partition-all` now accepts Clojure's `[n step coll]` arity for overlapping or gapped chunks that keep the incomplete tail
+- `partition-all` now accepts Clojure's `[n step coll]` arity for overlapping or gapped chunks that keep the incomplete tail (#2758)
 - `partition` now accepts Clojure's `[n step coll]` and `[n step pad coll]` arities: a custom step produces overlapping or gapped chunks, and a pad collection fills (or is dropped from) the final incomplete chunk. The existing `[n coll]` behavior is unchanged (#2752)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1457,15 +1457,21 @@ If map has duplicated values, some keys will be ignored."
              (list (vec (take n (concat p pad)))))))))))
 
 (defn partition-all
-  "Partitions collection into chunks of size n, including incomplete final partition."
-  {:example "(partition-all 3 [1 2 3 4 5 6 7]) ; => @[[1 2 3] [4 5 6] [7]]"}
-  [n coll]
-  (let [result (lazy-seq-from-generator
-                (php/call_user_func_array
-                 (php/array "\\Phel\\Lang\\Seq" "partitionAll")
-                 (php/array n coll)))]
-    (if (php/=== nil result)
-      '()
-      (copy-meta coll result))))
+  "Partitions collection into chunks of size `n`, including any incomplete trailing chunks. `step` (default `n`) is how far to advance between chunks, so a `step` smaller than `n` yields overlapping chunks. Each chunk is a vector."
+  {:example "(partition-all 3 [1 2 3 4 5 6 7]) ; => @[[1 2 3] [4 5 6] [7]]\n(partition-all 3 2 [0 1 2 3 4]) ; => @[[0 1 2] [2 3 4] [4]]"
+   :see-also ["partition" "partition-by"]}
+  ([n coll]
+   (let [result (lazy-seq-from-generator
+                 (php/call_user_func_array
+                  (php/array "\\Phel\\Lang\\Seq" "partitionAll")
+                  (php/array n coll)))]
+     (if (php/=== nil result)
+       '()
+       (copy-meta coll result))))
+  ([n step coll]
+   (lazy-seq
+     (let [s (seq coll)]
+       (when s
+         (cons (vec (take n s)) (partition-all n step (nthrest s step))))))))
 
 ;; Functional core

--- a/tests/phel/core/infinite-seqs.phel
+++ b/tests/phel/core/infinite-seqs.phel
@@ -863,6 +863,18 @@
     (is (true? (seq? result))
         "partition-all should return a lazy sequence")))
 
+(deftest test-partition-all-with-step
+  (is (= [[0 1 2] [2 3 4] [4]] (doall (partition-all 3 2 [0 1 2 3 4])))
+      "partition-all with a step keeps overlapping and trailing chunks")
+  (is (= [[0 1] [3 4] [6]] (doall (partition-all 2 3 [0 1 2 3 4 5 6])))
+      "partition-all with a step larger than n skips elements but keeps the tail")
+  (is (= (doall (partition-all 2 [1 2 3])) (doall (partition-all 2 2 [1 2 3])))
+      "partition-all with step n matches the two-argument arity")
+  (is (= [] (doall (partition-all 2 1 [])))
+      "partition-all with a step on an empty collection")
+  (is (= [[0 1] [1 2] [2 3]] (doall (take 3 (partition-all 2 1 (iterate inc 0)))))
+      "partition-all with a step is lazy over an infinite sequence"))
+
 ;; Helper functions for lazy-seq tests
 (defn my-range [n]
   (when (> n 0)


### PR DESCRIPTION
## 🤔 Background

#2752 gave `partition` its Clojure `step`/`pad` arities. `partition-all` has the same gap: Clojure supports `(partition-all n step coll)` for overlapping/gapped chunks that keep the incomplete tail; Phel only had `[n coll]`.

## 💡 Goal

Add the `[n step coll]` arity, Clojure-aligned, without touching the native `[n coll]` fast path.

## 🔖 Changes

- `partition-all` in `src/phel/core/seq-fns.phel` is now multi-arity:
  - `[n coll]` — unchanged; still delegates to the native `Seq::partitionAll`.
  - `[n step coll]` — lazy (`lazy-seq` + `nthrest`), advances by `step` between chunks, keeps every trailing chunk; vector chunks matching the native path (`(partition-all 2 2 coll)` ≡ `(partition-all 2 coll)`).
- Tests in `tests/phel/core/infinite-seqs.phel`: the Clojure reference cases `(3 2 [0..4]) => [[0 1 2] [2 3 4] [4]]` and `(2 3 [0..6]) => [[0 1] [3 4] [6]]`, step-n equivalence with the 2-arity, empty input, and laziness over `(iterate inc 0)`.

Full core suite green locally: 6434 passed, 0 failed.