### PR TITLE
feat(core): add random-sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - `select`, `project`, and `rename`: `clojure.set`-style relational helpers over sets (filter to a set; keep only some keys; rename keys) (#2755)
 - `index`: `clojure.set`-style grouping of a relation into a map keyed by selected columns (#2756)
 - `subseq` and `rsubseq`: lazy range queries over sorted maps and sorted sets — boundary tests (`>`, `>=`, `<`, `<=`) respect the collection's own comparator, ascending (`subseq`) or descending (`rsubseq`) (#2757)
+- `random-sample`: keeps each item of a collection independently with probability `prob`; lazy, with a transducer arity
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file.
 - `select`, `project`, and `rename`: `clojure.set`-style relational helpers over sets (filter to a set; keep only some keys; rename keys) (#2755)
 - `index`: `clojure.set`-style grouping of a relation into a map keyed by selected columns (#2756)
 - `subseq` and `rsubseq`: lazy range queries over sorted maps and sorted sets — boundary tests (`>`, `>=`, `<`, `<=`) respect the collection's own comparator, ascending (`subseq`) or descending (`rsubseq`) (#2757)
-- `random-sample`: keeps each item of a collection independently with probability `prob`; lazy, with a transducer arity
+- `random-sample`: keeps each item of a collection independently with probability `prob`; lazy, with a transducer arity (#2759)
 
 ### Changed
 

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -542,6 +542,15 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   (when-not (nil? xs)
     (get xs (rand-int (dec (count xs))))))
 
+(defn random-sample
+  "Returns the items of `coll` for which `(rand)` is less than `prob`, so each item is kept independently with probability `prob` (0 keeps nothing, 1 keeps everything). Lazy. Without a collection, returns a transducer."
+  {:example "(random-sample 0.5 (range 10)) ; => @[1 4 5 9]"
+   :see-also ["rand" "filter" "shuffle" "rand-nth"]}
+  ([prob]
+   (filter (fn [_] (< (rand) prob))))
+  ([prob coll]
+   (filter (fn [_] (< (rand) prob)) coll)))
+
 (defn extreme
   "Returns the most extreme value in `args` based on the binary `order` function."
   {:example "(extreme > [1 5 2]) ; => 5"

--- a/tests/phel/core/math-operation.phel
+++ b/tests/phel/core/math-operation.phel
@@ -226,6 +226,29 @@
 (deftest test-rand-with-zero-limit
   (is (zero? (rand 0)) "(rand 0) returns 0"))
 
+(deftest test-random-sample
+  (let [coll (vec (range 100))]
+    (is (= [] (random-sample 0 coll)) "probability 0 keeps nothing")
+    (is (= coll (random-sample 1 coll)) "probability 1 keeps everything")
+    (is (= [] (random-sample -1 coll)) "probability below 0 keeps nothing")
+    (is (= coll (random-sample 10 coll)) "probability above 1 keeps everything")
+    (is (= [] (random-sample 1 [])) "empty collection stays empty")
+    (is (= [] (random-sample 1 nil)) "nil collection yields empty")
+    (let [n (count (random-sample 0.5 coll))]
+      (is (and (>= n 0) (<= n 100)) "probability 0.5 keeps a subset"))
+    (is (every? (set coll) (random-sample 0.5 coll)) "sampled items come from the collection")))
+
+(deftest test-random-sample-transducer
+  (let [coll (vec (range 100))]
+    (is (= [] (transduce (random-sample 0) conj [] coll)) "transducer with probability 0")
+    (is (= coll (transduce (random-sample 1) conj [] coll)) "transducer with probability 1")
+    (let [n (count (transduce (random-sample 0.5) conj [] coll))]
+      (is (and (>= n 0) (<= n 100)) "transducer with probability 0.5 keeps a subset"))))
+
+(deftest test-random-sample-rejects-bad-input
+  (is (thrown? \Throwable (doall (random-sample nil [1 2 3]))) "nil probability throws")
+  (is (thrown? \Throwable (doall (random-sample 0.5 42))) "non-seqable collection throws"))
+
 (deftest test-min-key
   (is (= {:a 1} (min-key :a {:a 1} {:a 3} {:a 2}))
       "min-key with keyword key")


### PR DESCRIPTION
## 🤔 Background

Clojure's `random-sample` keeps each element of a collection independently with probability `prob` — the standard tool for probabilistic sampling of streams/collections. The `clojure-test-suite` specs it (`random_sample.cljc`). Phel had `rand`/`rand-int`/`rand-nth`/`shuffle` but no sampler.

## 💡 Goal

Add `random-sample`, Clojure-aligned, including the transducer arity.

## 🔖 Changes

- `random-sample` in `src/phel/core/math.phel`, after `rand-nth`:
  - `(random-sample prob coll)` — lazy `(filter (fn [_] (< (rand) prob)) coll)`; `prob <= 0` keeps nothing, `>= 1` keeps everything.
  - `(random-sample prob)` — transducer, by delegating to `filter`'s transducer arity.
  - `nil` probability throws (Phel's `<` rejects `nil`); non-seqable input throws when realized — both required by the suite.
- Tests in `tests/phel/core/math-operation.phel`: deterministic bounds (0 / 1 / -1 / 10), empty and `nil` collections, subset property and membership at `prob` 0.5, the transducer arity through `transduce`, and the two throwing cases.

Verified locally against every assertion in the suite's `random_sample.cljc` (including `transduce` paths). Full core suite green locally: 6447 passed, 0 failed.