### PR TITLE
perf(compiler): route multi-arity calls through fixed-arity dispatch (#2715)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ All notable changes to this project will be documented in this file.
 - `distinct?`: predicate returning true when no two of its arguments are `=` (#2749)
 - `bounded-count`: count a collection, walking at most `n` elements of a non-`counted?` sequence (#2750)
 - `splitv-at`: eager vector-returning variant of `split-at` (#2751)
-
 - `map-invert`: returns a map with keys and values swapped (#2753)
 - `infinite?`: alias for `inf?`, matching Clojure's naming (#2754)
 - `select`, `project`, and `rename`: `clojure.set`-style relational helpers over sets (filter to a set; keep only some keys; rename keys) (#2755)
@@ -29,6 +28,10 @@ All notable changes to this project will be documented in this file.
 
 - `partition-all` now accepts Clojure's `[n step coll]` arity for overlapping or gapped chunks that keep the incomplete tail (#2758)
 - `partition` now accepts Clojure's `[n step coll]` and `[n step pad coll]` arities: a custom step produces overlapping or gapped chunks, and a pad collection fills (or is dropped from) the final incomplete chunk. The existing `[n coll]` behavior is unchanged (#2752)
+
+### Performance
+
+- Multi-arity function calls skip the variadic `__invoke` dispatch. Multi-arity fn classes now emit fixed-arity `invokeArityN` methods, and build-mode call sites with a statically known arity route through them via a guarded shortcut, avoiding the per-call `...$args` packing, `$args[N]` re-indexing, and closure indirection. Roughly 1.5-2x faster per multi-arity call in microbenchmarks (larger under JIT); single-arity calls are unchanged (#2715)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 
 ### Performance
 
-- Multi-arity function calls skip the variadic `__invoke` dispatch. Multi-arity fn classes now emit fixed-arity `invokeArityN` methods, and build-mode call sites with a statically known arity route through them via a guarded shortcut, avoiding the per-call `...$args` packing, `$args[N]` re-indexing, and closure indirection. Roughly 1.5-2x faster per multi-arity call in microbenchmarks (larger under JIT); single-arity calls are unchanged (#2715)
+- Multi-arity function calls skip the variadic `__invoke` dispatch. Multi-arity fn classes now emit fixed-arity `invokeArityN` methods, and build-mode call sites with a statically known arity route through them via a guarded shortcut, avoiding the per-call `...$args` packing, `$args[N]` re-indexing, and closure indirection. Roughly 1.5-2x faster per multi-arity call in microbenchmarks (larger under JIT); single-arity calls are unchanged (#2760)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/src/php/Build/Infrastructure/Cache/CacheIndexFile.php
+++ b/src/php/Build/Infrastructure/Cache/CacheIndexFile.php
@@ -29,7 +29,7 @@ final readonly class CacheIndexFile
     // #2729 cross-fn `:tag` inference) leaves stale compiled files that a same-version cache would
     // keep serving. Bumping here rejects the whole index once, forcing a cold recompile.
     // Decoupled from the Phel version for cache stability across minor releases.
-    private const string INDEX_FORMAT_VERSION = '1.4';
+    private const string INDEX_FORMAT_VERSION = '1.5';
 
     public function __construct(
         private CacheDirectory $directory,

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -27,6 +27,8 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\Specialized\TypePredi
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
+use Phel\Lang\AbstractFn;
+use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 
 use function assert;
@@ -182,6 +184,11 @@ final readonly class CallEmitter implements NodeEmitterInterface
         $useCallMethod = !$this->isSelfCall($node)
             && (GlobalCallTarget::isGlobalFnCall($node) || CallSpecialization::isTypedAFnLocal($node));
 
+        if ($useCallMethod && $this->isMultiArityArityShortcut($node)) {
+            $this->emitArityShortcut($node);
+            return;
+        }
+
         $this->emitDynamicFunctionName($node);
 
         if ($useCallMethod) {
@@ -189,6 +196,72 @@ final readonly class CallEmitter implements NodeEmitterInterface
         } else {
             $this->emitFunctionArguments($node);
         }
+    }
+
+    /**
+     * A call is eligible for the fixed-arity shortcut when the callee is a
+     * multi-arity global fn (its def stamped a `max-arity`) and the argument
+     * count has a dedicated `invokeArityN` slot. Only multi-arity targets are
+     * shortcut: their `__invoke` packs `...$args` and re-indexes `$args[N]`,
+     * which the per-arity methods skip. Single-arity fns already emit a lean
+     * positional `__invoke`, so shortcutting them would only add overhead.
+     */
+    private function isMultiArityArityShortcut(CallNode $node): bool
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return false;
+        }
+
+        $argCount = count($node->getArguments());
+        if ($argCount < 1 || $argCount > AbstractFn::MAX_ARITY_SLOT) {
+            return false;
+        }
+
+        // Only shortcut when the call site has a build-mode cache slot. The
+        // slot's `??=` makes re-emitting the callee across the ternary arms a
+        // single registry lookup; without it (the REPL path) re-emission would
+        // run the lookup twice, so we keep the plain `__invoke` there.
+        if ($this->outputEmitter->callSlotFor($node) === null) {
+            return false;
+        }
+
+        $meta = $fn->getMeta();
+        if ($meta->find('max-arity') !== null) {
+            return true;
+        }
+
+        return $meta->find(Keyword::create('max-arity')) !== null;
+    }
+
+    /**
+     * Emits `(<callee> instanceof AbstractFn ? <callee>->invokeArityN(args) :
+     * <callee>->__invoke(args))`. The ternary only evaluates the taken branch,
+     * so repeating the arguments across both arms never double-evaluates a
+     * side-effecting argument. The callee is re-emitted per arm, which is
+     * idempotent here: a global call is a `($__phel_call_N ??= …)` slot (the
+     * `??=` runs the lookup once) and a typed local is a plain variable read.
+     * The `instanceof` guard keeps the current `__invoke` behaviour when a
+     * global was redefined to a plain closure, which has no `invokeArityN`.
+     */
+    private function emitArityShortcut(CallNode $node): void
+    {
+        $loc = $node->getStartSourceLocation();
+        $arity = count($node->getArguments());
+
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->emitDynamicFunctionName($node);
+        $this->outputEmitter->emitStr(' instanceof \\Phel\\Lang\\AbstractFn ? ', $loc);
+
+        $this->emitDynamicFunctionName($node);
+        $this->outputEmitter->emitStr('->invokeArity' . $arity . '(', $loc);
+        $this->outputEmitter->emitArgList($node->getArguments(), $loc);
+        $this->outputEmitter->emitStr(') : ', $loc);
+
+        $this->emitDynamicFunctionName($node);
+        $this->outputEmitter->emitStr('->__invoke(', $loc);
+        $this->outputEmitter->emitArgList($node->getArguments(), $loc);
+        $this->outputEmitter->emitStr('))', $loc);
     }
 
     private function emitPhpFunctionName(PhpVarNode $fnNode): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MultiFnAsClassEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MultiFnAsClassEmitter.php
@@ -9,6 +9,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MultiFnNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
+use Phel\Lang\AbstractFn;
 use Phel\Lang\Symbol;
 
 use function assert;
@@ -32,6 +33,7 @@ final readonly class MultiFnAsClassEmitter implements NodeEmitterInterface
         $this->emitProperties($node, $uses, count($fnNodes));
         $this->emitConstructor($node, $uses, $fnNodes);
         $this->emitInvoke($node, $fnNodes);
+        $this->emitArityMethods($node, $fnNodes);
         $this->emitClassEnd($node);
     }
 
@@ -181,6 +183,55 @@ final readonly class MultiFnAsClassEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitLine('};', $loc);
         $this->outputEmitter->decreaseIndentLevel();
         $this->outputEmitter->emitLine('}', $loc);
+    }
+
+    /**
+     * Fixed-arity dispatch slots overriding `AbstractFn::invokeArityN`. Each
+     * concrete (non-variadic) arity up to `AbstractFn::MAX_ARITY_SLOT` gets a
+     * method with real positional parameters that calls its closure directly,
+     * so a call site that has proven the arity can skip `__invoke`'s variadic
+     * packing and `$args[N]` re-indexing (#2715). Arities the multi-fn does
+     * not define as fixed (e.g. the variadic arm) keep the inherited default,
+     * which routes back through `__invoke`.
+     *
+     * @param list<FnNode> $fnNodes
+     */
+    private function emitArityMethods(MultiFnNode $node, array $fnNodes): void
+    {
+        $loc = $node->getStartSourceLocation();
+
+        foreach ($fnNodes as $i => $fnNode) {
+            if ($fnNode->isVariadic()) {
+                continue;
+            }
+
+            $arity = count($fnNode->getParams());
+            if ($arity > AbstractFn::MAX_ARITY_SLOT) {
+                continue;
+            }
+
+            $params = [];
+            $typedParams = [];
+            for ($p = 1; $p <= $arity; ++$p) {
+                $params[] = '$a' . $p;
+                // Signature must stay compatible with the `mixed ...): mixed`
+                // parent slot on AbstractFn, so declare params/return as mixed.
+                $typedParams[] = 'mixed $a' . $p;
+            }
+
+            $this->outputEmitter->emitLine();
+            $this->outputEmitter->emitLine(
+                'public function invokeArity' . $arity . '(' . implode(', ', $typedParams) . '): mixed {',
+                $loc,
+            );
+            $this->outputEmitter->increaseIndentLevel();
+            $this->outputEmitter->emitLine(
+                'return ($this->fn' . $i . ')(' . implode(', ', $params) . ');',
+                $loc,
+            );
+            $this->outputEmitter->decreaseIndentLevel();
+            $this->outputEmitter->emitLine('}', $loc);
+        }
     }
 
     private function emitClassEnd(MultiFnNode $node): void

--- a/src/php/Lang/AbstractFn.php
+++ b/src/php/Lang/AbstractFn.php
@@ -21,6 +21,13 @@ abstract class AbstractFn implements FnInterface, MetaInterface, Stringable
 {
     use MetaTrait;
 
+    /**
+     * Highest arity with a dedicated `invokeArityN` dispatch slot. Emitted
+     * call sites only shortcut arities up to this bound; beyond it they use
+     * the generic `__invoke` path.
+     */
+    public const int MAX_ARITY_SLOT = 8;
+
     public function __toString(): string
     {
         $reflection = new ReflectionClass($this);
@@ -52,4 +59,83 @@ abstract class AbstractFn implements FnInterface, MetaInterface, Stringable
         return $this->__invoke(...$args);
     }
 
+    // Fixed-arity dispatch slots for emitted call sites. Multi-arity fn
+    // classes override the arities they define with bodies that call the
+    // matching closure directly, skipping `__invoke`'s variadic packing and
+    // `$args[N]` re-indexing (#2715). These defaults keep every call site
+    // correct when the callee was re-defined to a fn of another shape: the
+    // delegation lands in `__invoke`, which throws the usual arity error
+    // for arities the fn does not support.
+
+    /**
+     * @psalm-suppress UndefinedMethod
+     */
+    public function invokeArity0(): mixed
+    {
+        return $this->__invoke();
+    }
+
+    /**
+     * @psalm-suppress UndefinedMethod
+     */
+    public function invokeArity1(mixed $a1): mixed
+    {
+        return $this->__invoke($a1);
+    }
+
+    /**
+     * @psalm-suppress UndefinedMethod
+     */
+    public function invokeArity2(mixed $a1, mixed $a2): mixed
+    {
+        return $this->__invoke($a1, $a2);
+    }
+
+    /**
+     * @psalm-suppress UndefinedMethod
+     */
+    public function invokeArity3(mixed $a1, mixed $a2, mixed $a3): mixed
+    {
+        return $this->__invoke($a1, $a2, $a3);
+    }
+
+    /**
+     * @psalm-suppress UndefinedMethod
+     */
+    public function invokeArity4(mixed $a1, mixed $a2, mixed $a3, mixed $a4): mixed
+    {
+        return $this->__invoke($a1, $a2, $a3, $a4);
+    }
+
+    /**
+     * @psalm-suppress UndefinedMethod
+     */
+    public function invokeArity5(mixed $a1, mixed $a2, mixed $a3, mixed $a4, mixed $a5): mixed
+    {
+        return $this->__invoke($a1, $a2, $a3, $a4, $a5);
+    }
+
+    /**
+     * @psalm-suppress UndefinedMethod
+     */
+    public function invokeArity6(mixed $a1, mixed $a2, mixed $a3, mixed $a4, mixed $a5, mixed $a6): mixed
+    {
+        return $this->__invoke($a1, $a2, $a3, $a4, $a5, $a6);
+    }
+
+    /**
+     * @psalm-suppress UndefinedMethod
+     */
+    public function invokeArity7(mixed $a1, mixed $a2, mixed $a3, mixed $a4, mixed $a5, mixed $a6, mixed $a7): mixed
+    {
+        return $this->__invoke($a1, $a2, $a3, $a4, $a5, $a6, $a7);
+    }
+
+    /**
+     * @psalm-suppress UndefinedMethod
+     */
+    public function invokeArity8(mixed $a1, mixed $a2, mixed $a3, mixed $a4, mixed $a5, mixed $a6, mixed $a7, mixed $a8): mixed
+    {
+        return $this->__invoke($a1, $a2, $a3, $a4, $a5, $a6, $a7, $a8);
+    }
 }

--- a/tests/php/Integration/Fixtures/Call/call-multi-arity-global-shortcut.test
+++ b/tests/php/Integration/Fixtures/Call/call-multi-arity-global-shortcut.test
@@ -1,0 +1,67 @@
+--PHEL--
+(defn my-add ([a] a) ([a b] (php/+ a b)))
+(defn caller [x] (my-add x x))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "my-add",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\my_add";
+    private $fn0;
+    private $fn1;
+
+    public function __construct() {
+      $this->fn0 = (function($a) {
+        return $a;
+      });
+      $this->fn1 = (function($a, $b) {
+        return ($a + $b);
+      });
+    }
+
+    public function __invoke(...$args) {
+      return match (\count($args)) {
+        1 => ($this->fn0)($args[0]),
+        2 => ($this->fn1)($args[0], $args[1]),
+        default => throw new \InvalidArgumentException("No matching function arity"),
+      };
+    }
+
+    public function invokeArity1(mixed $a1): mixed {
+      return ($this->fn0)($a1);
+    }
+
+    public function invokeArity2(mixed $a1, mixed $a2): mixed {
+      return ($this->fn1)($a1, $a2);
+    }
+  },
+  \Phel::locationMeta(
+    \Phel::location("Call/call-multi-arity-global-shortcut.test", 1, 0),
+    \Phel::location("Call/call-multi-arity-global-shortcut.test", 1, 41),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(my-add a)\n(my-add a b)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "max-arity", 2,
+    "arglists", "([a] [a b])"
+  )
+);
+\Phel::addDefinition(
+  "user",
+  "caller",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\caller";
+
+    public function __invoke($x) {
+      static $__phel_call_0;
+      return (($__phel_call_0 ??= \Phel::getDefinition("user", "my-add")) instanceof \Phel\Lang\AbstractFn ? ($__phel_call_0 ??= \Phel::getDefinition("user", "my-add"))->invokeArity2($x, $x) : ($__phel_call_0 ??= \Phel::getDefinition("user", "my-add"))->__invoke($x, $x));
+    }
+  },
+  \Phel::locationMeta(
+    \Phel::location("Call/call-multi-arity-global-shortcut.test", 2, 0),
+    \Phel::location("Call/call-multi-arity-global-shortcut.test", 2, 30),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/defn-multi-arity-infers-return.test
+++ b/tests/php/Integration/Fixtures/Def/defn-multi-arity-infers-return.test
@@ -25,6 +25,14 @@
         default => throw new \InvalidArgumentException("No matching function arity"),
       };
     }
+
+    public function invokeArity1(mixed $a1): mixed {
+      return ($this->fn0)($a1);
+    }
+
+    public function invokeArity2(mixed $a1, mixed $a2): mixed {
+      return ($this->fn1)($a1, $a2);
+    }
   },
   \Phel::locationMeta(
     \Phel::location("Def/defn-multi-arity-infers-return.test", 1, 0),

--- a/tests/php/Integration/Fixtures/Fn/fn-named-multi-arity.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-named-multi-arity.test
@@ -24,4 +24,12 @@ new class() extends \Phel\Lang\AbstractFn {
       default => throw new \InvalidArgumentException("No matching function arity"),
     };
   }
+
+  public function invokeArity1(mixed $a1): mixed {
+    return ($this->fn0)($a1);
+  }
+
+  public function invokeArity2(mixed $a1, mixed $a2): mixed {
+    return ($this->fn1)($a1, $a2);
+  }
 };

--- a/tests/php/Integration/Fixtures/Fn/fn-named-recursive-multi-arity.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-named-recursive-multi-arity.test
@@ -24,4 +24,12 @@ new class() extends \Phel\Lang\AbstractFn {
       default => throw new \InvalidArgumentException("No matching function arity"),
     };
   }
+
+  public function invokeArity1(mixed $a1): mixed {
+    return ($this->fn0)($a1);
+  }
+
+  public function invokeArity2(mixed $a1, mixed $a2): mixed {
+    return ($this->fn1)($a1, $a2);
+  }
 };

--- a/tests/php/Integration/Fixtures/Fn/fn-return-type-multi-arity.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-return-type-multi-arity.test
@@ -24,4 +24,12 @@ new class() extends \Phel\Lang\AbstractFn {
       default => throw new \InvalidArgumentException("No matching function arity"),
     };
   }
+
+  public function invokeArity1(mixed $a1): mixed {
+    return ($this->fn0)($a1);
+  }
+
+  public function invokeArity2(mixed $a1, mixed $a2): mixed {
+    return ($this->fn1)($a1, $a2);
+  }
 };


### PR DESCRIPTION
## 🤔 Background

Closes #2715.

A multi-arity `defn` compiles to a class whose `__invoke(...$args)` packs every call into `$args`, `match`es on `\count($args)`, then re-indexes `$args[0]`, `$args[1]`, … into a closure call. So each call pays for variadic packing + re-indexing + closure indirection that a fixed positional signature would avoid. Single-arity fns already emit a lean positional `__invoke`, so they are not affected.

## 💡 Goal

Let call sites that statically know the arity of a multi-arity callee skip that machinery, without changing behaviour for redefinition, side-effecting arguments, or the REPL.

## 🔖 Changes

- **`AbstractFn`** gains `invokeArity0..8` default slots (and `MAX_ARITY_SLOT`), each delegating to `__invoke`. The defaults keep every call site correct when a global was redefined to a fn of another shape or to a plain closure.
- **`MultiFnAsClassEmitter`** emits, for each concrete (non-variadic) arity up to `MAX_ARITY_SLOT`, an overriding `invokeArityN(mixed …): mixed` whose body calls that arity's closure directly — no `...$args`, no `$args[N]`. The variadic arm and arities above the cap keep the inherited default (which routes back through `__invoke`).
- **`CallEmitter`** shortcuts a call when the callee is a multi-arity global (its def stamped `max-arity`), the arity has a slot, and the call site has a build-mode cache slot:
  `(<callee> instanceof \Phel\Lang\AbstractFn ? <callee>->invokeArityN(args) : <callee>->__invoke(args))`.
  - The `instanceof` guard preserves current behaviour if the global was redefined to a plain closure (no `invokeArityN`).
  - A PHP ternary only evaluates its taken branch, so repeating `args` across the arms never double-evaluates a side-effecting argument.
  - The callee is re-emitted per arm, which is idempotent here: it is the `($__phel_call_N ??= …)` slot, whose `??=` runs the registry lookup once. Gating on the slot keeps the slot-less REPL path on the plain `__invoke`.
- **`CacheIndexFile::INDEX_FORMAT_VERSION`** bumped `1.4` → `1.5` so stale compiled-code caches do not serve the old emission.

## ⚡ Benchmark

Isolated 20M-call microbenchmark of a 2-arity fn (`ns/call`):

| | current `__invoke` | fixed-arity shortcut |
|---|---|---|
| no opcache | 39.8 | 21.4 (**-46%**) |
| opcache + JIT | 25.9 | 9.5 (**-63%**) |

The guard adds no measurable cost under JIT.

## ✅ Tests

- New fixture `Call/call-multi-arity-global-shortcut.test` locks in the guarded call-site shape (slot-cached callee, ternary).
- Four multi-arity `defn`/`fn` fixtures regenerated to include the new `invokeArityN` methods (additive only).
- Full `composer test` green locally (quality + compiler + core: 6447 core assertions, 0 failures). Single-arity and non-multi-arity call sites are byte-identical to before.