### PR TITLE
feat(core): add pr, prn, pr-str, prn-str readable-print family

### DIFF
--- a/.github/workflows/run-clojure-test-suite.yml
+++ b/.github/workflows/run-clojure-test-suite.yml
@@ -38,7 +38,7 @@ jobs:
           # PR/push runs gate against a pinned, reproducible suite commit; the
           # nightly cron tracks `main` to surface upstream drift; dispatch can
           # override either way.
-          ref: ${{ github.event.inputs.suite-ref || (github.event_name == 'schedule' && 'main' || 'c79e3f988799ce39d65632b1388b407d62612435') }}
+          ref: ${{ github.event.inputs.suite-ref || (github.event_name == 'schedule' && 'main' || 'fb73a48f02a2f5d6a3ecd188568413147b5e0903') }}
           path: clojure-test-suite
 
       - uses: shivammathur/setup-php@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - `index`: `clojure.set`-style grouping of a relation into a map keyed by selected columns (#2756)
 - `subseq` and `rsubseq`: lazy range queries over sorted maps and sorted sets — boundary tests (`>`, `>=`, `<`, `<=`) respect the collection's own comparator, ascending (`subseq`) or descending (`rsubseq`) (#2757)
 - `random-sample`: keeps each item of a collection independently with probability `prob`; lazy, with a transducer arity (#2759)
+- `pr`, `prn`, `pr-str`, and `prn-str`: readable-print family — like `print`/`println`/`print-str`/`println-str` but each value is printed readably (strings quoted and escaped). Phel has no char type, so character literals such as `\A` are single-character strings and print as `"A"` (ClojureScript-aligned) (#2743)
 
 ### Changed
 

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -7,7 +7,8 @@
 (use Phel.Shared.Printer.Printer)
 
 ;; I/O: stdout/formatting (`print`, `println`, `pr`, `prn`, `print-str`,
-;; `format`, `printf`, `with-output-buffer`); stderr debugging (`dbg`,
+;; `println-str`, `pr-str`, `prn-str`, `format`, `printf`,
+;; `with-output-buffer`); stderr debugging (`dbg`,
 ;; `dbg-write`); file helpers (`slurp`, `spit`,
 ;; `line-seq`, `file-seq`, `read-file-lazy`, `csv-seq`, `with-open`); and regex helpers
 ;; (`re-pattern`, `re-seq`, `re-find`, `re-matches`). Everything here touches
@@ -28,11 +29,10 @@
          (php/ob_end_clean)
          ~res))))
 
-(defn print-str
-  "Same as print. But instead of writing it to an output stream, the resulting string is returned."
-  [& xs]
-  (let [printer (php/:: Printer (nonReadable))
-        pp      #(php/-> printer (print %))]
+(defn- print-joined
+  "Space-joins `xs`, stringifying each element with `printer`."
+  [printer xs]
+  (let [pp #(php/-> printer (print %))]
     (case (count xs)
       0 ""
       1 (pp (first xs))
@@ -41,6 +41,18 @@
         (if seq
           (recur (str res " " (pp (first seq))) (next seq))
           res)))))
+
+(defn print-str
+  "Same as print. But instead of writing it to an output stream, the resulting string is returned."
+  [& xs]
+  (print-joined (php/:: Printer (nonReadable)) xs))
+
+(defn pr-str
+  "Same as `print-str`, but prints each value readably: strings are quoted and escaped so the output can be read back. Phel has no dedicated char type, so character literals such as `\\A` are single-character strings and print as `\"A\"` (ClojureScript-aligned; Clojure/JVM would print `\\A`)."
+  {:example "(pr-str \"a\" 1) ; => \"\\\"a\\\" 1\""
+   :see-also ["print-str" "prn-str" "prn"]}
+  [& xs]
+  (print-joined (php/:: Printer (readable)) xs))
 
 (defn print
   "Prints the given values to the default output stream. Returns nil."
@@ -61,6 +73,30 @@
    :see-also ["print-str" "println"]}
   [& xs]
   (str (apply print-str xs) "\n"))
+
+(defn pr
+  "Same as `print`, but prints each value readably (strings quoted). Returns nil."
+  {:example "(pr \"a\" 1) ; prints \"a\" 1"
+   :see-also ["print" "prn" "pr-str"]}
+  [& xs]
+  (php/print (apply pr-str xs))
+  nil)
+
+(defn prn
+  "Same as `pr` followed by a newline. Returns nil."
+  {:example "(prn \"a\" 1) ; prints \"a\" 1 and a newline"
+   :see-also ["println" "pr" "prn-str"]}
+  [& xs]
+  (apply pr xs)
+  (php/print "\n")
+  nil)
+
+(defn prn-str
+  "Same as `prn`, but instead of writing to an output stream the resulting string is returned, with a trailing newline."
+  {:example "(prn-str \"a\" 1) ; => \"\\\"a\\\" 1\\n\""
+   :see-also ["pr-str" "println-str" "prn"]}
+  [& xs]
+  (str (apply pr-str xs) "\n"))
 
 (defn format
   "Returns a formatted string. See PHP's [sprintf](https://www.php.net/manual/en/function.sprintf.php) for more information."

--- a/tests/phel/core/print-operation.phel
+++ b/tests/phel/core/print-operation.phel
@@ -52,8 +52,37 @@
   (is (= "[a b]\n" (println-str ["a" "b"])) "println-str on a collection")
   (is (= "nil\n" (println-str nil)) "println-str on nil"))
 
+(deftest test-pr-str
+  (is (= "" (pr-str)) "pr-str with no arg")
+  (is (= "\"a\"" (pr-str "a")) "pr-str quotes strings")
+  (is (= "\"a\\nb\"" (pr-str "a\nb")) "pr-str escapes newlines inside strings")
+  (is (= "\"a\" 1" (pr-str "a" 1)) "pr-str space-joins args, quoting only strings")
+  (is (= "[\"a\" \"b\"]" (pr-str ["a" "b"])) "pr-str on vector quotes elements")
+  (is (= "{\"a\" \"b\"}" (pr-str {"a" "b"})) "pr-str on hash map quotes elements")
+  (is (= "#{\"a\"}" (pr-str (hash-set "a"))) "pr-str on set quotes elements")
+  (is (= "x" (pr-str 'x)) "pr-str on symbol")
+  (is (= ":test" (pr-str :test)) "pr-str on keyword")
+  (is (= "1" (pr-str 1)) "pr-str on number")
+  (is (= "true" (pr-str true)) "pr-str on true")
+  (is (= "nil" (pr-str nil)) "pr-str on nil")
+  ;; Phel has no char type: \A is the string "A" and prints quoted (ClojureScript-aligned).
+  (is (= "\"A\"" (pr-str \A)) "pr-str on a character literal renders it as a quoted string")
+  (is (= "\" \"" (pr-str \space)) "pr-str on \\space renders a quoted space"))
+
+(deftest test-prn-str
+  (is (= "\n" (prn-str)) "prn-str with no args is just a newline")
+  (is (= "\"a\"\n" (prn-str "a")) "prn-str quotes and appends a newline")
+  (is (= "\"a\" 1\n" (prn-str "a" 1)) "prn-str joins args and appends a newline"))
+
 (deftest test-print
   (is (output? "hello\nworld" (print "hello\nworld")) "print hello\\nworld"))
+
+(deftest test-pr
+  (is (output? "\"hello\"" (pr "hello")) "pr writes readably")
+  (is (output? "\"a\" 1" (pr "a" 1)) "pr space-joins readable args"))
+
+(deftest test-prn
+  (is (output? "\"hello\"\n" (prn "hello")) "prn writes readably with a trailing newline"))
 
 (deftest test-println
   (is (output? "hello\nworld\n" (println "hello\nworld")) "println hello\\nworld"))


### PR DESCRIPTION
## 🤔 Background

Phel had `print`/`println`/`print-str`/`println-str` (non-readable), but no readable-print family. Issue #2743 asked whether closing the gap requires a distinct `Char` value type.

Decision (per issue discussion): **no `Char` type.** Phel compiles to PHP, a host with no char primitive — exactly ClojureScript's situation on JS. ClojureScript reads `\A` as the string `"A"` and prints it quoted, and Phel already documents `char`/`char?` as ClojureScript-aligned. Introducing a `Char` wrapper would break `char?`/equality and fight PHP interop at every `php/` string-fn boundary, for a parity property the accurate host model doesn't have. So we keep the string-as-char model and make the divergence explicit.

## 💡 Goal

Add the readable-print family under the string model, treating char literals rendering as quoted strings as intentional, documented behavior — not a bug.

## 🔖 Changes

- Add `pr`, `prn`, `pr-str`, `prn-str` to `phel.core` (readable variants of `print`/`println`/`print-str`/`println-str`; strings quoted and escaped via `Printer::readable()`).
- Extract a private `print-joined` helper so `print-str` and `pr-str` share the space-join loop (no duplication).
- Docstrings + CHANGELOG state the ClojureScript alignment: `(pr-str \A)` => `"A"`, not `\A`.
- Tests in `print-operation.phel` cover quoting, collections, multi-arg joins, newline escaping, and the char-literal divergence explicitly.

Non-breaking: no compiler/runtime changes; `char`/`char?`/equality/interop untouched.

**Refactor pass:** re-reviewed all touched files — reuse (`print-joined`) and docstring metadata already in the feature commit; no further changes surfaced, so no separate `ref(...)` commit.

Closes #2743
