### PR TITLE
fix(run): require active xdebug coverage mode when detecting coverage driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ All notable changes to this project will be documented in this file.
 
 - Multi-arity function calls skip the variadic `__invoke` dispatch. Multi-arity fn classes now emit fixed-arity `invokeArityN` methods, and build-mode call sites with a statically known arity route through them via a guarded shortcut, avoiding the per-call `...$args` packing, `$args[N]` re-indexing, and closure indirection. Roughly 1.5-2x faster per multi-arity call in microbenchmarks (larger under JIT); single-arity calls are unchanged (#2760)
 
+### Fixed
+
+- `phel test --coverage`: xdebug is only used as the coverage driver when `coverage` is among its active modes; otherwise the command fails fast with a hint to re-run with `XDEBUG_MODE=coverage` instead of emitting PHP warnings and an empty report (#2764)
+
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 
 ### Added

--- a/src/php/Run/Application/Test/Coverage/CoverageDriver.php
+++ b/src/php/Run/Application/Test/Coverage/CoverageDriver.php
@@ -8,13 +8,18 @@ use function constant;
 use function defined;
 use function extension_loaded;
 use function function_exists;
+use function in_array;
+use function is_array;
 
 /**
  * Thin adapter over the loaded line-coverage extension (pcov preferred, else
  * xdebug). Extension functions are resolved through string-named variables so
  * the source needs neither the pcov nor xdebug stubs to analyze, and never
- * references a symbol that may be absent. `detect()` returns null when neither
- * extension is available, letting the caller emit an actionable error.
+ * references a symbol that may be absent. `detect()` returns null when no
+ * usable extension is available — xdebug counts only when `coverage` is among
+ * its active modes, since `xdebug_start_code_coverage()` collects nothing
+ * otherwise — letting the caller emit an actionable error via
+ * `unavailabilityReason()`.
  */
 final readonly class CoverageDriver
 {
@@ -32,11 +37,27 @@ final readonly class CoverageDriver
             return new self(self::PCOV);
         }
 
-        if (extension_loaded(self::XDEBUG) && function_exists('xdebug_start_code_coverage')) {
+        if (extension_loaded(self::XDEBUG)
+            && function_exists('xdebug_start_code_coverage')
+            && self::xdebugCoverageModeActive()
+        ) {
             return new self(self::XDEBUG);
         }
 
         return null;
+    }
+
+    /**
+     * Why `detect()` returned null, phrased as a hint the user can act on.
+     */
+    public static function unavailabilityReason(): string
+    {
+        if (extension_loaded(self::XDEBUG) && !self::xdebugCoverageModeActive()) {
+            return "xdebug is loaded but 'coverage' is not an active mode; "
+                . 're-run with XDEBUG_MODE=coverage or set xdebug.mode=coverage in php.ini.';
+        }
+
+        return 'neither pcov nor xdebug is loaded.';
     }
 
     public function name(): string
@@ -86,5 +107,22 @@ final readonly class CoverageDriver
         $stop();
 
         return $data;
+    }
+
+    /**
+     * Whether xdebug currently runs with the `coverage` mode enabled (via
+     * `xdebug.mode` or the `XDEBUG_MODE` env override). Xdebug builds too old
+     * to expose `xdebug_info()` cannot be queried; assume usable.
+     */
+    private static function xdebugCoverageModeActive(): bool
+    {
+        if (!function_exists('xdebug_info')) {
+            return true;
+        }
+
+        $info = 'xdebug_info';
+        $modes = $info('mode');
+
+        return is_array($modes) && in_array('coverage', $modes, true);
     }
 }

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -221,7 +221,8 @@ HELP)
                 $coverageDriver = $this->getFacade()->detectCoverageDriver();
                 if (!$coverageDriver instanceof CoverageDriver) {
                     $output->writeln(
-                        '<error>--coverage requires the pcov or xdebug extension; neither is loaded.</error>',
+                        '<error>--coverage requires the pcov or xdebug extension; '
+                        . CoverageDriver::unavailabilityReason() . '</error>',
                     );
                     return self::FAILURE;
                 }

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -86,17 +86,21 @@ final class RunCommandTest extends AbstractTestCommand
 
     public function test_run_by_filename_outside_config(): void
     {
-        $tmpFile = __DIR__ . '/outside-script.phel';
+        // Must live outside the configured src/test dirs: parallel workers scan
+        // those for namespaces and would race with this file's deletion.
+        $tmpFile = sys_get_temp_dir() . '/phel-outside-script-' . bin2hex(random_bytes(4)) . '.phel';
         file_put_contents($tmpFile, "(ns outside\script)\n(php/print \"hello world\\n\")");
 
-        $this->expectOutputRegex('~hello world~');
+        try {
+            $this->expectOutputRegex('~hello world~');
 
-        $this->createRunCommand()->run(
-            $this->stubInput($tmpFile),
-            $this->stubOutput(),
-        );
-
-        unlink($tmpFile);
+            $this->createRunCommand()->run(
+                $this->stubInput($tmpFile),
+                $this->stubOutput(),
+            );
+        } finally {
+            unlink($tmpFile);
+        }
     }
 
     public function test_run_by_filename_resolves_bundled_namespace_fqn_without_require(): void

--- a/tests/php/Unit/Run/Application/Test/Coverage/CoverageDriverTest.php
+++ b/tests/php/Unit/Run/Application/Test/Coverage/CoverageDriverTest.php
@@ -8,6 +8,9 @@ use Phel\Run\Application\Test\Coverage\CoverageDriver;
 use PHPUnit\Framework\TestCase;
 
 use function extension_loaded;
+use function function_exists;
+use function in_array;
+use function is_array;
 
 final class CoverageDriverTest extends TestCase
 {
@@ -15,11 +18,35 @@ final class CoverageDriverTest extends TestCase
     {
         $driver = CoverageDriver::detect();
 
-        if (extension_loaded('pcov') || extension_loaded('xdebug')) {
+        if (extension_loaded('pcov')) {
             self::assertInstanceOf(CoverageDriver::class, $driver);
-            self::assertContains($driver->name(), [CoverageDriver::PCOV, CoverageDriver::XDEBUG]);
+            self::assertSame(CoverageDriver::PCOV, $driver->name());
+        } elseif (extension_loaded('xdebug') && $this->xdebugCoverageModeActive()) {
+            self::assertInstanceOf(CoverageDriver::class, $driver);
+            self::assertSame(CoverageDriver::XDEBUG, $driver->name());
         } else {
-            self::assertNull($driver, 'no driver when neither extension is loaded');
+            self::assertNull($driver, 'no driver without a usable coverage extension');
         }
+    }
+
+    public function test_unavailability_reason_names_the_missing_piece(): void
+    {
+        if (extension_loaded('xdebug') && !$this->xdebugCoverageModeActive()) {
+            self::assertStringContainsString('XDEBUG_MODE=coverage', CoverageDriver::unavailabilityReason());
+        } else {
+            self::assertStringContainsString('neither pcov nor xdebug', CoverageDriver::unavailabilityReason());
+        }
+    }
+
+    private function xdebugCoverageModeActive(): bool
+    {
+        if (!function_exists('xdebug_info')) {
+            return true;
+        }
+
+        $info = 'xdebug_info';
+        $modes = $info('mode');
+
+        return is_array($modes) && in_array('coverage', $modes, true);
     }
 }


### PR DESCRIPTION
## 🤔 Background

`CoverageDriver::detect()` picked xdebug as the line-coverage driver whenever the extension was loaded. But `xdebug_start_code_coverage()` only collects data when `coverage` is among the active `xdebug.mode` values — with any other mode (e.g. the common `develop` default), `phel test --coverage` emitted PHP warnings, reported "no project source files were executed", and produced empty reports. The four `TestCommandCoverageTest` integration tests failed on such machines instead of skipping.

## 💡 Goal

Treat xdebug without the `coverage` mode as "no driver available" so `phel test --coverage` fails fast with an actionable hint, and the integration tests skip gracefully on misconfigured environments.

## 🔖 Changes

- `CoverageDriver::detect()` also requires `coverage` to be an active xdebug mode (queried via `xdebug_info('mode')`, honoring the `XDEBUG_MODE` env override; xdebug builds too old to expose `xdebug_info()` are assumed usable).
- New `CoverageDriver::unavailabilityReason()` tells the user what is missing; `phel test --coverage` now prints `xdebug is loaded but 'coverage' is not an active mode; re-run with XDEBUG_MODE=coverage or set xdebug.mode=coverage in php.ini.` instead of the generic "neither is loaded" text.
- Unit tests cover both detection branches; the existing `TestCommandCoverageTest` end-to-end suite now skips (instead of failing) when the subprocess has xdebug in a non-coverage mode, and still fully passes under `XDEBUG_MODE=coverage`.
- CHANGELOG entry under Unreleased.