### PR TITLE
perf(emitter): drop $__truthy adapter when if-test is a typed native comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 
 ### Performance
 
+- `if` tests that lower to a native PHP comparison (typed `<`, `<=`, `>`, `>=`, `=`, and the `(not (= ...))` peephole) are spliced directly into the condition slot, dropping the redundant `($__truthy = ...) !== null && $__truthy !== false` adapter; `and`/`or` chains of such comparisons drop the per-arm adapters too (#2766)
 - Multi-arity function calls skip the variadic `__invoke` dispatch. Multi-arity fn classes now emit fixed-arity `invokeArityN` methods, and build-mode call sites with a statically known arity route through them via a guarded shortcut, avoiding the per-call `...$args` packing, `$args[N]` re-indexing, and closure indirection. Roughly 1.5-2x faster per multi-arity call in microbenchmarks (larger under JIT); single-arity calls are unchanged (#2760)
 
 ### Fixed

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -13,7 +13,6 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\FnInterface;
 
 use function count;
-use function in_array;
 use function is_string;
 
 /**
@@ -25,15 +24,6 @@ use function is_string;
  */
 final readonly class CallSpecialization
 {
-    /**
-     * {@see NumericOperationSpecialization::typedBinaryOpName()} results
-     * that are native PHP comparisons and therefore hard bools. The
-     * arithmetic results (`+`, `-`, `*`) are int/float expressions.
-     *
-     * @var list<string>
-     */
-    private const array BOOL_BINARY_OPS = ['<', '<=', '>', '>=', '==='];
-
     private function __construct() {}
 
     /**
@@ -61,14 +51,7 @@ final readonly class CallSpecialization
             return true;
         }
 
-        // Typed comparisons lower to a native PHP comparison, which is a
-        // hard bool; the arithmetic ops (`+`, `-`, `*`) are excluded — they
-        // lower to int/float expressions.
-        return in_array(
-            NumericOperationSpecialization::typedBinaryOpName($node),
-            self::BOOL_BINARY_OPS,
-            true,
-        );
+        return NumericOperationSpecialization::isTypedComparison($node);
     }
 
     public static function isSpecialized(CallNode $node): bool

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -13,6 +13,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\FnInterface;
 
 use function count;
+use function in_array;
 use function is_string;
 
 /**
@@ -24,6 +25,15 @@ use function is_string;
  */
 final readonly class CallSpecialization
 {
+    /**
+     * {@see NumericOperationSpecialization::typedBinaryOpName()} results
+     * that are native PHP comparisons and therefore hard bools. The
+     * arithmetic results (`+`, `-`, `*`) are int/float expressions.
+     *
+     * @var list<string>
+     */
+    private const array BOOL_BINARY_OPS = ['<', '<=', '>', '>=', '==='];
+
     private function __construct() {}
 
     /**
@@ -42,11 +52,23 @@ final readonly class CallSpecialization
             || TypePredicateSpecialization::isTypePredicate($node)
             || TypedValueSpecialization::isEmptyCheck($node)
             || TypedValueSpecialization::isContainsCheck($node)
+            || NumericOperationSpecialization::isNotEqPeephole($node)
         ) {
             return true;
         }
 
-        return TypePredicateSpecialization::isNumericPredicate($node) !== null;
+        if (TypePredicateSpecialization::isNumericPredicate($node) !== null) {
+            return true;
+        }
+
+        // Typed comparisons lower to a native PHP comparison, which is a
+        // hard bool; the arithmetic ops (`+`, `-`, `*`) are excluded — they
+        // lower to int/float expressions.
+        return in_array(
+            NumericOperationSpecialization::typedBinaryOpName($node),
+            self::BOOL_BINARY_OPS,
+            true,
+        );
     }
 
     public static function isSpecialized(CallNode $node): bool

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecialization.php
@@ -74,6 +74,14 @@ final readonly class NumericOperationSpecialization
      */
     private const array ARITHMETIC_OPS = ['+', '-', '*'];
 
+    /**
+     * {@see self::typedBinaryOpName()} results that are native PHP
+     * comparisons and therefore hard bools.
+     *
+     * @var list<string>
+     */
+    private const array BOOL_BINARY_OPS = ['<', '<=', '>', '>=', '==='];
+
     /** @var list<string> */
     private const array NUMERIC_PRIMITIVE_TAGS = ['int', 'float'];
 
@@ -217,6 +225,17 @@ final readonly class NumericOperationSpecialization
     public static function isTypedBinaryOp(CallNode $node): bool
     {
         return self::typedBinaryOpName($node) !== null;
+    }
+
+    /**
+     * `(<op> a b)` that lowers to a native PHP comparison (`<`, `<=`, `>`,
+     * `>=`, `===`) — a hard-bool expression the `IfEmitter` can splice into
+     * a condition slot without the Phel-truthy adapter. The arithmetic
+     * lowerings (`+`, `-`, `*`) are excluded: they produce int/float.
+     */
+    public static function isTypedComparison(CallNode $node): bool
+    {
+        return in_array(self::typedBinaryOpName($node), self::BOOL_BINARY_OPS, true);
     }
 
     /**

--- a/tests/php/Integration/Fixtures/If/if-typed-comparison-skips-truthy.test
+++ b/tests/php/Integration/Fixtures/If/if-typed-comparison-skips-truthy.test
@@ -1,0 +1,18 @@
+--PHEL--
+(fn [^int a] (if (> a 10) :big :small))
+(fn [^int a ^int b] (if (= a b) :eq :ne))
+(fn [^int a ^int b] (if (and (> a 1) (< b 2)) :in :out))
+--PHP--
+(function(int $a) {
+  static $__phel_const_0, $__phel_const_1;
+  return ((($a > 10)) ? ($__phel_const_0 ??= \Phel\Lang\Keyword::create("big")) : ($__phel_const_1 ??= \Phel\Lang\Keyword::create("small")));
+
+});(function(int $a, int $b) {
+  static $__phel_const_0, $__phel_const_1;
+  return ((($a === $b)) ? ($__phel_const_0 ??= \Phel\Lang\Keyword::create("eq")) : ($__phel_const_1 ??= \Phel\Lang\Keyword::create("ne")));
+
+});(function(int $a, int $b) {
+  static $__phel_const_0, $__phel_const_1;
+  return ((($a > 1)) && (($b < 2)) ? ($__phel_const_0 ??= \Phel\Lang\Keyword::create("in")) : ($__phel_const_1 ??= \Phel\Lang\Keyword::create("out")));
+
+});

--- a/tests/php/Integration/Fixtures/Let/loop-inferred-int-counter-native-arith.test
+++ b/tests/php/Integration/Fixtures/Let/loop-inferred-int-counter-native-arith.test
@@ -5,7 +5,7 @@
   /** @var int $i_1 */
   $i_1 = 0;
   while (true) {
-    if (($__truthy = ($i_1 < $n)) !== null && $__truthy !== false) {
+    if ((($i_1 < $n))) {
       $i_1 = ($i_1 + 1);
       continue;
 

--- a/tests/php/Integration/Fixtures/Let/loop-php-native-arith-chain.test
+++ b/tests/php/Integration/Fixtures/Let/loop-php-native-arith-chain.test
@@ -7,7 +7,7 @@
   /** @var float $sum_2 */
   $sum_2 = 0.0;
   while (true) {
-    if (($__truthy = ($i_1 < 10)) !== null && $__truthy !== false) {
+    if ((($i_1 < 10))) {
       $i_1 = ($i_1 + 1);
       $sum_2 = ($sum_2 + ($d * cos($angle)));
       continue;

--- a/tests/php/Integration/Fixtures/Let/loop-typed-binding-native-arith.test
+++ b/tests/php/Integration/Fixtures/Let/loop-typed-binding-native-arith.test
@@ -5,7 +5,7 @@
   /** @var int $i_1 */
   $i_1 = 0;
   while (true) {
-    if (($__truthy = ($i_1 < $n)) !== null && $__truthy !== false) {
+    if ((($i_1 < $n))) {
       $i_1 = ($i_1 + 1);
       continue;
 


### PR DESCRIPTION
## 🤔 Background

Typed comparisons (`<`, `<=`, `>`, `>=`, `=` on statically-proven primitives) already lower to native PHP comparison operators, but `IfEmitter` still wrapped them in the Phel-truthy adapter: `($__truthy = ($n > 10)) !== null && $__truthy !== false`. A native comparison is a hard `bool`, so the adapter is dead weight in exactly the code paths users optimized with type tags.

## 💡 Goal

Splice hard-bool comparison tests directly into the `if` condition slot, in ternary, statement, and `and`/`or` short-circuit contexts.

## 🔖 Changes

- `NumericOperationSpecialization::isTypedComparison()`: new predicate for bool-returning lowerings (`<`, `<=`, `>`, `>=`, `===`), excluding arithmetic (`+`, `-`, `*`)
- `CallSpecialization::isBoolReturningSpecialisation()` now consults it, plus the `(not (= ...))` peephole, so `BooleanExprDetector` reports these tests as hard bools
- New fixture `If/if-typed-comparison-skips-truthy.test`; three `Let/loop-*` fixtures updated to the leaner emission
- CHANGELOG entry under Performance

Closes #2766