### PR TITLE
chore(agents): allow model invocation of pr and gh-issue skills

### DIFF
--- a/.agnostic-ai/skills/gh-issue/SKILL.md
+++ b/.agnostic-ai/skills/gh-issue/SKILL.md
@@ -1,7 +1,6 @@
 ---
 description: Fetch a GitHub issue, create a branch, implement with TDD, and open a PR
 argument-hint: "[issue-number]"
-disable-model-invocation: true
 ---
 
 # GitHub Issue Workflow

--- a/.agnostic-ai/skills/pr/SKILL.md
+++ b/.agnostic-ai/skills/pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 description: Push branch and create a PR with concise description and labels
 argument-hint: "[issue-number]"
-disable-model-invocation: true
 allowed-tools: "Read, Edit, Bash(git *), Bash(gh *)"
 ---
 


### PR DESCRIPTION
## 🤔 Background

The `/gh-issues` watcher loop delegates each issue to `/gh-issue`, which in turn opens PRs via `/pr`. Both skills carried `disable-model-invocation: true`, so an in-session loop hit `Skill ... cannot be used with Skill tool` and had to re-implement their steps inline.

## 💡 Goal

Let the session invoke `/gh-issue` and `/pr` programmatically while keeping them user-invocable as before.

## 🔖 Changes

- Removed `disable-model-invocation: true` from `.agnostic-ai/skills/pr/SKILL.md` and `.agnostic-ai/skills/gh-issue/SKILL.md`; regenerated adapters via `agnostic-ai sync`