### PR TITLE
perf(core): add primitive return tags to core fns so binding inference reaches native ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 
 ### Performance
 
+- Core fns with contract-guaranteed primitive returns now carry explicit return tags (`count`, `compare` → `int`; `str`, `name`, `print-str`, `pr-str`, `println-str`, `prn-str` → `string`), so `let`/`loop` bindings initialized from them are type-inferred and downstream comparisons/concats hit the native-op emitter paths without user annotations. Their compiled `__invoke` signatures gain the matching native PHP return type (#2767)
 - `if` tests that lower to a native PHP comparison (typed `<`, `<=`, `>`, `>=`, `=`, and the `(not (= ...))` peephole) are spliced directly into the condition slot, dropping the redundant `($__truthy = ...) !== null && $__truthy !== false` adapter; `and`/`or` chains of such comparisons drop the per-arm adapters too (#2766)
 - Multi-arity function calls skip the variadic `__invoke` dispatch. Multi-arity fn classes now emit fixed-arity `invokeArityN` methods, and build-mode call sites with a statically known arity route through them via a guarded shortcut, avoiding the per-call `...$args` packing, `$args[N]` re-indexing, and closure indirection. Roughly 1.5-2x faster per multi-arity call in microbenchmarks (larger under JIT); single-arity calls are unchanged (#2760)
 

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -433,7 +433,7 @@
   `BigDecimal`). Throws `InvalidArgumentException` when `x` and `y` come from
   mutually incomparable categories (e.g. `(compare 1 [])`)."
   {:see-also ["<=>" "sort" "sort-by"]}
-  [x y]
+  ^int [x y]
   (cond
     (php/=== x nil) (if (php/=== y nil) 0 -1)
     (php/=== y nil) 1

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -44,14 +44,14 @@
 
 (defn print-str
   "Same as print. But instead of writing it to an output stream, the resulting string is returned."
-  [& xs]
+  ^string [& xs]
   (print-joined (php/:: Printer (nonReadable)) xs))
 
 (defn pr-str
   "Same as `print-str`, but prints each value readably: strings are quoted and escaped so the output can be read back. Phel has no dedicated char type, so character literals such as `\\A` are single-character strings and print as `\"A\"` (ClojureScript-aligned; Clojure/JVM would print `\\A`)."
   {:example "(pr-str \"a\" 1) ; => \"\\\"a\\\" 1\""
    :see-also ["print-str" "prn-str" "prn"]}
-  [& xs]
+  ^string [& xs]
   (print-joined (php/:: Printer (readable)) xs))
 
 (defn print
@@ -71,7 +71,7 @@
   "Same as `println`, but instead of writing to an output stream the resulting string is returned, with a trailing newline."
   {:example "(println-str \"a\" \"b\") ; => \"a b\\n\""
    :see-also ["print-str" "println"]}
-  [& xs]
+  ^string [& xs]
   (str (apply print-str xs) "\n"))
 
 (defn pr
@@ -95,7 +95,7 @@
   "Same as `prn`, but instead of writing to an output stream the resulting string is returned, with a trailing newline."
   {:example "(prn-str \"a\" 1) ; => \"\\\"a\\\" 1\\n\""
    :see-also ["pr-str" "println-str" "prn"]}
-  [& xs]
+  ^string [& xs]
   (str (apply pr-str xs) "\n"))
 
 (defn format

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -953,7 +953,7 @@ bindings is a vector of function specs: (letfn [(f [params] body) (g [params] bo
 
 (defn name
   "Returns the name string of a string, keyword or symbol."
-  [x]
+  ^string [x]
   (if (string? x) x (php/-> x (getName))))
 
 (defn namespace

--- a/src/phel/core/seq-basics.phel
+++ b/src/phel/core/seq-basics.phel
@@ -124,7 +124,7 @@
 Works with lists, vectors, hash-maps, sets, strings, and PHP arrays. Returns 0 for nil."
   {:example "(count [1 2 3]) ; => 3"
    :see-also ["empty?" "seq"]}
-  [coll]
+  ^int [coll]
   (if (php/instanceof coll Countable)
     (php/-> coll (count))
     (if (php/is_array coll)

--- a/src/phel/core/strings.phel
+++ b/src/phel/core/strings.phel
@@ -99,7 +99,7 @@ Throws `InvalidArgumentException` for any other input (including functions, numb
 
 (defn str
   "Creates a string by concatenating values together. If no arguments are provided an empty string is returned. Nil is represented as an empty string. Booleans are represented as \"true\" or \"false\" (matching Clojure semantics). Otherwise, it tries to call `__toString`."
-  [& args]
+  ^string [& args]
   (let [cnt (php/count args)]
     (if (php/=== cnt 0)
       ""

--- a/tests/php/Integration/Fixtures/Call/count-first-typed-string.test
+++ b/tests/php/Integration/Fixtures/Call/count-first-typed-string.test
@@ -2,7 +2,7 @@
 (fn [^string s] (count s))
 (fn [^string s] (first s))
 --PHP--
-(function(string $s) {
+(function(string $s): int {
   return mb_strlen($s);
 });(function(string $s) {
   return ($s === '' ? null : mb_substr($s, 0, 1));

--- a/tests/php/Integration/Fixtures/Call/name-namespace-tagged.test
+++ b/tests/php/Integration/Fixtures/Call/name-namespace-tagged.test
@@ -2,7 +2,7 @@
 (fn [^\Phel\Lang\Keyword k] (name k))
 (fn [^\Phel\Lang\Symbol s] (namespace s))
 --PHP--
-(function(\Phel\Lang\Keyword $k) {
+(function(\Phel\Lang\Keyword $k): string {
   return ($k->getName());
 });(function(\Phel\Lang\Symbol $s) {
   return ($s->getNamespace());

--- a/tests/php/Integration/Fixtures/Call/nil-some-check-specialised.test
+++ b/tests/php/Integration/Fixtures/Call/nil-some-check-specialised.test
@@ -7,6 +7,6 @@
   return ($x === null);
 });(function($x) {
   return ($x !== null);
-});(function(array $a) {
+});(function(array $a): int {
   return count($a);
 });

--- a/tests/php/Integration/Fixtures/Let/let-core-fn-return-tag-inference.test
+++ b/tests/php/Integration/Fixtures/Let/let-core-fn-return-tag-inference.test
@@ -1,0 +1,17 @@
+--PHEL--
+(fn [xs] (let [n (count xs)] (if (> n 10) :big :small)))
+(fn [a b] (let [c (compare a b)] (if (< c 0) :lt :gte)))
+--PHP--
+(function($xs) {
+  static $__phel_const_0, $__phel_const_1, $__phel_call_0;
+  /** @var int $n_1 */
+  $n_1 = ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "count"))->__invoke($xs);
+  return ((($n_1 > 10)) ? ($__phel_const_0 ??= \Phel\Lang\Keyword::create("big")) : ($__phel_const_1 ??= \Phel\Lang\Keyword::create("small")));
+
+});(function($a, $b) {
+  static $__phel_const_0, $__phel_const_1, $__phel_call_0;
+  /** @var int $c_2 */
+  $c_2 = ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "compare"))->__invoke($a, $b);
+  return ((($c_2 < 0)) ? ($__phel_const_0 ??= \Phel\Lang\Keyword::create("lt")) : ($__phel_const_1 ??= \Phel\Lang\Keyword::create("gte")));
+
+});


### PR DESCRIPTION
## 🤔 Background

The analyzer already propagates a callee's return `:tag` into `let`/`loop` binding types (`BindingTypeInferrer::globalReturnTag`), but core fns carried no tags — so `(let [n (count xs)] (> n 10))` stayed on full dynamic dispatch while the equivalent user-tagged fn went native.

## 💡 Goal

Feed the existing inference machinery data: tag every core fn whose contract guarantees a single primitive return, so ordinary user code reaches the native-op emitter paths with zero annotations.

## 🔖 Changes

- `^int`: `count`, `compare` (every branch verified int)
- `^string`: `str`, `name`, `print-str`, `pr-str`, `println-str`, `prn-str` (every branch verified string)
- Compiled `__invoke` signatures gain the matching native PHP return type (runtime-enforced; `composer test-core` proves no branch violates a tag)
- New fixture `Let/let-core-fn-return-tag-inference.test`; three `Call/*` fixtures updated for wrapper fns that now infer their own return types
- Benchmarks (`--ref` vs main, 1G memory): no regression beyond noise; typed benches improve — `mandel_typed` −7.7%, `sum_squares_typed` −4.6%, `fib_typed` −2.6%
- Final refactor pass surfaced zero changes (additions are one-line tags)

Closes #2767