### PR TITLE
fix(analyzer): multi-arity fn returned from another fn emitted invalid PHP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Multi-arity `fn` returned from another fn no longer emits invalid PHP (`ParseError: unexpected token "return"`): the per-arity closures are analyzed in expression context, so the generated constructor assignments splice plain closure expressions. `(fn [x] (fn ([a] ...) ([a b] ...)))` now works, with or without captured locals (#2776)
 - String concatenation no longer specializes over `php/json_encode`, `php/hex2bin`, or `php/str_replace`: their `string|false` / `string|array` returns could splice `false` into a native `.` concat and emit `""` where the dynamic `str` path renders `"false"`. The two compiler return-type tables are consolidated into one `PhpFunctionReturnTypes` with an explicit strict band (persistable tags) and a documented operand-only widening (`pow`) (#2768)
 - `phel test --coverage`: xdebug is only used as the coverage driver when `coverage` is among its active modes; otherwise the command fails fast with a hint to re-run with `XDEBUG_MODE=coverage` instead of emitting PHP warnings and an empty report (#2764)
 - Self-recursion inside a def whose init wraps the fn (e.g. `(def f (wrap (fn [n] ... (f ...))))`) no longer emits the `$this` self-call shortcut — the fn compiles to a plain closure there, so the shortcut invoked an unrelated object ("Object of type ... is not callable"); recursion now routes through the registry. Direct `(def f (fn ...))` inits keep the fast path

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -68,7 +68,10 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
         // Multi-arity defs do not get the deferred-then-grafted single walk
         // (`DefSymbol::graftInferredParamTags` only runs for single-arity
         // FnNodes), so each child must keep inferring its return type inline.
-        $childEnv = $env->withReturnInferenceDeferred(false);
+        // Children always splice into `$this->fnN = ...;` constructor
+        // assignments, so they must be analyzed in expression context —
+        // inheriting a return context would emit `= return (function...)`.
+        $childEnv = $env->withReturnInferenceDeferred(false)->withExpressionContext();
 
         $fnNodes = [];
         $hasVariadic = false;

--- a/tests/phel/core/multi-arity-fn.phel
+++ b/tests/phel/core/multi-arity-fn.phel
@@ -61,3 +61,15 @@
     ;; we use a higher-order self-reference passed out to verify scope.
     (is (= 3 ((fn f [x] (if (= x 0) 0 (+ 1 (f (dec x))))) 3))
         "inner f does not collide with outer f name from sibling fn")))
+
+(deftest multi-arity-fn-returned-from-fn
+  (let [make (fn [x]
+               (fn
+                 ([a] (+ a x))
+                 ([a b] (+ a b x))))
+        add10 (make 10)]
+    (is (= 15 (add10 5)) "returned multi-arity fn: one-arg overload with captured local")
+    (is (= 16 (add10 5 1)) "returned multi-arity fn: two-arg overload with captured local"))
+  (let [mk (fn [] (fn ([a] a) ([a b] b)))]
+    (is (= 7 ((mk) 7)) "returned multi-arity fn without captures: one-arg")
+    (is (= 9 ((mk) 7 9)) "returned multi-arity fn without captures: two-arg")))

--- a/tests/php/Integration/Fixtures/Fn/fn-named-multi-arity.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-named-multi-arity.test
@@ -10,11 +10,11 @@ new class() extends \Phel\Lang\AbstractFn {
     $this->fn0 = (function($x) {
       $foo = $this;
       return $x;
-    });;
+    });
     $this->fn1 = (function($x, $y) {
       $foo = $this;
       return $y;
-    });;
+    });
   }
 
   public function __invoke(...$args) {

--- a/tests/php/Integration/Fixtures/Fn/fn-named-recursive-multi-arity.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-named-recursive-multi-arity.test
@@ -10,11 +10,11 @@ new class() extends \Phel\Lang\AbstractFn {
     $this->fn0 = (function($x) {
       $myf = $this;
       return ($myf)($x, $x);
-    });;
+    });
     $this->fn1 = (function($x, $y) {
       $myf = $this;
       return $y;
-    });;
+    });
   }
 
   public function __invoke(...$args) {

--- a/tests/php/Integration/Fixtures/Fn/fn-return-type-multi-arity.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-return-type-multi-arity.test
@@ -10,11 +10,11 @@ new class() extends \Phel\Lang\AbstractFn {
     $this->fn0 = (function($x): int {
       $foo = $this;
       return $x;
-    });;
+    });
     $this->fn1 = (function($x, $y): int {
       $foo = $this;
       return $y;
-    });;
+    });
   }
 
   public function __invoke(...$args) {

--- a/tests/php/Integration/Fixtures/Fn/multi-fn-returned-from-fn.test
+++ b/tests/php/Integration/Fixtures/Fn/multi-fn-returned-from-fn.test
@@ -1,0 +1,42 @@
+--PHEL--
+(fn [x]
+  (fn
+    ([a] (+ a x))
+    ([a b] (+ a b x))))
+--PHP--
+(function($x) {
+  return new class($x) extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "";
+    private $x;
+    private $fn0;
+    private $fn1;
+
+    public function __construct($x) {
+      $this->x = $x;
+      $this->fn0 = (function($a) use($x) {
+        static $__phel_call_0;
+        return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, $x);
+      });
+      $this->fn1 = (function($a, $b) use($x) {
+        static $__phel_call_0;
+        return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, $b, $x);
+      });
+    }
+
+    public function __invoke(...$args) {
+      return match (\count($args)) {
+        1 => ($this->fn0)($args[0]),
+        2 => ($this->fn1)($args[0], $args[1]),
+        default => throw new \InvalidArgumentException("No matching function arity"),
+      };
+    }
+
+    public function invokeArity1(mixed $a1): mixed {
+      return ($this->fn0)($a1);
+    }
+
+    public function invokeArity2(mixed $a1, mixed $a2): mixed {
+      return ($this->fn1)($a1, $a2);
+    }
+  };
+});


### PR DESCRIPTION
## 🤔 Background

Any multi-arity `fn` in return position inside another fn compiled to `$this->fn0 = return (function...);;` — invalid PHP, fataling with `ParseError: unexpected token "return"` at load. Found via the #2772 emitter-coverage audit (`ClosureEmitterHelper` at 24% coverage; the uncovered path turned out to be broken, not just untested).

## 💡 Goal

Returned multi-arity fns work, with and without captured locals.

## 🔖 Changes

- `FnSymbol`: analyze multi-arity children in expression context — they always splice into constructor assignments, never stand alone (one line + rationale comment)
- Side cleanup: existing top-level multi-arity emissions lose a stray double semicolon (three fixtures updated)
- New fixture `Fn/multi-fn-returned-from-fn.test` (full generated class shape: captures, constructor, `match` dispatch, `invokeArityN`)
- New phel runtime test `multi-arity-fn-returned-from-fn` covering both arities, with and without captures
- Final refactor pass surfaced zero changes (single-line analyzer fix)

Closes #2776