### PR TITLE
fix(analyzer): defn with #inst literal crashed the macroexpansion location walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `defn` (or any macro-expanded form) containing a `#inst` literal no longer crashes compilation with a `TypeError` in the location-enrichment walk: `#inst` yields a raw `DateTimeImmutable`, which now passes through untouched like every other non-Phel literal (#2778)
 - Multi-arity `fn` returned from another fn no longer emits invalid PHP (`ParseError: unexpected token "return"`): the per-arity closures are analyzed in expression context, so the generated constructor assignments splice plain closure expressions. `(fn [x] (fn ([a] ...) ([a b] ...)))` now works, with or without captured locals (#2776)
 - String concatenation no longer specializes over `php/json_encode`, `php/hex2bin`, or `php/str_replace`: their `string|false` / `string|array` returns could splice `false` into a native `.` concat and emit `""` where the dynamic `str` path renders `"false"`. The two compiler return-type tables are consolidated into one `PhpFunctionReturnTypes` with an explicit strict band (persistable tags) and a documented operand-only widening (`pow`) (#2768)
 - `phel test --coverage`: xdebug is only used as the coverage driver when `coverage` is among its active modes; otherwise the command fails fast with a hint to re-run with `XDEBUG_MODE=coverage` instead of emitting PHP warnings and an empty report (#2764)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -236,14 +236,16 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
     }
 
     /**
-     * @param PersistentListInterface<mixed> $list
+     * `mixed` return: an inline expansion may produce literals outside the
+     * Phel type system; see {@see self::callMacroFn()} / #2778. The result
+     * feeds `analyzeMacro(mixed ...)`.
      *
-     * @return array<mixed>|bool|float|int|string|TypeInterface|null
+     * @param PersistentListInterface<mixed> $list
      */
     private function inlineExpand(
         PersistentListInterface $list,
         GlobalVarNode $node,
-    ): float|bool|int|string|TypeInterface|array|null {
+    ): mixed {
         $meta = $node->getMeta();
         $fn = $meta[Keyword::create('inline')];
 
@@ -259,15 +261,17 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
     }
 
     /**
-     * @param PersistentListInterface<mixed> $list
+     * `mixed` return: a macro expansion may produce literals outside the
+     * Phel type system; see {@see self::callMacroFn()} / #2778. The result
+     * feeds `analyzeMacro(mixed ...)`.
      *
-     * @return array<mixed>|bool|float|int|string|TypeInterface|null
+     * @param PersistentListInterface<mixed> $list
      */
     private function macroExpand(
         PersistentListInterface $list,
         GlobalVarNode $macroNode,
         NodeEnvironmentInterface $env,
-    ): float|bool|int|string|TypeInterface|array|null {
+    ): mixed {
         /** @psalm-suppress PossiblyNullArgument */
         $nodeName = $macroNode->getName()->getName();
 
@@ -286,15 +290,16 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
     }
 
     /**
-     * @param PersistentListInterface<mixed> $list
+     * `mixed` return: a macro may expand to literals outside the Phel type
+     * system (e.g. `#inst` → `DateTimeImmutable`); see enrichLocation/#2778.
      *
-     * @return array<mixed>|bool|float|int|string|TypeInterface|null
+     * @param PersistentListInterface<mixed> $list
      */
     private function callMacroFn(
         callable $fn,
         PersistentListInterface $list,
         NodeEnvironmentInterface $env,
-    ): float|bool|int|string|TypeInterface|array|null {
+    ): mixed {
         $envMap = $this->buildEnvMap($env);
         /** @var PersistentListInterface<mixed> $rest */
         $rest = $list->rest();
@@ -305,14 +310,14 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
     }
 
     /**
-     * @param PersistentListInterface<mixed> $list
+     * `mixed` return for the same reason as {@see self::callMacroFn()}.
      *
-     * @return array<mixed>|bool|float|int|string|TypeInterface|null
+     * @param PersistentListInterface<mixed> $list
      */
     private function callInlineFn(
         callable $fn,
         PersistentListInterface $list,
-    ): float|bool|int|string|TypeInterface|array|null {
+    ): mixed {
         /** @var PersistentListInterface<mixed> $rest */
         $rest = $list->rest();
         $arguments = $rest->toArray();
@@ -342,14 +347,15 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
     }
 
     /**
-     * @param array<mixed>|bool|float|int|string|TypeInterface|null $x
-     *
-     * @return array<mixed>|bool|float|int|string|TypeInterface|null
+     * `mixed` deliberately: a macro expansion may contain literals outside
+     * the Phel type system (e.g. `#inst` yields a raw `DateTimeImmutable`);
+     * anything that is neither a list nor a `TypeInterface` passes through
+     * untouched — see #2778.
      */
     private function enrichLocation(
-        float|bool|int|string|TypeInterface|array|null $x,
+        mixed $x,
         TypeInterface $parent,
-    ): float|bool|int|string|TypeInterface|array|null {
+    ): mixed {
         if ($x instanceof PersistentListInterface) {
             return $this->enrichLocationForList($x, $parent);
         }
@@ -368,7 +374,6 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
     {
         $result = [];
         foreach ($list->getIterator() as $item) {
-            /** @var array<mixed>|bool|float|int|string|TypeInterface|null $item */
             $result[] = $this->enrichLocation($item, $parent);
         }
 

--- a/tests/phel/core/exotic-literals.phel
+++ b/tests/phel/core/exotic-literals.phel
@@ -1,0 +1,15 @@
+(ns phel-test.core.exotic-literals
+  (:require phel\test :refer [deftest is]))
+
+(defn- make-inst [] #inst "2024-01-15T10:30:00Z")
+
+(deftest defn-body-exotic-literals
+  ;; #2778: a raw DateTimeImmutable literal inside a defn body crashed
+  ;; the macroexpansion location walk at compile time.
+  (is (= "2024-01-15" (php/-> (make-inst) (format "Y-m-d")))
+      "defn body with #inst literal compiles and evaluates")
+  (is (= 2/3 ((fn [] 2/3))) "ratio literal in fn body")
+  (is (= 1.5M ((fn [] 1.5M))) "big decimal literal in fn body")
+  (is (= #uuid "123e4567-e89b-12d3-a456-426614174000"
+         ((fn [] #uuid "123e4567-e89b-12d3-a456-426614174000")))
+      "uuid literal in fn body"))

--- a/tests/php/Integration/Fixtures/Fn/fn-exotic-literals.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-exotic-literals.test
@@ -1,0 +1,18 @@
+--PHEL--
+(fn [] 2/3)
+(fn [] 1.5M)
+(fn [] #uuid "123e4567-e89b-12d3-a456-426614174000")
+(fn [] #inst "2024-01-15T10:30:00Z")
+(fn [] 123456789012345678901234567890N)
+--PHP--
+(function() {
+  return \Phel\Lang\Ratio::create(\Phel\Lang\BigInt::fromString("2"), \Phel\Lang\BigInt::fromString("3"));
+});(function() {
+  return \Phel\Lang\BigDecimal::fromString("1.5");
+});(function() {
+  return \Phel\Lang\UUID::fromString("123e4567-e89b-12d3-a456-426614174000");
+});(function() {
+  return (new \DateTimeImmutable("2024-01-15T10:30:00.000000+00:00"));
+});(function() {
+  return \Phel\Lang\BigInt::fromString("123456789012345678901234567890");
+});


### PR DESCRIPTION
## 🤔 Background

`(defn g [] #inst "2024-01-15T10:30:00Z")` crashed compilation: `#inst` yields a raw `DateTimeImmutable`, and `InvokeSymbol`'s macroexpansion chain declared unions (`TypeInterface|array|scalar|null`) that exclude it. Every macro-expanded form containing such a literal fataled. Found via the #2772 emitter-coverage audit (exotic-literal fixtures for `LiteralEmitter`'s uncovered branches).

## 💡 Goal

Exotic literals (`#inst`, `#uuid`, `2/3`, `1.5M`, `123...N`) legal in any macro-expanded position.

## 🔖 Changes

- `InvokeSymbol`: `enrichLocation`, `callMacroFn`, `callInlineFn`, `macroExpand`, `inlineExpand` typed `mixed` with rationale comments — the old unions excluded values macros can legally return; results feed `analyzeMacro(mixed ...)` regardless
- New fixture `Fn/fn-exotic-literals.test`: Ratio, BigDecimal, UUID, DateTime, and BigInt literal emission (also closes the `LiteralEmitter` coverage gap from the audit matrix)
- New phel runtime test `exotic-literals.phel` covering the exact `defn` + `#inst` crash shape
- Final refactor pass surfaced zero further changes

Closes #2778