### PR TITLE
test(integration): fixture coverage for audited emitter gaps

### DIFF
--- a/tests/php/Integration/Fixtures/Call/get-in-specialisation-eligibility.test
+++ b/tests/php/Integration/Fixtures/Call/get-in-specialisation-eligibility.test
@@ -1,0 +1,19 @@
+--PHEL--
+(fn [^\Phel\Lang\Collections\Map\PersistentMapInterface m] (get-in m [:a :b]))
+(fn [^\Phel\Lang\Collections\Map\PersistentMapInterface m] (get-in m [:a] :dflt))
+(fn [^\Phel\Lang\Collections\Map\PersistentMapInterface m p] (get-in m p))
+(fn [m] (get-in m [:a]))
+--PHP--
+(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m) {
+  static $__phel_const_0, $__phel_const_1;
+  return (($m[(($__phel_const_0 ??= \Phel\Lang\Keyword::create("a")))] ?? null)[(($__phel_const_1 ??= \Phel\Lang\Keyword::create("b")))] ?? null);
+});(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m) {
+  static $__phel_const_0, $__phel_const_1, $__phel_call_0;
+  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "get-in"))->__invoke($m, ($__phel_const_0 ??= \Phel::vector([\Phel\Lang\Keyword::create("a")])), ($__phel_const_1 ??= \Phel\Lang\Keyword::create("dflt")));
+});(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m, $p) {
+  static $__phel_call_0;
+  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "get-in"))->__invoke($m, $p);
+});(function($m) {
+  static $__phel_const_0, $__phel_call_0;
+  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "get-in"))->__invoke($m, ($__phel_const_0 ??= \Phel::vector([\Phel\Lang\Keyword::create("a")])));
+});

--- a/tests/php/Integration/Fixtures/Def/def-collection-literal-with-meta.test
+++ b/tests/php/Integration/Fixtures/Def/def-collection-literal-with-meta.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def s ^{:a 1} #{1 2})
+(def v ^{:b 2} [3 4])
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "s",
+  \Phel::set([1, 2])->withMeta(\Phel::map(
+    \Phel\Lang\Keyword::create("a"), 1
+  )),
+  \Phel::locationMeta(\Phel::location("Def/def-collection-literal-with-meta.test", 1, 0), \Phel::location("Def/def-collection-literal-with-meta.test", 1, 22))
+);
+\Phel::addDefinition(
+  "user",
+  "v",
+  \Phel::vector([3, 4])->withMeta(\Phel::map(
+    \Phel\Lang\Keyword::create("b"), 2
+  )),
+  \Phel::locationMeta(\Phel::location("Def/def-collection-literal-with-meta.test", 2, 0), \Phel::location("Def/def-collection-literal-with-meta.test", 2, 21))
+);

--- a/tests/php/Integration/Fixtures/Ns/use-in-expression.test
+++ b/tests/php/Integration/Fixtures/Ns/use-in-expression.test
@@ -1,0 +1,9 @@
+--PHEL--
+(def u (use \DateTimeImmutable))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "u",
+  null,
+  \Phel::locationMeta(\Phel::location("Ns/use-in-expression.test", 1, 0), \Phel::location("Ns/use-in-expression.test", 1, 32))
+);


### PR DESCRIPTION
## 🤔 Background

Closes out the #2772 audit. Phase 1 (coverage matrix, posted on the issue) measured the emitter surface under xdebug: mostly ≥90% covered, with a handful of real gaps. Two of those gaps turned out to be live bugs, fixed separately: #2777 (multi-arity fn return emission) and #2779 (`#inst` in macroexpansion), whose fixtures also closed the `ClosureEmitterHelper` and `LiteralEmitter` gaps.

## 💡 Goal

Fixtures for the remaining reachable gaps; defensive/unreachable branches documented instead of fixtured.

## 🔖 Changes

- `Ns/use-in-expression.test`: `(use ...)` in expression position (UseEmitter nil-emission path, was 50%)
- `Def/def-collection-literal-with-meta.test`: set + vector literals carrying metadata (`withMeta` suffix branches of SetEmitter/VectorEmitter, were 80%)
- `Call/get-in-specialisation-eligibility.test`: literal-path `??` chain plus all three bail shapes — 3-arity default, dynamic path, untagged target (GetInSpecialization, was 82%)
- Not fixtured, per the audit scope: `NotSupportedAstException` (defensive throw), residual `ConstantScope`/source-map IO branches (not reachable from `.phel` input alone; documented in the matrix comment)
- Category merges: evaluated and rejected — low true duplication, high exact-match churn (rationale in the matrix comment)

Closes #2772