### PR TITLE
chore(deps): update gacela to 1.18 with app-scoped cache invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Gacela updated to 1.18: the persisted merged-config cache is now scoped per app root, so projects sharing the default system temp dir no longer read each other's merged config; Phel's freshness invalidator targets the scoped cache file
 - `partition-all` accepts Clojure's `[n step coll]` arity (#2758)
 - `partition` accepts Clojure's `[n step coll]` and `[n step pad coll]` arities; `[n coll]` unchanged (#2752)
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=8.4",
         "amphp/amp": "^3.1",
-        "gacela-project/gacela": "^1.16",
+        "gacela-project/gacela": "^1.18",
         "symfony/console": "^6.0|^7.0|^8.0",
         "symfony/polyfill-mbstring": "^1.30",
         "symfony/routing": "^7.3|^8.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "867f5a99189cbb68608d9cd62ff7ff96",
+    "content-hash": "791e5d88fe5b6f1ec47c4d490edcd69d",
     "packages": [
         {
             "name": "amphp/amp",
@@ -89,16 +89,16 @@
         },
         {
             "name": "gacela-project/container",
-            "version": "0.8.1",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/container.git",
-                "reference": "6251aaf6973ab7ddc41f596a18a8ea9334582a1b"
+                "reference": "db13556a11f6892c852ef0f26a9915aee2a3ba4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/container/zipball/6251aaf6973ab7ddc41f596a18a8ea9334582a1b",
-                "reference": "6251aaf6973ab7ddc41f596a18a8ea9334582a1b",
+                "url": "https://api.github.com/repos/gacela-project/container/zipball/db13556a11f6892c852ef0f26a9915aee2a3ba4e",
+                "reference": "db13556a11f6892c852ef0f26a9915aee2a3ba4e",
                 "shasum": ""
             },
             "require": {
@@ -125,8 +125,8 @@
             ],
             "authors": [
                 {
-                    "name": "Jose Maria Valera Reales",
-                    "email": "chemaclass@outlook.es",
+                    "name": "Jose M. Valera Reales",
+                    "email": "gacela@chemaclass.com",
                     "homepage": "https://chemaclass.com"
                 },
                 {
@@ -144,8 +144,8 @@
                 "resolver"
             ],
             "support": {
-                "issues": "https://github.com/gacela-project/resolver/issues",
-                "source": "https://github.com/gacela-project/container/tree/0.8.1"
+                "issues": "https://github.com/gacela-project/container/issues",
+                "source": "https://github.com/gacela-project/container/tree/0.10.0"
             },
             "funding": [
                 {
@@ -153,24 +153,24 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-06-05T11:50:32+00:00"
+            "time": "2026-07-19T22:59:58+00:00"
         },
         {
             "name": "gacela-project/gacela",
-            "version": "1.16.0",
+            "version": "1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/gacela.git",
-                "reference": "96dfcf6d9a6fceffc9452aff2f0658e472a136fd"
+                "reference": "d4f91871da18de2cdcc651c571d3932489436411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/96dfcf6d9a6fceffc9452aff2f0658e472a136fd",
-                "reference": "96dfcf6d9a6fceffc9452aff2f0658e472a136fd",
+                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/d4f91871da18de2cdcc651c571d3932489436411",
+                "reference": "d4f91871da18de2cdcc651c571d3932489436411",
                 "shasum": ""
             },
             "require": {
-                "gacela-project/container": "^0.8.1",
+                "gacela-project/container": "^0.10.0",
                 "php": ">=8.1"
             },
             "require-dev": {
@@ -193,6 +193,7 @@
                 "gacela-project/gacela-env-config-reader": "Allows to read .env config files",
                 "gacela-project/gacela-yaml-config-reader": "Allows to read yml/yaml config files",
                 "gacela-project/phpstan-extension": "A set of phpstan rules for Gacela",
+                "phpunit/phpunit": "Allows to extend Gacela\\Framework\\Testing\\GacelaTestCase in your tests",
                 "symfony/console": "Allows to use vendor/bin/gacela script"
             },
             "bin": [
@@ -230,7 +231,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/gacela/issues",
-                "source": "https://github.com/gacela-project/gacela/tree/1.16.0"
+                "source": "https://github.com/gacela-project/gacela/tree/1.18.0"
             },
             "funding": [
                 {
@@ -238,7 +239,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-07-15T05:36:26+00:00"
+            "time": "2026-07-20T05:33:57+00:00"
         },
         {
             "name": "psr/container",
@@ -8531,5 +8532,5 @@
     "platform-overrides": {
         "php": "8.4.6"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -42,13 +42,6 @@ parameters:
                 - src/php/Config/PhelExportConfig.php
                 - src/php/Lang/Collections/LazySeq/LazySeqConfig.php
                 - src/php/Lang/TypeFactory.php
-        # CompilerFacade::encodeNs() delegates through Gacela's cached() helper,
-        # which is typed `mixed`. The gacela.facadeOnlyDelegates rule forbids
-        # narrowing the result inline (a facade method must be a single
-        # delegation), so the mixed return cannot be cast away here.
-        -
-            identifier: return.type
-            path: src/php/Compiler/CompilerFacade.php
         # PhelConfig::with() rebuilds the immutable config by spreading a merged
         # array<string, mixed> into the constructor as named arguments. PHPStan
         # cannot map the dynamic spread back to each typed parameter; the public
@@ -56,12 +49,6 @@ parameters:
         -
             identifier: argument.type
             path: src/php/Config/PhelConfig.php
-        # CommandFacade's directory getters delegate through Gacela's cached()
-        # helper (mixed return) and the gacela.facadeOnlyDelegates rule forbids
-        # inline narrowing, mirroring CompilerFacade::encodeNs above.
-        -
-            identifier: return.type
-            path: src/php/Command/CommandFacade.php
         # Printer's dispatchers select a TypePrinterInterface<Concrete> per
         # runtime-matched type, which is sound by construction but an
         # existential type: generic invariance cannot relate it to the

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -80,8 +80,7 @@ final class BuildFactory extends AbstractFactory
         // evaluator — otherwise each fresh `new BuildFacade()` would
         // rebuild its dependency tree and the on-disk compiled-code
         // index would be re-included per load.
-        /** @var FileEvaluator $evaluator */
-        $evaluator = $this->singleton(
+        return $this->singleton(
             FileEvaluator::class,
             fn(): FileEvaluator => new FileEvaluator(
                 $this->getCompilerFacade(),
@@ -93,13 +92,11 @@ final class BuildFactory extends AbstractFactory
                 $this->createCompiledSecondaryStore(),
             ),
         );
-        return $evaluator;
     }
 
     public function createNamespaceExtractor(): NamespaceExtractorInterface
     {
-        /** @var NamespaceExtractorInterface $extractor */
-        $extractor = $this->singleton(
+        return $this->singleton(
             NamespaceExtractorInterface::class,
             function (): NamespaceExtractorInterface {
                 $excludedPaths = $this->createExcludedScanPaths();
@@ -124,7 +121,6 @@ final class BuildFactory extends AbstractFactory
                 );
             },
         );
-        return $extractor;
     }
 
     public function createCacheClearer(): CacheClearer
@@ -176,22 +172,18 @@ final class BuildFactory extends AbstractFactory
     {
         // Shared singleton: the FileEvaluator writes built secondaries into it
         // and the harvester drains it within the same build process.
-        /** @var CompiledSecondaryStore $store */
-        $store = $this->singleton(
+        return $this->singleton(
             CompiledSecondaryStore::class,
             static fn(): CompiledSecondaryStore => new CompiledSecondaryStore(),
         );
-        return $store;
     }
 
     private function createCompiledCodeCache(): ?CompiledCodeCache
     {
-        /** @var CompiledCodeCache|null $cache */
-        $cache = $this->singleton(
+        return $this->singleton(
             CompiledCodeCache::class,
             fn(): ?CompiledCodeCache => $this->buildCompiledCodeCache(),
         );
-        return $cache;
     }
 
     private function buildCompiledCodeCache(): ?CompiledCodeCache
@@ -208,14 +200,12 @@ final class BuildFactory extends AbstractFactory
 
     private function createDependencyTracker(): ?DependencyTracker
     {
-        /** @var DependencyTracker|null $tracker */
-        $tracker = $this->singleton(
+        return $this->singleton(
             DependencyTracker::class,
             fn(): ?DependencyTracker => $this->getConfig()->isCompiledCodeCacheEnabled()
                 ? new DependencyTracker($this->getConfig()->getCacheDir())
                 : null,
         );
-        return $tracker;
     }
 
     private function createNamespaceCache(): NamespaceCacheInterface

--- a/src/php/MergedConfigCacheInvalidator.php
+++ b/src/php/MergedConfigCacheInvalidator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel;
 
 use Closure;
+use Gacela\Framework\Config\AppEnv;
 use Gacela\Framework\Config\MergedConfigCache;
 
 use function basename;
@@ -12,7 +13,6 @@ use function dirname;
 use function implode;
 use function is_dir;
 use function is_file;
-use function is_string;
 use function md5;
 use function md5_file;
 use function preg_replace;
@@ -36,12 +36,15 @@ final readonly class MergedConfigCacheInvalidator
 {
     /**
      * @param string         $cacheDir          The dir where Gacela persists the merged-config cache
+     * @param string         $appRootDir        The app root Gacela scopes the cache filename to (1.18+);
+     *                                          must match the dir passed to `Gacela::bootstrap()`
      * @param list<string>   $fingerprintInputs Absolute paths whose contents determine the merged
      *                                          config (project config files + config data-model classes)
      * @param Closure():void $reloadConfig      Reloads Gacela's config from source after a cache clear
      */
     public function __construct(
         private string $cacheDir,
+        private string $appRootDir,
         private array $fingerprintInputs,
         private Closure $reloadConfig,
     ) {}
@@ -84,14 +87,12 @@ final readonly class MergedConfigCacheInvalidator
 
     /**
      * Rebuild Gacela's merged-config cache handle from public API only, mirroring
-     * how Gacela constructs it: the resolved cache dir plus the optional
-     * `APP_ENV` suffix.
+     * how Gacela constructs it: the resolved cache dir, the optional `APP_ENV`
+     * suffix, and the app root the filename is scoped to since Gacela 1.18.
      */
     private function mergedConfigCache(): MergedConfigCache
     {
-        $env = getenv('APP_ENV');
-
-        return new MergedConfigCache($this->cacheDir, is_string($env) ? $env : '');
+        return new MergedConfigCache($this->cacheDir, AppEnv::current(), $this->appRootDir);
     }
 
     /**

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -224,6 +224,7 @@ class Phel
 
         return new MergedConfigCacheInvalidator(
             $config->getCacheDir(),
+            $appRootDir,
             [
                 $appRootDir . '/' . self::PHEL_CONFIG_FILE_NAME,
                 $appRootDir . '/' . self::PHEL_CONFIG_LOCAL_FILE_NAME,

--- a/tests/php/Integration/ProvidesAttributeTest.php
+++ b/tests/php/Integration/ProvidesAttributeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Integration;
 
 use Gacela\Framework\Gacela;
+use Gacela\Framework\Testing\GacelaTestCase;
 use Phel\Api\ApiFacade;
 use Phel\Build\BuildFacade;
 use Phel\Command\CommandFacade;
@@ -14,15 +15,14 @@ use Phel\Filesystem\FilesystemFacade;
 use Phel\Formatter\FormatterFacade;
 use Phel\Interop\InteropFacade;
 use Phel\Run\RunFacade;
-use PHPUnit\Framework\TestCase;
 
 use function sprintf;
 
-final class ProvidesAttributeTest extends TestCase
+final class ProvidesAttributeTest extends GacelaTestCase
 {
     protected function setUp(): void
     {
-        Gacela::bootstrap(__DIR__);
+        $this->bootstrapGacela(__DIR__);
     }
 
     public function test_all_facades_resolve_from_container(): void
@@ -45,6 +45,9 @@ final class ProvidesAttributeTest extends TestCase
                 '%s should be resolvable from the Gacela container',
                 $facadeClass,
             ));
+            // Event-backed cross-check: the container (not a stale locator
+            // cache from a previous test) actually resolved the service.
+            $this->assertServiceResolved($facadeClass);
         }
     }
 

--- a/tests/php/Integration/Run/Command/Config/ConfigCommandTest.php
+++ b/tests/php/Integration/Run/Command/Config/ConfigCommandTest.php
@@ -4,35 +4,24 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Run\Command\Config;
 
-use Gacela\Framework\Bootstrap\GacelaConfig;
-use Gacela\Framework\Gacela;
-use Gacela\Framework\Testing\ContainerFixture;
+use Gacela\Framework\Testing\GacelaTestCase;
 use Phel\Config\PhelConfig;
 use Phel\Run\Infrastructure\Command\ConfigCommand;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 use function json_decode;
 
 use const JSON_THROW_ON_ERROR;
 
-final class ConfigCommandTest extends TestCase
+final class ConfigCommandTest extends GacelaTestCase
 {
-    use ContainerFixture;
-
     protected function setUp(): void
     {
-        $this->resetContainer();
-        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
-            $config->addAppConfigKeyValue(PhelConfig::SRC_DIRS, ['src/phel']);
-            $config->addAppConfigKeyValue(PhelConfig::VENDOR_DIR, 'vendor');
-            $config->addAppConfigKeyValue(PhelConfig::CACHE_DIR, '.phel/cache');
-        });
-    }
-
-    protected function tearDown(): void
-    {
-        $this->cleanupContainerTempDirs();
+        $this->bootstrapGacelaWithConfig(__DIR__, [
+            PhelConfig::SRC_DIRS => ['src/phel'],
+            PhelConfig::VENDOR_DIR => 'vendor',
+            PhelConfig::CACHE_DIR => '.phel/cache',
+        ]);
     }
 
     public function test_default_output_lists_sources_and_effective_config(): void
@@ -57,13 +46,12 @@ final class ConfigCommandTest extends TestCase
 
     public function test_valid_config_reports_no_validation_issues(): void
     {
-        $this->resetContainer();
         // Point src/test dirs at the project root, which always exists, so the
         // config validates clean.
-        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
-            $config->addAppConfigKeyValue(PhelConfig::SRC_DIRS, ['.']);
-            $config->addAppConfigKeyValue(PhelConfig::TEST_DIRS, ['.']);
-        });
+        $this->bootstrapGacelaWithConfig(__DIR__, [
+            PhelConfig::SRC_DIRS => ['.'],
+            PhelConfig::TEST_DIRS => ['.'],
+        ]);
 
         $tester = new CommandTester(new ConfigCommand());
         $exitCode = $tester->execute([]);
@@ -76,10 +64,9 @@ final class ConfigCommandTest extends TestCase
 
     public function test_absolute_src_dir_is_reported_in_the_validation_section(): void
     {
-        $this->resetContainer();
-        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
-            $config->addAppConfigKeyValue(PhelConfig::SRC_DIRS, ['/absolute/src']);
-        });
+        $this->bootstrapGacelaWithConfig(__DIR__, [
+            PhelConfig::SRC_DIRS => ['/absolute/src'],
+        ]);
 
         $tester = new CommandTester(new ConfigCommand());
         $exitCode = $tester->execute([]);

--- a/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
+++ b/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
@@ -4,31 +4,25 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Run\Command\Doctor;
 
-use Gacela\Framework\Bootstrap\GacelaConfig;
-use Gacela\Framework\Gacela;
-use Gacela\Framework\Testing\ContainerFixture;
+use Gacela\Framework\Testing\GacelaTestCase;
 use Phel\Config\PhelConfig;
 use Phel\Run\Infrastructure\Command\DoctorCommand;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
 
-final class DoctorCommandTest extends TestCase
+final class DoctorCommandTest extends GacelaTestCase
 {
-    use ContainerFixture;
-
     protected function setUp(): void
     {
-        $this->resetContainer();
-        $tempDir = $this->containerTempDir();
-        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($tempDir): void {
-            $config->addAppConfigKeyValue(PhelConfig::TEMP_DIR, $tempDir);
-        });
+        $this->bootstrapGacelaWithConfig(__DIR__, [
+            PhelConfig::TEMP_DIR => $this->containerTempDir(),
+        ]);
     }
 
     protected function tearDown(): void
     {
         $this->cleanupContainerTempDirs();
+        parent::tearDown();
     }
 
     public function test_doctor_command_outputs_success(): void
@@ -71,12 +65,10 @@ final class DoctorCommandTest extends TestCase
 
     public function test_doctor_fails_when_configuration_has_an_error(): void
     {
-        $this->resetContainer();
-        $tempDir = $this->containerTempDir();
-        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($tempDir): void {
-            $config->addAppConfigKeyValue(PhelConfig::TEMP_DIR, $tempDir);
-            $config->addAppConfigKeyValue(PhelConfig::SRC_DIRS, ['/absolute/src']);
-        });
+        $this->bootstrapGacelaWithConfig(__DIR__, [
+            PhelConfig::TEMP_DIR => $this->containerTempDir(),
+            PhelConfig::SRC_DIRS => ['/absolute/src'],
+        ]);
 
         $output = new BufferedOutput();
         $exitCode = new DoctorCommand()->run(
@@ -93,12 +85,11 @@ final class DoctorCommandTest extends TestCase
 
     public function test_doctor_succeeds_when_temp_dir_does_not_exist_yet(): void
     {
-        $this->resetContainer();
         $nonExistentTempDir = sys_get_temp_dir() . '/phel-doctor-fresh-' . uniqid('', true);
 
-        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($nonExistentTempDir): void {
-            $config->addAppConfigKeyValue(PhelConfig::TEMP_DIR, $nonExistentTempDir);
-        });
+        $this->bootstrapGacelaWithConfig(__DIR__, [
+            PhelConfig::TEMP_DIR => $nonExistentTempDir,
+        ]);
 
         self::assertDirectoryDoesNotExist($nonExistentTempDir);
 

--- a/tests/php/Unit/MergedConfigCacheInvalidatorTest.php
+++ b/tests/php/Unit/MergedConfigCacheInvalidatorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit;
 
 use Closure;
+use Gacela\Framework\Config\MergedConfigCache;
 use Phel\MergedConfigCacheInvalidator;
 use PHPUnit\Framework\TestCase;
 
@@ -67,7 +68,7 @@ final class MergedConfigCacheInvalidatorTest extends TestCase
     {
         $input = $this->dir . '/phel-config.php';
         file_put_contents($input, '<?php return 1;');
-        $cacheFile = $this->dir . '/gacela-merged-config.php';
+        $cacheFile = $this->cacheFilename();
         file_put_contents($cacheFile, '<?php return [];');
 
         $reloads = 0;
@@ -77,18 +78,18 @@ final class MergedConfigCacheInvalidatorTest extends TestCase
 
         self::assertSame(1, $reloads);
         self::assertFileDoesNotExist($cacheFile);
-        self::assertFileExists($this->dir . '/gacela-merged-config.fingerprint');
+        self::assertFileExists($this->fingerprintFilename());
     }
 
     public function test_refresh_skips_when_fingerprint_matches(): void
     {
         $input = $this->dir . '/phel-config.php';
         file_put_contents($input, '<?php return 1;');
-        $cacheFile = $this->dir . '/gacela-merged-config.php';
+        $cacheFile = $this->cacheFilename();
         file_put_contents($cacheFile, '<?php return [];');
 
         $fresh = $this->invalidator([$input]);
-        file_put_contents($this->dir . '/gacela-merged-config.fingerprint', $fresh->fingerprint());
+        file_put_contents($this->fingerprintFilename(), $fresh->fingerprint());
 
         $reloads = 0;
         $this->invalidator([$input], static function () use (&$reloads): void {
@@ -99,12 +100,35 @@ final class MergedConfigCacheInvalidatorTest extends TestCase
         self::assertFileExists($cacheFile);
     }
 
+    public function test_refresh_targets_the_app_scoped_cache_file(): void
+    {
+        // The app-scoped filename (Gacela 1.18+) embeds a hash of the app root,
+        // so it must differ from the legacy unscoped one the invalidator used
+        // to address before it learned about the app root.
+        self::assertNotSame($this->dir . '/gacela-merged-config.php', $this->cacheFilename());
+        self::assertStringStartsWith($this->dir . '/gacela-merged-config-', $this->cacheFilename());
+    }
+
+    /**
+     * The exact cache filename Gacela computes for this cache dir and app root.
+     */
+    private function cacheFilename(): string
+    {
+        return new MergedConfigCache($this->dir, '', $this->dir)->filename();
+    }
+
+    private function fingerprintFilename(): string
+    {
+        return (string) preg_replace('/\.php$/', '.fingerprint', $this->cacheFilename());
+    }
+
     /**
      * @param list<string> $inputs
      */
     private function invalidator(array $inputs, ?Closure $reload = null): MergedConfigCacheInvalidator
     {
         return new MergedConfigCacheInvalidator(
+            $this->dir,
             $this->dir,
             $inputs,
             $reload ?? static function (): void {},


### PR DESCRIPTION
## 🤔 Background

Gacela 1.18.0 is the latest stable (1.16 → 1.18). Release highlights relevant to Phel: the persisted merged-config cache filename now embeds an app-root hash (fixes cross-project cache poisoning in the shared system temp dir), `singleton()`/`cached()` gained generic return types, and `AbstractProvider::register()` became final (Phel never overrode it).

## 💡 Goal

Track latest stable and keep Phel's merged-config freshness invalidation correct against the new app-scoped cache filename.

## 🔖 Changes

- `composer.json`: `gacela-project/gacela` `^1.16` → `^1.18`
- `MergedConfigCacheInvalidator` now passes the app root dir and `AppEnv::current()` when rebuilding the cache handle; without this it would fingerprint/clear the legacy unscoped file while Gacela reads the app-scoped one, silently disabling stale-config detection. New unit test pins the app-scoped filename
- `BuildFactory`: dropped the `/** @var */` + temp-variable dance around `singleton()` (generic since 1.17)
- `phpstan.neon`: removed two now-dead `return.type` ignores for facade `cached()` delegation (generics fixed the inference)
- Deliberately NOT adopted: typed config accessors (`getBool()` etc.) throw on wrong-type values, which conflicts with Phel's lenient config philosophy (advisory validator + `ScalarCoercion` defaults)
- CHANGELOG entry under Unreleased

Full gate green: quality (PHPStan L9, Psalm, cs-fixer, Rector), 4009 unit + 1057 integration, 6509 core tests.
- Adopted 1.18's `GacelaTestCase` narrowly where bootstrap isolation pays off: `ProvidesAttributeTest` (bootstrapped with no reset/tearDown, real cross-test bleed hazard) plus `ConfigCommandTest`/`DoctorCommandTest` (inline `resetContainer(); Gacela::bootstrap(...)` pairs collapsed into `bootstrapGacelaWithConfig()`). Mass migration deliberately rejected: the event listener records every framework event per test, pure overhead for compile-heavy suites
- Evaluated and rejected the remaining 1.17/1.18 additions with reasons on record: lifecycle events (no timing payload, nothing to replace), build-time gacela cache warm (self-warms at bootstrap), `debug:module`/`debug:graph` exposure (gacela module discovery currently fatals on this repo's `tests/` dir), contextual/scalar bindings + container ArrayAccess (zero usage)
