### PR TITLE
ref(shared): record the Compiler back-edge decision and bound it with a test

### DIFF
--- a/src/php/Shared/CLAUDE.md
+++ b/src/php/Shared/CLAUDE.md
@@ -6,6 +6,32 @@ Leaf contract layer: facade interfaces, constants, cross-module value objects, a
 
 Cross-module facade contracts: Compiler, Build, Run, Command, Console, Formatter, Interop, Api. Modules inject these (`*FacadeInterface`), never concrete facades — enables dependency inversion. Add a new interface here when another module starts consuming it; keep its imports minimal.
 
+## Compiler Back-Edge (accepted cycle)
+
+`Facade/CompilerFacadeInterface` imports 11 symbols from `Phel\Compiler\Domain`, which keeps `{Compiler, Config, Filesystem, Lang, Shared}` in one SCC. **This is deliberate** (decided in #2785). It is the only Shared → Compiler edge, and `tests/php/Unit/Architecture/SharedCompilerBoundaryTest.php` fails the build if a second one appears or the symbol set changes.
+
+| Kind | Symbols |
+|------|---------|
+| Method signatures (6) | `AbstractNode`, `NodeEnvironmentInterface`, `GlobalEnvironmentInterface`, `TokenStream`, `EmitterResult`, `ReaderResult` |
+| `@throws` tags only (5) | `AnalyzerException`, `LexerValueException`, `UnexpectedParserException`, `UnfinishedParserException`, `ReaderException` |
+
+### Why it is not broken
+
+An SCC decomposes only when *every* back-edge goes, so partial moves are churn with no structural payoff: relocating just the five exceptions leaves the cycle exactly as it was.
+
+Removing all 11 means moving the analyzer AST into Shared. `AbstractNode` has ~554 references outside Shared and `NodeEnvironmentInterface` ~291. Shared would become the compiler, inverting the leaf-layer rule it exists to enforce.
+
+The two alternatives weighed in #2785 both cost more than the cycle does:
+
+- Primitives/serialized handles at the boundary: `analyze()` would return an untyped array, discarding the type safety PHPStan L9 / Psalm L1 enforce across those references.
+- Narrow Shared interfaces for AST/env: analyzer consumers match on concrete node types, so the interface either restates the node hierarchy in Shared or is too generic to type anything. Contrast `Shared\Parser\Node\NodeInterface`, which works precisely because the *parse tree* has a genuinely narrow contract.
+
+### Why it is benign
+
+The cycle is a static-analysis artifact over `use` statements, not a runtime one. No initialization order, autoloading, or build-order problem follows from it, and PHP has no module-level compilation unit.
+
+It also does not weaken the Gacela rule it appears to touch. Shared only *names* compiler types in a signature; it never instantiates one, and no factory gains a cross-module `new`. The dependency inversion this interface exists for (consumers injecting `CompilerFacadeInterface` rather than the concrete `CompilerFacade`) holds regardless of who owns the types in its signature.
+
 ## Constants
 
 | Const | Value / note |
@@ -74,3 +100,4 @@ Stateless strategy-pattern printer (see `Printer/CLAUDE.md`); consumers instanti
 - Leaf dependency: contracts + utilities only, never business logic.
 - Exceptions are cross-module: thrown and caught everywhere.
 - Utilities stay stateless: safe to instantiate without module context.
+- The one permitted outward edge is `CompilerFacadeInterface → Compiler\Domain` (see "Compiler Back-Edge" above). Adding a second Shared → Compiler import, or a new compiler type to that contract, breaks `SharedCompilerBoundaryTest`; widen it only deliberately, and update the rationale when you do.

--- a/tests/php/Unit/Architecture/SharedCompilerBoundaryTest.php
+++ b/tests/php/Unit/Architecture/SharedCompilerBoundaryTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Architecture;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Compiler\Domain\Emitter\EmitterResult;
+use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
+use Phel\Compiler\Domain\Lexer\TokenStream;
+use Phel\Compiler\Domain\Parser\Exceptions\UnexpectedParserException;
+use Phel\Compiler\Domain\Parser\Exceptions\UnfinishedParserException;
+use Phel\Compiler\Domain\Parser\ReadModel\ReaderResult;
+use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+use function dirname;
+use function sprintf;
+
+/**
+ * `Phel\Shared` is the leaf contract layer, so every other module may point at
+ * it. `CompilerFacadeInterface` points back, because the compiler's public
+ * surface is genuinely expressed in compiler types (AST nodes, the analyzer
+ * environment, the token stream).
+ *
+ * That back-edge is accepted deliberately; see the "Compiler Back-Edge"
+ * section of `src/php/Shared/CLAUDE.md` for the rationale. What must NOT happen
+ * is the edge quietly widening: a second Shared file reaching into Compiler, or
+ * a new compiler type leaking into the contract. Both are locked here.
+ *
+ * @see \Phel\Shared\Facade\CompilerFacadeInterface
+ */
+final class SharedCompilerBoundaryTest extends TestCase
+{
+    /**
+     * The only file in `Shared` allowed to import from `Phel\Compiler`,
+     * relative to `src/php/Shared`.
+     */
+    private const string ALLOWED_FILE = 'Facade/CompilerFacadeInterface.php';
+
+    /**
+     * Every compiler symbol the contract is allowed to name. Six carry the
+     * compiler's public types through method signatures; five appear only in
+     * `@throws` tags. Adding to this list widens the cycle, so it should be a
+     * deliberate, reviewed act rather than a silent import.
+     *
+     * @var list<string>
+     */
+    private const array ALLOWED_IMPORTS = [
+        AbstractNode::class,
+        GlobalEnvironmentInterface::class,
+        NodeEnvironmentInterface::class,
+        AnalyzerException::class,
+        EmitterResult::class,
+        LexerValueException::class,
+        TokenStream::class,
+        UnexpectedParserException::class,
+        UnfinishedParserException::class,
+        ReaderResult::class,
+        ReaderException::class,
+    ];
+
+    public function test_compiler_facade_interface_is_the_only_shared_file_importing_compiler(): void
+    {
+        $offenders = array_keys($this->compilerImportsPerSharedFile());
+
+        self::assertSame(
+            [self::ALLOWED_FILE],
+            $offenders,
+            sprintf(
+                "Only %s may import Phel\\Compiler.\nThe Shared -> Compiler cycle is accepted only because it is "
+                . "confined to that one contract; a second back-edge makes it structural.\n"
+                . 'See the "Compiler Back-Edge" section of src/php/Shared/CLAUDE.md.',
+                self::ALLOWED_FILE,
+            ),
+        );
+    }
+
+    public function test_the_compiler_contract_names_no_unlisted_compiler_types(): void
+    {
+        $imports = $this->compilerImportsPerSharedFile()[self::ALLOWED_FILE] ?? [];
+        sort($imports);
+
+        $expected = self::ALLOWED_IMPORTS;
+        sort($expected);
+
+        self::assertSame(
+            $expected,
+            $imports,
+            "The set of compiler types reachable from Phel\\Shared changed.\n"
+            . "Removing one is good news: drop it from ALLOWED_IMPORTS.\n"
+            . 'Adding one widens the cycle: justify it in src/php/Shared/CLAUDE.md first.',
+        );
+    }
+
+    public function test_the_documented_edge_count_matches_reality(): void
+    {
+        // The CLAUDE.md rationale quotes a concrete number; keep the two honest
+        // about each other so the prose cannot silently drift from the code.
+        self::assertCount(11, self::ALLOWED_IMPORTS);
+    }
+
+    /**
+     * @return array<string, list<string>> relative file path => imported compiler FQNs
+     */
+    private function compilerImportsPerSharedFile(): array
+    {
+        $sharedDir = dirname(__DIR__, 4) . '/src/php/Shared';
+        self::assertDirectoryExists($sharedDir);
+
+        $found = [];
+
+        /** @var SplFileInfo $file */
+        foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($sharedDir)) as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $contents = (string) file_get_contents($file->getPathname());
+            preg_match_all('/^use\s+(Phel\\\\Compiler\\\\[^;\s]+)\s*;/m', $contents, $matches);
+
+            if ($matches[1] === []) {
+                continue;
+            }
+
+            $relative = str_replace($sharedDir . '/', '', $file->getPathname());
+            $found[$relative] = $matches[1];
+        }
+
+        ksort($found);
+
+        return $found;
+    }
+}


### PR DESCRIPTION
## 🤔 Background

#2781 broke most of the Shared DIP cycle. One back-edge cluster remained: `Shared/Facade/CompilerFacadeInterface` names Compiler-owned types across 11 edges, keeping `{Compiler, Config, Filesystem, Lang, Shared}` in one SCC.

The issue asks for a **decision** (break it, or document it as intentional) with the rationale recorded in `src/php/Shared/CLAUDE.md`.

## 💡 Goal

Take direction **3**: accept the cycle, write down why, and make sure it cannot quietly grow.

## 🔖 Changes

- `src/php/Shared/CLAUDE.md` gains a **"Compiler Back-Edge (accepted cycle)"** section with the rationale, the 11 edges classified, and the rejected alternatives.
- New `tests/php/Unit/Architecture/SharedCompilerBoundaryTest.php` turns the decision into an enforced invariant.
- A line under Shared's **Key Constraints** points at both.

No `CHANGELOG.md` entry: this is an internal architecture decision with no user-facing behaviour change.

## 🔎 What the analysis found

`CompilerFacadeInterface` is the **only** file in `Shared/` importing `Phel\Compiler`. Its 11 edges split cleanly:

| Kind | Symbols |
|------|---------|
| Method signatures (6) | `AbstractNode`, `NodeEnvironmentInterface`, `GlobalEnvironmentInterface`, `TokenStream`, `EmitterResult`, `ReaderResult` |
| `@throws` tags only (5) | `AnalyzerException`, `LexerValueException`, `UnexpectedParserException`, `UnfinishedParserException`, `ReaderException` |

**The decisive point: an SCC decomposes only when *every* back-edge goes.** So the tempting cheap win (moving the five exception classes into `Shared\Exceptions`, where their `AbstractLocatedException` base and `ErrorCode` enum already live) is pure churn: the cycle would be bit-for-bit unchanged. It is all-or-nothing.

Going all the way means moving the analyzer AST into Shared. `AbstractNode` has **~554** references outside Shared, `NodeEnvironmentInterface` **~291**. Shared would become the compiler, inverting the leaf-layer rule it exists to enforce.

The two other directions cost more than the cycle does:

- **Primitives/serialized handles** (direction 1): `analyze()` returns an untyped array, discarding the type safety PHPStan L9 / Psalm L1 enforce across those ~554 references.
- **Narrow Shared interfaces** (direction 2): analyzer consumers match on concrete node types, so the interface either restates the node hierarchy in Shared or is too generic to type anything. `Shared\Parser\Node\NodeInterface` works precisely because the *parse tree* has a genuinely narrow contract; the analyzer AST does not.

And the cycle is benign in the ways that would actually hurt: it is a static-analysis artifact over `use` statements, so no initialization-order, autoloading, or build-order problem follows. No Gacela rule is bent either. Shared only *names* compiler types in a signature, never instantiates one, and no factory gains a cross-module `new`. The inversion the interface exists for (consumers injecting `CompilerFacadeInterface` instead of the concrete `CompilerFacade`) holds regardless of who owns the signature types.

## ✅ Why a test and not just prose

A doc-only change lets the edge widen silently, which is how it got here. The test pins both failure modes:

1. `CompilerFacadeInterface` stays the **only** Shared file importing Compiler.
2. Its imported symbol set stays **exactly** those 11.

Both guards were verified to actually fail: adding a second Shared file with a compiler import trips (1), and leaking one extra compiler type into the contract trips (2). A third assertion keeps the edge count quoted in `CLAUDE.md` honest against the list.

Removing an edge later is a one-line list edit, and the failure message says so.

## ⚠️ Note for the reviewer

This is a judgement call on your architecture, so it is worth your disagreement if you see it differently. If you would rather pursue direction 1 or 2, the test and the doc section should be dropped rather than amended.

The mandatory post-implementation refactor pass surfaced only a cross-reference casing fix, already folded in.

Closes #2785