### PR TITLE
test(repl): make ReplTestIo::writeln terminate the line

### DIFF
--- a/tests/php/Integration/Run/Command/Repl/ReplBareStdClassTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplBareStdClassTest.php
@@ -45,7 +45,7 @@ final class ReplBareStdClassTest extends AbstractTestCommand
         self::assertSame(0, $exitCode);
         self::assertCount(
             2,
-            array_keys($io->getRawOutputs(), 'Printer cannot print this type: stdClass', strict: true),
+            array_keys($io->getOutputLines(), 'Printer cannot print this type: stdClass', strict: true),
         );
     }
 

--- a/tests/php/Integration/Run/Command/Repl/ReplLazyBundledNamespaceTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplLazyBundledNamespaceTest.php
@@ -72,7 +72,7 @@ final class ReplLazyBundledNamespaceTest extends AbstractTestCommand
             $this->stubOutput(),
         );
 
-        $outputs = $io->getRawOutputs();
+        $outputs = $io->getOutputLines();
         self::assertContains('3', $outputs, '(+ 1 2) must work at boot without any bundle other than core');
         self::assertContains('false', $outputs, 'phel.html must not be loaded eagerly at REPL boot');
         self::assertNotContains('true', $outputs);
@@ -96,7 +96,7 @@ final class ReplLazyBundledNamespaceTest extends AbstractTestCommand
         );
 
         self::assertStringContainsString('&lt;div&gt;', $io->getOutputString(), 'A fully qualified bundle reference must resolve on demand');
-        self::assertContains('true', $io->getRawOutputs(), 'phel.html must be loaded after a fully qualified reference');
+        self::assertContains('true', $io->getOutputLines(), 'phel.html must be loaded after a fully qualified reference');
     }
 
     #[RunInSeparateProcess]

--- a/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
@@ -111,16 +111,16 @@ final class ReplPromptNamespaceTest extends AbstractTestCommand
             $this->stubOutput(),
         );
 
-        $outputs = $io->getRawOutputs();
-        self::assertSame('user:1> *ns*' . PHP_EOL, $outputs[2]);
+        $outputs = $io->getOutputLines();
+        self::assertSame('user:1> *ns*', $outputs[2]);
         self::assertSame('user', $outputs[3]);
-        self::assertSame('user:2> (ns mordor.core)' . PHP_EOL, $outputs[4]);
+        self::assertSame('user:2> (ns mordor.core)', $outputs[4]);
         self::assertSame('nil', $outputs[5]);
-        self::assertSame('mordor.core:3> *ns*' . PHP_EOL, $outputs[6]);
+        self::assertSame('mordor.core:3> *ns*', $outputs[6]);
         self::assertSame('mordor.core', $outputs[7]);
-        self::assertSame('mordor.core:4> (require [phel.test :as t])' . PHP_EOL, $outputs[8]);
+        self::assertSame('mordor.core:4> (require [phel.test :as t])', $outputs[8]);
         self::assertSame('phel.test', $outputs[9]);
-        self::assertSame('mordor.core:5> *ns*' . PHP_EOL, $outputs[10]);
+        self::assertSame('mordor.core:5> *ns*', $outputs[10]);
         self::assertSame('mordor.core', $outputs[11]);
     }
 

--- a/tests/php/Integration/Run/Command/Repl/ReplTestIo.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplTestIo.php
@@ -54,7 +54,7 @@ final class ReplTestIo implements ReplCommandIoInterface
     {
         if ($this->currentIndex < count($this->inputs)) {
             $inputLine = $this->inputs[$this->currentIndex];
-            $this->writeln($inputLine->__toString() . PHP_EOL);
+            $this->writeln($inputLine->__toString());
             ++$this->currentIndex;
 
             if ($inputLine->isCtrlD()) {
@@ -87,9 +87,14 @@ final class ReplTestIo implements ReplCommandIoInterface
         $this->outputs[] = $string;
     }
 
+    /**
+     * Terminates the line, like the real IO does. Without this the captured
+     * transcript runs an evaluated result straight into the next prompt
+     * (`3user:2> *1`), which is why the `.test` fixtures could never match.
+     */
     public function writeln(string $string = ''): void
     {
-        $this->outputs[] = $string;
+        $this->outputs[] = $string . PHP_EOL;
     }
 
     public function setInputs(InputLine ...$inputs): void
@@ -117,6 +122,22 @@ final class ReplTestIo implements ReplCommandIoInterface
     public function getRawOutputs(): array
     {
         return $this->outputs;
+    }
+
+    /**
+     * Raw outputs with the line terminator stripped, for assertions that care
+     * about the logical line and not its framing. Prefer this over
+     * {@see self::getRawOutputs()} when matching a whole entry, so the
+     * assertion does not have to spell out `. PHP_EOL`.
+     *
+     * @return list<string>
+     */
+    public function getOutputLines(): array
+    {
+        return array_map(
+            static fn(string $output): string => rtrim($output, PHP_EOL),
+            $this->outputs,
+        );
     }
 
     public function isBracketedPasteSupported(): bool


### PR DESCRIPTION
## 🤔 Background

`ReplTestIo` is the REPL IO test double shared by 8 integration test classes. Its `writeln()` appended the string verbatim, making it identical to `write()`:

```php
public function write(string $string = ''): void   { $this->outputs[] = $string; }
public function writeln(string $string = ''): void { $this->outputs[] = $string; }  // no newline
```

So a captured transcript ran an evaluated result straight into the next prompt:

```
user:1> (php/+ 1 2)
3user:2> *1
3user:3> (php/* *1 10)
```

`readline()` had been hand-compensating with a trailing `PHP_EOL` on the *prompt*, which is why prompts looked right and results did not.

## 💡 Goal

Make the double behave like the real IO, so a captured REPL transcript is actually a transcript.

## 🔖 Changes

- `writeln()` terminates the line; the compensating `. PHP_EOL` in `readline()` is removed.
- New `getOutputLines()` accessor returns the raw outputs with the terminator stripped. The four assertions that matched a whole entry now use it, so they compare logical lines instead of spelling out `. PHP_EOL` (`ReplPromptNamespaceTest`, `ReplLazyBundledNamespaceTest`, `ReplBareStdClassTest`).
- `getRawOutputs()` is untouched for callers that want the exact framing.

No production code changes; no `CHANGELOG.md` entry.

## 🔎 Why this matters beyond tidiness

`tests/php/Integration/Run/Command/Repl/Fixtures/` and `FixturesWithCoreLib/` hold 23 `--INPUT--`/`--EXPECT--` REPL fixtures. Their runner has been silently uncollected for a long time (the file is named `ReplTestCommand.php`, and PHPUnit matches suffix `Test.php`), and this concatenation bug is the single largest reason the fixtures cannot match real output. Fixing it here is the prerequisite for wiring that suite back up.

The remaining work on that suite is **not** in this PR: it still has failures from genuine drift (`def` now returns a var, the `[PHEL001]` error prefix, dot-separated namespace rendering) plus some resolution issues that need real investigation. I did not want to bundle a green refactor with a red restoration.

## ✅ Verification

The whole REPL integration suite is green (33 tests, 89 assertions), and `composer test` passes end to end (6509 core tests, static analysis clean).

Worth noting the re-baselined assertions were the *point* of the exercise: they were passing only because they asserted against the buggy framing.