### PR TITLE
fix(repl): report a mistyped closing bracket instead of hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this project will be documented in this file.
 - Lexer deprecation warnings for bare `#` and `#| |#` comments no longer promise removal "in Phel v0.33", a version that shipped 15 releases ago; they now read "in a future release", matching the backslash-separator warning (#2783)
 - Sorted sets carry the same NaN guard as hash sets, so a distinct sorted set holding `NAN` is never `=` to another set; previously this held only by accident of the default comparator and broke under a user comparator that orders `NAN` equal to itself (#2782)
 - `phel list:modules` and `phel cache:warm` no longer fatal in projects whose test suite holds a class that cannot be loaded standalone; the new `app-module-paths` config key (`PhelConfig::withAppModulePaths()`) scopes Gacela's module discovery, defaulting to today's whole-root walk (#2787)
+- The REPL reports a mistyped closing bracket instead of hanging: typing `(php/+ 1` and then `]` left it buffering for input that could never arrive, with no feedback and no way out but Ctrl-D. A closer with no matching opener is now handed to the parser, which raises the located error it always had ready
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/src/php/Compiler/Application/ParenthesesChecker.php
+++ b/src/php/Compiler/Application/ParenthesesChecker.php
@@ -43,6 +43,16 @@ final readonly class ParenthesesChecker
             }
         }
 
+        // A closer with no matching opener can never be repaired by appending
+        // more input, so the input is malformed rather than incomplete. Report
+        // it as ready and let the parser raise a located error. Otherwise the
+        // REPL, which buffers until this returns true, waits forever on a
+        // mistyped bracket: `(php/+ 1` then `]` leaves parens at 1 and brackets
+        // at -1, so the user gets no feedback at all and has to Ctrl-D out.
+        if ($parens < 0 || $brackets < 0 || $braces < 0) {
+            return true;
+        }
+
         return $parens <= 0 && $brackets <= 0 && $braces <= 0;
     }
 }

--- a/tests/php/Unit/Compiler/Application/ParenthesesCheckerTest.php
+++ b/tests/php/Unit/Compiler/Application/ParenthesesCheckerTest.php
@@ -33,6 +33,28 @@ final class ParenthesesCheckerTest extends TestCase
         self::assertFalse($this->isBalanced($code), $code);
     }
 
+    /**
+     * A closer with no matching opener cannot be repaired by typing more, so it
+     * counts as ready and the parser gets to raise a real error. The REPL
+     * buffers until this returns true, so reporting these as "keep waiting"
+     * left a mistyped bracket hanging with no feedback at all.
+     */
+    #[DataProvider('malformedCases')]
+    public function test_unrepairable_input_is_handed_to_the_parser(string $code): void
+    {
+        self::assertTrue($this->isBalanced($code), $code);
+    }
+
+    public static function malformedCases(): iterable
+    {
+        yield 'wrong closer while a list is open' => ["(php/+ 1\n2\n]"];
+        yield 'wrong closer while a vector is open' => ['[1 2)'];
+        yield 'wrong closer while a map is open' => ['{:a 1]'];
+        yield 'wrong closer while a set is open' => ['#{1 2)'];
+        yield 'stray closer on its own' => [']'];
+        yield 'closer before its opener' => [')('];
+    }
+
     public static function balancedCases(): iterable
     {
         yield 'empty' => [''];


### PR DESCRIPTION
## 🤔 Background

Typing an unmatched closer of the wrong kind leaves the REPL buffering for input that can never arrive:

```
user:1> (php/+ 1
....:2> 2
....:3> ]
....:4>
```

No error, no result, no prompt back. The only way out is Ctrl-D. Reproduced against `./bin/phel repl` on `main`, not just in tests.

## 🔍 Root cause

`ReplCommand::analyzeInputBuffer()` only evaluates once `hasBalancedParentheses()` returns true, otherwise it keeps buffering. `ParenthesesChecker` tracks the three bracket kinds independently and ends with:

```php
return $parens <= 0 && $brackets <= 0 && $braces <= 0;
```

For `(php/+ 1` … `]` that leaves **parens at 1** and **brackets at -1**. The `$parens <= 0` term is false, so the input is judged "incomplete, keep waiting" forever. The parser had the right error ready the whole time and was simply never asked for it.

## 💡 Fix

A closer with no matching opener cannot be repaired by appending more input, so it is malformed rather than incomplete. When any counter goes negative, report the input as ready and let the parser raise its located error:

```
Unterminated list (BRACKETS)
in string:3

1| (php/+ 1
2| 2
3| ]
   ^
```

Genuinely incomplete input (`(+ 1 2`, `[1 2 3`, `#?@(:phel [1`) is untouched and still buffers.

## 🔖 Changes

- `ParenthesesChecker`: early-return `true` when any counter is negative.
- `ParenthesesCheckerTest`: 6 cases for unrepairable input. Four of them fail without the fix (`(…]`, `[1 2)`, `{:a 1]`, `#{1 2)`); the other two pin behaviour that already held.
- `CHANGELOG.md` entry under `## Unreleased`.

Two other callers benefit: `EvalExecutor` and `CompileExecutor` answered `(foo]` with a blanket *"Unbalanced parentheses."* and now surface the precise located error instead.

## 🔎 How it surfaced

`tests/php/Integration/Run/Command/Repl/Fixtures/unterminated-list-multiline.test` has been asserting the correct output all along. It stopped protecting anything when its runner drifted out of PHPUnit's `Test.php` suffix and went uncollected. Wiring that suite back up is separate work (it depends on #2793); this PR stands alone and needs neither.

## ✅ Verification

`composer test` green end to end (6511 core tests, static analysis clean), plus the manual REPL reproduction above now printing the error.

One note for transparency: the first full-gate run hit an unrelated error in `CompileCommandTest` under the parallel runner. It passes in isolation (10/10) and the gate was clean on re-run, so it looks like a pre-existing paratest flake rather than anything from this change. Flagging it in case it is a known one.