### PR TITLE
fix(lang): give sorted collections a total order for NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to this project will be documented in this file.
 - Sorted sets carry the same NaN guard as hash sets, so a distinct sorted set holding `NAN` is never `=` to another set; previously this held only by accident of the default comparator and broke under a user comparator that orders `NAN` equal to itself (#2782)
 - `phel list:modules` and `phel cache:warm` no longer fatal in projects whose test suite holds a class that cannot be loaded standalone; the new `app-module-paths` config key (`PhelConfig::withAppModulePaths()`) scopes Gacela's module discovery, defaulting to today's whole-root walk (#2787)
 - The REPL reports a mistyped closing bracket instead of hanging: typing `(php/+ 1` and then `]` left it buffering for input that could never arrive, with no feedback and no way out but Ctrl-D. A closer with no matching opener is now handed to the parser, which raises the located error it always had ready
+- Sorted sets and sorted maps no longer store duplicate `NAN` under the default comparator: PHP's `NAN <=> NAN` is `1`, so the binary search never relocated an existing `NAN` and every insert appended a fresh one. The default comparator now matches Java `Double.compare` / Clojure `compare` (NaN equals itself, orders after every number), so `(count (sorted-set NAN NAN))` is `1` and `(contains? (sorted-set NAN) NAN)` is `true` (#2789)
 
 ## [0.48.0](https://github.com/phel-lang/phel-lang/compare/v0.47.0...v0.48.0) - 2026-07-15
 

--- a/src/php/Lang/Collections/SortedMap/SortedArrayHelper.php
+++ b/src/php/Lang/Collections/SortedMap/SortedArrayHelper.php
@@ -8,7 +8,9 @@ use Closure;
 use Phel\Lang\NamedInterface;
 
 use function count;
+use function is_float;
 use function is_int;
+use function is_nan;
 
 /**
  * Shared binary search and comparator logic for sorted collections.
@@ -25,6 +27,17 @@ final class SortedArrayHelper
     {
         if ($a instanceof NamedInterface && $b instanceof NamedInterface) {
             return $a->getFullName() <=> $b->getFullName();
+        }
+
+        // PHP's `NAN <=> x` is 1 for every operand (even NaN itself), which is
+        // not a total order, so the binary search can never relocate an
+        // existing NaN and sorted collections end up storing duplicates. Match
+        // Java `Double.compare` / Clojure `compare`: NaN equals itself and
+        // orders after every other value, restoring a total order.
+        $aIsNan = is_float($a) && is_nan($a);
+        $bIsNan = is_float($b) && is_nan($b);
+        if ($aIsNan || $bIsNan) {
+            return $aIsNan <=> $bIsNan;
         }
 
         return $a <=> $b;

--- a/tests/phel/core/nan-map-keys.phel
+++ b/tests/phel/core/nan-map-keys.phel
@@ -27,3 +27,12 @@
 (deftest test-sorted-set-with-nan-stays-reflexive
   (let [s (sorted-set nan)]
     (is (= s s) "a sorted set carrying NaN is still = to itself")))
+
+(deftest test-sorted-set-collapses-duplicate-nan
+  (is (= 2 (count (sorted-set nan nan nan 1))) "duplicate NaN elements collapse into one in a sorted set")
+  (is (contains? (sorted-set nan) nan) "contains? finds a NaN element in a sorted set"))
+
+(deftest test-nan-as-sorted-map-key
+  (is (= 2 (count (sorted-map nan 1 nan 2 1 3))) "re-assoc with the same NaN key updates in place in a sorted map")
+  (is (= 2 (get (sorted-map nan 1 nan 2) nan)) "re-assoc with the same NaN key overwrites the value")
+  (is (contains? (sorted-map nan 1) nan) "contains? finds a NaN key in a sorted map"))

--- a/tests/php/Unit/Lang/Collections/SortedMap/PersistentSortedMapTest.php
+++ b/tests/php/Unit/Lang/Collections/SortedMap/PersistentSortedMapTest.php
@@ -390,6 +390,23 @@ final class PersistentSortedMapTest extends TestCase
         self::assertNull($h->getComparator());
     }
 
+    /**
+     * The default comparator treats NaN as equal to itself and ordered after
+     * every number, so a NaN key stays retrievable and re-assoc updates it in
+     * place instead of storing a duplicate (see #2789).
+     */
+    public function test_default_comparator_collapses_duplicate_nan_key(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(NAN, 'a')
+            ->put(NAN, 'b')
+            ->put(1, 'x');
+
+        self::assertCount(2, $h);
+        self::assertTrue($h->contains(NAN));
+        self::assertSame('b', $h->find(NAN));
+    }
+
     public function test_string_keys_sorted(): void
     {
         $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())

--- a/tests/php/Unit/Lang/Collections/SortedMap/SortedArrayHelperTest.php
+++ b/tests/php/Unit/Lang/Collections/SortedMap/SortedArrayHelperTest.php
@@ -57,6 +57,20 @@ final class SortedArrayHelperTest extends TestCase
         self::assertGreaterThan(0, SortedArrayHelper::defaultCompare($b, $a));
     }
 
+    public function test_default_compare_nan_equals_itself(): void
+    {
+        // PHP's `NAN <=> NAN` is 1; the default comparator instead treats NaN
+        // as equal to itself (Java `Double.compare` / Clojure `compare`).
+        self::assertSame(0, SortedArrayHelper::defaultCompare(NAN, NAN));
+    }
+
+    public function test_default_compare_nan_orders_after_every_number(): void
+    {
+        self::assertSame(1, SortedArrayHelper::defaultCompare(NAN, 1));
+        self::assertSame(1, SortedArrayHelper::defaultCompare(NAN, PHP_INT_MAX));
+        self::assertSame(-1, SortedArrayHelper::defaultCompare(1, NAN));
+    }
+
     // ---- resolveComparator ----
 
     public function test_resolve_null_returns_default_comparator(): void
@@ -169,5 +183,14 @@ final class SortedArrayHelperTest extends TestCase
         self::assertSame(0, SortedArrayHelper::binarySearch($array, $a, $comp));
         self::assertSame(2, SortedArrayHelper::binarySearch($array, $b, $comp));
         self::assertSame(4, SortedArrayHelper::binarySearch($array, $c, $comp));
+    }
+
+    public function test_search_finds_nan_key_with_default_comparator(): void
+    {
+        $comp = SortedArrayHelper::resolveComparator(null);
+        // NaN sorts after every number, so it lives at the end of the array.
+        $array = [1, 'a', 2, 'b', NAN, 'n'];
+
+        self::assertSame(4, SortedArrayHelper::binarySearch($array, NAN, $comp));
     }
 }

--- a/tests/php/Unit/Lang/Collections/SortedSet/PersistentSortedSetTest.php
+++ b/tests/php/Unit/Lang/Collections/SortedSet/PersistentSortedSetTest.php
@@ -11,9 +11,6 @@ use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
 use PHPUnit\Framework\TestCase;
 
-use function is_float;
-use function is_nan;
-
 final class PersistentSortedSetTest extends TestCase
 {
     public function test_empty(): void
@@ -119,22 +116,21 @@ final class PersistentSortedSetTest extends TestCase
      */
     public function test_equals_is_reflexive_with_nan_element(): void
     {
-        $s = $this->emptySet($this->nanAwareComparator())->add(NAN)->add(1);
+        $s = $this->emptySet()->add(NAN)->add(1);
 
         $this->assertTrue($s->equals($s));
     }
 
     /**
      * A NaN element is never `=` to itself, so a set carrying one is unequal to
-     * any *distinct* set, matching PersistentHashSet. The comparator here
+     * any *distinct* set, matching PersistentHashSet. The default comparator
      * matches NaN, so `contains(NAN)` succeeds; without the guard in `equals()`
      * the element walk would then wrongly report the two sets equal.
      */
     public function test_equals_is_false_for_distinct_sets_carrying_nan(): void
     {
-        $comparator = $this->nanAwareComparator();
-        $s1 = $this->emptySet($comparator)->add(NAN)->add(1);
-        $s2 = $this->emptySet($comparator)->add(NAN)->add(1);
+        $s1 = $this->emptySet()->add(NAN)->add(1);
+        $s2 = $this->emptySet()->add(NAN)->add(1);
 
         $this->assertTrue($s1->contains(NAN));
         $this->assertFalse($s1->equals($s2));
@@ -230,33 +226,6 @@ final class PersistentSortedSetTest extends TestCase
 
         self::assertCount(1, $s1);
         self::assertCount(2, $s2);
-    }
-
-    /**
-     * Java `Double.compare` / Clojure `compare` semantics: NaN sorts equal to
-     * itself and after every other number. Users may legitimately supply such a
-     * comparator, and under it membership lookup matches NaN.
-     */
-    private function nanAwareComparator(): callable
-    {
-        return static function (mixed $a, mixed $b): int {
-            $aIsNan = is_float($a) && is_nan($a);
-            $bIsNan = is_float($b) && is_nan($b);
-
-            if ($aIsNan && $bIsNan) {
-                return 0;
-            }
-
-            if ($aIsNan) {
-                return 1;
-            }
-
-            if ($bIsNan) {
-                return -1;
-            }
-
-            return $a <=> $b;
-        };
     }
 
     private function emptySet(?callable $comparator = null): PersistentSortedSet

--- a/tests/php/Unit/Lang/Collections/SortedSet/PersistentSortedSetTest.php
+++ b/tests/php/Unit/Lang/Collections/SortedSet/PersistentSortedSetTest.php
@@ -141,6 +141,25 @@ final class PersistentSortedSetTest extends TestCase
         $this->assertFalse($s2->equals($s1));
     }
 
+    /**
+     * The default comparator matches Java `Double.compare` / Clojure `compare`:
+     * NaN equals itself and sorts after every number, so a sorted set collapses
+     * duplicate NaN elements instead of appending each one (see #2789).
+     */
+    public function test_default_comparator_collapses_duplicate_nan(): void
+    {
+        $s = $this->emptySet()->add(NAN)->add(NAN)->add(NAN)->add(1);
+
+        self::assertCount(2, $s);
+    }
+
+    public function test_default_comparator_membership_matches_nan(): void
+    {
+        $s = $this->emptySet()->add(NAN)->add(1);
+
+        self::assertTrue($s->contains(NAN));
+    }
+
     public function test_hash(): void
     {
         $s1 = $this->emptySet()->add(1)->add(2);


### PR DESCRIPTION
## 🤔 Background

PHP's `NAN <=> NAN` evaluates to `1`, not `0`, so the default sorted comparator is not a total order. The binary search in `SortedArrayHelper` therefore never locates an existing `NaN`, and every insert appends a new one. Sorted sets/maps silently store duplicate `NAN`, diverging from their hashed counterparts and from Clojure/Java (`Double.compare(NaN, NaN) == 0`).

## 💡 Goal

Make sorted collections follow the same `NaN` membership rule as hash collections: `NaN` equals itself and orders after every number, restoring a total order so a `NaN` element/key is deduped and stays retrievable.

## 🔖 Changes

- `SortedArrayHelper::defaultCompare()` treats `NaN` as equal to itself and greater than every other value (Java `Double.compare` / Clojure `compare` semantics). User-supplied comparators are unaffected.
- The `equals()` NaN guards (sorted set from #2788, sorted map inherited from `AbstractPersistentMap`) keep distinct collections carrying `NaN` structurally unequal, so `(= (sorted-set NAN) (sorted-set NAN))` stays `false`.
- Coverage: `SortedArrayHelperTest`, `PersistentSortedSetTest`, `PersistentSortedMapTest`, and `tests/phel/core/nan-map-keys.phel` (sorted-set + sorted-map). Refactor pass removed a now-redundant nan-aware comparator test helper.
- CHANGELOG updated under `## Unreleased`.

Closes #2789