### PR TITLE
fix(build): route cache writes and deletes through Gacela FileCache primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Build cache writes and deletes route through Gacela's `FileCache` primitives (`writeContentsAtomically`, `delete`), which lock, treat a short-byte write as failure, and invalidate opcache for the final path; a plain `file_put_contents(...) === false` missed truncated disk-full writes and a stale opcode entry could serve old content after a rewrite
 - `phel run` on an ad-hoc script fails immediately with the extractor's error when a required sibling `.phel` file cannot be read or parsed, instead of silently skipping it; namespaces that resolve elsewhere remain tolerated
 - `#inst` literals inside macro-expanded forms no longer crash compilation in the location-enrichment walk (#2778)
 - Multi-arity `fn` returned from another fn no longer emits invalid PHP; per-arity closures are analyzed in expression context (#2776)

--- a/src/php/Build/Application/CacheClearer.php
+++ b/src/php/Build/Application/CacheClearer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Build\Application;
 
+use Gacela\Framework\Cache\FileCache;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
@@ -54,7 +55,7 @@ final readonly class CacheClearer
             if ($file->isDir()) {
                 @rmdir($file->getPathname());
             } else {
-                @unlink($file->getPathname());
+                FileCache::delete($file->getPathname());
             }
         }
 

--- a/src/php/Build/Infrastructure/Cache/AtomicFileWriter.php
+++ b/src/php/Build/Infrastructure/Cache/AtomicFileWriter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Build\Infrastructure\Cache;
 
+use Gacela\Framework\Cache\FileCache;
 use Gacela\Framework\Cache\WritableDirectory;
 
 use function dirname;
@@ -20,21 +21,16 @@ final class AtomicFileWriter
             return false;
         }
 
-        $tempPath = $path . '.tmp.' . uniqid('', true);
-        if (file_put_contents($tempPath, $content) === false) {
+        // Gacela's primitive writes with LOCK_EX, treats a short byte count as
+        // failure (a plain `=== false` misses a truncated disk-full write), and
+        // invalidates opcache for the final path — needed because these files
+        // are `require`d back (compiled code, env refers/aliases), so a stale
+        // opcode entry would otherwise serve old content after a rewrite.
+        if (!FileCache::writeContentsAtomically($path, $content)) {
             trigger_error(
-                sprintf('Phel cache: failed to write temp file "%s"', $tempPath),
+                sprintf('Phel cache: failed to write "%s"', $path),
                 E_USER_WARNING,
             );
-            return false;
-        }
-
-        if (!rename($tempPath, $path)) {
-            trigger_error(
-                sprintf('Phel cache: failed to rename "%s" to "%s"', $tempPath, $path),
-                E_USER_WARNING,
-            );
-            @unlink($tempPath);
             return false;
         }
 

--- a/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
+++ b/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Build\Infrastructure\Cache;
 
+use Gacela\Framework\Cache\FileCache;
 use ParseError;
 use Phel\Build\Domain\Cache\CompiledCodeCacheInterface;
 
@@ -213,9 +214,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
         }
 
         $compiledPath = $this->getCompiledPath($sourcePath, $entry['namespace']);
-        if (file_exists($compiledPath)) {
-            @unlink($compiledPath);
-        }
+        FileCache::delete($compiledPath);
 
         unset($this->entries[$sourcePath], $this->touchedThisProcess[$sourcePath]);
         $this->tombstones[$sourcePath] = true;
@@ -232,7 +231,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
             $files = glob($compiledDir . '/*.php');
             if ($files !== false) {
                 foreach ($files as $file) {
-                    @unlink($file);
+                    FileCache::delete($file);
                 }
             }
         }
@@ -324,9 +323,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
 
             $entry = $this->entries[$sourcePath];
             $compiledPath = $this->getCompiledPath($sourcePath, $entry['namespace']);
-            if (file_exists($compiledPath)) {
-                @unlink($compiledPath);
-            }
+            FileCache::delete($compiledPath);
 
             unset($this->entries[$sourcePath]);
             ++$evicted;

--- a/src/php/Build/Infrastructure/Cache/PhpNamespaceCache.php
+++ b/src/php/Build/Infrastructure/Cache/PhpNamespaceCache.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Build\Infrastructure\Cache;
 
+use Gacela\Framework\Cache\FileCache;
 use Phel\Build\Domain\Cache\NamespaceCacheEntry;
 use Phel\Build\Domain\Cache\NamespaceCacheInterface;
 use Phel\Build\Domain\Extractor\ExcludedScanPaths;
@@ -89,9 +90,7 @@ final class PhpNamespaceCache implements NamespaceCacheInterface
         $this->entries = [];
         $this->dirty = false;
 
-        if (file_exists($this->cacheFile)) {
-            @unlink($this->cacheFile);
-        }
+        FileCache::delete($this->cacheFile);
     }
 
     /**

--- a/src/php/Build/Infrastructure/Cache/PhpScanIndexCache.php
+++ b/src/php/Build/Infrastructure/Cache/PhpScanIndexCache.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Build\Infrastructure\Cache;
 
+use Gacela\Framework\Cache\FileCache;
 use Phel\Build\Domain\Cache\ScanIndexCacheInterface;
 use Phel\Build\Domain\Cache\ScanIndexEntry;
 
@@ -84,9 +85,7 @@ final class PhpScanIndexCache implements ScanIndexCacheInterface
         $this->entries = [];
         $this->clearFlushPending();
 
-        if (file_exists($this->cacheFile)) {
-            @unlink($this->cacheFile);
-        }
+        FileCache::delete($this->cacheFile);
     }
 
     /**


### PR DESCRIPTION
## 🤔 Background

The Build module's file cache wrote and deleted cache files with raw `file_put_contents` + `rename` + `@unlink`. Two problems:

- `file_put_contents(...) === false` treats a **short** (truncated) write, e.g. on a full disk, as success — only a hard failure returns `false`.
- These cache files are `require`d back at runtime (compiled code, env refers/aliases). A rewrite left the previous entry in opcache, so a stale opcode could be served after the file changed.

Gacela ≥1.17 exposes `FileCache::writeContentsAtomically()` and `FileCache::delete()`, which lock (`LOCK_EX`), treat a short byte count as failure, and invalidate opcache for the final path. `main` is now on `gacela ^1.18`, so these primitives are available.

## 💡 Goal

Route all Build cache writes and deletes through Gacela's `FileCache` primitives instead of hand-rolled filesystem calls.

## 🔖 Changes

- `AtomicFileWriter`: `file_put_contents` + `rename` → `FileCache::writeContentsAtomically()`.
- `CacheClearer`, `CompiledCodeCache`: `@unlink` (+ `file_exists` guards) → `FileCache::delete()`.
- `PhpNamespaceCache`, `PhpScanIndexCache`: same delete swap.
- CHANGELOG `## Unreleased` → Fixed.

Tests: `unit,integration` cache/build suites green (343 passing); phpstan clean on the changed files.
