### PR TITLE
ref: code-quality sweep (dead code, shared types, weak types, comments)

### DIFF
--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -999,10 +999,3 @@ bindings is a vector of function specs: (letfn [(f [params] body) (g [params] bo
   [sym]
   (-> (get-global-env)
       (php/-> (resolveAsSymbol sym (php/:: NodeEnvironment (empty))))))
-
-(defn- inline-call? [meta arity]
-  (and (:inline meta)
-       (let [af (:inline-arity meta)]
-         (if af
-           (af arity)
-           true))))

--- a/src/phel/schema/generator.phel
+++ b/src/phel/schema/generator.phel
@@ -14,12 +14,6 @@
 
 (declare schema->gen)
 
-(defn- simple-string-gen [_args]
-  g/string-alphanumeric)
-
-(defn- simple-keyword-gen [_args]
-  g/keyword)
-
 (defn- inst-gen []
   (g/fmap (fn [secs] (php/:: \DateTimeImmutable (createFromFormat "U" (str secs))))
           (g/choose 0 2147483647)))

--- a/src/phel/test/rose.phel
+++ b/src/phel/test/rose.phel
@@ -1,7 +1,5 @@
 (ns phel.test.rose)
 
-;; Rose trees used to carry a value alongside lazy shrink candidates.
-;;
 ;; A rose tree is a hash-map `{:root v :children seq}` where `seq` is a
 ;; lazy sequence of rose trees representing smaller variants of `v`.
 ;; The shrinker walks the tree depth-first and keeps the smallest

--- a/src/php/Compiler/Domain/Analyzer/Ast/LocalVarNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/LocalVarNode.php
@@ -62,7 +62,10 @@ final class LocalVarNode extends AbstractNode
         return null;
     }
 
-    private function tagOf(mixed $meta): ?string
+    /**
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
+     */
+    private function tagOf(?PersistentMapInterface $meta): ?string
     {
         if (!$meta instanceof PersistentMapInterface) {
             return null;

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/MacroFormRewriter.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/MacroFormRewriter.php
@@ -143,7 +143,7 @@ final readonly class MacroFormRewriter
      *
      * @return PersistentVectorInterface<mixed>
      */
-    private function withReturnTypeTag(PersistentVectorInterface $params, mixed $tag): PersistentVectorInterface
+    private function withReturnTypeTag(PersistentVectorInterface $params, Symbol|string $tag): PersistentVectorInterface
     {
         $existing = $params->getMeta();
         if ($existing instanceof PersistentMapInterface

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -151,7 +151,10 @@ final readonly class MethodEmitter
         );
     }
 
-    private function extractTypeTag(mixed $meta): ?string
+    /**
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
+     */
+    private function extractTypeTag(?PersistentMapInterface $meta): ?string
     {
         if (!$meta instanceof PersistentMapInterface) {
             return null;
@@ -171,8 +174,10 @@ final readonly class MethodEmitter
      * `php/aset`, `php/array_push`, etc. propagate back to the caller's
      * binding. Surfaces the `(php/array)` mutation pattern at the Phel
      * level without forcing buffer-return-rebind dances.
+     *
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
      */
-    private function isByRef(mixed $meta): bool
+    private function isByRef(?PersistentMapInterface $meta): bool
     {
         if (!$meta instanceof PersistentMapInterface) {
             return false;

--- a/src/php/Compiler/Infrastructure/GlobalEnvironmentSingleton.php
+++ b/src/php/Compiler/Infrastructure/GlobalEnvironmentSingleton.php
@@ -33,21 +33,6 @@ final class GlobalEnvironmentSingleton
     }
 
     /**
-     * Ensures the GlobalEnvironment is initialized.
-     * If already initialized, returns the existing instance.
-     * If not, initializes a new one (which clears the Phel registry).
-     */
-    public static function ensureInitialized(): GlobalEnvironmentInterface
-    {
-        $existing = GlobalEnvironmentRegistry::get();
-        if ($existing instanceof GlobalEnvironmentInterface) {
-            return $existing;
-        }
-
-        return self::initializeNew();
-    }
-
-    /**
      * Returns the singleton, auto-creating a fresh `GlobalEnvironment`
      * when none exists — without clearing the Phel registry, unlike
      * `initializeNew()`. This keeps compiled artifacts usable when

--- a/src/php/Lsp/Application/Handler/CursorContext.php
+++ b/src/php/Lsp/Application/Handler/CursorContext.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Lsp\Application\Handler;
 
 use Phel\Api\Transfer\ProjectIndex;
+use Phel\Lsp\Application\Convert\PositionConverter;
 use Phel\Lsp\Application\Document\Document;
 use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
@@ -20,11 +21,13 @@ use Phel\Lsp\Application\Session\Session;
  * and the caller returns the method's empty response. This removes the
  * repeated four-step prelude from `Hover`, `Definition`, `References`, and
  * `Rename`.
+ *
+ * @phpstan-import-type Position from PositionConverter
  */
 final readonly class CursorContext
 {
     /**
-     * @param array{line: int, character: int} $position
+     * @param Position $position
      */
     private function __construct(
         public ProjectIndex $index,

--- a/src/php/Lsp/Application/Rpc/ParamsExtractor.php
+++ b/src/php/Lsp/Application/Rpc/ParamsExtractor.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Lsp\Application\Rpc;
 
+use Phel\Lsp\Application\Convert\PositionConverter;
+
 use function is_array;
 use function is_int;
 use function is_string;
@@ -16,6 +18,8 @@ use function is_string;
  * the field is missing or has the wrong type. Handlers then translate that
  * default into the LSP response that best fits their method (empty array,
  * `null`, etc.).
+ *
+ * @phpstan-import-type Position from PositionConverter
  */
 final class ParamsExtractor
 {
@@ -35,7 +39,7 @@ final class ParamsExtractor
     /**
      * @param array<string, mixed> $params
      *
-     * @return array{line: int, character: int}|null
+     * @return Position|null
      */
     public function position(array $params): ?array
     {

--- a/src/php/Profile/Domain/Formatter/TableFormatter.php
+++ b/src/php/Profile/Domain/Formatter/TableFormatter.php
@@ -23,6 +23,9 @@ use function strrpos;
 use function substr;
 use function uasort;
 
+/**
+ * @phpstan-import-type FnStat from ProfileReport
+ */
 final class TableFormatter
 {
     /**
@@ -142,7 +145,7 @@ final class TableFormatter
     }
 
     /**
-     * @param array{calls:int, totalNs:int, selfNs:int, maxNs:int} $r
+     * @param FnStat $r
      */
     private function renderFnRow(string $name, array $r, int $nameWidth): string
     {
@@ -160,7 +163,7 @@ final class TableFormatter
     }
 
     /**
-     * @return callable(array{calls:int, totalNs:int, selfNs:int, maxNs:int}, array{calls:int, totalNs:int, selfNs:int, maxNs:int}): int
+     * @return callable(FnStat, FnStat): int
      */
     private function sortComparator(SortOrder $sort): callable
     {

--- a/src/php/Profile/Domain/ProfileReport.php
+++ b/src/php/Profile/Domain/ProfileReport.php
@@ -8,12 +8,14 @@ namespace Phel\Profile\Domain;
  * Immutable snapshot of a profiling run: per-fn call stats (keyed by
  * `BOUND_TO` name, times in nanoseconds), per-source compile-phase times
  * (in milliseconds), and the total wall-clock time in milliseconds.
+ *
+ * @phpstan-type FnStat array{calls:int, totalNs:int, selfNs:int, maxNs:int}
  */
 final readonly class ProfileReport
 {
     /**
-     * @param array<string, array{calls:int, totalNs:int, selfNs:int, maxNs:int}> $fnStats
-     * @param array<string, array<string, float>>                                 $phaseMs
+     * @param array<string, FnStat>               $fnStats
+     * @param array<string, array<string, float>> $phaseMs
      */
     public function __construct(
         private array $fnStats,
@@ -24,7 +26,7 @@ final readonly class ProfileReport
     /**
      * Per-fn stats keyed by fn name; all `*Ns` values are nanoseconds.
      *
-     * @return array<string, array{calls:int, totalNs:int, selfNs:int, maxNs:int}>
+     * @return array<string, FnStat>
      */
     public function fnStats(): array
     {

--- a/src/php/Profile/Domain/ProfilerSession.php
+++ b/src/php/Profile/Domain/ProfilerSession.php
@@ -10,6 +10,9 @@ use Phel\Lang\ProfilerHookInterface;
 use function array_pop;
 use function hrtime;
 
+/**
+ * @phpstan-import-type FnStat from ProfileReport
+ */
 final class ProfilerSession implements ProfilerHookInterface
 {
     /**
@@ -21,7 +24,7 @@ final class ProfilerSession implements ProfilerHookInterface
      */
     private array $stack = [];
 
-    /** @var array<string, array{calls:int, totalNs:int, selfNs:int, maxNs:int}> */
+    /** @var array<string, FnStat> */
     private array $fnStats = [];
 
     /** @var array<string, array<string, float>> */

--- a/src/php/Watch/Application/MtimeFileSystemScanner.php
+++ b/src/php/Watch/Application/MtimeFileSystemScanner.php
@@ -21,6 +21,8 @@ use function is_file;
 /**
  * Filesystem scanner that walks directories recursively and returns a
  * snapshot of `.phel` files keyed by realpath with mtime + size.
+ *
+ * @phpstan-import-type FileStat from FileSystemScannerInterface
  */
 final class MtimeFileSystemScanner implements FileSystemScannerInterface
 {
@@ -29,7 +31,7 @@ final class MtimeFileSystemScanner implements FileSystemScannerInterface
     /**
      * @param list<string> $paths
      *
-     * @return array<string, array{mtime:int, size:int}>
+     * @return array<string, FileStat>
      */
     public function snapshot(array $paths): array
     {
@@ -51,7 +53,7 @@ final class MtimeFileSystemScanner implements FileSystemScannerInterface
     }
 
     /**
-     * @param array<string, array{mtime:int, size:int}> $snapshot
+     * @param array<string, FileStat> $snapshot
      */
     private function walkDirInto(array &$snapshot, string $dir): void
     {
@@ -77,7 +79,7 @@ final class MtimeFileSystemScanner implements FileSystemScannerInterface
     }
 
     /**
-     * @param array<string, array{mtime:int, size:int}> $snapshot
+     * @param array<string, FileStat> $snapshot
      */
     private function statInto(array &$snapshot, string $file): void
     {

--- a/src/php/Watch/Application/Watcher/PollingWatcher.php
+++ b/src/php/Watch/Application/Watcher/PollingWatcher.php
@@ -14,6 +14,8 @@ use Phel\Watch\Transfer\WatchEvent;
  * and diffs the mtime + size snapshot with the previous one. Events emitted
  * in the same `$debounceMs` window are coalesced into a single callback
  * invocation (which stops editor-save-induced double triggers).
+ *
+ * @phpstan-import-type FileStat from FileSystemScannerInterface
  */
 final class PollingWatcher implements FileWatcherInterface
 {
@@ -21,7 +23,7 @@ final class PollingWatcher implements FileWatcherInterface
 
     private bool $running = false;
 
-    /** @var array<string, array{mtime:int, size:int}> */
+    /** @var array<string, FileStat> */
     private array $lastSnapshot = [];
 
     public function __construct(
@@ -73,8 +75,8 @@ final class PollingWatcher implements FileWatcherInterface
     }
 
     /**
-     * @param array<string, array{mtime:int, size:int}> $previous
-     * @param array<string, array{mtime:int, size:int}> $current
+     * @param array<string, FileStat> $previous
+     * @param array<string, FileStat> $current
      *
      * @return list<WatchEvent>
      */

--- a/src/php/Watch/Domain/FileSystemScannerInterface.php
+++ b/src/php/Watch/Domain/FileSystemScannerInterface.php
@@ -7,13 +7,15 @@ namespace Phel\Watch\Domain;
 /**
  * Scans a list of paths and returns a mtime + size snapshot keyed by file path.
  * Injected into `PollingWatcher` so tests can fake the filesystem.
+ *
+ * @phpstan-type FileStat array{mtime:int, size:int}
  */
 interface FileSystemScannerInterface
 {
     /**
      * @param list<string> $paths
      *
-     * @return array<string, array{mtime:int, size:int}>
+     * @return array<string, FileStat>
      */
     public function snapshot(array $paths): array;
 }


### PR DESCRIPTION
## 🤔 Background

An 8-dimension code-quality sweep: deduplication, shared types, dead code, circular dependencies, weak types, defensive code, deprecated/legacy, and comments. Most dimensions turned out already clean, so this PR lands only the high-confidence, behavior-preserving fixes. Larger cross-module refactors surfaced by the sweep (a Compiler facade-interface relocation to break a module cycle, and a shared `:tag` extraction helper) are deferred to dedicated follow-up PRs.

## 💡 Goal

Land safe, verified code-quality improvements with zero behavior change.

## 🔖 Changes

- **Dead code**: remove 4 provably zero-reference internal symbols (`inline-call?`, `simple-string-gen`, `simple-keyword-gen`, and `GlobalEnvironmentSingleton::ensureInitialized()`).
- **Shared types**: centralize 3 duplicated PHPStan array-shape docblocks into named `@phpstan-type` / `@phpstan-import-type` across Lsp, Watch, and Profile (`Position`, `FileStat` 7 copies to 1, `FnStat` 5 copies to 1).
- **Weak types**: strengthen 4 `mixed` params to concrete native types in the compiler's meta-tag handling, deliberately leaving genuinely-dynamic Phel value boundaries as `mixed`.
- **Comments**: drop a stale-history comment in `rose.phel`.

Internal quality only, no user-facing behavior change, so no CHANGELOG entry. Verified locally: unit 4044, integration 1080, core 6516, PHPStan L9, and Psalm L1 all green.
