### PR TITLE
ref(core)!: remove ten long-deprecated core functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Removed
+
+- **BREAKING**: removed long-deprecated core functions, each a thin alias for its canonical form (#2784): `push` (use `conj`), `put` (use `assoc`), `unset` (use `dissoc`), `put-in` (use `assoc-in`), `unset-in` (use `dissoc-in`), `values` (use `vals`), `function?` (use `fn?`), `hash-map?` (use `map?`), `id` (use `identical?`), and `str-contains?` (use `phel\string\contains?`). The `push` branch of the assoc/conj emitter specialization is removed with them. See [the migration guide](docs/migration/removed-deprecated-core-fns.md). `set-meta!` stays deprecated-but-shipped, out of scope here.
+
 ## [0.49.0](https://github.com/phel-lang/phel-lang/compare/v0.48.0...v0.49.0) - 2026-07-22
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ modules, deployment) live on **[phel-lang.org](https://phel-lang.org/documentati
 - [Internals](internals/README.md): architecture, compiler phases, AST, emitter,
   macros, runtime, FAQ, benchmarks
 - [Migration: backslash to dot](migration/backslash-to-dot.md)
+- [Migration: removed deprecated core functions](migration/removed-deprecated-core-fns.md)
 - [Examples](examples/README.md): runnable single-file samples
 - [AI agents](../resources/agents/README.md): Claude Code, Cursor, Codex, Gemini, Copilot, Aider
 - [agent-docs](agent-docs.md) · [agent-metrics](agent-metrics.md)

--- a/docs/examples/14_doctrine-entity.phel
+++ b/docs/examples/14_doctrine-entity.phel
@@ -50,7 +50,7 @@
   "Pure: a new product with the price reduced by `pct` (0.0 .. 1.0).
   Structs are immutable, so this returns a fresh value instead of mutating."
   [p pct]
-  (put p :price (* (get p :price) (- 1 pct))))
+  (assoc p :price (* (get p :price) (- 1 pct))))
 
 ;; --- Prove the Doctrine mapping reached the generated PHP class --------------
 

--- a/docs/migration/removed-deprecated-core-fns.md
+++ b/docs/migration/removed-deprecated-core-fns.md
@@ -1,0 +1,44 @@
+# Migration: Removed Long-Deprecated Core Functions
+
+The core functions below were deprecated for many releases and are now **removed** ([#2784](https://github.com/phel-lang/phel-lang/issues/2784)). Each was a thin alias, so replace every call site with the canonical function; arguments and behavior are unchanged.
+
+| Removed | Deprecated since | Replacement |
+|---------|------------------|-------------|
+| `push` | 0.25.0 | `conj` |
+| `put` | 0.25.0 | `assoc` |
+| `unset` | 0.25.0 | `dissoc` |
+| `put-in` | 0.25.0 | `assoc-in` |
+| `unset-in` | 0.25.0 | `dissoc-in` |
+| `values` | 0.32.0 | `vals` |
+| `function?` | 0.32.0 | `fn?` |
+| `hash-map?` | 0.32.0 | `map?` |
+| `id` | 0.32.0 | `identical?` |
+| `str-contains?` | long-deprecated | `phel\string\contains?` |
+
+## How to migrate
+
+The replacement keeps the same signature:
+
+```phel
+(push coll x)      # -> (conj coll x)
+(put m :k v)       # -> (assoc m :k v)
+(unset m :k)       # -> (dissoc m :k)
+(put-in m ks v)    # -> (assoc-in m ks v)
+(unset-in m ks)    # -> (dissoc-in m ks)
+(values m)         # -> (vals m)
+(function? x)      # -> (fn? x)
+(hash-map? x)      # -> (map? x)
+(id a b)           # -> (identical? a b)
+```
+
+`str-contains?` now lives in the `phel\string` namespace:
+
+```phel
+(ns my-app (:require phel\string :as s))
+
+(str-contains? haystack needle)   # -> (s/contains? haystack needle)
+```
+
+## Still deprecated (not removed)
+
+`set-meta!` (use `with-meta`) remains available but deprecated; it is intentionally out of scope for this removal. The `warn-deprecations` infrastructure also stays, since it still serves live deprecations such as the `\` namespace separator (see [backslash-to-dot.md](backslash-to-dot.md)).

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -95,13 +95,6 @@
       (recur (first more) (next more))
       false)))
 
-(defn id
-  "Checks if all values are identical. Same as `a === b` in PHP."
-  {:deprecated "0.32.0"
-   :superseded-by "identical?"}
-  [a & more]
-  (apply identical? a more))
-
 (defn =
   "Checks if all values are equal (value equality, not identity)."
   {:example "(= [1 2 3] [1 2 3]) ; => true"}
@@ -328,12 +321,6 @@
   {:example "(nil? (get {:a 1} :b)) ; => true"}
   [x]
   (identical? x nil))
-
-(defn str-contains?
-  "Returns true if str contains s."
-  {:deprecated "Use phel\\string\\contains?"}
-  [str s]
-  (php/str_contains str s))
 
 (defn contains?
   "Returns true if key is present in collection (checks keys/indices, not values)."

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -307,13 +307,6 @@
   (or (php/instanceof x FnInterface)
       (php/is_callable x)))
 
-(defn function?
-  "Returns true if `x` is a function, false otherwise."
-  {:deprecated "0.32.0"
-   :superseded-by "fn?"}
-  [x]
-  (fn? x))
-
 (defn struct?
   "Returns true if `x` is a struct, false otherwise."
   [x]
@@ -326,13 +319,6 @@
   [x]
   (and (php/instanceof x PersistentMapInterface)
        (not (php/instanceof x AbstractPersistentStruct))))
-
-(defn hash-map?
-  "Returns true if `x` is a hash map, false otherwise."
-  {:deprecated "0.32.0"
-   :superseded-by "map?"}
-  [x]
-  (map? x))
 
 (defn vector?
   "Returns true if `x` is a vector. Map entries returned by iterating a hash map (`(first {:a 1})`) are vector-shaped two-element values, so this predicate also accepts the typed `MapEntry`."

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -350,13 +350,6 @@ Creates intermediate maps if they don't exist."
     (assoc ds k (assoc-in (get ds k {}) ks v))
     (assoc ds k v)))
 
-(defn put-in
-  "Puts a value into a nested data structure."
-  {:deprecated "0.25.0"
-   :superseded-by "assoc-in"}
-  [ds ks v]
-  (assoc-in ds ks v))
-
 (defn update
   "Updates a value in a datastructure by applying `f` to the current value."
   {:example "(update {:count 5} :count inc) ; => {:count 6}"
@@ -385,13 +378,6 @@ Creates intermediate maps if they don't exist."
         ds
         (assoc ds k (dissoc-in sub ks))))
     (dissoc ds k)))
-
-(defn unset-in
-  "Removes a value from a nested data structure."
-  {:deprecated "0.25.0"
-   :superseded-by "dissoc-in"}
-  [ds ks]
-  (dissoc-in ds ks))
 
 (defn drop
   "Drops the first `n` elements of `coll`. Returns a lazy sequence. When called with n only, returns a transducer."
@@ -835,14 +821,6 @@ Works with vectors, lists, sets, and strings."
    (let [start? (sorted-bound-fn sc start-test start-key)
          end?   (sorted-bound-fn sc end-test end-key)]
      (take-while start? (drop-while (fn [x] (not (end? x))) (rseq sc))))))
-
-(defn values
-  "Returns a sequence of all values in a map."
-  {:deprecated "0.32.0"
-   :superseded-by "vals"
-   :example "(values {:a 1 :b 2}) ; => [1 2]"}
-  [coll]
-  (vals coll))
 
 (defn pairs
   "Gets the pairs of an associative data structure."

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -47,13 +47,6 @@
         nil
         (php/aget coll (php/- n 1))))))
 
-(defn push
-  "Inserts `x` at the end of the sequence `coll`."
-  {:deprecated "0.25.0"
-   :superseded-by "conj"}
-  [coll x]
-  (conj coll x))
-
 (defn- pop*
   "Removes the last element of `coll`. Returns nil for nil or empty PHP arrays."
   [^:by-ref coll]
@@ -290,13 +283,6 @@
       (recur (assoc-pair acc (first remaining) (second remaining))
              (rest (rest remaining))))))
 
-(defn put
-  "Puts `value` mapped to `key` on the datastructure `ds`. Returns `ds`."
-  {:deprecated "0.25.0"
-   :superseded-by "assoc"}
-  [ds key value]
-  (assoc ds key value))
-
 (defn- dissoc-one
   [ds key]
   (cond
@@ -324,10 +310,3 @@
     (if (empty? remaining)
       acc
       (recur (dissoc-one acc (first remaining)) (next remaining)))))
-
-(defn unset
-  "Returns `ds` without `key`."
-  {:deprecated "0.25.0"
-   :superseded-by "dissoc"}
-  [ds key]
-  (dissoc ds key))

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/AssocConjSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/AssocConjSpecialization.php
@@ -63,7 +63,7 @@ final readonly class AssocConjSpecialization
             };
         }
 
-        if (($name === 'conj' || $name === 'push') && $argCount === 2) {
+        if ($name === 'conj' && $argCount === 2) {
             return match ($tag) {
                 PersistentVectorInterface::class => 'append',
                 default => null,

--- a/tests/phel/ai.phel
+++ b/tests/phel/ai.phel
@@ -313,7 +313,7 @@
                  {:text "b" :embedding [0.9 0.1 0.4]}
                  {:text "c" :embedding [0 0 0]}]
         results (ai/nearest query index 3)
-        by-text (reduce (fn [acc r] (put acc (get r :text) r)) {} results)]
+        by-text (reduce (fn [acc r] (assoc acc (get r :text) r)) {} results)]
     (foreach [item index]
       (let [r (get by-text (get item :text))]
         (is (= (ai/cosine-similarity query (get item :embedding))
@@ -348,28 +348,28 @@
 
 (deftest test-public-functions-exist
   ;; Chat API
-  (is (function? ai/configure) "configure is defined")
-  (is (function? ai/chat) "chat is defined")
+  (is (fn? ai/configure) "configure is defined")
+  (is (fn? ai/chat) "chat is defined")
   ;; with-config is a macro, can't use function? directly
-  (is (function? ai/complete) "complete is defined")
-  (is (function? ai/chat-with-history) "chat-with-history is defined")
+  (is (fn? ai/complete) "complete is defined")
+  (is (fn? ai/chat-with-history) "chat-with-history is defined")
   ;; Structured extraction & tools
-  (is (function? ai/extract) "extract is defined")
-  (is (function? ai/extract-many) "extract-many is defined")
-  (is (function? ai/tool) "tool is defined")
-  (is (function? ai/chat-with-tools) "chat-with-tools is defined")
-  (is (function? ai/tool-calls) "tool-calls is defined")
-  (is (function? ai/tool-result) "tool-result is defined")
-  (is (function? ai/run-tools) "run-tools is defined")
+  (is (fn? ai/extract) "extract is defined")
+  (is (fn? ai/extract-many) "extract-many is defined")
+  (is (fn? ai/tool) "tool is defined")
+  (is (fn? ai/chat-with-tools) "chat-with-tools is defined")
+  (is (fn? ai/tool-calls) "tool-calls is defined")
+  (is (fn? ai/tool-result) "tool-result is defined")
+  (is (fn? ai/run-tools) "run-tools is defined")
   ;; Embeddings & search
-  (is (function? ai/dot-product) "dot-product is defined")
-  (is (function? ai/magnitude) "magnitude is defined")
-  (is (function? ai/cosine-similarity) "cosine-similarity is defined")
-  (is (function? ai/embed) "embed is defined")
-  (is (function? ai/embed-one) "embed-one is defined")
-  (is (function? ai/nearest) "nearest is defined")
-  (is (function? ai/build-index) "build-index is defined")
-  (is (function? ai/search) "search is defined"))
+  (is (fn? ai/dot-product) "dot-product is defined")
+  (is (fn? ai/magnitude) "magnitude is defined")
+  (is (fn? ai/cosine-similarity) "cosine-similarity is defined")
+  (is (fn? ai/embed) "embed is defined")
+  (is (fn? ai/embed-one) "embed-one is defined")
+  (is (fn? ai/nearest) "nearest is defined")
+  (is (fn? ai/build-index) "build-index is defined")
+  (is (fn? ai/search) "search is defined"))
 
 ;; =====================================================================
 ;; Mock-HTTP coverage — exercises chat/complete/extract/chat-with-tools

--- a/tests/phel/core/basic-constructors.phel
+++ b/tests/phel/core/basic-constructors.phel
@@ -382,7 +382,7 @@
     (is (= :struct (type x)) "struct: common type")
     (is (true? (struct? x)) "struct: common type test")
     (is (= 1 (get x :a)) "struct: get value from struct")
-    (is (= (my-struct 12 2 3) (put x :a 12)) "struct: put value on struct")
+    (is (= (my-struct 12 2 3) (assoc x :a 12)) "struct: put value on struct")
     (is (true? (my-struct? x)) "struct: correct type")
     (is (false? (my-struct? :a)) "struct: incorrect type")))
 
@@ -425,6 +425,6 @@
                 "JF1260"        1
                 "JF1261"        1
                 "jiKUic"        1}
-        result (put m "PU4NVO" 1)]
+        result (assoc m "PU4NVO" 1)]
     (is (= 18 (count result)))
     (is (= 1 (result "PU4NVO")))))

--- a/tests/phel/core/basic-constructors.phel
+++ b/tests/phel/core/basic-constructors.phel
@@ -382,7 +382,7 @@
     (is (= :struct (type x)) "struct: common type")
     (is (true? (struct? x)) "struct: common type test")
     (is (= 1 (get x :a)) "struct: get value from struct")
-    (is (= (my-struct 12 2 3) (assoc x :a 12)) "struct: put value on struct")
+    (is (= (my-struct 12 2 3) (assoc x :a 12)) "struct: assoc value on struct")
     (is (true? (my-struct? x)) "struct: correct type")
     (is (false? (my-struct? :a)) "struct: incorrect type")))
 
@@ -407,7 +407,7 @@
     (is (= 1 (xs 0)) "list can be invoked to access elements")
     (is (= 3 (xs 2)) "list invocation supports other indices")))
 
-(deftest test-hash-map-put-17th-notice-issue-786
+(deftest test-hash-map-assoc-17th-notice-issue-786
   (let [m      {""              1
                 "0Mlq3z"        1
                 "bTOQLr"        1

--- a/tests/phel/core/boolean-operation.phel
+++ b/tests/phel/core/boolean-operation.phel
@@ -23,18 +23,6 @@
   (is (false? (and false 10)) "(and false 10)")
   (is (= 10 (and 10)) "(and 10)"))
 
-(deftest test-id
-  (is (true? (id false)) "(id false)")
-  (is (true? (id false false)) "(id false false)")
-  (is (true? (id false false false)) "(id false false false)")
-  (is (false? (id false true false)) "(id false true false)")
-  (is (true? (id 10 10)) "(id 10 10)")
-  (is (false? (id 10 10.0)) "(id 10 10.0)")
-  (is (true? (id :test :test)) "keywords are always identical")
-  (is (true? (id 'test 'test)) "symbol are always identical")
-  (is (false? (id [] [])) "two empty vectors are not identical")
-  (is (false? (id {} {})) "two empty maps are not identical"))
-
 (deftest test-=
   (is (true? (= false)) "(= false)")
   (is (true? (false? false)) "(false? false)")
@@ -249,10 +237,6 @@
   (is (true? (false? false)) "(false? false)")
   (is (false? (false? nil)) "(false? nil)")
   (is (false? (false? true)) "(false? true)"))
-
-(deftest test-str-contains?
-  (is (true? (str-contains? "abc" "a")))
-  (is (false? (str-contains? "abc" "d"))))
 
 (deftest test-contains?-map
   (let [full-name {:first-name "Marco" :last-name "Polo" :street nil}]

--- a/tests/phel/core/clojure-aliases.phel
+++ b/tests/phel/core/clojure-aliases.phel
@@ -24,17 +24,11 @@
   (is (true? (identical? :test :test)) "keywords are identical")
   (is (true? (identical? 1)) "single arg returns true"))
 
-(deftest test-id-still-works
-  (is (true? (id 10 10)) "deprecated id still works"))
-
 ;; --- fn? / function? aliases ---
 
 (deftest test-fn?
   (is (true? (fn? concat)) "fn? on function")
   (is (false? (fn? 42)) "fn? on int"))
-
-(deftest test-function?-still-works
-  (is (true? (function? concat)) "deprecated function? still works"))
 
 ;; --- map? / hash-map? aliases ---
 
@@ -42,17 +36,11 @@
   (is (true? (map? {})) "map? on map")
   (is (false? (map? [])) "map? on vector"))
 
-(deftest test-hash-map?-still-works
-  (is (true? (hash-map? {})) "deprecated hash-map? still works"))
-
 ;; --- vals / values aliases ---
 
 (deftest test-vals
   (is (= [1 2 3] (vals {:a 1 :b 2 :c 3})) "vals of map")
   (is (= [3 2 1] (vals [3 2 1])) "vals of vector"))
-
-(deftest test-values-still-works
-  (is (= [1 2 3] (values {:a 1 :b 2 :c 3})) "deprecated values still works"))
 
 ;; --- with-meta (public) / set-meta! ---
 

--- a/tests/phel/core/defstruct-readonly.phel
+++ b/tests/phel/core/defstruct-readonly.phel
@@ -20,14 +20,14 @@
 
 (deftest readonly-struct-put-returns-new-instance
   (let [p (point 1 2)
-        q (put p :x 9)]
+        q (assoc p :x 9)]
     (is (= 9 (q :x)) "put updates the field on the new instance")
     (is (= 2 (q :y)) "other fields are preserved")
     (is (= 1 (p :x)) "original struct is unchanged")))
 
 (deftest readonly-untyped-struct-still-works
   (let [u (untyped-point 1 2)
-        v (put u :a 5)]
+        v (assoc u :a 5)]
     (is (= 5 (v :a)) "untyped readonly field updates via put")
     (is (= 1 (u :a)) "original is unchanged")))
 

--- a/tests/phel/core/defstruct-readonly.phel
+++ b/tests/phel/core/defstruct-readonly.phel
@@ -18,7 +18,7 @@
   (let [ro (readonly-prop? "phel_test\\core\\defstruct_readonly\\point" "x")]
     (is (true? ro) "x property is declared readonly")))
 
-(deftest readonly-struct-put-returns-new-instance
+(deftest readonly-struct-assoc-returns-new-instance
   (let [p (point 1 2)
         q (assoc p :x 9)]
     (is (= 9 (q :x)) "put updates the field on the new instance")

--- a/tests/phel/core/dissoc-typed-collection.phel
+++ b/tests/phel/core/dissoc-typed-collection.phel
@@ -1,4 +1,4 @@
-(ns phel-test.core.push-dissoc-typed-collection
+(ns phel-test.core.dissoc-typed-collection
   (:require phel.test :refer [deftest is]))
 
 ;; Tagged `dissoc` takes the specialised emitter path (a direct

--- a/tests/phel/core/doseq.phel
+++ b/tests/phel/core/doseq.phel
@@ -13,38 +13,38 @@
     (doseq [x :in [1 2 3 4]
             :when (even? x)
             :let [y (* x 2)]]
-      (swap! captured (fn [xs] (push xs y))))
+      (swap! captured (fn [xs] (conj xs y))))
     (is (= [4 8] (deref captured)) "doseq honors modifiers from for")))
 
 (deftest test-doseq-clojure-style-bindings
   (let [captured (atom [])]
     (doseq [x [1 2 3]]
-      (swap! captured (fn [xs] (push xs x))))
+      (swap! captured (fn [xs] (conj xs x))))
     (is (= [1 2 3] (deref captured)) "doseq accepts Clojure-style binding pairs")))
 
 (deftest test-doseq-clojure-style-nested
   (let [captured (atom [])]
     (doseq [x [1 2]
             y [3 4]]
-      (swap! captured (fn [xs] (push xs [x y]))))
+      (swap! captured (fn [xs] (conj xs [x y]))))
     (is (= [[1 3] [1 4] [2 3] [2 4]] (deref captured)) "doseq nested Clojure-style")))
 
 (deftest test-doseq-clojure-style-with-when
   (let [captured (atom [])]
     (doseq [x [1 2 3 4 5]
             :when (odd? x)]
-      (swap! captured (fn [xs] (push xs x))))
+      (swap! captured (fn [xs] (conj xs x))))
     (is (= [1 3 5] (deref captured)) "doseq Clojure-style with :when modifier")))
 
 (deftest test-doseq-map-destructuring
   (let [captured (atom {})]
     (doseq [[k v] {:a 0 :b 1}]
-      (swap! captured put k v))
+      (swap! captured assoc k v))
     (is (= {:a 0 :b 1} (deref captured))
         "doseq binds [k v] from map entries, Clojure-aligned"))
   (let [captured (atom [])]
     (doseq [entry {:a 0 :b 1}]
-      (swap! captured (fn [xs] (push xs entry))))
+      (swap! captured (fn [xs] (conj xs entry))))
     (is (= [[:a 0] [:b 1]] (deref captured))
         "doseq yields [k v] pair vectors when iterating a map"))
   (let [acc (atom {})]
@@ -56,7 +56,7 @@
 (deftest test-doseq-vector-of-vectors-destructuring
   (let [captured (atom [])]
     (doseq [[a b] [[1 2] [3 4]]]
-      (swap! captured (fn [xs] (push xs (+ a b)))))
+      (swap! captured (fn [xs] (conj xs (+ a b)))))
     (is (= [3 7] (deref captured))
         "doseq destructuring over vector of vectors still iterates elements")))
 
@@ -70,7 +70,7 @@
   (let [captured (atom {})]
     (doseq [[k v] {:a 1 :b 2 :c 3}
             :when (odd? v)]
-      (swap! captured put k v))
+      (swap! captured assoc k v))
     (is (= {:a 1 :c 3} (deref captured))
         "doseq over map honors :when modifier after destructuring")))
 
@@ -78,7 +78,7 @@
   (let [captured (atom {})]
     (doseq [[k v] {:a 1 :b 2}
             :let [v2 (* v 10)]]
-      (swap! captured put k v2))
+      (swap! captured assoc k v2))
     (is (= {:a 10 :b 20} (deref captured))
         "doseq over map supports :let over destructured bindings")))
 
@@ -93,7 +93,7 @@
   (let [captured (atom [])]
     (doseq [[k v] {:a 1 :b 2}
             i [10 20]]
-      (swap! captured (fn [xs] (push xs [k (+ v i)]))))
+      (swap! captured (fn [xs] (conj xs [k (+ v i)]))))
     (is (= [[:a 11] [:a 21] [:b 12] [:b 22]] (deref captured))
         "doseq supports Clojure-style map destructuring nested with a vector iteration")))
 

--- a/tests/phel/core/for-loop.phel
+++ b/tests/phel/core/for-loop.phel
@@ -34,7 +34,7 @@
   (is
    (=
     {0 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7 8 8 9 9 10 10 11 11 12 12 13 13 14 14 15 15 16 16 17 17 18 18 19 19}
-    (let [x (transient {})] (for [i :range [0 20]] (put x i i)) (persistent x)))
+    (let [x (transient {})] (for [i :range [0 20]] (assoc x i i)) (persistent x)))
    "for loop with transient map"))
 
 (deftest test-reduce

--- a/tests/phel/core/function-operation.phel
+++ b/tests/phel/core/function-operation.phel
@@ -81,8 +81,8 @@
 (deftest test-some-fn-pred-order
   ;; All preds are tried on all args before moving to next pred
   (let [log (atom [])
-        p1  (fn [x] (swap! log push [:p1 x]) nil)
-        p2  (fn [x] (swap! log push [:p2 x]) (= x :match))]
+        p1  (fn [x] (swap! log conj [:p1 x]) nil)
+        p2  (fn [x] (swap! log conj [:p2 x]) (= x :match))]
     ((some-fn p1 p2) :a :match)
     (is (= [[:p1 :a] [:p1 :match] [:p2 :a] [:p2 :match]] (deref log))
         "some-fn tries each pred on all args before advancing")))
@@ -125,8 +125,8 @@
 (deftest test-every-pred-pred-order
   ;; All preds are tried on all args before moving to next pred
   (let [log (atom [])
-        p1  (fn [x] (swap! log push [:p1 x]) true)
-        p2  (fn [x] (swap! log push [:p2 x]) true)]
+        p1  (fn [x] (swap! log conj [:p1 x]) true)
+        p2  (fn [x] (swap! log conj [:p2 x]) true)]
     ((every-pred p1 p2) :a :b)
     (is (= [[:p1 :a] [:p1 :b] [:p2 :a] [:p2 :b]] (deref log))
         "every-pred tries each pred on all args before advancing")))

--- a/tests/phel/core/meta.phel
+++ b/tests/phel/core/meta.phel
@@ -68,7 +68,7 @@
   (let [m    {:foo "bar"}
         data (set-meta! {:a 1 :b 2} m)]
     (is (= m (meta (keys data))) "keys preserves metadata")
-    (is (= m (meta (vals data))) "values preserves metadata")
+    (is (= m (meta (vals data))) "vals preserves metadata")
     (is (= m (meta (pairs data))) "pairs preserves metadata")
     (is (= m (meta (kvs data))) "kvs preserves metadata")
     (is (= m (meta (select-keys data [:a]))) "select-keys preserves metadata")))

--- a/tests/phel/core/meta.phel
+++ b/tests/phel/core/meta.phel
@@ -57,7 +57,7 @@
     (is (= m (meta (frequencies data))) "frequencies preserves metadata")))
 
 (deftest test-vary-meta
-  (is (= {:a 1 :b 2} (meta (vary-meta (set-meta! [] {:a 1}) put :b 2)))
+  (is (= {:a 1 :b 2} (meta (vary-meta (set-meta! [] {:a 1}) assoc :b 2)))
       "vary-meta adds key to existing metadata")
   (is (= {:count 1} (meta (vary-meta (set-meta! [] {:count 0}) update-in [:count] inc)))
       "vary-meta with update-in")
@@ -68,7 +68,7 @@
   (let [m    {:foo "bar"}
         data (set-meta! {:a 1 :b 2} m)]
     (is (= m (meta (keys data))) "keys preserves metadata")
-    (is (= m (meta (values data))) "values preserves metadata")
+    (is (= m (meta (vals data))) "values preserves metadata")
     (is (= m (meta (pairs data))) "pairs preserves metadata")
     (is (= m (meta (kvs data))) "kvs preserves metadata")
     (is (= m (meta (select-keys data [:a]))) "select-keys preserves metadata")))

--- a/tests/phel/core/multi-arity-fn.phel
+++ b/tests/phel/core/multi-arity-fn.phel
@@ -41,7 +41,7 @@
                (fact 5)))
       "named fn bound to a different local still self-recurses")
   (is (= [1 2 3 4 5] ((fn collect [n]
-                        (if (zero? n) [] (push (collect (dec n)) n))) 5))
+                        (if (zero? n) [] (conj (collect (dec n)) n))) 5))
       "named fn with non-trivial recursive body"))
 
 (deftest named-fn-multi-arity-self-call
@@ -63,7 +63,7 @@
         "inner f does not collide with outer f name from sibling fn")))
 
 (deftest multi-arity-fn-returned-from-fn
-  (let [make (fn [x]
+  (let [make  (fn [x]
                (fn
                  ([a] (+ a x))
                  ([a b] (+ a b x))))

--- a/tests/phel/core/ns.phel
+++ b/tests/phel/core/ns.phel
@@ -74,13 +74,13 @@
 
 (deftest test-ns-publics-returns-map
   (let [publics (ns-publics "phel\\core")]
-    (is (hash-map? publics) "ns-publics returns a hash-map")
+    (is (map? publics) "ns-publics returns a hash-map")
     (is (> (count publics) 0) "ns-publics has entries for phel\\core")
     (is (not (nil? (get publics "map"))) "ns-publics contains 'map'")))
 
 (deftest test-ns-aliases-and-refers
-  (is (hash-map? (ns-aliases "phel\\core")) "ns-aliases returns a hash-map")
-  (is (hash-map? (ns-refers "phel\\core")) "ns-refers returns a hash-map"))
+  (is (map? (ns-aliases "phel\\core")) "ns-aliases returns a hash-map")
+  (is (map? (ns-refers "phel\\core")) "ns-refers returns a hash-map"))
 
 ;; ----------------------------------------------------------------------------
 ;; Dot-separator parity (#1795)

--- a/tests/phel/core/php-callable.phel
+++ b/tests/phel/core/php-callable.phel
@@ -12,7 +12,7 @@
 
 (deftest free-function-callable-runs
   (is (= "HI" (upper "hi")) "the free-function callable invokes the PHP function")
-  (is (true? (function? upper)) "it is a real callable value"))
+  (is (true? (fn? upper)) "it is a real callable value"))
 
 (deftest static-method-callable-runs
   (is (= :foo (make-kw "foo")) "the static-method callable invokes Keyword::create"))

--- a/tests/phel/core/push-dissoc-typed-collection.phel
+++ b/tests/phel/core/push-dissoc-typed-collection.phel
@@ -1,16 +1,9 @@
 (ns phel-test.core.push-dissoc-typed-collection
   (:require phel.test :refer [deftest is]))
 
-;; Tagged targets take the specialised emitter path
-;; (direct PersistentVector::append / PersistentMap::remove chain);
-;; the untagged counterparts go through the runtime dispatch. Both
-;; must agree.
-
-(defn- push-tagged [^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" v x]
-  (push v x))
-
-(defn- push-untagged [v x]
-  (push v x))
+;; Tagged `dissoc` takes the specialised emitter path (a direct
+;; PersistentMap::remove chain); the untagged counterpart goes through
+;; runtime dispatch. Both must agree.
 
 (defn- dissoc-tagged [^"\Phel\Lang\Collections\Map\PersistentMapInterface" m & ks]
   (apply dissoc m ks))
@@ -23,12 +16,6 @@
 
 (defn- dissoc-tagged-1 [^"\Phel\Lang\Collections\Map\PersistentMapInterface" m a]
   (dissoc m a))
-
-(deftest test-push-typed-vector-matches-runtime
-  (is (= [1 2 3] (push-tagged [1 2] 3)) "specialised push appends to a vector")
-  (is (= (push-untagged [1 2] 3) (push-tagged [1 2] 3))
-      "tagged push agrees with untagged push")
-  (is (= [99] (push-tagged [] 99)) "specialised push onto empty vector"))
 
 (deftest test-dissoc-variadic-typed-map-matches-runtime
   (is (= {:b 2} (dissoc-tagged-1 {:a 1 :b 2} :a))

--- a/tests/phel/core/sequence-functions.phel
+++ b/tests/phel/core/sequence-functions.phel
@@ -361,10 +361,6 @@
   (is (nil? (keys {})) "keys of empty map is nil")
   (is (nil? (keys [])) "keys of empty vector is nil"))
 
-(deftest test-values
-  (is (= [1 2 3] (values {:a 1 :b 2 :c 3})) "values of map")
-  (is (= [3 2 1] (values [3 2 1])) "values of vector"))
-
 (deftest test-vals
   (is (= [1 2 3] (vals {:a 1 :b 2 :c 3})) "vals of map")
   (is (nil? (vals nil)) "vals of nil is nil")
@@ -568,7 +564,7 @@
   (is (= {:a {:b {:c [:d :e] :f :g}}} (deep-merge {:a {:b {:c [:d]}}} {:a {:b {:c [:e] :f :g}}}))))
 
 (deftest test-collection-stay-the-same-in-deep-merge
-  (is (hash-map? (deep-merge {:a :b} {:c :d})))
+  (is (map? (deep-merge {:a :b} {:c :d})))
   (is (vector? (deep-merge [:a :b] [:c])))
   (is (set? (deep-merge (hash-set :a :b) (hash-set :c))))
   (is (list? (deep-merge '(:a :b) '(:c)))))

--- a/tests/phel/core/sequence-operation.phel
+++ b/tests/phel/core/sequence-operation.phel
@@ -64,29 +64,10 @@
     (php/apush-in arr [0] 3)
     (is (= (php/array (php/array 1 2 3)) arr) "nested php array push")))
 
-(deftest test-push
+(deftest test-native-apush
   (let [x (php/array)]
     (php/apush x 1)
-    (is (= (php/array 1) x) "native push on PHP array"))
-
-  (let [x (php/array)]
-    (is (= (php/array 1) (push x 1)) "push on PHP array"))
-
-  (let [x (php/array)]
-    (push x 1)
-    (is (= (php/array) x) "push on PHP array, keeps initial state because it's immutable"))
-
-  (let [x []]
-    (push x 1)
-    (is (= [] x) "push on existing vector, keeps initial state because it's immutable"))
-
-  (is (= [1] (push [] 1)) "push on vector")
-
-  (let [x (hash-set)]
-    (push x 1)
-    (is (= (hash-set) x) "push on existing set, keeps initial state because it's immutable"))
-
-  (is (= #{1} (push #{} 1)) "push on set"))
+    (is (= (php/array 1) x) "native push on PHP array")))
 
 (deftest test-conj
   (is (= [] (conj)) "conj without arguments returns an empty vector")
@@ -302,7 +283,7 @@
   (is (= "x" (get nil 1 "x")) "get on nil with optional value")
   (is (= "x" (get {:a "a" :b "b"} :c "x")) "get on undefined key with optional value on map")
   (is (= "x" (get #{} 4 "x")) "get on undefined key with optional value on set")
-  (is (id 0 (get {:a 0} :a)) "gets zero from a map"))
+  (is (identical? 0 (get {:a 0} :a)) "gets zero from a map"))
 
 (deftest test-get-keyword
   (is (= 1 (:a {:a 1 :b 2})))
@@ -388,11 +369,6 @@
   (is (nil? (nthnext [1 2] 5)) "nthnext past end returns nil")
   (is (nil? (nthnext nil 3)) "nthnext on nil returns nil"))
 
-(deftest test-put
-  (is (= {:a nil :b 2} (put {:a 1 :b 2} :a nil)) "put: nil on map")
-  (is (= {:a 3 :b 2} (put {:a 1 :b 2} :a 3)) "put: replace entry on map")
-  (is (= {:a 1 :b 2 :c 3} (put {:a 1 :b 2} :c 3)) "put: append entry on map"))
-
 (deftest test-assoc
   (is (= {:a nil :b 2} (assoc {:a 1 :b 2} :a nil)) "assoc: nil on map")
   (is (= {:a 3 :b 2} (assoc {:a 1 :b 2} :a 3)) "assoc: replace entry on map")
@@ -417,9 +393,6 @@
   ;; TypeError (or, on older builds, a raw int-coercion warning).
   (is (thrown? \InvalidArgumentException (assoc [1 2 3] :k 9)) "assoc: rejects keyword key on vector")
   (is (thrown? \InvalidArgumentException (assoc [1 2 3] "0" 9)) "assoc: rejects string key on vector"))
-
-(deftest test-unset
-  (is (= {:b 2} (unset {:a 1 :b 2} :a)) "unset: remove key from map"))
 
 (deftest test-dissoc
   (is (= {:b 2} (dissoc {:a 1 :b 2} :a)) "dissoc: remove key from map")

--- a/tests/phel/core/set-operation.phel
+++ b/tests/phel/core/set-operation.phel
@@ -74,10 +74,10 @@
 
 (deftest test-set-push
   (let [s1 (hash-set 1 2)
-        s2 (push s1 3)]
+        s2 (conj s1 3)]
     (is (= (hash-set 1 2 3) s2) "set push"))
   (let [s1 (hash-set 1 2)
-        s2 (push s1 2)]
+        s2 (conj s1 2)]
     (is (= (hash-set 1 2) s2) "set push existing value")))
 
 (deftest test-set-concat

--- a/tests/phel/core/sorted-collections.phel
+++ b/tests/phel/core/sorted-collections.phel
@@ -23,14 +23,14 @@
 
 (deftest test-sorted-map-put-maintains-order
   (let [m (sorted-map :b 2 :a 1)]
-    (is (= [:a :b :c] (keys (put m :c 3))) "put maintains order")))
+    (is (= [:a :b :c] (keys (assoc m :c 3))) "put maintains order")))
 
 (deftest test-sorted-map-remove-maintains-order
   (let [m (sorted-map :c 3 :b 2 :a 1)]
-    (is (= [:a :c] (keys (unset m :b))) "unset maintains order")))
+    (is (= [:a :c] (keys (dissoc m :b))) "unset maintains order")))
 
 (deftest test-sorted-map-is-map
-  (is (hash-map? (sorted-map :a 1)) "hash-map? returns true for sorted map"))
+  (is (map? (sorted-map :a 1)) "hash-map? returns true for sorted map"))
 
 (deftest test-sorted-map-merge
   (let [m1     (sorted-map 1 "a" 3 "c")
@@ -40,7 +40,7 @@
 
 (deftest test-sorted-map-persistent
   (let [m1 (sorted-map :a 1)
-        m2 (put m1 :b 2)]
+        m2 (assoc m1 :b 2)]
     (is (= 1 (count m1)) "original unchanged")
     (is (= 2 (count m2)) "new map has both entries")))
 
@@ -53,7 +53,7 @@
 (deftest test-sorted-map-by-operations
   (let [m (sorted-map-by (fn [a b] (compare b a)) 1 "a" 2 "b")]
     (is (= "a" (get m 1)) "get works with custom comparator")
-    (is (= [3 2 1] (keys (put m 3 "c"))) "put maintains custom order")))
+    (is (= [3 2 1] (keys (assoc m 3 "c"))) "put maintains custom order")))
 
 (deftest test-sorted-map-by-with-predicate-comparator
   (is (= [13 14 15] (keys (sorted-map-by < 13 :a 14 :b 15 :c)))

--- a/tests/phel/core/tag-types.phel
+++ b/tests/phel/core/tag-types.phel
@@ -17,7 +17,7 @@
 
 (deftest typed-struct-still-persistent
   (let [a (boxed 1)
-        b (put a :value "two")]
+        b (assoc a :value "two")]
     (is (= 1 (a :value)) "original is unchanged")
     (is (= "two" (b :value)) "put returns an updated copy")))
 

--- a/tests/phel/core/type-operation.phel
+++ b/tests/phel/core/type-operation.phel
@@ -287,9 +287,6 @@
   (is (false? (special-symbol? 42)) "special-symbol? on integer")
   (is (false? (special-symbol? nil)) "special-symbol? on nil"))
 
-(deftest test-function?
-  (is (true? (function? concat)) "function? on concat"))
-
 (deftest test-ifn?
   (is (true? (ifn? inc)) "ifn? on function")
   (is (true? (ifn? :a)) "ifn? on keyword")
@@ -306,9 +303,6 @@
   (is (= 1 ('a {'a 1})) "symbol looks itself up in a map")
   (is (= "default" ('a {} "default")) "symbol returns default when key missing")
   (is (nil? ('a nil)) "symbol on nil returns nil"))
-
-(deftest test-hash-map?
-  (is (true? (hash-map? {})) "hash-map?"))
 
 (deftest test-vector?
   (is (true? (vector? [])) "vector?")

--- a/tests/phel/core/utility-functions.phel
+++ b/tests/phel/core/utility-functions.phel
@@ -218,7 +218,7 @@
 
 (deftest test-eval-form
   (is (= 2 (eval '(+ 1 1))) "eval simple expression")
-  (is (function? (eval (fn [x] x))) "eval returns a closure passed in unchanged")
+  (is (fn? (eval (fn [x] x))) "eval returns a closure passed in unchanged")
   (let [identity-fn (fn [x] x)]
     (is (= identity-fn (eval identity-fn)) "eval of a closure returns the same closure"))
   (is (= 42 ((eval (fn [x] x)) 42)) "closure returned by eval is callable"))

--- a/tests/phel/core/vars-watchers.phel
+++ b/tests/phel/core/vars-watchers.phel
@@ -9,7 +9,7 @@
 (deftest test-add-watch-fires-on-alter-var-root
   (let [log (atom [])]
     (add-watch #'watched-counter :log
-               (fn [k r o n] (swap! log (fn [xs] (push xs [o n])))))
+               (fn [k r o n] (swap! log (fn [xs] (conj xs [o n])))))
     (alter-var-root #'watched-counter inc)
     (alter-var-root #'watched-counter inc)
     (is (= [[0 1] [1 2]] (deref log))

--- a/tests/phel/core/watches-validators.phel
+++ b/tests/phel/core/watches-validators.phel
@@ -43,7 +43,7 @@
         v   (atom 0)]
     (add-watch v :logger
                (fn [key ref old-val new-val]
-                 (swap! log (fn [xs] (push xs [old-val new-val])))))
+                 (swap! log (fn [xs] (conj xs [old-val new-val])))))
     (swap! v inc)
     (swap! v inc)
     (is (= [[0 1] [1 2]] (deref log)) "watch fires on each swap")))
@@ -53,7 +53,7 @@
         v   (atom :a)]
     (add-watch v :log
                (fn [key ref old-val new-val]
-                 (swap! log (fn [xs] (push xs new-val)))))
+                 (swap! log (fn [xs] (conj xs new-val)))))
     (reset! v :b)
     (reset! v :c)
     (is (= [:b :c] (deref log)) "watch fires on set!")))
@@ -88,8 +88,8 @@
   (let [log-a (atom [])
         log-b (atom [])
         v     (atom 0)]
-    (add-watch v :a (fn [k r o n] (swap! log-a (fn [xs] (push xs n)))))
-    (add-watch v :b (fn [k r o n] (swap! log-b (fn [xs] (push xs n)))))
+    (add-watch v :a (fn [k r o n] (swap! log-a (fn [xs] (conj xs n)))))
+    (add-watch v :b (fn [k r o n] (swap! log-b (fn [xs] (conj xs n)))))
     (swap! v inc)
     (is (= [1] (deref log-a)) "watch :a fires")
     (is (= [1] (deref log-b)) "watch :b fires")))
@@ -135,7 +135,7 @@
   (let [log (atom [])
         v   (atom 1)]
     (set-validator! v pos?)
-    (add-watch v :log (fn [k r o n] (swap! log (fn [xs] (push xs n)))))
+    (add-watch v :log (fn [k r o n] (swap! log (fn [xs] (conj xs n)))))
     (swap! v inc)
     (is (= [2] (deref log)) "watch fires when validator passes")))
 

--- a/tests/phel/gen.phel
+++ b/tests/phel/gen.phel
@@ -115,7 +115,7 @@
 (deftest test-map-of
   (let [vs (g/sample (g/map-of g/keyword g/nat) 10
                      {:size 3 :seed fixed-seed})]
-    (is (every? hash-map? vs))))
+    (is (every? map? vs))))
 
 (deftest test-set-of
   (let [vs (g/sample (g/set-of g/nat) 10 {:size 4 :seed fixed-seed})]

--- a/tests/phel/phel-async-fqn-regression.phel
+++ b/tests/phel/phel-async-fqn-regression.phel
@@ -2,10 +2,10 @@
   (:require phel.test :refer [deftest is]))
 
 (deftest phel-async-delay-resolves-via-fqn
-  (is (function? phel.async/delay)))
+  (is (fn? phel.async/delay)))
 
 (deftest phel-html-escape-resolves-via-fqn
-  (is (function? phel.html/escape-html)))
+  (is (fn? phel.html/escape-html)))
 
 (deftest phel-json-encode-resolves-via-fqn
-  (is (function? phel.json/encode)))
+  (is (fn? phel.json/encode)))

--- a/tests/phel/pprint.phel
+++ b/tests/phel/pprint.phel
@@ -1,6 +1,7 @@
 (ns phel-test.pprint
   (:require phel.test :refer [deftest is])
-  (:require phel.pprint :refer [pprint-str inspect]))
+  (:require phel.pprint :refer [pprint-str inspect])
+  (:require phel.string :as s))
 
 ;; ---------------------------
 ;; Scalar values (no wrapping)
@@ -32,11 +33,11 @@
 
 (deftest test-pprint-wide-vector
   (let [result (pprint-str [1 2 3 4 5] 10)]
-    (is (str-contains? result "\n") "wide vector wraps to multiple lines")))
+    (is (s/contains? result "\n") "wide vector wraps to multiple lines")))
 
 (deftest test-pprint-wide-map
   (let [result (pprint-str {:alpha "one" :beta "two" :gamma "three"} 20)]
-    (is (str-contains? result "\n") "wide map wraps to multiple lines")))
+    (is (s/contains? result "\n") "wide map wraps to multiple lines")))
 
 ;; --------------------------------
 ;; Nested structures
@@ -44,12 +45,12 @@
 
 (deftest test-pprint-nested
   (let [result (pprint-str {:a [1 2 3] :b {:c 4 :d 5}} 20)]
-    (is (str-contains? result "\n") "nested structure wraps")))
+    (is (s/contains? result "\n") "nested structure wraps")))
 
 (deftest test-pprint-deeply-nested
   (let [data   {:a {:b {:c [1 2 3]}}}
         result (pprint-str data 15)]
-    (is (str-contains? result "\n") "deeply nested structure wraps")))
+    (is (s/contains? result "\n") "deeply nested structure wraps")))
 
 ;; --------------------------------
 ;; Custom width
@@ -58,7 +59,7 @@
 (deftest test-pprint-custom-width
   (is (= "[1 2 3]" (pprint-str [1 2 3] 80)) "wide enough stays on one line")
   (let [result (pprint-str [1 2 3] 5)]
-    (is (str-contains? result "\n") "narrow width forces wrapping")))
+    (is (s/contains? result "\n") "narrow width forces wrapping")))
 
 ;; --------------------------------
 ;; Empty collections
@@ -87,11 +88,11 @@
 (deftest test-inspect-output-plain-when-captured
   (let [output (with-output-buffer (inspect {:a 1}))]
     (is (= "{:a 1}\n" output) "captured output is the plain pretty print")
-    (is (not (str-contains? output (php/chr 27))) "no ANSI escape codes when not on a TTY")))
+    (is (not (s/contains? output (php/chr 27))) "no ANSI escape codes when not on a TTY")))
 
 (deftest test-inspect-output-wraps-wide-values
   (let [output (with-output-buffer (inspect [:alpha :beta :gamma] 10))]
-    (is (str-contains? output "\n :beta") "wide value wraps like pprint")
+    (is (s/contains? output "\n :beta") "wide value wraps like pprint")
     (is (= "[:alpha\n :beta\n :gamma]\n" output) "wrapped layout matches pprint-str plus newline")))
 
 (deftest test-inspect-threading-pipeline

--- a/tests/phel/repl.phel
+++ b/tests/phel/repl.phel
@@ -63,7 +63,7 @@
 
 (deftest test-get-symbol-info-returns-map-for-known-symbol
   (let [info (get-symbol-info "phel\\core" "map")]
-    (is (hash-map? info) "get-symbol-info returns a map for a known symbol")
+    (is (map? info) "get-symbol-info returns a map for a known symbol")
     (is (string? (get info :doc)) "info contains :doc as a string")
     (is (= "phel.core" (get info :ns)) "info contains :ns in display form")
     (is (= "map" (get info :name)) "info contains :name")))
@@ -110,7 +110,7 @@
 
 (deftest test-ns-publics-returns-map
   (let [publics (ns-publics "phel\\core")]
-    (is (hash-map? publics) "ns-publics returns a hash-map")
+    (is (map? publics) "ns-publics returns a hash-map")
     (is (> (count publics) 0) "ns-publics has entries for phel\\core")))
 
 (deftest test-ns-publics-contains-known-functions
@@ -130,7 +130,7 @@
 
 (deftest test-ns-aliases-returns-map
   (let [aliases (ns-aliases "phel-test.repl")]
-    (is (hash-map? aliases) "ns-aliases returns a hash-map")))
+    (is (map? aliases) "ns-aliases returns a hash-map")))
 
 (deftest test-ns-aliases-contains-expected-alias
   (let [aliases (ns-aliases "phel-test.repl")]
@@ -142,7 +142,7 @@
 
 (deftest test-ns-refers-returns-map
   (let [refers (ns-refers "phel-test.repl")]
-    (is (hash-map? refers) "ns-refers returns a hash-map")))
+    (is (map? refers) "ns-refers returns a hash-map")))
 
 (deftest test-ns-refers-contains-expected-refers
   (let [refers (ns-refers "phel-test.repl")]
@@ -189,7 +189,7 @@
   (let [result (let [r (atom nil)]
                  (with-output-buffer (reset! r (test-ns "phel-test.test-framework")))
                  (deref r))]
-    (is (hash-map? result) "test-ns returns a hash-map")
+    (is (map? result) "test-ns returns a hash-map")
     (is (not (nil? (get result :pass))) "result contains :pass key")
     (is (not (nil? (get result :fail))) "result contains :fail key")
     (is (not (nil? (get result :error))) "result contains :error key")
@@ -514,12 +514,12 @@
     (reset! ai/config original)))
 
 (deftest test-ai-repl-public-functions-exist
-  (is (function? explain) "explain is defined")
-  (is (function? suggest) "suggest is defined")
-  (is (function? fix) "fix is defined")
-  (is (function? review) "review is defined")
-  (is (function? embed-ns) "embed-ns is defined")
-  (is (function? search-ns) "search-ns is defined"))
+  (is (fn? explain) "explain is defined")
+  (is (fn? suggest) "suggest is defined")
+  (is (fn? fix) "fix is defined")
+  (is (fn? review) "review is defined")
+  (is (fn? embed-ns) "embed-ns is defined")
+  (is (fn? search-ns) "search-ns is defined"))
 
 ;; ------------------
 ;; find-ns / create-ns / remove-ns / intern / ns-interns

--- a/tests/phel/rose.phel
+++ b/tests/phel/rose.phel
@@ -148,7 +148,7 @@
   (let [entries [(r/rose-pure [:a 1])
                  (r/rose-pure [:b 2])]
         t       (r/rose-map entries)]
-    (is (hash-map? (r/rose-root t)) "root is a hash-map")
+    (is (map? (r/rose-root t)) "root is a hash-map")
     (is (= 1 (get (r/rose-root t) :a)) "value preserved under key :a")
     (is (= 2 (get (r/rose-root t) :b)) "value preserved under key :b")))
 

--- a/tests/phel/router.phel
+++ b/tests/phel/router.phel
@@ -93,10 +93,10 @@
 
 (defn- mv [name]
   (fn [handler request]
-    (handler (update-in request [:attributes :mv] (fnil push []) name))))
+    (handler (update-in request [:attributes :mv] (fnil conj []) name))))
 
 (defn- handler [request]
-  {:status 200 :body (push (get-in request [:attributes :mv] []) :ok)})
+  {:status 200 :body (conj (get-in request [:attributes :mv] []) :ok)})
 
 (defn- req [uri & [method]]
   (h/request-from-map (cond-> {:uri uri} method (assoc :method method))))

--- a/tests/php/Integration/Fixtures/Call/push-typed-vector.test
+++ b/tests/php/Integration/Fixtures/Call/push-typed-vector.test
@@ -1,7 +1,0 @@
---PHEL--
-(fn [^\Phel\Lang\Collections\Vector\PersistentVectorInterface v]
-  (push v 99))
---PHP--
-(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
-  return ($v->append(99));
-});


### PR DESCRIPTION
## 🤔 Background

Follow-up to the legacy-code audit (#2781). Issue #2784 planned a removal release for core functions deprecated for many releases, gated on maintainer confirmation of the list. Confirmed: remove the ten below now (breaking, semver-signaled).

## 💡 Goal

Delete the long-deprecated core aliases and their shims, keeping every code path on the single canonical function.

## 🔖 Changes

- **Removed 10 core fns** (each a thin alias, behavior identical): `push` → `conj`, `put` → `assoc`, `unset` → `dissoc`, `put-in` → `assoc-in`, `unset-in` → `dissoc-in`, `values` → `vals`, `function?` → `fn?`, `hash-map?` → `map?`, `id` → `identical?`, `str-contains?` → `phel\string\contains?`.
- **Compiler**: dropped the `push` branch of `AssocConjSpecialization` (kept `conj`; the `assoc`/`conj` PHP-method emission is untouched, and its unit test had no `push` case).
- **Tests**: migrated incidental call sites to the canonical fns; deleted the dedicated deprecation deftests (their superseders are already covered); removed the obsolete `push-typed-vector` integration fixture; renamed `push-dissoc-typed-collection` to `dissoc-typed-collection`.
- **Docs**: added `docs/migration/removed-deprecated-core-fns.md` (linked from the docs README) and a BREAKING entry under `## Unreleased` in the changelog.

**Preserved on purpose**: `set-meta!` (also deprecated since 0.32.0) is intentionally out of scope per the issue's list, so it stays deprecated-but-shipped. The `warn-deprecations` infrastructure also stays, since it still serves live deprecations such as the `\` namespace separator.

Verified locally green: PHPStan L9, Psalm L1, cs-fixer, test-unit (4054), integration (1079), test-core (6483).

Closes #2784
