### PR TITLE
docs(core): add :example/:see-also to 12 undocumented core fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- Documented 12 previously-undocumented core functions with `:example`/`:see-also` metadata (`str`, `gensym`, `print-str`, `name`, `identical?`, `not=`, `<=`, `>=`, `<=>`, `>=<`, `truthy?`, `compare`)
+
 ### Removed
 
 - **BREAKING**: removed long-deprecated core functions, each a thin alias for its canonical form (#2784): `push` (use `conj`), `put` (use `assoc`), `unset` (use `dissoc`), `put-in` (use `assoc-in`), `unset-in` (use `dissoc-in`), `values` (use `vals`), `function?` (use `fn?`), `hash-map?` (use `map?`), `id` (use `identical?`), and `str-contains?` (use `phel\string\contains?`). The `push` branch of the assoc/conj emitter specialization is removed with them. See [the migration guide](docs/migration/removed-deprecated-core-fns.md). `set-meta!` stays deprecated-but-shipped, out of scope here.

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -87,6 +87,8 @@
 
 (defn identical?
   "Checks if all values are identical. Same as `a === b` in PHP."
+  {:example "(identical? :a :a) ; => true"
+   :see-also ["=" "true?"]}
   [a & more]
   (case (count more)
     0 true
@@ -145,6 +147,8 @@
 
 (defn not=
   "Checks if all values are unequal. Same as `a != b` in PHP."
+  {:example "(not= 1 2) ; => true"
+   :see-also ["=" "=="]}
   [a & more]
   (case (count more)
     0 false
@@ -200,6 +204,8 @@
 
 (defn <=
   "Checks if each argument is less than or equal to the following argument. Returns a boolean."
+  {:example "(<= 1 1 2) ; => true"
+   :see-also ["<" ">="]}
   [a & more]
   (case (count more)
     0 true
@@ -221,6 +227,8 @@
 
 (defn >=
   "Checks if each argument is greater than or equal to the following argument. Returns a boolean."
+  {:example "(>= 3 3 2) ; => true"
+   :see-also [">" "<="]}
   [a & more]
   (case (count more)
     0 true
@@ -231,6 +239,8 @@
 
 (defn <=>
   "Alias for the spaceship PHP operator in ascending order. Returns an int. Dispatches on `Ratio` and `BigInt` so numeric ordering stays correct for those types."
+  {:example "(<=> 1 2) ; => -1\n(<=> 2 2) ; => 0"
+   :see-also ["compare" ">=<"]}
   [a b]
   (if (or (numeric-object? a) (numeric-object? b))
     (php/:: NumericOperations (compare a b))
@@ -238,6 +248,8 @@
 
 (defn >=<
   "Alias for the spaceship PHP operator in descending order. Returns an int."
+  {:example "(>=< 1 2) ; => 1"
+   :see-also ["compare" "<=>"]}
   [a b]
   (if (or (numeric-object? a) (numeric-object? b))
     (php/:: NumericOperations (compare b a))
@@ -307,6 +319,8 @@
 
 (defn truthy?
   "Checks if `x` is truthy. Same as `x == true` in PHP."
+  {:example "(truthy? 0) ; => true\n(truthy? nil) ; => false"
+   :see-also ["true?" "false?" "nil?"]}
   [x]
   (php/:: Truthy (isTruthy x)))
 
@@ -419,7 +433,8 @@
   compared across the numeric tower (int, float, `Ratio`, `BigInt`,
   `BigDecimal`). Throws `InvalidArgumentException` when `x` and `y` come from
   mutually incomparable categories (e.g. `(compare 1 [])`)."
-  {:see-also ["<=>" "sort" "sort-by"]}
+  {:example "(compare 1 2) ; => -1\n(compare :a :a) ; => 0"
+   :see-also ["<=>" "sort" "sort-by"]}
   ^int [x y]
   (cond
     (php/=== x nil) (if (php/=== y nil) 0 -1)

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -44,6 +44,8 @@
 
 (defn print-str
   "Same as print. But instead of writing it to an output stream, the resulting string is returned."
+  {:example "(print-str \"a\" 1) ; => \"a 1\""
+   :see-also ["pr-str" "println-str" "str"]}
   ^string [& xs]
   (print-joined (php/:: Printer (nonReadable)) xs))
 

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -953,6 +953,8 @@ bindings is a vector of function specs: (letfn [(f [params] body) (g [params] bo
 
 (defn name
   "Returns the name string of a string, keyword or symbol."
+  {:example "(name :foo) ; => \"foo\"\n(name 'bar) ; => \"bar\""
+   :see-also ["namespace" "full-name" "keyword"]}
   ^string [x]
   (if (string? x) x (php/-> x (getName))))
 

--- a/src/phel/core/strings.phel
+++ b/src/phel/core/strings.phel
@@ -73,6 +73,8 @@ Throws `InvalidArgumentException` for any other input (including functions, numb
 
 (defn gensym
   "Generates a new unique symbol."
+  {:example "(gensym) ; => __phel_1"
+   :see-also ["symbol"]}
   []
   (php/:: Symbol (gen)))
 
@@ -99,6 +101,8 @@ Throws `InvalidArgumentException` for any other input (including functions, numb
 
 (defn str
   "Creates a string by concatenating values together. If no arguments are provided an empty string is returned. Nil is represented as an empty string. Booleans are represented as \"true\" or \"false\" (matching Clojure semantics). Otherwise, it tries to call `__toString`."
+  {:example "(str \"a\" \"b\" \"c\") ; => \"abc\"\n(str 1 2 3) ; => \"123\"\n(str 1 nil true) ; => \"1true\"\n(str) ; => \"\""
+   :see-also ["print-str" "pr-str" "format"]}
   ^string [& args]
   (let [cnt (php/count args)]
     (if (php/=== cnt 0)


### PR DESCRIPTION
## 🤔 Background

A coverage sweep of the core stdlib found ~92% of public functions already carry `:example`/`:see-also`, but a handful of common functions were missing them.

## 💡 Goal

Close those documentation gaps so every affected fn renders a usable example in `phel doc` and the website API reference.

## 🔖 Changes

- Added `:example` (and `:see-also` where useful) to 12 core functions: `str`, `gensym`, `print-str`, `name`, `identical?`, `not=`, `<=`, `>=`, `<=>`, `>=<`, `truthy?`, `compare`.
- Every example was executed to capture its real readable output; doc-only metadata, no behavior change.