### PR TITLE
docs(core): add examples to exception + nested-seq accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Documented 12 previously-undocumented core functions with `:example`/`:see-also` metadata (`str`, `gensym`, `print-str`, `name`, `identical?`, `not=`, `<=`, `>=`, `<=>`, `>=<`, `truthy?`, `compare`)
 - Documented 9 more core functions (`union`, `intersection`, `difference`, `symmetric-difference`, `constantly`, `complement`, `tree-seq`, `merge-with`, `deep-merge`) and fixed the malformed `juxt` example
 - Documented the reduced/volatile transducer primitives (`reduced`, `reduced?`, `unreduced`, `completing`, `volatile!`, `vreset!`, `vswap!`, `volatile?`)
+- Documented the remaining exception accessors (`ex-data`, `ex-message`, `ex-cause`) and nested-seq accessors (`ffirst`, `nfirst`, `nnext`)
 
 ### Removed
 

--- a/src/phel/core/exceptions.phel
+++ b/src/phel/core/exceptions.phel
@@ -19,19 +19,22 @@
 
 (defn ex-data
   "Returns the data map from an ex-info exception, or nil if not an ExceptionInfo."
-  {:see-also ["ex-info" "ex-message" "ex-cause"]}
+  {:example "(ex-data (ex-info \"boom\" {:a 1})) ; => {:a 1}"
+   :see-also ["ex-info" "ex-message" "ex-cause"]}
   [ex]
   (when (php/instanceof ex ExceptionInfo)
     (php/-> ex (getData))))
 
 (defn ex-message
   "Returns the message of an exception."
-  {:see-also ["ex-info" "ex-data" "ex-cause"]}
+  {:example "(ex-message (ex-info \"boom\" {})) ; => \"boom\""
+   :see-also ["ex-info" "ex-data" "ex-cause"]}
   [ex]
   (php/-> ex (getMessage)))
 
 (defn ex-cause
   "Returns the cause of an exception, or nil."
-  {:see-also ["ex-info" "ex-data" "ex-message"]}
+  {:example "(ex-cause (ex-info \"boom\" {})) ; => nil"
+   :see-also ["ex-info" "ex-data" "ex-message"]}
   [ex]
   (php/-> ex (getPrevious)))

--- a/src/phel/core/seq-basics.phel
+++ b/src/phel/core/seq-basics.phel
@@ -76,6 +76,8 @@
 
 (defn ffirst
   "Same as `(first (first coll))`."
+  {:example "(ffirst [[1 2] [3 4]]) ; => 1"
+   :see-also ["first" "second" "fnext"]}
   [coll]
   (first (first coll)))
 
@@ -103,6 +105,8 @@
 
 (defn nfirst
   "Same as `(next (first coll))`."
+  {:example "(nfirst [[1 2 3] [4 5]]) ; => [2 3]"
+   :see-also ["ffirst" "next" "nnext"]}
   [coll]
   (next (first coll)))
 
@@ -115,6 +119,8 @@
 
 (defn nnext
   "Same as `(next (next coll))`."
+  {:example "(nnext [1 2 3 4]) ; => [3 4]"
+   :see-also ["next" "nfirst" "fnext"]}
   [coll]
   (next (next coll)))
 


### PR DESCRIPTION
## 🤔 Background

Continuing the core stdlib documentation sweep (after #2801–#2803). The exception accessors and nested-seq accessors carried `:see-also`/docstrings but no runnable `:example`.

## 💡 Goal

Give each accessor a usable example in `phel doc` and the website API reference.

## 🔖 Changes

- Added `:example` (+ `:see-also` where missing) to 6 functions: `ex-data`, `ex-message`, `ex-cause`, `ffirst`, `nfirst`, `nnext`.
- All examples executed for real output; doc-only metadata, no behavior change.