### PR TITLE
docs(core): add examples to threading macros + misc core fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Documented the reduced/volatile transducer primitives (`reduced`, `reduced?`, `unreduced`, `completing`, `volatile!`, `vreset!`, `vswap!`, `volatile?`)
 - Documented the remaining exception accessors (`ex-data`, `ex-message`, `ex-cause`) and nested-seq accessors (`ffirst`, `nfirst`, `nnext`)
 - Documented the binding macros (`if-let`, `when-let`, `if-some`, `when-some`, `when-first`) and compile-bridge fns (`namespace`, `full-name`, `read-string`, `eval`, `protocol-type-key`)
+- Documented threading macros (`some->`, `some->>`, `as->`, `doto`), `comp`/`take`/`cat`/`pop`, `format`, `macroexpand-1`, and predicates/accessors (`atom?`, `var?`, `delay?`, `get-validator`, `identity`, `make-hierarchy`)
 
 ### Removed
 

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -37,12 +37,15 @@ Optional `:meta` and `:validator` keyword arguments may follow the value in any 
 
 (defn atom?
   "Returns true if the given value is an atom."
+  {:example "(atom? (atom 1)) ; => true"
+   :see-also ["atom" "var?"]}
   [x]
   (php/instanceof x Atom))
 
 (defn var?
   "Returns true if the given value is a `Var`, the first-class handle to a global definition produced by `(var sym)` and `#'sym`."
-  {:see-also ["var-get" "find-var" "alter-var-root"]}
+  {:example "(var? #'map) ; => true"
+   :see-also ["var-get" "find-var" "alter-var-root"]}
   [x]
   (php/instanceof x PhelVar))
 
@@ -221,7 +224,8 @@ Returns the new value after the swap."
 
 (defn get-validator
   "Returns the validator function of a variable, or nil."
-  {:see-also ["set-validator!"]}
+  {:example "(get-validator (atom 1)) ; => nil"
+   :see-also ["set-validator!"]}
   [variable]
   (php/-> variable (getValidator)))
 
@@ -400,6 +404,8 @@ Returns the new value after the swap."
 
 (defn identity
   "Returns its argument."
+  {:example "(identity 42) ; => 42"
+   :see-also ["constantly" "comp"]}
   [x]
   x)
 

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -102,6 +102,8 @@
 
 (defn format
   "Returns a formatted string. See PHP's [sprintf](https://www.php.net/manual/en/function.sprintf.php) for more information."
+  {:example "(format \"%d-%s\" 1 \"a\") ; => \"1-a\""
+   :see-also ["str" "printf"]}
   [fmt & xs]
   (apply php/sprintf fmt xs))
 
@@ -320,6 +322,8 @@ See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-co
 
 (defmacro some->
   "Threads `x` through the forms like `->` but stops when a form returns `nil`."
+  {:example "(some-> {:a 1} :a inc) ; => 2"
+   :see-also ["some->>" "->" "as->"]}
   [x & forms]
   (loop [x     x
          forms (if (empty? forms) nil forms)]
@@ -344,6 +348,8 @@ See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-co
 
 (defmacro some->>
   "Threads `x` through the forms like `->>` but stops when a form returns `nil`."
+  {:example "(some->> 5 (+ 3) (* 2)) ; => 16"
+   :see-also ["some->" "->>" "as->"]}
   [x & forms]
   (loop [x     x
          forms (if (empty? forms) nil forms)]
@@ -368,6 +374,8 @@ See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-co
 
 (defmacro as->
   "Binds `name` to `expr`, evaluates the first form in the lexical context of that binding, then binds name to that result, repeating for each successive form, returning the result of the last form."
+  {:example "(as-> 1 x (+ x 2) (* x 3)) ; => 9"
+   :see-also ["->" "->>" "some->"]}
   [expr name & forms]
   `(let [~name ~expr
          ~@(interleave (repeat (count forms) name) forms)]
@@ -375,6 +383,8 @@ See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-co
 
 (defmacro doto
   "Evaluates x then calls all of the methods and functions with the value of x supplied at the front of the given arguments. The forms are evaluated in order. Returns x."
+  {:example "(deref (doto (atom 0) (reset! 5))) ; => 5"
+   :see-also ["->" "atom"]}
   [x & forms]
   (let [gx (gensym)]
     `(let [~gx ~x]

--- a/src/phel/core/lazy.phel
+++ b/src/phel/core/lazy.phel
@@ -27,7 +27,8 @@
 
 (defn delay?
   "Returns true if x is a Delay."
-  {:see-also ["delay" "force"]}
+  {:example "(delay? (delay 1)) ; => true"
+   :see-also ["delay" "force"]}
   [x]
   (php/instanceof x Delay))
 

--- a/src/phel/core/macroexpand.phel
+++ b/src/phel/core/macroexpand.phel
@@ -11,6 +11,8 @@
 
 (defn macroexpand-1
   "Expands the given form once if it is a macro call."
+  {:example "(macroexpand-1 '(when true 1)) ; => (if true (do 1))"
+   :see-also ["macroexpand"]}
   [form]
   (if (and (list? form) (not (empty? form)))
     (let [op (first form)]

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -55,7 +55,8 @@
   "Creates a fresh, empty hierarchy.
 
 Returns a map with `:parents`, `:descendants`, and `:ancestors` keys, each holding an empty map. Matches Clojure's hierarchy shape so consumers can destructure any of the three relationship views."
-  {:see-also ["derive" "isa?" "parents" "ancestors" "descendants"]}
+  {:example "(make-hierarchy) ; => {:parents {}, :descendants {}, :ancestors {}}"
+   :see-also ["derive" "isa?" "parents" "ancestors" "descendants"]}
   []
   {:parents {}, :descendants {}, :ancestors {}})
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -91,6 +91,8 @@
 
 (defn comp
   "Takes a list of functions and returns a function that is the composition of those functions."
+  {:example "((comp inc (fn [x] (* x 2))) 3) ; => 7"
+   :see-also ["partial" "juxt" "identity"]}
   [& fs]
   (case (count fs)
     0 identity
@@ -453,6 +455,8 @@ Creates intermediate maps if they don't exist."
 
 (defn take
   "Takes the first `n` elements of `coll`. When called with n only, returns a transducer."
+  {:example "(take 2 [1 2 3 4]) ; => @[1 2]"
+   :see-also ["drop" "take-while"]}
   [n & args]
   (case (count args)
     0 (fn [rf]
@@ -1108,7 +1112,8 @@ With one argument returns an infinite lazy sequence of calls to f."
 
 (defn cat
   "A transducer that concatenates the contents of each input into the reduction."
-  {:see-also ["mapcat" "transduce"]}
+  {:example "(transduce cat conj [] [[1 2] [3 4]]) ; => [1 2 3 4]"
+   :see-also ["mapcat" "transduce"]}
   [rf]
   (let [rrf (preserving-reduced rf)]
     (xf-step rf (fn [result input] (reduce rrf result input)))))

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -58,6 +58,8 @@
 
 (defmacro pop
   "Removes the last element of a collection. Returns nil for nil."
+  {:example "(pop [1 2 3]) ; => [1 2]"
+   :see-also ["conj" "rest"]}
   [coll]
   (if (symbol? coll)
     `(pop* ~coll)


### PR DESCRIPTION
## 🤔 Background

Continuing the core stdlib documentation sweep (after #2801–#2805). A scan surfaced the remaining high-value gaps — the threading macros, common seq fns, and several predicates/accessors without `:example`.

## 💡 Goal

Close the meaningful `:example` gaps in core so the common user-facing fns each render a runnable example in `phel doc` and the website API reference.

## 🔖 Changes

- Added `:example` (+ `:see-also` where missing) to 16 fns: `some->`, `some->>`, `as->`, `doto`, `comp`, `take`, `cat`, `pop`, `format`, `macroexpand-1`, `atom?`, `var?`, `delay?`, `get-validator`, `identity`, `make-hierarchy`.
- All examples executed for real output; doc-only metadata, no behavior change.