### PR TITLE
ref: dedup type-printer colour helper, emitter guard, core-ns const

### DIFF
--- a/src/php/Api/Application/SymbolMetadataFinder.php
+++ b/src/php/Api/Application/SymbolMetadataFinder.php
@@ -10,6 +10,7 @@ use Phel\Api\Domain\SymbolMetadataFinderInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Shared\Api\PhelFunction;
+use Phel\Shared\CompilerConstants;
 use Phel\Shared\MungeInterface;
 use Phel\Shared\ScalarCoercion;
 
@@ -28,8 +29,6 @@ use function trim;
  */
 final class SymbolMetadataFinder implements SymbolMetadataFinderInterface
 {
-    private const string CORE_NAMESPACE = 'phel.core';
-
     /** @var list<PhelFunction>|null */
     private ?array $catalogCache = null;
 
@@ -113,11 +112,11 @@ final class SymbolMetadataFinder implements SymbolMetadataFinderInterface
     private function candidateNamespacesFor(string $currentNs): array
     {
         $canonical = $this->canonicalNs($currentNs);
-        if ($canonical === self::CORE_NAMESPACE) {
-            return [self::CORE_NAMESPACE];
+        if ($canonical === CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return [CompilerConstants::PHEL_CORE_NAMESPACE];
         }
 
-        return [$canonical, self::CORE_NAMESPACE];
+        return [$canonical, CompilerConstants::PHEL_CORE_NAMESPACE];
     }
 
     private function lookupQualified(string $ns, string $name): ?PhelFunction

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefInterfaceEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefInterfaceEmitter.php
@@ -19,6 +19,7 @@ use function var_export;
 
 final readonly class DefInterfaceEmitter implements NodeEmitterInterface
 {
+    use EvalGuardedEmitterTrait;
     use PhpAttributeEmitterTrait;
 
     public function __construct(
@@ -35,15 +36,6 @@ final readonly class DefInterfaceEmitter implements NodeEmitterInterface
         } else {
             $this->emitInline($node);
         }
-    }
-
-    private function shouldEmitViaEval(): bool
-    {
-        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
-            return true;
-        }
-
-        return $this->outputEmitter->isInsideClassScope();
     }
 
     /**

--- a/src/php/Shared/Printer/TypePrinter/ArrayPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/ArrayPrinter.php
@@ -14,6 +14,10 @@ use function sprintf;
  */
 final readonly class ArrayPrinter implements TypePrinterInterface
 {
+    use ColorizeTrait;
+
+    private const string COLOR = '0;37';
+
     public function __construct(
         private PrinterInterface $printer,
         private bool $withColor = false,
@@ -28,7 +32,7 @@ final readonly class ArrayPrinter implements TypePrinterInterface
             ? $this->formatValuesFromList($form)
             : $this->formatKeyValuesFromDict($form);
 
-        return sprintf('<PHP-Array [%s]>', $this->color(implode(', ', $arr)));
+        return sprintf('<PHP-Array [%s]>', $this->colorize(implode(', ', $arr), self::COLOR));
     }
 
     /**
@@ -67,14 +71,5 @@ final readonly class ArrayPrinter implements TypePrinterInterface
         }
 
         return $result;
-    }
-
-    private function color(string $str): string
-    {
-        if ($this->withColor) {
-            return sprintf("\033[0;37m%s\033[0m", $str);
-        }
-
-        return $str;
     }
 }

--- a/src/php/Shared/Printer/TypePrinter/BigDecimalPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/BigDecimalPrinter.php
@@ -6,29 +6,21 @@ namespace Phel\Shared\Printer\TypePrinter;
 
 use Phel\Lang\BigDecimal;
 
-use function sprintf;
-
 /**
  * @implements TypePrinterInterface<BigDecimal>
  */
 final class BigDecimalPrinter implements TypePrinterInterface
 {
+    use ColorizeTrait;
     use WithColorTrait;
+
+    private const string COLOR = '0;92';
 
     /**
      * @param BigDecimal $form
      */
     public function print(mixed $form): string
     {
-        return $this->color($form->__toString() . 'M');
-    }
-
-    private function color(string $str): string
-    {
-        if ($this->withColor) {
-            return sprintf("\033[0;92m%s\033[0m", $str);
-        }
-
-        return $str;
+        return $this->colorize($form->__toString() . 'M', self::COLOR);
     }
 }

--- a/src/php/Shared/Printer/TypePrinter/BooleanPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/BooleanPrinter.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Printer\TypePrinter;
 
-use function sprintf;
-
 /**
  * @implements TypePrinterInterface<bool>
  */
 final class BooleanPrinter implements TypePrinterInterface
 {
+    use ColorizeTrait;
     use WithColorTrait;
+
+    private const string COLOR = '0;94';
 
     /**
      * @param bool $form
@@ -20,15 +21,6 @@ final class BooleanPrinter implements TypePrinterInterface
     {
         $str = $form ? 'true' : 'false';
 
-        return $this->color($str);
-    }
-
-    private function color(string $str): string
-    {
-        if ($this->withColor) {
-            return sprintf("\033[0;94m%s\033[0m", $str);
-        }
-
-        return $str;
+        return $this->colorize($str, self::COLOR);
     }
 }

--- a/src/php/Shared/Printer/TypePrinter/ColorizeTrait.php
+++ b/src/php/Shared/Printer/TypePrinter/ColorizeTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared\Printer\TypePrinter;
+
+use function sprintf;
+
+/**
+ * Wraps a string in an ANSI colour escape when colour output is enabled.
+ * Each printer keeps its own SGR code in a `COLOR` constant; only the escape
+ * scaffolding is shared here.
+ *
+ * Using printers must expose the `$withColor` property (via WithColorTrait or
+ * their own constructor).
+ *
+ * @property-read bool $withColor
+ */
+trait ColorizeTrait
+{
+    private function colorize(string $str, string $code): string
+    {
+        if ($this->withColor) {
+            return sprintf("\033[%sm%s\033[0m", $code, $str);
+        }
+
+        return $str;
+    }
+}

--- a/src/php/Shared/Printer/TypePrinter/DateTimePrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/DateTimePrinter.php
@@ -20,7 +20,10 @@ use function sprintf;
  */
 final class DateTimePrinter implements TypePrinterInterface
 {
+    use ColorizeTrait;
     use WithColorTrait;
+
+    private const string COLOR = '0;92';
 
     /**
      * @param DateTimeInterface $form
@@ -31,15 +34,6 @@ final class DateTimePrinter implements TypePrinterInterface
             ? 'Y-m-d\TH:i:sP'
             : 'Y-m-d\TH:i:s.uP';
 
-        return $this->color(sprintf('#inst "%s"', $form->format($format)));
-    }
-
-    private function color(string $str): string
-    {
-        if ($this->withColor) {
-            return sprintf("\033[0;92m%s\033[0m", $str);
-        }
-
-        return $str;
+        return $this->colorize(sprintf('#inst "%s"', $form->format($format)), self::COLOR);
     }
 }

--- a/src/php/Shared/Printer/TypePrinter/KeywordPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/KeywordPrinter.php
@@ -6,29 +6,21 @@ namespace Phel\Shared\Printer\TypePrinter;
 
 use Phel\Lang\Keyword;
 
-use function sprintf;
-
 /**
  * @implements TypePrinterInterface<Keyword>
  */
 final class KeywordPrinter implements TypePrinterInterface
 {
+    use ColorizeTrait;
     use WithColorTrait;
+
+    private const string COLOR = '0;93';
 
     /**
      * @param Keyword $form
      */
     public function print(mixed $form): string
     {
-        return $this->color($form->__toString());
-    }
-
-    private function color(string $str): string
-    {
-        if ($this->withColor) {
-            return sprintf("\033[0;93m%s\033[0m", $str);
-        }
-
-        return $str;
+        return $this->colorize($form->__toString(), self::COLOR);
     }
 }

--- a/src/php/Shared/Printer/TypePrinter/NonPrintableClassPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/NonPrintableClassPrinter.php
@@ -4,29 +4,21 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Printer\TypePrinter;
 
-use function sprintf;
-
 /**
  * @implements TypePrinterInterface<object>
  */
 final class NonPrintableClassPrinter implements TypePrinterInterface
 {
+    use ColorizeTrait;
     use WithColorTrait;
+
+    private const string COLOR = '1;35';
 
     /**
      * @param object $form
      */
     public function print(mixed $form): string
     {
-        return 'Printer cannot print this type: ' . $this->color($form::class);
-    }
-
-    private function color(string $str): string
-    {
-        if ($this->withColor) {
-            return sprintf("\033[1;35m%s\033[0m", $str);
-        }
-
-        return $str;
+        return 'Printer cannot print this type: ' . $this->colorize($form::class, self::COLOR);
     }
 }

--- a/src/php/Shared/Printer/TypePrinter/NullPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/NullPrinter.php
@@ -4,26 +4,18 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Printer\TypePrinter;
 
-use function sprintf;
-
 /**
  * @template-implements TypePrinterInterface<null>
  */
 final class NullPrinter implements TypePrinterInterface
 {
+    use ColorizeTrait;
     use WithColorTrait;
+
+    private const string COLOR = '0;96';
 
     public function print(mixed $form): string
     {
-        return $this->color('nil');
-    }
-
-    private function color(string $str): string
-    {
-        if ($this->withColor) {
-            return sprintf("\033[0;96m%s\033[0m", $str);
-        }
-
-        return $str;
+        return $this->colorize('nil', self::COLOR);
     }
 }

--- a/src/php/Shared/Printer/TypePrinter/NumberPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/NumberPrinter.php
@@ -8,14 +8,16 @@ use function is_float;
 use function is_infinite;
 use function is_nan;
 use function preg_match;
-use function sprintf;
 
 /**
  * @implements TypePrinterInterface<float|int>
  */
 final class NumberPrinter implements TypePrinterInterface
 {
+    use ColorizeTrait;
     use WithColorTrait;
+
+    private const string COLOR = '0;92';
 
     /**
      * @param float|int $form
@@ -23,10 +25,10 @@ final class NumberPrinter implements TypePrinterInterface
     public function print(mixed $form): string
     {
         if (is_float($form)) {
-            return $this->color($this->printFloat($form));
+            return $this->colorize($this->printFloat($form), self::COLOR);
         }
 
-        return $this->color((string) $form);
+        return $this->colorize((string) $form, self::COLOR);
     }
 
     /**
@@ -50,14 +52,5 @@ final class NumberPrinter implements TypePrinterInterface
         // which would make a float indistinguishable from an int. Restore
         // it unless the cast already carries a decimal point or exponent.
         return preg_match('/[.eE]/', $str) === 1 ? $str : $str . '.0';
-    }
-
-    private function color(string $str): string
-    {
-        if ($this->withColor) {
-            return sprintf("\033[0;92m%s\033[0m", $str);
-        }
-
-        return $str;
     }
 }

--- a/src/php/Shared/Printer/TypePrinter/RatioPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/RatioPrinter.php
@@ -6,29 +6,21 @@ namespace Phel\Shared\Printer\TypePrinter;
 
 use Phel\Lang\Ratio;
 
-use function sprintf;
-
 /**
  * @implements TypePrinterInterface<Ratio>
  */
 final class RatioPrinter implements TypePrinterInterface
 {
+    use ColorizeTrait;
     use WithColorTrait;
+
+    private const string COLOR = '0;92';
 
     /**
      * @param Ratio $form
      */
     public function print(mixed $form): string
     {
-        return $this->color($form->__toString());
-    }
-
-    private function color(string $str): string
-    {
-        if ($this->withColor) {
-            return sprintf("\033[0;92m%s\033[0m", $str);
-        }
-
-        return $str;
+        return $this->colorize($form->__toString(), self::COLOR);
     }
 }

--- a/src/php/Shared/Printer/TypePrinter/StringPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/StringPrinter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phel\Shared\Printer\TypePrinter;
 
 use function ord;
-use function sprintf;
 use function strlen;
 
 /**
@@ -13,6 +12,8 @@ use function strlen;
  */
 final readonly class StringPrinter implements TypePrinterInterface
 {
+    use ColorizeTrait;
+
     private const array SPECIAL_CHARACTERS = [
         9 => '\t',
         10 => '\n',
@@ -24,6 +25,8 @@ final readonly class StringPrinter implements TypePrinterInterface
         36 => '\$',
         92 => '\\\\',
     ];
+
+    private const string COLOR = '0;95';
 
     public function __construct(
         private bool $readable,
@@ -44,7 +47,7 @@ final readonly class StringPrinter implements TypePrinterInterface
     {
         $str = $this->parseString($form);
 
-        return $this->color($str);
+        return $this->colorize($str, self::COLOR);
     }
 
     private function parseString(string $str): string
@@ -131,14 +134,5 @@ final readonly class StringPrinter implements TypePrinterInterface
     private function isMask11110XXX(int $asciiChar): bool
     {
         return ($asciiChar & 0xF8) === 0xF0;
-    }
-
-    private function color(string $str): string
-    {
-        if ($this->withColor) {
-            return sprintf("\033[0;95m%s\033[0m", $str);
-        }
-
-        return $str;
     }
 }

--- a/src/php/Shared/Printer/TypePrinter/SymbolPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/SymbolPrinter.php
@@ -6,29 +6,21 @@ namespace Phel\Shared\Printer\TypePrinter;
 
 use Phel\Lang\Symbol;
 
-use function sprintf;
-
 /**
  * @implements TypePrinterInterface<Symbol>
  */
 final class SymbolPrinter implements TypePrinterInterface
 {
+    use ColorizeTrait;
     use WithColorTrait;
+
+    private const string COLOR = '0;91';
 
     /**
      * @param Symbol $form
      */
     public function print(mixed $form): string
     {
-        return $this->color($form->getFullName());
-    }
-
-    private function color(string $str): string
-    {
-        if ($this->withColor) {
-            return sprintf("\033[0;91m%s\033[0m", $str);
-        }
-
-        return $str;
+        return $this->colorize($form->getFullName(), self::COLOR);
     }
 }

--- a/src/php/Shared/Printer/TypePrinter/UUIDPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/UUIDPrinter.php
@@ -13,22 +13,16 @@ use function sprintf;
  */
 final class UUIDPrinter implements TypePrinterInterface
 {
+    use ColorizeTrait;
     use WithColorTrait;
+
+    private const string COLOR = '0;92';
 
     /**
      * @param UUID $form
      */
     public function print(mixed $form): string
     {
-        return $this->color(sprintf('#uuid "%s"', $form));
-    }
-
-    private function color(string $str): string
-    {
-        if ($this->withColor) {
-            return sprintf("\033[0;92m%s\033[0m", $str);
-        }
-
-        return $str;
+        return $this->colorize(sprintf('#uuid "%s"', $form), self::COLOR);
     }
 }

--- a/src/php/Shared/Printer/TypePrinter/VarPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/VarPrinter.php
@@ -6,29 +6,21 @@ namespace Phel\Shared\Printer\TypePrinter;
 
 use Phel\Lang\PhelVar;
 
-use function sprintf;
-
 /**
  * @implements TypePrinterInterface<PhelVar>
  */
 final class VarPrinter implements TypePrinterInterface
 {
+    use ColorizeTrait;
     use WithColorTrait;
+
+    private const string COLOR = '0;91';
 
     /**
      * @param PhelVar $form
      */
     public function print(mixed $form): string
     {
-        return $this->color("#'" . $form->getFullName());
-    }
-
-    private function color(string $str): string
-    {
-        if ($this->withColor) {
-            return sprintf("\033[0;91m%s\033[0m", $str);
-        }
-
-        return $str;
+        return $this->colorize("#'" . $form->getFullName(), self::COLOR);
     }
 }


### PR DESCRIPTION
## 🤔 Background

Part of an internal code-quality sweep. A read-only pass surfaced three leftover duplications where a shared helper already existed (or was one extraction away).

## 💡 Goal

Remove real duplication with zero behaviour change — identical compiled output and identical printed output.

## 🔖 Changes

- **Type printers**: 13 `TypePrinter` classes each declared a byte-identical `color()` differing only in the ANSI code. Extracted `ColorizeTrait::colorize($str, $code)`; each printer keeps its SGR code in a per-type `COLOR` constant (~78 lines removed).
- **Emitter**: `DefInterfaceEmitter` re-declared a byte-identical `shouldEmitViaEval()`; it now uses the existing `EvalGuardedEmitterTrait`, like the other `def*` emitters.
- **Constant**: `SymbolMetadataFinder` had a local `'phel.core'` const; it now uses the shared `CompilerConstants::PHEL_CORE_NAMESPACE`.

Verified locally: PHPStan L9, Psalm L1, and printer/emitter (`Def` fixtures are exact-match) / `Munge` / `SymbolMetadataFinder` suites green (482 tests). Internal-only, no user-facing change, so no CHANGELOG entry (consistent with #2798/#2799).