### PR TITLE
ref: extract repeated array-shapes into @phpstan-type aliases

### DIFF
--- a/src/php/Lang/DynamicScope.php
+++ b/src/php/Lang/DynamicScope.php
@@ -21,6 +21,8 @@ use function count;
  * stack of frames, and the main (non-fiber) context has its own stack.
  * This is the backing store for both the `binding` macro and "binding
  * conveyance" into `future`/`async` bodies.
+ *
+ * @phpstan-type ScopeFrame array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}
  */
 final class DynamicScope
 {
@@ -63,11 +65,11 @@ final class DynamicScope
      * 'dynamic' => array<string,mixed>,
      * 'redefs' => list<array{string,string,mixed}>]`.
      *
-     * @var list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>
+     * @var list<ScopeFrame>
      */
     private array $mainRecordings = [];
 
-    /** @var WeakMap<Fiber<mixed, mixed, mixed, mixed>, list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>> */
+    /** @var WeakMap<Fiber<mixed, mixed, mixed, mixed>, list<ScopeFrame>> */
     private WeakMap $fiberRecordings;
 
     private function __construct()
@@ -75,7 +77,7 @@ final class DynamicScope
         /** @var WeakMap<Fiber<mixed, mixed, mixed, mixed>, list<array<string, mixed>>> $map */
         $map = new WeakMap();
         $this->fiberStacks = $map;
-        /** @var WeakMap<Fiber<mixed, mixed, mixed, mixed>, list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>> $recMap */
+        /** @var WeakMap<Fiber<mixed, mixed, mixed, mixed>, list<ScopeFrame>> $recMap */
         $recMap = new WeakMap();
         $this->fiberRecordings = $recMap;
     }
@@ -93,7 +95,7 @@ final class DynamicScope
         /** @var WeakMap<Fiber<mixed, mixed, mixed, mixed>, list<array<string, mixed>>> $map */
         $map = new WeakMap();
         $this->fiberStacks = $map;
-        /** @var WeakMap<Fiber<mixed, mixed, mixed, mixed>, list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>> $recMap */
+        /** @var WeakMap<Fiber<mixed, mixed, mixed, mixed>, list<ScopeFrame>> $recMap */
         $recMap = new WeakMap();
         $this->fiberRecordings = $recMap;
     }
@@ -152,7 +154,7 @@ final class DynamicScope
     }
 
     /**
-     * @return array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}
+     * @return ScopeFrame
      */
     public function popRecording(): array
     {
@@ -320,7 +322,7 @@ final class DynamicScope
     }
 
     /**
-     * @param array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>} $entry
+     * @param ScopeFrame $entry
      */
     private function pushRecording(array $entry): void
     {
@@ -333,14 +335,14 @@ final class DynamicScope
             return;
         }
 
-        /** @var list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}> $stack */
+        /** @var list<ScopeFrame> $stack */
         $stack = $this->fiberRecordings[$fiber] ?? [];
         $stack[] = $entry;
         $this->fiberRecordings[$fiber] = $stack;
     }
 
     /**
-     * @return array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}|null
+     * @return ScopeFrame|null
      */
     private function popTopRecording(): ?array
     {
@@ -354,7 +356,7 @@ final class DynamicScope
             return null;
         }
 
-        /** @var list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}> $stack */
+        /** @var list<ScopeFrame> $stack */
         $stack = $this->fiberRecordings[$fiber];
         $entry = array_pop($stack);
         if ($stack === []) {
@@ -367,7 +369,7 @@ final class DynamicScope
     }
 
     /**
-     * @return list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>
+     * @return list<ScopeFrame>
      */
     private function currentRecordings(): array
     {
@@ -376,7 +378,7 @@ final class DynamicScope
             return $this->mainRecordings;
         }
 
-        /** @var list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}> $stack */
+        /** @var list<ScopeFrame> $stack */
         $stack = $this->fiberRecordings[$fiber] ?? [];
         return $stack;
     }

--- a/src/php/Lsp/Application/Convert/LocationConverter.php
+++ b/src/php/Lsp/Application/Convert/LocationConverter.php
@@ -12,7 +12,7 @@ use function strlen;
 /**
  * Convert Api Location/Definition value objects into LSP Location shapes.
  *
- * @phpstan-import-type Range from PositionConverter
+ * @phpstan-import-type LspLocation from PositionConverter
  */
 final readonly class LocationConverter
 {
@@ -22,7 +22,7 @@ final readonly class LocationConverter
     ) {}
 
     /**
-     * @return array{uri: string, range: Range}
+     * @return LspLocation
      */
     public function fromLocation(Location $location): array
     {
@@ -38,7 +38,7 @@ final readonly class LocationConverter
     }
 
     /**
-     * @return array{uri: string, range: Range}
+     * @return LspLocation
      */
     public function fromDefinition(Definition $definition): array
     {

--- a/src/php/Lsp/Application/Convert/PositionConverter.php
+++ b/src/php/Lsp/Application/Convert/PositionConverter.php
@@ -15,6 +15,7 @@ namespace Phel\Lsp\Application\Convert;
  * @phpstan-type Position array{line: int, character: int}
  * @phpstan-type Range array{start: Position, end: Position}
  * @phpstan-type TextEdit array{range: Range, newText: string}
+ * @phpstan-type LspLocation array{uri: string, range: Range}
  */
 final class PositionConverter
 {

--- a/src/php/Lsp/Application/Convert/SymbolInformationBuilder.php
+++ b/src/php/Lsp/Application/Convert/SymbolInformationBuilder.php
@@ -14,7 +14,7 @@ use function strlen;
  * `textDocument/documentSymbol` and `workspace/symbol`. Centralising the
  * construction keeps both responses in sync when the spec's fields drift.
  *
- * @phpstan-import-type Range from PositionConverter
+ * @phpstan-import-type LspLocation from PositionConverter
  */
 final readonly class SymbolInformationBuilder
 {
@@ -28,7 +28,7 @@ final readonly class SymbolInformationBuilder
      * @return array{
      *     name: string,
      *     kind: int,
-     *     location: array{uri: string, range: Range}
+     *     location: LspLocation
      * }
      */
     public function fromDefinition(Definition $def): array
@@ -53,7 +53,7 @@ final readonly class SymbolInformationBuilder
      *     name: string,
      *     kind: int,
      *     containerName: string,
-     *     location: array{uri: string, range: Range}
+     *     location: LspLocation
      * }
      */
     public function fromDefinitionWithContainer(Definition $def): array

--- a/src/php/Run/Application/Test/TestWorkerHandle.php
+++ b/src/php/Run/Application/Test/TestWorkerHandle.php
@@ -43,7 +43,7 @@ final class TestWorkerHandle
 
     /**
      * @param closed-resource|resource $process
-     * @param array<int, resource> $pipes
+     * @param array<int, resource>     $pipes
      */
     public function __construct(private readonly mixed $process, array $pipes)
     {

--- a/src/php/Run/Application/Test/TestWorkerHandle.php
+++ b/src/php/Run/Application/Test/TestWorkerHandle.php
@@ -42,6 +42,7 @@ final class TestWorkerHandle
     private ?string $assignedNamespace = null;
 
     /**
+     * @param closed-resource|resource $process
      * @param array<int, resource> $pipes
      */
     public function __construct(private readonly mixed $process, array $pipes)


### PR DESCRIPTION
## 🤔 Background

Internal code-quality sweep. A read-only type pass surfaced repeated inline array-shapes that already had a home (or were one alias away), plus one resource property missing the phpdoc its siblings carry.

## 💡 Goal

Reduce annotation duplication with zero behaviour change — docblocks only, no runtime effect.

## 🔖 Changes

- **LSP**: the `{uri, range}` wire shape appeared inline 4× across `LocationConverter` + `SymbolInformationBuilder`. Extracted `@phpstan-type LspLocation` in `PositionConverter` (the missing 4th member of the existing `Position`/`Range`/`TextEdit` family) and imported it. Named `LspLocation` to avoid clashing with the `Api\Transfer\Location` class already imported in `LocationConverter`.
- **Lang**: `DynamicScope`'s binding-recording frame shape appeared inline 11× (`@var`/`@param`/`@return`, incl. inside `list<>`/`WeakMap<>`). Collapsed to `@phpstan-type ScopeFrame` on the class docblock. Kept as an alias, **not** a promoted class — this is the hot `binding`/`with-redefs` runtime path.
- **Run**: `TestWorkerHandle::$process` gains `@param closed-resource|resource` — the only resource holder missing the phpdoc its 3 sibling pipe props already carry.

Verified locally: PHPStan L9, Psalm L1, and DynamicScope / LSP-convert / TestWorker suites green (131 tests). Annotation-only → no CHANGELOG entry.