### PR TITLE
fix: migrate test fixture off removed function? predicate

### DIFF
--- a/tests/php/Integration/Run/Command/Run/Fixtures/phel-async-fqn-script.phel
+++ b/tests/php/Integration/Run/Command/Run/Fixtures/phel-async-fqn-script.phel
@@ -1,4 +1,4 @@
 (ns phel-async-fqn-script)
 
-(when (function? phel.async/delay)
+(when (fn? phel.async/delay)
   (println "phel.async/delay resolved"))


### PR DESCRIPTION
## 🤔 Background

`a0ffafe3b` removed the `function?` core alias (use `fn?`). One test fixture, `phel-async-fqn-script.phel`, still called it. The suite stayed green only because `RunCommandTest` enables the file cache and reuses a warm compiled entry from before the removal — a cold CI cache raises `[PHEL001] Cannot resolve symbol 'function?'` and the test flips red.

## 💡 Goal

Remove the latent cold-cache breakage; keep behaviour identical.

## 🔖 Changes

- `phel-async-fqn-script.phel`: `function?` → `fn?` (the documented 1:1 replacement). Verified passing **cold** in an isolated `TMPDIR` (fresh compiled cache), not just warm.