### PR TITLE
ref: drop stale/restating comments in slurp and assoc/conj emitter

### DIFF
--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -164,11 +164,9 @@
   (let [is-url? (php/preg_match "/^(https?|ftp):\/\//i" path)]
     ;; Validate for non-URLs
     (when-not is-url?
-      ;; Check if path is a directory
       (when (php/is_dir path)
         (throw (php/new \InvalidArgumentException
                         (str "Cannot read directory: " path))))
-      ;; Check if file exists
       (when-not (php/is_file path)
         (throw (php/new \InvalidArgumentException
                         (str "File not found: " path)))))
@@ -179,7 +177,6 @@
           offset           (or (:offset opts) 0)
           length           (or (:length opts) nil)
           content          (file-get-contents-silenced path use-include-path context offset length)]
-      ;; Check if file_get_contents failed
       (when (= content false)
         (throw (php/new \InvalidArgumentException
                         (str "Failed to read from: " path))))

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/AssocConjSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/AssocConjSpecialization.php
@@ -26,15 +26,12 @@ final readonly class AssocConjSpecialization
     private function __construct() {}
 
     /**
-     * `(assoc coll k v)` 3-arg / `(conj coll x)` 2-arg / `(push coll x)`
-     * 2-arg / `(dissoc coll k)` 2-arg specialise to a direct method call
-     * when the target carries an inferred persistent-collection tag:
+     * `(assoc coll k v)` 3-arg / `(conj coll x)` 2-arg / `(dissoc coll k)` 2-arg
+     * specialise to a direct method call when the target carries an inferred
+     * persistent-collection tag:
      *
      *  - `PersistentMapInterface`  → `put` / `remove`
      *  - `PersistentVectorInterface` → `update` / `append`
-     *
-     * `push` is the deprecated alias for the 2-arg `conj` (its body is
-     * `(conj coll x)`), so on a vector it appends exactly like `conj`.
      *
      * Variadic `dissoc` is handled by {@see self::typedDissocKeys()};
      * variadic `assoc` / `conj` need a runtime loop and are not specialised


### PR DESCRIPTION
## 🤔 Background

Internal comment sweep. Two spots carried comments that no longer help a reader.

## 💡 Goal

Remove noise; no behaviour change.

## 🔖 Changes

- **`io.phel`**: `slurp` had three comments that restate the guard immediately below them (`;; Check if path is a directory`, `;; Check if file exists`, `;; Check if file_get_contents failed`) — the exception messages already carry the meaning. Kept the two section headers.
- **`AssocConjSpecialization`**: `a0ffafe3b` removed the `push` branch of this emitter specialization, but the docblock still listed a `(push coll x)` signature entry and a "`push` is the deprecated alias" paragraph — dead documentation, dropped.

Comment-only → no CHANGELOG entry.