### PR TITLE
ref: codebase quality sweep (dedup, dead code, cycles, types, error handling)

### DIFF
--- a/.agnostic-ai/rules/php.md
+++ b/.agnostic-ai/rules/php.md
@@ -12,6 +12,11 @@ globs: src/php/**,tests/php/**
 - Prefer `final` classes unless inheritance is explicitly needed
 - Use `readonly` properties where possible
 
+## Type naming
+
+- `@template` generic parameters are `T`-prefixed: `TKey`, `TValue`, not bare `K`/`V`. The prefix exists to keep a generic parameter distinguishable from a real class name at its use site.
+- `@phpstan-type` aliases are **not** `T`-prefixed. They are file-scoped docblock macros, never ambiguous with a class, and several deliberately mirror external spec object names (the LSP handlers) where a prefix would break the correspondence.
+
 ## Module Pattern (Gacela)
 
 - Each module exposes a `Facade` as its public API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Sorted collection comparators are now typed `bool|int` rather than `int`. Phel's `<` returns a boolean, so `(sorted-map-by < ...)` never matched its own declared contract
+- `phel lint` now exits 2 with a clear message when `phel-lint.phel` exists but is unreadable, unparseable, or not a map, instead of silently falling back to the built-in default rules. A missing or empty config file still means defaults
+- Parse and lex failures during namespace extraction now report the underlying reason and chain the original exception, replacing a bare `Cannot parse file: <path>` with no line or cause
+- `phel format` now surfaces I/O failures instead of printing a stack trace and silently skipping the file
+
 ### Changed
 
 - Documented 60+ previously-undocumented public core functions with runnable `:example`/`:see-also` metadata — threading macros, set/sequence helpers, transducer & volatile primitives, binding & protocol macros, exception/sequence accessors, and assorted predicates — and fixed a malformed `juxt` example
@@ -11,6 +18,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 - **BREAKING**: removed long-deprecated core functions, each a thin alias for its canonical form (#2784): `push` (use `conj`), `put` (use `assoc`), `unset` (use `dissoc`), `put-in` (use `assoc-in`), `unset-in` (use `dissoc-in`), `values` (use `vals`), `function?` (use `fn?`), `hash-map?` (use `map?`), `id` (use `identical?`), and `str-contains?` (use `phel\string\contains?`). The `push` branch of the assoc/conj emitter specialization is removed with them. See [the migration guide](docs/migration/removed-deprecated-core-fns.md). `set-meta!` stays deprecated-but-shipped, out of scope here.
+- Removed unused internals with no callers anywhere: `Phel\Lang\Collections\LazySeq\LazySeqConfig::EAGER_THRESHOLD` (a public constant whose docblock described an eager-realization optimization that was never implemented), `Phel\Build\Domain\Cache\NamespaceCacheInterface::remove()` and `::clear()`, `Phel\Nrepl\Domain\Session\SessionRegistry::ids()`, and the empty `Phel\Fiber\FiberProvider`
 
 ## [0.49.0](https://github.com/phel-lang/phel-lang/compare/v0.48.0...v0.49.0) - 2026-07-22
 

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,6 @@
     ],
     "config": {
         "allow-plugins": {
-            "composer/package-versions-deprecated": true,
             "ergebnis/composer-normalize": true
         },
         "platform": {

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -199,6 +199,8 @@ final class Phel extends InternalPhel
      * Close the pending binding recording, push its dynamic values as
      * a fiber-local frame, run `$body`, then always pop the frame and
      * undo any with-redefs mutations (even on exception).
+     *
+     * @param Closure(): mixed $body
      */
     public static function commitAndRunBindingFrame(Closure $body): mixed
     {
@@ -235,6 +237,7 @@ final class Phel extends InternalPhel
      * fiber entry point of conveyed futures.
      *
      * @param array<string, mixed> $frame
+     * @param Closure(): mixed     $body
      */
     public static function withDynamicBindings(array $frame, Closure $body): mixed
     {
@@ -411,6 +414,8 @@ final class Phel extends InternalPhel
     /**
      * Create a persistent sorted map with a custom comparator.
      *
+     * @param callable(mixed, mixed): (bool|int) $comparator spaceship- or predicate-style
+     *
      * @return PersistentMapInterface<mixed, mixed>
      */
     public static function sortedMapBy(callable $comparator, mixed ...$kvs): PersistentMapInterface
@@ -438,7 +443,8 @@ final class Phel extends InternalPhel
     /**
      * Create a persistent sorted set with a custom comparator.
      *
-     * @param list<mixed>|null $values
+     * @param callable(mixed, mixed): (bool|int) $comparator spaceship- or predicate-style
+     * @param list<mixed>|null                   $values
      *
      * @return PersistentHashSetInterface<mixed>
      */

--- a/src/php/Api/ApiFacade.php
+++ b/src/php/Api/ApiFacade.php
@@ -16,6 +16,13 @@ use Phel\Shared\Api\PhelFunction;
 use Phel\Shared\Facade\ApiFacadeInterface;
 
 /**
+ * The LSP SignatureHelp wire shape this module produces. Declared here (the
+ * module's public API) so both resolvers behind it describe one payload.
+ *
+ * @phpstan-type SignatureParameter array{label: string}
+ * @phpstan-type SignatureInformation array{label: string, parameters: list<SignatureParameter>, documentation?: string}
+ * @phpstan-type SignatureHelp array{signatures: list<SignatureInformation>, activeSignature: int, activeParameter: int}
+ *
  * @extends AbstractFacade<ApiFactory>
  */
 final class ApiFacade extends AbstractFacade implements ApiFacadeInterface
@@ -173,7 +180,7 @@ final class ApiFacade extends AbstractFacade implements ApiFacadeInterface
      * LSP SignatureHelp payload for the plain Phel function call enclosing the
      * cursor, or null when not applicable.
      *
-     * @return array{signatures: list<array{label: string, parameters: list<array{label: string}>, documentation?: string}>, activeSignature: int, activeParameter: int}|null
+     * @return SignatureHelp|null
      */
     public function phelSignatureAt(string $source, int $line, int $col, string $currentNs = 'user'): ?array
     {

--- a/src/php/Api/Application/PhelSignatureResolver.php
+++ b/src/php/Api/Application/PhelSignatureResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Api\Application;
 
+use Phel\Api\ApiFacade;
 use Phel\Api\Domain\SymbolMetadataFinderInterface;
 use Phel\Shared\Api\PhelFunction;
 
@@ -20,6 +21,10 @@ use function substr;
  * {@see PhpInteropDocResolver::signatureAt()}, which only covers `php/...`
  * interop calls. Returns null when the cursor is not inside a resolvable Phel
  * call, so the handler can fall through.
+ *
+ * @phpstan-import-type SignatureHelp from ApiFacade
+ * @phpstan-import-type SignatureInformation from ApiFacade
+ * @phpstan-import-type SignatureParameter from ApiFacade
  */
 final readonly class PhelSignatureResolver
 {
@@ -29,7 +34,7 @@ final readonly class PhelSignatureResolver
     ) {}
 
     /**
-     * @return array{signatures: list<array{label: string, parameters: list<array{label: string}>, documentation?: string}>, activeSignature: int, activeParameter: int}|null
+     * @return SignatureHelp|null
      */
     public function signatureAt(string $source, int $line, int $col, string $currentNs = 'user'): ?array
     {
@@ -74,7 +79,7 @@ final readonly class PhelSignatureResolver
     /**
      * @param non-empty-list<string> $arities
      *
-     * @return array{signatures: list<array{label: string, parameters: list<array{label: string}>, documentation?: string}>, activeSignature: int, activeParameter: int}
+     * @return SignatureHelp
      */
     private function response(array $arities, string $doc, int $activeParameter): array
     {
@@ -106,7 +111,7 @@ final readonly class PhelSignatureResolver
      * smallest signature with more parameters than the active index, falling
      * back to the largest (variadic) arity when the caret is past them all.
      *
-     * @param non-empty-list<array{label: string, parameters: list<array{label: string}>, documentation?: string}> $signatures
+     * @param non-empty-list<SignatureInformation> $signatures
      */
     private function bestArity(array $signatures, int $activeParameter): int
     {
@@ -165,7 +170,7 @@ final readonly class PhelSignatureResolver
     /**
      * @param list<string> $parameters
      *
-     * @return list<array{label: string}>
+     * @return list<SignatureParameter>
      */
     private function parameterInformation(array $parameters): array
     {

--- a/src/php/Api/Application/PhpInteropDocResolver.php
+++ b/src/php/Api/Application/PhpInteropDocResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Api\Application;
 
+use Phel\Api\ApiFacade;
 use Phel\Api\Transfer\PhpInteropCall;
 use Phel\Api\Transfer\PhpInteropClass;
 use Phel\Api\Transfer\PhpInteropContext;
@@ -21,6 +22,9 @@ use function strlen;
  * reflector and context resolver as completion. Both entry points return null
  * when the cursor is not over a resolvable PHP symbol, so callers fall through
  * to the Phel behaviour.
+ *
+ * @phpstan-import-type SignatureHelp from ApiFacade
+ * @phpstan-import-type SignatureParameter from ApiFacade
  */
 final readonly class PhpInteropDocResolver
 {
@@ -57,7 +61,7 @@ final readonly class PhpInteropDocResolver
      * chained calls report the innermost method, and `activeParameter` tracks
      * the argument the cursor sits on.
      *
-     * @return array{signatures: list<array{label: string, parameters: list<array{label: string}>, documentation?: string}>, activeSignature: int, activeParameter: int}|null
+     * @return SignatureHelp|null
      */
     public function signatureAt(string $source, int $line, int $col): ?array
     {
@@ -71,7 +75,7 @@ final readonly class PhpInteropDocResolver
     }
 
     /**
-     * @return array{signatures: list<array{label: string, parameters: list<array{label: string}>, documentation?: string}>, activeSignature: int, activeParameter: int}|null
+     * @return SignatureHelp|null
      */
     private function constructorSignature(PhpInteropCall $call): ?array
     {
@@ -98,7 +102,7 @@ final readonly class PhpInteropDocResolver
     }
 
     /**
-     * @return array{signatures: list<array{label: string, parameters: list<array{label: string}>, documentation?: string}>, activeSignature: int, activeParameter: int}|null
+     * @return SignatureHelp|null
      */
     private function methodCallSignature(PhpInteropCall $call): ?array
     {
@@ -181,7 +185,7 @@ final readonly class PhpInteropDocResolver
     }
 
     /**
-     * @return array{signatures: list<array{label: string, parameters: list<array{label: string}>, documentation?: string}>, activeSignature: int, activeParameter: int}
+     * @return SignatureHelp
      */
     private function signatureResponse(PhpInteropSignature $signature, int $activeParameter): array
     {
@@ -205,7 +209,7 @@ final readonly class PhpInteropDocResolver
     /**
      * @param list<string> $parameters
      *
-     * @return list<array{label: string}>
+     * @return list<SignatureParameter>
      */
     private function parameterInformation(array $parameters): array
     {

--- a/src/php/Api/Infrastructure/PhelFunctionRuntimeLoader.php
+++ b/src/php/Api/Infrastructure/PhelFunctionRuntimeLoader.php
@@ -23,6 +23,9 @@ use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
 
+/**
+ * @phpstan-import-type RegistrySnapshot from Registry
+ */
 final readonly class PhelFunctionRuntimeLoader
 {
     public function __construct(
@@ -88,7 +91,7 @@ final readonly class PhelFunctionRuntimeLoader
      * the loaded state so that callers (REPL, nREPL) keep their session
      * intact while still seeing the freshly loaded documentation namespaces.
      *
-     * @param array{definitions: array<string, array<string, mixed>>, definitionsMetaData: array<string, array<string, mixed>>} $previousRegistry
+     * @param RegistrySnapshot $previousRegistry
      */
     private function mergePreviousState(
         GlobalEnvironmentInterface $previousEnv,

--- a/src/php/Api/Transfer/Definition.php
+++ b/src/php/Api/Transfer/Definition.php
@@ -4,6 +4,19 @@ declare(strict_types=1);
 
 namespace Phel\Api\Transfer;
 
+/**
+ * @phpstan-type SerializedDefinition array{
+ *     namespace: string,
+ *     name: string,
+ *     uri: string,
+ *     line: int,
+ *     col: int,
+ *     kind: string,
+ *     signature: list<string>,
+ *     docstring: string,
+ *     private: bool,
+ * }
+ */
 final readonly class Definition
 {
     public const string KIND_DEFN = 'defn';
@@ -43,17 +56,7 @@ final readonly class Definition
     }
 
     /**
-     * @return array{
-     *     namespace: string,
-     *     name: string,
-     *     uri: string,
-     *     line: int,
-     *     col: int,
-     *     kind: string,
-     *     signature: list<string>,
-     *     docstring: string,
-     *     private: bool,
-     * }
+     * @return SerializedDefinition
      */
     public function toArray(): array
     {

--- a/src/php/Api/Transfer/Location.php
+++ b/src/php/Api/Transfer/Location.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Phel\Api\Transfer;
 
+/**
+ * @phpstan-type SerializedLocation array{uri: string, line: int, col: int, endLine: int, endCol: int}
+ */
 final readonly class Location
 {
     public function __construct(
@@ -15,7 +18,7 @@ final readonly class Location
     ) {}
 
     /**
-     * @return array{uri: string, line: int, col: int, endLine: int, endCol: int}
+     * @return SerializedLocation
      */
     public function toArray(): array
     {

--- a/src/php/Api/Transfer/ProjectIndex.php
+++ b/src/php/Api/Transfer/ProjectIndex.php
@@ -15,6 +15,9 @@ use function count;
  * Caching hook: a future implementation can key this by file-hash via
  * `ProjectIndexer` so that incremental reindexing avoids redoing parses
  * for unchanged files. For v1 the index is built from scratch each time.
+ *
+ * @phpstan-import-type SerializedDefinition from Definition
+ * @phpstan-import-type SerializedLocation from Location
  */
 final readonly class ProjectIndex
 {
@@ -67,18 +70,8 @@ final readonly class ProjectIndex
      * @return array{
      *     namespaces: int,
      *     definitions: int,
-     *     symbols: array<string, array{
-     *         namespace: string,
-     *         name: string,
-     *         uri: string,
-     *         line: int,
-     *         col: int,
-     *         kind: string,
-     *         signature: list<string>,
-     *         docstring: string,
-     *         private: bool,
-     *     }>,
-     *     references: array<string, list<array{uri: string, line: int, col: int, endLine: int, endCol: int}>>,
+     *     symbols: array<string, SerializedDefinition>,
+     *     references: array<string, list<SerializedLocation>>,
      * }
      */
     public function toArray(): array

--- a/src/php/Build/Application/NamespaceExtractor.php
+++ b/src/php/Build/Application/NamespaceExtractor.php
@@ -95,8 +95,8 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
             }
 
             throw ExtractorException::cannotExtractNamespaceFromPath($path);
-        } catch (AbstractParserException|ReaderException|LexerValueException) {
-            throw ExtractorException::cannotParseFile($path);
+        } catch (AbstractParserException|ReaderException|LexerValueException $e) {
+            throw ExtractorException::cannotParseFile($path, $e);
         }
     }
 

--- a/src/php/Build/BuildConfig.php
+++ b/src/php/Build/BuildConfig.php
@@ -11,8 +11,6 @@ use Phel\Shared\CompileOptions;
 use Phel\Shared\PhelProjectDirectory;
 use Phel\Shared\ScalarCoercion;
 
-use function is_string;
-
 final class BuildConfig extends AbstractConfig implements BuildConfigInterface
 {
     /**
@@ -80,15 +78,11 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
 
     public function getCacheDir(): string
     {
-        $envOverride = getenv('PHEL_CACHE_DIR');
-        if (is_string($envOverride) && $envOverride !== '') {
-            return $envOverride;
-        }
-
-        $cacheDir = ScalarCoercion::toString($this->get(PhelConfig::CACHE_DIR, '.phel/cache'));
-        $phelDir = ScalarCoercion::toString($this->get(PhelConfig::PHEL_DIR, ''));
-
-        return PhelProjectDirectory::resolve($this->getAppRootDir(), $cacheDir, $phelDir);
+        return PhelProjectDirectory::resolveCacheDir(
+            $this->getAppRootDir(),
+            ScalarCoercion::toString($this->get(PhelConfig::CACHE_DIR, '.phel/cache')),
+            ScalarCoercion::toString($this->get(PhelConfig::PHEL_DIR, '')),
+        );
     }
 
     public function getNamespaceCacheFile(): string

--- a/src/php/Build/Domain/Cache/NamespaceCacheEntry.php
+++ b/src/php/Build/Domain/Cache/NamespaceCacheEntry.php
@@ -6,6 +6,14 @@ namespace Phel\Build\Domain\Cache;
 
 use Phel\Shared\NamespaceInformation;
 
+/**
+ * `SerializedNamespaceCacheEntry` is what this entry writes; the read side
+ * accepts `PartialNamespaceCacheEntry` because cache files written before
+ * `isPrimaryDefinition` existed omit that key (it defaults to true).
+ *
+ * @phpstan-type SerializedNamespaceCacheEntry array{mtime: int, namespace: string, dependencies: list<string>, isPrimaryDefinition: bool}
+ * @phpstan-type PartialNamespaceCacheEntry array{mtime: int, namespace: string, dependencies: list<string>, isPrimaryDefinition?: bool}
+ */
 final readonly class NamespaceCacheEntry
 {
     /**
@@ -41,7 +49,7 @@ final readonly class NamespaceCacheEntry
     }
 
     /**
-     * @return array{mtime: int, namespace: string, dependencies: list<string>, isPrimaryDefinition: bool}
+     * @return SerializedNamespaceCacheEntry
      */
     public function toArray(): array
     {
@@ -54,7 +62,7 @@ final readonly class NamespaceCacheEntry
     }
 
     /**
-     * @param array{mtime: int, namespace: string, dependencies: list<string>, isPrimaryDefinition?: bool} $data
+     * @param PartialNamespaceCacheEntry $data
      */
     public static function fromArray(string $file, array $data): self
     {

--- a/src/php/Build/Domain/Cache/NamespaceCacheInterface.php
+++ b/src/php/Build/Domain/Cache/NamespaceCacheInterface.php
@@ -10,14 +10,10 @@ interface NamespaceCacheInterface
 
     public function put(string $file, NamespaceCacheEntry $entry): void;
 
-    public function remove(string $file): void;
-
     /**
      * @return list<string>
      */
     public function getAllFiles(): array;
 
     public function save(): void;
-
-    public function clear(): void;
 }

--- a/src/php/Build/Domain/Compile/BuildReport.php
+++ b/src/php/Build/Domain/Compile/BuildReport.php
@@ -15,6 +15,8 @@ use function is_file;
  * Summary of a `phel build` run: namespace count, per-namespace compiled size,
  * total size, fresh/cached breakdown, and wall-clock duration. Surfaced by
  * `phel build --report` to spot bloat and verify CI builds.
+ *
+ * @phpstan-import-type SerializedBuildReportEntry from BuildReportEntry
  */
 final readonly class BuildReport
 {
@@ -96,7 +98,7 @@ final readonly class BuildReport
      *     cached: int,
      *     total_bytes: int,
      *     duration_ms: float,
-     *     entries: list<array{namespace: string, bytes: int, cached: bool}>
+     *     entries: list<SerializedBuildReportEntry>
      * }
      */
     public function toArray(): array

--- a/src/php/Build/Domain/Compile/BuildReportEntry.php
+++ b/src/php/Build/Domain/Compile/BuildReportEntry.php
@@ -7,6 +7,8 @@ namespace Phel\Build\Domain\Compile;
 /**
  * One namespace line in a {@see BuildReport}: its compiled byte size and
  * whether it was reused from the build cache.
+ *
+ * @phpstan-type SerializedBuildReportEntry array{namespace: string, bytes: int, cached: bool}
  */
 final readonly class BuildReportEntry
 {
@@ -17,7 +19,7 @@ final readonly class BuildReportEntry
     ) {}
 
     /**
-     * @return array{namespace: string, bytes: int, cached: bool}
+     * @return SerializedBuildReportEntry
      */
     public function toArray(): array
     {

--- a/src/php/Build/Domain/Extractor/ExtractorException.php
+++ b/src/php/Build/Domain/Extractor/ExtractorException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Build\Domain\Extractor;
 
 use RuntimeException;
+use Throwable;
 
 use function sprintf;
 
@@ -20,9 +21,21 @@ final class ExtractorException extends RuntimeException
         return new self('Cannot extract namespace from file: ' . $path);
     }
 
-    public static function cannotParseFile(string $path): self
+    /**
+     * @param ?Throwable $previous the lexer/parser/reader failure that caused this;
+     *                             its message is appended so the caller sees why
+     */
+    public static function cannotParseFile(string $path, ?Throwable $previous = null): self
     {
-        return new self('Cannot parse file: ' . $path);
+        if (!$previous instanceof Throwable) {
+            return new self('Cannot parse file: ' . $path);
+        }
+
+        return new self(
+            sprintf('Cannot parse file: %s: %s', $path, $previous->getMessage()),
+            0,
+            $previous,
+        );
     }
 
     public static function cannotResolveRequiredNamespace(string $requiredNs, string $requiringNs): self

--- a/src/php/Build/Infrastructure/Cache/NullNamespaceCache.php
+++ b/src/php/Build/Infrastructure/Cache/NullNamespaceCache.php
@@ -19,11 +19,6 @@ final class NullNamespaceCache implements NamespaceCacheInterface
         // No-op
     }
 
-    public function remove(string $file): void
-    {
-        // No-op
-    }
-
     /**
      * @return list<string>
      */
@@ -33,11 +28,6 @@ final class NullNamespaceCache implements NamespaceCacheInterface
     }
 
     public function save(): void
-    {
-        // No-op
-    }
-
-    public function clear(): void
     {
         // No-op
     }

--- a/src/php/Build/Infrastructure/Cache/PhpNamespaceCache.php
+++ b/src/php/Build/Infrastructure/Cache/PhpNamespaceCache.php
@@ -13,6 +13,10 @@ use function is_array;
 use function is_int;
 use function is_string;
 
+/**
+ * @phpstan-import-type PartialNamespaceCacheEntry from NamespaceCacheEntry
+ * @phpstan-import-type SerializedNamespaceCacheEntry from NamespaceCacheEntry
+ */
 final class PhpNamespaceCache implements NamespaceCacheInterface
 {
     private const string VERSION = '1.0';
@@ -134,7 +138,7 @@ final class PhpNamespaceCache implements NamespaceCacheInterface
                 && is_string($entryData['namespace'])
                 && is_array($entryData['dependencies'])
             ) {
-                /** @var array{mtime: int, namespace: string, dependencies: list<string>, isPrimaryDefinition?: bool} $entryData */
+                /** @var PartialNamespaceCacheEntry $entryData */
                 $entries[$file] = NamespaceCacheEntry::fromArray($file, $entryData);
             }
         }
@@ -143,7 +147,7 @@ final class PhpNamespaceCache implements NamespaceCacheInterface
     }
 
     /**
-     * @return array{version: string, entries: array<string, array{mtime: int, namespace: string, dependencies: list<string>, isPrimaryDefinition: bool}>}
+     * @return array{version: string, entries: array<string, SerializedNamespaceCacheEntry>}
      */
     private function toArray(): array
     {

--- a/src/php/Build/Infrastructure/Cache/PhpNamespaceCache.php
+++ b/src/php/Build/Infrastructure/Cache/PhpNamespaceCache.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Build\Infrastructure\Cache;
 
-use Gacela\Framework\Cache\FileCache;
 use Phel\Build\Domain\Cache\NamespaceCacheEntry;
 use Phel\Build\Domain\Cache\NamespaceCacheInterface;
 use Phel\Build\Domain\Extractor\ExcludedScanPaths;
@@ -30,7 +29,7 @@ final class PhpNamespaceCache implements NamespaceCacheInterface
         $this->entries = $this->loadEntriesFromFile();
 
         // `loadEntriesFromFile` may evict entries under always-excluded
-        // segments; persist that cleanup at shutdown even if no put/remove
+        // segments; persist that cleanup at shutdown even if no put
         // happens during the run.
         if ($this->dirty) {
             $this->registerShutdown();
@@ -47,15 +46,6 @@ final class PhpNamespaceCache implements NamespaceCacheInterface
         $this->entries[$file] = $entry;
         $this->dirty = true;
         $this->registerShutdown();
-    }
-
-    public function remove(string $file): void
-    {
-        if (isset($this->entries[$file])) {
-            unset($this->entries[$file]);
-            $this->dirty = true;
-            $this->registerShutdown();
-        }
     }
 
     /**
@@ -83,14 +73,6 @@ final class PhpNamespaceCache implements NamespaceCacheInterface
         if ($written) {
             $this->dirty = false;
         }
-    }
-
-    public function clear(): void
-    {
-        $this->entries = [];
-        $this->dirty = false;
-
-        FileCache::delete($this->cacheFile);
     }
 
     /**

--- a/src/php/CLAUDE.md
+++ b/src/php/CLAUDE.md
@@ -21,6 +21,7 @@ Rules:
 - Cross-module access goes through facades only; inject `*FacadeInterface`, never a concrete facade.
 - A Factory may only `new` classes from its own module or `Phel\Shared`; cross-module instances come via the injected Facade.
 - New modules add their `FacadeInterface` to `Shared/Facade/`.
+- The module graph has exactly four cyclic pairs (`Api <-> Run`, `Compiler <-> Shared`, `Lang <-> Shared`, `Phel <-> Run`), each documented in the owning module's CLAUDE.md and pinned by `tests/php/Unit/Architecture/ModuleDependencyCycleTest.php`. `Api <-> Run` is the only mutual Gacela provider pair. Adding a fifth needs a written rationale, not just a green build.
 
 ## Module Map
 

--- a/src/php/Command/Application/TextExceptionPrinter.php
+++ b/src/php/Command/Application/TextExceptionPrinter.php
@@ -224,7 +224,11 @@ final readonly class TextExceptionPrinter implements ExceptionPrinterInterface
 
             $class = $frame['class'] ?? '';
             $type = $frame['type'] ?? '';
-            $fn = $frame['function'] ?? ''; // @phpstan-ignore-line
+            // PHP always sets `function` on a trace frame, but Psalm's stub
+            // marks it optional while PHPStan's marks it required, so neither
+            // a plain read nor a `??` default satisfies both.
+            // @phpstan-ignore nullCoalesce.offset
+            $fn = $frame['function'] ?? '';
             $argString = $this->exceptionArgsPrinter->buildPhpArgsString($frame['args'] ?? []);
             $str .= sprintf('#%d %s(%d): %s%s%s(%s)', $i, $file, $line, $class, $type, $fn, $argString) . PHP_EOL;
         }

--- a/src/php/Command/Domain/Exceptions/ExceptionArgsPrinter.php
+++ b/src/php/Command/Domain/Exceptions/ExceptionArgsPrinter.php
@@ -96,9 +96,6 @@ final readonly class ExceptionArgsPrinter implements ExceptionArgsPrinterInterfa
         }
 
         if (is_resource($arg)) {
-            /**
-             * @psalm-suppress UndefinedFunction
-             */
             return 'Resource id #' . get_resource_id($arg);
         }
 

--- a/src/php/Command/Domain/Exceptions/Extractor/FilePositionExtractorInterface.php
+++ b/src/php/Command/Domain/Exceptions/Extractor/FilePositionExtractorInterface.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Phel\Command\Domain\Exceptions\Extractor;
 
 use Phel\Command\Domain\Exceptions\Extractor\ReadModel\FilePosition;
+use Phel\Shared\Facade\CommandFacadeInterface;
 
+/**
+ * @phpstan-import-type CompiledFileLineMap from CommandFacadeInterface
+ */
 interface FilePositionExtractorInterface
 {
     public function getOriginal(string $filename, int $line): FilePosition;
@@ -16,7 +20,7 @@ interface FilePositionExtractorInterface
      * `[phpLine => phelLine]` map; empty filename when the file carries no
      * source map.
      *
-     * @return array{filename: string, lines: array<int, int>}
+     * @return CompiledFileLineMap
      */
     public function getFileLineMap(string $filename): array;
 }

--- a/src/php/Compiler/CompilerConfig.php
+++ b/src/php/Compiler/CompilerConfig.php
@@ -9,8 +9,6 @@ use Phel\Config\PhelConfig;
 use Phel\Shared\PhelProjectDirectory;
 use Phel\Shared\ScalarCoercion;
 
-use function is_string;
-
 final class CompilerConfig extends AbstractConfig
 {
     public function assertsEnabled(): bool
@@ -29,20 +27,16 @@ final class CompilerConfig extends AbstractConfig
     }
 
     /**
-     * Mirrors {@see \Phel\Build\BuildConfig::getCacheDir()} so the
-     * intermediate-artifact cache lands in the same `<cacheDir>` the rest of
-     * the build cache uses and is cleared along with it.
+     * Shares `PhelProjectDirectory::resolveCacheDir()` with the build config,
+     * so the intermediate-artifact cache lands in the same `<cacheDir>` the
+     * rest of the build cache uses and is cleared along with it.
      */
     public function getCacheDir(): string
     {
-        $envOverride = getenv('PHEL_CACHE_DIR');
-        if (is_string($envOverride) && $envOverride !== '') {
-            return $envOverride;
-        }
-
-        $cacheDir = ScalarCoercion::toString($this->get(PhelConfig::CACHE_DIR, '.phel/cache'));
-        $phelDir = ScalarCoercion::toString($this->get(PhelConfig::PHEL_DIR, ''));
-
-        return PhelProjectDirectory::resolve($this->getAppRootDir(), $cacheDir, $phelDir);
+        return PhelProjectDirectory::resolveCacheDir(
+            $this->getAppRootDir(),
+            ScalarCoercion::toString($this->get(PhelConfig::CACHE_DIR, '.phel/cache')),
+            ScalarCoercion::toString($this->get(PhelConfig::PHEL_DIR, '')),
+        );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
@@ -81,32 +81,12 @@ final class BackslashSeparatorDeprecator
 
     public function maybeWarn(Symbol $symbol): void
     {
-        if (!$this->enabled) {
-            return;
-        }
-
         $location = $symbol->getStartLocation();
         if (!$location instanceof SourceLocation) {
             return;
         }
 
-        $file = $location->getFile();
-        if ($file === '' || $this->isPhelStdlibSource($file)) {
-            return;
-        }
-
-        $original = $symbol->getFullName();
-        if (!$this->containsBackslashSeparator($original)) {
-            return;
-        }
-
-        $key = $file . '|' . $original;
-        if (isset($this->seen[$key])) {
-            return;
-        }
-
-        $this->seen[$key] = true;
-        ($this->emitter)($this->buildMessage($original, $file, $location->getLine()));
+        $this->maybeWarnString($symbol->getFullName(), $location);
     }
 
     public function maybeWarnString(string $namespace, SourceLocation $location): void

--- a/src/php/Compiler/Domain/Analyzer/SymbolSuggestionProvider.php
+++ b/src/php/Compiler/Domain/Analyzer/SymbolSuggestionProvider.php
@@ -14,6 +14,9 @@ use function strcmp;
 use function strlen;
 use function usort;
 
+/**
+ * @phpstan-type ScoredCandidate array{symbol: string, subsequence: int, prefix: int, distance: int}
+ */
 final class SymbolSuggestionProvider
 {
     private const int MAX_EDIT_DISTANCE = 3;
@@ -50,7 +53,7 @@ final class SymbolSuggestionProvider
      * Scores a candidate against the typed symbol, or returns `null` when the
      * candidate is too dissimilar to suggest.
      *
-     * @return array{symbol: string, subsequence: int, prefix: int, distance: int}|null
+     * @return ScoredCandidate|null
      */
     private function score(string $undefinedSymbol, string $candidate): ?array
     {
@@ -87,8 +90,8 @@ final class SymbolSuggestionProvider
      * prefix, then smaller edit distance, then alphabetically for a stable,
      * deterministic result.
      *
-     * @param array{symbol: string, subsequence: int, prefix: int, distance: int} $a
-     * @param array{symbol: string, subsequence: int, prefix: int, distance: int} $b
+     * @param ScoredCandidate $a
+     * @param ScoredCandidate $b
      */
     private function byRelevance(array $a, array $b): int
     {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -335,8 +335,8 @@ final class AnalyzePersistentList
 
     /**
      * Lazy `name => factory` dispatch registry, built once. The factories defer
-     * construction so each analyzer is still only instantiated on first use
-     * (and then memoized in `$symbolAnalyzerCache`), matching the old `match`.
+     * construction so each analyzer is only instantiated on first use (and then
+     * memoized in `$symbolAnalyzerCache`).
      *
      * @return array<string, callable(): SpecialFormAnalyzerInterface>
      */

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -272,7 +272,6 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
         GlobalVarNode $macroNode,
         NodeEnvironmentInterface $env,
     ): mixed {
-        /** @psalm-suppress PossiblyNullArgument */
         $nodeName = $macroNode->getName()->getName();
 
         $ns = str_replace('-', '_', $macroNode->getNamespace());

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
@@ -77,7 +77,6 @@ final readonly class LetSymbol implements SpecialFormAnalyzerInterface
      */
     private function analyzeLetOrLoop(PersistentListInterface $list, NodeEnvironmentInterface $env): AbstractNode
     {
-        /** @psalm-suppress PossiblyNullArgument */
         /** @var PersistentVectorInterface<mixed> $bindingVector */
         $bindingVector = $list->get(1);
         $bindings = $this->analyzeBindings($bindingVector, $env->withDisallowRecurFrame());

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoopSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoopSymbol.php
@@ -113,7 +113,6 @@ final readonly class LoopSymbol implements SpecialFormAnalyzerInterface
         $rest2 = $rest1->rest();
         $exprs = $rest2->toArray();
 
-        /** @psalm-suppress PossiblyNullArgument */
         /** @var PersistentVectorInterface<mixed> $bindingVector */
         $bindingVector = $list->get(1);
         $bindings = $this->analyzeBindings($bindingVector, $env->withDisallowRecurFrame());

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
@@ -97,7 +97,6 @@ final readonly class PhpObjectCallSymbol implements SpecialFormAnalyzerInterface
             $segment,
         );
 
-        /** @psalm-suppress PossiblyNullArgument */
         /** @var Symbol $callSymbol */
         $callSymbol = $segment->get(0);
         return new MethodCallNode($env, $callSymbol, $args, $segment->getStartLocation());
@@ -105,7 +104,6 @@ final readonly class PhpObjectCallSymbol implements SpecialFormAnalyzerInterface
 
     private function callExprForPropertyCall(NodeEnvironmentInterface $env, Symbol $segment): PropertyOrConstantAccessNode
     {
-        /** @psalm-suppress PossiblyNullArgument */
         return new PropertyOrConstantAccessNode($env, $segment, $segment->getStartLocation());
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowerer.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowerer.php
@@ -42,6 +42,10 @@ use function is_string;
  * directly — bypassing the context-prefix machinery that would
  * inject `return …;` inside a match arm and break PHP syntax.
  */
+/**
+ * @phpstan-type MatchArm array{key: mixed, expr: mixed}
+ * @phpstan-type LoweredMatch array{init: AbstractNode, arms: list<MatchArm>, fallback: mixed}
+ */
 final readonly class IfChainMatchLowerer
 {
     /** @var list<string> */
@@ -58,7 +62,7 @@ final readonly class IfChainMatchLowerer
      * with no outer `let`. Every test must reference the **same**
      * `LocalVarNode` shadow.
      *
-     * @return array{init: LocalVarNode, arms: list<array{key: mixed, expr: mixed}>, fallback: mixed}|null
+     * @return array{init: LocalVarNode, arms: list<MatchArm>, fallback: mixed}|null
      */
     public static function analyseIfChain(IfNode $root): ?array
     {
@@ -104,7 +108,7 @@ final readonly class IfChainMatchLowerer
     }
 
     /**
-     * @return array{init: AbstractNode, arms: list<array{key: mixed, expr: mixed}>, fallback: mixed}|null
+     * @return LoweredMatch|null
      */
     public static function analyse(LetNode $root): ?array
     {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LoweredMatchEmitterTrait.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LoweredMatchEmitterTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
-use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
@@ -12,11 +11,13 @@ use Phel\Lang\SourceLocation;
  * Emits the PHP `match` expression for a lowered `cond` / `case` chain
  * shape produced by {@see IfChainMatchLowerer}. Composing emitters must
  * also use {@see WithOutputEmitterTrait}.
+ *
+ * @phpstan-import-type LoweredMatch from IfChainMatchLowerer
  */
 trait LoweredMatchEmitterTrait
 {
     /**
-     * @param array{init: AbstractNode, arms: list<array{key: mixed, expr: mixed}>, fallback: mixed} $shape
+     * @param LoweredMatch $shape
      */
     private function emitLoweredMatch(array $shape, NodeEnvironmentInterface $env, ?SourceLocation $loc): void
     {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
@@ -18,6 +18,10 @@ use function count;
 use function is_int;
 use function is_string;
 
+/**
+ * @phpstan-type LocationLiteral array{file: string, line: int, column: int}
+ * @phpstan-type DefLocationMeta array{start: LocationLiteral, end: LocationLiteral, extras: list<array{AbstractNode, AbstractNode}>}
+ */
 final class MapEmitter implements NodeEmitterInterface
 {
     use WithOutputEmitterTrait;
@@ -64,7 +68,7 @@ final class MapEmitter implements NodeEmitterInterface
      * `\Phel::location("file", line, col)` helper invocation — same map
      * at runtime, far less generated PHP per definition.
      *
-     * @return array{file: string, line: int, column: int}|null
+     * @return LocationLiteral|null
      */
     private function locationLiteral(MapNode $node): ?array
     {
@@ -108,7 +112,7 @@ final class MapEmitter implements NodeEmitterInterface
     }
 
     /**
-     * @param array{file: string, line: int, column: int} $location
+     * @param LocationLiteral $location
      */
     private function emitLocationHelper(array $location, ?SourceLocation $loc): void
     {
@@ -133,7 +137,7 @@ final class MapEmitter implements NodeEmitterInterface
      * Phel maps are unordered and metadata is read by key). Maps missing
      * either location entry fall through to the generic `\Phel::map(...)` path.
      *
-     * @return array{start: array{file: string, line: int, column: int}, end: array{file: string, line: int, column: int}, extras: list<array{AbstractNode, AbstractNode}>}|null
+     * @return DefLocationMeta|null
      */
     private function defLocationMeta(MapNode $node): ?array
     {
@@ -174,7 +178,7 @@ final class MapEmitter implements NodeEmitterInterface
     }
 
     /**
-     * @param array{start: array{file: string, line: int, column: int}, end: array{file: string, line: int, column: int}, extras: list<array{AbstractNode, AbstractNode}>} $meta
+     * @param DefLocationMeta $meta
      */
     private function emitDefLocationMetaHelper(array $meta, ?SourceLocation $loc): void
     {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -160,11 +160,14 @@ final readonly class MethodEmitter
     }
 
     /**
-     * `^:by-ref` (and the historical `^:reference` alias used inside
-     * `phel.core`) compiles the param to PHP `&$param` so mutations via
+     * `^:by-ref` compiles the param to PHP `&$param` so mutations via
      * `php/aset`, `php/array_push`, etc. propagate back to the caller's
      * binding. Surfaces the `(php/array)` mutation pattern at the Phel
      * level without forcing buffer-return-rebind dances.
+     *
+     * `^:reference` is the historical alias, kept for source compatibility;
+     * nothing in `src/phel/` uses it any more (only the
+     * `Fn/fn-param-by-ref-legacy-reference-alias` fixture pins it).
      *
      * @param PersistentMapInterface<mixed, mixed>|null $meta
      */

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -136,10 +136,6 @@ final readonly class PhelConfig implements JsonSerializable
         return $config;
     }
 
-    // ========================================
-    // Getters
-    // ========================================
-
     /**
      * @return list<string>
      */
@@ -263,10 +259,6 @@ final readonly class PhelConfig implements JsonSerializable
         return $this->optimizationLevel;
     }
 
-    // ========================================
-    // Layout
-    // ========================================
-
     /**
      * Apply a project layout (nested or flat). Returns a new instance with src,
      * test, format, and export-from directories fully reset to the layout's
@@ -284,10 +276,6 @@ final readonly class PhelConfig implements JsonSerializable
             'exportConfig' => $this->exportConfig->withFromDirectories($layout->getExportFromDirs()),
         ]);
     }
-
-    // ========================================
-    // Immutable with*() API
-    // ========================================
 
     /**
      * Directories scanned for Phel source namespaces (relative to the project
@@ -606,10 +594,6 @@ final readonly class PhelConfig implements JsonSerializable
         return $this->with(['stripSymbolMeta' => $strip]);
     }
 
-    // ========================================
-    // Validation
-    // ========================================
-
     /**
      * Validate the configuration and return any errors found.
      *
@@ -619,10 +603,6 @@ final readonly class PhelConfig implements JsonSerializable
     {
         return new PhelConfigValidator()->validate($this);
     }
-
-    // ========================================
-    // Serialization
-    // ========================================
 
     /**
      * @return array<string, mixed>

--- a/src/php/Fiber/CLAUDE.md
+++ b/src/php/Fiber/CLAUDE.md
@@ -13,7 +13,7 @@ Cooperative async primitives (promises, futures, single-threaded scheduler) back
 
 ## Dependencies
 
-- None. `FiberProvider` is empty; no cross-module facades.
+- None. The module has no Provider; no cross-module facades.
 - `FiberConfig::defaultSleepMicroseconds()` = 500µs (top-level busy-poll sleep when awaiting outside a Fiber).
 
 ## Structure

--- a/src/php/Fiber/FiberProvider.php
+++ b/src/php/Fiber/FiberProvider.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Phel\Fiber;
-
-use Gacela\Framework\AbstractProvider;
-
-final class FiberProvider extends AbstractProvider {}

--- a/src/php/Filesystem/Application/TempDirFinder.php
+++ b/src/php/Filesystem/Application/TempDirFinder.php
@@ -47,7 +47,6 @@ final class TempDirFinder
         if (!$this->fileIo->isWritable($tempDir)) {
             @chmod($tempDir, 0777);
 
-            // @phpstan-ignore-next-line if.alwaysFalse
             if ($this->fileIo->isWritable($tempDir)) {
                 return $this->cachedTempDir = $tempDir;
             }

--- a/src/php/Filesystem/Domain/FileIoInterface.php
+++ b/src/php/Filesystem/Domain/FileIoInterface.php
@@ -10,6 +10,11 @@ interface FileIoInterface
      * Returns true if the directory is writable by the current process.
      *
      * Abstraction over PHP's is_writable() so callers can be mocked in tests.
+     *
+     * Impure by nature: the answer depends on filesystem state, so two calls
+     * with the same argument may legitimately disagree (e.g. after a chmod).
+     *
+     * @phpstan-impure
      */
     public function isWritable(string $tempDir): bool;
 }

--- a/src/php/Formatter/Application/PathsFormatter.php
+++ b/src/php/Formatter/Application/PathsFormatter.php
@@ -13,7 +13,6 @@ use Phel\Formatter\Domain\PathFilterInterface;
 use Phel\Formatter\Domain\Rules\Zipper\ZipperException;
 use Phel\Shared\Facade\CommandFacadeInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Throwable;
 
 final readonly class PathsFormatter
 {
@@ -33,6 +32,12 @@ final readonly class PathsFormatter
     ) {}
 
     /**
+     * Only the failures {@see self::formatFile()} documents as coming from the
+     * file itself (bad source, missing path) are reported and skipped, so one
+     * unformattable file does not abort the batch. Anything else — an I/O
+     * failure, a bug in a rule — propagates: swallowing it would report a
+     * successful run that silently skipped files.
+     *
      * @param list<string> $paths
      *
      * @return list<string> paths whose contents changed (or would change under $dryRun)
@@ -49,7 +54,7 @@ final readonly class PathsFormatter
                 }
             } catch (AbstractParserException $e) {
                 $this->commandFacade->writeLocatedException($output, $e, $e->getCodeSnippet());
-            } catch (Throwable $e) {
+            } catch (FilePathException|LexerValueException|ZipperException $e) {
                 $this->commandFacade->writeStackTrace($output, $e);
             }
         }

--- a/src/php/Formatter/CLAUDE.md
+++ b/src/php/Formatter/CLAUDE.md
@@ -44,7 +44,7 @@ Symbol lists live as `FormatterFactory` constants; `createIndentRule()` instanti
 | `Application/PathsFormatter.php` | Discovers files, formats each, reports changes |
 | `Application/PhelPathFilter.php` | Recursively finds `.phel` files (impl of `PathFilterInterface`) |
 | `Domain/Rules/` | Rule classes + `IndentRule` |
-| `Domain/Rules/Indenter/` | `BlockIndenter`, `InnerIndenter`, `LineIndenter`, `ListIndenter` |
+| `Domain/Rules/Indenter/` | `BlockIndenter`, `InnerIndenter`, `LineIndenter`, `ListIndenter`; `FormSymbolMatcherTrait` reads a location's head symbol and matches it against the indenter's symbol |
 | `Domain/Rules/Pair/PairAligner.php` | Backing logic for `AlignPairsRule` |
 | `Domain/Rules/Zipper/` | `ParseTreeZipper` (AST traversal/transform), `AbstractZipper` |
 | `Infrastructure/IO/SystemFileIo.php` | `FileIoInterface` impl |

--- a/src/php/Formatter/Domain/Rules/Indenter/BlockIndenter.php
+++ b/src/php/Formatter/Domain/Rules/Indenter/BlockIndenter.php
@@ -6,8 +6,6 @@ namespace Phel\Formatter\Domain\Rules\Indenter;
 
 use Phel\Formatter\Domain\Rules\Zipper\ParseTreeZipper;
 use Phel\Formatter\Domain\Rules\Zipper\ZipperException;
-use Phel\Lang\Symbol;
-use Phel\Shared\Parser\Node\SymbolNode;
 
 use function is_null;
 
@@ -20,6 +18,8 @@ use function is_null;
  */
 final readonly class BlockIndenter implements IndenterInterface
 {
+    use FormSymbolMatcherTrait;
+
     private ListIndenter $listIndenter;
 
     /**
@@ -79,21 +79,5 @@ final readonly class BlockIndenter implements IndenterInterface
         }
 
         return $left->isComment();
-    }
-
-    private function indentMatches(string $key, ?Symbol $formSymbol): bool
-    {
-        return $formSymbol instanceof Symbol && $key === $formSymbol->getName();
-    }
-
-    private function formSymbol(ParseTreeZipper $loc): ?Symbol
-    {
-        $leftMostNode = $loc->leftMost()->getNode();
-
-        if ($leftMostNode instanceof SymbolNode) {
-            return $leftMostNode->getValue();
-        }
-
-        return null;
     }
 }

--- a/src/php/Formatter/Domain/Rules/Indenter/FormSymbolMatcherTrait.php
+++ b/src/php/Formatter/Domain/Rules/Indenter/FormSymbolMatcherTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Formatter\Domain\Rules\Indenter;
+
+use Phel\Formatter\Domain\Rules\Zipper\ParseTreeZipper;
+use Phel\Lang\Symbol;
+use Phel\Shared\Parser\Node\SymbolNode;
+
+/**
+ * Reads the head symbol of the form a zipper location sits in and compares it
+ * against an indenter's configured symbol.
+ */
+trait FormSymbolMatcherTrait
+{
+    private function indentMatches(string $key, ?Symbol $formSymbol): bool
+    {
+        return $formSymbol instanceof Symbol && $key === $formSymbol->getName();
+    }
+
+    private function formSymbol(ParseTreeZipper $loc): ?Symbol
+    {
+        $leftMostNode = $loc->leftMost()->getNode();
+
+        if ($leftMostNode instanceof SymbolNode) {
+            return $leftMostNode->getValue();
+        }
+
+        return null;
+    }
+}

--- a/src/php/Formatter/Domain/Rules/Indenter/InnerIndenter.php
+++ b/src/php/Formatter/Domain/Rules/Indenter/InnerIndenter.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Phel\Formatter\Domain\Rules\Indenter;
 
 use Phel\Formatter\Domain\Rules\Zipper\ParseTreeZipper;
-use Phel\Lang\Symbol;
-use Phel\Shared\Parser\Node\SymbolNode;
 
 /**
  * Indents a form's body by one extra level relative to its head line.
@@ -17,6 +15,8 @@ use Phel\Shared\Parser\Node\SymbolNode;
  */
 final readonly class InnerIndenter implements IndenterInterface
 {
+    use FormSymbolMatcherTrait;
+
     private LineIndenter $lineIndenter;
 
     /**
@@ -43,22 +43,6 @@ final readonly class InnerIndenter implements IndenterInterface
             $up = $loc->upSkipWhitespace();
 
             return $this->lineIndenter->getMargin($up, $indentWidth) + $indentWidth;
-        }
-
-        return null;
-    }
-
-    private function indentMatches(string $key, ?Symbol $formSymbol): bool
-    {
-        return $formSymbol instanceof Symbol && $key === $formSymbol->getName();
-    }
-
-    private function formSymbol(ParseTreeZipper $loc): ?Symbol
-    {
-        $leftMostNode = $loc->leftMost()->getNode();
-
-        if ($leftMostNode instanceof SymbolNode) {
-            return $leftMostNode->getValue();
         }
 
         return null;

--- a/src/php/Formatter/Domain/Rules/Zipper/AbstractZipper.php
+++ b/src/php/Formatter/Domain/Rules/Zipper/AbstractZipper.php
@@ -206,9 +206,6 @@ abstract class AbstractZipper
      * @return mixed
      *
      * @psalm-return T
-     *
-     * @psalm-suppress InvalidReturnType
-     * @psalm-suppress InvalidReturnStatement
      */
     public function root()
     {

--- a/src/php/Lang/AbstractType.php
+++ b/src/php/Lang/AbstractType.php
@@ -11,6 +11,8 @@ use Stringable;
  */
 abstract class AbstractType implements TypeInterface, Stringable
 {
+    use CopyLocationFromTrait;
+
     private ?SourceLocation $startLocation = null;
 
     private ?SourceLocation $endLocation = null;
@@ -42,19 +44,4 @@ abstract class AbstractType implements TypeInterface, Stringable
         return $this->endLocation;
     }
 
-    /**
-     * Copies the start and end location from $other.
-     *
-     * @param mixed $other The object to copy from
-     */
-    public function copyLocationFrom(mixed $other): static
-    {
-        if ($other instanceof SourceLocationInterface) {
-            return $this
-                ->setStartLocation($other->getStartLocation())
-                ->setEndLocation($other->getEndLocation());
-        }
-
-        return $this;
-    }
 }

--- a/src/php/Lang/Atom.php
+++ b/src/php/Lang/Atom.php
@@ -16,10 +16,10 @@ final class Atom extends AbstractType
 {
     use MetaTrait;
 
-    /** @var array<string, callable> */
+    /** @var array<string, callable(Keyword, self<T>, T, T): void> */
     private array $watches = [];
 
-    /** @var callable|null */
+    /** @var (callable(T): mixed)|null */
     private $validator;
 
     /**
@@ -62,6 +62,11 @@ final class Atom extends AbstractType
         return $this->value;
     }
 
+    /**
+     * @param callable(Keyword, self<T>, T, T): void $fn called after every successful
+     *                                                   {@see self::set()} with the watch key,
+     *                                                   this atom, the old and the new value
+     */
     public function addWatch(string $key, callable $fn): void
     {
         $this->watches[$key] = $fn;
@@ -72,6 +77,10 @@ final class Atom extends AbstractType
         unset($this->watches[$key]);
     }
 
+    /**
+     * @param (callable(T): mixed)|null $fn the return value is checked for Phel truthiness,
+     *                                      so any value is accepted
+     */
     public function setValidator(?callable $fn): void
     {
         if ($fn !== null) {
@@ -81,6 +90,9 @@ final class Atom extends AbstractType
         $this->validator = $fn;
     }
 
+    /**
+     * @return (callable(T): mixed)|null
+     */
     public function getValidator(): ?callable
     {
         return $this->validator;
@@ -101,6 +113,10 @@ final class Atom extends AbstractType
         return crc32(spl_object_hash($this));
     }
 
+    /**
+     * @param T                         $value
+     * @param (callable(T): mixed)|null $validator
+     */
     private function validate(mixed $value, ?callable $validator = null): void
     {
         $fn = $validator ?? $this->validator;
@@ -109,6 +125,10 @@ final class Atom extends AbstractType
         }
     }
 
+    /**
+     * @param T $oldValue
+     * @param T $newValue
+     */
     private function notifyWatches(mixed $oldValue, mixed $newValue): void
     {
         foreach ($this->watches as $key => $callback) {

--- a/src/php/Lang/BigDecimal.php
+++ b/src/php/Lang/BigDecimal.php
@@ -32,6 +32,8 @@ use function substr;
  */
 final readonly class BigDecimal implements TypeInterface, Stringable
 {
+    use CopyLocationFromTrait;
+
     private const int MAX_DIVIDE_SCALE = 100;
 
     /**
@@ -302,17 +304,6 @@ final readonly class BigDecimal implements TypeInterface, Stringable
     public function getEndLocation(): ?SourceLocation
     {
         return $this->endLocation;
-    }
-
-    public function copyLocationFrom(mixed $other): static
-    {
-        if ($other instanceof SourceLocationInterface) {
-            return $this
-                ->setStartLocation($other->getStartLocation())
-                ->setEndLocation($other->getEndLocation());
-        }
-
-        return $this;
     }
 
     private function toCanonicalString(): string

--- a/src/php/Lang/BigInt.php
+++ b/src/php/Lang/BigInt.php
@@ -27,6 +27,8 @@ use function substr;
  */
 final readonly class BigInt implements TypeInterface, Stringable
 {
+    use CopyLocationFromTrait;
+
     /**
      * @param int                                       $sign      -1, 0, or 1; must be 0 iff magnitude is empty
      * @param list<int>                                 $magnitude base-10^9 digits, least-significant first; no trailing zeros
@@ -85,17 +87,6 @@ final readonly class BigInt implements TypeInterface, Stringable
     public function getEndLocation(): ?SourceLocation
     {
         return $this->endLocation;
-    }
-
-    public function copyLocationFrom(mixed $other): static
-    {
-        if ($other instanceof SourceLocationInterface) {
-            return $this
-                ->setStartLocation($other->getStartLocation())
-                ->setEndLocation($other->getEndLocation());
-        }
-
-        return $this;
     }
 
     public static function zero(): self

--- a/src/php/Lang/CLAUDE.md
+++ b/src/php/Lang/CLAUDE.md
@@ -44,6 +44,8 @@ No Gacela pattern: foundational leaf module; all types used directly by other mo
 
 Other utilities: `DynamicScope` (dynamic bindings), `Truthy`, `TypeStringifier`, `Hasher`/`Equalizer` (collection hashing/equality).
 
+Shared behaviour traits: `MetaTrait` (`getMeta`/`withMeta`), `HashCombinerTrait`, `CopyLocationFromTrait` (the `SourceLocationInterface::copyLocationFrom()` default; declares `setStartLocation`/`setEndLocation` abstract, so each type keeps its own copy-vs-mutate strategy).
+
 ## Runtime Infrastructure
 
 | Class | Notes |

--- a/src/php/Lang/Collections/LazySeq/LazySeqConfig.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeqConfig.php
@@ -10,13 +10,6 @@ namespace Phel\Lang\Collections\LazySeq;
 final class LazySeqConfig
 {
     /**
-     * Collections with fewer elements than this threshold will be realized eagerly.
-     * This optimizes performance for small collections where lazy evaluation overhead
-     * would be greater than the benefit.
-     */
-    public const int EAGER_THRESHOLD = 32;
-
-    /**
      * Size of chunks when using chunked sequences.
      * Chunked sequences realize elements in batches for better performance.
      */

--- a/src/php/Lang/Collections/LazySeq/LazySeqInterface.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeqInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Lang\Collections\LazySeq;
 
+use IteratorAggregate;
 use Phel\Lang\ConsInterface;
 use Phel\Lang\SeqInterface;
 use Phel\Lang\TypeInterface;
@@ -12,12 +13,17 @@ use Phel\Lang\TypeInterface;
  * Interface for lazy sequences.
  * Lazy sequences defer computation until values are actually needed.
  *
+ * Iterability is part of the contract: consumers such as the printer walk a
+ * lazy seq element by element instead of forcing `toArray()`, which would
+ * never terminate for an infinite sequence.
+ *
  * @template T
  *
  * @extends SeqInterface<T, LazySeqInterface<T>>
  * @extends ConsInterface<LazySeqInterface<T>>
+ * @extends IteratorAggregate<int, T>
  */
-interface LazySeqInterface extends TypeInterface, SeqInterface, ConsInterface
+interface LazySeqInterface extends TypeInterface, SeqInterface, ConsInterface, IteratorAggregate
 {
     /**
      * Checks if this lazy sequence has been realized (computed).

--- a/src/php/Lang/Collections/LazySeq/MemoizedThunk.php
+++ b/src/php/Lang/Collections/LazySeq/MemoizedThunk.php
@@ -15,7 +15,7 @@ use function assert;
  */
 final class MemoizedThunk
 {
-    /** @var callable|null The thunk to invoke (null after first invocation) */
+    /** @var (callable(): mixed)|null The thunk to invoke (null after first invocation) */
     private $fn;
 
     /** @var bool Whether the thunk has been invoked */
@@ -25,7 +25,7 @@ final class MemoizedThunk
     private mixed $result = null;
 
     /**
-     * @param callable $fn The thunk to memoize
+     * @param callable(): mixed $fn The thunk to memoize
      */
     public function __construct(callable $fn)
     {

--- a/src/php/Lang/Collections/Map/MapEntry.php
+++ b/src/php/Lang/Collections/Map/MapEntry.php
@@ -8,10 +8,10 @@ use Countable;
 use IteratorAggregate;
 use Phel\Lang\CdrInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\CopyLocationFromTrait;
 use Phel\Lang\EqualsInterface;
 use Phel\Lang\FirstInterface;
 use Phel\Lang\SourceLocation;
-use Phel\Lang\SourceLocationInterface;
 use Phel\Lang\TypeFactory;
 use Phel\Lang\TypeInterface;
 use Stringable;
@@ -37,6 +37,8 @@ use function sprintf;
  */
 final readonly class MapEntry implements TypeInterface, Stringable, Countable, IteratorAggregate, FirstInterface, CdrInterface
 {
+    use CopyLocationFromTrait;
+
     /**
      * @param PersistentMapInterface<mixed, mixed>|null $meta
      */
@@ -156,17 +158,6 @@ final readonly class MapEntry implements TypeInterface, Stringable, Countable, I
     public function getEndLocation(): ?SourceLocation
     {
         return $this->endLocation;
-    }
-
-    public function copyLocationFrom(mixed $other): static
-    {
-        if ($other instanceof SourceLocationInterface) {
-            return $this
-                ->setStartLocation($other->getStartLocation())
-                ->setEndLocation($other->getEndLocation());
-        }
-
-        return $this;
     }
 
     private function scalarEquals(mixed $a, mixed $b): bool

--- a/src/php/Lang/Collections/SortedMap/PersistentSortedMap.php
+++ b/src/php/Lang/Collections/SortedMap/PersistentSortedMap.php
@@ -26,11 +26,14 @@ use function count;
  */
 final class PersistentSortedMap extends AbstractPersistentMap
 {
+    /** @var Closure(mixed, mixed): int */
     private readonly Closure $effectiveComparator;
 
     /**
-     * @param array<int, mixed>           $array          Flat [k, v, k, v, ...] in sorted key order
-     * @param ?Closure(mixed, mixed): int $userComparator Original user comparator (null = natural order)
+     * @param array<int, mixed>                  $array          Flat [k, v, k, v, ...] in sorted key order
+     * @param ?Closure(mixed, mixed): (bool|int) $userComparator Original user comparator (null = natural
+     *                                                           order). `(sorted-map-by < ...)` passes a
+     *                                                           predicate, hence the `bool` arm.
      */
     public function __construct(
         HasherInterface $hasher,
@@ -46,7 +49,7 @@ final class PersistentSortedMap extends AbstractPersistentMap
     }
 
     /**
-     * @param ?callable(mixed, mixed): int $comparator
+     * @param ?callable(mixed, mixed): (bool|int) $comparator spaceship- or predicate-style
      *
      * @return self<K, V>
      */
@@ -61,8 +64,8 @@ final class PersistentSortedMap extends AbstractPersistentMap
     }
 
     /**
-     * @param array<int, mixed>            $kvs
-     * @param ?callable(mixed, mixed): int $comparator
+     * @param array<int, mixed>                   $kvs
+     * @param ?callable(mixed, mixed): (bool|int) $comparator spaceship- or predicate-style
      *
      * @return self<K, V>
      */
@@ -190,7 +193,7 @@ final class PersistentSortedMap extends AbstractPersistentMap
     /**
      * Returns the user-provided comparator, or null for natural order.
      *
-     * @return ?Closure(mixed, mixed): int
+     * @return ?Closure(mixed, mixed): (bool|int)
      */
     public function getComparator(): ?Closure
     {

--- a/src/php/Lang/Collections/SortedMap/SortedArrayHelper.php
+++ b/src/php/Lang/Collections/SortedMap/SortedArrayHelper.php
@@ -17,6 +17,7 @@ use function is_nan;
  */
 final class SortedArrayHelper
 {
+    /** @var (Closure(mixed, mixed): int)|null */
     private static ?Closure $defaultComparator = null;
 
     /**
@@ -46,6 +47,15 @@ final class SortedArrayHelper
     /**
      * Resolves a user-provided comparator into a non-null Closure.
      * Returns the default comparator when null is given.
+     *
+     * A user comparator may be spaceship-style (`int`) or predicate-style
+     * (`bool`, e.g. Phel's `<`); {@see self::adaptForBinarySearch()} is what
+     * collapses both shapes down to `int`.
+     *
+     * The parameter stays an unparameterised `?callable`: Psalm cannot relate a
+     * signatured callable type to the `instanceof Closure` narrowing below.
+     *
+     * @return Closure(mixed, mixed): (bool|int)
      */
     public static function resolveComparator(?callable $comparator): Closure
     {
@@ -61,6 +71,10 @@ final class SortedArrayHelper
      * of whether the user passed a spaceship-style comparator (returning
      * negative/zero/positive) or a predicate-style comparator returning
      * a boolean (such as `<` or `>`).
+     *
+     * @param Closure(mixed, mixed): (bool|int) $comparator
+     *
+     * @return Closure(mixed, mixed): int
      */
     public static function adaptForBinarySearch(Closure $comparator): Closure
     {
@@ -81,9 +95,11 @@ final class SortedArrayHelper
     /**
      * Binary search for a key in a sorted flat [k, v, k, v, ...] array.
      *
-     * @param array<int, mixed> $array      The flat sorted array
-     * @param mixed             $key        The key to search for
-     * @param Closure           $comparator Non-null comparator function
+     * @param array<int, mixed>          $array      The flat sorted array
+     * @param mixed                      $key        The key to search for
+     * @param Closure(mixed, mixed): int $comparator Non-null comparator function,
+     *                                               already normalised by
+     *                                               {@see self::adaptForBinarySearch()}
      *
      * @return int The array index (even) if found, or -(insertionPoint) - 1 if not found
      */

--- a/src/php/Lang/Collections/SortedMap/TransientSortedMap.php
+++ b/src/php/Lang/Collections/SortedMap/TransientSortedMap.php
@@ -24,11 +24,14 @@ final class TransientSortedMap implements TransientMapInterface
 {
     use TransientStateTrait;
 
+    /** @var Closure(mixed, mixed): int */
     private readonly Closure $effectiveComparator;
 
     /**
-     * @param array<int, mixed>           $array          Flat [k, v, k, v, ...] in sorted key order
-     * @param ?Closure(mixed, mixed): int $userComparator Original user comparator (null = natural order)
+     * @param array<int, mixed>                  $array          Flat [k, v, k, v, ...] in sorted key order
+     * @param ?Closure(mixed, mixed): (bool|int) $userComparator Original user comparator (null = natural
+     *                                                           order). `(sorted-map-by < ...)` passes a
+     *                                                           predicate, hence the `bool` arm.
      */
     public function __construct(
         private readonly HasherInterface $hasher,

--- a/src/php/Lang/CopyLocationFromTrait.php
+++ b/src/php/Lang/CopyLocationFromTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+/**
+ * Default `SourceLocationInterface::copyLocationFrom()` for types that already
+ * implement the start/end accessors. Values with an unlocated `$other` keep
+ * their own span.
+ */
+trait CopyLocationFromTrait
+{
+    abstract public function setStartLocation(?SourceLocation $startLocation): static;
+
+    abstract public function setEndLocation(?SourceLocation $endLocation): static;
+
+    /**
+     * Copies the start and end location from $other.
+     *
+     * @param mixed $other The object to copy from
+     */
+    public function copyLocationFrom(mixed $other): static
+    {
+        if ($other instanceof SourceLocationInterface) {
+            return $this
+                ->setStartLocation($other->getStartLocation())
+                ->setEndLocation($other->getEndLocation());
+        }
+
+        return $this;
+    }
+}

--- a/src/php/Lang/Delay.php
+++ b/src/php/Lang/Delay.php
@@ -11,9 +11,12 @@ final class Delay
 {
     private mixed $value = null;
 
-    /** @var callable|null */
+    /** @var (callable(): mixed)|null */
     private $fn;
 
+    /**
+     * @param callable(): mixed $fn nullary thunk, invoked at most once
+     */
     public function __construct(callable $fn)
     {
         $this->fn = $fn;

--- a/src/php/Lang/DynamicScope.php
+++ b/src/php/Lang/DynamicScope.php
@@ -310,6 +310,7 @@ final class DynamicScope
      * Push a frame, execute the closure, always pop on return or throw.
      *
      * @param array<string, mixed> $frame
+     * @param Closure(): mixed     $fn
      */
     public function withFrame(array $frame, Closure $fn): mixed
     {

--- a/src/php/Lang/Eduction.php
+++ b/src/php/Lang/Eduction.php
@@ -21,11 +21,14 @@ use function count;
  */
 final class Eduction implements IteratorAggregate
 {
-    /** @var callable */
+    /** @var callable(callable(mixed...): mixed): (callable(mixed...): mixed) */
     private $xform;
 
     /**
-     * @param iterable<mixed> $coll
+     * @param callable(callable(mixed...): mixed): (callable(mixed...): mixed) $xform transducer:
+     *                                                                                takes the step fn and returns the wrapped step fn, which is then called with
+     *                                                                                0, 1 or 2 arguments (init / completion / accumulation arities)
+     * @param iterable<mixed>                                                  $coll
      */
     public function __construct(
         callable $xform,
@@ -73,13 +76,10 @@ final class Eduction implements IteratorAggregate
 
     /**
      * @param list<mixed> $buffer
-     *
-     * @psalm-suppress TypeDoesNotContainType,NoValue
      */
     private function drain(array &$buffer): Generator
     {
         while ($buffer !== []) {
-            /** @psalm-suppress NoValue */
             yield array_shift($buffer);
         }
     }

--- a/src/php/Lang/EqualizerInterface.php
+++ b/src/php/Lang/EqualizerInterface.php
@@ -6,9 +6,6 @@ namespace Phel\Lang;
 
 interface EqualizerInterface
 {
-    /**
-     * @return bool True, if $a is equals $b
-     */
     public function equals(mixed $a, mixed $b): bool;
 
     /**

--- a/src/php/Lang/Generators/FileGenerator.php
+++ b/src/php/Lang/Generators/FileGenerator.php
@@ -25,24 +25,7 @@ final class FileGenerator
      */
     public static function fileLines(string $filename): Generator
     {
-        if (!is_file($filename)) {
-            throw new InvalidArgumentException(
-                'Argument filename should be a valid path to a file: ' . $filename,
-            );
-        }
-
-        if (!is_readable($filename)) {
-            throw new InvalidArgumentException(
-                'File is not readable: ' . $filename,
-            );
-        }
-
-        $handle = fopen($filename, 'r');
-        if ($handle === false) {
-            throw new RuntimeException(
-                'Failed to open file: ' . $filename,
-            );
-        }
+        $handle = self::openForReading($filename, 'r');
 
         try {
             while (($line = fgets($handle)) !== false) {
@@ -129,24 +112,7 @@ final class FileGenerator
             );
         }
 
-        if (!is_file($filename)) {
-            throw new InvalidArgumentException(
-                'Argument filename should be a valid path to a file: ' . $filename,
-            );
-        }
-
-        if (!is_readable($filename)) {
-            throw new InvalidArgumentException(
-                'File is not readable: ' . $filename,
-            );
-        }
-
-        $handle = fopen($filename, 'rb');
-        if ($handle === false) {
-            throw new RuntimeException(
-                'Failed to open file: ' . $filename,
-            );
-        }
+        $handle = self::openForReading($filename, 'rb');
 
         try {
             while (!feof($handle)) {
@@ -175,6 +141,28 @@ final class FileGenerator
         string $enclosure = '"',
         string $escape = '\\',
     ): Generator {
+        $handle = self::openForReading($filename, 'r');
+
+        try {
+            $typeFactory = TypeFactory::getInstance();
+            while (($row = fgetcsv($handle, 0, $separator, $enclosure, $escape)) !== false) {
+                /** @psalm-var list<string|null> $row */
+                $cleanRow = array_map(static fn(?string $val): string => $val ?? '', $row);
+                yield $typeFactory->persistentVectorFromArray($cleanRow);
+            }
+        } finally {
+            fclose($handle);
+        }
+    }
+
+    /**
+     * Validates that `$filename` names a readable file and opens it, so every
+     * reader in this class rejects bad input with the same messages.
+     *
+     * @return resource
+     */
+    private static function openForReading(string $filename, string $mode)
+    {
         if (!is_file($filename)) {
             throw new InvalidArgumentException(
                 'Argument filename should be a valid path to a file: ' . $filename,
@@ -187,22 +175,13 @@ final class FileGenerator
             );
         }
 
-        $handle = fopen($filename, 'r');
+        $handle = fopen($filename, $mode);
         if ($handle === false) {
             throw new RuntimeException(
                 'Failed to open file: ' . $filename,
             );
         }
 
-        try {
-            $typeFactory = TypeFactory::getInstance();
-            while (($row = fgetcsv($handle, 0, $separator, $enclosure, $escape)) !== false) {
-                /** @psalm-var list<string|null> $row */
-                $cleanRow = array_map(static fn(?string $val): string => $val ?? '', $row);
-                yield $typeFactory->persistentVectorFromArray($cleanRow);
-            }
-        } finally {
-            fclose($handle);
-        }
+        return $handle;
     }
 }

--- a/src/php/Lang/PhelVar.php
+++ b/src/php/Lang/PhelVar.php
@@ -138,6 +138,8 @@ final readonly class PhelVar implements EqualsInterface, FnInterface, HashableIn
      * argument.
      */
     /**
+     * @param callable(PersistentMapInterface<mixed, mixed>|null, mixed...): (PersistentMapInterface<mixed, mixed>|null) $f
+     *
      * @return PersistentMapInterface<mixed, mixed>|null
      */
     public function alterMeta(callable $f, mixed ...$args): ?PersistentMapInterface
@@ -194,6 +196,8 @@ final readonly class PhelVar implements EqualsInterface, FnInterface, HashableIn
      * Registers a watch function under `$key`. The function is called with
      * `($keyword, $var, $oldValue, $newValue)` after a successful
      * `alterRoot()`. Re-adding the same key replaces the previous fn.
+     *
+     * @param callable(Keyword, self, mixed, mixed): void $fn
      */
     public function addWatch(string $key, callable $fn): void
     {

--- a/src/php/Lang/PhelVarStateRegistry.php
+++ b/src/php/Lang/PhelVarStateRegistry.php
@@ -28,7 +28,7 @@ final class PhelVarStateRegistry
     /** @var array<string, ?PersistentMapInterface<mixed, mixed>> */
     private array $metaOverrides = [];
 
-    /** @var array<string, array<string, callable>> */
+    /** @var array<string, array<string, callable(Keyword, PhelVar, mixed, mixed): void>> */
     private array $watches = [];
 
     /** @var array<string, bool> */
@@ -72,6 +72,9 @@ final class PhelVarStateRegistry
         $this->invalidateDynamicCache($ns, $name);
     }
 
+    /**
+     * @param callable(Keyword, PhelVar, mixed, mixed): void $fn
+     */
     public function addWatch(string $ns, string $name, string $watchKey, callable $fn): void
     {
         $this->watches[$this->key($ns, $name)][$watchKey] = $fn;
@@ -87,7 +90,7 @@ final class PhelVarStateRegistry
     }
 
     /**
-     * @return array<string, callable>
+     * @return array<string, callable(Keyword, PhelVar, mixed, mixed): void>
      */
     public function getWatches(string $ns, string $name): array
     {

--- a/src/php/Lang/PhpClass.php
+++ b/src/php/Lang/PhpClass.php
@@ -30,6 +30,8 @@ use function sprintf;
  */
 final readonly class PhpClass implements TypeInterface, Stringable
 {
+    use CopyLocationFromTrait;
+
     /**
      * @param PersistentMapInterface<mixed, mixed>|null $meta
      */
@@ -137,14 +139,4 @@ final readonly class PhpClass implements TypeInterface, Stringable
         return $this->endLocation;
     }
 
-    public function copyLocationFrom(mixed $other): static
-    {
-        if ($other instanceof SourceLocationInterface) {
-            return $this
-                ->setStartLocation($other->getStartLocation())
-                ->setEndLocation($other->getEndLocation());
-        }
-
-        return $this;
-    }
 }

--- a/src/php/Lang/Ratio.php
+++ b/src/php/Lang/Ratio.php
@@ -22,6 +22,8 @@ use function sprintf;
  */
 final readonly class Ratio implements Stringable, TypeInterface
 {
+    use CopyLocationFromTrait;
+
     /**
      * @param PersistentMapInterface<mixed, mixed>|null $meta
      */
@@ -238,17 +240,6 @@ final readonly class Ratio implements Stringable, TypeInterface
     public function getEndLocation(): ?SourceLocation
     {
         return $this->endLocation;
-    }
-
-    public function copyLocationFrom(mixed $other): static
-    {
-        if ($other instanceof SourceLocationInterface) {
-            return $this
-                ->setStartLocation($other->getStartLocation())
-                ->setEndLocation($other->getEndLocation());
-        }
-
-        return $this;
     }
 
     /**

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -10,6 +10,9 @@ use RuntimeException;
 use function array_key_exists;
 use function sprintf;
 
+/**
+ * @phpstan-type RegistrySnapshot array{definitions: array<string, array<string, mixed>>, definitionsMetaData: array<string, array<string, mixed>>}
+ */
 final class Registry
 {
     /**
@@ -49,7 +52,7 @@ final class Registry
     }
 
     /**
-     * @return array{definitions: array<string, array<string, mixed>>, definitionsMetaData: array<string, array<string, mixed>>}
+     * @return RegistrySnapshot
      */
     public function snapshot(): array
     {
@@ -60,7 +63,7 @@ final class Registry
     }
 
     /**
-     * @param array{definitions: array<string, array<string, mixed>>, definitionsMetaData: array<string, array<string, mixed>>} $snapshot
+     * @param RegistrySnapshot $snapshot
      */
     public function restore(array $snapshot): void
     {

--- a/src/php/Lang/TagRegistry.php
+++ b/src/php/Lang/TagRegistry.php
@@ -24,7 +24,7 @@ use function sort;
  */
 final class TagRegistry
 {
-    /** @var array<string, callable> */
+    /** @var array<string, callable(mixed): mixed> */
     private array $handlers = [];
 
     private static ?self $instance = null;
@@ -40,6 +40,9 @@ final class TagRegistry
         return self::$instance;
     }
 
+    /**
+     * @param callable(mixed): mixed $handler receives the read form, returns its replacement
+     */
     public function register(string $tag, callable $handler): void
     {
         $this->handlers[$tag] = $handler;
@@ -55,6 +58,9 @@ final class TagRegistry
         return array_key_exists($tag, $this->handlers);
     }
 
+    /**
+     * @return (callable(mixed): mixed)|null
+     */
     public function get(string $tag): ?callable
     {
         $handler = $this->handlers[$tag] ?? null;

--- a/src/php/Lang/TypeFactory.php
+++ b/src/php/Lang/TypeFactory.php
@@ -120,8 +120,8 @@ final class TypeFactory
     }
 
     /**
-     * @param array<int, mixed>            $kvs
-     * @param ?callable(mixed, mixed): int $comparator
+     * @param array<int, mixed>                   $kvs
+     * @param ?callable(mixed, mixed): (bool|int) $comparator spaceship- or predicate-style
      *
      * @return PersistentMapInterface<mixed, mixed>
      */
@@ -131,8 +131,8 @@ final class TypeFactory
     }
 
     /**
-     * @param array<int, mixed>            $values
-     * @param ?callable(mixed, mixed): int $comparator
+     * @param array<int, mixed>                   $values
+     * @param ?callable(mixed, mixed): (bool|int) $comparator spaceship- or predicate-style
      *
      * @return PersistentHashSetInterface<mixed>
      */

--- a/src/php/Lang/UUID.php
+++ b/src/php/Lang/UUID.php
@@ -28,6 +28,8 @@ use function substr;
  */
 final readonly class UUID implements TypeInterface, Stringable
 {
+    use CopyLocationFromTrait;
+
     private const string CANONICAL_REGEX = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i';
 
     /**
@@ -162,14 +164,4 @@ final readonly class UUID implements TypeInterface, Stringable
         return $this->endLocation;
     }
 
-    public function copyLocationFrom(mixed $other): static
-    {
-        if ($other instanceof SourceLocationInterface) {
-            return $this
-                ->setStartLocation($other->getStartLocation())
-                ->setEndLocation($other->getEndLocation());
-        }
-
-        return $this;
-    }
 }

--- a/src/php/Lint/Application/Config/ConfigLoader.php
+++ b/src/php/Lint/Application/Config/ConfigLoader.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Phel\Lint\Application\Config;
 
+use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
 use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
 use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
+use Phel\Lint\Domain\Exception\LintConfigException;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use Phel\Shared\Parser\Node\NodeInterface;
 use Phel\Shared\Parser\Node\TriviaNodeInterface;
-
-use Throwable;
 
 use function count;
 use function file_get_contents;
@@ -24,6 +24,9 @@ use function is_string;
 /**
  * Loads a `.phel-lint.phel` EDN-style config into a `RuleSettings`
  * instance. Missing files are not an error: callers just get defaults.
+ * A file that exists but cannot be read, parsed, or is not a map raises
+ * a {@see LintConfigException} — linting with the defaults would silently
+ * ignore what the user asked for.
  *
  * Expected shape (Phel map of keywords):
  *
@@ -39,6 +42,9 @@ final readonly class ConfigLoader
         private CompilerFacadeInterface $compilerFacade,
     ) {}
 
+    /**
+     * @throws LintConfigException
+     */
     public function load(string $path, RuleSettings $defaults): RuleSettings
     {
         if (!is_file($path)) {
@@ -47,12 +53,17 @@ final readonly class ConfigLoader
 
         $contents = @file_get_contents($path);
         if ($contents === false) {
+            throw LintConfigException::cannotRead($path);
+        }
+
+        $map = $this->parseFirstForm($contents, $path);
+        if ($map === null) {
+            // Empty config file: nothing to override.
             return $defaults;
         }
 
-        $map = $this->parseMap($contents, $path);
         if (!$map instanceof PersistentMapInterface) {
-            return $defaults;
+            throw LintConfigException::notAMap($path);
         }
 
         $severities = $this->extractSeverities($map);
@@ -62,18 +73,17 @@ final readonly class ConfigLoader
     }
 
     /**
-     * @return PersistentMapInterface<mixed, mixed>|null
+     * Reads the first non-trivia form of the config file. Returns `null` when
+     * the file holds no data form at all (empty or comments only).
+     *
+     * @throws LintConfigException on a lex/parse/read failure
      */
-    private function parseMap(string $source, string $uri): ?PersistentMapInterface
+    private function parseFirstForm(string $source, string $uri): mixed
     {
         try {
             $tokenStream = $this->compilerFacade->lexString($source, $uri);
             while (true) {
-                try {
-                    $parseTree = $this->compilerFacade->parseNext($tokenStream);
-                } catch (AbstractParserException) {
-                    return null;
-                }
+                $parseTree = $this->compilerFacade->parseNext($tokenStream);
 
                 if (!$parseTree instanceof NodeInterface) {
                     return null;
@@ -83,21 +93,10 @@ final readonly class ConfigLoader
                     continue;
                 }
 
-                try {
-                    $readerResult = $this->compilerFacade->read($parseTree);
-                } catch (ReaderException) {
-                    return null;
-                }
-
-                $form = $readerResult->getAst();
-                if ($form instanceof PersistentMapInterface) {
-                    return $form;
-                }
-
-                return null;
+                return $this->compilerFacade->read($parseTree)->getAst();
             }
-        } catch (Throwable) {
-            return null;
+        } catch (AbstractParserException|ReaderException|LexerValueException $e) {
+            throw LintConfigException::cannotParse($uri, $e);
         }
     }
 

--- a/src/php/Lint/Application/Rule/ArityMismatchRule.php
+++ b/src/php/Lint/Application/Rule/ArityMismatchRule.php
@@ -28,6 +28,8 @@ use function sprintf;
  *
  * Cross-namespace arity (via `ProjectIndex`) is deferred to v2 — the
  * v1 index stores formatted signatures, not parsed parameter lists.
+ *
+ * @phpstan-type ArityRange array{min:int, max:int}
  */
 final readonly class ArityMismatchRule implements LintRuleInterface
 {
@@ -59,7 +61,7 @@ final readonly class ArityMismatchRule implements LintRuleInterface
     /**
      * @param list<mixed> $forms
      *
-     * @return array<string, array{min:int, max:int}>
+     * @return array<string, ArityRange>
      */
     private function collectLocalFunctions(array $forms): array
     {
@@ -102,7 +104,7 @@ final readonly class ArityMismatchRule implements LintRuleInterface
     /**
      * @param PersistentListInterface<mixed> $form
      *
-     * @return ?array{min:int, max:int}
+     * @return ?ArityRange
      */
     private function collectArities(PersistentListInterface $form): ?array
     {
@@ -156,8 +158,8 @@ final readonly class ArityMismatchRule implements LintRuleInterface
     }
 
     /**
-     * @param array<string, array{min:int, max:int}> $localFns
-     * @param list<Diagnostic>                       $result
+     * @param array<string, ArityRange> $localFns
+     * @param list<Diagnostic>          $result
      */
     private function inspectCalls(mixed $form, array $localFns, string $uri, array &$result): void
     {

--- a/src/php/Lint/Application/Rule/ShadowedBindingRule.php
+++ b/src/php/Lint/Application/Rule/ShadowedBindingRule.php
@@ -103,30 +103,7 @@ final readonly class ShadowedBindingRule implements LintRuleInterface
         $size = count($bindings);
         $newScope = $scope;
         for ($i = 0; $i < $size; $i += 2) {
-            $sym = $bindings->get($i);
-            if (!$sym instanceof Symbol) {
-                continue;
-            }
-
-            $name = $sym->getName();
-            if ($name === '&') {
-                continue;
-            }
-
-            if ($name === '_') {
-                continue;
-            }
-
-            if (in_array($name, $newScope, true)) {
-                $result[] = DiagnosticBuilder::fromForm(
-                    $this->code(),
-                    sprintf("Shadowed binding: '%s' shadows a local with the same name.", $name),
-                    $uri,
-                    $sym,
-                );
-            }
-
-            $newScope[] = $name;
+            $newScope = $this->noteBinding($bindings->get($i), $newScope, $uri, $result);
         }
 
         return $newScope;
@@ -173,32 +150,44 @@ final readonly class ShadowedBindingRule implements LintRuleInterface
         $newScope = $scope;
         $count = count($params);
         for ($i = 0; $i < $count; ++$i) {
-            $sym = $params->get($i);
-            if (!$sym instanceof Symbol) {
-                continue;
-            }
-
-            $name = $sym->getName();
-            if ($name === '&') {
-                continue;
-            }
-
-            if ($name === '_') {
-                continue;
-            }
-
-            if (in_array($name, $newScope, true)) {
-                $result[] = DiagnosticBuilder::fromForm(
-                    $this->code(),
-                    sprintf("Shadowed binding: '%s' shadows a local with the same name.", $name),
-                    $uri,
-                    $sym,
-                );
-            }
-
-            $newScope[] = $name;
+            $newScope = $this->noteBinding($params->get($i), $newScope, $uri, $result);
         }
 
         return $newScope;
+    }
+
+    /**
+     * Adds one bound name to `$scope`, reporting it first when the same name is
+     * already in scope. `&` and `_` are ignored: the former is the variadic
+     * marker, the latter the conventional "unused" placeholder.
+     *
+     * @param list<string>     $scope
+     * @param list<Diagnostic> $result
+     *
+     * @return list<string>
+     */
+    private function noteBinding(mixed $sym, array $scope, string $uri, array &$result): array
+    {
+        if (!$sym instanceof Symbol) {
+            return $scope;
+        }
+
+        $name = $sym->getName();
+        if ($name === '&' || $name === '_') {
+            return $scope;
+        }
+
+        if (in_array($name, $scope, true)) {
+            $result[] = DiagnosticBuilder::fromForm(
+                $this->code(),
+                sprintf("Shadowed binding: '%s' shadows a local with the same name.", $name),
+                $uri,
+                $sym,
+            );
+        }
+
+        $scope[] = $name;
+
+        return $scope;
     }
 }

--- a/src/php/Lint/Application/Rule/UnusedImportRule.php
+++ b/src/php/Lint/Application/Rule/UnusedImportRule.php
@@ -19,6 +19,8 @@ use function sprintf;
 /**
  * Flags `(:use Foo\Bar)` or `(:use Foo\Bar :as B)` entries whose imported
  * class alias is never referenced in the file body.
+ *
+ * @phpstan-type ImportEntry array{alias:string, display:string, anchor: bool|float|int|string|TypeInterface|null}
  */
 final readonly class UnusedImportRule implements LintRuleInterface
 {
@@ -59,7 +61,7 @@ final readonly class UnusedImportRule implements LintRuleInterface
     /**
      * @param PersistentListInterface<mixed> $nsForm
      *
-     * @return list<array{alias:string, display:string, anchor: bool|float|int|string|TypeInterface|null}>
+     * @return list<ImportEntry>
      */
     private function collectImports(PersistentListInterface $nsForm): array
     {
@@ -76,7 +78,7 @@ final readonly class UnusedImportRule implements LintRuleInterface
     /**
      * @param PersistentListInterface<mixed> $clause
      *
-     * @return list<array{alias:string, display:string, anchor: bool|float|int|string|TypeInterface|null}>
+     * @return list<ImportEntry>
      */
     private function importsInClause(PersistentListInterface $clause): array
     {

--- a/src/php/Lint/Application/Rule/UnusedRequireRule.php
+++ b/src/php/Lint/Application/Rule/UnusedRequireRule.php
@@ -20,6 +20,8 @@ use function sprintf;
 /**
  * Flags `(:require foo)` or `(:require foo :refer [bar])` entries whose
  * alias and referred symbols are never mentioned anywhere else in the file.
+ *
+ * @phpstan-type RequireEntry array{alias:string, refers:list<string>, display:string, anchor: bool|float|int|string|TypeInterface|null}
  */
 final readonly class UnusedRequireRule implements LintRuleInterface
 {
@@ -82,7 +84,7 @@ final readonly class UnusedRequireRule implements LintRuleInterface
     /**
      * @param PersistentListInterface<mixed> $nsForm
      *
-     * @return list<array{alias:string, refers:list<string>, display:string, anchor: bool|float|int|string|TypeInterface|null}>
+     * @return list<RequireEntry>
      */
     private function collectRequires(PersistentListInterface $nsForm): array
     {
@@ -99,7 +101,7 @@ final readonly class UnusedRequireRule implements LintRuleInterface
     /**
      * @param PersistentListInterface<mixed> $clause
      *
-     * @return list<array{alias:string, refers:list<string>, display:string, anchor: bool|float|int|string|TypeInterface|null}>
+     * @return list<RequireEntry>
      */
     private function parseRequireClauseEntries(PersistentListInterface $clause): array
     {
@@ -128,7 +130,7 @@ final readonly class UnusedRequireRule implements LintRuleInterface
     /**
      * @param PersistentVectorInterface<mixed> $vector
      *
-     * @return array{alias:string, refers:list<string>, display:string, anchor: bool|float|int|string|TypeInterface|null}
+     * @return RequireEntry
      */
     private function parseVectorEntry(PersistentVectorInterface $vector): array
     {
@@ -176,7 +178,7 @@ final readonly class UnusedRequireRule implements LintRuleInterface
     /**
      * @param PersistentListInterface<mixed> $clause
      *
-     * @return array{0: array{alias:string, refers:list<string>, display:string, anchor: bool|float|int|string|TypeInterface|null}, 1: int}
+     * @return array{0: RequireEntry, 1: int}
      */
     private function parseFlatEntry(PersistentListInterface $clause, int $startIndex): array
     {

--- a/src/php/Lint/CLAUDE.md
+++ b/src/php/Lint/CLAUDE.md
@@ -46,6 +46,7 @@ Add a rule: implement `LintRuleInterface` in `Application/Rule/`, add a code con
 
 - Severities: `:error`, `:warning`, `:info`, `:hint`, `:off`
 - Exclude patterns match file path (when they contain `/` or `.phel`) or namespace name, via `fnmatch`
+- A missing config file means defaults. A file that exists but is unreadable, unparseable, or not a map raises `Domain\Exception\LintConfigException` and `phel lint` exits 2 — never silently falls back to defaults
 
 ## Output Formats
 

--- a/src/php/Lint/Domain/Exception/LintConfigException.php
+++ b/src/php/Lint/Domain/Exception/LintConfigException.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Domain\Exception;
+
+use RuntimeException;
+use Throwable;
+
+use function sprintf;
+
+/**
+ * Raised when a lint config file exists but cannot be used. A missing config
+ * file is not an error (callers get the defaults); a present but broken one is,
+ * because silently linting with the defaults hides the user's intent.
+ */
+final class LintConfigException extends RuntimeException
+{
+    public static function cannotRead(string $path): self
+    {
+        return new self(sprintf('Cannot read lint config file: %s', $path));
+    }
+
+    public static function cannotParse(string $path, Throwable $previous): self
+    {
+        return new self(
+            sprintf('Cannot parse lint config file %s: %s', $path, $previous->getMessage()),
+            0,
+            $previous,
+        );
+    }
+
+    public static function notAMap(string $path): self
+    {
+        return new self(sprintf(
+            'Lint config file %s must contain a single map, e.g. {:rules {:phel/unused-binding :off}}',
+            $path,
+        ));
+    }
+}

--- a/src/php/Lint/Infrastructure/Command/LintCommand.php
+++ b/src/php/Lint/Infrastructure/Command/LintCommand.php
@@ -9,6 +9,7 @@ use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Lint\Application\Cache\LintCache;
 use Phel\Lint\Application\Config\RuleSettings;
 use Phel\Lint\Application\Formatter\HumanFormatter;
+use Phel\Lint\Domain\Exception\LintConfigException;
 use Phel\Lint\LintConfig;
 use Phel\Lint\LintFacade;
 use Phel\Lint\LintFactory;
@@ -33,7 +34,7 @@ use function sprintf;
  * `./bin/phel lint <paths>` — read-only semantic linter. Exits with:
  *   0 — no errors
  *   1 — one or more errors (warnings/infos do not fail)
- *   2 — invocation error (bad flags, no readable files).
+ *   2 — invocation error (bad flags, no readable files, unusable config file).
  */
 #[ServiceMap(method: 'getFacade', className: LintFacade::class)]
 #[ServiceMap(method: 'getFactory', className: LintFactory::class)]
@@ -124,7 +125,14 @@ HELP)
             return self::EXIT_INVOCATION_ERROR;
         }
 
-        $settings = $this->loadSettings($input);
+        try {
+            $settings = $this->loadSettings($input);
+        } catch (LintConfigException $lintConfigException) {
+            $output->writeln(sprintf('<error>%s</error>', $lintConfigException->getMessage()));
+
+            return self::EXIT_INVOCATION_ERROR;
+        }
+
         $cache = $this->maybeCache($input, $settings);
 
         // Load phel core so analyzeSource() resolves core symbols like

--- a/src/php/Lint/Infrastructure/Command/LintCommand.php
+++ b/src/php/Lint/Infrastructure/Command/LintCommand.php
@@ -12,6 +12,7 @@ use Phel\Lint\Application\Formatter\HumanFormatter;
 use Phel\Lint\LintConfig;
 use Phel\Lint\LintFacade;
 use Phel\Lint\LintFactory;
+use Phel\Shared\ExistingPaths;
 use Phel\Shared\PhelProjectDirectory;
 use Phel\Shared\ScalarCoercion;
 use Symfony\Component\Console\Command\Command;
@@ -23,8 +24,6 @@ use Throwable;
 
 use function getcwd;
 use function implode;
-use function is_dir;
-use function is_file;
 use function is_string;
 use function rtrim;
 use function sprintf;
@@ -105,7 +104,7 @@ HELP)
             $paths = $this->defaultPaths();
         }
 
-        $paths = $this->filterExistingPaths($paths);
+        $paths = ExistingPaths::filter($paths);
         if ($paths === []) {
             $output->writeln('<error>No readable .phel files or directories found to lint.</error>');
 
@@ -154,23 +153,6 @@ HELP)
         $cmd = $this->getFactory()->getCommandFacade();
 
         return $cmd->getProjectSourceDirectories();
-    }
-
-    /**
-     * @param list<string> $paths
-     *
-     * @return list<string>
-     */
-    private function filterExistingPaths(array $paths): array
-    {
-        $filtered = [];
-        foreach ($paths as $path) {
-            if (is_file($path) || is_dir($path)) {
-                $filtered[] = $path;
-            }
-        }
-
-        return $filtered;
     }
 
     private function loadSettings(InputInterface $input): RuleSettings

--- a/src/php/Lint/LintFacade.php
+++ b/src/php/Lint/LintFacade.php
@@ -8,6 +8,7 @@ use Gacela\Framework\AbstractFacade;
 use Phel\Lint\Application\Cache\LintCache;
 use Phel\Lint\Application\Config\RuleSettings;
 use Phel\Lint\Application\Formatter\FormatterRegistry;
+use Phel\Lint\Domain\Exception\LintConfigException;
 use Phel\Lint\Transfer\LintResult;
 
 /**
@@ -25,6 +26,9 @@ final class LintFacade extends AbstractFacade
             ->run($paths, $settings);
     }
 
+    /**
+     * @throws LintConfigException when $configPath exists but is unreadable or malformed
+     */
     public function loadSettings(string $configPath, RuleSettings $defaults): RuleSettings
     {
         return $this->getFactory()

--- a/src/php/Lsp/Application/Handler/CompletionHandler.php
+++ b/src/php/Lsp/Application/Handler/CompletionHandler.php
@@ -12,6 +12,9 @@ use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
 
+/**
+ * @phpstan-import-type CompletionItem from CompletionConverter
+ */
 final readonly class CompletionHandler implements HandlerInterface
 {
     public function __construct(
@@ -33,7 +36,7 @@ final readonly class CompletionHandler implements HandlerInterface
     /**
      * @param array<string, mixed> $params
      *
-     * @return array{isIncomplete: bool, items: list<array{label: string, kind: int, detail: string, documentation: string}>}
+     * @return array{isIncomplete: bool, items: list<CompletionItem>}
      */
     public function handle(array $params, Session $session): array
     {

--- a/src/php/Lsp/CLAUDE.md
+++ b/src/php/Lsp/CLAUDE.md
@@ -6,7 +6,7 @@ Language Server Protocol v3.17 over stdio (JSON-RPC 2.0, `Content-Length` framin
 
 | Method | Returns | Purpose |
 |--------|---------|---------|
-| `createServer($input, $output)` | `LspServer` | Wire streams; caller owns the loop via `LspServer::serve()` |
+| `createServer($output)` | `LspServer` | Bind the notification stream; caller owns the loop via `LspServer::serve($input, $output)` |
 | `createDispatcher()` | `RequestDispatcher` | Dispatcher with every handler registered (test support) |
 
 ## Dependencies

--- a/src/php/Lsp/Infrastructure/Command/LspCommand.php
+++ b/src/php/Lsp/Infrastructure/Command/LspCommand.php
@@ -65,7 +65,7 @@ HELP);
         }
 
         try {
-            return $this->getFacade()->createServer($stdin, $stdout)->serve($stdin, $stdout);
+            return $this->getFacade()->createServer($stdout)->serve($stdin, $stdout);
         } catch (Throwable $throwable) {
             $output->writeln(sprintf('<error>LSP server crashed: %s</error>', $throwable->getMessage()));
             return self::FAILURE;

--- a/src/php/Lsp/LspFacade.php
+++ b/src/php/Lsp/LspFacade.php
@@ -14,15 +14,15 @@ use Phel\Lsp\Application\Rpc\RequestDispatcher;
 final class LspFacade extends AbstractFacade
 {
     /**
-     * Build an LSP server around the given streams. The caller owns the loop
-     * via {@see LspServer::serve()}.
+     * Build an LSP server bound to the given output stream (used for
+     * server-initiated notifications). The caller owns the loop and supplies
+     * both streams to {@see LspServer::serve()}.
      *
-     * @param resource $input
      * @param resource $output
      */
-    public function createServer($input, $output): LspServer
+    public function createServer($output): LspServer
     {
-        return $this->getFactory()->createServer($input, $output);
+        return $this->getFactory()->createServer($output);
     }
 
     /**

--- a/src/php/Lsp/LspFactory.php
+++ b/src/php/Lsp/LspFactory.php
@@ -52,10 +52,9 @@ use Phel\Shared\Facade\RunFacadeInterface;
 final class LspFactory extends AbstractFactory
 {
     /**
-     * @param resource $input
      * @param resource $output
      */
-    public function createServer($input, $output): LspServer
+    public function createServer($output): LspServer
     {
         $responses = $this->createResponseBuilder();
         $writer = $this->createMessageWriter();

--- a/src/php/Nrepl/Domain/Session/SessionRegistry.php
+++ b/src/php/Nrepl/Domain/Session/SessionRegistry.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Nrepl\Domain\Session;
 
-use function array_keys;
 use function bin2hex;
 use function random_bytes;
 
@@ -36,14 +35,6 @@ final class SessionRegistry
         unset($this->sessions[$id]);
 
         return true;
-    }
-
-    /**
-     * @return list<string>
-     */
-    public function ids(): array
-    {
-        return array_keys($this->sessions);
     }
 
     private function generateId(): string

--- a/src/php/Nrepl/Infrastructure/ClientFiberPool.php
+++ b/src/php/Nrepl/Infrastructure/ClientFiberPool.php
@@ -24,8 +24,12 @@ final class ClientFiberPool
     /** @var list<Fiber<mixed, mixed, mixed, mixed>> */
     private array $fibers = [];
 
+    /** @var (Closure(string): void)|null */
     private readonly ?Closure $errorLogger;
 
+    /**
+     * @param (callable(string): void)|null $errorLogger receives one already-formatted log line
+     */
     public function __construct(?callable $errorLogger = null)
     {
         $this->errorLogger = $errorLogger === null ? null : Closure::fromCallable($errorLogger);

--- a/src/php/Nrepl/Infrastructure/NreplSocketServer.php
+++ b/src/php/Nrepl/Infrastructure/NreplSocketServer.php
@@ -39,8 +39,12 @@ final class NreplSocketServer
 
     private readonly ClientFiberPool $fiberPool;
 
+    /** @var (Closure(string): void)|null */
     private readonly ?Closure $logger;
 
+    /**
+     * @param (callable(string): void)|null $logger receives one already-formatted log line
+     */
     public function __construct(
         private readonly OpDispatcher $dispatcher,
         private readonly int $port,

--- a/src/php/Nrepl/NreplFacade.php
+++ b/src/php/Nrepl/NreplFacade.php
@@ -13,6 +13,9 @@ use Phel\Nrepl\Infrastructure\NreplSocketServer;
  */
 final class NreplFacade extends AbstractFacade
 {
+    /**
+     * @param (callable(string): void)|null $logger receives one already-formatted log line
+     */
     public function createSocketServer(
         int $port,
         string $host,

--- a/src/php/Nrepl/NreplFactory.php
+++ b/src/php/Nrepl/NreplFactory.php
@@ -29,6 +29,9 @@ use Phel\Shared\Printer\PrinterInterface;
  */
 final class NreplFactory extends AbstractFactory
 {
+    /**
+     * @param (callable(string): void)|null $logger receives one already-formatted log line
+     */
     public function createSocketServer(
         int $port,
         string $host,

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -243,7 +243,6 @@ class Phel
         }
 
         try {
-            /** @psalm-suppress UnresolvableInclude */
             $config = require $configPath;
         } catch (Throwable) {
             return [];

--- a/src/php/Run/Application/Test/ParallelTestOrchestrator.php
+++ b/src/php/Run/Application/Test/ParallelTestOrchestrator.php
@@ -231,7 +231,6 @@ final readonly class ParallelTestOrchestrator
                 continue;
             }
 
-            /** @psalm-suppress InvalidArgument resource → int cast for use as array key */
             $map[(int) $worker->stdoutHandle()] = $worker;
         }
 
@@ -264,7 +263,6 @@ final readonly class ParallelTestOrchestrator
 
         $out = [];
         foreach ($reads as $stream) {
-            /** @psalm-suppress InvalidArgument resource → int cast for use as array key */
             $key = (int) $stream;
             if (isset($busyByStream[$key])) {
                 $out[] = $busyByStream[$key];

--- a/src/php/Run/Domain/Repl/ReplCommandIoInterface.php
+++ b/src/php/Run/Domain/Repl/ReplCommandIoInterface.php
@@ -25,18 +25,12 @@ interface ReplCommandIoInterface
     /**
      * @psalm-taint-escape html
      * @psalm-taint-escape has_quotes
-     *
-     * @psalm-suppress TaintedHtml
-     * @psalm-suppress TaintedTextWithQuotes
      */
     public function write(string $string = ''): void;
 
     /**
      * @psalm-taint-escape html
      * @psalm-taint-escape has_quotes
-     *
-     * @psalm-suppress TaintedHtml
-     * @psalm-suppress TaintedTextWithQuotes
      */
     public function writeln(string $string = ''): void;
 

--- a/src/php/Run/Domain/Repl/ReplErrorFormatter.php
+++ b/src/php/Run/Domain/Repl/ReplErrorFormatter.php
@@ -47,13 +47,11 @@ final readonly class ReplErrorFormatter
     public function format(Throwable $e): ReplFormattedError
     {
         $cause = $this->unwrap($e);
-        $fullTrace = $this->exceptionPrinter->getStackTraceString($e);
 
         return new ReplFormattedError(
             $this->buildHeadline($cause),
             $this->hintResolver->hintFor($cause),
-            $this->filterTrace($fullTrace),
-            $fullTrace,
+            $this->filterTrace($this->exceptionPrinter->getStackTraceString($e)),
         );
     }
 

--- a/src/php/Run/Domain/Repl/ReplFormattedError.php
+++ b/src/php/Run/Domain/Repl/ReplFormattedError.php
@@ -10,6 +10,5 @@ final readonly class ReplFormattedError
         public string $headline,
         public ?string $hint,
         public string $trace,
-        public string $fullTrace,
     ) {}
 }

--- a/src/php/Run/Domain/Repl/ReplOutputTrait.php
+++ b/src/php/Run/Domain/Repl/ReplOutputTrait.php
@@ -36,28 +36,18 @@ trait ReplOutputTrait
     /**
      * @psalm-taint-escape html
      * @psalm-taint-escape has_quotes
-     *
-     * @psalm-suppress TaintedHtml
-     * @psalm-suppress TaintedTextWithQuotes
      */
     public function write(string $string = ''): void
     {
-        /** @psalm-suppress TaintedHtml */
-        /** @psalm-suppress TaintedTextWithQuotes */
         echo $string; // phpcs:ignore
     }
 
     /**
      * @psalm-taint-escape html
      * @psalm-taint-escape has_quotes
-     *
-     * @psalm-suppress TaintedHtml
-     * @psalm-suppress TaintedTextWithQuotes
      */
     public function writeln(string $string = ''): void
     {
-        /** @psalm-suppress TaintedHtml */
-        /** @psalm-suppress TaintedTextWithQuotes */
         echo $string . PHP_EOL; // phpcs:ignore
     }
 }

--- a/src/php/Run/Infrastructure/Command/ReplCommand.php
+++ b/src/php/Run/Infrastructure/Command/ReplCommand.php
@@ -191,7 +191,6 @@ HELP);
 
         ++$this->lineNumber;
 
-        /** @psalm-suppress RedundantCondition */
         if ($input === null && $isInitialInput) {
             // Ctrl+D will exit the repl
             $this->inputBuffer[] = self::EXIT_REPL;

--- a/src/php/Shared/CLAUDE.md
+++ b/src/php/Shared/CLAUDE.md
@@ -62,6 +62,7 @@ It also does not weaken the Gacela rule it appears to touch. Shared only *names*
 
 - `Parser/ReadModel/CodeSnippet` — `SourceLocation` (start/end) + source string; pure data.
 - `Parser/Node/*` — parse-tree VOs (`FileNode`, `ListNode`, `SymbolNode`, `MetaNode`, trivia nodes, …) plus the lexer `Token`. De-facto AST contract consumed by Formatter, Lint, Api; Compiler produces them. Living here removes `CompilerFacadeInterface → Compiler\Domain` references.
+- Two shape-only base classes keep the leaf VOs one-liners: `AbstractAtomNode` (scalar atoms: `Boolean`, `Keyword`, `Nil`, `Number`, `String`, `Symbol`) and `AbstractTriviaNode` (`Whitespace`, `Newline`, `Comma`, `Comment`). Its constructor is `final`, so a trivia subclass carries no state of its own; `createWithToken()` returns `static`.
 
 ## Printer (`Printer/`)
 
@@ -74,6 +75,7 @@ Stateless strategy-pattern printer (see `Printer/CLAUDE.md`); consumers instanti
 | `Munge` | namespace/symbol encoding: `encode()`, `encodePhpNs()`, `encodeRegistryKey()`, `decodeNs()`; static `canonicalNs()`, `displayNs()` |
 | `ColorStyle` | ANSI colors; static factories `withStyles()`, `noStyles()`; `green/yellow/blue/red/color()` |
 | `ScalarCoercion` | coerce config `mixed`→scalar with default: static `toString()`, `toInt()`, `toFloat()`, `toStringList()` |
+| `ExistingPaths` | static `filter(list<string>)` → drops paths that are neither a file nor a dir. Shared by the `lint` / `watch` commands and `WatchRunner` so a user-supplied path list narrows identically everywhere |
 | `ResourceUsageFormatter` | `resourceUsageSinceStartOfRequest()` → "Time: HH:MM:SS.mmm, Memory: X.XX MB" |
 | `PhelProjectDirectory` | manages `.phel/` dir; static `ensure()`/`path()`/`resolve()`. Effective location: `PHEL_DIR` env → `withPhelDir()` override → `<projectRoot>/.phel` |
 | `VersionFinder` | pure version-string builder from explicit git inputs (no I/O); `getVersion()`. `LATEST_VERSION` const is bumped by `tools/release.sh` |

--- a/src/php/Shared/CLAUDE.md
+++ b/src/php/Shared/CLAUDE.md
@@ -75,7 +75,7 @@ Stateless strategy-pattern printer (see `Printer/CLAUDE.md`); consumers instanti
 | `ColorStyle` | ANSI colors; static factories `withStyles()`, `noStyles()`; `green/yellow/blue/red/color()` |
 | `ScalarCoercion` | coerce config `mixed`→scalar with default: static `toString()`, `toInt()`, `toFloat()`, `toStringList()` |
 | `ResourceUsageFormatter` | `resourceUsageSinceStartOfRequest()` → "Time: HH:MM:SS.mmm, Memory: X.XX MB" |
-| `PhelProjectDirectory` | manages `.phel/` dir; static `ensure()`/`path()`/`resolve()`. Effective location: `PHEL_DIR` env → `withPhelDir()` override → `<projectRoot>/.phel` |
+| `PhelProjectDirectory` | manages `.phel/` dir; static `ensure()`/`path()`/`resolve()`/`resolveCacheDir()`. Effective location: `PHEL_DIR` env → `withPhelDir()` override → `<projectRoot>/.phel`. `resolveCacheDir()` (`PHEL_CACHE_DIR` env → `resolve()`) is the single source for `BuildConfig::getCacheDir()` and `CompilerConfig::getCacheDir()`, so the build cache and the intermediate-artifact cache cannot drift apart — and so Compiler needs no reference to Build |
 | `VersionFinder` | pure version-string builder from explicit git inputs (no I/O); `getVersion()`. `LATEST_VERSION` const is bumped by `tools/release.sh` |
 | `VersionResolver` | gathers ambient version inputs (git working copy, Composer `InstalledVersions`, build-time `.phel-release.php`/`OFFICIAL_RELEASE`) and calls `VersionFinder`; `resolve()`. Console and Run consume directly, so neither owns version-detection wiring |
 | `CompiledSourceHash` | static `of(code, optLevel)` → compiled-code cache key (mixes `\|O{level}` when level>0, plain `md5` at 0). Shared so Build's `FileEvaluator` writer and `SecondaryFileHarvester` reader key identically |

--- a/src/php/Shared/ExistingPaths.php
+++ b/src/php/Shared/ExistingPaths.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared;
+
+use function is_dir;
+use function is_file;
+
+/**
+ * Drops paths that name neither a readable file nor a directory, so CLI
+ * commands can accept user-supplied paths and report an empty selection
+ * instead of failing per entry.
+ */
+final class ExistingPaths
+{
+    /**
+     * @param list<string> $paths
+     *
+     * @return list<string>
+     */
+    public static function filter(array $paths): array
+    {
+        $filtered = [];
+        foreach ($paths as $path) {
+            if (is_file($path) || is_dir($path)) {
+                $filtered[] = $path;
+            }
+        }
+
+        return $filtered;
+    }
+}

--- a/src/php/Shared/Facade/CommandFacadeInterface.php
+++ b/src/php/Shared/Facade/CommandFacadeInterface.php
@@ -11,6 +11,9 @@ use Phel\Shared\Parser\ReadModel\CodeSnippet;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
+/**
+ * @phpstan-type CompiledFileLineMap array{filename: string, lines: array<int, int>}
+ */
 interface CommandFacadeInterface
 {
     public function writeLocatedException(
@@ -74,7 +77,7 @@ interface CommandFacadeInterface
      * Maps every mapped generated line of a compiled PHP file back to its Phel
      * source, for coverage reporting. Empty filename when no source map.
      *
-     * @return array{filename: string, lines: array<int, int>}
+     * @return CompiledFileLineMap
      */
     public function getCompiledFileLineMap(string $compiledFile): array;
 }

--- a/src/php/Shared/Parser/Node/AbstractTriviaNode.php
+++ b/src/php/Shared/Parser/Node/AbstractTriviaNode.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared\Parser\Node;
+
+use Phel\Lang\SourceLocation;
+
+/**
+ * Shared shape of the token-backed trivia nodes (whitespace, newline, comma,
+ * comment): the verbatim source text plus its span. Subclasses exist only to
+ * keep the categories distinguishable via `instanceof`.
+ */
+abstract readonly class AbstractTriviaNode implements TriviaNodeInterface
+{
+    final public function __construct(
+        private string $code,
+        private SourceLocation $startLocation,
+        private SourceLocation $endLocation,
+    ) {}
+
+    public static function createWithToken(Token $token): static
+    {
+        return new static(
+            $token->getCode(),
+            $token->getStartLocation(),
+            $token->getEndLocation(),
+        );
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getStartLocation(): SourceLocation
+    {
+        return $this->startLocation;
+    }
+
+    public function getEndLocation(): SourceLocation
+    {
+        return $this->endLocation;
+    }
+}

--- a/src/php/Shared/Parser/Node/CommaNode.php
+++ b/src/php/Shared/Parser/Node/CommaNode.php
@@ -4,37 +4,4 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Parser\Node;
 
-use Phel\Lang\SourceLocation;
-
-final readonly class CommaNode implements TriviaNodeInterface
-{
-    public function __construct(
-        private string $code,
-        private SourceLocation $startLocation,
-        private SourceLocation $endLocation,
-    ) {}
-
-    public static function createWithToken(Token $token): self
-    {
-        return new self(
-            $token->getCode(),
-            $token->getStartLocation(),
-            $token->getEndLocation(),
-        );
-    }
-
-    public function getCode(): string
-    {
-        return $this->code;
-    }
-
-    public function getStartLocation(): SourceLocation
-    {
-        return $this->startLocation;
-    }
-
-    public function getEndLocation(): SourceLocation
-    {
-        return $this->endLocation;
-    }
-}
+final readonly class CommaNode extends AbstractTriviaNode {}

--- a/src/php/Shared/Parser/Node/CommentNode.php
+++ b/src/php/Shared/Parser/Node/CommentNode.php
@@ -4,37 +4,4 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Parser\Node;
 
-use Phel\Lang\SourceLocation;
-
-final readonly class CommentNode implements TriviaNodeInterface
-{
-    public function __construct(
-        private string $code,
-        private SourceLocation $startLocation,
-        private SourceLocation $endLocation,
-    ) {}
-
-    public static function createWithToken(Token $token): self
-    {
-        return new self(
-            $token->getCode(),
-            $token->getStartLocation(),
-            $token->getEndLocation(),
-        );
-    }
-
-    public function getCode(): string
-    {
-        return $this->code;
-    }
-
-    public function getStartLocation(): SourceLocation
-    {
-        return $this->startLocation;
-    }
-
-    public function getEndLocation(): SourceLocation
-    {
-        return $this->endLocation;
-    }
-}
+final readonly class CommentNode extends AbstractTriviaNode {}

--- a/src/php/Shared/Parser/Node/NewlineNode.php
+++ b/src/php/Shared/Parser/Node/NewlineNode.php
@@ -4,37 +4,4 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Parser\Node;
 
-use Phel\Lang\SourceLocation;
-
-final readonly class NewlineNode implements TriviaNodeInterface
-{
-    public function __construct(
-        private string $code,
-        private SourceLocation $startLocation,
-        private SourceLocation $endLocation,
-    ) {}
-
-    public static function createWithToken(Token $token): self
-    {
-        return new self(
-            $token->getCode(),
-            $token->getStartLocation(),
-            $token->getEndLocation(),
-        );
-    }
-
-    public function getCode(): string
-    {
-        return $this->code;
-    }
-
-    public function getStartLocation(): SourceLocation
-    {
-        return $this->startLocation;
-    }
-
-    public function getEndLocation(): SourceLocation
-    {
-        return $this->endLocation;
-    }
-}
+final readonly class NewlineNode extends AbstractTriviaNode {}

--- a/src/php/Shared/Parser/Node/WhitespaceNode.php
+++ b/src/php/Shared/Parser/Node/WhitespaceNode.php
@@ -4,37 +4,4 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Parser\Node;
 
-use Phel\Lang\SourceLocation;
-
-final readonly class WhitespaceNode implements TriviaNodeInterface
-{
-    public function __construct(
-        private string $code,
-        private SourceLocation $startLocation,
-        private SourceLocation $endLocation,
-    ) {}
-
-    public static function createWithToken(Token $token): self
-    {
-        return new self(
-            $token->getCode(),
-            $token->getStartLocation(),
-            $token->getEndLocation(),
-        );
-    }
-
-    public function getCode(): string
-    {
-        return $this->code;
-    }
-
-    public function getStartLocation(): SourceLocation
-    {
-        return $this->startLocation;
-    }
-
-    public function getEndLocation(): SourceLocation
-    {
-        return $this->endLocation;
-    }
-}
+final readonly class WhitespaceNode extends AbstractTriviaNode {}

--- a/src/php/Shared/PhelProjectDirectory.php
+++ b/src/php/Shared/PhelProjectDirectory.php
@@ -26,6 +26,8 @@ final class PhelProjectDirectory
 
     public const string DIR_ENV = 'PHEL_DIR';
 
+    public const string CACHE_DIR_ENV = 'PHEL_CACHE_DIR';
+
     private const string GITIGNORE_FILENAME = '.gitignore';
 
     private const string GITIGNORE_CONTENT = "# Created automatically by Phel.\n*\n";
@@ -92,6 +94,25 @@ final class PhelProjectDirectory
         }
 
         return rtrim($projectRoot, '/\\') . DIRECTORY_SEPARATOR . $configPath;
+    }
+
+    /**
+     * Effective build-cache directory: `PHEL_CACHE_DIR` env var wins outright,
+     * otherwise the configured `cache-dir` is resolved through the active
+     * state directory.
+     *
+     * Single source for every config that exposes a cache directory, so the
+     * intermediate-artifact cache and the build cache cannot drift apart (and
+     * are cleared together).
+     */
+    public static function resolveCacheDir(string $projectRoot, string $configuredCacheDir, string $configuredDir = ''): string
+    {
+        $envOverride = getenv(self::CACHE_DIR_ENV);
+        if (is_string($envOverride) && $envOverride !== '') {
+            return $envOverride;
+        }
+
+        return self::resolve($projectRoot, $configuredCacheDir, $configuredDir);
     }
 
     private static function resolveBase(string $projectRoot, string $configuredDir): string

--- a/src/php/Shared/Printer/TypePrinter/ConsPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/ConsPrinter.php
@@ -17,8 +17,6 @@ final readonly class ConsPrinter implements TypePrinterInterface
 
     /**
      * @param Cons<mixed> $form
-     *
-     * @psalm-suppress MoreSpecificImplementedParamType
      */
     public function print(mixed $form): string
     {

--- a/src/php/Shared/Printer/TypePrinter/LazySeqPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/LazySeqPrinter.php
@@ -17,9 +17,6 @@ final readonly class LazySeqPrinter implements TypePrinterInterface
 
     /**
      * @param LazySeqInterface<mixed> $form
-     *
-     * @psalm-suppress MoreSpecificImplementedParamType
-     * @psalm-suppress RawObjectIteration
      */
     public function print(mixed $form): string
     {
@@ -28,7 +25,6 @@ final readonly class LazySeqPrinter implements TypePrinterInterface
         $count = 0;
         $limit = LazySeqConfig::REPL_DISPLAY_LIMIT;
 
-        /** @phpstan-ignore foreach.nonIterable */
         foreach ($form as $value) {
             if ($count >= $limit) {
                 $values[] = '...';

--- a/src/php/Watch/Application/WatchRunner.php
+++ b/src/php/Watch/Application/WatchRunner.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Watch\Application;
 
+use Phel\Shared\ExistingPaths;
 use Phel\Shared\Facade\CommandFacadeInterface;
 use Phel\Watch\Application\Watcher\FileWatcherBuilder;
 use Phel\Watch\Domain\ReloadOrchestratorInterface;
@@ -12,7 +13,6 @@ use Phel\Watch\Transfer\WatchEvent;
 use function array_unique;
 use function array_values;
 use function is_dir;
-use function is_file;
 
 /**
  * Orchestrates one full watch session: picks a backend, resolves source
@@ -34,7 +34,7 @@ final readonly class WatchRunner
      */
     public function run(array $paths, array $options = []): void
     {
-        $paths = $this->filterExistingPaths($paths);
+        $paths = ExistingPaths::filter($paths);
         if ($paths === []) {
             return;
         }
@@ -47,23 +47,6 @@ final readonly class WatchRunner
             /** @var list<WatchEvent> $events */
             $orchestrator->handleChanges($events, $srcDirs);
         });
-    }
-
-    /**
-     * @param list<string> $paths
-     *
-     * @return list<string>
-     */
-    private function filterExistingPaths(array $paths): array
-    {
-        $filtered = [];
-        foreach ($paths as $path) {
-            if (is_file($path) || is_dir($path)) {
-                $filtered[] = $path;
-            }
-        }
-
-        return $filtered;
     }
 
     /**

--- a/src/php/Watch/Application/Watcher/PollingWatcher.php
+++ b/src/php/Watch/Application/Watcher/PollingWatcher.php
@@ -39,6 +39,10 @@ final class PollingWatcher implements FileWatcherInterface
         return self::NAME;
     }
 
+    /**
+     * @param list<string>                    $paths
+     * @param callable(list<WatchEvent>):void $onChange
+     */
     public function watch(array $paths, callable $onChange): void
     {
         $this->running = true;

--- a/src/php/Watch/Infrastructure/Command/WatchCommand.php
+++ b/src/php/Watch/Infrastructure/Command/WatchCommand.php
@@ -7,6 +7,7 @@ namespace Phel\Watch\Infrastructure\Command;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel;
+use Phel\Shared\ExistingPaths;
 use Phel\Shared\ScalarCoercion;
 use Phel\Watch\WatchConfig;
 use Phel\Watch\WatchFacade;
@@ -19,8 +20,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 use function implode;
-use function is_dir;
-use function is_file;
 use function sprintf;
 
 /**
@@ -96,7 +95,7 @@ HELP)
             $paths = $this->defaultPaths();
         }
 
-        $paths = $this->filterExistingPaths($paths);
+        $paths = ExistingPaths::filter($paths);
         if ($paths === []) {
             $output->writeln('<error>No readable paths to watch.</error>');
             return self::FAILURE;
@@ -142,22 +141,5 @@ HELP)
         $cmd = $this->getFactory()->getCommandFacade();
 
         return $cmd->getSourceDirectories();
-    }
-
-    /**
-     * @param list<string> $paths
-     *
-     * @return list<string>
-     */
-    private function filterExistingPaths(array $paths): array
-    {
-        $filtered = [];
-        foreach ($paths as $path) {
-            if (is_file($path) || is_dir($path)) {
-                $filtered[] = $path;
-            }
-        }
-
-        return $filtered;
     }
 }

--- a/tests/phel/core/file-operation.phel
+++ b/tests/phel/core/file-operation.phel
@@ -28,14 +28,6 @@
       (php/chdir old-cwd))
     (php/unlink target-file)))
 
-;; Note: URL tests are commented out to avoid network dependencies in CI
-;; These can be tested manually or in integration test suites
-;;
-;; (deftest test-slurp-with-url
-;;   (let [result (slurp "https://httpbin.org/robots.txt")]
-;;     (is (string? result) "slurp should successfully read from URL")
-;;     (is (> (php/strlen result) 0) "slurp should return non-empty content from URL")))
-
 (deftest test-spit
   (let [target-directory (str (php/sys_get_temp_dir))
         target-file      (str target-directory php/DIRECTORY_SEPARATOR "test-spit.txt")]

--- a/tests/php/Integration/Bootstrap/ConfigLoadErrorTest.php
+++ b/tests/php/Integration/Bootstrap/ConfigLoadErrorTest.php
@@ -9,17 +9,14 @@ use Gacela\Framework\Testing\ContainerFixture;
 use Phel\Config\ConfigLoadException;
 use Phel\Config\PhelConfig;
 use Phel\Phel;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
 
 use function bin2hex;
 use function file_put_contents;
-use function is_dir;
 use function mkdir;
 use function random_bytes;
-use function rmdir;
-use function scandir;
 use function sys_get_temp_dir;
-use function unlink;
 
 /**
  * End-to-end check that {@see Phel::bootstrap()} turns a broken
@@ -28,6 +25,8 @@ use function unlink;
  */
 final class ConfigLoadErrorTest extends TestCase
 {
+    use RemoveDirTrait;
+
     use ContainerFixture;
 
     private string $dir;
@@ -98,29 +97,4 @@ final class ConfigLoadErrorTest extends TestCase
         Phel::bootstrap($this->dir);
     }
 
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        foreach (scandir($dir) ?: [] as $entry) {
-            if ($entry === '.') {
-                continue;
-            }
-
-            if ($entry === '..') {
-                continue;
-            }
-
-            $path = $dir . '/' . $entry;
-            if (is_dir($path)) {
-                $this->removeDir($path);
-            } else {
-                @unlink($path);
-            }
-        }
-
-        @rmdir($dir);
-    }
 }

--- a/tests/php/Integration/Build/Cache/CompiledCodeCacheIntegrationTest.php
+++ b/tests/php/Integration/Build/Cache/CompiledCodeCacheIntegrationTest.php
@@ -5,17 +5,18 @@ declare(strict_types=1);
 namespace PhelTest\Integration\Build\Cache;
 
 use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 
 /**
  * Integration tests for CompiledCodeCache verifying end-to-end cache behavior.
  */
 final class CompiledCodeCacheIntegrationTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private string $cacheDir;
 
     private string $sourceFile;
@@ -201,25 +202,4 @@ final class CompiledCodeCacheIntegrationTest extends TestCase
         self::assertNotNull($fresh->get($nestedFile, 'hash_nested'));
     }
 
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $files = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST,
-        );
-
-        foreach ($files as $file) {
-            if ($file->isDir()) {
-                rmdir($file->getRealPath());
-            } else {
-                unlink($file->getRealPath());
-            }
-        }
-
-        rmdir($dir);
-    }
 }

--- a/tests/php/Integration/Compiler/Evaluator/RequireEvaluatorTest.php
+++ b/tests/php/Integration/Compiler/Evaluator/RequireEvaluatorTest.php
@@ -10,10 +10,13 @@ use Phel\Compiler\Domain\Evaluator\RequireEvaluator;
 use Phel\Config\PhelConfig;
 use Phel\Filesystem\FilesystemFacade;
 use Phel\Filesystem\Infrastructure\RealFilesystem;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
 
 final class RequireEvaluatorTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private RequireEvaluator $evaluator;
 
     private FilesystemFacade $filesystem;
@@ -33,7 +36,7 @@ final class RequireEvaluatorTest extends TestCase
         $this->filesystem->clearAll();
 
         if ($this->tempDir !== '' && is_dir($this->tempDir)) {
-            $this->deleteDirRecursive($this->tempDir);
+            $this->removeDir($this->tempDir);
         }
     }
 
@@ -54,30 +57,4 @@ final class RequireEvaluatorTest extends TestCase
         self::assertDirectoryExists($this->tempDir);
     }
 
-    private function deleteDirRecursive(string $dir): void
-    {
-        $items = scandir($dir);
-        if ($items === false) {
-            return;
-        }
-
-        foreach ($items as $item) {
-            if ($item === '.') {
-                continue;
-            }
-
-            if ($item === '..') {
-                continue;
-            }
-
-            $path = $dir . DIRECTORY_SEPARATOR . $item;
-            if (is_dir($path)) {
-                $this->deleteDirRecursive($path);
-            } else {
-                unlink($path);
-            }
-        }
-
-        rmdir($dir);
-    }
 }

--- a/tests/php/Integration/Config/MergedConfigCacheInvalidationTest.php
+++ b/tests/php/Integration/Config/MergedConfigCacheInvalidationTest.php
@@ -8,6 +8,7 @@ use Gacela\Framework\Config\Config;
 use Gacela\Framework\Testing\ContainerFixture;
 use Phel\Config\PhelConfig;
 use Phel\Phel;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
 
 use function sys_get_temp_dir;
@@ -15,6 +16,8 @@ use function uniqid;
 
 final class MergedConfigCacheInvalidationTest extends TestCase
 {
+    use RemoveDirTrait;
+
     use ContainerFixture;
 
     private string $projectDir = '';
@@ -81,26 +84,4 @@ final class MergedConfigCacheInvalidationTest extends TestCase
         );
     }
 
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $items = scandir($dir) ?: [];
-        foreach ($items as $item) {
-            if ($item === '.') {
-                continue;
-            }
-
-            if ($item === '..') {
-                continue;
-            }
-
-            $path = $dir . '/' . $item;
-            is_dir($path) ? $this->removeDir($path) : unlink($path);
-        }
-
-        rmdir($dir);
-    }
 }

--- a/tests/php/Integration/Lint/LintCacheFingerprintTest.php
+++ b/tests/php/Integration/Lint/LintCacheFingerprintTest.php
@@ -8,6 +8,7 @@ use Phel;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Lang\Symbol;
 use Phel\Lint\Infrastructure\Command\LintCommand;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
@@ -17,13 +18,10 @@ use function array_map;
 use function chdir;
 use function file_put_contents;
 use function getcwd;
-use function is_dir;
 use function json_decode;
 use function mkdir;
-use function scandir;
 use function sys_get_temp_dir;
 use function uniqid;
-use function unlink;
 
 /**
  * Verifies that changing phel-lint.phel config (severities or exclude
@@ -32,6 +30,8 @@ use function unlink;
  */
 final class LintCacheFingerprintTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private string $projectRoot;
 
     private string $configPath;
@@ -155,30 +155,4 @@ final class LintCacheFingerprintTest extends TestCase
         GlobalEnvironmentSingleton::initializeNew();
     }
 
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $entries = scandir($dir) ?: [];
-        foreach ($entries as $entry) {
-            if ($entry === '.') {
-                continue;
-            }
-
-            if ($entry === '..') {
-                continue;
-            }
-
-            $path = $dir . '/' . $entry;
-            if (is_dir($path)) {
-                $this->removeDir($path);
-            } else {
-                @unlink($path);
-            }
-        }
-
-        @rmdir($dir);
-    }
 }

--- a/tests/php/Integration/Lint/LintConfigFileTest.php
+++ b/tests/php/Integration/Lint/LintConfigFileTest.php
@@ -57,6 +57,56 @@ final class LintConfigFileTest extends TestCase
         }
     }
 
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_malformed_config_file_fails_the_run(): void
+    {
+        $this->bootstrap();
+
+        $configPath = tempnam(sys_get_temp_dir(), 'lint-cfg-');
+        self::assertIsString($configPath);
+        file_put_contents($configPath, "{:rules {:phel/unused-binding :off}\n");
+
+        try {
+            $tester = new CommandTester(new LintCommand());
+            $exitCode = $tester->execute([
+                'paths' => [__DIR__ . '/Fixtures/unused_binding.phel'],
+                '--config' => $configPath,
+                '--no-cache' => true,
+            ]);
+
+            self::assertSame(LintCommand::EXIT_INVOCATION_ERROR, $exitCode);
+            self::assertStringContainsString('Cannot parse lint config file', $tester->getDisplay());
+        } finally {
+            @unlink($configPath);
+        }
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_config_file_that_is_not_a_map_fails_the_run(): void
+    {
+        $this->bootstrap();
+
+        $configPath = tempnam(sys_get_temp_dir(), 'lint-cfg-');
+        self::assertIsString($configPath);
+        file_put_contents($configPath, "[:rules]\n");
+
+        try {
+            $tester = new CommandTester(new LintCommand());
+            $exitCode = $tester->execute([
+                'paths' => [__DIR__ . '/Fixtures/unused_binding.phel'],
+                '--config' => $configPath,
+                '--no-cache' => true,
+            ]);
+
+            self::assertSame(LintCommand::EXIT_INVOCATION_ERROR, $exitCode);
+            self::assertStringContainsString('must contain a single map', $tester->getDisplay());
+        } finally {
+            @unlink($configPath);
+        }
+    }
+
     private function bootstrap(): void
     {
         Phel::bootstrap(__DIR__);

--- a/tests/php/Integration/Phar/PharExecutionTest.php
+++ b/tests/php/Integration/Phar/PharExecutionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Phar;
 
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
 
 use function dirname;
@@ -23,6 +24,8 @@ use function sprintf;
  */
 final class PharExecutionTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private const string PHAR_RELATIVE_PATH = '/build/out/phel.phar';
 
     private string $pharPath;
@@ -364,26 +367,4 @@ final class PharExecutionTest extends TestCase
         return ['exit' => $exit, 'stdout' => $stdout, 'stderr' => $stderr];
     }
 
-    private function removeDir(string $dir): void
-    {
-        $entries = scandir($dir) ?: [];
-        foreach ($entries as $entry) {
-            if ($entry === '.') {
-                continue;
-            }
-
-            if ($entry === '..') {
-                continue;
-            }
-
-            $path = $dir . '/' . $entry;
-            if (is_dir($path) && !is_link($path)) {
-                $this->removeDir($path);
-            } else {
-                @unlink($path);
-            }
-        }
-
-        @rmdir($dir);
-    }
 }

--- a/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
+++ b/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Integration\Run\Command\AgentInstall;
 
 use Phel\Run\Infrastructure\Command\AgentInstallCommand;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -12,6 +13,8 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 final class AgentInstallCommandTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private string $testDir;
 
     private string $originalCwd;
@@ -27,7 +30,7 @@ final class AgentInstallCommandTest extends TestCase
     protected function tearDown(): void
     {
         chdir($this->originalCwd);
-        $this->removeDirectory($this->testDir);
+        $this->removeDir($this->testDir);
     }
 
     public function test_install_all_creates_every_skill_target(): void
@@ -307,34 +310,4 @@ final class AgentInstallCommandTest extends TestCase
         return new AgentInstallCommand()->run(new ArrayInput($args), $output ?? new BufferedOutput());
     }
 
-    private function removeDirectory(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $items = scandir($dir);
-        if ($items === false) {
-            return;
-        }
-
-        foreach ($items as $item) {
-            if ($item === '.') {
-                continue;
-            }
-
-            if ($item === '..') {
-                continue;
-            }
-
-            $path = $dir . '/' . $item;
-            if (is_dir($path) && !is_link($path)) {
-                $this->removeDirectory($path);
-            } else {
-                unlink($path);
-            }
-        }
-
-        rmdir($dir);
-    }
 }

--- a/tests/php/Integration/Run/Command/Init/InitCommandTest.php
+++ b/tests/php/Integration/Run/Command/Init/InitCommandTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Integration\Run\Command\Init;
 
 use Iterator;
 use Phel\Run\Infrastructure\Command\InitCommand;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
@@ -14,6 +15,8 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 final class InitCommandTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private string $testDir;
 
     protected function setUp(): void
@@ -24,7 +27,7 @@ final class InitCommandTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->removeDirectory($this->testDir);
+        $this->removeDir($this->testDir);
     }
 
     public function test_creates_flat_layout_structure_by_default(): void
@@ -554,30 +557,4 @@ final class InitCommandTest extends TestCase
         self::assertStringContainsString('phel-examples/my-api', (string) file_get_contents($this->testDir . '/composer.json'));
     }
 
-    private function removeDirectory(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $items = scandir($dir);
-        foreach ($items as $item) {
-            if ($item === '.') {
-                continue;
-            }
-
-            if ($item === '..') {
-                continue;
-            }
-
-            $path = $dir . '/' . $item;
-            if (is_dir($path)) {
-                $this->removeDirectory($path);
-            } else {
-                unlink($path);
-            }
-        }
-
-        rmdir($dir);
-    }
 }

--- a/tests/php/Integration/Run/Command/Run/OpcacheReexecTest.php
+++ b/tests/php/Integration/Run/Command/Run/OpcacheReexecTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Run\Command\Run;
 
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
 
 use function bin2hex;
@@ -12,7 +13,6 @@ use function escapeshellarg;
 use function exec;
 use function file_put_contents;
 use function implode;
-use function is_dir;
 use function mkdir;
 use function random_bytes;
 use function sprintf;
@@ -26,6 +26,8 @@ use function sys_get_temp_dir;
  */
 final class OpcacheReexecTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private string $repoRoot;
 
     private string $projectDir;
@@ -89,12 +91,4 @@ final class OpcacheReexecTest extends TestCase
         return [$exitCode, implode("\n", $output)];
     }
 
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        exec('rm -rf ' . escapeshellarg($dir));
-    }
 }

--- a/tests/php/Support/RemoveDirTrait.php
+++ b/tests/php/Support/RemoveDirTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Support;
+
+use function is_dir;
+use function is_link;
+use function rmdir;
+use function scandir;
+use function unlink;
+
+/**
+ * Recursive directory removal for test fixtures and temp dirs.
+ *
+ * Symlinked directories are unlinked rather than descended into, so a fixture
+ * that links out of its own tree can never delete anything outside it. Removal
+ * failures are ignored: this runs in `tearDown()`, where a leftover file must
+ * not mask the assertion that actually failed.
+ */
+trait RemoveDirTrait
+{
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.') {
+                continue;
+            }
+
+            if ($entry === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $entry;
+            if (is_dir($path) && !is_link($path)) {
+                $this->removeDir($path);
+            } else {
+                @unlink($path);
+            }
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/php/Unit/Architecture/ModuleDependencyCycleTest.php
+++ b/tests/php/Unit/Architecture/ModuleDependencyCycleTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Architecture;
+
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+use function dirname;
+use function sprintf;
+
+/**
+ * Locks the module-level dependency graph of `src/php` against new cycles.
+ *
+ * The graph is built from `use Phel\<Module>\…;` statements, which is the only
+ * form that creates real compile-time coupling. Docblock `{@see}` tags and
+ * class names embedded in generated-code templates are deliberately ignored:
+ * they read like edges to a naive scanner but bind nothing.
+ *
+ * Four cyclic module pairs exist today and each is documented where it lives.
+ * Three of them are one file wide on at least one side, so a regression shows
+ * up as a *new* file in {@see self::CYCLE_CLOSING_FILES} rather than as a new
+ * pair, which is why both are asserted.
+ *
+ * @see SharedCompilerBoundaryTest for the Shared -> Compiler back-edge
+ */
+final class ModuleDependencyCycleTest extends TestCase
+{
+    /**
+     * Every module pair that points at each other, smaller name first.
+     *
+     * - `Compiler <-> Shared`: accepted in #2785; rationale in `src/php/Shared/CLAUDE.md`.
+     * - `Lang <-> Shared`: accepted; `src/php/Lang/CLAUDE.md` names both edges
+     *   (`AbstractType::__toString` needs `Printer`, `AbstractPersistentStruct` needs `Munge`).
+     * - `Api <-> Run`: the only mutual Gacela provider pair (see below).
+     * - `Phel <-> Run`: the composition root wires `RunFacade`, and `RunCommand`
+     *   calls back into `Phel::setupRuntimeArgs()`.
+     *
+     * @var list<string>
+     */
+    private const array KNOWN_CYCLES = [
+        'Api <-> Run',
+        'Compiler <-> Shared',
+        'Lang <-> Shared',
+        'Phel <-> Run',
+    ];
+
+    /**
+     * The files that close each direction of the three narrow cycles, relative
+     * to `src/php`. `Compiler <-> Shared` is excluded: its Compiler -> Shared
+     * side is ~80 files by design, and its single back-edge file is already
+     * pinned by {@see SharedCompilerBoundaryTest}.
+     *
+     * @var array<string, list<string>>
+     */
+    private const array CYCLE_CLOSING_FILES = [
+        'Api -> Run' => ['Api/ApiProvider.php'],
+        'Run -> Api' => ['Run/RunProvider.php'],
+        'Lang -> Shared' => ['Lang/Collections/Struct/AbstractPersistentStruct.php', 'Lang/TypeStringifier.php'],
+        'Phel -> Run' => ['Phel.php'],
+        'Run -> Phel' => ['Run/Infrastructure/Command/RunCommand.php'],
+    ];
+
+    /**
+     * Gacela providers naming each other's concrete facade is the strongest
+     * form of module cycle: it couples the wiring, not just a type signature.
+     * Exactly one such pair is tolerated.
+     *
+     * @var list<string>
+     */
+    private const array KNOWN_PROVIDER_CYCLES = [
+        'Api <-> Run',
+    ];
+
+    /** @var array<string, array<string, list<string>>>|null from module => to module => relative files */
+    private static ?array $edges = null;
+
+    public function test_module_dependency_cycles_do_not_grow(): void
+    {
+        self::assertSame(
+            self::KNOWN_CYCLES,
+            $this->cyclicPairs($this->moduleEdges()),
+            "The set of cyclic module pairs in src/php changed.\n"
+            . "Removing one is good news: drop it from KNOWN_CYCLES.\n"
+            . 'Adding one needs a documented rationale in the owning module CLAUDE.md first.',
+        );
+    }
+
+    public function test_narrow_cycles_are_not_widened(): void
+    {
+        $edges = $this->moduleEdges();
+
+        foreach (self::CYCLE_CLOSING_FILES as $edge => $expected) {
+            [$from, $to] = explode(' -> ', $edge);
+
+            self::assertSame(
+                $expected,
+                $edges[$from][$to] ?? [],
+                sprintf(
+                    "The %s edge is no longer confined to its documented file(s).\n"
+                    . 'A cycle that widens from one file to many stops being a wiring detail and becomes structural.',
+                    $edge,
+                ),
+            );
+        }
+    }
+
+    public function test_no_new_mutual_gacela_provider_dependencies(): void
+    {
+        self::assertSame(
+            self::KNOWN_PROVIDER_CYCLES,
+            $this->cyclicPairs($this->providerEdges()),
+            "Two Gacela providers now require each other's concrete facade.\n"
+            . 'Break it by moving the shared behaviour into Phel\\Shared, or by having one side '
+            . 'depend on the module its neighbour was merely delegating to.',
+        );
+    }
+
+    /**
+     * @param array<string, array<string, list<string>>> $edges
+     *
+     * @return list<string>
+     */
+    private function cyclicPairs(array $edges): array
+    {
+        $pairs = [];
+
+        foreach ($edges as $from => $targets) {
+            foreach (array_keys($targets) as $to) {
+                if (!isset($edges[$to][$from])) {
+                    continue;
+                }
+
+                $pairs[] = $from < $to
+                    ? sprintf('%s <-> %s', $from, $to)
+                    : sprintf('%s <-> %s', $to, $from);
+            }
+        }
+
+        $pairs = array_values(array_unique($pairs));
+        sort($pairs);
+
+        return $pairs;
+    }
+
+    /**
+     * @return array<string, array<string, list<string>>>
+     */
+    private function moduleEdges(): array
+    {
+        if (self::$edges !== null) {
+            return self::$edges;
+        }
+
+        $edges = [];
+
+        foreach ($this->sourceFiles() as $relative => $contents) {
+            $from = $this->moduleOfNamespace($contents);
+            if ($from === null) {
+                continue;
+            }
+
+            preg_match_all('/^use\s+(?:function\s+|const\s+)?Phel\\\\(\w+)/m', $contents, $matches);
+
+            foreach (array_unique($matches[1]) as $to) {
+                if ($to !== $from) {
+                    $edges[$from][$to][] = $relative;
+                }
+            }
+        }
+
+        foreach ($edges as &$targets) {
+            foreach ($targets as &$files) {
+                sort($files);
+            }
+        }
+
+        return self::$edges = $edges;
+    }
+
+    /**
+     * The same graph restricted to Gacela `*Provider` classes.
+     *
+     * @return array<string, array<string, list<string>>>
+     */
+    private function providerEdges(): array
+    {
+        $providerEdges = [];
+
+        foreach ($this->moduleEdges() as $from => $targets) {
+            foreach ($targets as $to => $files) {
+                $providers = array_values(array_filter(
+                    $files,
+                    static fn(string $file): bool => str_ends_with($file, 'Provider.php'),
+                ));
+
+                if ($providers !== []) {
+                    $providerEdges[$from][$to] = $providers;
+                }
+            }
+        }
+
+        return $providerEdges;
+    }
+
+    private function moduleOfNamespace(string $contents): ?string
+    {
+        if (!preg_match('/^namespace\s+(Phel(?:\\\\\w+)*);/m', $contents, $matches)) {
+            return null;
+        }
+
+        // Root-level files (`src/php/Phel.php`) form the composition root, which
+        // the graph treats as a module of its own.
+        return explode('\\', $matches[1])[1] ?? 'Phel';
+    }
+
+    /**
+     * @return array<string, string> relative path => file contents
+     */
+    private function sourceFiles(): array
+    {
+        $sourceDir = dirname(__DIR__, 4) . '/src/php';
+        self::assertDirectoryExists($sourceDir);
+
+        $files = [];
+
+        /** @var SplFileInfo $file */
+        foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($sourceDir)) as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $relative = str_replace($sourceDir . '/', '', $file->getPathname());
+            $files[$relative] = (string) file_get_contents($file->getPathname());
+        }
+
+        ksort($files);
+
+        return $files;
+    }
+}

--- a/tests/php/Unit/Build/Application/CachedNamespaceExtractorScanIndexTest.php
+++ b/tests/php/Unit/Build/Application/CachedNamespaceExtractorScanIndexTest.php
@@ -10,12 +10,13 @@ use Phel\Build\Domain\Extractor\TopologicalNamespaceSorter;
 use Phel\Build\Infrastructure\Cache\NullNamespaceCache;
 use Phel\Build\Infrastructure\Cache\PhpScanIndexCache;
 use Phel\Shared\NamespaceInformation;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 
 final class CachedNamespaceExtractorScanIndexTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private string $dir;
 
     private string $cacheFile;
@@ -202,25 +203,4 @@ final class CachedNamespaceExtractorScanIndexTest extends TestCase
         );
     }
 
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $files = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST,
-        );
-
-        foreach ($files as $file) {
-            if ($file->isDir()) {
-                rmdir($file->getRealPath());
-            } else {
-                unlink($file->getRealPath());
-            }
-        }
-
-        rmdir($dir);
-    }
 }

--- a/tests/php/Unit/Build/Application/CachedNamespaceExtractorTest.php
+++ b/tests/php/Unit/Build/Application/CachedNamespaceExtractorTest.php
@@ -10,12 +10,13 @@ use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\Extractor\TopologicalNamespaceSorter;
 use Phel\Build\Infrastructure\Cache\NullNamespaceCache;
 use Phel\Shared\NamespaceInformation;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 
 final class CachedNamespaceExtractorTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private string $dir;
 
     protected function setUp(): void
@@ -184,25 +185,4 @@ final class CachedNamespaceExtractorTest extends TestCase
         self::assertSame('good\\ns', $infos[0]->getNamespace());
     }
 
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $files = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST,
-        );
-
-        foreach ($files as $file) {
-            if ($file->isDir()) {
-                rmdir($file->getRealPath());
-            } else {
-                unlink($file->getRealPath());
-            }
-        }
-
-        rmdir($dir);
-    }
 }

--- a/tests/php/Unit/Build/Application/FileEvaluatorTest.php
+++ b/tests/php/Unit/Build/Application/FileEvaluatorTest.php
@@ -16,15 +16,16 @@ use Phel\Lang\Registry;
 use Phel\Shared\CompileOptions;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use Phel\Shared\NamespaceInformation;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 use RuntimeException;
 
 use function sprintf;
 
 final class FileEvaluatorTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private string $tempDir;
 
     protected function setUp(): void
@@ -815,25 +816,4 @@ final class FileEvaluatorTest extends TestCase
         );
     }
 
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $files = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST,
-        );
-
-        foreach ($files as $file) {
-            if ($file->isDir()) {
-                rmdir($file->getRealPath());
-            } else {
-                unlink($file->getRealPath());
-            }
-        }
-
-        rmdir($dir);
-    }
 }

--- a/tests/php/Unit/Build/Domain/Compile/SecondaryFileHarvesterTest.php
+++ b/tests/php/Unit/Build/Domain/Compile/SecondaryFileHarvesterTest.php
@@ -12,20 +12,19 @@ use Phel\Build\Infrastructure\IO\SystemFileIo;
 use Phel\Shared\CompiledSourceHash;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use Phel\Shared\NamespaceInformation;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
 
-use function array_diff;
 use function file_get_contents;
-use function is_dir;
 use function md5;
 use function mkdir;
-use function rmdir;
 use function sys_get_temp_dir;
 use function uniqid;
-use function unlink;
 
 final class SecondaryFileHarvesterTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private string $tempDir;
 
     protected function setUp(): void
@@ -96,17 +95,4 @@ final class SecondaryFileHarvesterTest extends TestCase
         return $destDir . '/phel/core/meta.php';
     }
 
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        foreach (array_diff(scandir($dir) ?: [], ['.', '..']) as $entry) {
-            $path = $dir . '/' . $entry;
-            is_dir($path) ? $this->removeDir($path) : unlink($path);
-        }
-
-        rmdir($dir);
-    }
 }

--- a/tests/php/Unit/Build/Domain/Extractor/NamespaceExtractorTest.php
+++ b/tests/php/Unit/Build/Domain/Extractor/NamespaceExtractorTest.php
@@ -10,6 +10,7 @@ use Phel\Build\Domain\Extractor\ExtractorException;
 use Phel\Build\Domain\Extractor\TopologicalNamespaceSorter;
 use Phel\Build\Infrastructure\IO\SystemFileIo;
 use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
 use Phel\Phel;
 use Phel\Shared\NamespaceInformation;
 use PHPUnit\Framework\TestCase;
@@ -74,6 +75,23 @@ final class NamespaceExtractorTest extends TestCase
         $this->expectException(ExtractorException::class);
         $fileContent = '## markdown-style comments are not valid phel';
         $this->extractNamespace($fileContent);
+    }
+
+    public function test_parse_failure_keeps_the_underlying_reason(): void
+    {
+        try {
+            $this->extractNamespace('## markdown-style comments are not valid phel');
+            self::fail('Expected an ExtractorException.');
+        } catch (ExtractorException $extractorException) {
+            $previous = $extractorException->getPrevious();
+
+            self::assertInstanceOf(LexerValueException::class, $previous);
+            self::assertStringContainsString(
+                $previous->getMessage(),
+                $extractorException->getMessage(),
+                'The lexer/parser reason must survive into the ExtractorException message.',
+            );
+        }
     }
 
     public function test_scan_skips_unparseable_files(): void

--- a/tests/php/Unit/Build/Infrastructure/Cache/CompiledCodeCacheTest.php
+++ b/tests/php/Unit/Build/Infrastructure/Cache/CompiledCodeCacheTest.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Build\Infrastructure\Cache;
 
 use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 
 use function sprintf;
 
 final class CompiledCodeCacheTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private string $cacheDir;
 
     private string $sourceFile;
@@ -478,25 +479,4 @@ final class CompiledCodeCacheTest extends TestCase
         self::assertSame($envData, $cache->getEnvironment('test\\namespace'));
     }
 
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $files = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST,
-        );
-
-        foreach ($files as $file) {
-            if ($file->isDir()) {
-                rmdir($file->getRealPath());
-            } else {
-                unlink($file->getRealPath());
-            }
-        }
-
-        rmdir($dir);
-    }
 }

--- a/tests/php/Unit/Build/Infrastructure/Cache/DependencyTrackerTest.php
+++ b/tests/php/Unit/Build/Infrastructure/Cache/DependencyTrackerTest.php
@@ -6,12 +6,13 @@ namespace PhelTest\Unit\Build\Infrastructure\Cache;
 
 use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
 use Phel\Build\Infrastructure\Cache\DependencyTracker;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 
 final class DependencyTrackerTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private string $cacheDir;
 
     protected function setUp(): void
@@ -22,7 +23,7 @@ final class DependencyTrackerTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->removeDirectory($this->cacheDir);
+        $this->removeDir($this->cacheDir);
     }
 
     public function test_invalidate_dependents_cascades_to_direct_dependents(): void
@@ -122,25 +123,4 @@ final class DependencyTrackerTest extends TestCase
         self::assertSame([], $invalidated);
     }
 
-    private function removeDirectory(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST,
-        );
-
-        foreach ($iterator as $file) {
-            if ($file->isDir()) {
-                @rmdir($file->getPathname());
-            } else {
-                @unlink($file->getPathname());
-            }
-        }
-
-        @rmdir($dir);
-    }
 }

--- a/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
@@ -260,8 +260,6 @@ final class GlobalEnvironmentTest extends TestCase
         );
     }
 
-    // ========================================
-
     public function test_resolve_absolute_definition_name(): void
     {
         $env = new GlobalEnvironment();

--- a/tests/php/Unit/Compiler/Cache/FileSystemReaderResultCacheTest.php
+++ b/tests/php/Unit/Compiler/Cache/FileSystemReaderResultCacheTest.php
@@ -9,10 +9,13 @@ use Phel\Compiler\Domain\Parser\ReadModel\ReaderResult;
 use Phel\Compiler\Infrastructure\Cache\FileSystemReaderResultCache;
 use Phel\Lang\SourceLocation;
 use Phel\Shared\Parser\ReadModel\CodeSnippet;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
 
 final class FileSystemReaderResultCacheTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private string $cacheDir;
 
     protected function setUp(): void
@@ -138,17 +141,4 @@ final class FileSystemReaderResultCacheTest extends TestCase
         );
     }
 
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $files = glob($dir . '/*') ?: [];
-        foreach ($files as $file) {
-            is_dir($file) ? $this->removeDir($file) : @unlink($file);
-        }
-
-        @rmdir($dir);
-    }
 }

--- a/tests/php/Unit/Formatter/Application/PathsFormatterTest.php
+++ b/tests/php/Unit/Formatter/Application/PathsFormatterTest.php
@@ -39,7 +39,7 @@ final class PathsFormatterTest extends TestCase
 
     public function test_write_failure_propagates_instead_of_being_swallowed(): void
     {
-        $io = new class implements FileIoInterface {
+        $io = new class() implements FileIoInterface {
             public function checkIfValid(string $filename): void {}
 
             public function getContents(string $filename): string
@@ -92,10 +92,10 @@ final class PathsFormatterTest extends TestCase
      */
     private function formatterThrowing(?string $failingPath, ?LexerValueException $exception): FormatterInterface
     {
-        return new class($failingPath, $exception) implements FormatterInterface {
+        return new readonly class($failingPath, $exception) implements FormatterInterface {
             public function __construct(
-                private readonly ?string $failingPath,
-                private readonly ?LexerValueException $exception,
+                private ?string $failingPath,
+                private ?LexerValueException $exception,
             ) {}
 
             public function format(string $string, string $source = self::DEFAULT_SOURCE): string
@@ -114,11 +114,11 @@ final class PathsFormatterTest extends TestCase
      */
     private function pathFilter(array $paths): PathFilterInterface
     {
-        return new class($paths) implements PathFilterInterface {
+        return new readonly class($paths) implements PathFilterInterface {
             /**
              * @param list<string> $paths
              */
-            public function __construct(private readonly array $paths) {}
+            public function __construct(private array $paths) {}
 
             public function filterPaths(array $paths): array
             {

--- a/tests/php/Unit/Formatter/Application/PathsFormatterTest.php
+++ b/tests/php/Unit/Formatter/Application/PathsFormatterTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Formatter\Application;
+
+use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
+use Phel\Formatter\Application\PathsFormatter;
+use Phel\Formatter\Domain\FormatterInterface;
+use Phel\Formatter\Domain\IO\FileIoInterface;
+use Phel\Formatter\Domain\PathFilterInterface;
+use Phel\Shared\Facade\CommandFacadeInterface;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+use function sprintf;
+
+final class PathsFormatterTest extends TestCase
+{
+    public function test_lexer_failure_on_one_file_does_not_abort_the_batch(): void
+    {
+        $io = $this->fileIo(['a.phel' => '(a', 'b.phel' => '(b)']);
+        $formatter = $this->formatterThrowing('a.phel', new LexerValueException('bad token'));
+
+        $output = new BufferedOutput();
+        $changed = new PathsFormatter(
+            $this->commandFacade(),
+            $formatter,
+            $this->pathFilter(['a.phel', 'b.phel']),
+            $io,
+        )->format(['ignored'], $output);
+
+        self::assertSame(['b.phel'], $changed);
+        self::assertStringContainsString('bad token', $output->fetch());
+    }
+
+    public function test_write_failure_propagates_instead_of_being_swallowed(): void
+    {
+        $io = new class implements FileIoInterface {
+            public function checkIfValid(string $filename): void {}
+
+            public function getContents(string $filename): string
+            {
+                return '(a)';
+            }
+
+            public function putContents(string $filename, string $data): void
+            {
+                throw new RuntimeException(sprintf('Unable to write file "%s".', $filename));
+            }
+        };
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to write file "a.phel".');
+
+        new PathsFormatter(
+            $this->commandFacade(),
+            $this->formatterThrowing(null, null),
+            $this->pathFilter(['a.phel']),
+            $io,
+        )->format(['ignored'], new BufferedOutput());
+    }
+
+    /**
+     * @param array<string, string> $contents
+     */
+    private function fileIo(array $contents): FileIoInterface
+    {
+        return new class($contents) implements FileIoInterface {
+            /**
+             * @param array<string, string> $contents
+             */
+            public function __construct(private array $contents) {}
+
+            public function checkIfValid(string $filename): void {}
+
+            public function getContents(string $filename): string
+            {
+                return $this->contents[$filename] ?? '';
+            }
+
+            public function putContents(string $filename, string $data): void {}
+        };
+    }
+
+    /**
+     * Formats by appending a newline (so every file counts as "changed"),
+     * except for $failingPath which raises $exception.
+     */
+    private function formatterThrowing(?string $failingPath, ?LexerValueException $exception): FormatterInterface
+    {
+        return new class($failingPath, $exception) implements FormatterInterface {
+            public function __construct(
+                private readonly ?string $failingPath,
+                private readonly ?LexerValueException $exception,
+            ) {}
+
+            public function format(string $string, string $source = self::DEFAULT_SOURCE): string
+            {
+                if ($source === $this->failingPath && $this->exception instanceof LexerValueException) {
+                    throw $this->exception;
+                }
+
+                return $string . "\n";
+            }
+        };
+    }
+
+    /**
+     * @param list<string> $paths
+     */
+    private function pathFilter(array $paths): PathFilterInterface
+    {
+        return new class($paths) implements PathFilterInterface {
+            /**
+             * @param list<string> $paths
+             */
+            public function __construct(private readonly array $paths) {}
+
+            public function filterPaths(array $paths): array
+            {
+                return $this->paths;
+            }
+        };
+    }
+
+    private function commandFacade(): CommandFacadeInterface
+    {
+        $facade = $this->createStub(CommandFacadeInterface::class);
+        $facade->method('writeStackTrace')
+            ->willReturnCallback(static function (OutputInterface $output, Throwable $e): void {
+                $output->writeln($e->getMessage());
+            });
+
+        return $facade;
+    }
+}

--- a/tests/php/Unit/Lang/Collections/SortedMap/SortedArrayHelperTest.php
+++ b/tests/php/Unit/Lang/Collections/SortedMap/SortedArrayHelperTest.php
@@ -12,8 +12,6 @@ use PHPUnit\Framework\TestCase;
 
 final class SortedArrayHelperTest extends TestCase
 {
-    // ---- defaultCompare ----
-
     public function test_default_compare_integers(): void
     {
         self::assertSame(-1, SortedArrayHelper::defaultCompare(1, 2));
@@ -71,8 +69,6 @@ final class SortedArrayHelperTest extends TestCase
         self::assertSame(-1, SortedArrayHelper::defaultCompare(1, NAN));
     }
 
-    // ---- resolveComparator ----
-
     public function test_resolve_null_returns_default_comparator(): void
     {
         $comp = SortedArrayHelper::resolveComparator(null);
@@ -103,8 +99,6 @@ final class SortedArrayHelperTest extends TestCase
 
         self::assertInstanceOf(Closure::class, $result);
     }
-
-    // ---- binarySearch ----
 
     public function test_search_empty_array(): void
     {

--- a/tests/php/Unit/Lang/Generators/CombineGeneratorTest.php
+++ b/tests/php/Unit/Lang/Generators/CombineGeneratorTest.php
@@ -9,8 +9,6 @@ use PHPUnit\Framework\TestCase;
 
 final class CombineGeneratorTest extends TestCase
 {
-    // ==================== concat tests ====================
-
     public function test_concat_skips_null_arguments(): void
     {
         $result = CombineGenerator::concat([1, 2], null, [3, 4]);
@@ -24,8 +22,6 @@ final class CombineGeneratorTest extends TestCase
 
         self::assertSame([1, null, 2, 3], iterator_to_array($result, false));
     }
-
-    // ==================== interpose tests ====================
 
     public function test_interpose_basic(): void
     {
@@ -54,8 +50,6 @@ final class CombineGeneratorTest extends TestCase
 
         self::assertSame(['a', '-', 'b', '-', 'c'], iterator_to_array($result, false));
     }
-
-    // ==================== interleave tests ====================
 
     public function test_interleave_basic(): void
     {
@@ -91,8 +85,6 @@ final class CombineGeneratorTest extends TestCase
 
         self::assertSame([1, 'a', 'x', 2, 'b', 'y'], iterator_to_array($result, false));
     }
-
-    // ==================== mapMulti tests ====================
 
     public function test_map_multi_basic(): void
     {

--- a/tests/php/Unit/Lang/Generators/DedupeGeneratorTest.php
+++ b/tests/php/Unit/Lang/Generators/DedupeGeneratorTest.php
@@ -9,8 +9,6 @@ use PHPUnit\Framework\TestCase;
 
 final class DedupeGeneratorTest extends TestCase
 {
-    // ==================== compact tests ====================
-
     public function test_compact_removes_null_by_default(): void
     {
         $result = DedupeGenerator::compact([1, null, 2, null, 3]);
@@ -184,8 +182,6 @@ final class DedupeGeneratorTest extends TestCase
         self::assertSame([false, 0, '', null, 1], $resultArray);
     }
 
-    // ==================== distinct tests ====================
-
     public function test_distinct_basic(): void
     {
         $result = DedupeGenerator::distinct([1, 2, 1, 3, 2, 4]);
@@ -227,8 +223,6 @@ final class DedupeGeneratorTest extends TestCase
         self::assertContains($obj1, $resultArray);
         self::assertContains($obj2, $resultArray);
     }
-
-    // ==================== dedupe tests ====================
 
     public function test_dedupe_basic(): void
     {

--- a/tests/php/Unit/Lang/Generators/FileGeneratorTest.php
+++ b/tests/php/Unit/Lang/Generators/FileGeneratorTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang\Generators;
+
+use InvalidArgumentException;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Generators\FileGenerator;
+use PHPUnit\Framework\TestCase;
+
+use function sys_get_temp_dir;
+
+final class FileGeneratorTest extends TestCase
+{
+    private string $file = '';
+
+    protected function setUp(): void
+    {
+        $this->file = tempnam(sys_get_temp_dir(), 'phel-file-generator-') ?: '';
+        self::assertNotSame('', $this->file);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->file)) {
+            unlink($this->file);
+        }
+    }
+
+    public function test_file_lines_strips_line_endings(): void
+    {
+        file_put_contents($this->file, "one\r\ntwo\nthree");
+
+        self::assertSame(
+            ['one', 'two', 'three'],
+            iterator_to_array(FileGenerator::fileLines($this->file), false),
+        );
+    }
+
+    public function test_file_lines_rejects_missing_file(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Argument filename should be a valid path to a file: ');
+
+        iterator_to_array(FileGenerator::fileLines($this->file . '-missing'), false);
+    }
+
+    public function test_read_file_chunks_yields_non_empty_chunks(): void
+    {
+        file_put_contents($this->file, 'abcdef');
+
+        self::assertSame(
+            ['abc', 'def'],
+            iterator_to_array(FileGenerator::readFileChunks($this->file, 3), false),
+        );
+    }
+
+    public function test_read_file_chunks_rejects_non_positive_chunk_size(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Chunk size must be positive, got: 0');
+
+        iterator_to_array(FileGenerator::readFileChunks($this->file, 0), false);
+    }
+
+    public function test_read_file_chunks_rejects_missing_file(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Argument filename should be a valid path to a file: ');
+
+        iterator_to_array(FileGenerator::readFileChunks($this->file . '-missing'), false);
+    }
+
+    public function test_csv_lines_yields_vectors(): void
+    {
+        file_put_contents($this->file, "a,b\nc,d\n");
+
+        $rows = iterator_to_array(FileGenerator::csvLines($this->file), false);
+
+        self::assertCount(2, $rows);
+        self::assertInstanceOf(PersistentVectorInterface::class, $rows[0]);
+        self::assertSame(['a', 'b'], iterator_to_array($rows[0], false));
+        self::assertInstanceOf(PersistentVectorInterface::class, $rows[1]);
+        self::assertSame(['c', 'd'], iterator_to_array($rows[1], false));
+    }
+
+    public function test_csv_lines_rejects_missing_file(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Argument filename should be a valid path to a file: ');
+
+        iterator_to_array(FileGenerator::csvLines($this->file . '-missing'), false);
+    }
+
+    public function test_file_seq_yields_the_file_itself(): void
+    {
+        self::assertSame([$this->file], iterator_to_array(FileGenerator::fileSeq($this->file), false));
+    }
+
+    public function test_file_seq_rejects_missing_path(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Path does not exist: ');
+
+        iterator_to_array(FileGenerator::fileSeq($this->file . '-missing'), false);
+    }
+}

--- a/tests/php/Unit/Lang/Generators/SequenceGeneratorTest.php
+++ b/tests/php/Unit/Lang/Generators/SequenceGeneratorTest.php
@@ -13,8 +13,6 @@ use Traversable;
 
 final class SequenceGeneratorTest extends TestCase
 {
-    // ==================== toIterable tests ====================
-
     public function test_to_iterable_with_array(): void
     {
         $result = SequenceGenerator::toIterable([1, 2, 3]);
@@ -56,8 +54,6 @@ final class SequenceGeneratorTest extends TestCase
         self::assertSame([1, 2, 3], iterator_to_array($result, false));
     }
 
-    // ==================== toIterator tests ====================
-
     public function test_to_iterator_reuses_iterator_instances(): void
     {
         $iterator = new ArrayIterator([1, 2, 3]);
@@ -98,8 +94,6 @@ final class SequenceGeneratorTest extends TestCase
         self::assertSame(['🎉', '🎊'], iterator_to_array($result, false));
     }
 
-    // ==================== indexed tests ====================
-
     public function test_indexed_pairs_values_with_zero_based_indexes(): void
     {
         $result = SequenceGenerator::indexed(['a', 'b', 'c']);
@@ -120,8 +114,6 @@ final class SequenceGeneratorTest extends TestCase
 
         self::assertSame([], iterator_to_array($result, false));
     }
-
-    // ==================== range tests ====================
 
     public function test_range_basic(): void
     {

--- a/tests/php/Unit/Lang/Generators/SliceGeneratorTest.php
+++ b/tests/php/Unit/Lang/Generators/SliceGeneratorTest.php
@@ -10,8 +10,6 @@ use PHPUnit\Framework\TestCase;
 
 final class SliceGeneratorTest extends TestCase
 {
-    // ==================== take tests ====================
-
     public function test_take_basic(): void
     {
         $result = SliceGenerator::take(3, [1, 2, 3, 4, 5]);
@@ -49,8 +47,6 @@ final class SliceGeneratorTest extends TestCase
         self::assertLessThanOrEqual(3, $callCount);
     }
 
-    // ==================== takeWhile tests ====================
-
     public function test_take_while_basic(): void
     {
         $result = SliceGenerator::takeWhile(
@@ -80,8 +76,6 @@ final class SliceGeneratorTest extends TestCase
 
         self::assertSame([1, 2, 3], iterator_to_array($result, false));
     }
-
-    // ==================== takeNth tests ====================
 
     public function test_take_nth_basic(): void
     {
@@ -118,8 +112,6 @@ final class SliceGeneratorTest extends TestCase
         self::assertSame(['🎉', '🎊'], iterator_to_array($result, false));
     }
 
-    // ==================== drop tests ====================
-
     public function test_drop_basic(): void
     {
         $result = SliceGenerator::drop(2, [1, 2, 3, 4, 5]);
@@ -140,8 +132,6 @@ final class SliceGeneratorTest extends TestCase
 
         self::assertSame([1, 2, 3], iterator_to_array($result, false));
     }
-
-    // ==================== dropWhile tests ====================
 
     public function test_drop_while_basic(): void
     {

--- a/tests/php/Unit/Lang/Generators/TransformGeneratorTest.php
+++ b/tests/php/Unit/Lang/Generators/TransformGeneratorTest.php
@@ -51,8 +51,6 @@ final class TransformGeneratorTest extends TestCase
         self::assertSame([], iterator_to_array($result, false));
     }
 
-    // ==================== map tests ====================
-
     public function test_map_basic(): void
     {
         $result = TransformGenerator::map(
@@ -100,8 +98,6 @@ final class TransformGeneratorTest extends TestCase
         self::assertSame(1, $callCount);
     }
 
-    // ==================== mapIndexed tests ====================
-
     public function test_map_indexed_basic(): void
     {
         $result = TransformGenerator::mapIndexed(
@@ -131,8 +127,6 @@ final class TransformGeneratorTest extends TestCase
 
         self::assertSame(['0:🎉', '1:🎊'], iterator_to_array($result, false));
     }
-
-    // ==================== filter tests ====================
 
     public function test_filter_basic(): void
     {
@@ -174,8 +168,6 @@ final class TransformGeneratorTest extends TestCase
         self::assertSame(['a', 'c'], iterator_to_array($result, false));
     }
 
-    // ==================== keep tests ====================
-
     public function test_keep_basic(): void
     {
         $result = TransformGenerator::keep(
@@ -205,8 +197,6 @@ final class TransformGeneratorTest extends TestCase
 
         self::assertSame([0, 0], iterator_to_array($result, false));
     }
-
-    // ==================== keepIndexed tests ====================
 
     public function test_keep_indexed_basic(): void
     {

--- a/tests/php/Unit/MergedConfigCacheInvalidatorTest.php
+++ b/tests/php/Unit/MergedConfigCacheInvalidatorTest.php
@@ -7,10 +7,13 @@ namespace PhelTest\Unit;
 use Closure;
 use Gacela\Framework\Config\MergedConfigCache;
 use Phel\MergedConfigCacheInvalidator;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
 
 final class MergedConfigCacheInvalidatorTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private string $dir = '';
 
     private ?string $previousAppEnv = null;
@@ -135,25 +138,4 @@ final class MergedConfigCacheInvalidatorTest extends TestCase
         );
     }
 
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        foreach (scandir($dir) ?: [] as $item) {
-            if ($item === '.') {
-                continue;
-            }
-
-            if ($item === '..') {
-                continue;
-            }
-
-            $path = $dir . '/' . $item;
-            is_dir($path) ? $this->removeDir($path) : unlink($path);
-        }
-
-        rmdir($dir);
-    }
 }

--- a/tests/php/Unit/Run/Application/Agent/AgentInstallerTest.php
+++ b/tests/php/Unit/Run/Application/Agent/AgentInstallerTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Unit\Run\Application\Agent;
 
 use Phel\Run\Application\Agent\AgentInstaller;
 use Phel\Run\Domain\Agent\AgentPlatform;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -13,6 +14,8 @@ use function dirname;
 
 final class AgentInstallerTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private AgentInstaller $installer;
 
     private string $sourceRoot;
@@ -181,34 +184,4 @@ final class AgentInstallerTest extends TestCase
         file_put_contents($path, $contents);
     }
 
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $items = scandir($dir);
-        if ($items === false) {
-            return;
-        }
-
-        foreach ($items as $item) {
-            if ($item === '.') {
-                continue;
-            }
-
-            if ($item === '..') {
-                continue;
-            }
-
-            $path = $dir . '/' . $item;
-            if (is_dir($path) && !is_link($path)) {
-                $this->removeDir($path);
-            } else {
-                unlink($path);
-            }
-        }
-
-        rmdir($dir);
-    }
 }

--- a/tests/php/Unit/Run/Infrastructure/Command/TestCommandFilterNoMatchesTest.php
+++ b/tests/php/Unit/Run/Infrastructure/Command/TestCommandFilterNoMatchesTest.php
@@ -12,8 +12,6 @@ use Symfony\Component\Console\Command\Command;
 
 final class TestCommandFilterNoMatchesTest extends TestCase
 {
-    // --- isNoMatchWithSelectors ---
-
     public function test_no_selector_zero_total_is_not_a_no_match(): void
     {
         self::assertFalse($this->isNoMatch(0, []));
@@ -88,14 +86,10 @@ final class TestCommandFilterNoMatchesTest extends TestCase
         ]));
     }
 
-    // --- exit-code constants are self::FAILURE on no-match ---
-
     public function test_failure_constant_is_non_zero(): void
     {
         self::assertSame(Command::FAILURE, 1);
     }
-
-    // --- helpers ---
 
     /**
      * @param array<string, mixed> $options

--- a/tests/php/Unit/Shared/PhelProjectDirectoryTest.php
+++ b/tests/php/Unit/Shared/PhelProjectDirectoryTest.php
@@ -122,4 +122,40 @@ final class PhelProjectDirectoryTest extends TestCase
             PhelProjectDirectory::resolve('/project', 'phar:///app/phel.phar/state'),
         );
     }
+
+    public function test_resolve_cache_dir_falls_back_to_resolve(): void
+    {
+        self::assertSame(
+            PhelProjectDirectory::resolve('/project', '.phel/cache', 'custom'),
+            PhelProjectDirectory::resolveCacheDir('/project', '.phel/cache', 'custom'),
+        );
+    }
+
+    public function test_resolve_cache_dir_env_var_wins_over_everything(): void
+    {
+        putenv(PhelProjectDirectory::CACHE_DIR_ENV . '=/env/override/cache');
+
+        try {
+            self::assertSame(
+                '/env/override/cache',
+                PhelProjectDirectory::resolveCacheDir('/project', '.phel/cache', 'custom'),
+            );
+        } finally {
+            putenv(PhelProjectDirectory::CACHE_DIR_ENV);
+        }
+    }
+
+    public function test_resolve_cache_dir_ignores_an_empty_env_var(): void
+    {
+        putenv(PhelProjectDirectory::CACHE_DIR_ENV . '=');
+
+        try {
+            self::assertSame(
+                '/project' . self::SEP . '.phel' . self::SEP . 'cache',
+                PhelProjectDirectory::resolveCacheDir('/project', '.phel/cache'),
+            );
+        } finally {
+            putenv(PhelProjectDirectory::CACHE_DIR_ENV);
+        }
+    }
 }

--- a/tests/php/Unit/Watch/Application/MtimeFileSystemScannerTest.php
+++ b/tests/php/Unit/Watch/Application/MtimeFileSystemScannerTest.php
@@ -5,18 +5,19 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Watch\Application;
 
 use Phel\Watch\Application\MtimeFileSystemScanner;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
 
 use function file_put_contents;
 use function mkdir;
-use function rmdir;
 use function sys_get_temp_dir;
 use function touch;
 use function uniqid;
-use function unlink;
 
 final class MtimeFileSystemScannerTest extends TestCase
 {
+    use RemoveDirTrait;
+
     private string $root;
 
     protected function setUp(): void
@@ -100,30 +101,4 @@ final class MtimeFileSystemScannerTest extends TestCase
         self::assertSame(1_700_000_000, $snapshot[$path]['mtime']);
     }
 
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        foreach (scandir($dir) ?: [] as $entry) {
-            if ($entry === '.') {
-                continue;
-            }
-
-            if ($entry === '..') {
-                continue;
-            }
-
-            $path = $dir . '/' . $entry;
-            if (is_dir($path)) {
-                $this->removeDir($path);
-                continue;
-            }
-
-            @unlink($path);
-        }
-
-        @rmdir($dir);
-    }
 }


### PR DESCRIPTION
## 🤔 Background

A broad code-quality sweep across the whole tree, run as eight independent audits: duplication, type-alias consolidation, dead code, dependency cycles, weak types, defensive error handling, legacy/fallback code, and comment quality. Each audit produced a written assessment first, and only the high-confidence findings were implemented.

The headline is worth stating plainly: **most of these areas came back clean.** PHPStan level 9 with `treatPhpDocTypesAsCertain`, Psalm level 1, Rector and php-cs-fixer already eliminate whole categories of defect before they can land. Concretely, the audits found zero empty catch bodies, zero `set_error_handler`/`error_reporting` manipulation, zero redundant type guards, zero `@deprecated` tags in `src/php/`, zero PHP-version guards, zero Gacela factory-boundary violations, and zero class-level dependency cycles crossing a module boundary. Of 480 raw Psalm dead-code signals, six were real.

What did surface was concentrated in a few specific places, and includes four genuine bugs.

## 💡 Goal

Fix the real defects the audits found, remove the code that is provably dead, cut the one accidental module cycle, and add guards so the cleaned-up invariants stay true. Everything here is behaviour-preserving except the four bug fixes, which are covered by new tests.

## 🔖 Changes

### Bugs fixed

- **Sorted-collection comparators were mistyped.** Eight declarations claimed comparators return `int`, but Phel's `<` returns a boolean and `(sorted-map-by < ...)` is a tested, supported call. Now `bool|int`.
- **`phel lint` silently ignored a broken config.** An unreadable, unparseable, or non-map `phel-lint.phel` degraded to the built-in default rules with no warning, so you could lint against the wrong ruleset indefinitely. Now raises `LintConfigException` and exits 2. A missing or empty file still means defaults.
- **Namespace-extraction errors discarded their cause.** `ExtractorException::cannotParseFile` threw away both the underlying lexer/parser message and `$previous`, leaving `Cannot parse file: <path>` with no line number and no chain.
- **`phel format` swallowed I/O failures.** A catch-all `Throwable` turned real I/O errors and rule bugs into a printed stack trace plus a silently skipped file. Narrowed to the three exception types `formatFile()` actually documents, so a malformed source file still does not abort the batch.

### Dependency graph

- Cut the only accidental module cycle, `Compiler -> Build`. It was a single `{@see \Phel\Build\BuildConfig::getCacheDir()}` docblock pointing down the stack, and that docblock was a symptom: `CompilerConfig::getCacheDir()` and `BuildConfig::getCacheDir()` were byte-identical. Both now delegate to `Phel\Shared\PhelProjectDirectory::resolveCacheDir()`, which already owns `.phel/` path resolution. That one edge sat on 24 of 34 elementary cycles; the graph drops to 9, leaving only the four documented-as-deliberate pairs.
- Added `tests/php/Unit/Architecture/ModuleDependencyCycleTest`, extending the existing architecture suite rather than duplicating `SharedCompilerBoundaryTest`. It pins the exact cyclic pair set and the exact files closing each direction, so a narrow, deliberate cycle cannot quietly widen into a broad one.

### Duplication

- `AbstractTriviaNode` for the four identical trivia parse nodes; `CopyLocationFromTrait` for `copyLocationFrom` across the `Lang` value types; `Shared\ExistingPaths` for a triplicated path filter; folded duplicate bodies in the deprecator, the shadowed-binding rule and the indenters.
- Consolidated **19 hand-rolled recursive-rmdir helpers, which had drifted into 8 different variants**, into one `PhelTest\Support\RemoveDirTrait`.

### Types

- Removed 29 of 74 `@psalm-suppress` annotations as provably dead, established by stripping every inline suppression, running `psalm --no-cache`, and diffing the real errors against the annotation list. Ten were `Tainted*` tags that never evaluate because taint analysis is not enabled anywhere in this repo; six duplicated global suppressions already in `psalm.xml`.
- Expressed three more types properly instead of silencing them, notably `LazySeqInterface extends IteratorAggregate<int, T>`: both `final` implementers already did this and the printer already `foreach`ed the interface type, so iterability was an undeclared requirement.
- Gave 24 `callable`/`Closure` positions a real signature, each derived from the invocation site plus every call site.
- Added 18 `@phpstan-type` aliases removing 45 lines of inline `array{…}` repetition, and gave the two cross-module shapes a single owner: `RegistrySnapshot` on `Lang\Registry`, `CompiledFileLineMap` on `Shared\Facade\CommandFacadeInterface` (a `Shared -> Command\Domain` import would add a new outward edge on the leaf layer).

### Removals

- The empty `FiberProvider`, `NamespaceCacheInterface::remove()`/`clear()`, `SessionRegistry::ids()`, a write-only `ReplFormattedError` field, an unused input-stream parameter on the LSP `createServer`, and `LazySeqConfig::EAGER_THRESHOLD`, a public constant documenting an eager-realization optimization that no code implements.
- A dead `allow-plugins` entry for a package absent from require, lock and vendor.
- 89 lines of comment-only noise: a commented-out test block, a "matching the old `match`" work-in-motion note, a docblock restating `@return bool True, if $a is equals $b`, and 39 decorative divider lines.

### Coverage

- `Phel\Lang\Generators\FileGenerator` had **zero test coverage** despite backing `file-lines`, `csv-lines` and `read-file-chunks`. Nine tests added before anything was refactored around it.
- New tests for the lint-config failure path, the extractor error chain, the formatter error path, and the `Shared` cache-dir seam.

### Convention

- Scoped the `T`-prefix type-naming rule to `@template` generic parameters, where the repo is genuinely inconsistent (`TKey`/`TValue` vs bare `K`/`V`). It explicitly does not apply to `@phpstan-type` aliases: those are file-scoped docblock macros, never ambiguous with a class name, and several deliberately mirror LSP spec object names where a prefix would break the correspondence. All 35 aliases now follow one convention.

## ✅ Verification

Full gate green on the merged result, not just per-workstream: PHPStan level 9 clean after `clear-result-cache` (1040 files), Psalm level 1 clean, php-cs-fixer 0 of 1650, Rector clean, 5153 unit + integration tests with 14867 assertions, 6483 Phel core tests. Reflection-wired paths that tests do not reach were exercised by hand: `bin/phel --help`, `debug:modules`, `validate:config`, `doc map`, `ns`, `build --help`.

## 📋 Deliberately not included

Each audit kept a ranked backlog of medium-confidence findings, which will follow as separate PRs rather than being buried here. The notable ones:

- `phel format` still exits 0 when a file fails to parse, a real CI hazard. The fix needs a new return shape on `FormatterFacadeInterface::format()`, so it is a public API change.
- `LazySeq::$realized` is unsound: `(lazy-seq 5)` stores a non-`SeqInterface` in a `?SeqInterface` property. Proven, but the fix widens a declaration.
- `TransientHashSet::__invoke` has no `TransientSortedSet` counterpart, so `((transient (sorted-set :a)) :a)` does not behave like the hash-set case. These two classes are the largest clone in `src/php`, but deduplicating them would bake the asymmetry in, so the gap should be settled first.
- Four tests that assert nothing meaningful, and the public deprecation surface inventory for the next major.

The `Shared <-> Compiler` cycle (#2785) was confirmed still narrow at one file and 11 symbols, and left untouched as intended. The `\` namespace separator was left in place.
