### PR TITLE
feat: enforce the standalone-comment convention with a `phel/comment-style` lint rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- New `phel lint` rule `phel/comment-style` (warning, on by default): flags a whole-line comment written with a single `;`, which the convention reserves for comments trailing code on the same line
+
 ### Fixed
 
 - Sorted collection comparators are now typed `bool|int` rather than `int`. Phel's `<` returns a boolean, so `(sorted-map-by < ...)` never matched its own declared contract

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -22,9 +22,9 @@
                  "source" "track" "wbr"))
 
 (defn- container-tag? [tag]
-  ; Void elements (br, img, input, ...) are always self-closing per the HTML
-  ; spec: they never render a closing tag or children, even if children were
-  ; mistakenly supplied.
+  ;; Void elements (br, img, input, ...) are always self-closing per the HTML
+  ;; spec: they never render a closing tag or children, even if children were
+  ;; mistakenly supplied.
   (not (contains? void-tags tag)))
 
 (defn- normalize-element [[tag & content]]

--- a/src/phel/json.phel
+++ b/src/phel/json.phel
@@ -32,8 +32,8 @@
    :see-also ["encode" "decode-value"]}
   [x]
   (cond
-    ; An empty map must encode as a JSON object `{}`, not the `[]` an empty
-    ; php/array would produce; a stdClass forces object encoding.
+    ;; An empty map must encode as a JSON object `{}`, not the `[]` an empty
+    ;; php/array would produce; a stdClass forces object encoding.
     (and (map? x) (empty? x)) (php/new \stdClass)
     (php/is_iterable x)       (encode-value-iterable x)
     (symbol? x)               (name x)
@@ -61,9 +61,9 @@
     (indexed? x)   (for [v :in x] (decode-value v))
     (php-array? x) (let [hashmap (transient {})]
                      (foreach [k v x]
-                       ; JSON object keys are strings, but php/json_decode coerces
-                       ; numeric keys to ints; stringify first so `(keyword k)`
-                       ; never collapses them to a single nil key.
+                       ;; JSON object keys are strings, but php/json_decode coerces
+                       ;; numeric keys to ints; stringify first so `(keyword k)`
+                       ;; never collapses them to a single nil key.
                        (php/-> hashmap (put (keyword (str k)) (decode-value v))))
                      (persistent hashmap))
     true           x))

--- a/src/php/Lint/Application/Config/RuleRegistry.php
+++ b/src/php/Lint/Application/Config/RuleRegistry.php
@@ -30,6 +30,8 @@ final class RuleRegistry
 
     public const string DISCOURAGED_VAR = 'phel/discouraged-var';
 
+    public const string COMMENT_STYLE = 'phel/comment-style';
+
     /**
      * @return list<string>
      */
@@ -46,6 +48,7 @@ final class RuleRegistry
             self::DUPLICATE_KEY,
             self::INVALID_DESTRUCTURING,
             self::DISCOURAGED_VAR,
+            self::COMMENT_STYLE,
         ];
     }
 }

--- a/src/php/Lint/Application/Rule/CommentStyleRule.php
+++ b/src/php/Lint/Application/Rule/CommentStyleRule.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Domain\LintRuleInterface;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+use Phel\Shared\Parser\Node\Token;
+use Throwable;
+
+use function str_ends_with;
+use function str_starts_with;
+
+/**
+ * Flags a comment that sits alone on its line but opens with a single `;`.
+ *
+ * The convention (shared with Clojure) reserves the two forms by position:
+ * `;` trails code on the same line, `;;` (or more) owns the whole line.
+ *
+ * Works on the token stream rather than the source text because only the
+ * lexer knows which `;` actually starts a comment: a `;` inside a string
+ * literal, a regex literal or a `#| ... |#` block never yields a comment
+ * token, so it can never be flagged. Bare `#` line comments are out of
+ * scope; the lexer already deprecates them.
+ */
+final readonly class CommentStyleRule implements LintRuleInterface
+{
+    public function __construct(
+        private CompilerFacadeInterface $compilerFacade,
+    ) {}
+
+    public function code(): string
+    {
+        return RuleRegistry::COMMENT_STYLE;
+    }
+
+    public function apply(FileAnalysis $analysis): array
+    {
+        $result = [];
+
+        try {
+            $tokenStream = $this->compilerFacade->lexString($analysis->source, $analysis->uri);
+
+            // A comment is "standalone" when nothing but indentation precedes
+            // it on its line. Newlines and line comments are the only tokens
+            // that can end a line, so tracking them is enough; whitespace is
+            // indentation and leaves the flag untouched.
+            $atLineStart = true;
+            foreach ($tokenStream as $token) {
+                $type = $token->getType();
+
+                if ($type === Token::T_WHITESPACE) {
+                    continue;
+                }
+
+                if ($type === Token::T_NEWLINE) {
+                    $atLineStart = true;
+
+                    continue;
+                }
+
+                if ($type !== Token::T_COMMENT) {
+                    $atLineStart = false;
+
+                    continue;
+                }
+
+                $code = $token->getCode();
+                if ($atLineStart && $this->isSingleSemicolon($code)) {
+                    $result[] = $this->diagnostic($token, $analysis->uri);
+                }
+
+                // `;` comments swallow their trailing newline (except at EOF);
+                // a `#| ... |#` block does not, so code may follow it inline.
+                $atLineStart = str_ends_with($code, "\n");
+            }
+        } catch (Throwable) {
+            // Best effort: a file that does not lex is already reported by the
+            // parse/analyze path, so staying silent avoids a duplicate error.
+        }
+
+        return $result;
+    }
+
+    private function isSingleSemicolon(string $code): bool
+    {
+        return str_starts_with($code, ';') && !str_starts_with($code, ';;');
+    }
+
+    private function diagnostic(Token $token, string $uri): Diagnostic
+    {
+        $start = $token->getStartLocation();
+
+        return new Diagnostic(
+            code: $this->code(),
+            severity: Diagnostic::SEVERITY_WARNING,
+            message: "Standalone comment should start with ';;'; a single ';' is reserved for comments that trail code on the same line.",
+            uri: $uri,
+            startLine: $start->getLine(),
+            startCol: $start->getColumn(),
+            endLine: $start->getLine(),
+            endCol: $start->getColumn() + 1,
+        );
+    }
+}

--- a/src/php/Lint/CLAUDE.md
+++ b/src/php/Lint/CLAUDE.md
@@ -30,9 +30,19 @@ Exit codes: `0` clean/warnings only, `1` errors, `2` invocation error.
 ## Rule Set (v1)
 
 - Errors: `phel/unresolved-symbol`, `phel/arity-mismatch`, `phel/invalid-destructuring`, `phel/duplicate-key`
-- Warnings: `phel/unused-binding`, `phel/unused-require`, `phel/unused-import`, `phel/shadowed-binding`, `phel/redundant-do`, `phel/discouraged-var`
+- Warnings: `phel/unused-binding`, `phel/unused-require`, `phel/unused-import`, `phel/shadowed-binding`, `phel/redundant-do`, `phel/discouraged-var`, `phel/comment-style`
 
-Add a rule: implement `LintRuleInterface` in `Application/Rule/`, add a code constant to `RuleRegistry`, register it in `LintFactory::createRules()`. Do not edit existing rules.
+Every shipped rule is on by default (it has an entry in `LintConfig::defaultSeverities()`); a rule with no entry there is off until a config opts it in.
+
+Add a rule: implement `LintRuleInterface` in `Application/Rule/`, add a code constant to `RuleRegistry`, register it in `LintFactory::createRules()`, and give it a default severity in `LintConfig::defaultSeverities()`. Do not edit existing rules.
+
+### `phel/comment-style`
+
+Enforces the positional comment convention (`.claude/rules/phel.md`, shared with Clojure): `;` trails code on the same line, `;;` (or more) owns the whole line. Flags only a comment that starts a line and opens with exactly one `;`.
+
+- `;;;`+ is clean — the rule asks that a whole-line comment is not written with the inline marker, and Clojure-style `;;;` section headers stay legal.
+- Scans the **token stream**, not the source text: only the lexer knows which `;` opens a comment, so a `;` in a string literal, a regex literal, or a `#| ... |#` block can never be flagged.
+- Bare `#` line comments are out of scope; the lexer already emits a deprecation for them.
 
 ## Config File
 

--- a/src/php/Lint/LintConfig.php
+++ b/src/php/Lint/LintConfig.php
@@ -34,6 +34,7 @@ final class LintConfig extends AbstractConfig
             RuleRegistry::SHADOWED_BINDING => Diagnostic::SEVERITY_WARNING,
             RuleRegistry::REDUNDANT_DO => Diagnostic::SEVERITY_WARNING,
             RuleRegistry::DISCOURAGED_VAR => Diagnostic::SEVERITY_WARNING,
+            RuleRegistry::COMMENT_STYLE => Diagnostic::SEVERITY_WARNING,
         ];
     }
 

--- a/src/php/Lint/LintFactory.php
+++ b/src/php/Lint/LintFactory.php
@@ -17,6 +17,7 @@ use Phel\Lint\Application\Formatter\HumanFormatter;
 use Phel\Lint\Application\Formatter\JsonFormatter;
 use Phel\Lint\Application\LintRunner;
 use Phel\Lint\Application\Rule\ArityMismatchRule;
+use Phel\Lint\Application\Rule\CommentStyleRule;
 use Phel\Lint\Application\Rule\DiscouragedVarRule;
 use Phel\Lint\Application\Rule\DuplicateKeyRule;
 use Phel\Lint\Application\Rule\InvalidDestructuringRule;
@@ -74,6 +75,7 @@ final class LintFactory extends AbstractFactory
             new DuplicateKeyRule($this->getCompilerFacade()),
             new InvalidDestructuringRule(),
             new DiscouragedVarRule(),
+            new CommentStyleRule($this->getCompilerFacade()),
         ];
     }
 

--- a/tests/phel/cli.phel
+++ b/tests/phel/cli.phel
@@ -163,10 +163,10 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest test-application-uses-addcommand-when-available
-  ; Symfony 7.4 deprecated add() in favour of addCommand().
-  ; Capture any deprecation triggered while building the application and
-  ; assert that none mention Application::add().
-  ; Use an atom so the error-handler closure captures a reference-stable cell.
+  ;; Symfony 7.4 deprecated add() in favour of addCommand().
+  ;; Capture any deprecation triggered while building the application and
+  ;; assert that none mention Application::add().
+  ;; Use an atom so the error-handler closure captures a reference-stable cell.
   (let [deprecations (atom [])
         _            (php/set_error_handler
                       (fn [_ msg _ _]
@@ -181,9 +181,9 @@
     (is (= [] found) "no deprecation for Application::add() — addCommand() used instead")))
 
 (defn- handler-closure [cmd]
-  ; Extract the Closure registered via Command::setCode across all supported
-  ; Symfony versions. Symfony 6 stores the raw Closure on `Command::$code`;
-  ; 7+ wraps it in an InvokableCommand whose own `$code` holds the Closure.
+  ;; Extract the Closure registered via Command::setCode across all supported
+  ;; Symfony versions. Symfony 6 stores the raw Closure on `Command::$code`;
+  ;; 7+ wraps it in an InvokableCommand whose own `$code` holds the Closure.
   (let [rc  (php/new \ReflectionClass cmd)
         cp  (php/-> rc (getProperty "code"))
         raw (php/-> cp (getValue cmd))]
@@ -194,10 +194,10 @@
         (php/-> icp (getValue raw))))))
 
 (deftest test-handler-closure-has-typed-symfony-params
-  ; Symfony 8 enforces named types on Command::setCode closure params.
-  ; Phel `(fn [input output] ...)` would lower to an untyped __invoke;
-  ; reflect on the registered Closure and assert each param carries the
-  ; Symfony interface as a named type. Works on Symfony 6, 7, and 8.
+  ;; Symfony 8 enforces named types on Command::setCode closure params.
+  ;; Phel `(fn [input output] ...)` would lower to an untyped __invoke;
+  ;; reflect on the registered Closure and assert each param carries the
+  ;; Symfony interface as a named type. Works on Symfony 6, 7, and 8.
   (let [cmd     (cli/command {:name "x" :run (fn [_] 0)})
         closure (handler-closure cmd)
         rf      (php/new \ReflectionFunction closure)

--- a/tests/phel/core/boolean-operation.phel
+++ b/tests/phel/core/boolean-operation.phel
@@ -61,9 +61,9 @@
   (is (false? (= [:a ["1"]] [:a [1]])) "nested vectors with different types are not equal")
   (is (false? (= [1] [1 2])) "vectors with different size are not equals"))
 
-; Regression tests for https://github.com/phel-lang/phel-lang/issues/1546.
-; Sequential collections with the same elements must compare equal regardless
-; of argument order or concrete type (list/vector/lazy-seq).
+;; Regression tests for https://github.com/phel-lang/phel-lang/issues/1546.
+;; Sequential collections with the same elements must compare equal regardless
+;; of argument order or concrete type (list/vector/lazy-seq).
 (deftest test-=-list-vector
   (is (true? (= '(1 2) [1 2])) "list = vector")
   (is (true? (= [1 2] '(1 2))) "vector = list")

--- a/tests/phel/core/infinite-seqs.phel
+++ b/tests/phel/core/infinite-seqs.phel
@@ -9,9 +9,9 @@
   (is (= [:x :x :x] (take 3 (repeatedly (fn [] :x))))
       "(take 3 (repeatedly (fn [] :x)))"))
 
-; Regression test for https://github.com/phel-lang/phel-lang/issues/2186.
-; (repeatedly f) must not invoke f at construction; constructing with an
-; arity-incompatible fn (identity) must succeed because the seq is unrealized.
+;; Regression test for https://github.com/phel-lang/phel-lang/issues/2186.
+;; (repeatedly f) must not invoke f at construction; constructing with an
+;; arity-incompatible fn (identity) must succeed because the seq is unrealized.
 (deftest test-repeatedly-defers-fn-call
   (let [call (repeatedly identity)]
     (is (false? (realized? call))
@@ -24,9 +24,9 @@
     (is (= [:z :z :z :z] (take 4 call))
         "values from a deferred (repeatedly f) are realized on demand")))
 
-; Regression test for https://github.com/phel-lang/phel-lang/issues/2210.
-; (repeatedly n f) must defer invoking f until the seq is realized so
-; constructing with an arity-incompatible fn (identity) succeeds.
+;; Regression test for https://github.com/phel-lang/phel-lang/issues/2210.
+;; (repeatedly n f) must defer invoking f until the seq is realized so
+;; constructing with an arity-incompatible fn (identity) succeeds.
 (deftest test-repeatedly-arity-two-defers-fn-call
   (let [call (repeatedly 1000 identity)]
     (is (true? (lazy-seq? call))
@@ -50,9 +50,9 @@
   (is (some? (and (range)))
       "range with no args should return truthy value"))
 
-; Regression tests for https://github.com/phel-lang/phel-lang/issues/1286.
-; Comparisons that can short-circuit must not realize an infinite lazy
-; sequence — previously these blew up with an integer-overflow allocation.
+;; Regression tests for https://github.com/phel-lang/phel-lang/issues/1286.
+;; Comparisons that can short-circuit must not realize an infinite lazy
+;; sequence — previously these blew up with an integer-overflow allocation.
 (deftest test-infinite-range-equality-short-circuits
   (let [r (range)]
     (is (= r r)
@@ -171,9 +171,9 @@
   (is (= [0 2 4 6 8] (take 5 (filter even? (iterate inc 0))))
       "filter on infinite sequence should work without hanging"))
 
-; Regression test for https://github.com/phel-lang/phel-lang/issues/2187.
-; A sparse-predicate filter over an infinite source used to hang because the
-; chunked seq tried to pre-realize 32 elements that would never arrive.
+;; Regression test for https://github.com/phel-lang/phel-lang/issues/2187.
+;; A sparse-predicate filter over an infinite source used to hang because the
+;; chunked seq tried to pre-realize 32 elements that would never arrive.
 (deftest test-remove-on-infinite-seq-with-bounded-result
   (is (= '(0 1 2) (take 3 (remove (partial < 5) (range))))
       "(take 3 (remove (partial < 5) (range))) must not hang"))
@@ -182,9 +182,9 @@
   (is (= '(0 1 2) (take 3 (filter (partial >= 5) (range))))
       "(take 3 (filter (partial >= 5) (range))) must not hang"))
 
-; Regression tests for https://github.com/phel-lang/phel-lang/issues/2191.
-; `concat` must return an unrealized lazy seq across all non-zero arities;
-; previously the result was eagerly chunked and `realized?` reported `true`.
+;; Regression tests for https://github.com/phel-lang/phel-lang/issues/2191.
+;; `concat` must return an unrealized lazy seq across all non-zero arities;
+;; previously the result was eagerly chunked and `realized?` reported `true`.
 (deftest test-concat-arity-one-defers-realization
   (is (false? (realized? (concat [1 2 3 4 5])))
       "(concat coll) should be unrealized until accessed"))
@@ -205,10 +205,10 @@
   (is (= [0 1 2 3 4] (take 5 (concat (range) (range))))
       "(take n (concat (range) …)) must not hang"))
 
-; Regression tests for https://github.com/phel-lang/phel-lang/issues/2188.
-; `map` must (a) defer realization across all non-transducer arities,
-; (b) produce a lazy seq even for nil/empty input, and (c) iterate maps
-; as `[k v]` pair vectors (not values-only).
+;; Regression tests for https://github.com/phel-lang/phel-lang/issues/2188.
+;; `map` must (a) defer realization across all non-transducer arities,
+;; (b) produce a lazy seq even for nil/empty input, and (c) iterate maps
+;; as `[k v]` pair vectors (not values-only).
 (deftest test-map-defers-realization-arity-2
   (is (false? (realized? (map inc (range 5))))
       "(map f coll) must be unrealized until accessed"))
@@ -242,9 +242,9 @@
   (is (= [0 1 2 3 4] (take 5 (map identity (range))))
       "(take n (map f (range))) must not hang"))
 
-; Regression test for https://github.com/phel-lang/phel-lang/issues/2190.
-; `distinct` must produce an unrealized lazy seq; previously the result
-; was pre-chunked and `realized?` was true at construction.
+;; Regression test for https://github.com/phel-lang/phel-lang/issues/2190.
+;; `distinct` must produce an unrealized lazy seq; previously the result
+;; was pre-chunked and `realized?` was true at construction.
 (deftest test-distinct-defers-realization
   (let [s (distinct [1 1 1 2 1 2 1 2 3 1 2 3 1 2 3 4 1 2 3 4 5])]
     (is (false? (realized? s))

--- a/tests/phel/core/interop-by-ref.phel
+++ b/tests/phel/core/interop-by-ref.phel
@@ -28,8 +28,8 @@
 
 (deftest php-ref-survives-an-enclosing-closure-wrap
   (let [m nil]
-    ; the `do` sits in expression position, so the emitter wraps it in an IIFE;
-    ; the by-ref local must still be captured by reference through that wrap.
+    ;; the `do` sits in expression position, so the emitter wraps it in an IIFE;
+    ;; the by-ref local must still be captured by reference through that wrap.
     (php/intval (do (php/preg_match "/(\\d+)/" "abc123" (php/ref m)) 0))
     (is (= "123" (php/aget m 1)) "by-ref survives an enclosing IIFE wrap")))
 

--- a/tests/phel/core/sequence-functions.phel
+++ b/tests/phel/core/sequence-functions.phel
@@ -444,10 +444,10 @@
   (is (= {1 ["a"] 2 ["as" "aa"] 3 ["asd"] 4 ["asdf" "qwer"]}
          (group-by php/strlen ["a" "as" "asd" "aa" "asdf" "qwer"])) "group-by"))
 
-; Regression test for https://github.com/phel-lang/phel-lang/issues/2189.
-; `group-by` must preserve element metadata. The root cause was reader-attached
-; meta `^{:k v} […]` being dropped during emit; group-by itself only proxies
-; the elements through. Both reader meta and `set-meta!` paths must round-trip.
+;; Regression test for https://github.com/phel-lang/phel-lang/issues/2189.
+;; `group-by` must preserve element metadata. The root cause was reader-attached
+;; meta `^{:k v} […]` being dropped during emit; group-by itself only proxies
+;; the elements through. Both reader meta and `set-meta!` paths must round-trip.
 (deftest test-group-by-retains-element-metadata-via-reader-meta
   (let [g (group-by first [^{:foo true} [[1] [2]] ^{:bar true} [[1] [3]]])]
     (is (= {:foo true} (meta (first (get g [1]))))
@@ -464,7 +464,7 @@
     (is (= {:bar true} (meta (second (get g [1]))))
         "group-by preserves set-meta! meta on the second bucket element")))
 
-; Direct coverage of the underlying reader-meta-on-literal plumbing fix.
+;; Direct coverage of the underlying reader-meta-on-literal plumbing fix.
 (deftest test-reader-meta-on-vector-literal
   (is (= {:foo true} (meta ^{:foo true} [1 2]))
       "reader meta map on a vector literal survives compile/emit"))

--- a/tests/phel/core/sequence-operation.phel
+++ b/tests/phel/core/sequence-operation.phel
@@ -325,10 +325,10 @@
   (is (thrown? OutOfBoundsException (nth (transient [1 2 3]) 5)) "nth throws on transient vector out of bounds")
   (is (thrown? OutOfBoundsException (nth "abc" 5)) "nth throws on string out of bounds"))
 
-; Regression tests for https://github.com/phel-lang/phel-lang/issues/2211.
-; `get` / `nth` on a vector with a non-int key used to leak a raw PHP
-; "could not be converted to int" warning from
-; AbstractPersistentVector::offsetExists / get.
+;; Regression tests for https://github.com/phel-lang/phel-lang/issues/2211.
+;; `get` / `nth` on a vector with a non-int key used to leak a raw PHP
+;; "could not be converted to int" warning from
+;; AbstractPersistentVector::offsetExists / get.
 (deftest test-get-vector-non-int-key-returns-default
   (is (nil? (get [1 2 3] :a)) "get on vector with keyword key returns nil")
   (is (nil? (get [1 2 3] "x")) "get on vector with string key returns nil")

--- a/tests/phel/core/threading-macros.phel
+++ b/tests/phel/core/threading-macros.phel
@@ -61,27 +61,27 @@
 
 (deftest threading-macros-preserve-form-metadata
   (let [m {:line 1}]
-    (let [form     (set-meta! '(+ 2) m)
+    (let [form     (with-meta '(+ 2) m)
           expanded (macroexpand-1 (list '-> 1 form))]
       (is (= m (meta (identity expanded))) "-> preserves metadata"))
 
-    (let [form     (set-meta! '(+ 2) m)
+    (let [form     (with-meta '(+ 2) m)
           expanded (macroexpand-1 (list '->> 1 form))]
       (is (= m (meta (identity expanded))) "->> preserves metadata"))
 
-    (let [form     (set-meta! '(+ 2) m)
+    (let [form     (with-meta '(+ 2) m)
           expanded (macroexpand-1 (list 'some-> 'x form))
           if-expr  (second (rest expanded))
           call     (first (rest (rest (rest if-expr))))]
       (is (= m (meta (identity call))) "some-> preserves metadata"))
 
-    (let [form     (set-meta! '(+ 2) m)
+    (let [form     (with-meta '(+ 2) m)
           expanded (macroexpand-1 (list 'some->> 'xs form))
           if-expr  (second (rest expanded))
           call     (first (rest (rest (rest if-expr))))]
       (is (= m (meta (identity call))) "some->> preserves metadata"))
 
-    (let [form     (set-meta! '(foo 42) m)
+    (let [form     (with-meta '(foo 42) m)
           expanded (macroexpand-1 (list 'doto 'obj form))
           call     (second (rest expanded))]
       (is (= m (meta (identity call))) "doto preserves metadata"))))

--- a/tests/phel/json/decode/value.phel
+++ b/tests/phel/json/decode/value.phel
@@ -40,6 +40,6 @@
          (json/decode sample-data)))))
 
 (deftest test-json-decode-numeric-keys-become-keywords
-  ; php/json_decode coerces numeric object keys to ints; they must still
-  ; become keywords, not collapse to a single nil key.
+  ;; php/json_decode coerces numeric object keys to ints; they must still
+  ;; become keywords, not collapse to a single nil key.
   (is (= {:1 "one" :2 "two"} (json/decode "{\"1\":\"one\",\"2\":\"two\"}"))))

--- a/tests/phel/string.phel
+++ b/tests/phel/string.phel
@@ -227,7 +227,7 @@
   (is (= "0foo0" (s/pad-both "foo" 5 "0"))))
 
 (deftest test-pad-empty-pad-string-falls-back-to-space
-  ; An empty pad string used to throw an uncatchable PHP str_pad error.
+  ;; An empty pad string used to throw an uncatchable PHP str_pad error.
   (is (= "  foo" (s/pad-left "foo" 5 "")))
   (is (= "foo  " (s/pad-right "foo" 5 "")))
   (is (= " foo " (s/pad-both "foo" 5 ""))))

--- a/tests/php/Integration/Lint/Fixtures/comment_style.phel
+++ b/tests/php/Integration/Lint/Fixtures/comment_style.phel
@@ -1,0 +1,5 @@
+(ns fixtures\comment-style)
+
+; standalone comment written with the inline marker
+(defn greet [name]
+  (str "Hello, " name)) ; inline comment, correct usage

--- a/tests/php/Integration/Lint/LintCommandTest.php
+++ b/tests/php/Integration/Lint/LintCommandTest.php
@@ -110,6 +110,32 @@ final class LintCommandTest extends TestCase
 
     #[PreserveGlobalState(false)]
     #[RunInSeparateProcess]
+    public function test_it_reports_comment_style_only_for_the_standalone_comment(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandTester(new LintCommand());
+        $exit = $tester->execute([
+            'paths' => [__DIR__ . '/Fixtures/comment_style.phel'],
+            '--format' => 'json',
+            '--no-cache' => true,
+        ]);
+
+        $payload = json_decode(trim($tester->getDisplay()), true);
+        self::assertIsArray($payload);
+
+        $commentStyle = array_values(array_filter(
+            $payload,
+            static fn(array $d): bool => $d['code'] === 'phel/comment-style',
+        ));
+
+        self::assertCount(1, $commentStyle, 'Only the whole-line `;` comment must be flagged');
+        self::assertSame(3, $commentStyle[0]['startLine']);
+        self::assertSame(0, $exit, 'Comment style is a warning, so the command still succeeds');
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function test_github_format_emits_annotation_commands(): void
     {
         $this->bootstrap();

--- a/tests/php/Unit/Lint/Application/Rule/CommentStyleRuleTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/CommentStyleRuleTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Rule;
+
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Application\Rule\CommentStyleRule;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+final class CommentStyleRuleTest extends RuleTestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_a_standalone_single_semicolon_comment(): void
+    {
+        $rule = new CommentStyleRule($this->compilerFacade());
+        $analysis = $this->buildAnalysis("; a standalone comment\n(def x 1)\n");
+
+        $diagnostics = $rule->apply($analysis);
+
+        self::assertCount(1, $diagnostics);
+        self::assertSame(RuleRegistry::COMMENT_STYLE, $diagnostics[0]->code);
+        self::assertStringContainsString(';;', $diagnostics[0]->message);
+        self::assertSame(1, $diagnostics[0]->startLine);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_an_indented_standalone_single_semicolon_comment(): void
+    {
+        $rule = new CommentStyleRule($this->compilerFacade());
+        $analysis = $this->buildAnalysis("(defn f []\n  ; explain\n  1)\n");
+
+        $diagnostics = $rule->apply($analysis);
+
+        self::assertCount(1, $diagnostics);
+        self::assertSame(2, $diagnostics[0]->startLine);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_a_standalone_double_semicolon_comment(): void
+    {
+        $rule = new CommentStyleRule($this->compilerFacade());
+        $analysis = $this->buildAnalysis(";; a standalone comment\n(def x 1)\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_an_inline_comment_after_code(): void
+    {
+        $rule = new CommentStyleRule($this->compilerFacade());
+        $analysis = $this->buildAnalysis("(def x 1) ; why one\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    /**
+     * Three or more semicolons stay clean: the rule only asks that a
+     * whole-line comment is not written with the inline marker. Clojure uses
+     * `;;;` for section headers and Phel does not forbid it.
+     */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_three_or_more_semicolons(): void
+    {
+        $rule = new CommentStyleRule($this->compilerFacade());
+        $analysis = $this->buildAnalysis(";;; section header\n;;;; sub section\n(def x 1)\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_a_semicolon_inside_a_string_literal(): void
+    {
+        $rule = new CommentStyleRule($this->compilerFacade());
+        $analysis = $this->buildAnalysis("(def doc\n  \"usage:\n  ; => 42\")\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_a_semicolon_inside_a_multiline_comment(): void
+    {
+        $rule = new CommentStyleRule($this->compilerFacade());
+        $analysis = $this->buildAnalysis("#|\n; not a line comment\n|#\n(def x 1)\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_a_bare_hash_line_comment(): void
+    {
+        $rule = new CommentStyleRule($this->compilerFacade());
+        $analysis = $this->buildAnalysis("# legacy comment\n(def x 1)\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_every_line_of_a_single_semicolon_block(): void
+    {
+        $rule = new CommentStyleRule($this->compilerFacade());
+        $analysis = $this->buildAnalysis("; first\n; second\n; third\n(def x 1)\n");
+
+        self::assertCount(3, $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_a_standalone_comment_on_the_last_line_without_newline(): void
+    {
+        $rule = new CommentStyleRule($this->compilerFacade());
+        $analysis = $this->buildAnalysis("(def x 1)\n; trailing");
+
+        self::assertCount(1, $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_a_comment_after_a_multiline_string_ends_on_that_line(): void
+    {
+        $rule = new CommentStyleRule($this->compilerFacade());
+        $analysis = $this->buildAnalysis("(def s \"one\ntwo\") ; closing note\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`.claude/rules/phel.md` documents a positional comment convention (shared with Clojure): `;` trails code on the same line, `;;` owns the whole line, `#| |#` is multiline, `#_` skips a form. Nothing enforced it, so the codebase had drifted: 58 whole-line comments were written with a single `;`. The census across `src/phel/`, `tests/phel/`, `docs/` and `resources/` was 208 correct `;;` standalone comments, 0 uses of `;;;`, and 58 violations, so the documented convention holds and there is no deliberate third form to accommodate.

Separately, `tests/phel/core/threading-macros.phel` still called `set-meta!`, deprecated since 0.32.0.

## 💡 Goal

Fix the existing violations, add a lint rule so the convention stays fixed, and retire the deprecated call.

## 🔖 Changes

**Convention sweep (`style:`)** — 58 standalone `;` comments across 10 files rewritten to `;;`. Found by lexing every `.phel` file in the repo and keeping only `T_COMMENT` tokens that both start a line and open with exactly one `;`. Comment-only: the diff is 58 insertions / 58 deletions and every changed line is a comment, so no executable code moved. A naive `grep` would have produced two false positives (`;` inside docstrings in `src/phel/core/uuid.phel` and `src/phel/reader.phel`); the lexer-based pass correctly leaves both alone.

**New lint rule `phel/comment-style` (`feat:`)** — `src/php/Lint/Application/Rule/CommentStyleRule.php`, registered in `RuleRegistry` / `LintFactory::createRules()` and enabled by default at `warning` severity, matching every other shipped rule.

- Scans the **token stream**, not the source text: only the lexer knows which `;` opens a comment, so a `;` inside a string literal, a regex literal, or a `#| ... |#` block can never be flagged.
- "Standalone" is derived from the tokens rather than column math: newlines and line comments are the only tokens that can end a line, and whitespace is indentation, so the flag is exact for indented comments, comments after a multi-line string, and a comment on the final line with no trailing newline.
- `;;;` and longer runs stay clean and are documented as such: the rule only asks that a whole-line comment is not written with the inline marker, and Clojure-style `;;;` section headers remain legal.
- Bare `#` line comments are out of scope; the lexer already deprecates them.
- 11 unit tests in `tests/php/Unit/Lint/Application/Rule/CommentStyleRuleTest.php` plus an end-to-end `LintCommandTest` case over a new fixture that carries one violating and one correct comment, asserting exactly one diagnostic and exit code 0.
- `src/php/Lint/CLAUDE.md` documents the rule, and now also states the default-on convention and that a new rule needs a `LintConfig::defaultSeverities()` entry.

**Deprecated call retired (`test:`)** — the five `set-meta!` call sites in `tests/phel/core/threading-macros.phel` became `with-meta`. This is safe rather than a blind substitution: `set-meta!` has been defined as exactly `(with-meta obj meta)` since 0.32.0, and `MetaInterface::withMeta` returns a new instance rather than mutating, so the `!` no longer denotes anything. Every site binds the result to `form` and reads only `form` afterwards, so none relied on the quoted literal being mutated in place.

**Verification** — `phpstan` (L9), `psalm` (L1), `csrun`, `rector`, `phpunit --testsuite=unit,integration` (5155 tests), `composer test-core` (6483 assertions), and `phel format --dry-run` on every touched `.phel` file all pass.
