### PR TITLE
ref: make four vacuous tests assert, drop three dead loop guards

### DIFF
--- a/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
+++ b/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
@@ -235,10 +235,9 @@ final class ChunkedSeq extends AbstractType implements LazySeqInterface, Countab
     {
         $current = $this;
 
-        // Iteratively process chunks to avoid deep recursion
-        /** @psalm-suppress RedundantCondition */
-        /** @phpstan-ignore instanceof.alwaysTrue */
-        while ($current instanceof self) {
+        // Iteratively process chunks to avoid deep recursion. `$current` only
+        // ever advances to another `self`; every other tail shape breaks below.
+        while (true) {
             // Yield elements from current chunk
             foreach ($current->chunk->toArray() as $value) {
                 yield $value;

--- a/src/php/Lang/Collections/LazySeq/Cons.php
+++ b/src/php/Lang/Collections/LazySeq/Cons.php
@@ -186,9 +186,10 @@ final class Cons extends AbstractType implements SeqInterface, IteratorAggregate
      */
     private function walkTail(): iterable
     {
+        // `$this->rest` is a non-nullable `LazySeqInterface` and `$current` only
+        // ever advances to another one, so the walk ends on the returns below.
         $current = $this->rest;
-        /** @phpstan-ignore instanceof.alwaysTrue */
-        while ($current instanceof LazySeqInterface) {
+        while (true) {
             $head = $current->first();
             if ($head === null) {
                 return;

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -313,9 +313,9 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
         $result = [];
         $seq = $this;
 
-        /** @psalm-suppress RedundantCondition */
-        /** @phpstan-ignore instanceof.alwaysTrue */
-        while ($seq instanceof self) {
+        // `$seq` only ever advances to another `self` (every other tail shape
+        // breaks below), so the walk is bounded by the breaks, not by a guard.
+        while (true) {
             // `realize() === null` is the only reliable "empty" signal;
             // `first() === null` is ambiguous because the user may have
             // stored `nil` as a legitimate value. Empty `Countable`

--- a/tests/php/Unit/Api/Infrastructure/Daemon/JsonRpcFramingTest.php
+++ b/tests/php/Unit/Api/Infrastructure/Daemon/JsonRpcFramingTest.php
@@ -40,11 +40,11 @@ final class JsonRpcFramingTest extends TestCase
         fwrite($stream, "not-json\n");
         rewind($stream);
 
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid JSON payload received by daemon');
+
         try {
             $framing->readMessage($stream);
-            self::fail('Expected RuntimeException');
-        } catch (RuntimeException) {
-            self::assertTrue(true);
         } finally {
             fclose($stream);
         }

--- a/tests/php/Unit/Build/Infrastructure/Cache/DependencyTrackerTest.php
+++ b/tests/php/Unit/Build/Infrastructure/Cache/DependencyTrackerTest.php
@@ -91,18 +91,34 @@ final class DependencyTrackerTest extends TestCase
     public function test_register_dependencies_handles_circular_deps_gracefully(): void
     {
         $tracker = new DependencyTracker($this->cacheDir);
+        $compiledCache = new CompiledCodeCache($this->cacheDir, 'test');
 
         $fileA = $this->cacheDir . '/a.phel';
         $fileB = $this->cacheDir . '/b.phel';
         file_put_contents($fileA, '(ns app\\a)');
         file_put_contents($fileB, '(ns app\\b)');
 
-        // Register A -> B and B -> A (circular)
+        $compiledCache->put($fileA, 'app\\a', md5('(ns app\\a)'), '$x = 1;');
+        $compiledCache->put($fileB, 'app\\b', md5('(ns app\\b)'), '$y = 2;');
+
+        // Register A -> B and B -> A (circular at the namespace level)
         $tracker->registerDependencies($fileA, 'app\\a', ['app\\b']);
         $tracker->registerDependencies($fileB, 'app\\b', ['app\\a']);
 
-        // Should not throw — cycles are silently ignored
-        self::assertTrue(true);
+        // Files point at namespaces and namespaces have no outgoing edges, so a
+        // mutual require is not a cycle in the tracked graph: resolution still
+        // terminates and reaches both files from either end of the cycle.
+        self::assertSame(
+            [$fileA, $fileB],
+            $this->sorted($tracker->invalidateDependentsOf('app\\a', $compiledCache)),
+        );
+        self::assertSame(
+            [$fileA, $fileB],
+            $this->sorted($tracker->invalidateDependentsOf('app\\b', $compiledCache)),
+        );
+
+        self::assertNull($compiledCache->get($fileA, md5('(ns app\\a)')));
+        self::assertNull($compiledCache->get($fileB, md5('(ns app\\b)')));
     }
 
     public function test_clear_removes_all_tracked_dependencies(): void
@@ -123,4 +139,15 @@ final class DependencyTrackerTest extends TestCase
         self::assertSame([], $invalidated);
     }
 
+    /**
+     * @param list<string> $paths
+     *
+     * @return list<string>
+     */
+    private function sorted(array $paths): array
+    {
+        sort($paths);
+
+        return $paths;
+    }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/BindingValidatorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/BindingValidatorTest.php
@@ -56,8 +56,10 @@ final class BindingValidatorTest extends TestCase
     #[DataProvider('providerValidTypes')]
     public function test_valid_types(mixed $type): void
     {
+        // `assertSupportedBinding()` returns void: passing means it did not throw.
+        $this->expectNotToPerformAssertions();
+
         $this->validator->assertSupportedBinding($type);
-        self::assertTrue(true); // this assertion ensures that no exception was thrown
     }
 
     public static function providerValidTypes(): Generator

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/FnSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/FnSymbolTest.php
@@ -89,9 +89,7 @@ final class FnSymbolTest extends TestCase
     {
         if ($error) {
             $this->expectException(AbstractLocatedException::class);
-            $this->expectExceptionMessageMatches('/(Variable names must start with a letter or underscore)*/i');
-        } else {
-            self::assertTrue(true); // In order to have an assertion without an error
+            $this->expectExceptionMessage('Variable names must start with a letter or underscore: ' . $paramName);
         }
 
         // This is the same as: (fn [paramName])
@@ -102,7 +100,15 @@ final class FnSymbolTest extends TestCase
             ]),
         ]);
 
-        $this->analyze($list);
+        $node = $this->analyze($list);
+
+        // Accepted names survive analysis verbatim, so the param list proves the
+        // name was kept rather than merely that nothing blew up.
+        self::assertInstanceOf(FnNode::class, $node);
+        self::assertSame(
+            [$paramName],
+            array_map(static fn(Symbol $param): string => $param->getName(), $node->getParams()),
+        );
     }
 
     public static function providerVarNamesMustStartWithLetterOrUnderscore(): Generator

--- a/tests/php/Unit/Watch/Application/Watcher/FileWatcherBuilderTest.php
+++ b/tests/php/Unit/Watch/Application/Watcher/FileWatcherBuilderTest.php
@@ -10,10 +10,36 @@ use Phel\Watch\Application\Watcher\FswatchWatcher;
 use Phel\Watch\Application\Watcher\InotifyWatcher;
 use Phel\Watch\Application\Watcher\PollingWatcher;
 use Phel\Watch\Domain\FileSystemScannerInterface;
+use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
+
+use function count;
+use function extension_loaded;
 
 final class FileWatcherBuilderTest extends TestCase
 {
+    use RemoveDirTrait;
+
+    private string $cleanDir;
+
+    /** @var list<string> */
+    private array $binDirs = [];
+
+    private string|false $originalPath;
+
+    protected function setUp(): void
+    {
+        $this->cleanDir = sys_get_temp_dir() . '/phel-watcher-builder-test-' . uniqid();
+        mkdir($this->cleanDir, 0777, true);
+        $this->originalPath = getenv('PATH');
+    }
+
+    protected function tearDown(): void
+    {
+        putenv($this->originalPath === false ? 'PATH' : 'PATH=' . $this->originalPath);
+        $this->removeDir($this->cleanDir);
+    }
+
     public function test_polling_is_always_available(): void
     {
         $builder = $this->builder();
@@ -53,9 +79,7 @@ final class FileWatcherBuilderTest extends TestCase
 
     public function test_create_inotify_when_requested_and_available(): void
     {
-        if (!InotifyWatcher::isAvailable()) {
-            self::markTestSkipped('inotifywait not available on host');
-        }
+        $this->usePathWith('inotifywait');
 
         $watcher = $this->builder()->create(InotifyWatcher::NAME);
 
@@ -64,9 +88,7 @@ final class FileWatcherBuilderTest extends TestCase
 
     public function test_create_fswatch_when_requested_and_available(): void
     {
-        if (!FswatchWatcher::isAvailable()) {
-            self::markTestSkipped('fswatch not available on host');
-        }
+        $this->usePathWith('fswatch');
 
         $watcher = $this->builder()->create(FswatchWatcher::NAME);
 
@@ -85,23 +107,38 @@ final class FileWatcherBuilderTest extends TestCase
 
     public function test_fallback_to_polling_when_preferred_backend_is_unavailable(): void
     {
-        // We request fswatch/inotify explicitly: when the binary is missing,
-        // the builder should silently fall back to polling rather than throw.
+        if (extension_loaded('inotify')) {
+            self::markTestSkipped('ext-inotify keeps the inotify backend available regardless of PATH');
+        }
+
+        // No backend binary is reachable, so every request has to degrade to
+        // polling rather than throw, on any OS family.
+        $this->usePathWith();
         $builder = $this->builder();
 
-        if (!FswatchWatcher::isAvailable()) {
-            $watcher = $builder->create(FswatchWatcher::NAME);
-            self::assertInstanceOf(PollingWatcher::class, $watcher);
+        self::assertInstanceOf(PollingWatcher::class, $builder->create(FswatchWatcher::NAME));
+        self::assertInstanceOf(PollingWatcher::class, $builder->create(InotifyWatcher::NAME));
+        self::assertInstanceOf(PollingWatcher::class, $builder->create());
+    }
+
+    /**
+     * Replaces PATH with a throwaway directory holding only the named stub
+     * binaries, so backend probing (`command -v <binary>`) sees exactly the
+     * environment the test describes instead of whatever the host has installed.
+     */
+    private function usePathWith(string ...$binaries): void
+    {
+        $binDir = $this->cleanDir . '/bin-' . count($this->binDirs);
+        mkdir($binDir, 0777, true);
+        $this->binDirs[] = $binDir;
+
+        foreach ($binaries as $binary) {
+            $path = $binDir . '/' . $binary;
+            file_put_contents($path, "#!/bin/sh\nexit 0\n");
+            chmod($path, 0755);
         }
 
-        if (!InotifyWatcher::isAvailable()) {
-            $watcher = $builder->create(InotifyWatcher::NAME);
-            self::assertInstanceOf(PollingWatcher::class, $watcher);
-        }
-
-        // Either branch runs depending on the host; both assertions simply
-        // confirm the contract that an unavailable backend never throws.
-        self::assertTrue(true);
+        putenv('PATH=' . $binDir);
     }
 
     private function builder(): FileWatcherBuilder


### PR DESCRIPTION
## 🤔 Background

Two related bits of dead weight, both surfaced by earlier audits and verified independently here.

Four unit tests ended in `self::assertTrue(true)` (or its equivalent), so they reported green without ever pinning behaviour. The worst of them was actively broken: in `JsonRpcFramingTest` the `catch (RuntimeException)` also catches PHPUnit's own `AssertionFailedError` (which extends `RuntimeException`), so the `self::fail('Expected RuntimeException')` immediately above it was swallowed by the same catch. That test passed even when `readMessage()` did not throw at all.

Separately, three `while ($x instanceof ...)` loop guards in `Lang/Collections/LazySeq/` were proven invariant by both PHPStan (`instanceof.alwaysTrue`) and Psalm (`RedundantCondition`), and had been living behind suppression annotations because removing them is a code change rather than a type change.

## 💡 Goal

Make the tests fail when the code they cover breaks, and delete the guards only after establishing that they are dead by construction rather than dead because something else is wrong.

Every test touched here was mutation-checked: the production code it covers was temporarily broken, the test confirmed red, and the break reverted.

## 🔖 Changes

### Tests that now assert something

- **`JsonRpcFramingTest`** — replaced the try/catch/`assertTrue(true)` with `expectException` + `expectExceptionMessage`, which pins the message and no longer lets a missing throw pass. `finally { fclose(...) }` is kept.
- **`FileWatcherBuilderTest`** — backend probing shells out to `command -v`, so `PATH` is now replaced with a throwaway directory holding only the stub binaries each test declares. Three consequences:
  - `test_fallback_to_polling_when_preferred_backend_is_unavailable` asserts polling for the fswatch request, the inotify request, and auto-detect, instead of asserting nothing on a host that has both binaries. It skips only when `ext-inotify` is loaded, the one input `PATH` cannot neutralise.
  - `test_create_fswatch_when_requested_and_available` and `test_create_inotify_when_requested_and_available` no longer `markTestSkipped` on hosts without the binaries; they now run everywhere and assert which watcher class comes back.
  - The old test also asserted the wrong contract: on Linux with `inotifywait` installed, requesting an unavailable `fswatch` falls through to auto-detect and yields `InotifyWatcher`, not `PollingWatcher`. The controlled version states the real rule, which is that polling is the floor when nothing is available.
- **`DependencyTrackerTest`** — the circular-dependency test asserts the resolved set from *both* ends of the cycle plus the dropped cache entries. Asserting only one end left a mutation alive (dropping the `file -> ns` edge for one direction still passed), which is why both directions are checked. Worth recording: a mutual require is not actually a cycle in the tracked graph, since files point at namespaces and namespaces have no outgoing edges, so `CycleDetectedException` never fires on this input. The test now documents that rather than implying a cycle was caught and swallowed.
- **`FnSymbolTest`** — the accepted-name branch asserts the analysed `FnNode`'s param list (which proves `&form`, `&env`, `&_special` survive verbatim), and the rejected branch swaps `expectExceptionMessageMatches('/(...)*/i')` for `expectExceptionMessage`. The old regex ends in `*`, so it matched the empty string and therefore every possible message.
- **`BindingValidatorTest`** — `assertSupportedBinding()` returns void and passing means "did not throw", so this one switched to `expectNotToPerformAssertions()`, the idiom already used in `NumericCoercionTest` and `InvokeSymbolTest`. Mutation-checked by making the validator reject `Symbol`.

### Dead loop guards

`LazySeq::toArray()`, `ChunkedSeq::getIterator()` and `Cons::walkTail()` opened with a guard that can never be false. They are invariant **by construction, not because of a latent bug**:

- All three classes are `final`.
- The seed is `$this` in the first two, and `Cons::$rest` (a non-nullable `private readonly LazySeqInterface`) in the third.
- Each loop variable is only ever reassigned inside a branch that has already narrowed the next value to the same type; every other tail shape `break`s or `return`s first.

So no value that ought to reach the guard is being wrongly excluded, and removing it costs no reachability. Each guard became `while (true)` (the existing style in `Lang/Generators/`, `Shared/ProjectRootResolver`, and elsewhere) with the invariant recorded in a comment, and the two `@phpstan-ignore` / `@psalm-suppress` annotations go away with them. Behaviour is unchanged.

Coverage note for the guards: disabling each loop body turns tests red, so all three are exercised. `LazySeq::toArray` and `ChunkedSeq::getIterator` are covered by the PHP unit suite; `Cons::walkTail` is covered only by the Phel core suite (`composer test-core`), and thinly at that (2 failures out of 6483). That gap is pre-existing and left alone here.

No `CHANGELOG.md` entry: nothing user-facing changed.
