### PR TITLE
fix: resolve hook scripts from the main checkout so worktrees stop erroring

### DIFF
--- a/.agnostic-ai/hooks/posttooluse-apply-patch-edit-write-86135fa8.yaml
+++ b/.agnostic-ai/hooks/posttooluse-apply-patch-edit-write-86135fa8.yaml
@@ -1,6 +1,6 @@
 command:
-    - .claude/hooks/format-php.sh
-    - .claude/hooks/format-phel.sh
+    - 'sh -c ''r=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || exit 0; s="$(dirname "$r")/.claude/hooks/format-php.sh"; [ -x "$s" ] || exit 0; exec "$s"'''
+    - 'sh -c ''r=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || exit 0; s="$(dirname "$r")/.claude/hooks/format-phel.sh"; [ -x "$s" ] || exit 0; exec "$s"'''
 event: PostToolUse
 matcher: apply_patch|Edit|Write
 name: posttooluse-apply-patch-edit-write-86135fa8

--- a/.agnostic-ai/hooks/pretooluse-bash-apply-patch-edit-wr-dcd130ba.yaml
+++ b/.agnostic-ai/hooks/pretooluse-bash-apply-patch-edit-wr-dcd130ba.yaml
@@ -1,4 +1,4 @@
-command: .claude/hooks/protect-files.sh
+command: 'sh -c ''r=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || exit 0; s="$(dirname "$r")/.claude/hooks/protect-files.sh"; [ -x "$s" ] || exit 0; exec "$s"'''
 event: PreToolUse
 matcher: Bash|apply_patch|Edit|Write
 name: pretooluse-bash-apply-patch-edit-wr-dcd130ba

--- a/.agnostic-ai/hooks/sessionstart-compact-b52e8c85.yaml
+++ b/.agnostic-ai/hooks/sessionstart-compact-b52e8c85.yaml
@@ -1,4 +1,4 @@
-command: .claude/hooks/compact-context.sh
+command: 'sh -c ''r=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || exit 0; s="$(dirname "$r")/.claude/hooks/compact-context.sh"; [ -x "$s" ] || exit 0; exec "$s"'''
 event: SessionStart
 matcher: compact
 name: sessionstart-compact-b52e8c85


### PR DESCRIPTION
## 🤔 Background

Every `Edit`, `Write` and `Bash` call made from a git worktree emitted a stream of non-blocking hook errors:

```
Failed with non-blocking status code: /bin/sh: .claude/hooks/protect-files.sh: No such file or directory
PreToolUse:Bash hook error
```

The cause is structural. The hook commands were **relative** paths (`.claude/hooks/protect-files.sh`), and `.claude/` is gitignored (`.gitignore:47`), so a freshly created worktree never contains the scripts. The relative path resolved against the worktree, where nothing was there.

## 💡 Goal

Make the hooks work from any worktree, and fail silently rather than noisily when a script genuinely is not installed.

## 🔖 Changes

Each of the four hook commands now resolves its script through `git rev-parse --path-format=absolute --git-common-dir`, which points at the **main checkout** from inside any worktree, and exits 0 when the script is missing instead of erroring:

```sh
sh -c 'r=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || exit 0; s="$(dirname "$r")/.claude/hooks/protect-files.sh"; [ -x "$s" ] || exit 0; exec "$s"'
```

`exec` preserves stdin, so the hook still receives its JSON payload unchanged.

Edited in `.agnostic-ai/hooks/*.yaml` (the specs, which are tracked) rather than in the generated `.claude/settings.json`, then regenerated with `agnostic-ai sync`. Editing the generated file directly does not survive the next sync.

## ✅ Verification

Run from inside a worktree, driving the real hook payload through the new command:

- ordinary file: exits 0, no output
- `composer.lock`: exits 2 with `Protected file: ... edit blocked`

Worth noting: the `protect-files.sh` guard covering `tools/release.sh` and `composer.lock` had been **silently inactive in every worktree** until now, so this restores a safety check rather than only removing noise. Auto-formatting of touched `.php` and `.phel` files also now runs in worktrees.

`agnostic-ai sync --check` is clean, so the specs and both generated targets agree.