### PR TITLE
ref: name the four FileIoInterface contracts, fix stale ApiFacade @return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **BREAKING** (PHP API): the four unrelated module interfaces all named `FileIoInterface` are renamed after what each one actually does, so an import no longer needs its namespace read to be understood: `Phel\Filesystem\Domain\FileIoInterface` → `DirectoryWritabilityCheckerInterface`, `Phel\Build\Domain\IO\FileIoInterface` → `FileContentsIoInterface`, `Phel\Formatter\Domain\IO\FileIoInterface` → `ValidatedFileIoInterface`, `Phel\Interop\Domain\FileCreator\FileIoInterface` → `FileWriterInterface`. Method signatures are unchanged; the interfaces stay four separate contracts and were not merged
 - Documented 60+ previously-undocumented public core functions with runnable `:example`/`:see-also` metadata — threading macros, set/sequence helpers, transducer & volatile primitives, binding & protocol macros, exception/sequence accessors, and assorted predicates — and fixed a malformed `juxt` example
 
 ### Removed

--- a/src/php/Api/ApiFacade.php
+++ b/src/php/Api/ApiFacade.php
@@ -167,7 +167,7 @@ final class ApiFacade extends AbstractFacade implements ApiFacadeInterface
      * LSP SignatureHelp payload for the PHP-interop call enclosing the cursor,
      * or null when not applicable.
      *
-     * @return array{signatures: list<array{label: string}>, activeSignature: int, activeParameter: int}|null
+     * @return SignatureHelp|null
      */
     public function phpInteropSignatureAt(string $source, int $line, int $col): ?array
     {

--- a/src/php/Build/Application/FileCompiler.php
+++ b/src/php/Build/Application/FileCompiler.php
@@ -8,7 +8,7 @@ use Phel\Build\BuildFacade;
 use Phel\Build\Domain\Compile\FileCompilerInterface;
 use Phel\Build\Domain\Compile\SymbolMetaStripper;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
-use Phel\Build\Domain\IO\FileIoInterface;
+use Phel\Build\Domain\IO\FileContentsIoInterface;
 use Phel\Shared\CompiledFile;
 use Phel\Shared\CompileOptions;
 use Phel\Shared\Facade\CompilerFacadeInterface;
@@ -22,7 +22,7 @@ final readonly class FileCompiler implements FileCompilerInterface
     public function __construct(
         private CompilerFacadeInterface $compilerFacade,
         private NamespaceExtractorInterface $namespaceExtractor,
-        private FileIoInterface $fileIo,
+        private FileContentsIoInterface $fileIo,
         private int $defaultOptimizationLevel = CompileOptions::DEFAULT_OPTIMIZATION_LEVEL,
         private bool $stripSymbolMeta = false,
     ) {}

--- a/src/php/Build/Application/NamespaceExtractor.php
+++ b/src/php/Build/Application/NamespaceExtractor.php
@@ -9,7 +9,7 @@ use Phel\Build\Domain\Extractor\ExtractorException;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\Extractor\NamespaceFileGrouper;
 use Phel\Build\Domain\Extractor\NamespaceSorterInterface;
-use Phel\Build\Domain\IO\FileIoInterface;
+use Phel\Build\Domain\IO\FileContentsIoInterface;
 use Phel\Compiler\Domain\Analyzer\Ast\InNsNode;
 use Phel\Compiler\Domain\Analyzer\Ast\NsNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
@@ -39,7 +39,7 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
     public function __construct(
         private CompilerFacadeInterface $compilerFacade,
         NamespaceSorterInterface $namespaceSorter,
-        private FileIoInterface $fileIo,
+        private FileContentsIoInterface $fileIo,
         ?ExcludedScanPaths $excludedPaths = null,
     ) {
         $this->grouper = new NamespaceFileGrouper($namespaceSorter);

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -28,7 +28,7 @@ use Phel\Build\Domain\Extractor\FirstFormExtractor;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\Extractor\NamespaceSorterInterface;
 use Phel\Build\Domain\Extractor\TopologicalNamespaceSorter;
-use Phel\Build\Domain\IO\FileIoInterface;
+use Phel\Build\Domain\IO\FileContentsIoInterface;
 use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
 use Phel\Build\Infrastructure\Cache\DependencyTracker;
 use Phel\Build\Infrastructure\Cache\PhpNamespaceCache;
@@ -247,7 +247,7 @@ final class BuildFactory extends AbstractFactory
         );
     }
 
-    private function createFileIo(): FileIoInterface
+    private function createFileIo(): FileContentsIoInterface
     {
         return new SystemFileIo();
     }

--- a/src/php/Build/Domain/Compile/SecondaryFileHarvester.php
+++ b/src/php/Build/Domain/Compile/SecondaryFileHarvester.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phel\Build\Domain\Compile;
 
 use Phel\Build\Domain\Cache\CompiledCodeCacheInterface;
-use Phel\Build\Domain\IO\FileIoInterface;
+use Phel\Build\Domain\IO\FileContentsIoInterface;
 use Phel\Shared\CompiledSourceHash;
 use Phel\Shared\NamespaceInformation;
 use Phel\Shared\SourceMap\SourceMapSiblings;
@@ -39,7 +39,7 @@ final readonly class SecondaryFileHarvester
 {
     public function __construct(
         private CompiledTargetPathResolver $targetPathResolver,
-        private FileIoInterface $fileIo,
+        private FileContentsIoInterface $fileIo,
         private CompiledSecondaryStore $compiledSecondaryStore,
         private ?CompiledCodeCacheInterface $compiledCodeCache = null,
         private int $optimizationLevel = 0,

--- a/src/php/Build/Domain/IO/FileContentsIoInterface.php
+++ b/src/php/Build/Domain/IO/FileContentsIoInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Build\Domain\IO;
 
-interface FileIoInterface
+interface FileContentsIoInterface
 {
     public function getContents(string $filename): string;
 

--- a/src/php/Build/Infrastructure/IO/SystemFileIo.php
+++ b/src/php/Build/Infrastructure/IO/SystemFileIo.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Phel\Build\Infrastructure\IO;
 
-use Phel\Build\Domain\IO\FileIoInterface;
+use Phel\Build\Domain\IO\FileContentsIoInterface;
 use RuntimeException;
 
 use function sprintf;
 
-final class SystemFileIo implements FileIoInterface
+final class SystemFileIo implements FileContentsIoInterface
 {
     public function getContents(string $filename): string
     {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/LiteralArithmeticFolder.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/LiteralArithmeticFolder.php
@@ -27,6 +27,8 @@ use function min;
  * The set of fns evaluated here is the vetted, effect-free list that
  * {@see Simplification\SymbolicPurityDetector}'s `PURE_CORE_FNS` mirrors.
  * Keep the two in sync when adding a pure-but-not-foldable core fn.
+ *
+ * @phpstan-type ReducerSpec array{identity: int, op: 'add'|'mul'}
  */
 final readonly class LiteralArithmeticFolder
 {
@@ -44,7 +46,7 @@ final readonly class LiteralArithmeticFolder
      * `(+)` and `(*)` are also foldable. `-` and `/` use one-arg semantics
      * that differ from a reducer and live in their own helpers.
      *
-     * @var array<string, array{identity: int, op: 'add'|'mul'}>
+     * @var array<string, ReducerSpec>
      */
     private const array NUMERIC_REDUCERS = [
         '+' => ['identity' => 0, 'op' => 'add'],
@@ -261,8 +263,8 @@ final readonly class LiteralArithmeticFolder
     }
 
     /**
-     * @param array{identity: int, op: 'add'|'mul'} $spec
-     * @param list<float|int>                       $literals
+     * @param ReducerSpec     $spec
+     * @param list<float|int> $literals
      */
     private function reduce(array $spec, array $literals): int|float|null
     {

--- a/src/php/Filesystem/Application/FileIo.php
+++ b/src/php/Filesystem/Application/FileIo.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Phel\Filesystem\Application;
 
-use Phel\Filesystem\Domain\FileIoInterface;
+use Phel\Filesystem\Domain\DirectoryWritabilityCheckerInterface;
 
 /**
  * Thin adapter around PHP's is_writable() so permission checks can be
  * stubbed/mocked in tests instead of touching the real filesystem.
  */
-final class FileIo implements FileIoInterface
+final class FileIo implements DirectoryWritabilityCheckerInterface
 {
     public function isWritable(string $tempDir): bool
     {

--- a/src/php/Filesystem/Application/TempDirFinder.php
+++ b/src/php/Filesystem/Application/TempDirFinder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Filesystem\Application;
 
-use Phel\Filesystem\Domain\FileIoInterface;
+use Phel\Filesystem\Domain\DirectoryWritabilityCheckerInterface;
 use Phel\Shared\Exceptions\FileException;
 
 /**
@@ -22,7 +22,7 @@ final class TempDirFinder
     private string $cachedTempDir = '';
 
     public function __construct(
-        private readonly FileIoInterface $fileIo,
+        private readonly DirectoryWritabilityCheckerInterface $fileIo,
         private readonly string $configTempDir,
     ) {}
 

--- a/src/php/Filesystem/CLAUDE.md
+++ b/src/php/Filesystem/CLAUDE.md
@@ -24,7 +24,7 @@ None (no Provider). `FilesystemConfig` reads `PhelConfig::KEEP_GENERATED_TEMP_FI
 | `Domain/NullFilesystem` | No-op strategy when files are kept |
 | `Application/TempDirFinder` | Resolve/create/validate temp dir |
 | `Application/TempDirHealthCheck` | Health probe (separate from finder) |
-| `Application/FileIo` + `Domain/FileIoInterface` | `is_writable` wrapper for testability |
+| `Application/FileIo` + `Domain/DirectoryWritabilityCheckerInterface` | `is_writable` wrapper for testability |
 
 ## Key Constraints
 

--- a/src/php/Filesystem/Domain/DirectoryWritabilityCheckerInterface.php
+++ b/src/php/Filesystem/Domain/DirectoryWritabilityCheckerInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Filesystem\Domain;
 
-interface FileIoInterface
+interface DirectoryWritabilityCheckerInterface
 {
     /**
      * Returns true if the directory is writable by the current process.

--- a/src/php/Formatter/Application/PathsFormatter.php
+++ b/src/php/Formatter/Application/PathsFormatter.php
@@ -8,7 +8,7 @@ use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
 use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
 use Phel\Formatter\Domain\Exception\FilePathException;
 use Phel\Formatter\Domain\FormatterInterface;
-use Phel\Formatter\Domain\IO\FileIoInterface;
+use Phel\Formatter\Domain\IO\ValidatedFileIoInterface;
 use Phel\Formatter\Domain\PathFilterInterface;
 use Phel\Formatter\Domain\Rules\Zipper\ZipperException;
 use Phel\Shared\Facade\CommandFacadeInterface;
@@ -18,18 +18,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 final readonly class PathsFormatter
 {
     /**
-     * @param CommandFacadeInterface $commandFacade Writes located exceptions and
-     *                                              stack traces to the CLI output
-     * @param FormatterInterface     $formatter     Formats a single file's source
-     * @param PathFilterInterface    $pathFilter    Expands the input paths into the
-     *                                              concrete `.phel` files to format
-     * @param FileIoInterface        $fileIo        Reads and writes file contents
+     * @param CommandFacadeInterface   $commandFacade Writes located exceptions and
+     *                                                stack traces to the CLI output
+     * @param FormatterInterface       $formatter     Formats a single file's source
+     * @param PathFilterInterface      $pathFilter    Expands the input paths into the
+     *                                                concrete `.phel` files to format
+     * @param ValidatedFileIoInterface $fileIo        Reads and writes file contents
      */
     public function __construct(
         private CommandFacadeInterface $commandFacade,
         private FormatterInterface $formatter,
         private PathFilterInterface $pathFilter,
-        private FileIoInterface $fileIo,
+        private ValidatedFileIoInterface $fileIo,
     ) {}
 
     /**

--- a/src/php/Formatter/CLAUDE.md
+++ b/src/php/Formatter/CLAUDE.md
@@ -59,7 +59,7 @@ Symbol lists live as `FormatterFactory` constants; `createIndentRule()` instanti
 | `Domain/Rules/Indenter/` | `BlockIndenter`, `InnerIndenter`, `LineIndenter`, `ListIndenter`; `FormSymbolMatcherTrait` reads a location's head symbol and matches it against the indenter's symbol |
 | `Domain/Rules/Pair/PairAligner.php` | Backing logic for `AlignPairsRule` |
 | `Domain/Rules/Zipper/` | `ParseTreeZipper` (AST traversal/transform), `AbstractZipper` |
-| `Infrastructure/IO/SystemFileIo.php` | `FileIoInterface` impl |
+| `Infrastructure/IO/SystemFileIo.php` | `ValidatedFileIoInterface` impl |
 | `Infrastructure/Command/FormatCommand.php` | `phel format` CLI command |
 
 ## Key Constraints

--- a/src/php/Formatter/Domain/IO/ValidatedFileIoInterface.php
+++ b/src/php/Formatter/Domain/IO/ValidatedFileIoInterface.php
@@ -6,7 +6,7 @@ namespace Phel\Formatter\Domain\IO;
 
 use Phel\Formatter\Domain\Exception\FilePathException;
 
-interface FileIoInterface
+interface ValidatedFileIoInterface
 {
     /**
      * @throws FilePathException

--- a/src/php/Formatter/FormatterFactory.php
+++ b/src/php/Formatter/FormatterFactory.php
@@ -10,7 +10,7 @@ use Phel\Formatter\Application\Formatter;
 use Phel\Formatter\Application\PathsFormatter;
 use Phel\Formatter\Application\PhelPathFilter;
 use Phel\Formatter\Domain\FormatterInterface;
-use Phel\Formatter\Domain\IO\FileIoInterface;
+use Phel\Formatter\Domain\IO\ValidatedFileIoInterface;
 use Phel\Formatter\Domain\PathFilterInterface;
 use Phel\Formatter\Domain\Rules\AlignPairsRule;
 use Phel\Formatter\Domain\Rules\Indenter\BlockIndenter;
@@ -143,7 +143,7 @@ final class FormatterFactory extends AbstractFactory
         return $facade;
     }
 
-    private function createFileIo(): FileIoInterface
+    private function createFileIo(): ValidatedFileIoInterface
     {
         return new SystemFileIo();
     }

--- a/src/php/Formatter/Infrastructure/IO/SystemFileIo.php
+++ b/src/php/Formatter/Infrastructure/IO/SystemFileIo.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Phel\Formatter\Infrastructure\IO;
 
 use Phel\Formatter\Domain\Exception\FilePathException;
-use Phel\Formatter\Domain\IO\FileIoInterface;
+use Phel\Formatter\Domain\IO\ValidatedFileIoInterface;
 use RuntimeException;
 
 use function sprintf;
 
-final class SystemFileIo implements FileIoInterface
+final class SystemFileIo implements ValidatedFileIoInterface
 {
     /**
      * @throws FilePathException

--- a/src/php/Interop/Domain/FileCreator/FileCreator.php
+++ b/src/php/Interop/Domain/FileCreator/FileCreator.php
@@ -12,7 +12,7 @@ final readonly class FileCreator implements FileCreatorInterface
 {
     public function __construct(
         private string $destinationDir,
-        private FileIoInterface $io,
+        private FileWriterInterface $io,
     ) {}
 
     public function createFromWrapper(Wrapper $wrapper): void

--- a/src/php/Interop/Domain/FileCreator/FileWriterInterface.php
+++ b/src/php/Interop/Domain/FileCreator/FileWriterInterface.php
@@ -6,7 +6,7 @@ namespace Phel\Interop\Domain\FileCreator;
 
 use RuntimeException;
 
-interface FileIoInterface
+interface FileWriterInterface
 {
     /**
      * Creates the directory (including missing parents); a no-op if it already exists.

--- a/src/php/Interop/Infrastructure/IO/FileSystemIo.php
+++ b/src/php/Interop/Infrastructure/IO/FileSystemIo.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Phel\Interop\Infrastructure\IO;
 
-use Phel\Interop\Domain\FileCreator\FileIoInterface;
+use Phel\Interop\Domain\FileCreator\FileWriterInterface;
 use RuntimeException;
 
 use function sprintf;
 
-final readonly class FileSystemIo implements FileIoInterface
+final readonly class FileSystemIo implements FileWriterInterface
 {
     public function createDirectory(string $directory): void
     {

--- a/src/php/Interop/InteropFactory.php
+++ b/src/php/Interop/InteropFactory.php
@@ -12,7 +12,7 @@ use Phel\Interop\Domain\ExportFinder\FunctionsToExportFinder;
 use Phel\Interop\Domain\ExportFinder\FunctionsToExportFinderInterface;
 use Phel\Interop\Domain\FileCreator\FileCreator;
 use Phel\Interop\Domain\FileCreator\FileCreatorInterface;
-use Phel\Interop\Domain\FileCreator\FileIoInterface;
+use Phel\Interop\Domain\FileCreator\FileWriterInterface;
 use Phel\Interop\Domain\Generator\Builder\CompiledPhpClassBuilder;
 use Phel\Interop\Domain\Generator\Builder\CompiledPhpMethodBuilder;
 use Phel\Interop\Domain\Generator\Builder\WrapperRelativeFilenamePathBuilder;
@@ -102,7 +102,7 @@ final class InteropFactory extends AbstractFactory
         return $facade;
     }
 
-    private function createFileSystemIo(): FileIoInterface
+    private function createFileSystemIo(): FileWriterInterface
     {
         return new FileSystemIo();
     }

--- a/src/php/Lang/Collections/Vector/RangeIterator.php
+++ b/src/php/Lang/Collections/Vector/RangeIterator.php
@@ -9,7 +9,9 @@ use Iterator;
 use function assert;
 
 /**
- * @implements Iterator<int, mixed>
+ * @template T
+ *
+ * @implements Iterator<int, T>
  */
 final class RangeIterator implements Iterator
 {
@@ -17,11 +19,11 @@ final class RangeIterator implements Iterator
 
     private readonly int $vectorCount;
 
-    /** @var array<int, mixed>|null */
+    /** @var array<int, T>|null */
     private ?array $currentArray = null;
 
     /**
-     * @param PersistentVector<mixed> $vector
+     * @param PersistentVector<T> $vector
      */
     public function __construct(
         private readonly PersistentVector $vector,
@@ -36,6 +38,9 @@ final class RangeIterator implements Iterator
         }
     }
 
+    /**
+     * @return T
+     */
     public function current(): mixed
     {
         assert($this->currentArray !== null);

--- a/src/php/Lint/Application/Cache/LintCache.php
+++ b/src/php/Lint/Application/Cache/LintCache.php
@@ -30,12 +30,14 @@ use const JSON_THROW_ON_ERROR;
  * The cache is opt-in: callers pass an absolute base directory (usually
  * the project root + `.phel/lint-cache/`). When the directory cannot be
  * created we degrade silently — lint still works, just without caching.
+ *
+ * @phpstan-type IndexEntry array{hash: string, fingerprint: string, diagnostics: list<array<string, mixed>>}
  */
 final class LintCache
 {
     private const string INDEX_FILE = 'index.json';
 
-    /** @var array<string, array{hash: string, fingerprint: string, diagnostics: list<array<string, mixed>>}>|null */
+    /** @var array<string, IndexEntry>|null */
     private ?array $index = null;
 
     public function __construct(
@@ -147,7 +149,7 @@ final class LintCache
             return;
         }
 
-        /** @var array<string, array{hash: string, fingerprint: string, diagnostics: list<array<string, mixed>>}> $decoded */
+        /** @var array<string, IndexEntry> $decoded */
         $this->index = $decoded;
     }
 

--- a/tests/php/Unit/Build/Application/FileCompilerTest.php
+++ b/tests/php/Unit/Build/Application/FileCompilerTest.php
@@ -6,7 +6,7 @@ namespace PhelTest\Unit\Build\Application;
 
 use Phel\Build\Application\FileCompiler;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
-use Phel\Build\Domain\IO\FileIoInterface;
+use Phel\Build\Domain\IO\FileContentsIoInterface;
 use Phel\Compiler\Domain\Emitter\EmitterResult;
 use Phel\Shared\CompileOptions;
 use Phel\Shared\Facade\CompilerFacadeInterface;
@@ -22,7 +22,7 @@ final class FileCompilerTest extends TestCase
         $compiler = new FileCompiler(
             $this->createCapturingCompilerFacade(),
             $this->createNamespaceExtractor(),
-            $this->createStub(FileIoInterface::class),
+            $this->createStub(FileContentsIoInterface::class),
         );
 
         $compiler->compileFile('/src/test.phel', '/out/test.php', false);
@@ -36,7 +36,7 @@ final class FileCompilerTest extends TestCase
         $compiler = new FileCompiler(
             $this->createCapturingCompilerFacade(),
             $this->createNamespaceExtractor(),
-            $this->createStub(FileIoInterface::class),
+            $this->createStub(FileContentsIoInterface::class),
             defaultOptimizationLevel: 2,
         );
 
@@ -51,7 +51,7 @@ final class FileCompilerTest extends TestCase
         $compiler = new FileCompiler(
             $this->createCapturingCompilerFacade(),
             $this->createNamespaceExtractor(),
-            $this->createStub(FileIoInterface::class),
+            $this->createStub(FileContentsIoInterface::class),
             defaultOptimizationLevel: 2,
         );
 

--- a/tests/php/Unit/Filesystem/Application/TempDirFinderTest.php
+++ b/tests/php/Unit/Filesystem/Application/TempDirFinderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Filesystem\Application;
 
 use Phel\Filesystem\Application\TempDirFinder;
-use Phel\Filesystem\Domain\FileIoInterface;
+use Phel\Filesystem\Domain\DirectoryWritabilityCheckerInterface;
 use Phel\Shared\Exceptions\FileException;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
@@ -18,7 +18,7 @@ final class TempDirFinderTest extends TestCase
         $dir = sys_get_temp_dir() . '/phel-unwritable-' . uniqid('', true);
         mkdir($dir);
 
-        $fileIo = self::createStub(FileIoInterface::class);
+        $fileIo = self::createStub(DirectoryWritabilityCheckerInterface::class);
         $fileIo->method('isWritable')->willReturn(false);
 
         $finder = new TempDirFinder($fileIo, $dir);
@@ -40,7 +40,7 @@ final class TempDirFinderTest extends TestCase
         mkdir($dir);
         chmod($dir, 0555);
 
-        $fileIo = $this->createMock(FileIoInterface::class);
+        $fileIo = $this->createMock(DirectoryWritabilityCheckerInterface::class);
         $fileIo->expects(self::exactly(2))
             ->method('isWritable')
             ->with($dir)

--- a/tests/php/Unit/Formatter/Application/PathsFormatterTest.php
+++ b/tests/php/Unit/Formatter/Application/PathsFormatterTest.php
@@ -7,7 +7,7 @@ namespace PhelTest\Unit\Formatter\Application;
 use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
 use Phel\Formatter\Application\PathsFormatter;
 use Phel\Formatter\Domain\FormatterInterface;
-use Phel\Formatter\Domain\IO\FileIoInterface;
+use Phel\Formatter\Domain\IO\ValidatedFileIoInterface;
 use Phel\Formatter\Domain\PathFilterInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
 use PHPUnit\Framework\TestCase;
@@ -55,7 +55,7 @@ final class PathsFormatterTest extends TestCase
 
     public function test_write_failure_propagates_instead_of_being_swallowed(): void
     {
-        $io = new class() implements FileIoInterface {
+        $io = new class() implements ValidatedFileIoInterface {
             public function checkIfValid(string $filename): void {}
 
             public function getContents(string $filename): string
@@ -83,9 +83,9 @@ final class PathsFormatterTest extends TestCase
     /**
      * @param array<string, string> $contents
      */
-    private function fileIo(array $contents): FileIoInterface
+    private function fileIo(array $contents): ValidatedFileIoInterface
     {
-        return new class($contents) implements FileIoInterface {
+        return new class($contents) implements ValidatedFileIoInterface {
             /**
              * @param array<string, string> $contents
              */


### PR DESCRIPTION
## 🤔 Background

Continuing the type-strength sweep. The previous passes landed the `@phpstan-type` alias
convention and T-prefixed every `@template`. What was left were the items those passes
parked plus two areas nobody had audited: generics coverage on container classes, and
whether any `:tag` metadata in the Phel stdlib is actually wrong.

The parked ones:

- `ApiFacade::phpInteropSignatureAt()` carried a `@return` that no longer matched its
  implementation. It was skipped last time because it is a public Facade signature.
- Four different interfaces, in four different modules, were all named `FileIoInterface`.
  They model four different concepts, so this is a naming problem, not a duplication one.

## 💡 Goal

Type-only changes, provably behaviour-preserving. No `assert()`, no `instanceof` guard, no
type weakened to make analysis pass.

## 🔖 Changes

**Renamed the four `FileIoInterface` contracts after what each one does.** They are *not*
merged: the method sets barely overlap, and Formatter's throwing `checkIfValid()`
precondition is exactly the kind of difference a shared name hides.

| Module | Was | Now | Contract |
|---|---|---|---|
| Filesystem | `Domain\FileIoInterface` | `DirectoryWritabilityCheckerInterface` | `isWritable()` |
| Build | `Domain\IO\FileIoInterface` | `FileContentsIoInterface` | get/put/remove contents |
| Formatter | `Domain\IO\FileIoInterface` | `ValidatedFileIoInterface` | get/put, after validating the path |
| Interop | `Domain\FileCreator\FileIoInterface` | `FileWriterInterface` | create dir + write |

Method signatures are untouched. Both module `CLAUDE.md` tables that named the old
interface are updated, and the CHANGELOG carries a `**BREAKING** (PHP API)` note since a
downstream implementer would need the new name.

**Fixed the stale `@return` on `ApiFacade::phpInteropSignatureAt()`.** It declared each
signature entry as `array{label: string}`, dropping `parameters` (always built) and
`documentation` (present whenever the reflected phpdoc is non-empty). It now uses the
module's own `SignatureHelp` alias, which is what `PhpInteropDocResolver::signatureAt()`
actually returns and what the sibling `phelSignatureAt()` already declared. The two are
`??`-chained at the one call site, so they were made to look like different types for no
reason. Blast radius: the method is not on `Phel\Shared\Facade\ApiFacadeInterface`, and its
single consumer, `SignatureHelpHandler`, takes `array<string, mixed>|null`.

**Two same-file duplicated shapes became `@phpstan-type` aliases.** Both are the drift case
the convention exists for, a docblock plus a second site PHPStan will not cross-check:
`IndexEntry` in `LintCache` (property `@var` plus the inline narrowing on the decoded
on-disk index) and `ReducerSpec` in `LiteralArithmeticFolder` (const `@var` plus the
`reduce()` `@param` that consumes it).

**`RangeIterator` gained `@template T`.** It is constructed in exactly one place, from
`PersistentVector<T>`, and `PersistentVector::getRangeIterator()` already declares
`Traversable<int, T>`, a claim that previously only held because `mixed` is permissive.
Now it derives. No call sites changed.

### Assessed and deliberately left alone

- `ScanIndexEntry`'s nested serialized-`NamespaceInformation` shape is used exactly once,
  and `NamespaceCacheEntry`'s look-alike is a different shape for a different concept. An
  alias with no second site to keep in sync is indirection without the payoff.
- `BigIntMagnitude`'s `array{0: list<int>, 1: list<int>}` and
  `DefaultLangAliasesRegistrar`'s `array{Symbol, Symbol}` are both short and
  self-describing. Naming positional pair shapes is what invites the structural
  look-alike problem flagged in the previous pass.
- The three-site `array{0: TKey|null, 1: HashMapNodeInterface<TKey, TValue>|TValue}` in
  the hash-map nodes is the best dedup candidate by count but is not expressible: PHPStan
  has no generic type aliases, and hardcoding `mixed` would weaken three precise
  signatures.
- `MapEntry` and `PersistentQueue` are template-able in principle, but every producer
  hands them arbitrary runtime Phel values, so the parameters would resolve to `mixed` at
  100% of call sites. For `PersistentQueue` that means 31 references edited to spell
  `<mixed>` out loud.
- The Phel stdlib's 10 explicit type tags were each verified against every return path
  (`count`, `compare`, `name`, `print-str`, `pr-str`, `println-str`, `prn-str`, `str`, and
  the two `cli.phel` interop param tags). All correct, so there is no `:tag` bug to fix and
  none was added: the stdlib stays inference-backed by design. `^:pure`, `^:memoize` and
  `^:async` have zero occurrences in `src/phel/`.
