### PR TITLE
ref: put four psalm Mixed* handlers back to work; drop two blanket exemptions

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -42,13 +42,6 @@ parameters:
                 - src/php/Config/PhelExportConfig.php
                 - src/php/Lang/Collections/LazySeq/LazySeqConfig.php
                 - src/php/Lang/TypeFactory.php
-        # PhelConfig::with() rebuilds the immutable config by spreading a merged
-        # array<string, mixed> into the constructor as named arguments. PHPStan
-        # cannot map the dynamic spread back to each typed parameter; the public
-        # with*() callers supply correctly-typed values.
-        -
-            identifier: argument.type
-            path: src/php/Config/PhelConfig.php
         # Printer's dispatchers select a TypePrinterInterface<Concrete> per
         # runtime-matched type, which is sound by construction but an
         # existential type: generic invariance cannot relate it to the

--- a/psalm.xml
+++ b/psalm.xml
@@ -48,18 +48,52 @@
         <MoreSpecificImplementedParamType errorLevel="suppress" />
         <RedundantCastGivenDocblockType errorLevel="suppress" />
 
-        <!-- Type safety suppressions for dynamic code -->
+        <!-- Mixed* handlers: what stays global and why.
+
+             A Phel value is an open set (interop admits arbitrary PHP objects,
+             arrays and resources), so `mixed` is the honest type across Lang's
+             collections, the printers and the analyzer's special forms. On top
+             of that, psalm-gacela only suppresses UndefinedMagicMethod for
+             `getFacade()`/`getFactory()`/`getConfig()`; it does not resolve
+             their return types the way phpstan-gacela does, so every facade
+             call in a `*Command`/`*Daemon` reads as `mixed` and cascades.
+
+             Measured with all twelve handlers enabled (psalm 6.16, no cache):
+             650 errors over 187 of 1050 files spanning 16 of the 19 modules
+             (plus `src/Phel.php`), of which 95 are the direct psalm-gacela gap
+             and 176 sit in `Infrastructure/Command`/`Infrastructure/Daemon`
+             alone. No directory isolates them, so the high-volume handlers stay
+             global; phpstan level 9 covers explicit `mixed` misuse instead.
+
+             MixedFunctionCall and MixedArrayAssignment had zero occurrences at
+             all, and MixedArrayAccess/MixedArrayOffset only a handful, so those
+             four stay ENABLED and new leaks are caught. Each file listed below
+             is an irreducible position, not a to-do. -->
         <MixedArgument errorLevel="suppress" />
         <MixedArgumentTypeCoercion errorLevel="suppress" />
-        <MixedArrayAccess errorLevel="suppress" />
-        <MixedArrayAssignment errorLevel="suppress" />
-        <MixedArrayOffset errorLevel="suppress" />
         <MixedAssignment errorLevel="suppress" />
-        <MixedFunctionCall errorLevel="suppress" />
         <MixedMethodCall errorLevel="suppress" />
         <MixedOperand errorLevel="suppress" />
         <MixedPropertyTypeCoercion errorLevel="suppress" />
         <MixedReturnStatement errorLevel="suppress" />
         <MixedReturnTypeCoercion errorLevel="suppress" />
+
+        <MixedArrayAccess>
+            <errorLevel type="suppress">
+                <!-- `$config` comes back from the Command facade (psalm-gacela gap). -->
+                <file name="src/php/Command/Infrastructure/ComposerVendorDirectoriesFinder.php" />
+                <!-- Structural `toArray()` duck-typing: the value set is open by design. -->
+                <file name="src/php/Lang/Collections/Vector/AbstractPersistentVector.php" />
+            </errorLevel>
+        </MixedArrayAccess>
+        <MixedArrayOffset>
+            <errorLevel type="suppress">
+                <!-- Property keys are `string` by declaration; psalm loses them
+                     across the `walk()` call that fills the property. -->
+                <file name="src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php" />
+                <!-- Symfony's `Command::getAliases(): array` carries no value type. -->
+                <file name="src/php/Console/Infrastructure/Command/LazyCommandLoader.php" />
+            </errorLevel>
+        </MixedArrayOffset>
     </issueHandlers>
 </psalm>

--- a/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
+++ b/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
@@ -307,7 +307,14 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
             return;
         }
 
-        uasort($this->entries, static fn($a, $b): int => $a['last_accessed'] <=> $b['last_accessed']);
+        uasort(
+            $this->entries,
+            /**
+             * @param CacheEntry $a
+             * @param CacheEntry $b
+             */
+            static fn(array $a, array $b): int => $a['last_accessed'] <=> $b['last_accessed'],
+        );
 
         $evictCount = max(1, (int) floor($this->maxEntries / 10));
 

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/StringParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/StringParser.php
@@ -44,27 +44,9 @@ final class StringParser
 
     private function parseEscapedString(string $str): string
     {
-        $callback = function (array $matches): string {
-            $str = $matches[1];
-
-            if (isset(self::STRING_REPLACEMENTS[$str])) {
-                return self::STRING_REPLACEMENTS[$str];
-            }
-
-            if ($str[0] === 'x' || $str[0] === 'X') {
-                return chr((int) hexdec(substr((string) $str, 1)));
-            }
-
-            if ($str[0] === 'u') {
-                return $this->parseUnicodeEscape($matches);
-            }
-
-            return chr((int) octdec((string) $str));
-        };
-
         $result = preg_replace_callback(
             self::ESCAPE_SEQUENCE_PATTERN,
-            $callback,
+            $this->replaceEscapeSequence(...),
             str_replace('\\"', '"', $str),
         );
 
@@ -73,6 +55,30 @@ final class StringParser
         }
 
         return $result;
+    }
+
+    /**
+     * @param array<int, string> $matches
+     *
+     * @throws StringParserException
+     */
+    private function replaceEscapeSequence(array $matches): string
+    {
+        $sequence = $matches[1];
+
+        if (isset(self::STRING_REPLACEMENTS[$sequence])) {
+            return self::STRING_REPLACEMENTS[$sequence];
+        }
+
+        if ($sequence[0] === 'x' || $sequence[0] === 'X') {
+            return chr((int) hexdec(substr($sequence, 1)));
+        }
+
+        if ($sequence[0] === 'u') {
+            return $this->parseUnicodeEscape($matches);
+        }
+
+        return chr((int) octdec($sequence));
     }
 
     /**

--- a/src/php/Compiler/Domain/Parser/ReadModel/ReaderResult.php
+++ b/src/php/Compiler/Domain/Parser/ReadModel/ReaderResult.php
@@ -13,6 +13,14 @@ final readonly class ReaderResult
         private CodeSnippet $codeSnippet,
     ) {}
 
+    /**
+     * The read form. `mixed` is deliberate and cannot be narrowed to
+     * `bool|float|int|string|TypeInterface|null`: a tagged literal is dispatched
+     * through `TagRegistry`, whose handlers are `callable(mixed): mixed` and can
+     * be registered from Phel at runtime via `(register-tag ...)`, so a handler
+     * may hand back any PHP value interop can produce. Callers that only ever
+     * see untagged forms narrow with a local `@var` instead.
+     */
     public function getAst(): mixed
     {
         return $this->ast;

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -639,35 +639,61 @@ final readonly class PhelConfig implements JsonSerializable
      * overridden. Each public `with*()` method delegates to this, allowing
      * single-line immutable updates.
      *
-     * @param array<string, mixed> $overrides
+     * The parameter is a partial shape keyed by constructor parameter name, and
+     * every field is forwarded as an explicit named argument. That keeps each
+     * value typed end to end (a dynamic `...[...$base, ...$overrides]` spread
+     * collapses to `mixed` for both phpstan and psalm). Keep the keys and types
+     * in sync with the constructor.
+     *
+     * @param array{
+     *     srcDirs?: list<string>,
+     *     testDirs?: list<string>,
+     *     vendorDir?: string,
+     *     errorLogFile?: string,
+     *     exportConfig?: PhelExportConfig,
+     *     buildConfig?: PhelBuildConfig,
+     *     ignoreWhenBuilding?: list<string>,
+     *     noCacheWhenBuilding?: list<string>,
+     *     keepGeneratedTempFiles?: bool,
+     *     tempDir?: string,
+     *     cacheDir?: string,
+     *     formatDirs?: list<string>,
+     *     appModulePaths?: list<string>,
+     *     enableAsserts?: bool,
+     *     warnDeprecations?: bool,
+     *     enableNamespaceCache?: bool,
+     *     enableCompiledCodeCache?: bool,
+     *     enableIntermediateCache?: bool,
+     *     phelDir?: string,
+     *     optimizationLevel?: int,
+     *     stripSymbolMeta?: bool,
+     * } $overrides
      */
     private function with(array $overrides): self
     {
-        $base = [
-            'srcDirs' => $this->srcDirs,
-            'testDirs' => $this->testDirs,
-            'vendorDir' => $this->vendorDir,
-            'errorLogFile' => $this->errorLogFile,
-            'exportConfig' => $this->exportConfig,
-            'buildConfig' => $this->buildConfig,
-            'ignoreWhenBuilding' => $this->ignoreWhenBuilding,
-            'noCacheWhenBuilding' => $this->noCacheWhenBuilding,
-            'keepGeneratedTempFiles' => $this->keepGeneratedTempFiles,
-            'tempDir' => $this->tempDir,
-            'cacheDir' => $this->cacheDir,
-            'formatDirs' => $this->formatDirs,
-            'appModulePaths' => $this->appModulePaths,
-            'enableAsserts' => $this->enableAsserts,
-            'warnDeprecations' => $this->warnDeprecations,
-            'enableNamespaceCache' => $this->enableNamespaceCache,
-            'enableCompiledCodeCache' => $this->enableCompiledCodeCache,
-            'enableIntermediateCache' => $this->enableIntermediateCache,
-            'phelDir' => $this->phelDir,
-            'optimizationLevel' => $this->optimizationLevel,
-            'stripSymbolMeta' => $this->stripSymbolMeta,
-        ];
-
-        return new self(...[...$base, ...$overrides]);
+        return new self(
+            srcDirs: $overrides['srcDirs'] ?? $this->srcDirs,
+            testDirs: $overrides['testDirs'] ?? $this->testDirs,
+            vendorDir: $overrides['vendorDir'] ?? $this->vendorDir,
+            errorLogFile: $overrides['errorLogFile'] ?? $this->errorLogFile,
+            exportConfig: $overrides['exportConfig'] ?? $this->exportConfig,
+            buildConfig: $overrides['buildConfig'] ?? $this->buildConfig,
+            ignoreWhenBuilding: $overrides['ignoreWhenBuilding'] ?? $this->ignoreWhenBuilding,
+            noCacheWhenBuilding: $overrides['noCacheWhenBuilding'] ?? $this->noCacheWhenBuilding,
+            keepGeneratedTempFiles: $overrides['keepGeneratedTempFiles'] ?? $this->keepGeneratedTempFiles,
+            tempDir: $overrides['tempDir'] ?? $this->tempDir,
+            cacheDir: $overrides['cacheDir'] ?? $this->cacheDir,
+            formatDirs: $overrides['formatDirs'] ?? $this->formatDirs,
+            appModulePaths: $overrides['appModulePaths'] ?? $this->appModulePaths,
+            enableAsserts: $overrides['enableAsserts'] ?? $this->enableAsserts,
+            warnDeprecations: $overrides['warnDeprecations'] ?? $this->warnDeprecations,
+            enableNamespaceCache: $overrides['enableNamespaceCache'] ?? $this->enableNamespaceCache,
+            enableCompiledCodeCache: $overrides['enableCompiledCodeCache'] ?? $this->enableCompiledCodeCache,
+            enableIntermediateCache: $overrides['enableIntermediateCache'] ?? $this->enableIntermediateCache,
+            phelDir: $overrides['phelDir'] ?? $this->phelDir,
+            optimizationLevel: $overrides['optimizationLevel'] ?? $this->optimizationLevel,
+            stripSymbolMeta: $overrides['stripSymbolMeta'] ?? $this->stripSymbolMeta,
+        );
     }
 
 }

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -43,7 +43,7 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
     private mixed $realized = null;
 
     /**
-     * @param callable                                  $fn   A thunk (nullary function) that returns a sequence or null
+     * @param callable(): mixed                         $fn   A thunk (nullary function) that returns a sequence or null
      * @param PersistentMapInterface<mixed, mixed>|null $meta Metadata for this sequence
      */
     public function __construct(

--- a/src/php/Lang/Generators/CombineGenerator.php
+++ b/src/php/Lang/Generators/CombineGenerator.php
@@ -122,8 +122,8 @@ final class CombineGenerator
      *   mapMulti(fn($a, $b) => $a . $b, ['a', 'b'], ['1', '2'])   // => ['a1', 'b2']
      *   mapMulti(fn($a, $b) => $a + $b, [1, 2, 3], [10, 20])      // => [11, 22] (stops at shortest)
      *
-     * @param callable $f            The mapping function
-     * @param mixed    ...$iterables The sequences to map over
+     * @param callable(mixed...): mixed $f            The mapping function, one argument per iterable
+     * @param mixed                     ...$iterables The sequences to map over
      *
      * @return Generator<int, mixed>
      */

--- a/src/php/Lsp/Application/Rpc/RequestDispatcher.php
+++ b/src/php/Lsp/Application/Rpc/RequestDispatcher.php
@@ -52,8 +52,12 @@ final class RequestDispatcher
     public function dispatch(array $message, Session $session): ?array
     {
         $id = $message['id'] ?? null;
-        $method = is_string($message['method'] ?? null) ? $message['method'] : '';
-        $params = is_array($message['params'] ?? null) ? $message['params'] : [];
+        // Bind before testing: re-reading the offset inside the ternary loses the
+        // `is_string`/`is_array` narrowing, leaving `$method`/`$params` as mixed.
+        $rawMethod = $message['method'] ?? null;
+        $rawParams = $message['params'] ?? null;
+        $method = is_string($rawMethod) ? $rawMethod : '';
+        $params = is_array($rawParams) ? $rawParams : [];
         /** @var array<string, mixed> $params */
 
         if ($method === '') {
@@ -64,7 +68,6 @@ final class RequestDispatcher
             return $this->responses->error($id, ResponseBuilder::INVALID_REQUEST, 'Missing method.');
         }
 
-        /** @psalm-suppress MixedArrayTypeCoercion */
         $handler = $this->handlers[$method] ?? null;
         if (!$handler instanceof HandlerInterface) {
             if ($id === null) {


### PR DESCRIPTION
## 🤔 Background

`psalm.xml` globally suppressed the entire `Mixed*` handler family, all twelve of
them. A clean psalm run therefore carried **zero** signal about `mixed`, leaving
phpstan level 9 to do that work alone. Separately, `phpstan.neon` disabled *all*
`argument.type` checks across the whole of `PhelConfig.php` for the sake of one
dynamic spread.

I removed the suppressions, ran `psalm --no-cache` over `src/`, and triaged the
output by handler, module and cause. Measured with all twelve handlers enabled:

| | |
|---|---|
| Total errors | **650** |
| Files affected | **187 of 1050** |
| Modules affected | **16 of 19** (plus `src/Phel.php`) |
| From psalm-gacela not typing `getFacade()`/`getFactory()`/`getConfig()` | **95 direct, 176 with cascade** |

That last row is the headline: `vendor/gacela-project/gacela/psalm-gacela.xml`
only silences `UndefinedMagicMethod` for the three magic accessors and does no
return-type resolution, so `$this->getFacade()` reads as `mixed` for psalm while
`phpstan-gacela` resolves it correctly. One upstream gap accounts for 27% of the
volume. Most of the remainder is the genuinely open Phel value set (interop
admits arbitrary PHP objects, arrays and resources), where `mixed` is the honest
type.

Since no directory isolates any of that, directory-level narrowing is not
possible, and file-level narrowing for the high-volume handlers would be a
hand-maintained 180-entry list, i.e. a worse baseline than an actual baseline
file. So the eight high-volume handlers stay global, but the numbers and the
three structural causes are now recorded in `psalm.xml` so this does not have to
be re-derived.

## 💡 Goal

Get psalm contributing real `mixed` signal where it can, and replace two wide
blanket exemptions with either nothing or a precisely scoped one.

Psalm goes from **0 of 12** `Mixed*` handlers carrying signal to **4 of 12**, and
`phpstan.neon` loses its whole-file `argument.type` exemption entirely. All
changes are type-only and provably behaviour-preserving: no new runtime
`assert()` or `instanceof`, no type weakened to make analysis pass.

## 🔖 Changes

**Four psalm handlers now enabled**

- `MixedFunctionCall` and `MixedArrayAssignment` had **zero** occurrences with
  the suppression lifted. Dead config, invisible because psalm does not report
  unused issue handlers. Deleted outright.
- `MixedArrayAccess` (6) and `MixedArrayOffset` (5) were small enough to attack.
  Four of the eleven are fixed properly; the remaining five are scoped to four
  files with a one-line reason each, instead of a global blanket.

**Source fixes behind that**

- `RequestDispatcher::dispatch()` binds the raw offsets before testing them.
  Re-reading `$message['method']` inside the ternary loses the `is_string`
  narrowing, so `$method` stayed `mixed`. This also retires the
  `@psalm-suppress MixedArrayTypeCoercion` that was covering the consequence.
- `StringParser`'s escape callback becomes `private function replaceEscapeSequence()`
  with a typed `$matches`, matching the sibling `parseUnicodeEscape()`. Psalm
  ignores `@param` on closure assignments, so a docblock on the closure was not
  enough. Also drops two now-redundant `(string)` casts and a local `$str` that
  shadowed the enclosing parameter.
- `CompiledCodeCache::evictLRU()` types its `uasort` callback with the existing
  `CacheEntry` shape; psalm does not infer `uasort` params from the array's value
  type.
- `LazySeq::__construct()` gets `callable(): mixed $fn` (the property it feeds was
  already `(callable(): mixed)|null`), and `CombineGenerator::mapMulti()` gets
  `callable(mixed...): mixed $f`. Those were the last two bare `callable`
  docblocks in `src/`.

**`phpstan.neon`: the `PhelConfig.php` exemption is deleted, not narrowed**

The wide `identifier: argument.type` exemption covered exactly one line:
`new self(...[...$base, ...$overrides])`. A dynamic named-argument spread of
`array<string, mixed>` collapses to `mixed` for both analysers.

`PhelConfig::with()` now declares `$overrides` as a partial `array{...}` shape and
forwards each field as an explicit named argument, which is green on both
analysers and drops the 21-line `$base` array (the method is shorter than before).
`with()` is private with 21 in-file call sites, every one passing a non-null
value, and the only nullable constructor parameter (`tempDir`) is only ever given
a `string` by `withTempDir()`, so `??` and key-presence are equivalent here.

A shape-plus-spread variant was tried first and rejected: phpstan merges the two
shapes and goes green, but psalm cannot merge shapes across `[...$a, ...$b]` and
regressed into 21 unsuppressed `PossiblyInvalidArgument`.

**`ReaderResult::getAst()` stays `mixed`, and now says why**

Typing it was assessed and deliberately not done. The reader tree is already well
typed, but `TaggedLiteralNode` dispatches to `TagRegistry` handlers declared
`callable(mixed): mixed` and registrable from Phel at runtime via
`(register-tag ...)`. A user handler is an ordinary Phel function, so it can
return any value interop can produce. Narrowing `getAst()` to
`bool|float|int|string|TypeInterface|null` would push an unsound type onto eight
call sites and into `CompilerFacadeInterface`. A docblock now records this so it
is not re-litigated.

**Also checked, nothing to do**

Zero unparameterised `Closure`/`Traversable`/`ArrayAccess`/`IteratorAggregate`;
every `implements IteratorAggregate` has a matching `@implements ...<K, V>`. Ran
psalm with `findUnusedPsalmSuppress="true"`: all 43 remaining `@psalm-suppress`
are live, as are all 3 `@phpstan-ignore`. Probed whether psalm resolves the
repo's 36 `@phpstan-type` aliases given there are no `@psalm-type` equivalents:
it does, so no duplication is needed.

**Follow-up worth filing upstream (not in this PR):** a psalm plugin or stub
typing Gacela's `getFacade()` from the `#[ServiceMap]` attribute the way
`phpstan-gacela` does would remove ~27% of the remaining volume in one move and
would likely make `MixedMethodCall` (91) enable-able too.

**Verification** (all with caches cleared): `phpstan clear-result-cache` plus a
full level-9 run OK; `psalm --no-cache` clean; `phpunit --testsuite=unit,integration`
5189 tests / 14885 assertions / 0 failures; `bin/phel test` 6488 passed / 0
failed; `php-cs-fixer --dry-run` 0 of 1661; `rector --dry-run` OK.

No CHANGELOG entry: these are type annotations, analyser config and one private
method's internals. Nothing user-facing changes.
