### PR TITLE
docs: correct 34 wrong :example outputs, docs/ drift, and verbose comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
 - `(lazy-seq <non-seq>)` (e.g. `(lazy-seq 5)`) now reports `Don't know how to create a seq from: int` instead of leaking a PHP `TypeError` about an internal method's return type
 - A transient sorted set is now callable for membership lookup, `((transient (sorted-set :a)) :a)`, matching the transient hash set instead of raising "object is not callable"
 - A `data-readers.phel` whose `phel.reader` bootstrap fails now reports the failing file and the underlying cause, instead of leaving every `(register-tag ...)` in it silently unregistered
+- Corrected 34 `:example` blocks whose documented output did not match what Phel actually prints, verified by evaluating every example and diffing against `pr-str`. Sets print `#{…}` not `(hash-set …)` (`union`, `intersection`, `difference`, `symmetric-difference`, `select`, `project`, `rename`, `index`, `test/gen/set-of`); float-returning fns print `2.0` not `2` (`ceil`, `floor`, `round`, `sqrt`, `mean`, `double`, `float`, `double-array`, `float-array`, `ai/magnitude`, `ai/cosine-similarity`); `subseq`/`rsubseq`/`repeatedly` return PHP arrays `@[…]`; quasiquote namespace-qualifies (`` `(+ 1 ,(+ 2 3)) `` yields `(phel.core/+ 1 5)`); `phel\http` structs print fully qualified (`(phel.http.response …)`); `phel\html/doctype` returns a `raw-string` struct; `parse-double "Infinity"` prints `Infinity`; `queue` prints `<-(1 2 3)-<`; maps print `,` between pairs; and `test/get-stats` now shows its `:skipped` bucket
+- `phel\walk/postwalk`'s example no longer throws: `(postwalk inc [1 [2 3]])` passes the inner vectors to `inc`, so it is now `(postwalk #(if (int? %) (inc %) %) [1 [2 3]])`
 
 ### Changed
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -17,6 +17,8 @@ enable tab-completion (see the [README](../README.md#enable-shell-completion-opt
 | `api-daemon` | Long-running JSON-RPC daemon exposing the Api semantic-analysis facade over stdio (for tooling) |
 | `build` `b` | Build the current project: compile every namespace to PHP in the output dir |
 | `cache:clear` | Clear the temp and cache directories |
+| `cache:warm` | Pre-resolve all module classes and warm the cache for production |
+| `completion` | Dump the shell completion script for bash, zsh, or fish |
 | `compile` | Compile a Phel snippet/file/stdin and print the emitted PHP — does not evaluate |
 | `config` | Show the effective Phel configuration and where it comes from |
 | `doc` | Display the docs for any/all Phel functions |

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -16,7 +16,7 @@ Compiler is PHP. Stdlib is Phel: `src/phel/core.phel` bootstraps the core namesp
 
 ## Modules
 
-Every directory under `src/php/` is a [Gacela](https://gacela-project.com/) module. `Facade` for public API, `Provider` for cross-module deps, `Factory` for internal wiring.
+Every directory under `src/php/` is a module. Most follow the [Gacela](https://gacela-project.com/) pattern: `Facade` for public API, `Provider` for cross-module deps, `Factory` for internal wiring. `Lang/`, `Shared/`, `Config/` and `HttpClient/` are leaves with no Gacela wiring; their `CLAUDE.md` says "No Gacela Pattern".
 
 | Module | Purpose |
 |--------|---------|
@@ -86,7 +86,7 @@ Each module ships `CLAUDE.md` with API + constraints. Read it before editing.
 ```
 
 - Everything depends on `Compiler/` and `Lang/`.
-- `Lang/` is a leaf; `Shared/Printer/` depends on `Lang/` (not the other way).
+- `Lang/` and `Shared/` are leaves for every other module, but they reference each other: `Shared/Printer/` prints `Lang/` values, and `Lang/TypeStringifier` calls `Printer::readable()`. This is one of the four deliberate cycles listed in `src/php/CLAUDE.md` and pinned by `tests/php/Unit/Architecture/ModuleDependencyCycleTest.php`.
 - `Lsp/`, `Nrepl/`, `Watch/` reuse the compiler facade; not on the compile path.
 
 ## Compile-time vs runtime

--- a/docs/internals/cli-flag-conventions.md
+++ b/docs/internals/cli-flag-conventions.md
@@ -14,7 +14,7 @@ muscle memory transfers between commands. New commands MUST follow these.
 | Config file path | `--config` | — | Path to a command-specific config. |
 | Preview without writing | `--dry-run` | — | Boolean; print intended actions only. |
 | Overwrite existing files | `--force` | — | Boolean. |
-| Optimization level | `--optimization-level` | `-O` | `build`/`compile`. |
+| Optimization level | `--optimization-level` | `-O` | `build` only; `compile` reads the configured level and has no override flag. |
 
 Global flags (`--help/-h`, `--quiet/-q`, `--verbose/-v`, `--version/-V`,
 `--no-interaction/-n`, `--ansi/--no-ansi`) come from Symfony Console; never
@@ -23,7 +23,8 @@ re-declare them or reuse their short letters.
 ## Reserved short letters
 
 `-h -q -v -V -n` are Symfony globals. Within Phel commands: `-f` = format
-(or filter on `test`), `-o` = output, `-s` = sort, `-O` = optimization level,
+(or filter on `test`), `-o` = output, `-s` = sort (`--simple` on `ns`, pre-existing),
+`-O` = optimization level,
 `-t` is command-local (`compile --target`, `init --template`, `run --with-time`),
 `-p` = port (`nrepl`), `-m` = minimal (`init`), `-b` = backend (`watch`).
 

--- a/docs/internals/compiler.md
+++ b/docs/internals/compiler.md
@@ -19,7 +19,8 @@ Paths are relative to `src/php/Compiler/`, except `Shared/Munge.php` (under `src
 - `compile()` / `compileForCache()`: full pipeline to `EmitterResult`
 - `compileForm()`: start from already-read Phel data
 - `eval()` / `evalForm()`: compile + execute
-- `lexString()` / `parseAll()` / `read()` / `analyze()`: single-stage hooks for LSP, nREPL, linter
+- `lexString()` / `parseAll()` / `parseNext()` / `read()` / `analyze()`: single-stage hooks for LSP, nREPL, linter
+- `readFormsBestEffort()`: lex → parse → read as a `Generator`, never throwing, for tooling over a buffer mid-edit
 
 ## Tracing `(print "hi")`
 

--- a/docs/internals/faq.md
+++ b/docs/internals/faq.md
@@ -18,7 +18,9 @@ Grouped by reader.
 
 ## Coming from Clojure
 
-**Missing features.** No agents, no STM/refs (use `Atom` + `swap!`), no `core.async` (Phel has fibers + futures via `Fiber/`, see [async](https://phel-lang.org/documentation/language/async/)), no protocols (use `definterface`), no records (use `defstruct`).
+**Missing features.** No agents, no STM/refs (use `Atom` + `swap!`), no `core.async` (Phel has fibers + futures via `Fiber/`, see [async](https://phel-lang.org/documentation/language/async/)).
+
+**Present.** `defprotocol` / `extend-type` / `extend-protocol` / `satisfies?` and `defrecord` live in `src/phel/core/protocols.phel`. `definterface` is the lower-level PHP-interface form; `defstruct` the lower-level fixed-key map.
 
 **Real persistent collections?** Yes. `PersistentVector` (32-way trie), `PersistentHashMap` (HAMT), `LazySeq` (per-element realisation). Under `Lang/Collections/`.
 

--- a/docs/internals/macros.md
+++ b/docs/internals/macros.md
@@ -4,7 +4,7 @@ Compile-time function. Takes Phel forms, returns Phel forms. Analyzer replaces t
 
 ## Mechanism
 
-`(defmacro when [test & body] ...)` is a `def` whose `Atom` carries `:macro true`. At runtime it is a function. At compile time, the analyzer:
+`(defmacro when [test & body] ...)` is a `def` whose metadata carries `:macro true` (read by `DefSymbol`, stored in `Registry`). At runtime it is a function. At compile time, the analyzer:
 
 1. Sees `(when x y)`.
 2. Resolves head to `GlobalVarNode`.
@@ -51,10 +51,12 @@ Matches user-facing `&form` / `&env`.
 |-------|--------|
 | `` `x `` | `(quote x)` |
 | `` `~x `` | `x` |
-| `` `(a b) `` | `(list (quote a) (quote b))` |
-| `` `(a ~x) `` | `(list (quote a) x)` |
-| `` `(a ~@xs b) `` | `(concat (list (quote a)) xs (list (quote b)))` |
-| `` `[a ~x] `` | `(vec (concat (list (quote a)) (list x)))` |
+| `` `(a b) `` | `(apply list (concat (list (quote a)) (list (quote b))))` |
+| `` `(a ~x) `` | `(apply list (concat (list (quote a)) (list x)))` |
+| `` `(a ~@xs b) `` | `(apply list (concat (list (quote a)) xs (list (quote b))))` |
+| `` `[a ~x] `` | `(apply vector (concat (list (quote a)) (list x)))` |
+
+Every collection form goes through `concat` and is rebuilt by `apply`, so a splice can contribute any number of elements. `~` and `,` are the same reader token. Check any case with `(read-string "`(a ~x)")`.
 
 Symbols inside quasiquote get namespace-qualified to the *defining* namespace. Easy half of hygiene: `` `(map f xs) `` resolves to `phel.core/map` regardless of caller shadowing.
 

--- a/docs/internals/special-forms.md
+++ b/docs/internals/special-forms.md
@@ -4,19 +4,19 @@ A list with a recognised head symbol routes to a dedicated analyzer. Anything el
 
 ## Dispatch
 
-`Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php` matches the head against `Symbol::NAME_*` constants in `src/php/Lang/Symbol.php`. On match it dispatches to a `SpecialFormAnalyzerInterface` impl in `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`; on miss it falls through to `InvokeSymbol`.
+`Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php` looks the head up in `specialFormFactories()`, keyed by the `Symbol::NAME_*` constants in `src/php/Lang/Symbol.php`. Each value is a closure, so an analyzer is built on first use and memoized in `$symbolAnalyzerCache`. A miss falls through to `InvokeSymbol`.
 
 ```php
-match ($symbolName) {
-    Symbol::NAME_DEF   => new DefSymbol($this->analyzer),
-    Symbol::NAME_FN    => new FnSymbol($this->analyzer, $this->assertsEnabled),
-    Symbol::NAME_IF    => new IfSymbol($this->analyzer),
-    Symbol::NAME_LET   => new LetSymbol($this->analyzer, ...),
-    Symbol::NAME_LOOP  => new LoopSymbol($this->analyzer, ...),
-    Symbol::NAME_RECUR => new RecurSymbol($this->analyzer),
+return $this->specialFormFactories = [
+    Symbol::NAME_DEF   => fn(): SpecialFormAnalyzerInterface => new DefSymbol($this->analyzer),
+    Symbol::NAME_FN    => fn(): SpecialFormAnalyzerInterface => new FnSymbol($this->analyzer, $this->assertsEnabled),
+    Symbol::NAME_IF    => fn(): SpecialFormAnalyzerInterface => new IfSymbol($this->analyzer),
+    Symbol::NAME_RECUR => fn(): SpecialFormAnalyzerInterface => new RecurSymbol($this->analyzer),
     // ...
-};
+];
 ```
+
+`specialFormNames()` returns the keys, so tooling never has to hardcode the list.
 
 Each handler returns one `AbstractNode`. Every node maps 1:1 to an `*Emitter.php` under `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/`.
 
@@ -89,7 +89,7 @@ Run `(macroexpand-1 'form)` to see the truth.
 1. `public const string NAME_FOO = 'foo';` in `src/php/Lang/Symbol.php`
 2. `FooNode extends AbstractNode` in `Compiler/Domain/Analyzer/Ast/`
 3. `FooSymbol implements SpecialFormAnalyzerInterface` in `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`: validate, recurse via `$this->analyzer->analyze(...)`, return `FooNode`
-4. Branch in the `AnalyzePersistentList` `match`
+4. Entry in `AnalyzePersistentList::specialFormFactories()`
 5. `FooEmitter` in `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/`, registered in `NodeEmitterFactory`; honor `NodeEnvironment` context
 
 Add a fixture `tests/php/Integration/Fixtures/Foo/foo-basic.test` plus an analyzer PHPUnit test.

--- a/docs/migration/removed-deprecated-core-fns.md
+++ b/docs/migration/removed-deprecated-core-fns.md
@@ -20,15 +20,15 @@ The core functions below were deprecated for many releases and are now **removed
 The replacement keeps the same signature:
 
 ```phel
-(push coll x)      # -> (conj coll x)
-(put m :k v)       # -> (assoc m :k v)
-(unset m :k)       # -> (dissoc m :k)
-(put-in m ks v)    # -> (assoc-in m ks v)
-(unset-in m ks)    # -> (dissoc-in m ks)
-(values m)         # -> (vals m)
-(function? x)      # -> (fn? x)
-(hash-map? x)      # -> (map? x)
-(id a b)           # -> (identical? a b)
+(push coll x)      ; -> (conj coll x)
+(put m :k v)       ; -> (assoc m :k v)
+(unset m :k)       ; -> (dissoc m :k)
+(put-in m ks v)    ; -> (assoc-in m ks v)
+(unset-in m ks)    ; -> (dissoc-in m ks)
+(values m)         ; -> (vals m)
+(function? x)      ; -> (fn? x)
+(hash-map? x)      ; -> (map? x)
+(id a b)           ; -> (identical? a b)
 ```
 
 `str-contains?` now lives in the `phel\string` namespace:
@@ -36,7 +36,7 @@ The replacement keeps the same signature:
 ```phel
 (ns my-app (:require phel\string :as s))
 
-(str-contains? haystack needle)   # -> (s/contains? haystack needle)
+(str-contains? haystack needle)   ; -> (s/contains? haystack needle)
 ```
 
 ## Still deprecated (not removed)

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -601,7 +601,7 @@ Similar to `extract`, but returns a vector of maps when the text contains multip
 
 (defn magnitude
   "Computes the magnitude (L2 norm) of a numeric vector."
-  {:example "(magnitude [3 4]) ; => 5"
+  {:example "(magnitude [3 4]) ; => 5.0"
    :see-also ["dot-product" "cosine-similarity"]}
   [v]
   (php/sqrt (apply + (map #(* % %) v))))
@@ -615,7 +615,7 @@ Similar to `extract`, but returns a vector of maps when the text contains multip
 
 (defn cosine-similarity
   "Computes the cosine similarity between two numeric vectors. Returns a float between -1.0 and 1.0, where 1.0 means identical direction."
-  {:example "(cosine-similarity [1 0] [0 1]) ; => 0"
+  {:example "(cosine-similarity [1 0] [0 1]) ; => 0.0"
    :see-also ["dot-product" "magnitude" "nearest"]}
   [a b]
   (similarity-with-mags a (magnitude a) b (magnitude b)))

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -40,19 +40,19 @@
 
 (def queue
   {:doc "Creates a persistent FIFO queue. With no arguments returns an empty queue; with arguments returns a queue with the values pushed in order so that the first argument is at the front."
-   :example "(queue 1 2 3) ; => first 1, then 2, then 3"}
+   :example "(queue 1 2 3) ; => <-(1 2 3)-<"}
   (fn [& xs]
     (php/:: Phel (queue (apply php/array xs)))))
 
 (def hash-map
   {:doc "Creates a new hash map. If no argument is provided, an empty hash map is created. The number of parameters must be even. Shortcut: {}"
-   :example "(hash-map :a 1 :b 2) ; => {:a 1 :b 2}"}
+   :example "(hash-map :a 1 :b 2) ; => {:a 1, :b 2}"}
   (fn [& xs]
     (php/:: Phel (map (apply php/array xs)))))
 
 (def array-map
   {:doc "Constructs a map from the given key/value pairs. If any keys are equal, later values replace earlier ones, as if by repeated `assoc`. Phel has no distinct array-map type, so the result is the same persistent map as `hash-map` — `array-map` exists for `.cljc` interop with Clojure sources."
-   :example "(array-map :a 1 :b 2) ; => {:a 1 :b 2}"
+   :example "(array-map :a 1 :b 2) ; => {:a 1, :b 2}"
    :see-also ["hash-map"]}
   (fn [& xs]
     (php/:: Phel (map (apply php/array xs)))))

--- a/src/phel/core/arrays.phel
+++ b/src/phel/core/arrays.phel
@@ -167,14 +167,14 @@
 
 (defn float-array
   "Creates a PHP array of floats. Accepts the same arities as `int-array`; coerces elements to float via `floatval` and zero-pads with `0.0`."
-  {:example "(float-array 3) ; => <PHP-Array [0, 0, 0]>\n(float-array 4 1.5) ; => <PHP-Array [1.5, 1.5, 1.5, 1.5]>"
+  {:example "(float-array 3) ; => <PHP-Array [0.0, 0.0, 0.0]>\n(float-array 4 1.5) ; => <PHP-Array [1.5, 1.5, 1.5, 1.5]>"
    :see-also ["double-array" "int-array" "long-array" "short-array"]}
   ([size-or-seq] (typed-array php/floatval 0.0 size-or-seq))
   ([size init-val-or-seq] (typed-array php/floatval 0.0 size init-val-or-seq)))
 
 (defn double-array
   "Creates a PHP array of doubles (same as float-array in PHP). Accepts the same arities and semantics as `float-array`."
-  {:example "(double-array 3) ; => <PHP-Array [0, 0, 0]>\n(double-array 4 1.5) ; => <PHP-Array [1.5, 1.5, 1.5, 1.5]>"
+  {:example "(double-array 3) ; => <PHP-Array [0.0, 0.0, 0.0]>\n(double-array 4 1.5) ; => <PHP-Array [1.5, 1.5, 1.5, 1.5]>"
    :see-also ["float-array" "int-array" "long-array" "short-array"]}
   ([size-or-seq] (typed-array php/floatval 0.0 size-or-seq))
   ([size init-val-or-seq] (typed-array php/floatval 0.0 size init-val-or-seq)))

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -16,7 +16,7 @@
 
 (defn union
   "Union multiple sets into a new one."
-  {:example "(union (hash-set 1 2) (hash-set 2 3)) ; => (hash-set 1 2 3)"
+  {:example "(union (hash-set 1 2) (hash-set 2 3)) ; => #{1 2 3}"
    :see-also ["intersection" "difference"]}
   [& sets]
   (let [target (transient (hash-set))]
@@ -37,7 +37,7 @@
 
 (defn intersection
   "Intersect multiple sets into a new one."
-  {:example "(intersection (hash-set 1 2 3) (hash-set 2 3 4)) ; => (hash-set 2 3)"
+  {:example "(intersection (hash-set 1 2 3) (hash-set 2 3 4)) ; => #{2 3}"
    :see-also ["union" "difference"]}
   [set & sets]
   (reduce intersection-pair set sets))
@@ -58,14 +58,14 @@
 
 (defn difference
   "Difference between multiple sets into a new one."
-  {:example "(difference (hash-set 1 2 3) (hash-set 2)) ; => (hash-set 1 3)"
+  {:example "(difference (hash-set 1 2 3) (hash-set 2)) ; => #{1 3}"
    :see-also ["union" "intersection"]}
   [set & sets]
   (reduce difference-pair set sets))
 
 (defn symmetric-difference
   "Symmetric difference between multiple sets into a new one."
-  {:example "(symmetric-difference (hash-set 1 2) (hash-set 2 3)) ; => (hash-set 1 3)"
+  {:example "(symmetric-difference (hash-set 1 2) (hash-set 2 3)) ; => #{1 3}"
    :see-also ["difference" "union"]}
   [set & sets]
   (reduce #(union (difference %1 %2) (difference %2 %1)) set sets))
@@ -86,28 +86,28 @@
 
 (defn select
   "Returns a set of the elements of `xset` for which `(pred element)` is logical true."
-  {:example "(select even? (hash-set 1 2 3 4)) ; => (hash-set 2 4)"
+  {:example "(select even? (hash-set 1 2 3 4)) ; => #{2 4}"
    :see-also ["filter" "project"]}
   [pred xset]
   (set (filter pred xset)))
 
 (defn project
   "Returns a set of maps, keeping only the keys in `ks` from each map in the relation `xrel`."
-  {:example "(project (hash-set {:a 1 :b 2}) [:a]) ; => (hash-set {:a 1})"
+  {:example "(project (hash-set {:a 1 :b 2}) [:a]) ; => #{{:a 1}}"
    :see-also ["select-keys" "rename" "select"]}
   [xrel ks]
   (set (map (fn [m] (select-keys m ks)) xrel)))
 
 (defn rename
   "Returns a set of maps like the relation `xrel`, with the keys of each map renamed according to `kmap` (a map of old-key to new-key)."
-  {:example "(rename (hash-set {:a 1 :b 2}) {:a :x}) ; => (hash-set {:x 1 :b 2})"
+  {:example "(rename (hash-set {:a 1 :b 2}) {:a :x}) ; => #{{:x 1, :b 2}}"
    :see-also ["rename-keys" "project"]}
   [xrel kmap]
   (set (map (fn [m] (rename-keys m kmap)) xrel)))
 
 (defn index
   "Returns a map that groups the maps in the relation `xrel` by their values for the keys in `ks`. Each key is `(select-keys map ks)` and each value is the set of maps sharing those key-values."
-  {:example "(index (hash-set {:name \"a\" :dept 1} {:name \"b\" :dept 1}) [:dept]) ; => {{:dept 1} (hash-set {:name \"a\" :dept 1} {:name \"b\" :dept 1})}"
+  {:example "(index (hash-set {:name \"a\" :dept 1} {:name \"b\" :dept 1}) [:dept]) ; => {{:dept 1} #{{:name \"a\", :dept 1} {:name \"b\", :dept 1}}}"
    :see-also ["project" "select" "group-by"]}
   [xrel ks]
   (reduce

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -440,7 +440,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
    return `0.0` and `nil` returns `0.0`. Non-numeric objects such as
    keywords, vectors, or maps raise `InvalidArgumentException` instead of
    leaking a raw PHP float-coercion warning."
-  {:example "(float 1) ; => 1\n(float 1/2) ; => 0.5"
+  {:example "(float 1) ; => 1.0\n(float 1/2) ; => 0.5"
    :see-also ["double" "int?" "number?"]}
   [x]
   (cond
@@ -453,7 +453,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn double
   "Coerces `x` to a double. In PHP there is no distinction between float and double; both map to the same native PHP float type. Alias for `float`."
-  {:example "(double 1) ; => 1"
+  {:example "(double 1) ; => 1.0"
    :see-also ["float" "int?" "number?"]}
   [x]
   (float x))
@@ -628,7 +628,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn mean
   "Returns the mean of `xs` as a float."
-  {:example "(mean [1 2 3]) ; => 2"
+  {:example "(mean [1 2 3]) ; => 2.0"
    :see-also ["sum" "median"]}
   [xs]
   (php/fdiv (sum xs) (count xs)))
@@ -834,7 +834,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn floor
   "Returns the largest integer not greater than `x`. Ints and `BigInt` values are returned unchanged. Ratios collapse via floor division. Floats route through PHP's `floor`."
-  {:example "(floor 1.7) ; => 1\n(floor -1.2) ; => -2\n(floor 7/3) ; => 2"
+  {:example "(floor 1.7) ; => 1.0\n(floor -1.2) ; => -2.0\n(floor 7/3) ; => 2"
    :see-also ["ceil" "round" "quot"]}
   [x]
   (assert-non-nil x)
@@ -849,7 +849,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn ceil
   "Returns the smallest integer not less than `x`. Ints and `BigInt` values are returned unchanged. Ratios collapse via ceiling division. Floats route through PHP's `ceil`."
-  {:example "(ceil 1.2) ; => 2\n(ceil -1.7) ; => -1\n(ceil 7/3) ; => 3"
+  {:example "(ceil 1.2) ; => 2.0\n(ceil -1.7) ; => -1.0\n(ceil 7/3) ; => 3"
    :see-also ["floor" "round" "quot"]}
   [x]
   (assert-non-nil x)
@@ -864,7 +864,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn round
   "Rounds `x` to the nearest integer using PHP's `round` (half away from zero). Ints and `BigInt` values are returned unchanged. Ratios and floats return floats."
-  {:example "(round 1.5) ; => 2\n(round -1.5) ; => -2\n(round 5) ; => 5"
+  {:example "(round 1.5) ; => 2.0\n(round -1.5) ; => -2.0\n(round 5) ; => 5"
    :see-also ["floor" "ceil"]}
   [x]
   (assert-non-nil x)
@@ -876,7 +876,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 (defn sqrt
   "Returns the square root of `x` as a float. Negative inputs return
   `##NaN` (matches PHP's `sqrt`)."
-  {:example "(sqrt 9) ; => 3\n(sqrt 2) ; => 1.4142135623731"
+  {:example "(sqrt 9) ; => 3.0\n(sqrt 2) ; => 1.4142135623731"
    :see-also ["**" "abs"]}
   [x]
   (assert-non-nil x)

--- a/src/phel/core/parsing.phel
+++ b/src/phel/core/parsing.phel
@@ -19,7 +19,7 @@
 
 (defn parse-double
   "Parses a string as a float. Returns `nil` for non-numeric input or for inputs that are not strings. Accepts `Infinity`, `-Infinity`, and `NaN` alongside regular decimal and scientific notation."
-  {:example "(parse-double \"3.14\") ; => 3.14\n(parse-double \"Infinity\") ; => INF"
+  {:example "(parse-double \"3.14\") ; => 3.14\n(parse-double \"Infinity\") ; => Infinity"
    :see-also ["parse-long"]}
   [s]
   (when (string? s)

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -343,10 +343,8 @@
   {:example "(list? '(1 2)) ; => true\n(list? [1 2]) ; => false"
    :see-also ["vector?" "seq?" "sequential?"]}
   [x]
-  ;; Two checks on purpose, both against the interface: `instanceof` gives the
-  ;; shape, `isList` separates a real list from the seq view `seq` builds over a
-  ;; vector or a map (both are `PersistentListInterface` values). Dropping
-  ;; either half makes `(list? (seq [1 2]))` return true.
+  ;; A seq view over a vector or a map is also a `PersistentListInterface`, so
+  ;; dropping either half makes `(list? (seq [1 2]))` return true.
   (and (php/instanceof x PersistentListInterface)
        (php/-> x (isList))))
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -796,7 +796,7 @@ Works with vectors, lists, sets, and strings."
 
 (defn subseq
   "Returns a lazy sequence of the entries of the sorted collection `sc` (map entries for a sorted map, elements for a sorted set) whose keys satisfy the boundary test, in ascending order. With one boundary, use `>` / `>=` to start after or at `bound-key` and `<` / `<=` to stop before or at it. With two boundaries, returns the entries between them, e.g. `(subseq sm >= 2 < 5)`. Boundaries respect the collection's own comparator (`sorted-map-by` / `sorted-set-by`)."
-  {:example "(subseq (sorted-map 1 :a 2 :b 3 :c) >= 2) ; => ([2 :b] [3 :c])"
+  {:example "(subseq (sorted-map 1 :a 2 :b 3 :c) >= 2) ; => @[[2 :b] [3 :c]]"
    :see-also ["rsubseq" "sorted-map" "sorted-set" "take-while" "drop-while"]}
   ([sc test bound-key]
    (assert-sorted-coll "subseq" sc)
@@ -812,7 +812,7 @@ Works with vectors, lists, sets, and strings."
 
 (defn rsubseq
   "Like `subseq`, but returns the matching entries in descending order. With one boundary, use `<` / `<=` to start from the top end and `>` / `>=` to stop; with two boundaries, returns the entries between them in reverse, e.g. `(rsubseq sm >= 2 < 5)`."
-  {:example "(rsubseq (sorted-map 1 :a 2 :b 3 :c) <= 2) ; => ([2 :b] [1 :a])"
+  {:example "(rsubseq (sorted-map 1 :a 2 :b 3 :c) <= 2) ; => @[[2 :b] [1 :a]]"
    :see-also ["subseq" "rseq" "sorted-map" "sorted-set"]}
   ([sc test bound-key]
    (assert-sorted-coll "rsubseq" sc)
@@ -1022,7 +1022,7 @@ With one argument returns an infinite lazy sequence of x."
   "Returns a vector of length n with values produced by repeatedly calling f.
 
 With one argument returns an infinite lazy sequence of calls to f."
-  {:example "(repeatedly 3 rand) ; => [0.234 0.892 0.456] (random values)"
+  {:example "(repeatedly 3 rand) ; => @[0.234 0.892 0.456] (random values)"
    :see-also ["repeat" "iterate"]}
   [a & rest]
   (case (count rest)

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -175,7 +175,7 @@
 (defn doctype
   "Returns an HTML doctype declaration for the given type. Supports `:html4`,
   `:xhtml-strict`, `:xhtml-transitional`, and `:html5`. Defaults to `:html5`."
-  {:example "(doctype :html5) ; => \"<!DOCTYPE html>\\n\""
+  {:example "(doctype :html5) ; => (phel.html.raw_string \"<!DOCTYPE html>\\n\")"
    :see-also ["html"]}
   [type]
   (raw-string (get doctypes type (:html5 doctypes))))

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -56,7 +56,7 @@
   `HTTP_X_FORWARDED_PROTO`, `REQUEST_SCHEME`, or `HTTPS`; the path from
   `REQUEST_URI`; and the host/port via the `$_SERVER` host fields. Returns a
   uri struct."
-  {:example "(uri-from-globals) ; => (uri \"https\" nil \"example.com\" 443 \"/path\" \"foo=bar\" nil)"
+  {:example "(uri-from-globals) ; => (phel.http.uri \"https\" nil \"example.com\" 443 \"/path\" \"foo=bar\" nil)"
    :see-also ["uri-from-string" "request-from-globals"]}
   [& [server]]
   (let [server (or server php/$_SERVER)
@@ -81,7 +81,7 @@
 
 (defn uri-from-string
   "Parses a URI string into a uri struct. Handles UTF-8 URLs and IPv6 addresses in brackets. Throws `InvalidArgumentException` on a malformed string."
-  {:example "(uri-from-string \"https://example.com/path?foo=bar\") ; => (uri \"https\" nil \"example.com\" nil \"/path\" \"foo=bar\" nil)"
+  {:example "(uri-from-string \"https://example.com/path?foo=bar\") ; => (phel.http.uri \"https\" nil \"example.com\" nil \"/path\" \"foo=bar\" nil)"
    :see-also ["uri-from-globals" "request-from-map"]}
   [url]
   (let [matches      (php/array)
@@ -238,7 +238,7 @@
   "Extracts a request from args. The optional `raw-body` (the raw request body
   string) is decoded into `:parsed-body` when the `Content-Type` is
   `application/json`; form bodies still come from `post-parameter`."
-  {:example "(request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES (php/file_get_contents \"php://input\")) ; => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"
+  {:example "(request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES (php/file_get_contents \"php://input\")) ; => (phel.http.request \"GET\" (phel.http.uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"
    :see-also ["request-from-globals" "request-from-map"]}
   [server get-parameter post-parameter cookies files & [raw-body]]
   (let [method          (get-method-from-globals server)
@@ -271,7 +271,7 @@
 
 (defn request-from-globals
   "Extracts a request from `$_SERVER`, `$_GET`, `$_POST`, `$_COOKIE`, `$_FILES` and, for JSON requests, the raw request body (`php://input`). Requires a web request context (PHP-FPM, mod_php, or `php -S`); it cannot be used from the REPL or a CLI script - use `request-from-map` for testing."
-  {:example "(request-from-globals) ; => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"
+  {:example "(request-from-globals) ; => (phel.http.request \"GET\" (phel.http.uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"
    :see-also ["request-from-globals-args" "request-from-map"]}
   []
   (request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES
@@ -283,7 +283,7 @@
   `:headers`, `:parsed-body`, `:query-params`, `:cookie-params`,
   `:server-params`, `:uploaded-files`, `:version`, and `:attributes`. Missing
   keys default to nil, `{}`, `[]`, or `\"1.1\"` as appropriate."
-  {:example "(request-from-map {:method \"POST\" :uri \"https://api.example.com/users\"}) ; => (request \"POST\" (uri ...) {} nil {} {} {} [] \"1.1\" {})"
+  {:example "(request-from-map {:method \"POST\" :uri \"https://api.example.com/users\"}) ; => (phel.http.request \"POST\" (phel.http.uri \"https\" nil \"api.example.com\" nil \"/users\" nil nil) {} nil {} {} {} [] \"1.1\" {})"
    :see-also ["request-from-globals" "response-from-map"]}
   [{:method method
     :uri uri
@@ -384,7 +384,7 @@
   "Creates a response struct from a map. Optional keys: `:status` (defaults
   200), `:headers` (`{}`), `:body` (`\"\"`), `:version` (`\"1.1\"`), and
   `:reason` (auto-filled from the HTTP status code when omitted)."
-  {:example "(response-from-map {:status 200 :body \"Hello World\"}) ; => (response 200 {} \"Hello World\" \"1.1\" \"OK\")"
+  {:example "(response-from-map {:status 200 :body \"Hello World\"}) ; => (phel.http.response 200 {} \"Hello World\" \"1.1\" \"OK\")"
    :see-also ["response-from-string" "json-response" "html-response"]}
   [{:status status, :headers headers, :body body, :version version, :reason reason}]
   (let [status  (or status 200)
@@ -397,7 +397,7 @@
 (defn response-from-string
   "Creates a 200 OK response with the given body string. Shorthand for
   `(response-from-map {:body s})`."
-  {:example "(response-from-string \"Hello World\") ; => (response 200 {} \"Hello World\" \"1.1\" \"OK\")"
+  {:example "(response-from-string \"Hello World\") ; => (phel.http.response 200 {} \"Hello World\" \"1.1\" \"OK\")"
    :see-also ["response-from-map" "json-response"]}
   [s]
   (response-from-map {:body s}))
@@ -405,7 +405,7 @@
 (defn json-response
   "Creates a response with `status` and a JSON-encoded `data` body and a
   `Content-Type: application/json` header."
-  {:example "(json-response 200 {:message \"pong\"}) ; => (response 200 {:content-type \"application/json\"} \"{\\\"message\\\":\\\"pong\\\"}\" \"1.1\" \"OK\")"
+  {:example "(json-response 200 {:message \"pong\"}) ; => (phel.http.response 200 {:content-type \"application/json\"} \"{\\\"message\\\":\\\"pong\\\"}\" \"1.1\" \"OK\")"
    :see-also ["response-from-map" "html-response"]}
   [status data]
   (response-from-map
@@ -416,7 +416,7 @@
 (defn html-response
   "Creates a response with `status` and an HTML `body` and a
   `Content-Type: text/html; charset=utf-8` header."
-  {:example "(html-response 200 \"<h1>Hi</h1>\") ; => (response 200 {:content-type \"text/html; charset=utf-8\"} \"<h1>Hi</h1>\" \"1.1\" \"OK\")"
+  {:example "(html-response 200 \"<h1>Hi</h1>\") ; => (phel.http.response 200 {:content-type \"text/html; charset=utf-8\"} \"<h1>Hi</h1>\" \"1.1\" \"OK\")"
    :see-also ["response-from-map" "json-response"]}
   [status body]
   (response-from-map

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -508,7 +508,7 @@ Returns nil. Prints one name per line, sorted alphabetically."
 
   Useful for nREPL and other tooling that needs to separate printed output from
   return values."
-  {:example "(eval-capturing \"(do (println \\\"hello\\\") 42)\") ; => {:value 42 :out \"hello\\n\" :success true :error nil}"
+  {:example "(eval-capturing \"(do (println \\\"hello\\\") 42)\") ; => {:value 42, :out \"hello\\n\", :success true, :error nil}"
    :see-also ["compile-str" "load-file"]}
   [code-str]
   (php/ob_start)

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -1455,7 +1455,7 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
 
 (defn get-stats
   "Returns the current test statistics as a hash-map with :failed and :counts keys."
-  {:example "(get-stats) ; => {:failed [] :counts {:failed 0 :error 0 :pass 0 :total 0}}"}
+  {:example "(get-stats) ; => {:failed [], :skipped [], :counts {:failed 0, :error 0, :pass 0, :skipped 0, :total 0}}"}
   []
   (deref stats))
 

--- a/src/phel/test/gen.phel
+++ b/src/phel/test/gen.phel
@@ -284,7 +284,7 @@
 
 (defn map-of
   "Generator of hash-maps with keys from `kg` and values from `vg`. Number of entries is in `[0, size]`."
-  {:example "((map-of keyword int) 2) ; => {:a 1 :b -3}"}
+  {:example "((map-of keyword int) 2) ; => {:a 1, :b -3}"}
   [kg vg]
   (fn [size]
     (loop [i 0 n (rand-int* 0 (non-negative size)) m {}]
@@ -294,7 +294,7 @@
 
 (defn set-of
   "Generator of hash-sets with elements from `g`. Cardinality in `[0, size]`."
-  {:example "((set-of nat) 3) ; => (set 1 2 3)"}
+  {:example "((set-of nat) 3) ; => #{1 2 3}"}
   [g]
   (fn [size]
     (loop [i 0 n (rand-int* 0 (non-negative size)) s (hash-set)]

--- a/src/phel/walk.phel
+++ b/src/phel/walk.phel
@@ -26,7 +26,7 @@
   "Performs a depth-first, post-order traversal of `form`. Calls `f` on each sub-form, uses `f`'s return value in place of the original. Walks into vectors, lists, hash-maps, and hash-sets."
   {:doc "Bottom-up tree walk — applies f after recursing into children."
    :see-also ["prewalk" "walk" "postwalk-replace"]
-   :example "(postwalk inc [1 [2 3]]) ; => [2 [3 4]]"}
+   :example "(postwalk #(if (int? %) (inc %) %) [1 [2 3]]) ; => [2 [3 4]]"}
   [f form]
   (walk #(postwalk f %) f form))
 

--- a/src/php/Api/Infrastructure/NativeSymbolCatalog.php
+++ b/src/php/Api/Infrastructure/NativeSymbolCatalog.php
@@ -256,7 +256,7 @@ Creates a new hash map. If no argument is provided, an empty hash map is created
             'docUrl' => '/documentation/data-structures/#maps',
             'signatures' => ['(hash-map & xs)'],
             'desc' => 'Creates a new hash map. If no argument is provided, an empty hash map is created. The number of parameters must be even.',
-            'example' => '(hash-map :name "Alice" :age 30) ; => {:name "Alice" :age 30}',
+            'example' => '(hash-map :name "Alice" :age 30) ; => {:name "Alice", :age 30}',
         ],
         Symbol::NAME_NS => [
             'doc' => '```phel
@@ -472,7 +472,7 @@ Values that should be evaluated in a macro are marked with the unquote function.
             'docUrl' => '/documentation/macros/#quasiquote',
             'signatures' => ['(unquote expr)'],
             'desc' => 'Values that should be evaluated in a macro are marked with the unquote function. Shortcut: ,',
-            'example' => '`(+ 1 ,(+ 2 3)) ; => (+ 1 5)',
+            'example' => '`(+ 1 ,(+ 2 3)) ; => (phel.core/+ 1 5)',
         ],
         Symbol::NAME_UNQUOTE_SPLICING => [
             'doc' => '```phel
@@ -483,7 +483,7 @@ Values that should be evaluated in a macro are marked with the unquote function.
             'docUrl' => '/documentation/macros/#quasiquote',
             'signatures' => ['(unquote-splicing expr)'],
             'desc' => 'Values that should be evaluated in a macro are marked with the unquote function. Shortcut: ,@',
-            'example' => '`(+ ,@[1 2 3]) ; => (+ 1 2 3)',
+            'example' => '`(+ ,@[1 2 3]) ; => (phel.core/+ 1 2 3)',
         ],
         Symbol::NAME_USE => [
             'doc' => '```phel

--- a/src/php/Compiler/Application/BestEffortFormReader.php
+++ b/src/php/Compiler/Application/BestEffortFormReader.php
@@ -16,17 +16,8 @@ use Phel\Shared\Parser\Node\TriviaNodeInterface;
 use Throwable;
 
 /**
- * Streams the top-level forms of a source buffer through the front half of the
- * pipeline (lex -> parse -> read), never throwing.
- *
- * Tooling that inspects source it does not control (linter, indexer,
- * completion) has to keep working on a buffer the user is still typing. A
- * broken form must not lose the forms before it, so parse failures stop the
- * stream, read failures skip the offending form, and anything else ends it
- * quietly.
- *
- * Callers that need the failures reported instead of swallowed must drive
- * `lexString`/`parseNext`/`read` themselves.
+ * Backs {@see \Phel\Shared\Facade\CompilerFacadeInterface::readFormsBestEffort()},
+ * which documents the contract and when to prefer the throwing single-stage hooks.
  */
 final readonly class BestEffortFormReader
 {

--- a/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
@@ -80,11 +80,6 @@ final class NodeEnvironment implements NodeEnvironmentInterface
         return isset($this->localsByName[$x->getName()]);
     }
 
-    /**
-     * Gets the shadowed name of a local variable.
-     *
-     * @param Symbol $local The local variable
-     */
     public function getShadowed(Symbol $local): ?Symbol
     {
         if ($this->isShadowed($local)) {

--- a/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironmentInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironmentInterface.php
@@ -16,11 +16,6 @@ interface NodeEnvironmentInterface extends ContextualEnvironmentInterface
 
     public function hasLocal(Symbol $x): bool;
 
-    /**
-     * Gets the shadowed name of a local variable.
-     *
-     * @param Symbol $local The local variable
-     */
     public function getShadowed(Symbol $local): ?Symbol;
 
     public function isShadowed(Symbol $local): bool;

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -144,8 +144,7 @@ final class AnalyzePersistentList
      * character is a PHP identifier character or namespace separator, so
      * operator-style symbols like `php/.`, `..`, `:.`, … are left alone.
      * Source locations are preserved.
-     */
-    /**
+     *
      * @param PersistentListInterface<mixed> $list
      *
      * @return PersistentListInterface<mixed>

--- a/src/php/Lang/Collections/HashSet/TransientHashSetInterface.php
+++ b/src/php/Lang/Collections/HashSet/TransientHashSetInterface.php
@@ -24,12 +24,9 @@ interface TransientHashSetInterface extends Countable, ContainsInterface
     /**
      * Removes $value in place; removing an absent value is a no-op.
      *
-     * Not dead code: `phel.core/disj!` calls this through PHP interop
-     * (`(php/-> tcoll (remove value))` in `src/phel/core/transients.phel`),
-     * dispatching on this interface, so it never appears in a PHP-symbol grep.
-     * It is the transient counterpart of `PersistentHashSetInterface::remove()`,
-     * which `phel.core/disj` reaches the same way. Pinned by
-     * `tests/php/Unit/Lang/Collections/HashSet/TransientHashSetRemoveTest.php`.
+     * Called from Phel through PHP interop by `phel.core/disj!`
+     * (`(php/-> tcoll (remove value))` in `src/phel/core/transients.phel`), so it
+     * has no PHP-side call site to grep for. Do not remove as unused.
      *
      * @param TValue $value
      *

--- a/src/php/Lang/Collections/LazySeq/Chunk.php
+++ b/src/php/Lang/Collections/LazySeq/Chunk.php
@@ -69,8 +69,6 @@ final readonly class Chunk
     }
 
     /**
-     * Returns the first element in this chunk.
-     *
      * @return T|null
      */
     public function first(): mixed
@@ -83,8 +81,6 @@ final readonly class Chunk
     }
 
     /**
-     * Converts this chunk to a PHP array.
-     *
      * @return array<int, T>
      */
     public function toArray(): array

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -56,8 +56,6 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
     }
 
     /**
-     * Creates a LazySeq from a Generator.
-     *
      * @template TValue
      *
      * @param Generator<int, TValue>                    $generator
@@ -126,8 +124,6 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
     }
 
     /**
-     * Creates a LazySeq from any iterable.
-     *
      * @template TValue
      *
      * @param iterable<TValue>                          $iterable
@@ -168,8 +164,6 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
     }
 
     /**
-     * Creates a LazySeq from an array.
-     *
      * @template TValue
      *
      * @param array<int, TValue>                        $array

--- a/src/php/Lang/Collections/LinkedList/PersistentListInterface.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentListInterface.php
@@ -53,13 +53,10 @@ interface PersistentListInterface extends TypeInterface, SeqInterface, IteratorA
      * `list` constructor; false when it was synthesised by `seq` over a
      * non-list collection (see `TypeFactory::persistentSeqListFromArray()`).
      *
-     * Not dead code: `phel.core/list?` calls this through PHP interop
-     * (`(php/-> x (isList))` in `src/phel/core/predicates.phel`), so it never
-     * appears in a PHP-symbol grep. It is the only way to tell a real list from
-     * a seq view, since both are `PersistentListInterface` instances, and it is
-     * deliberately on the interface so third-party implementations answer
-     * `list?` correctly. Pinned by
-     * `tests/php/Unit/Lang/Collections/LinkedList/PersistentListIsListTest.php`.
+     * Called from Phel through PHP interop by `phel.core/list?`
+     * (`(php/-> x (isList))` in `src/phel/core/predicates.phel`), so it has no
+     * PHP-side call site to grep for. Do not remove as unused: it is the only
+     * way to tell a real list from a seq view, since both are instances here.
      */
     public function isList(): bool;
 }

--- a/src/php/Lang/Collections/Vector/PersistentVector.php
+++ b/src/php/Lang/Collections/Vector/PersistentVector.php
@@ -99,9 +99,6 @@ final class PersistentVector extends AbstractPersistentVector
         return new self($this->hasher, $this->equalizer, $meta, $this->count, $this->shift, $this->root, $this->tail);
     }
 
-    /**
-     * Return the number of elements in this vector.
-     */
     public function count(): int
     {
         return max(0, $this->count);

--- a/src/php/Lang/CopyLocationFromTrait.php
+++ b/src/php/Lang/CopyLocationFromTrait.php
@@ -15,11 +15,6 @@ trait CopyLocationFromTrait
 
     abstract public function setEndLocation(?SourceLocation $endLocation): static;
 
-    /**
-     * Copies the start and end location from $other.
-     *
-     * @param mixed $other The object to copy from
-     */
     public function copyLocationFrom(mixed $other): static
     {
         if ($other instanceof SourceLocationInterface) {

--- a/src/php/Lang/FirstInterface.php
+++ b/src/php/Lang/FirstInterface.php
@@ -10,8 +10,6 @@ namespace Phel\Lang;
 interface FirstInterface
 {
     /**
-     * Returns the first value.
-     *
      * @return T|null
      */
     public function first();

--- a/src/php/Lang/IdenticalInterface.php
+++ b/src/php/Lang/IdenticalInterface.php
@@ -6,8 +6,5 @@ namespace Phel\Lang;
 
 interface IdenticalInterface
 {
-    /**
-     * Checks if $other is identical to $this.
-     */
     public function identical(mixed $other): bool;
 }

--- a/src/php/Lang/NamedInterface.php
+++ b/src/php/Lang/NamedInterface.php
@@ -6,14 +6,8 @@ namespace Phel\Lang;
 
 interface NamedInterface
 {
-    /**
-     * Return the name of the object.
-     */
     public function getName(): string;
 
-    /**
-     * Return the namespace of the object.
-     */
     public function getNamespace(): ?string;
 
     /**

--- a/src/php/Nrepl/Domain/Op/OpHandlerInterface.php
+++ b/src/php/Nrepl/Domain/Op/OpHandlerInterface.php
@@ -9,8 +9,6 @@ interface OpHandlerInterface
     public function name(): string;
 
     /**
-     * Handle a single op request.
-     *
      * @return list<OpResponse>
      */
     public function handle(OpRequest $request): array;

--- a/src/php/Shared/Parser/Node/InnerNodeInterface.php
+++ b/src/php/Shared/Parser/Node/InnerNodeInterface.php
@@ -7,8 +7,6 @@ namespace Phel\Shared\Parser\Node;
 interface InnerNodeInterface extends NodeInterface
 {
     /**
-     * Returns all children of this node.
-     *
      * @return list<NodeInterface>
      */
     public function getChildren(): array;

--- a/src/php/Watch/Application/Watcher/AbstractShellWatcher.php
+++ b/src/php/Watch/Application/Watcher/AbstractShellWatcher.php
@@ -126,9 +126,6 @@ abstract class AbstractShellWatcher implements FileWatcherInterface
         $this->close();
     }
 
-    /**
-     * Detect whether the external binary is on PATH.
-     */
     final protected static function binaryIsOnPath(string $binary): bool
     {
         $handle = @popen('command -v ' . escapeshellarg($binary) . ' 2>/dev/null', 'r');

--- a/src/php/Watch/Domain/ClockInterface.php
+++ b/src/php/Watch/Domain/ClockInterface.php
@@ -14,8 +14,5 @@ interface ClockInterface
      */
     public function nowMs(): int;
 
-    /**
-     * Sleep for the given number of milliseconds.
-     */
     public function sleepMs(int $ms): void;
 }


### PR DESCRIPTION
## 🤔 Background

Third pass of the comment/docs audit. The first two passes swept `src/`, `tests/` and the example trees for stale, restating and dead comments. This one covers three areas nobody had audited before — `:example` metadata correctness, `docs/` prose accuracy, and module `CLAUDE.md` accuracy — plus a re-read of the comments the last seven PRs (#2812–#2819) added.

Everything below was checked by **running something**, not by reading:

- `./bin/phel doc -f json` → 956 documented symbols, 786 `:example` blocks, **686 runnable one-liners across 22 namespaces**. Each was `eval`'d in a namespace where its symbol resolves (non-core namespaces got `:refer`-based harnesses, so require-awareness holds) and its `pr-str` diffed against the documented output.
- Every `docs/` claim about a flag, a path, a composer script or an expansion was re-run (`phel <cmd> --help`, `read-string`, `macroexpand`, path existence).
- Every module's `CLAUDE.md` was diffed against its facade's actual public methods.

## 💡 Goal

`:example` metadata is public API documentation: it feeds `phel doc <fn>` and the website API reference. An example whose output Phel never prints is a user-facing documentation bug, and 34 of them were. The `docs/` guides had drifted the same way. Fix both, and trim the handful of genuinely verbose comments the recent PRs added without touching the ones that earn their place.

## 🔖 Changes

### `:example` correctness — 34 real mismatches, verified by evaluation

Clean namespaces (0 mismatches): `string`, `edn`, `base64`, `json`, `reader`, `transit`, `test.rose`, `schema*`, `php`.

- **Sets print `#{…}`, not `(hash-set …)`** — `union`, `intersection`, `difference`, `symmetric-difference`, `select`, `project`, `rename`, `index`, `test.gen/set-of`.
- **Float-returning fns print `2.0`, not `2`** — `ceil`, `floor`, `round`, `sqrt`, `mean`, `double`, `float`, `double-array`, `float-array`, `ai/magnitude`, `ai/cosine-similarity`. The old examples actively misled about the return type.
- **PHP array vs vector** — `subseq`, `rsubseq` and `repeatedly` return a PHP array printed `@[…]`; the examples showed a Phel vector or a seq.
- **Quasiquote namespace-qualifies** — `` `(+ 1 ,(+ 2 3)) `` yields `(phel.core/+ 1 5)`, not `(+ 1 5)`. That is the single most educational fact about quasiquote and the example was hiding it.
- **`phel\http` structs print fully qualified** — `(phel.http.response …)` / `(phel.http.request …)` / `(phel.http.uri …)`, across 7 examples.
- **`phel\html/doctype` returns a struct**, not a string: `(phel.html.raw_string "<!DOCTYPE html>\n")`.
- **`phel\walk/postwalk`'s example threw.** `(postwalk inc [1 [2 3]])` raises `Expected a number, got PersistentVector`, because `postwalk` also visits the inner vectors. Replaced with `(postwalk #(if (int? %) (inc %) %) [1 [2 3]])`, verified to produce `[2 [3 4]]`.
- **Stale shape** — `phel\test/get-stats` gained a `:skipped` list and a `:skipped` count since its example was written.
- Also: `parse-double "Infinity"` prints `Infinity` (not `INF`); `queue` prints `<-(1 2 3)-<` (the example was prose); maps print `,` between pairs (`hash-map`, `array-map`, `repl/eval-capturing`, `test.gen/map-of`).

Left alone deliberately, and reported rather than "fixed": nondeterministic examples (`rand`, `gensym`, `shuffle`, `random-uuid`, `test.gen` generators), examples that use undefined placeholder symbols on purpose (`x`, `a`, `counter`), and `core/list` / `core/quote`, whose leading `'` is a reading aid rather than a claim about printed output.

### `docs/` prose accuracy

- **`internals/faq.md`** claimed "no protocols (use `definterface`), no records (use `defstruct`)". `defprotocol`, `extend-type`, `extend-protocol`, `satisfies?`, `extends?` and `defrecord` all live in `src/phel/core/protocols.phel`.
- **`internals/architecture.md`** claimed `Shared/Printer/` depends on `Lang/` "not the other way". `src/php/Lang/TypeStringifier.php` imports `Phel\Shared\Printer\Printer` — this is the `Lang <-> Shared` cycle that `src/php/CLAUDE.md` documents as deliberate and `ModuleDependencyCycleTest` pins. Also softened "**every** directory under `src/php/` is a Gacela module" (`Lang`, `Shared`, `Config`, `HttpClient` are leaves).
- **`internals/macros.md`**: 4 of 6 rows of the quasiquote rewrite table were wrong. Verified with `read-string`: `` `(a b) `` → `(apply list (concat (list (quote a)) (list (quote b))))`, not `(list (quote a) (quote b))`. Also, macro-ness is metadata read by `DefSymbol` and stored in `Registry`; the page said an `Atom` carries it.
- **`internals/special-forms.md`**: dispatch is a lazily-built `specialFormFactories()` closure map memoized in `$symbolAnalyzerCache`, not the inline `match ($symbolName) { … => new DefSymbol(…) }` the page showed. "Adding one" step 4 updated to match, and `specialFormNames()` noted as the enumerable source of truth.
- **`internals/cli-flag-conventions.md`**: `-O`/`--optimization-level` was documented for `build`/`compile`; `phel compile --help` has only `-t/--target`. Also noted that `phel ns -s` is `--simple`, which the "`-s` = sort" reservation did not cover.
- **`cli-reference.md`**: the table introduced as "every `phel` command" omitted `completion` (referenced two paragraphs above it) and `cache:warm`.
- **`internals/compiler.md`**: added `readFormsBestEffort()` to the facade entry points — it was added by the very PR set under audit and is aimed at exactly the LSP/nREPL/linter callers the list names.
- **`migration/removed-deprecated-core-fns.md`**: 10 lines inside ```phel fences used `#` for comments. The convention is `;`, and `#` line comments are lexer-deprecated.

### Comments added by the last seven PRs

The great majority earn their place and are untouched — the `json` empty-map/`stdClass` note, the HTML void-element rule, the `phel/comment-style` token-stream rationale, the `LazySeq` raw-value caching note, the `FormatResult` two-bucket contract, the `DataReadersLoadException` opt-in reasoning, and the 20-line "three properties, each pinned by a test" block in `Phel::readAppModulePaths()` (verbose, but every numbered point is an independently checkable invariant). Only these were trimmed:

- Two 7-and-8-line "not dead code, called via interop" notes (`TransientHashSetInterface::remove()`, `PersistentListInterface::isList()`) reduced to the 3 lines that inform. The interop pointer stays; "it is the transient counterpart of X", "deliberately on the interface", and "Pinned by `<test file>`" do not.
- `BestEffortFormReader`'s class docblock repeated its facade method's docblock almost verbatim (a third condensed copy is in `Compiler/CLAUDE.md`). It now points at the interface, which is where consumers read the contract.
- **`AnalyzePersistentList::expandConstructorShorthand()` had two consecutive `/** … */` blocks.** PHP and every IDE associate only the second, so the whole prose explanation of the `(ClassName. args)` shorthand was an orphaned comment nothing displayed. Merged.
- `phel.core/list?`'s 4-line note trimmed to the 2 lines that say something the code does not.

### Marginal docblocks

Removed 16 one-line docblocks that only restate the method name (`Returns the first element in this chunk`, `Return the number of elements in this vector`, `Sleep for the given number of milliseconds`, …), keeping every `@return`, `@template` and `@param` that PHPStan L9 / Psalm L1 consume. Kept the ones that add a fact the name does not: `getFullName()` ("namespace **and** name"), `nowMs()` ("since the Unix epoch"), `getPhelFunctions()` ("**public**"), `getAllPhelDirectories()` ("src, tests **and vendor**"), `getCode()` ("**concatenates**"), `renderTable()` ("**ASCII**").

### Module `CLAUDE.md` — audited, no changes needed

Every `src/php/<Module>/CLAUDE.md` was diffed against its facade's actual public methods: no facade method is undocumented and no documented facade method has disappeared. The six recent structural changes are all correctly reflected — the five removed facade passthroughs (`Lsp`, `Nrepl`, `Watch`), `CompilerFacade::readFormsBestEffort()`, `Shared\Formatter\FormatResult`, and `Shared\PhelProjectDirectory::resolveCacheDir()`. `Formatter/CLAUDE.md`'s indenter symbol lists were spot-checked against `FormatterFactory::INNER_INDENT_SYMBOLS` / `BLOCK_INDENT_SYMBOLS` and match exactly.

### 🐛 Two runtime bugs the audit surfaced — reported, **not** fixed here

Both need a code change plus a test, so they belong in their own PR rather than a documentation one:

1. **`phel\repl/compile-str` throws on every call.** `src/phel/repl.phel:216` calls `(php/-> res (getCode))`; `Phel\Compiler\Domain\Emitter\EmitterResult` has `getPhpCode()` / `getSourceMap()` / `getCodeWithSourceMap()` but no `getCode()`. Its example is doubly wrong: even with the method name corrected, `(compile-str "(+ 1 2)")` returns `""`, because a pure top-level value is discarded in statement context (documented in `phel compile --help`). It needs a working example written against whatever the fixed behaviour is.
2. **`reduce` over an `Eduction` throws** — `(reduce + (eduction (map inc) (filter odd?) [1 2 3 4]))`, which is `core/eduction`'s own example, raises `Object of class Phel\Lang\Eduction could not be converted to string`. `(into [] (eduction …))` works, so the eduction is fine and `reduce`'s dispatch is the gap. The example is left as-is because it documents the intended behaviour.

### Scope

The `src/php/` diff is comment-only, mechanically verified: every changed line is a `//`, `/**`, `*` or `*/` line, except three `'example' => '…'` string literals in `NativeSymbolCatalog`, which are documentation data feeding `phel doc` (it shadows the `.phel` metadata for `hash-map`, `unquote` and `unquote-splicing`). The `src/phel/` diff touches only `:example` strings and one `;;` comment. No behaviour changes.

Verified: `composer phpstan` (L9, 0 errors), `composer psalm` (L1, 0 errors), `composer csrun`, `composer rector`, `phpunit --testsuite=unit,integration` (5189 tests), `composer test-core` (6488 tests).
