### PR TITLE
feat: give every deprecation a discoverable, consistent signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - New `phel lint` rule `phel/comment-style` (warning, on by default): flags a whole-line comment written with a single `;`, which the convention reserves for comments trailing code on the same line
+- Any `def`/`defn` carrying `:deprecated` metadata now warns at every call site when deprecation warnings are enabled (`--warn-deprecations`, `PHEL_WARN_DEPRECATIONS=1`, or `withWarnDeprecations(true)`). Works for project code too: `^{:deprecated "1.4.0" :superseded-by "new-fn"}` puts your own consumers on a migration path. Notices are deduplicated per `(file, symbol)` pair and suppressed inside phel's bundled stdlib
+- `^:reference` (the historical spelling of the `^:by-ref` fn-param hint) now emits a deprecation notice pointing at `^:by-ref`. It was the one deprecated construct with no user-visible signal at all
+- New [migration guide for the currently deprecated surface](docs/migration/deprecated-surface.md): every live deprecation, its replacement, a mechanical before/after, and how it announces itself
 
 ### Fixed
 
@@ -28,6 +31,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - **BREAKING** (PHP API): the four unrelated module interfaces all named `FileIoInterface` are renamed after what each one actually does, so an import no longer needs its namespace read to be understood: `Phel\Filesystem\Domain\FileIoInterface` → `DirectoryWritabilityCheckerInterface`, `Phel\Build\Domain\IO\FileIoInterface` → `FileContentsIoInterface`, `Phel\Formatter\Domain\IO\FileIoInterface` → `ValidatedFileIoInterface`, `Phel\Interop\Domain\FileCreator\FileIoInterface` → `FileWriterInterface`. Method signatures are unchanged; the interfaces stay four separate contracts and were not merged
+- `phel\test/print-summary` is now marked deprecated: `run-tests` already emits the `:summary` event at the end of a run, so calling it yourself double-reports. The test runner no longer routes through it internally. React to the `:summary` event in a custom reporter instead
+- Every deprecation notice the compiler raises now goes through one switch, one message factory, and one dedup table (`Phel\Compiler\Domain\Deprecation\DeprecationWarnings`). Syntax notices share a single message shape, so they read identically and cannot drift back into naming a concrete removal version, and `BackslashSeparatorDeprecator` no longer carries a second enabled flag or a second bundled-stdlib check
 - Documented 60+ previously-undocumented public core functions with runnable `:example`/`:see-also` metadata — threading macros, set/sequence helpers, transducer & volatile primitives, binding & protocol macros, exception/sequence accessors, and assorted predicates — and fixed a malformed `juxt` example
 - (PHP API) The sub-parsers and sub-readers under `Phel\Compiler\Domain\{Parser,Reader}\Expression*` now depend on `ParserInterface`/`ReaderInterface` instead of the concrete `Phel\Compiler\Application\{Parser,Reader}`, so the compiler's `Domain` layer no longer reaches out into `Application`. Both interfaces gain the `readExpression()` method the recursion goes through; the shipped implementations already had it
 - (PHP API) `Phel\Build\Infrastructure\Cache\NullScanIndexCache` moved to `Phel\Build\Domain\Cache\NullScanIndexCache`, and `Phel\Lsp\Domain\HandlerInterface` moved to `Phel\Lsp\Application\HandlerInterface`. Both now sit in the layer that matches what they depend on; behaviour is unchanged

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ modules, deployment) live on **[phel-lang.org](https://phel-lang.org/documentati
 - [Project Layout](project-layout.md): the `.phel/` directory and runtime state
 - [Internals](internals/README.md): architecture, compiler phases, AST, emitter,
   macros, runtime, FAQ, benchmarks
+- [Migration: the currently deprecated surface](migration/deprecated-surface.md): every live deprecation, its replacement, and how it announces itself
 - [Migration: backslash to dot](migration/backslash-to-dot.md)
 - [Migration: removed deprecated core functions](migration/removed-deprecated-core-fns.md)
 - [Examples](examples/README.md): runnable single-file samples

--- a/docs/migration/backslash-to-dot.md
+++ b/docs/migration/backslash-to-dot.md
@@ -30,6 +30,8 @@ return PhelConfig::forProject()
 
 When enabled, the compiler emits one `E_USER_DEPRECATED` per unique `(file, symbol)` pair, so large projects do not drown in duplicates. `--warn-deprecations` is consumed by the `phel` bootstrap before Symfony's per-command parsers run, so it works with every subcommand.
 
+The same switch turns on every other opt-in deprecation detector, notably the call-site warnings for definitions carrying `:deprecated` metadata. See [deprecated-surface.md](deprecated-surface.md) for the full list.
+
 ## What is detected today
 
 Symbols flowing through the analyzer's `SymbolResolver` or the `ns`-form analyzer emit warnings:

--- a/docs/migration/deprecated-surface.md
+++ b/docs/migration/deprecated-surface.md
@@ -1,0 +1,180 @@
+# Migration: The Currently Deprecated Surface
+
+Everything below still works today. Everything below is scheduled for removal in
+a future major release. This page is the single map of that surface: what the
+item is, what replaces it, and the mechanical before/after.
+
+Two related pages cover migrations that already finished:
+
+- [Removed deprecated core functions](removed-deprecated-core-fns.md)
+- [Backslash namespace separator to dot](backslash-to-dot.md) (deep dive on the
+  one item below with its own tracking issue)
+
+## How a deprecation announces itself
+
+Everything the **compiler** knows about, syntax and definitions alike, goes
+through one switch: `Phel\Compiler\Domain\Deprecation\DeprecationWarnings`. It
+is off by default and reports when you ask for it.
+
+CLI-option deprecations are the one thing outside it: they always print a
+one-line notice on stderr through `Phel\Shared\Console\DeprecatedOptionWarner`,
+because a renamed flag is a single unmissable event rather than something
+scattered through your source.
+
+Turn compiler deprecation warnings on with any of:
+
+```bash
+vendor/bin/phel run --warn-deprecations src/main.phel
+PHEL_WARN_DEPRECATIONS=1 vendor/bin/phel test
+```
+
+```php
+return PhelConfig::forProject()->withWarnDeprecations(true);
+```
+
+Uses inside phel's own bundled stdlib are suppressed, so the output lists only
+code you own. Notices about a *definition* or a `\`-separated symbol are
+deduplicated per `(file, subject)` pair, since one name can recur hundreds of
+times in a file. Syntax notices are not deduplicated: each occurrence is a
+separate edit you have to make.
+
+Deprecation messages never name a concrete removal version on purpose: the
+release such a message promises inevitably ships and the text goes stale.
+
+## Reader syntax
+
+| Deprecated | Replacement |
+|---|---|
+| `#\| ... \|#` multiline comment | `;;` line comments, or `#_` to skip one form |
+| `#` line comment | `;` (trailing) / `;;` (whole line) |
+| `\|(...)` short fn | `#(...)` |
+| `,` unquote | `~` |
+| `,@` unquote-splicing | `~@` |
+| `foo$` auto-gensym | `foo#` |
+
+```phel
+# old line comment                    ;; new line comment
+
+#|
+  old block comment
+|#
+;; new block comment, one `;;` per line
+;; (or `#_` in front of a single form to skip it)
+
+(map |(+ $ 1) xs)                     (map #(+ % 1) xs)
+
+`(let [x ,init] ,@body)               `(let [x ~init] ~@body)
+
+`(let [acc$ 0] ,@body)                `(let [acc# 0] ~@body)
+```
+
+Note that `|()` uses `$`/`$1` for its arguments while `#()` uses `%`/`%1`, so
+converting a short fn means renaming its parameters too. `,` is optional
+whitespace *outside* a quasiquote, and stays that way: only `,` inside a
+`` ` `` form is the deprecated unquote.
+
+## Namespace separator
+
+`\` still parses as a namespace separator; `.` is the target form.
+
+```phel
+(ns my-app\core                       (ns my-app.core
+  (:require phel\string :as s))         (:require phel.string :as s))
+
+(phel\core/map inc xs)                (phel.core/map inc xs)
+\Phel\Lang\ExceptionInfo              Phel.Lang.ExceptionInfo
+```
+
+Full detail, including what is and is not detected today, is in
+[backslash-to-dot.md](backslash-to-dot.md). Tracked in
+[#1567](https://github.com/phel-lang/phel-lang/issues/1567).
+
+## Function-parameter metadata
+
+`^:reference` marks a by-reference parameter. `^:by-ref` is the canonical
+spelling and the two are exactly equivalent.
+
+```phel
+(defn fill [^:reference buffer]       (defn fill [^:by-ref buffer]
+  (php/array_push buffer 1))            (php/array_push buffer 1))
+```
+
+## Core library
+
+### `set-meta!`
+
+A thin alias for `with-meta`, deprecated since `0.32.0`. Same arguments, same
+return value.
+
+```phel
+(set-meta! [] {:a 1})                 (with-meta [] {:a 1})
+```
+
+`(doc set-meta!)` and `phel doc set-meta!` also print a `DEPRECATED:` line, with
+or without the flag.
+
+### `phel\test/print-summary`
+
+`run-tests` already emits the `:summary` event at the end of a run, so calling
+`print-summary` yourself double-reports. Custom reporters should react to the
+`:summary` event instead of triggering it.
+
+```phel
+(t/run-tests {} 'my-app.core-test)    (t/run-tests {} 'my-app.core-test)
+(t/print-summary)                     ;; nothing else needed
+```
+
+If a test *harness* needs a summary for stats it assembled itself, keep reading
+the stats atom and fan out its own event rather than calling `print-summary`.
+
+`(doc print-summary)` also prints a `DEPRECATED:` line, with or without the flag.
+
+## CLI options
+
+| Deprecated | Replacement |
+|---|---|
+| `phel index --out=PATH` | `phel index --output=PATH` (`-o`) |
+| `phel config --json` | `phel config --format=json` (`-f json`) |
+
+```bash
+phel index --out=index.json           phel index --output=index.json
+phel config --json                    phel config --format=json
+```
+
+Both old spellings still work and print a one-line notice on stderr, so a
+pipeline consuming stdout is unaffected. The conventions these were aligned to
+are in [../internals/cli-flag-conventions.md](../internals/cli-flag-conventions.md).
+
+## Project layout
+
+The REPL history file moved from `<project>/.phel-repl-history` to
+`<project>/.phel/repl-history`, alongside the rest of the runtime state (see
+[../project-layout.md](../project-layout.md)).
+
+Nothing to do: the first REPL start after upgrading moves the file and prints
+one notice. Set `PHEL_QUIET_MIGRATION=1` to silence it. What does need updating
+is anything that names the old path literally, typically a `.gitignore` entry
+or a CI cache key:
+
+```gitignore
+.phel-repl-history                    .phel/
+```
+
+## Deprecating your own definitions
+
+The mechanism is not phel-specific. Any `def`/`defn` carrying
+`:deprecated` metadata warns at every call site once warnings are enabled, so
+a library can put its consumers on the same migration path:
+
+```phel
+(defn old-parse
+  "Parses a config string."
+  {:deprecated "1.4.0"
+   :superseded-by "parse-config"}
+  [s]
+  (parse-config s))
+```
+
+`:deprecated` accepts a version string (rendered as "since 1.4.0"), any other
+string (rendered verbatim as the reason), or `true`. `:superseded-by` is
+optional and names the replacement. Both keys also show up in `phel doc`.

--- a/docs/migration/removed-deprecated-core-fns.md
+++ b/docs/migration/removed-deprecated-core-fns.md
@@ -42,3 +42,5 @@ The replacement keeps the same signature:
 ## Still deprecated (not removed)
 
 `set-meta!` (use `with-meta`) remains available but deprecated; it is intentionally out of scope for this removal. The `warn-deprecations` infrastructure also stays, since it still serves live deprecations such as the `\` namespace separator (see [backslash-to-dot.md](backslash-to-dot.md)).
+
+[deprecated-surface.md](deprecated-surface.md) maps the whole set of deprecations that are still shipped, with a before/after for each.

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -1095,11 +1095,19 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
      :skipped (or skipped 0)
      :total total}))
 
-(defn print-summary
-  "Emits the `:summary` event to the active reporter set. Kept for backwards compatibility; prefer letting `run-tests` emit the event at the end of the run."
-  {:example "(print-summary)"}
+(defn- emit-summary!
+  "Emits the `:summary` event for the current stats to the active reporter set."
   []
   (fan-out! (summary-event (deref stats))))
+
+(defn print-summary
+  "Emits the `:summary` event to the active reporter set. Deprecated: `run-tests` already emits the event at the end of a run, so calling this yourself double-reports."
+  {:deprecated "run-tests already emits the :summary event at the end of a run"
+   :superseded-by "run-tests"
+   :see-also ["run-tests"]
+   :example "(print-summary)"}
+  []
+  (emit-summary!))
 
 ;; --------
 ;; Fixtures
@@ -1416,7 +1424,7 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
   (dofor [namespace :in namespaces
           :when (not (should-stop?))]
     (run-one-ns! options namespace))
-  (print-summary)
+  (emit-summary!)
   (print-slowest! options)
   (when-let [path (:last-failed-file options)]
     (write-last-failed! path)))

--- a/src/php/Compiler/Application/Lexer.php
+++ b/src/php/Compiler/Application/Lexer.php
@@ -14,7 +14,6 @@ use Phel\Shared\Parser\Node\Token;
 
 use function count;
 use function mb_strlen;
-use function sprintf;
 use function strlen;
 
 final class Lexer implements LexerInterface
@@ -131,7 +130,12 @@ final class Lexer implements LexerInterface
                 $endLocation = $this->createSourceLocation($source);
 
                 if ($warnDeprecations) {
-                    DeprecationWarnings::warn(sprintf('"#| ... |#" multiline comments are deprecated and will be removed in a future release. Use ";;" for line comments or "#_" to skip a single form (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()));
+                    DeprecationWarnings::warn(DeprecationWarnings::syntaxMessage(
+                        '"#| ... |#"',
+                        'multiline comments',
+                        '";;" or "#_"',
+                        $startLocation,
+                    ));
                 }
 
                 yield new Token(Token::T_COMMENT, $comment, $startLocation, $endLocation);
@@ -146,21 +150,7 @@ final class Lexer implements LexerInterface
                 $tokenType = count($matches);
 
                 if ($warnDeprecations && isset(self::DEPRECATABLE_TYPES[$tokenType])) {
-                    if ($tokenType === Token::T_COMMENT && str_starts_with($matches[0], '#')) {
-                        DeprecationWarnings::warn(sprintf('Bare "#" line comments are deprecated and will be removed in a future release. Use ";" or ";;" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()));
-                    }
-
-                    if ($tokenType === Token::T_FN) {
-                        DeprecationWarnings::warn(sprintf('Using "|()" for short functions is deprecated, use "#()" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()));
-                    }
-
-                    if ($tokenType === Token::T_UNQUOTE_SPLICING && $matches[0] === ',@') {
-                        DeprecationWarnings::warn(sprintf('Using "," for unquote-splicing is deprecated, use "~@" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()));
-                    }
-
-                    if ($tokenType === Token::T_UNQUOTE && $matches[0] === ',') {
-                        DeprecationWarnings::warn(sprintf('Using "," for unquote is deprecated, use "~" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()));
-                    }
+                    $this->warnDeprecatedToken($tokenType, $matches[0], $startLocation);
                 }
 
                 yield new Token($tokenType, $matches[0], $startLocation, $endLocation);
@@ -172,6 +162,44 @@ final class Lexer implements LexerInterface
         }
 
         yield new Token(Token::T_EOF, '', $startLocation, $startLocation);
+    }
+
+    /**
+     * Only reached when the source-level gate already passed and the token is
+     * one of the four {@see self::DEPRECATABLE_TYPES}; every other token skips
+     * this call entirely.
+     */
+    private function warnDeprecatedToken(int $tokenType, string $lexeme, SourceLocation $location): void
+    {
+        if ($tokenType === Token::T_COMMENT && str_starts_with($lexeme, '#')) {
+            DeprecationWarnings::warn(
+                DeprecationWarnings::syntaxMessage('"#"', 'line comments', '";" or ";;"', $location),
+            );
+
+            return;
+        }
+
+        if ($tokenType === Token::T_FN) {
+            DeprecationWarnings::warn(
+                DeprecationWarnings::syntaxMessage('"|()"', 'short functions', '"#()"', $location),
+            );
+
+            return;
+        }
+
+        if ($tokenType === Token::T_UNQUOTE_SPLICING && $lexeme === ',@') {
+            DeprecationWarnings::warn(
+                DeprecationWarnings::syntaxMessage('","', 'unquote-splicing', '"~@"', $location),
+            );
+
+            return;
+        }
+
+        if ($tokenType === Token::T_UNQUOTE && $lexeme === ',') {
+            DeprecationWarnings::warn(
+                DeprecationWarnings::syntaxMessage('","', 'unquote', '"~"', $location),
+            );
+        }
     }
 
     private function moveCursor(string $str): void

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -107,13 +107,25 @@ GOTCHA: only eager core fns can be lowered to a native loop. `reduce` (3-arity) 
 - `^:php/override` on a method (defstruct/defenum interface impls, definterface methods) → `#[\Override]` (PHP 8.3); `PhpAttributeEmitterTrait::phpAttributeLines` renders it ahead of explicit `:php/attr` lines. Struct/enum inline method impls emit method-level `:php/attr`/`:php/doc`/`^:php/override` too.
 - Export wrappers carry the same `:php/attr` via `Interop`'s `CompiledPhpMethodBuilder` (see `src/php/Interop/CLAUDE.md`).
 
-## Syntax Deprecations
+## Deprecation Warnings
 
-`Domain/Deprecation/DeprecationWarnings` is the single process-wide switch for every `E_USER_DEPRECATED` notice the compiler raises about deprecated Phel syntax. Off by default; turned on by `--warn-deprecations` (`Console\Application\WarnDeprecationsFlag`), `PHEL_WARN_DEPRECATIONS`, or the `warn-deprecations` config key (`CompilerFactory::createAnalyzer()`).
+`Domain/Deprecation/DeprecationWarnings` is the single process-wide switch for every `E_USER_DEPRECATED` notice the compiler raises, syntax and definition alike. Off by default; turned on by `--warn-deprecations` (`Console\Application\WarnDeprecationsFlag`), `PHEL_WARN_DEPRECATIONS`, or the `warn-deprecations` config key (`CompilerFactory::createAnalyzer()`). It owns four things so no detector re-implements them: the enabled flag, the bundled-stdlib suppression, the `(file, subject)` dedup, and the syntax message shape.
 
-- Emitters: `Application/Lexer` (bare `#` comments, `#| ... |#` blocks, `|()` short fns, `,`/`,@` unquote), `Domain/Reader/QuasiquoteTransformer` (`$` auto-gensym), `Domain/Analyzer/Environment/BackslashSeparatorDeprecator` (`\` namespace separator).
-- Never suppress one with `@`: that hides it unconditionally, so a `--warn-deprecations` run prints nothing. Call `warn()`/`warnForSource()` instead.
-- `isEnabledForSource()`/`isBundledStdlibSource()` drop notices whose source is phel's own `src/phel` or has no file, so only code the user can edit is flagged. The Lexer resolves it once per source, not per token.
+Detectors detect and nothing else — they hold no flag, no dedup table, and no emitter, so there is exactly one gate and one place to enable:
+
+| Detector | Catches |
+|---|---|
+| `Application/Lexer` | bare `#` comments, `#\| ... \|#` blocks, `\|()` short fns, `,`/`,@` unquote |
+| `Domain/Reader/QuasiquoteTransformer` | `$` auto-gensym |
+| `Domain/Emitter/.../NodeEmitter/MethodEmitter` | `^:reference` fn params |
+| `Domain/Analyzer/Environment/BackslashSeparatorDeprecator` | `\` namespace separator |
+| `Domain/Analyzer/Environment/DeprecatedDefinitionWarner` | any resolved definition whose meta carries `:deprecated` (`:superseded-by` names the replacement); works for project code too |
+
+- Never suppress a notice with `@`: that hides it unconditionally, so a `--warn-deprecations` run prints nothing. Call `warn()` / `warnForSource()` / `warnOnceForSource()` / `warnSyntax()` instead.
+- `syntaxMessage()` is the only way to phrase a syntax notice. It has nowhere to put a concrete removal version, which is the point: a named release ships and the message goes stale (#2783). `LexerTest::VERSION_REFERENCE` still guards it.
+- `warnOnceForSource()` dedups per `(file, subject)` — used where one subject recurs across a file (a deprecated definition, a `\`-separated symbol). Syntax notices deliberately do not dedup: each occurrence is a separate edit.
+- `isEnabledForSource()` / `isBundledStdlibSource()` drop notices whose source is phel's own `src/phel` or has no file, so only code the user can edit is flagged. The Lexer resolves it once per source, not per token.
+- `SymbolResolver::globalVarNode()` is the single `GlobalVarNode` construction point, so every resolved definition passes the `:deprecated` check exactly once. `GlobalEnvironment` injects both analyzer detectors into it.
 
 ## Global Environment
 

--- a/src/php/Compiler/CompilerFactory.php
+++ b/src/php/Compiler/CompilerFactory.php
@@ -18,7 +18,6 @@ use Phel\Compiler\Application\ParenthesesChecker;
 use Phel\Compiler\Application\Parser;
 use Phel\Compiler\Application\Reader;
 use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
-use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
 use Phel\Compiler\Domain\Cache\ReaderResultCacheInterface;
 use Phel\Compiler\Domain\Compiler\CodeCompilerInterface;
@@ -251,11 +250,11 @@ final class CompilerFactory extends AbstractFactory
 
     /**
      * Applies the `warn-deprecations` config key to the process-wide
-     * deprecation switches, which the lexer and reader also read. Hooked
-     * here rather than on `createLexer()` because every compile pipeline
-     * builds its analyzer up front, before a single token is lexed, and
-     * the lexer-only consumers (linting, best-effort form reading) are
-     * tooling paths that must stay quiet.
+     * deprecation switch, which the lexer, reader and analyzer all read.
+     * Hooked here rather than on `createLexer()` because every compile
+     * pipeline builds its analyzer up front, before a single token is
+     * lexed, and the lexer-only consumers (linting, best-effort form
+     * reading) are tooling paths that must stay quiet.
      */
     private function enableConfiguredDeprecationWarnings(): void
     {
@@ -264,6 +263,5 @@ final class CompilerFactory extends AbstractFactory
         }
 
         DeprecationWarnings::enable();
-        BackslashSeparatorDeprecator::enable();
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
@@ -11,15 +11,15 @@ use Phel\Lang\Symbol;
 use function sprintf;
 use function str_replace;
 use function str_starts_with;
-use function trigger_error;
-
-use const E_USER_DEPRECATED;
 
 /**
- * Emits `E_USER_DEPRECATED` warnings when user code uses `\` as the
- * namespace separator (e.g. `phel\core/map`, `\Phel\Lang\Foo`) so the
- * codebase can migrate to Clojure-compatible dot syntax ahead of the
- * backslash form being removed.
+ * Detects `\` used as the namespace separator (e.g. `phel\core/map`,
+ * `\Phel\Lang\Foo`) so the codebase can migrate to Clojure-compatible dot
+ * syntax ahead of the backslash form being removed.
+ *
+ * Detection only: the enabled gate, the bundled-stdlib suppression, and the
+ * per-`(file, symbol)` dedup all belong to {@see DeprecationWarnings}, which
+ * is why this class is stateless.
  *
  * Scope of detection is intentionally narrow: only symbols that pass
  * through `SymbolResolver::resolve()` — call sites and qualified refs.
@@ -30,52 +30,13 @@ final class BackslashSeparatorDeprecator
 {
     private static ?self $instance = null;
 
-    /** @var array<string, true> */
-    private array $seen = [];
-
-    /** @var callable(string): void */
-    private $emitter;
-
-    public function __construct(
-        private readonly bool $enabled,
-        ?callable $emitter = null,
-    ) {
-        $this->emitter = $emitter ?? static function (string $msg): void {
-            trigger_error($msg, E_USER_DEPRECATED);
-        };
-    }
-
     /**
-     * Returns the process-wide deprecator, creating it lazily from the
-     * shared {@see DeprecationWarnings} switch so every detection site
-     * shares the same dedup state across a compile run.
+     * Shared instance. Stateless, so it exists only to spare the analyzer a
+     * per-resolution allocation; there is nothing to reset between runs.
      */
     public static function getInstance(): self
     {
-        return self::$instance ??= new self(DeprecationWarnings::isEnabled());
-    }
-
-    /**
-     * Replace the singleton with a preconfigured instance — used by tests
-     * that need to assert on captured messages or flip the enabled flag.
-     */
-    public static function useInstance(self $instance): void
-    {
-        self::$instance = $instance;
-    }
-
-    public static function enable(): void
-    {
-        self::$instance = new self(true);
-    }
-
-    /**
-     * Drop the cached singleton so the next `getInstance()` call re-reads
-     * the environment. Intended for test `tearDown()` hooks.
-     */
-    public static function resetInstance(): void
-    {
-        self::$instance = null;
+        return self::$instance ??= new self();
     }
 
     public function maybeWarn(Symbol $symbol): void
@@ -90,12 +51,7 @@ final class BackslashSeparatorDeprecator
 
     public function maybeWarnString(string $namespace, SourceLocation $location): void
     {
-        if (!$this->enabled) {
-            return;
-        }
-
-        $file = $location->getFile();
-        if ($file === '' || DeprecationWarnings::isBundledStdlibSource($file)) {
+        if (!DeprecationWarnings::isEnabled()) {
             return;
         }
 
@@ -103,13 +59,12 @@ final class BackslashSeparatorDeprecator
             return;
         }
 
-        $key = $file . '|' . $namespace;
-        if (isset($this->seen[$key])) {
-            return;
-        }
-
-        $this->seen[$key] = true;
-        ($this->emitter)($this->buildMessage($namespace, $file, $location->getLine()));
+        $file = $location->getFile();
+        DeprecationWarnings::warnOnceForSource(
+            $file,
+            $namespace,
+            $this->buildMessage($namespace, $file, $location->getLine()),
+        );
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/Environment/DeprecatedDefinitionWarner.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/DeprecatedDefinitionWarner.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Environment;
+
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+
+use function is_string;
+use function sprintf;
+
+/**
+ * Detects a *call site* of a definition whose metadata carries
+ * `:deprecated`, so a deprecated `def`/`defn` announces itself instead of
+ * being discoverable only through `(doc ...)`.
+ *
+ * This is the generic mechanism behind every definition-level deprecation:
+ * marking a definition is enough, no bespoke detector is needed. It works for
+ * project code too — `^{:deprecated "1.4.0" :superseded-by "new-fn"}` on a
+ * user `defn` warns at every call site.
+ *
+ * Recognised metadata keys:
+ *
+ * - `:deprecated` — required. A version string (`"0.32.0"`) is rendered as
+ *   "since <version>"; any other string is rendered verbatim as the reason;
+ *   `true` marks it deprecated with no further detail.
+ * - `:superseded-by` — optional replacement name, rendered as "use X instead".
+ *
+ * Detection only: the enabled gate, the bundled-stdlib suppression, and the
+ * per-`(file, symbol)` dedup belong to {@see DeprecationWarnings}.
+ */
+final class DeprecatedDefinitionWarner
+{
+    private const string VERSION_PATTERN = '/^\d+\.\d+(\.\d+)?$/';
+
+    private static ?self $instance = null;
+
+    /**
+     * Shared instance. Stateless, so it exists only to spare the analyzer a
+     * per-resolution allocation; there is nothing to reset between runs.
+     */
+    public static function getInstance(): self
+    {
+        return self::$instance ??= new self();
+    }
+
+    /**
+     * @param PersistentMapInterface<mixed, mixed> $definitionMeta the `def` metadata of the resolved definition
+     */
+    public function maybeWarn(string $ns, Symbol $name, PersistentMapInterface $definitionMeta): void
+    {
+        if (!DeprecationWarnings::isEnabled()) {
+            return;
+        }
+
+        $deprecated = $definitionMeta->find(Keyword::create('deprecated'));
+        if ($deprecated === null || $deprecated === false) {
+            return;
+        }
+
+        $location = $name->getStartLocation();
+        if (!$location instanceof SourceLocation) {
+            return;
+        }
+
+        $fullName = $ns . '/' . $name->getName();
+        DeprecationWarnings::warnOnceForSource(
+            $location->getFile(),
+            $fullName,
+            $this->buildMessage($fullName, $location, $deprecated, $definitionMeta),
+        );
+    }
+
+    /**
+     * @param PersistentMapInterface<mixed, mixed> $definitionMeta
+     */
+    private function buildMessage(
+        string $fullName,
+        SourceLocation $location,
+        mixed $deprecated,
+        PersistentMapInterface $definitionMeta,
+    ): string {
+        return sprintf(
+            "Definition '%s' used at %s:%d is deprecated%s.%s It will be removed in a future release.",
+            $fullName,
+            $location->getFile(),
+            $location->getLine(),
+            $this->detail($deprecated),
+            $this->replacement($definitionMeta),
+        );
+    }
+
+    private function detail(mixed $deprecated): string
+    {
+        if (!is_string($deprecated) || $deprecated === '') {
+            return '';
+        }
+
+        return preg_match(self::VERSION_PATTERN, $deprecated) === 1
+            ? sprintf(' (since %s)', $deprecated)
+            : sprintf(': %s', $deprecated);
+    }
+
+    /**
+     * @param PersistentMapInterface<mixed, mixed> $definitionMeta
+     */
+    private function replacement(PersistentMapInterface $definitionMeta): string
+    {
+        $supersededBy = $definitionMeta->find(Keyword::create('superseded-by'));
+
+        if (!is_string($supersededBy) || $supersededBy === '') {
+            return '';
+        }
+
+        return sprintf(" Use '%s' instead.", $supersededBy);
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -71,6 +71,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
             $this,
             new MagicConstantResolver(),
             BackslashSeparatorDeprecator::getInstance(),
+            DeprecatedDefinitionWarner::getInstance(),
         );
         $this->addInternalBuildModeDefinition();
     }

--- a/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
@@ -42,6 +42,7 @@ final readonly class SymbolResolver
         private GlobalEnvironment $globalEnv,
         private MagicConstantResolver $magicConstantResolver,
         private ?BackslashSeparatorDeprecator $backslashDeprecator = null,
+        private ?DeprecatedDefinitionWarner $deprecatedDefinitionWarner = null,
     ) {}
 
     public function resolve(Symbol $name, NodeEnvironmentInterface $env): ?AbstractNode
@@ -145,7 +146,11 @@ final readonly class SymbolResolver
             throw new RuntimeException('resolveWithAlias called with a Symbol without namespace');
         }
 
+        // The namespace part is dropped, but the call-site location must ride
+        // along: it feeds the source map and the deprecation notices raised
+        // when the resolved definition turns out to be deprecated.
         $finalName = Symbol::create($name->getName());
+        $finalName->copyLocationFrom($name);
 
         // A leading backslash marks a PHP class FQN (e.g. `\DateTimeImmutable/foo`).
         // Don't translate those — let the alias pass through verbatim so static
@@ -296,7 +301,7 @@ final readonly class SymbolResolver
 
         $def = $this->globalEnv->getDefinition($ns, $name);
         if ($def instanceof PersistentMapInterface) {
-            return new GlobalVarNode($env, $ns, $name, $def, $name->getStartLocation());
+            return $this->globalVarNode($env, $ns, $name, $def);
         }
 
         return null;
@@ -323,6 +328,23 @@ final readonly class SymbolResolver
         if (!$this->isPrivateDefinitionAllowed($def)) {
             return null;
         }
+
+        return $this->globalVarNode($env, $ns, $name, $def);
+    }
+
+    /**
+     * Single construction point for {@see GlobalVarNode}, so every resolved
+     * definition passes the `:deprecated`-metadata check exactly once.
+     *
+     * @param PersistentMapInterface<mixed, mixed> $def
+     */
+    private function globalVarNode(
+        NodeEnvironmentInterface $env,
+        string $ns,
+        Symbol $name,
+        PersistentMapInterface $def,
+    ): GlobalVarNode {
+        $this->deprecatedDefinitionWarner?->maybeWarn($ns, $name, $def);
 
         return new GlobalVarNode($env, $ns, $name, $def, $name->getStartLocation());
     }

--- a/src/php/Compiler/Domain/Deprecation/DeprecationWarnings.php
+++ b/src/php/Compiler/Domain/Deprecation/DeprecationWarnings.php
@@ -4,28 +4,40 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Deprecation;
 
+use Phel\Lang\SourceLocation;
+
 use function dirname;
 use function in_array;
-
+use function sprintf;
 use function trigger_error;
 
 use const E_USER_DEPRECATED;
 
 /**
- * Process-wide switch for the compiler's own `E_USER_DEPRECATED` notices
- * about deprecated Phel syntax (bare `#` comments, `#| ... |#` blocks,
- * `|()` short fns, `,`/`,@` unquote, `$` auto-gensym, `\` namespace
- * separators).
+ * Process-wide switch for every `E_USER_DEPRECATED` notice the compiler
+ * raises, covering both kinds of deprecation:
+ *
+ * - **syntax** — bare `#` comments, `#| ... |#` blocks, `|()` short fns,
+ *   `,`/`,@` unquote, `$` auto-gensym, `^:reference` params, and the `\`
+ *   namespace separator;
+ * - **definitions** — any `def`/`defn` whose metadata carries `:deprecated`.
  *
  * Every notice is gated: off by default, on when the user asks for it via
  * `--warn-deprecations`, `PHEL_WARN_DEPRECATIONS`, or the
  * `warn-deprecations` config key. Suppressing a notice with `@` instead
  * would hide it unconditionally, so a `--warn-deprecations` run would
  * print nothing and the deprecation could never be acted on.
+ *
+ * This class owns the four concerns a detector would otherwise re-implement:
+ * the enabled flag, the bundled-stdlib suppression, the per-`(file, subject)`
+ * dedup, and the syntax message shape. Detectors only detect.
  */
 final class DeprecationWarnings
 {
     private static ?bool $enabled = null;
+
+    /** @var array<string, true> */
+    private static array $seen = [];
 
     public static function isEnabled(): bool
     {
@@ -43,12 +55,14 @@ final class DeprecationWarnings
     }
 
     /**
-     * Drop the cached flag so the next `isEnabled()` call re-reads the
-     * environment. Intended for test `tearDown()` hooks.
+     * Drop the cached flag and the dedup table so the next `isEnabled()`
+     * call re-reads the environment and every subject can warn again.
+     * Intended for test `tearDown()` hooks.
      */
     public static function reset(): void
     {
         self::$enabled = null;
+        self::$seen = [];
     }
 
     /**
@@ -105,6 +119,82 @@ final class DeprecationWarnings
         }
 
         trigger_error($message, E_USER_DEPRECATED);
+    }
+
+    /**
+     * Like {@see warnForSource()}, but reports each `(sourceFile, subject)`
+     * pair only once per process. Used where one subject recurs across a
+     * file — a deprecated definition called fifty times, or a `\`-separated
+     * symbol referenced throughout a namespace — and fifty identical lines
+     * would bury the rest of the output.
+     *
+     * Syntax notices deliberately do NOT dedup: each occurrence sits at a
+     * different line and the user has to edit every one of them.
+     */
+    public static function warnOnceForSource(string $sourceFile, string $subject, string $message): void
+    {
+        if (!self::isEnabledForSource($sourceFile)) {
+            return;
+        }
+
+        $key = $sourceFile . '|' . $subject;
+        if (isset(self::$seen[$key])) {
+            return;
+        }
+
+        self::$seen[$key] = true;
+        trigger_error($message, E_USER_DEPRECATED);
+    }
+
+    /**
+     * The one message shape for a deprecated *syntax* construct:
+     *
+     *     Using <construct> for <purpose> is deprecated and will be removed
+     *     in a future release; use <replacement> instead (at file:line:col)
+     *
+     * Going through a factory rather than a per-site `sprintf` keeps the
+     * wording uniform and makes the "never name a concrete removal version"
+     * rule structural instead of a convention: there is nowhere to put one.
+     * A named release inevitably ships and the message goes stale (#2783,
+     * which advertised "v0.33" until v0.48).
+     *
+     * @param string $construct   the deprecated syntax, pre-quoted for the reader (e.g. `'"|()"'`)
+     * @param string $purpose     what the construct is used for, as a noun phrase (e.g. `'short functions'`)
+     * @param string $replacement the syntax to use instead, pre-quoted (e.g. `'"#()"'`)
+     */
+    public static function syntaxMessage(
+        string $construct,
+        string $purpose,
+        string $replacement,
+        ?SourceLocation $location,
+    ): string {
+        return sprintf(
+            'Using %s for %s is deprecated and will be removed in a future release; use %s instead%s',
+            $construct,
+            $purpose,
+            $replacement,
+            $location instanceof SourceLocation
+                ? sprintf(' (at %s:%d:%d)', $location->getFile(), $location->getLine(), $location->getColumn())
+                : '',
+        );
+    }
+
+    /**
+     * Builds the syntax notice with {@see syntaxMessage()} and reports it,
+     * gated on the source. For callers that lex a whole file, resolve
+     * {@see isEnabledForSource()} once and use {@see warn()} instead so the
+     * gate is not re-evaluated per token.
+     */
+    public static function warnSyntax(
+        string $construct,
+        string $purpose,
+        string $replacement,
+        ?SourceLocation $location,
+    ): void {
+        self::warnForSource(
+            $location instanceof SourceLocation ? $location->getFile() : '',
+            self::syntaxMessage($construct, $purpose, $replacement, $location),
+        );
     }
 
     private static function readEnvFlag(): bool

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\BodyConstantScanner;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\ConstantScope;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
@@ -70,7 +71,7 @@ final readonly class MethodEmitter
             if ($isVariadicTail) {
                 $this->outputEmitter->emitPhpVariable($symbol, $loc = null, $asReference = false, $isVariadic = true);
             } else {
-                $isReference = $this->isByRef($meta);
+                $isReference = $this->isByRef($symbol, $meta);
                 $this->outputEmitter->emitPhpVariable($symbol, $loc = null, $isReference);
             }
 
@@ -165,13 +166,15 @@ final readonly class MethodEmitter
      * binding. Surfaces the `(php/array)` mutation pattern at the Phel
      * level without forcing buffer-return-rebind dances.
      *
-     * `^:reference` is the historical alias, kept for source compatibility;
-     * nothing in `src/phel/` uses it any more (only the
-     * `Fn/fn-param-by-ref-legacy-reference-alias` fixture pins it).
+     * `^:reference` is the historical alias, kept for source compatibility and
+     * scheduled for removal in the next major (see
+     * `docs/migration/deprecated-surface.md`). Nothing in `src/phel/` uses it;
+     * it now announces itself with an `E_USER_DEPRECATED` notice so a project
+     * still on the old spelling learns about it before the removal lands.
      *
      * @param PersistentMapInterface<mixed, mixed>|null $meta
      */
-    private function isByRef(?PersistentMapInterface $meta): bool
+    private function isByRef(Symbol $param, ?PersistentMapInterface $meta): bool
     {
         if (!$meta instanceof PersistentMapInterface) {
             return false;
@@ -181,7 +184,18 @@ final readonly class MethodEmitter
             return true;
         }
 
-        return $meta->find(Keyword::create('reference')) === true;
+        if ($meta->find(Keyword::create('reference')) !== true) {
+            return false;
+        }
+
+        DeprecationWarnings::warnSyntax(
+            '"^:reference"',
+            'by-reference fn parameters',
+            '"^:by-ref"',
+            $param->getStartLocation(),
+        );
+
+        return true;
     }
 
     /**

--- a/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
+++ b/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
@@ -15,7 +15,6 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVector;
 use Phel\Lang\Keyword;
-use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
 
@@ -241,15 +240,13 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
             return;
         }
 
-        $location = $form->getStartLocation();
         $suggested = substr($name, 0, -1) . Symbol::NAME_HASH;
-        $where = $location instanceof SourceLocation
-            ? sprintf(' (at %s:%d:%d)', $location->getFile(), $location->getLine(), $location->getColumn())
-            : '';
 
-        DeprecationWarnings::warnForSource(
-            $location instanceof SourceLocation ? $location->getFile() : '',
-            sprintf('Using "%s" auto-gensym suffix is deprecated, use "%s" instead%s', $name, $suggested, $where),
+        DeprecationWarnings::warnSyntax(
+            sprintf('"%s"', $name),
+            'auto-gensym',
+            sprintf('"%s"', $suggested),
+            $form->getStartLocation(),
         );
     }
 }

--- a/src/php/Console/Application/WarnDeprecationsFlag.php
+++ b/src/php/Console/Application/WarnDeprecationsFlag.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Console\Application;
 
-use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
 use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
 
 use function array_filter;
@@ -14,10 +13,10 @@ use function str_starts_with;
 /**
  * CLI bridge for `PHEL_WARN_DEPRECATIONS`: detects the
  * `--warn-deprecations` flag in argv, turns on the process-wide
- * `DeprecationWarnings` switch (which every syntax deprecation notice is
- * gated on) plus the `BackslashSeparatorDeprecator` singleton, and returns
- * argv with the flag stripped so Symfony's per-command input parsers do
- * not complain about an unknown option.
+ * `DeprecationWarnings` switch (the single gate every deprecation notice
+ * is checked against, syntax and definition alike), and returns argv with
+ * the flag stripped so Symfony's per-command input parsers do not complain
+ * about an unknown option.
  *
  * Accepted forms: `--warn-deprecations` and `--warn-deprecations=1`.
  * Any other shape is passed through unchanged.
@@ -39,7 +38,6 @@ final class WarnDeprecationsFlag
 
         if ($filtered !== $argv) {
             DeprecationWarnings::enable();
-            BackslashSeparatorDeprecator::enable();
         }
 
         return $filtered;

--- a/tests/php/Integration/Compiler/ByRefParamDeprecationTest.php
+++ b/tests/php/Integration/Compiler/ByRefParamDeprecationTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Compiler;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompileOptions;
+use PHPUnit\Framework\TestCase;
+
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_USER_DEPRECATED;
+
+/**
+ * `^:reference` is the historical spelling of `^:by-ref`. It stays accepted
+ * until the next major, but it must announce itself under
+ * `--warn-deprecations` so a project on the old spelling learns about it
+ * before the removal lands.
+ */
+final class ByRefParamDeprecationTest extends TestCase
+{
+    /**
+     * A deprecation notice must not name a concrete removal version: the
+     * release it promises inevitably ships and the message goes stale (#2783).
+     */
+    private const string VERSION_REFERENCE = '/v?\d+\.\d+(\.\d+)?/';
+
+    private static GlobalEnvironmentInterface $globalEnv;
+
+    private CompilerFacade $compilerFacade;
+
+    public static function setUpBeforeClass(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Symbol::resetGen();
+        $globalEnv = GlobalEnvironmentSingleton::initializeNew();
+        new BuildFacade()->compileFile(
+            __DIR__ . '/../../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core'),
+        );
+        self::$globalEnv = $globalEnv;
+    }
+
+    protected function setUp(): void
+    {
+        $this->compilerFacade = new CompilerFacade();
+        self::$globalEnv->setNs('user');
+        Symbol::resetGen();
+        DeprecationWarnings::enable();
+    }
+
+    protected function tearDown(): void
+    {
+        DeprecationWarnings::reset();
+    }
+
+    public function test_legacy_reference_alias_is_silent_unless_warnings_are_enabled(): void
+    {
+        DeprecationWarnings::disable();
+
+        self::assertNull(
+            $this->compileCapturingDeprecation('(fn [^:reference parts] (php/array_push parts "x"))'),
+        );
+    }
+
+    public function test_legacy_reference_alias_emits_deprecation(): void
+    {
+        $warning = $this->compileCapturingDeprecation('(fn [^:reference parts] (php/array_push parts "x"))');
+
+        self::assertNotNull($warning);
+        self::assertStringContainsString('"^:reference"', $warning);
+        self::assertStringContainsString('"^:by-ref"', $warning);
+        self::assertStringContainsString('a future release', $warning);
+        self::assertDoesNotMatchRegularExpression(self::VERSION_REFERENCE, $warning);
+    }
+
+    public function test_canonical_by_ref_spelling_stays_silent(): void
+    {
+        self::assertNull(
+            $this->compileCapturingDeprecation('(fn [^:by-ref parts] (php/array_push parts "x"))'),
+        );
+    }
+
+    public function test_legacy_reference_alias_still_compiles_to_a_php_reference(): void
+    {
+        $warning = $this->compileCapturingDeprecation(
+            '(fn [^:reference parts] (php/array_push parts "x"))',
+            $compiled,
+        );
+
+        self::assertNotNull($warning);
+        self::assertStringContainsString('&$parts', (string) $compiled);
+    }
+
+    private function compileCapturingDeprecation(string $phelCode, ?string &$compiled = null): ?string
+    {
+        $warning = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
+            $warning = $errstr;
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $compiled = $this->compilerFacade
+                ->compile($phelCode, new CompileOptions())
+                ->getPhpCode();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $warning;
+    }
+}

--- a/tests/php/Support/CapturesDeprecationsTrait.php
+++ b/tests/php/Support/CapturesDeprecationsTrait.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Support;
+
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
+
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_USER_DEPRECATED;
+
+/**
+ * Captures the `E_USER_DEPRECATED` notices raised while deprecation warnings
+ * are on.
+ *
+ * Detectors hold no injectable emitter: every notice goes through the one
+ * `DeprecationWarnings` gate and out as a real PHP deprecation, so a test
+ * observes them the same way a user does.
+ *
+ * Call `startCapturingDeprecations()` (enables the switch and installs the
+ * handler) and `stopCapturingDeprecations()` (restores both). Calling stop
+ * without a matching start is safe, so it belongs in `tearDown()`.
+ */
+trait CapturesDeprecationsTrait
+{
+    /** @var list<string> */
+    private array $capturedDeprecations = [];
+
+    private bool $deprecationHandlerInstalled = false;
+
+    private function startCapturingDeprecations(): void
+    {
+        $this->capturedDeprecations = [];
+        DeprecationWarnings::reset();
+        DeprecationWarnings::enable();
+
+        set_error_handler(
+            function (int $errno, string $message): bool {
+                $this->capturedDeprecations[] = $message;
+
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+        $this->deprecationHandlerInstalled = true;
+    }
+
+    private function stopCapturingDeprecations(): void
+    {
+        if ($this->deprecationHandlerInstalled) {
+            restore_error_handler();
+            $this->deprecationHandlerInstalled = false;
+        }
+
+        DeprecationWarnings::reset();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function capturedDeprecations(): array
+    {
+        return $this->capturedDeprecations;
+    }
+}

--- a/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
@@ -5,157 +5,151 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Compiler\Analyzer\Environment;
 
 use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
+use PhelTest\Support\CapturesDeprecationsTrait;
 use PHPUnit\Framework\TestCase;
 
 use function dirname;
 
 final class BackslashSeparatorDeprecatorTest extends TestCase
 {
-    /** @var list<string> */
-    private array $captured = [];
+    use CapturesDeprecationsTrait;
 
     protected function setUp(): void
     {
-        $this->captured = [];
+        $this->startCapturingDeprecations();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->stopCapturingDeprecations();
     }
 
     public function test_emits_for_backslash_namespace_symbol(): void
     {
-        $deprecator = $this->deprecator(enabled: true);
-        $deprecator->maybeWarn($this->locatedRawNameSymbol('phel\\core/map', '/app/user.phel'));
+        $this->deprecator()->maybeWarn($this->locatedRawNameSymbol('phel\\core/map', '/app/user.phel'));
 
-        self::assertCount(1, $this->captured);
-        self::assertStringContainsString("'phel\\core/map'", $this->captured[0]);
-        self::assertStringContainsString("'phel.core/map'", $this->captured[0]);
-        self::assertStringContainsString('/app/user.phel', $this->captured[0]);
+        $captured = $this->capturedDeprecations();
+        self::assertCount(1, $captured);
+        self::assertStringContainsString("'phel\\core/map'", $captured[0]);
+        self::assertStringContainsString("'phel.core/map'", $captured[0]);
+        self::assertStringContainsString('/app/user.phel', $captured[0]);
     }
 
     public function test_emits_for_leading_backslash_class_fqn(): void
     {
-        $deprecator = $this->deprecator(enabled: true);
-        $deprecator->maybeWarn($this->locatedSymbol(null, '\\Phel\\Lang\\Foo', '/app/user.phel'));
+        $this->deprecator()->maybeWarn($this->locatedSymbol(null, '\\Phel\\Lang\\Foo', '/app/user.phel'));
 
-        self::assertCount(1, $this->captured);
-        self::assertStringContainsString("'\\Phel\\Lang\\Foo'", $this->captured[0]);
-        self::assertStringContainsString("'Phel.Lang.Foo'", $this->captured[0]);
+        $captured = $this->capturedDeprecations();
+        self::assertCount(1, $captured);
+        self::assertStringContainsString("'\\Phel\\Lang\\Foo'", $captured[0]);
+        self::assertStringContainsString("'Phel.Lang.Foo'", $captured[0]);
     }
 
-    public function test_stays_silent_when_disabled(): void
+    public function test_stays_silent_when_warnings_are_disabled(): void
     {
-        $deprecator = $this->deprecator(enabled: false);
-        $deprecator->maybeWarn($this->locatedSymbol('phel.core', 'map', '/app/user.phel'));
+        DeprecationWarnings::disable();
 
-        self::assertSame([], $this->captured);
+        $this->deprecator()->maybeWarn($this->locatedRawNameSymbol('phel\\core/map', '/app/user.phel'));
+
+        self::assertSame([], $this->capturedDeprecations());
     }
 
     public function test_no_warning_for_dot_separated_symbol(): void
     {
-        $deprecator = $this->deprecator(enabled: true);
-        $deprecator->maybeWarn($this->locatedSymbol('phel.core', 'map', '/app/user.phel'));
+        $this->deprecator()->maybeWarn($this->locatedSymbol('phel.core', 'map', '/app/user.phel'));
 
-        self::assertSame([], $this->captured);
+        self::assertSame([], $this->capturedDeprecations());
     }
 
     public function test_dedupes_same_file_and_pattern(): void
     {
-        $deprecator = $this->deprecator(enabled: true);
+        $deprecator = $this->deprecator();
         $deprecator->maybeWarn($this->locatedRawNameSymbol('phel\\core/map', '/app/user.phel'));
         $deprecator->maybeWarn($this->locatedRawNameSymbol('phel\\core/map', '/app/user.phel'));
 
-        self::assertCount(1, $this->captured);
+        self::assertCount(1, $this->capturedDeprecations());
     }
 
     public function test_emits_again_for_different_file(): void
     {
-        $deprecator = $this->deprecator(enabled: true);
+        $deprecator = $this->deprecator();
         $deprecator->maybeWarn($this->locatedRawNameSymbol('phel\\core/map', '/app/a.phel'));
         $deprecator->maybeWarn($this->locatedRawNameSymbol('phel\\core/map', '/app/b.phel'));
 
-        self::assertCount(2, $this->captured);
+        self::assertCount(2, $this->capturedDeprecations());
     }
 
     public function test_suppresses_warnings_from_phel_stdlib_sources(): void
     {
-        $deprecator = $this->deprecator(enabled: true);
-        $deprecator->maybeWarn($this->locatedSymbol(
-            'phel.core',
-            'map',
+        $this->deprecator()->maybeWarn($this->locatedRawNameSymbol(
+            'phel\\core/map',
             dirname(__DIR__, 6) . '/src/phel/walk.phel',
         ));
 
-        self::assertSame([], $this->captured);
+        self::assertSame([], $this->capturedDeprecations());
     }
 
     public function test_warns_for_user_nested_layout_sources(): void
     {
-        $deprecator = $this->deprecator(enabled: true);
-        $deprecator->maybeWarn($this->locatedRawNameSymbol('my\\project/run', '/app/src/phel/main.phel'));
+        $this->deprecator()->maybeWarn($this->locatedRawNameSymbol('my\\project/run', '/app/src/phel/main.phel'));
 
-        self::assertCount(1, $this->captured);
+        self::assertCount(1, $this->capturedDeprecations());
     }
 
     public function test_emits_for_backslash_namespace_string(): void
     {
-        $deprecator = $this->deprecator(enabled: true);
-        $deprecator->maybeWarnString('my\\project', new SourceLocation('/app/user.phel', 1, 1));
+        $this->deprecator()->maybeWarnString('my\\project', new SourceLocation('/app/user.phel', 1, 1));
 
-        self::assertCount(1, $this->captured);
-        self::assertStringContainsString("'my\\project'", $this->captured[0]);
-        self::assertStringContainsString("'my.project'", $this->captured[0]);
+        $captured = $this->capturedDeprecations();
+        self::assertCount(1, $captured);
+        self::assertStringContainsString("'my\\project'", $captured[0]);
+        self::assertStringContainsString("'my.project'", $captured[0]);
     }
 
     public function test_no_warning_for_leading_only_backslash_php_global_constant(): void
     {
-        $deprecator = $this->deprecator(enabled: true);
-        $deprecator->maybeWarn($this->locatedSymbol(null, '\\JSON_UNESCAPED_SLASHES', '/app/user.phel'));
+        $this->deprecator()->maybeWarn($this->locatedSymbol(null, '\\JSON_UNESCAPED_SLASHES', '/app/user.phel'));
 
-        self::assertSame([], $this->captured);
+        self::assertSame([], $this->capturedDeprecations());
     }
 
     public function test_no_warning_for_leading_only_backslash_php_global_function(): void
     {
-        $deprecator = $this->deprecator(enabled: true);
-        $deprecator->maybeWarn($this->locatedSymbol(null, '\\strlen', '/app/user.phel'));
+        $this->deprecator()->maybeWarn($this->locatedSymbol(null, '\\strlen', '/app/user.phel'));
 
-        self::assertSame([], $this->captured);
+        self::assertSame([], $this->capturedDeprecations());
     }
 
     public function test_no_warning_for_leading_only_backslash_top_level_class(): void
     {
-        $deprecator = $this->deprecator(enabled: true);
-        $deprecator->maybeWarn($this->locatedSymbol(null, '\\DateTimeInterface', '/app/user.phel'));
+        $this->deprecator()->maybeWarn($this->locatedSymbol(null, '\\DateTimeInterface', '/app/user.phel'));
 
-        self::assertSame([], $this->captured);
+        self::assertSame([], $this->capturedDeprecations());
     }
 
     public function test_emits_for_leading_backslash_when_internal_separator_present(): void
     {
-        $deprecator = $this->deprecator(enabled: true);
-        $deprecator->maybeWarn($this->locatedSymbol(null, '\\Foo\\Bar', '/app/user.phel'));
+        $this->deprecator()->maybeWarn($this->locatedSymbol(null, '\\Foo\\Bar', '/app/user.phel'));
 
-        self::assertCount(1, $this->captured);
-        self::assertStringContainsString("'\\Foo\\Bar'", $this->captured[0]);
-        self::assertStringContainsString("'Foo.Bar'", $this->captured[0]);
+        $captured = $this->capturedDeprecations();
+        self::assertCount(1, $captured);
+        self::assertStringContainsString("'\\Foo\\Bar'", $captured[0]);
+        self::assertStringContainsString("'Foo.Bar'", $captured[0]);
     }
 
     public function test_suppresses_when_location_is_missing(): void
     {
-        $deprecator = $this->deprecator(enabled: true);
-        $deprecator->maybeWarn(Symbol::createForNamespace('phel.core', 'map'));
+        $this->deprecator()->maybeWarn(Symbol::createForNamespace('phel.core', 'map'));
 
-        self::assertSame([], $this->captured);
+        self::assertSame([], $this->capturedDeprecations());
     }
 
-    private function deprecator(bool $enabled): BackslashSeparatorDeprecator
+    private function deprecator(): BackslashSeparatorDeprecator
     {
-        return new BackslashSeparatorDeprecator(
-            $enabled,
-            function (string $msg): void {
-                $this->captured[] = $msg;
-            },
-        );
+        return BackslashSeparatorDeprecator::getInstance();
     }
 
     private function locatedSymbol(?string $ns, string $name, string $file): Symbol

--- a/tests/php/Unit/Compiler/Analyzer/Environment/DeprecatedDefinitionWarnerTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/DeprecatedDefinitionWarnerTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\Environment;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Environment\DeprecatedDefinitionWarner;
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+use PhelTest\Support\CapturesDeprecationsTrait;
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+
+final class DeprecatedDefinitionWarnerTest extends TestCase
+{
+    use CapturesDeprecationsTrait;
+
+    protected function setUp(): void
+    {
+        $this->startCapturingDeprecations();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->stopCapturingDeprecations();
+    }
+
+    public function test_warns_with_version_and_replacement(): void
+    {
+        $this->warner()->maybeWarn(
+            'phel.core',
+            $this->locatedSymbol('set-meta!', '/app/user.phel'),
+            $this->meta(['deprecated' => '0.32.0', 'superseded-by' => 'with-meta']),
+        );
+
+        $captured = $this->capturedDeprecations();
+        self::assertCount(1, $captured);
+        self::assertStringContainsString("'phel.core/set-meta!'", $captured[0]);
+        self::assertStringContainsString('/app/user.phel:1', $captured[0]);
+        self::assertStringContainsString('(since 0.32.0)', $captured[0]);
+        self::assertStringContainsString("Use 'with-meta' instead.", $captured[0]);
+    }
+
+    public function test_renders_non_version_metadata_as_a_reason(): void
+    {
+        $this->warner()->maybeWarn(
+            'phel.test',
+            $this->locatedSymbol('print-summary', '/app/user.phel'),
+            $this->meta(['deprecated' => 'run-tests emits it already']),
+        );
+
+        $captured = $this->capturedDeprecations();
+        self::assertCount(1, $captured);
+        self::assertStringContainsString(': run-tests emits it already', $captured[0]);
+    }
+
+    public function test_warns_for_boolean_true_metadata_without_detail(): void
+    {
+        $this->warner()->maybeWarn(
+            'my.app',
+            $this->locatedSymbol('old-fn', '/app/user.phel'),
+            $this->meta(['deprecated' => true]),
+        );
+
+        $captured = $this->capturedDeprecations();
+        self::assertCount(1, $captured);
+        self::assertStringContainsString("'my.app/old-fn' used at /app/user.phel:1 is deprecated.", $captured[0]);
+    }
+
+    public function test_stays_silent_when_warnings_are_disabled(): void
+    {
+        DeprecationWarnings::disable();
+
+        $this->warner()->maybeWarn(
+            'phel.core',
+            $this->locatedSymbol('set-meta!', '/app/user.phel'),
+            $this->meta(['deprecated' => '0.32.0']),
+        );
+
+        self::assertSame([], $this->capturedDeprecations());
+    }
+
+    public function test_stays_silent_for_a_definition_without_deprecated_metadata(): void
+    {
+        $this->warner()->maybeWarn(
+            'phel.core',
+            $this->locatedSymbol('with-meta', '/app/user.phel'),
+            $this->meta(['doc' => 'Returns obj with meta attached.']),
+        );
+
+        self::assertSame([], $this->capturedDeprecations());
+    }
+
+    public function test_stays_silent_when_deprecated_metadata_is_false(): void
+    {
+        $this->warner()->maybeWarn(
+            'phel.core',
+            $this->locatedSymbol('with-meta', '/app/user.phel'),
+            $this->meta(['deprecated' => false]),
+        );
+
+        self::assertSame([], $this->capturedDeprecations());
+    }
+
+    public function test_dedupes_repeated_use_in_the_same_file(): void
+    {
+        $warner = $this->warner();
+        $meta = $this->meta(['deprecated' => '0.32.0']);
+
+        $warner->maybeWarn('phel.core', $this->locatedSymbol('set-meta!', '/app/a.phel'), $meta);
+        $warner->maybeWarn('phel.core', $this->locatedSymbol('set-meta!', '/app/a.phel'), $meta);
+
+        self::assertCount(1, $this->capturedDeprecations());
+    }
+
+    public function test_warns_again_in_a_different_file(): void
+    {
+        $warner = $this->warner();
+        $meta = $this->meta(['deprecated' => '0.32.0']);
+
+        $warner->maybeWarn('phel.core', $this->locatedSymbol('set-meta!', '/app/a.phel'), $meta);
+        $warner->maybeWarn('phel.core', $this->locatedSymbol('set-meta!', '/app/b.phel'), $meta);
+
+        self::assertCount(2, $this->capturedDeprecations());
+    }
+
+    public function test_suppresses_uses_inside_phels_own_stdlib(): void
+    {
+        $this->warner()->maybeWarn(
+            'phel.core',
+            $this->locatedSymbol('set-meta!', dirname(__DIR__, 6) . '/src/phel/walk.phel'),
+            $this->meta(['deprecated' => '0.32.0']),
+        );
+
+        self::assertSame([], $this->capturedDeprecations());
+    }
+
+    public function test_stays_silent_when_the_call_site_has_no_location(): void
+    {
+        $this->warner()->maybeWarn(
+            'phel.core',
+            Symbol::create('set-meta!'),
+            $this->meta(['deprecated' => '0.32.0']),
+        );
+
+        self::assertSame([], $this->capturedDeprecations());
+    }
+
+    private function warner(): DeprecatedDefinitionWarner
+    {
+        return DeprecatedDefinitionWarner::getInstance();
+    }
+
+    private function locatedSymbol(string $name, string $file): Symbol
+    {
+        $symbol = Symbol::create($name);
+        $symbol->setStartLocation(new SourceLocation($file, 1, 1));
+
+        return $symbol;
+    }
+
+    /**
+     * @param array<string, mixed> $pairs
+     *
+     * @return PersistentMapInterface<mixed, mixed>
+     */
+    private function meta(array $pairs): PersistentMapInterface
+    {
+        $flat = [];
+        foreach ($pairs as $key => $value) {
+            $flat[] = Keyword::create($key);
+            $flat[] = $value;
+        }
+
+        return Phel::map(...$flat);
+    }
+}

--- a/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
@@ -11,6 +11,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
 use Phel\Compiler\Domain\Analyzer\Environment\BundledNamespaceResolverInterface;
+use Phel\Compiler\Domain\Analyzer\Environment\DeprecatedDefinitionWarner;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\MagicConstantResolver;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
@@ -21,10 +22,13 @@ use Phel\Lang\Ratio;
 use Phel\Lang\Registry;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
+use PhelTest\Support\CapturesDeprecationsTrait;
 use PHPUnit\Framework\TestCase;
 
 final class SymbolResolverTest extends TestCase
 {
+    use CapturesDeprecationsTrait;
+
     private GlobalEnvironment $globalEnv;
 
     private SymbolResolver $resolver;
@@ -34,6 +38,11 @@ final class SymbolResolverTest extends TestCase
         Phel::clear();
         $this->globalEnv = new GlobalEnvironment();
         $this->resolver = new SymbolResolver($this->globalEnv, new MagicConstantResolver());
+    }
+
+    protected function tearDown(): void
+    {
+        $this->stopCapturingDeprecations();
     }
 
     public function test_resolve_magic_dir_constant(): void
@@ -432,22 +441,68 @@ final class SymbolResolverTest extends TestCase
 
     public function test_resolve_fires_backslash_deprecation_when_wired(): void
     {
-        $captured = [];
-        $deprecator = new BackslashSeparatorDeprecator(
-            enabled: true,
-            emitter: static function (string $msg) use (&$captured): void {
-                $captured[] = $msg;
-            },
+        $this->startCapturingDeprecations();
+        $resolver = new SymbolResolver(
+            $this->globalEnv,
+            new MagicConstantResolver(),
+            BackslashSeparatorDeprecator::getInstance(),
         );
-        $resolver = new SymbolResolver($this->globalEnv, new MagicConstantResolver(), $deprecator);
 
         $sym = Symbol::createForNamespace(null, 'phel\\core/map');
         $sym->setStartLocation(new SourceLocation('/app/user.phel', 1, 1));
 
         $resolver->resolve($sym, NodeEnvironment::empty());
 
+        $captured = $this->capturedDeprecations();
         self::assertCount(1, $captured);
         self::assertStringContainsString("'phel\\core/map'", $captured[0]);
+    }
+
+    public function test_resolve_fires_deprecated_definition_warning_when_wired(): void
+    {
+        $this->startCapturingDeprecations();
+        $resolver = new SymbolResolver(
+            $this->globalEnv,
+            new MagicConstantResolver(),
+            null,
+            DeprecatedDefinitionWarner::getInstance(),
+        );
+
+        $this->globalEnv->addDefinition('bar', Symbol::create('old-fn'));
+        Phel::addDefinition('bar', 'old-fn', null, Phel::map(
+            Keyword::create('deprecated'),
+            '0.32.0',
+            Keyword::create('superseded-by'),
+            'new-fn',
+        ));
+
+        $sym = Symbol::createForNamespace('bar', 'old-fn');
+        $sym->setStartLocation(new SourceLocation('/app/user.phel', 3, 5));
+
+        self::assertInstanceOf(GlobalVarNode::class, $resolver->resolve($sym, NodeEnvironment::empty()));
+        $captured = $this->capturedDeprecations();
+        self::assertCount(1, $captured);
+        self::assertStringContainsString("'bar/old-fn'", $captured[0]);
+        self::assertStringContainsString("Use 'new-fn' instead.", $captured[0]);
+    }
+
+    public function test_resolve_stays_silent_for_a_definition_without_deprecated_metadata(): void
+    {
+        $this->startCapturingDeprecations();
+        $resolver = new SymbolResolver(
+            $this->globalEnv,
+            new MagicConstantResolver(),
+            null,
+            DeprecatedDefinitionWarner::getInstance(),
+        );
+
+        $this->globalEnv->addDefinition('bar', Symbol::create('fresh-fn'));
+
+        $sym = Symbol::createForNamespace('bar', 'fresh-fn');
+        $sym->setStartLocation(new SourceLocation('/app/user.phel', 3, 5));
+
+        self::assertInstanceOf(GlobalVarNode::class, $resolver->resolve($sym, NodeEnvironment::empty()));
+        self::assertSame([], $this->capturedDeprecations());
     }
 
     public function test_resolve_clojure_fqn_uses_munged_registry_lookup(): void

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/InNsSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/InNsSymbolTest.php
@@ -8,7 +8,6 @@ use Generator;
 use Phel;
 use Phel\Compiler\Application\Analyzer;
 use Phel\Compiler\Domain\Analyzer\Ast\InNsNode;
-use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
@@ -19,12 +18,15 @@ use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use Phel\Shared\CompilerConstants;
 use Phel\Shared\ReplConstants;
+use PhelTest\Support\CapturesDeprecationsTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
 final class InNsSymbolTest extends TestCase
 {
+    use CapturesDeprecationsTrait;
+
     private Analyzer $analyzer;
 
     protected function setUp(): void
@@ -32,6 +34,11 @@ final class InNsSymbolTest extends TestCase
         Registry::getInstance()->clear();
         $globalEnv = new GlobalEnvironment();
         $this->analyzer = new Analyzer($globalEnv);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->stopCapturingDeprecations();
     }
 
     public function test_requires_at_least_one_argument(): void
@@ -257,8 +264,7 @@ final class InNsSymbolTest extends TestCase
 
     public function test_backslash_in_ns_form_emits_deprecation(): void
     {
-        $captured = [];
-        $this->installCapturingDeprecator($captured);
+        $this->startCapturingDeprecations();
 
         $list = Phel::list([
             Symbol::create(Symbol::NAME_IN_NS),
@@ -266,17 +272,14 @@ final class InNsSymbolTest extends TestCase
         ]);
         new InNsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
 
-        self::assertCount(1, $captured);
-        self::assertStringContainsString("'my\\project'", $captured[0]);
-        self::assertStringContainsString("'my.project'", $captured[0]);
-
-        BackslashSeparatorDeprecator::resetInstance();
+        self::assertCount(1, $this->capturedDeprecations());
+        self::assertStringContainsString("'my\\project'", $this->capturedDeprecations()[0]);
+        self::assertStringContainsString("'my.project'", $this->capturedDeprecations()[0]);
     }
 
     public function test_dot_in_ns_form_emits_no_deprecation(): void
     {
-        $captured = [];
-        $this->installCapturingDeprecator($captured);
+        $this->startCapturingDeprecations();
 
         $list = Phel::list([
             Symbol::create(Symbol::NAME_IN_NS),
@@ -284,15 +287,12 @@ final class InNsSymbolTest extends TestCase
         ]);
         new InNsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
 
-        self::assertSame([], $captured);
-
-        BackslashSeparatorDeprecator::resetInstance();
+        self::assertSame([], $this->capturedDeprecations());
     }
 
     public function test_backslash_string_in_ns_form_emits_deprecation(): void
     {
-        $captured = [];
-        $this->installCapturingDeprecator($captured);
+        $this->startCapturingDeprecations();
 
         $list = Phel::list([
             Symbol::create(Symbol::NAME_IN_NS),
@@ -301,24 +301,9 @@ final class InNsSymbolTest extends TestCase
         $list->setStartLocation(new SourceLocation('/app/user.phel', 1, 1));
         new InNsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
 
-        self::assertCount(1, $captured);
-        self::assertStringContainsString("'my\\project'", $captured[0]);
-        self::assertStringContainsString("'my.project'", $captured[0]);
-
-        BackslashSeparatorDeprecator::resetInstance();
-    }
-
-    /**
-     * @param list<string> $captured
-     */
-    private function installCapturingDeprecator(array &$captured): void
-    {
-        BackslashSeparatorDeprecator::useInstance(new BackslashSeparatorDeprecator(
-            enabled: true,
-            emitter: static function (string $msg) use (&$captured): void {
-                $captured[] = $msg;
-            },
-        ));
+        self::assertCount(1, $this->capturedDeprecations());
+        self::assertStringContainsString("'my\\project'", $this->capturedDeprecations()[0]);
+        self::assertStringContainsString("'my.project'", $this->capturedDeprecations()[0]);
     }
 
     private function locatedSymbol(string $name, string $file): Symbol

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
@@ -10,7 +10,6 @@ use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\NsNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
-use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
@@ -20,11 +19,14 @@ use Phel\Lang\Keyword;
 use Phel\Lang\Registry;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
+use PhelTest\Support\CapturesDeprecationsTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class NsSymbolTest extends TestCase
 {
+    use CapturesDeprecationsTrait;
+
     private AnalyzerInterface $analyzer;
 
     private GlobalEnvironment $globalEnv;
@@ -41,7 +43,7 @@ final class NsSymbolTest extends TestCase
 
     protected function tearDown(): void
     {
-        BackslashSeparatorDeprecator::resetInstance();
+        $this->stopCapturingDeprecations();
     }
 
     public function test_first_argument_must_be_symbol(): void
@@ -1183,8 +1185,7 @@ final class NsSymbolTest extends TestCase
 
     public function test_backslash_ns_form_emits_deprecation(): void
     {
-        $captured = [];
-        $this->installCapturingDeprecator($captured);
+        $this->startCapturingDeprecations();
 
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
@@ -1192,17 +1193,15 @@ final class NsSymbolTest extends TestCase
         ]);
         new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
 
-        self::assertCount(1, $captured);
-        self::assertStringContainsString("'my\\project'", $captured[0]);
-        self::assertStringContainsString("'my.project'", $captured[0]);
+        self::assertCount(1, $this->capturedDeprecations());
+        self::assertStringContainsString("'my\\project'", $this->capturedDeprecations()[0]);
+        self::assertStringContainsString("'my.project'", $this->capturedDeprecations()[0]);
 
-        BackslashSeparatorDeprecator::resetInstance();
     }
 
     public function test_backslash_require_emits_deprecation(): void
     {
-        $captured = [];
-        $this->installCapturingDeprecator($captured);
+        $this->startCapturingDeprecations();
 
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
@@ -1215,20 +1214,18 @@ final class NsSymbolTest extends TestCase
         new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
 
         $requireWarnings = array_values(array_filter(
-            $captured,
+            $this->capturedDeprecations(),
             static fn(string $m): bool => str_contains($m, "'phel\\walk'"),
         ));
 
         self::assertCount(1, $requireWarnings, 'exactly one warning for the backslash require symbol');
         self::assertStringContainsString("'phel.walk'", $requireWarnings[0]);
 
-        BackslashSeparatorDeprecator::resetInstance();
     }
 
     public function test_backslash_use_emits_deprecation(): void
     {
-        $captured = [];
-        $this->installCapturingDeprecator($captured);
+        $this->startCapturingDeprecations();
 
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
@@ -1241,20 +1238,18 @@ final class NsSymbolTest extends TestCase
         new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
 
         $useWarnings = array_values(array_filter(
-            $captured,
+            $this->capturedDeprecations(),
             static fn(string $m): bool => str_contains($m, "'\\Phel\\Lang\\Keyword'"),
         ));
 
         self::assertCount(1, $useWarnings, 'exactly one warning for the backslash use symbol');
         self::assertStringContainsString("'Phel.Lang.Keyword'", $useWarnings[0]);
 
-        BackslashSeparatorDeprecator::resetInstance();
     }
 
     public function test_dot_use_emits_no_deprecation(): void
     {
-        $captured = [];
-        $this->installCapturingDeprecator($captured);
+        $this->startCapturingDeprecations();
 
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
@@ -1266,15 +1261,13 @@ final class NsSymbolTest extends TestCase
         ]);
         new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
 
-        self::assertSame([], $captured);
+        self::assertSame([], $this->capturedDeprecations());
 
-        BackslashSeparatorDeprecator::resetInstance();
     }
 
     public function test_dot_ns_form_emits_no_deprecation(): void
     {
-        $captured = [];
-        $this->installCapturingDeprecator($captured);
+        $this->startCapturingDeprecations();
 
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
@@ -1286,22 +1279,8 @@ final class NsSymbolTest extends TestCase
         ]);
         new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
 
-        self::assertSame([], $captured);
+        self::assertSame([], $this->capturedDeprecations());
 
-        BackslashSeparatorDeprecator::resetInstance();
-    }
-
-    /**
-     * @param list<string> $captured
-     */
-    private function installCapturingDeprecator(array &$captured): void
-    {
-        BackslashSeparatorDeprecator::useInstance(new BackslashSeparatorDeprecator(
-            enabled: true,
-            emitter: static function (string $msg) use (&$captured): void {
-                $captured[] = $msg;
-            },
-        ));
     }
 
     private function locatedSymbol(string $name, string $file): Symbol

--- a/tests/php/Unit/Compiler/Deprecation/DeprecationWarningsTest.php
+++ b/tests/php/Unit/Compiler/Deprecation/DeprecationWarningsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Compiler\Deprecation;
 
 use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
+use Phel\Lang\SourceLocation;
 use PHPUnit\Framework\TestCase;
 
 use function dirname;
@@ -76,6 +77,97 @@ final class DeprecationWarningsTest extends TestCase
         DeprecationWarnings::enable();
 
         self::assertFalse(DeprecationWarnings::isEnabledForSource(''));
+    }
+
+    public function test_warn_once_reports_a_subject_only_once_per_file(): void
+    {
+        DeprecationWarnings::enable();
+
+        self::assertSame(['first'], $this->capture(static function (): void {
+            DeprecationWarnings::warnOnceForSource('/app/user.phel', 'phel.core/set-meta!', 'first');
+            DeprecationWarnings::warnOnceForSource('/app/user.phel', 'phel.core/set-meta!', 'second');
+        }));
+    }
+
+    public function test_warn_once_reports_the_same_subject_again_in_another_file(): void
+    {
+        DeprecationWarnings::enable();
+
+        self::assertCount(2, $this->capture(static function (): void {
+            DeprecationWarnings::warnOnceForSource('/app/a.phel', 'phel.core/set-meta!', 'in a');
+            DeprecationWarnings::warnOnceForSource('/app/b.phel', 'phel.core/set-meta!', 'in b');
+        }));
+    }
+
+    public function test_warn_once_obeys_the_switch_and_the_stdlib_suppression(): void
+    {
+        DeprecationWarnings::disable();
+        self::assertSame([], $this->capture(static function (): void {
+            DeprecationWarnings::warnOnceForSource('/app/user.phel', 'subject', 'off');
+        }));
+
+        DeprecationWarnings::enable();
+        $stdlibFile = dirname(__DIR__, 5) . '/src/phel/walk.phel';
+        self::assertSame([], $this->capture(static function () use ($stdlibFile): void {
+            DeprecationWarnings::warnOnceForSource($stdlibFile, 'subject', 'stdlib');
+        }));
+    }
+
+    public function test_reset_clears_the_dedup_table(): void
+    {
+        DeprecationWarnings::enable();
+        $this->capture(static function (): void {
+            DeprecationWarnings::warnOnceForSource('/app/user.phel', 'subject', 'first');
+        });
+
+        DeprecationWarnings::reset();
+        DeprecationWarnings::enable();
+
+        self::assertSame(['again'], $this->capture(static function (): void {
+            DeprecationWarnings::warnOnceForSource('/app/user.phel', 'subject', 'again');
+        }));
+    }
+
+    public function test_syntax_message_has_one_shape_and_no_room_for_a_version(): void
+    {
+        $message = DeprecationWarnings::syntaxMessage(
+            '"|()"',
+            'short functions',
+            '"#()"',
+            new SourceLocation('/app/user.phel', 7, 3),
+        );
+
+        self::assertSame(
+            'Using "|()" for short functions is deprecated and will be removed in a future release; '
+            . 'use "#()" instead (at /app/user.phel:7:3)',
+            $message,
+        );
+        // The factory takes no version argument, so a notice cannot promise a
+        // release that later ships and goes stale (#2783).
+        self::assertDoesNotMatchRegularExpression('/v?\d+\.\d+(\.\d+)?/', $message);
+    }
+
+    public function test_syntax_message_omits_the_location_when_there_is_none(): void
+    {
+        self::assertSame(
+            'Using "," for unquote is deprecated and will be removed in a future release; use "~" instead',
+            DeprecationWarnings::syntaxMessage('","', 'unquote', '"~"', null),
+        );
+    }
+
+    public function test_warn_syntax_is_gated_on_the_same_switch(): void
+    {
+        $location = new SourceLocation('/app/user.phel', 1, 1);
+
+        DeprecationWarnings::disable();
+        self::assertSame([], $this->capture(static function () use ($location): void {
+            DeprecationWarnings::warnSyntax('"x"', 'things', '"y"', $location);
+        }));
+
+        DeprecationWarnings::enable();
+        self::assertCount(1, $this->capture(static function () use ($location): void {
+            DeprecationWarnings::warnSyntax('"x"', 'things', '"y"', $location);
+        }));
     }
 
     /**

--- a/tests/php/Unit/Console/Application/WarnDeprecationsFlagTest.php
+++ b/tests/php/Unit/Console/Application/WarnDeprecationsFlagTest.php
@@ -9,19 +9,21 @@ use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
 use Phel\Console\Application\WarnDeprecationsFlag;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
+use PhelTest\Support\CapturesDeprecationsTrait;
 use PHPUnit\Framework\TestCase;
 
 final class WarnDeprecationsFlagTest extends TestCase
 {
+    use CapturesDeprecationsTrait;
+
     protected function tearDown(): void
     {
-        BackslashSeparatorDeprecator::resetInstance();
-        // The flag is process-wide: leaving it on would make unrelated tests
-        // in this run start emitting syntax deprecations.
-        DeprecationWarnings::reset();
+        // The switch is process-wide: leaving it on would make unrelated tests
+        // in this run start emitting deprecations.
+        $this->stopCapturingDeprecations();
     }
 
-    public function test_strips_plain_flag_and_enables_syntax_deprecations(): void
+    public function test_strips_plain_flag_and_enables_deprecation_warnings(): void
     {
         DeprecationWarnings::disable();
 
@@ -30,7 +32,7 @@ final class WarnDeprecationsFlagTest extends TestCase
         self::assertTrue(DeprecationWarnings::isEnabled());
     }
 
-    public function test_leaves_syntax_deprecations_untouched_when_flag_absent(): void
+    public function test_leaves_deprecation_warnings_untouched_when_flag_absent(): void
     {
         DeprecationWarnings::disable();
 
@@ -46,35 +48,27 @@ final class WarnDeprecationsFlagTest extends TestCase
         self::assertSame($argv, WarnDeprecationsFlag::applyAndStrip($argv));
     }
 
-    public function test_strips_plain_flag_and_enables_deprecator(): void
+    /**
+     * The flag flips one switch, and every detector reads that switch, so
+     * turning it on is enough to make the analyzer's backslash detector fire
+     * without the flag knowing the detector exists.
+     */
+    public function test_the_one_switch_reaches_the_analyzer_detectors(): void
     {
-        $captured = [];
-        // Preconfigure the singleton so applyAndStrip's new instance replaces it.
-        // We'll assert via the installed deprecator after.
+        DeprecationWarnings::disable();
+        $this->captureDeprecationsWithoutEnabling();
+
         $result = WarnDeprecationsFlag::applyAndStrip(
             ['phel', 'test', '--warn-deprecations', '--filter=foo'],
         );
 
         self::assertSame(['phel', 'test', '--filter=foo'], $result);
 
-        // Swap the now-enabled deprecator for a capturing one, then reach
-        // through a fake symbol to prove it actually fires.
-        $instance = BackslashSeparatorDeprecator::getInstance();
-        $viaFlag = new BackslashSeparatorDeprecator(
-            enabled: true,
-            emitter: static function (string $msg) use (&$captured): void {
-                $captured[] = $msg;
-            },
+        BackslashSeparatorDeprecator::getInstance()->maybeWarn(
+            $this->locatedRawNameSymbol('phel\\core/map', '/app/user.phel'),
         );
-        BackslashSeparatorDeprecator::useInstance($viaFlag);
 
-        $sym = Symbol::createForNamespace(null, 'phel\\core/map');
-        $sym->setStartLocation(new SourceLocation('/app/user.phel', 1, 1));
-
-        $viaFlag->maybeWarn($sym);
-
-        self::assertInstanceOf(BackslashSeparatorDeprecator::class, $instance);
-        self::assertCount(1, $captured);
+        self::assertCount(1, $this->capturedDeprecations());
     }
 
     public function test_strips_flag_with_value_form(): void
@@ -86,33 +80,38 @@ final class WarnDeprecationsFlagTest extends TestCase
         self::assertSame(['phel', 'run', 'src/main.phel'], $result);
     }
 
-    public function test_preserves_disabled_default_when_flag_absent(): void
+    public function test_detectors_stay_silent_when_the_flag_is_absent(): void
     {
-        // Verify that without the flag the singleton stays in its default
-        // (env-var-driven) state. We force-reset first so the test does not
-        // depend on any prior configuration.
-        BackslashSeparatorDeprecator::resetInstance();
+        DeprecationWarnings::disable();
+        $this->captureDeprecationsWithoutEnabling();
 
         $result = WarnDeprecationsFlag::applyAndStrip(['phel', 'test']);
 
         self::assertSame(['phel', 'test'], $result);
 
-        $captured = [];
-        $instance = BackslashSeparatorDeprecator::getInstance();
-        // Force a capturing disabled instance to confirm the flag-absent
-        // path does not flip the enabled bit.
-        BackslashSeparatorDeprecator::useInstance(new BackslashSeparatorDeprecator(
-            enabled: false,
-            emitter: static function (string $msg) use (&$captured): void {
-                $captured[] = $msg;
-            },
-        ));
+        BackslashSeparatorDeprecator::getInstance()->maybeWarn(
+            $this->locatedRawNameSymbol('phel\\core/map', '/app/user.phel'),
+        );
 
-        $sym = Symbol::createForNamespace('phel.core', 'map');
-        $sym->setStartLocation(new SourceLocation('/app/user.phel', 1, 1));
-        BackslashSeparatorDeprecator::getInstance()->maybeWarn($sym);
+        self::assertSame([], $this->capturedDeprecations());
+    }
 
-        self::assertInstanceOf(BackslashSeparatorDeprecator::class, $instance);
-        self::assertSame([], $captured);
+    /**
+     * Installs the capture handler but leaves the switch exactly as the test
+     * set it, so `applyAndStrip` is the only thing that can turn it on.
+     */
+    private function captureDeprecationsWithoutEnabling(): void
+    {
+        $enabled = DeprecationWarnings::isEnabled();
+        $this->startCapturingDeprecations();
+        $enabled ? DeprecationWarnings::enable() : DeprecationWarnings::disable();
+    }
+
+    private function locatedRawNameSymbol(string $rawName, string $file): Symbol
+    {
+        $symbol = Symbol::createForNamespace(null, $rawName);
+        $symbol->setStartLocation(new SourceLocation($file, 1, 1));
+
+        return $symbol;
     }
 }


### PR DESCRIPTION
Rebased onto `main` after #2829, which landed the same area from the other direction. See "Reconciliation with #2829" below for what survived and why.

## 🤔 Background

Phel ships a set of deprecated-but-still-working public API: reader syntax (`#| |#`, bare `#` comments, `|()`, `,`/`,@`, `foo$`), the `^:reference` fn-param alias, `set-meta!`, `phel\test/print-summary`, the `--out`/`--json` CLI aliases, the legacy REPL history path, and the `\` namespace separator. None of it can be removed before the next major.

An audit of how each item announces itself found three that were **silently** deprecated: documented somewhere, or not documented at all, with no signal reaching the user.

- `^:reference` had no signal of any kind. Its only record was a private docblock in `MethodEmitter` and one integration fixture. A user grepping `--warn-deprecations` output saw nothing.
- `phel\test/print-summary` had no `:deprecated` metadata, so `(doc print-summary)` stayed silent even though its docstring said "kept for backwards compatibility". Worse, `test.phel`'s own `execute-run!` called the shim, so it could never be deleted without also editing the runner.
- `set-meta!` had the metadata (so `phel doc` flagged it) but nothing at compile time, and there was no general path for definition-level deprecations. Every future core deprecation would have needed its own bespoke detector, the way the `\` separator has one.

## 💡 Goal

Since the public surface cannot be removed yet, build the infrastructure that makes removing it a non-event later: close the signal gaps, make the mechanism singular, and write down the map.

No public API is removed here. The `\` separator is untouched.

Companion issue with the full removal set, `file:line` for every item, and the grep-the-literal follow-through traps: #2827.

## 🔖 Changes

**A generic mechanism for definition deprecations.** Any `def`/`defn` carrying `:deprecated` metadata now warns at every call site when deprecation warnings are enabled. Marking a definition is enough; no bespoke detector. It works for project code too:

```phel
(defn old-parse
  {:deprecated "1.4.0" :superseded-by "parse-config"}
  [s]
  (parse-config s))
```

**`^:reference` now announces itself**, pointing at `^:by-ref`.

**`print-summary` is marked deprecated** and `execute-run!` calls a new private `emit-summary!`, so the test runner no longer routes through its own back-compat shim.

**`SymbolResolver::globalVarNode()`** becomes the single `GlobalVarNode` construction point, so every resolved definition passes the deprecation check exactly once. The aliased-resolution path now carries the call-site location it was silently dropping, which also gives fully-qualified call sites a source-map entry they did not have.

**`docs/migration/deprecated-surface.md`** maps the whole live deprecated surface: what each item is, what replaces it, a mechanical before/after, and how it announces itself. Modelled on `removed-deprecated-core-fns.md`, linked from `docs/README.md` and cross-linked from both existing migration guides.

## 🤝 Reconciliation with #2829

#2829 and this branch built overlapping deprecation infrastructure in parallel. **#2829's `Compiler\Domain\Deprecation\DeprecationWarnings` survives as the single mechanism.** It won on the merits, not on merge order:

- It fixed a real bug this branch did not even see. All six syntax notices were `@`-suppressed, so `--warn-deprecations` printed nothing; my `SyntaxDeprecation` faithfully preserved the `@` and would have shipped the bug forward.
- Making syntax notices opt-in is correct, and it is load-bearing: phel's own `protocols.phel` uses `,` for unquote, so always-on floods stderr. The bundled-stdlib suppression stays for the same reason.
- `Compiler\Domain\Deprecation` is the right home. My `Shared\Deprecations` placement split one concern across two modules and pulled a `Shared → Lang` edge in for `SourceLocation`.

Deleted from this branch: `Shared\Deprecations\SyntaxDeprecation`, `Analyzer\Environment\DeprecationChannel`, `Analyzer\Environment\DeprecationWarnings`.

Folded into the survivor, the two things it lacked:

- `warnOnceForSource(file, subject, message)` — per-`(file, subject)` dedup. It already existed, privately, inside `BackslashSeparatorDeprecator`; definition notices need the same thing (one deprecated fn called fifty times in a file should not print fifty lines). Syntax notices deliberately still do not dedup, since each occurrence is a separate edit.
- `syntaxMessage(construct, purpose, replacement, ?SourceLocation)` — the one shape for a syntax notice. The point is that it takes no version argument, so the "never name a concrete removal version" rule (#2783, where a message advertised "v0.33" until v0.48) is structural rather than a convention plus a regex assertion. `LexerTest::VERSION_REFERENCE` still guards it, and a new unit test pins the exact shape.

Then the duplication that #2829 left behind, which was mine to finish rather than add to:

- `BackslashSeparatorDeprecator` no longer carries its own enabled flag, dedup table, or emitter. `::enable()` is gone, so `CompilerFactory` and `WarnDeprecationsFlag` flip **one** switch instead of a pair that had to be kept in sync by hand.
- Both analyzer detectors are now stateless and only detect. `useInstance()`/`resetInstance()` are gone with the state they existed to manage.
- Consequently no detector has an injectable emitter, so tests observe notices the way a user does, as real `E_USER_DEPRECATED`. The new `PhelTest\Support\CapturesDeprecationsTrait` replaces four hand-rolled capture helpers across `BackslashSeparatorDeprecatorTest`, `NsSymbolTest`, `InNsSymbolTest`, `WarnDeprecationsFlagTest`, and `SymbolResolverTest`.

**The lexer's per-source gate from #2829 is untouched** — `DeprecationWarnings::isEnabledForSource($source)` still resolves once per source, and the per-token path is still a single boolean. Only the message construction moved behind the factory. `WarnDeprecationsFlagTest` now asserts the reverse direction too: flipping the one switch reaches the analyzer detectors without the flag knowing they exist.

Net result: one gate, one suppression path, one dedup table, one enable switch, one message shape.

## ✅ Verification

Empirical, on a throwaway project using both a deprecated syntax form and a deprecated `defn`:

```
$ phel run --warn-deprecations src/main.phel
Deprecated: Using "#" for line comments is deprecated and will be removed in a
  future release; use ";" or ";;" instead (at .../main.phel:12:0)
Deprecated: Using "|()" for short functions is deprecated and will be removed in
  a future release; use "#()" instead (at .../main.phel:13:12)
Deprecated: Definition 'recon.main/legacy-parse' used at .../main.phel:15 is
  deprecated (since 1.4.0). Use 'parse-config' instead. It will be removed in a
  future release.
Deprecated: Definition 'phel.core/set-meta!' used at .../main.phel:17 is
  deprecated (since 0.32.0). Use 'with-meta' instead. It will be removed in a
  future release.
a @[2 3 4] b x c {:k 1}

$ phel run src/main.phel
a @[2 3 4] b x c {:k 1}
```

Same result via `PHEL_WARN_DEPRECATIONS=1`. `composer test-core` prints **zero** deprecation lines (6488 passed) despite `tests/phel/` calling `set-meta!` 28 times on purpose, because the switch is off by default.

Gates: phpstan, psalm, php-cs-fixer, rector (full run, cache cleared), `--testsuite=unit` (4146), `--testsuite=integration` (1091), `composer test-core` (6488), plus `bin/phel --help` and `phel doc set-meta!`.

## 📝 Notes

The inventory refresh caught one wrong claim worth recording: `set-meta!` does **not** have zero remaining call sites in `tests/phel/`. The `with-meta` switchover covered `src/phel/`, but `tests/phel/` still has 28 deliberate uses, including `test-set-meta!-still-works`, which exists purely to pin the alias. That test must be deleted at the major, not "fixed".

The `--warn-deprecations` run above also re-surfaces a pre-existing backslash false positive: a macro body referencing a `\`-form class FQN (`\Phel\Lang\MetaInterface` inside `phel.core`'s `meta`) is attributed to the *user's* file. Out of scope here, documented in #2827.

Not done on purpose: no public API removed, no internal removals (a fresh scan for unused private methods and constants across all of `src/` produced only false positives, so the earlier waves really did take it), and `rector.php` skip entries left alone since the extension-less ones are live directory prefixes.

Refs #2827
