### PR TITLE
fix: report suppressed syntax deprecations, unreadable lint sources, and chain error causes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Syntax deprecation notices (bare `#` comments, `#| ... |#` blocks, `|()` short fns, `,`/`,@` unquote, `$` auto-gensym) are no longer suppressed with `@`, which hid them from every real run: `--warn-deprecations` printed nothing at all. They are now gated on the same switch as the backslash-separator warning, off by default and reported when asked for, and suppressed for phel's own bundled `src/phel` sources so only code the user can edit is flagged
+- `phel lint` no longer skips a `.phel` file it cannot read, which reported the file as clean and let the run exit 0; it now raises `LintSourceException` naming the path
+- Parser, reader and analyzer errors now chain the sub-parser, tag-handler or path-resolver exception that produced them as `getPrevious()`, so the error log keeps the original throw site. The located message shown to the user is unchanged
+- Building a map from an odd number of elements now reports `An even number of elements must be provided to build a map, got 3` instead of the ungrammatical, count-less `A even number of elements must be provided`
 - Sorted collection comparators are now typed `bool|int` rather than `int`. Phel's `<` returns a boolean, so `(sorted-map-by < ...)` never matched its own declared contract
 - `phel lint` now exits 2 with a clear message when `phel-lint.phel` exists but is unreadable, unparseable, or not a map, instead of silently falling back to the built-in default rules. A missing or empty config file still means defaults
 - Parse and lex failures during namespace extraction now report the underlying reason and chain the original exception, replacing a bare `Cannot parse file: <path>` with no line or cause

--- a/src/php/Compiler/Application/Lexer.php
+++ b/src/php/Compiler/Application/Lexer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Compiler\Application;
 
 use Generator;
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
 use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
 use Phel\Compiler\Domain\Lexer\LexerInterface;
 use Phel\Compiler\Domain\Lexer\TokenStream;
@@ -117,6 +118,9 @@ final class Lexer implements LexerInterface
         // strlen() === mb_strlen(), so moveCursor can take the cheaper path.
         $this->isAscii = preg_match('/[\x80-\xFF]/', $code) === 0;
         $end = strlen($code);
+        // Resolved once per source, not per token: the flag is process-wide
+        // and the stdlib-suppression check is a path comparison.
+        $warnDeprecations = DeprecationWarnings::isEnabledForSource($source);
 
         $startLocation = $this->createSourceLocation($source);
 
@@ -126,10 +130,9 @@ final class Lexer implements LexerInterface
                 $this->moveCursor($comment);
                 $endLocation = $this->createSourceLocation($source);
 
-                @trigger_error(
-                    sprintf('"#| ... |#" multiline comments are deprecated and will be removed in a future release. Use ";;" for line comments or "#_" to skip a single form (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
-                    E_USER_DEPRECATED,
-                );
+                if ($warnDeprecations) {
+                    DeprecationWarnings::warn(sprintf('"#| ... |#" multiline comments are deprecated and will be removed in a future release. Use ";;" for line comments or "#_" to skip a single form (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()));
+                }
 
                 yield new Token(Token::T_COMMENT, $comment, $startLocation, $endLocation);
 
@@ -142,33 +145,21 @@ final class Lexer implements LexerInterface
                 $endLocation = $this->createSourceLocation($source);
                 $tokenType = count($matches);
 
-                if (isset(self::DEPRECATABLE_TYPES[$tokenType])) {
+                if ($warnDeprecations && isset(self::DEPRECATABLE_TYPES[$tokenType])) {
                     if ($tokenType === Token::T_COMMENT && str_starts_with($matches[0], '#')) {
-                        @trigger_error(
-                            sprintf('Bare "#" line comments are deprecated and will be removed in a future release. Use ";" or ";;" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
-                            E_USER_DEPRECATED,
-                        );
+                        DeprecationWarnings::warn(sprintf('Bare "#" line comments are deprecated and will be removed in a future release. Use ";" or ";;" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()));
                     }
 
                     if ($tokenType === Token::T_FN) {
-                        @trigger_error(
-                            sprintf('Using "|()" for short functions is deprecated, use "#()" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
-                            E_USER_DEPRECATED,
-                        );
+                        DeprecationWarnings::warn(sprintf('Using "|()" for short functions is deprecated, use "#()" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()));
                     }
 
                     if ($tokenType === Token::T_UNQUOTE_SPLICING && $matches[0] === ',@') {
-                        @trigger_error(
-                            sprintf('Using "," for unquote-splicing is deprecated, use "~@" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
-                            E_USER_DEPRECATED,
-                        );
+                        DeprecationWarnings::warn(sprintf('Using "," for unquote-splicing is deprecated, use "~@" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()));
                     }
 
                     if ($tokenType === Token::T_UNQUOTE && $matches[0] === ',') {
-                        @trigger_error(
-                            sprintf('Using "," for unquote is deprecated, use "~" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
-                            E_USER_DEPRECATED,
-                        );
+                        DeprecationWarnings::warn(sprintf('Using "," for unquote is deprecated, use "~" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()));
                     }
                 }
 

--- a/src/php/Compiler/Application/Parser.php
+++ b/src/php/Compiler/Application/Parser.php
@@ -36,6 +36,7 @@ use Phel\Shared\Parser\Node\TriviaNodeInterface;
 use Phel\Shared\Parser\Node\WhitespaceNode;
 
 use SplStack;
+use Throwable;
 
 final readonly class Parser implements ParserInterface
 {
@@ -227,7 +228,12 @@ final readonly class Parser implements ParserInterface
         try {
             return $this->atomParser->parse($token);
         } catch (KeywordParserException $keywordParserException) {
-            throw $this->createUnexceptedParserException($tokenStream, $token, $keywordParserException->getMessage());
+            throw $this->createUnexceptedParserException(
+                $tokenStream,
+                $token,
+                $keywordParserException->getMessage(),
+                $keywordParserException,
+            );
         }
     }
 
@@ -295,7 +301,12 @@ final readonly class Parser implements ParserInterface
                 ->createStringParser()
                 ->parse($token);
         } catch (StringParserException $stringParserException) {
-            throw $this->createUnexceptedParserException($tokenStream, $token, $stringParserException->getMessage());
+            throw $this->createUnexceptedParserException(
+                $tokenStream,
+                $token,
+                $stringParserException->getMessage(),
+                $stringParserException,
+            );
         }
     }
 
@@ -313,9 +324,19 @@ final readonly class Parser implements ParserInterface
             ->parse($token);
     }
 
-    private function createUnexceptedParserException(TokenStream $tokenStream, Token $currentToken, string $message): UnexpectedParserException
-    {
-        return UnexpectedParserException::forSnippet($tokenStream->getCodeSnippet(), $currentToken, $message);
+    private function createUnexceptedParserException(
+        TokenStream $tokenStream,
+        Token $currentToken,
+        string $message,
+        ?Throwable $nestedException = null,
+    ): UnexpectedParserException {
+        return UnexpectedParserException::forSnippet(
+            $tokenStream->getCodeSnippet(),
+            $currentToken,
+            $message,
+            null,
+            $nestedException,
+        );
     }
 
     private function createUnfinishedParserException(TokenStream $tokenStream, Token $currentToken, string $message): UnfinishedParserException

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -107,6 +107,14 @@ GOTCHA: only eager core fns can be lowered to a native loop. `reduce` (3-arity) 
 - `^:php/override` on a method (defstruct/defenum interface impls, definterface methods) → `#[\Override]` (PHP 8.3); `PhpAttributeEmitterTrait::phpAttributeLines` renders it ahead of explicit `:php/attr` lines. Struct/enum inline method impls emit method-level `:php/attr`/`:php/doc`/`^:php/override` too.
 - Export wrappers carry the same `:php/attr` via `Interop`'s `CompiledPhpMethodBuilder` (see `src/php/Interop/CLAUDE.md`).
 
+## Syntax Deprecations
+
+`Domain/Deprecation/DeprecationWarnings` is the single process-wide switch for every `E_USER_DEPRECATED` notice the compiler raises about deprecated Phel syntax. Off by default; turned on by `--warn-deprecations` (`Console\Application\WarnDeprecationsFlag`), `PHEL_WARN_DEPRECATIONS`, or the `warn-deprecations` config key (`CompilerFactory::createAnalyzer()`).
+
+- Emitters: `Application/Lexer` (bare `#` comments, `#| ... |#` blocks, `|()` short fns, `,`/`,@` unquote), `Domain/Reader/QuasiquoteTransformer` (`$` auto-gensym), `Domain/Analyzer/Environment/BackslashSeparatorDeprecator` (`\` namespace separator).
+- Never suppress one with `@`: that hides it unconditionally, so a `--warn-deprecations` run prints nothing. Call `warn()`/`warnForSource()` instead.
+- `isEnabledForSource()`/`isBundledStdlibSource()` drop notices whose source is phel's own `src/phel` or has no file, so only code the user can edit is flagged. The Lexer resolves it once per source, not per token.
+
 ## Global Environment
 
 Process-wide singleton in `Domain/Analyzer/Environment/GlobalEnvironmentRegistry`.

--- a/src/php/Compiler/CompilerFactory.php
+++ b/src/php/Compiler/CompilerFactory.php
@@ -23,6 +23,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
 use Phel\Compiler\Domain\Cache\ReaderResultCacheInterface;
 use Phel\Compiler\Domain\Compiler\CodeCompilerInterface;
 use Phel\Compiler\Domain\Compiler\EvalCompilerInterface;
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
 use Phel\Compiler\Domain\Emitter\FileEmitter;
 use Phel\Compiler\Domain\Emitter\FileEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitter;
@@ -133,9 +134,7 @@ final class CompilerFactory extends AbstractFactory
 
     public function createAnalyzer(): AnalyzerInterface
     {
-        if ($this->getConfig()->warnDeprecationsEnabled()) {
-            BackslashSeparatorDeprecator::enable();
-        }
+        $this->enableConfiguredDeprecationWarnings();
 
         return new Analyzer(
             $this->getGlobalEnvironment(),
@@ -248,5 +247,23 @@ final class CompilerFactory extends AbstractFactory
     private function getGlobalEnvironment(): GlobalEnvironmentInterface
     {
         return $this->createGlobalEnvironmentManager()->initialize();
+    }
+
+    /**
+     * Applies the `warn-deprecations` config key to the process-wide
+     * deprecation switches, which the lexer and reader also read. Hooked
+     * here rather than on `createLexer()` because every compile pipeline
+     * builds its analyzer up front, before a single token is lexed, and
+     * the lexer-only consumers (linting, best-effort form reading) are
+     * tooling paths that must stay quiet.
+     */
+    private function enableConfiguredDeprecationWarnings(): void
+    {
+        if (!$this->getConfig()->warnDeprecationsEnabled()) {
+            return;
+        }
+
+        DeprecationWarnings::enable();
+        BackslashSeparatorDeprecator::enable();
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Analyzer\Environment;
 
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 
-use function dirname;
-use function in_array;
 use function sprintf;
 use function str_replace;
 use function str_starts_with;
@@ -48,12 +47,12 @@ final class BackslashSeparatorDeprecator
 
     /**
      * Returns the process-wide deprecator, creating it lazily from the
-     * `PHEL_WARN_DEPRECATIONS` env var so every detection site shares
-     * the same dedup state across a compile run.
+     * shared {@see DeprecationWarnings} switch so every detection site
+     * shares the same dedup state across a compile run.
      */
     public static function getInstance(): self
     {
-        return self::$instance ??= new self(self::readEnvFlag());
+        return self::$instance ??= new self(DeprecationWarnings::isEnabled());
     }
 
     /**
@@ -96,7 +95,7 @@ final class BackslashSeparatorDeprecator
         }
 
         $file = $location->getFile();
-        if ($file === '' || $this->isPhelStdlibSource($file)) {
+        if ($file === '' || DeprecationWarnings::isBundledStdlibSource($file)) {
             return;
         }
 
@@ -111,27 +110,6 @@ final class BackslashSeparatorDeprecator
 
         $this->seen[$key] = true;
         ($this->emitter)($this->buildMessage($namespace, $file, $location->getLine()));
-    }
-
-    private static function readEnvFlag(): bool
-    {
-        $flag = getenv('PHEL_WARN_DEPRECATIONS');
-
-        return !in_array($flag, [false, '', '0'], true);
-    }
-
-    /**
-     * Source-path suppression for phel's bundled stdlib. The path is
-     * anchored to this package's own `src/phel`, so nested-layout user
-     * projects with their own `src/phel` still receive warnings.
-     */
-    private function isPhelStdlibSource(string $file): bool
-    {
-        $normalized = str_replace('\\', '/', $file);
-        $stdlibRoot = str_replace('\\', '/', dirname(__DIR__, 5) . '/phel');
-
-        return $normalized === $stdlibRoot
-            || str_starts_with($normalized, $stdlibRoot . '/');
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoadSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoadSymbol.php
@@ -40,7 +40,11 @@ final readonly class LoadSymbol implements SpecialFormAnalyzerInterface
         try {
             $resolution = $this->pathResolver->resolve($callerNamespace, $pathArg);
         } catch (InvalidArgumentException $invalidArgumentException) {
-            throw AnalyzerException::withLocation($invalidArgumentException->getMessage(), $list);
+            throw AnalyzerException::withLocation(
+                $invalidArgumentException->getMessage(),
+                $list,
+                $invalidArgumentException,
+            );
         }
 
         return new LoadNode(

--- a/src/php/Compiler/Domain/Deprecation/DeprecationWarnings.php
+++ b/src/php/Compiler/Domain/Deprecation/DeprecationWarnings.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Deprecation;
+
+use function dirname;
+use function in_array;
+
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
+
+/**
+ * Process-wide switch for the compiler's own `E_USER_DEPRECATED` notices
+ * about deprecated Phel syntax (bare `#` comments, `#| ... |#` blocks,
+ * `|()` short fns, `,`/`,@` unquote, `$` auto-gensym, `\` namespace
+ * separators).
+ *
+ * Every notice is gated: off by default, on when the user asks for it via
+ * `--warn-deprecations`, `PHEL_WARN_DEPRECATIONS`, or the
+ * `warn-deprecations` config key. Suppressing a notice with `@` instead
+ * would hide it unconditionally, so a `--warn-deprecations` run would
+ * print nothing and the deprecation could never be acted on.
+ */
+final class DeprecationWarnings
+{
+    private static ?bool $enabled = null;
+
+    public static function isEnabled(): bool
+    {
+        return self::$enabled ??= self::readEnvFlag();
+    }
+
+    public static function enable(): void
+    {
+        self::$enabled = true;
+    }
+
+    public static function disable(): void
+    {
+        self::$enabled = false;
+    }
+
+    /**
+     * Drop the cached flag so the next `isEnabled()` call re-reads the
+     * environment. Intended for test `tearDown()` hooks.
+     */
+    public static function reset(): void
+    {
+        self::$enabled = null;
+    }
+
+    /**
+     * Whether a deprecation found in `$sourceFile` should be reported.
+     * Bundled-stdlib sources are excluded: a user cannot act on deprecated
+     * syntax inside phel's own `src/phel`, so warning about it would bury
+     * the notices that do concern their code.
+     *
+     * Callers scanning many tokens from one source should call this once
+     * and reuse the result instead of paying for it per token.
+     */
+    public static function isEnabledForSource(string $sourceFile): bool
+    {
+        return self::isEnabled()
+            && $sourceFile !== ''
+            && !self::isBundledStdlibSource($sourceFile);
+    }
+
+    /**
+     * Source-path suppression for phel's bundled stdlib. The path is
+     * anchored to this package's own `src/phel`, so nested-layout user
+     * projects with their own `src/phel` still receive warnings.
+     */
+    public static function isBundledStdlibSource(string $file): bool
+    {
+        $normalized = str_replace('\\', '/', $file);
+        $stdlibRoot = str_replace('\\', '/', dirname(__DIR__, 4) . '/phel');
+
+        return $normalized === $stdlibRoot
+            || str_starts_with($normalized, $stdlibRoot . '/');
+    }
+
+    /**
+     * Emits `$message` as an `E_USER_DEPRECATED` notice when deprecation
+     * warnings are enabled, and does nothing otherwise.
+     */
+    public static function warn(string $message): void
+    {
+        if (!self::isEnabled()) {
+            return;
+        }
+
+        trigger_error($message, E_USER_DEPRECATED);
+    }
+
+    /**
+     * Like {@see warn()}, but silent for deprecations located in phel's
+     * bundled stdlib.
+     */
+    public static function warnForSource(string $sourceFile, string $message): void
+    {
+        if (!self::isEnabledForSource($sourceFile)) {
+            return;
+        }
+
+        trigger_error($message, E_USER_DEPRECATED);
+    }
+
+    private static function readEnvFlag(): bool
+    {
+        $flag = getenv('PHEL_WARN_DEPRECATIONS');
+
+        return !in_array($flag, [false, '', '0'], true);
+    }
+}

--- a/src/php/Compiler/Domain/Parser/Exceptions/AbstractParserException.php
+++ b/src/php/Compiler/Domain/Parser/Exceptions/AbstractParserException.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Parser\Exceptions;
 use Phel\Lang\SourceLocation;
 use Phel\Shared\Exceptions\AbstractLocatedException;
 use Phel\Shared\Parser\ReadModel\CodeSnippet;
+use Throwable;
 
 abstract class AbstractParserException extends AbstractLocatedException
 {
@@ -15,8 +16,9 @@ abstract class AbstractParserException extends AbstractLocatedException
         private readonly CodeSnippet $codeSnippet,
         SourceLocation $startLocation,
         SourceLocation $endLocation,
+        ?Throwable $nestedException = null,
     ) {
-        parent::__construct($message, $startLocation, $endLocation);
+        parent::__construct($message, $startLocation, $endLocation, $nestedException);
     }
 
     public function getCodeSnippet(): CodeSnippet

--- a/src/php/Compiler/Domain/Parser/Exceptions/UnexpectedParserException.php
+++ b/src/php/Compiler/Domain/Parser/Exceptions/UnexpectedParserException.php
@@ -7,16 +7,27 @@ namespace Phel\Compiler\Domain\Parser\Exceptions;
 use Phel\Shared\Exceptions\ErrorCode;
 use Phel\Shared\Parser\Node\Token;
 use Phel\Shared\Parser\ReadModel\CodeSnippet;
+use Throwable;
 
 final class UnexpectedParserException extends AbstractParserException
 {
-    public static function forSnippet(CodeSnippet $snippet, Token $token, string $message, ?ErrorCode $errorCode = null): self
-    {
+    /**
+     * `$nestedException` keeps the sub-parser failure that produced `$message`
+     * reachable via `getPrevious()`; the located output is unchanged.
+     */
+    public static function forSnippet(
+        CodeSnippet $snippet,
+        Token $token,
+        string $message,
+        ?ErrorCode $errorCode = null,
+        ?Throwable $nestedException = null,
+    ): self {
         $e = new self(
             $message,
             $snippet,
             $token->getStartLocation(),
             $token->getEndLocation(),
+            $nestedException,
         );
 
         if ($errorCode instanceof ErrorCode) {

--- a/src/php/Compiler/Domain/Reader/Exceptions/ReaderException.php
+++ b/src/php/Compiler/Domain/Reader/Exceptions/ReaderException.php
@@ -8,6 +8,7 @@ use Phel\Lang\SourceLocation;
 use Phel\Shared\Exceptions\AbstractLocatedException;
 use Phel\Shared\Parser\Node\NodeInterface;
 use Phel\Shared\Parser\ReadModel\CodeSnippet;
+use Throwable;
 
 final class ReaderException extends AbstractLocatedException
 {
@@ -16,12 +17,22 @@ final class ReaderException extends AbstractLocatedException
         SourceLocation $startLocation,
         SourceLocation $endLocation,
         private readonly CodeSnippet $codeSnippet,
+        ?Throwable $nestedException = null,
     ) {
-        parent::__construct($message, $startLocation, $endLocation);
+        parent::__construct($message, $startLocation, $endLocation, $nestedException);
     }
 
-    public static function forNode(NodeInterface $node, NodeInterface $root, string $message): self
-    {
+    /**
+     * `$nestedException` keeps the original throw site (a failing tag handler,
+     * for example) reachable via `getPrevious()`; the located message shown to
+     * the user is unaffected.
+     */
+    public static function forNode(
+        NodeInterface $node,
+        NodeInterface $root,
+        string $message,
+        ?Throwable $nestedException = null,
+    ): self {
         $codeSnippet = new CodeSnippet(
             $root->getStartLocation(),
             $root->getEndLocation(),
@@ -33,6 +44,7 @@ final class ReaderException extends AbstractLocatedException
             $node->getStartLocation(),
             $node->getEndLocation(),
             $codeSnippet,
+            $nestedException,
         );
     }
 

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/TaggedLiteralReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/TaggedLiteralReader.php
@@ -58,13 +58,13 @@ final readonly class TaggedLiteralReader
         try {
             return $handler($formValue);
         } catch (TagHandlerException $e) {
-            throw ReaderException::forNode($node, $root, $e->getMessage());
+            throw ReaderException::forNode($node, $root, $e->getMessage(), $e);
         } catch (Throwable $e) {
             throw ReaderException::forNode($node, $root, sprintf(
                 "Tagged-literal handler for '#%s' threw an error: %s",
                 $tag,
                 $e->getMessage(),
-            ));
+            ), $e);
         }
     }
 

--- a/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
+++ b/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
@@ -8,6 +8,7 @@ use Phel;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
 use Phel\Compiler\Domain\Reader\Exceptions\SpliceNotInListException;
 use Phel\Lang\Collections\LinkedList\PersistentList;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
@@ -26,9 +27,6 @@ use function is_string;
 use function sprintf;
 use function str_ends_with;
 use function substr;
-use function trigger_error;
-
-use const E_USER_DEPRECATED;
 
 final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInterface
 {
@@ -249,9 +247,9 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
             ? sprintf(' (at %s:%d:%d)', $location->getFile(), $location->getLine(), $location->getColumn())
             : '';
 
-        @trigger_error(
+        DeprecationWarnings::warnForSource(
+            $location instanceof SourceLocation ? $location->getFile() : '',
             sprintf('Using "%s" auto-gensym suffix is deprecated, use "%s" instead%s', $name, $suggested, $where),
-            E_USER_DEPRECATED,
         );
     }
 }

--- a/src/php/Console/Application/WarnDeprecationsFlag.php
+++ b/src/php/Console/Application/WarnDeprecationsFlag.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Console\Application;
 
 use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
 
 use function array_filter;
 use function array_values;
@@ -12,10 +13,11 @@ use function str_starts_with;
 
 /**
  * CLI bridge for `PHEL_WARN_DEPRECATIONS`: detects the
- * `--warn-deprecations` flag in argv, configures the process-wide
- * `BackslashSeparatorDeprecator` singleton, and returns argv with the
- * flag stripped so Symfony's per-command input parsers do not complain
- * about an unknown option.
+ * `--warn-deprecations` flag in argv, turns on the process-wide
+ * `DeprecationWarnings` switch (which every syntax deprecation notice is
+ * gated on) plus the `BackslashSeparatorDeprecator` singleton, and returns
+ * argv with the flag stripped so Symfony's per-command input parsers do
+ * not complain about an unknown option.
  *
  * Accepted forms: `--warn-deprecations` and `--warn-deprecations=1`.
  * Any other shape is passed through unchanged.
@@ -36,6 +38,7 @@ final class WarnDeprecationsFlag
         ));
 
         if ($filtered !== $argv) {
+            DeprecationWarnings::enable();
             BackslashSeparatorDeprecator::enable();
         }
 

--- a/src/php/Lang/Collections/Map/PersistentArrayMap.php
+++ b/src/php/Lang/Collections/Map/PersistentArrayMap.php
@@ -10,6 +10,7 @@ use RuntimeException;
 use Traversable;
 
 use function count;
+use function sprintf;
 
 /**
  * Map implementation based on a single array. The array stores the key value pair directly.
@@ -58,7 +59,10 @@ final class PersistentArrayMap extends AbstractPersistentMap
     public static function fromArray(HasherInterface $hasher, EqualizerInterface $equalizer, array $kvs): PersistentMapInterface
     {
         if (count($kvs) % 2 !== 0) {
-            throw new RuntimeException('A even number of elements must be provided');
+            throw new RuntimeException(sprintf(
+                'An even number of elements must be provided to build a map, got %d',
+                count($kvs),
+            ));
         }
 
         $result = self::empty($hasher, $equalizer)->asTransient();

--- a/src/php/Lang/Collections/Map/PersistentHashMap.php
+++ b/src/php/Lang/Collections/Map/PersistentHashMap.php
@@ -12,6 +12,7 @@ use stdClass;
 use Traversable;
 
 use function count;
+use function sprintf;
 
 /**
  * @template TKey
@@ -63,7 +64,10 @@ final class PersistentHashMap extends AbstractPersistentMap
         }
 
         if (count($kvs) % 2 !== 0) {
-            throw new RuntimeException('A even number of elements must be provided');
+            throw new RuntimeException(sprintf(
+                'An even number of elements must be provided to build a map, got %d',
+                count($kvs),
+            ));
         }
 
         $result = self::empty($hasher, $equalizer)->asTransient();

--- a/src/php/Lang/Collections/SortedMap/PersistentSortedMap.php
+++ b/src/php/Lang/Collections/SortedMap/PersistentSortedMap.php
@@ -14,6 +14,7 @@ use RuntimeException;
 use Traversable;
 
 use function count;
+use function sprintf;
 
 /**
  * Sorted map implementation based on a flat array maintained in sorted key order.
@@ -72,7 +73,10 @@ final class PersistentSortedMap extends AbstractPersistentMap
     public static function fromArray(HasherInterface $hasher, EqualizerInterface $equalizer, array $kvs, ?callable $comparator = null): self
     {
         if (count($kvs) % 2 !== 0) {
-            throw new RuntimeException('A even number of elements must be provided');
+            throw new RuntimeException(sprintf(
+                'An even number of elements must be provided to build a sorted map, got %d',
+                count($kvs),
+            ));
         }
 
         $result = self::empty($hasher, $equalizer, $comparator)->asTransient();

--- a/src/php/Lint/Application/LintRunner.php
+++ b/src/php/Lint/Application/LintRunner.php
@@ -8,6 +8,7 @@ use Phel\Api\ApiFacade;
 use Phel\Api\Transfer\ProjectIndex;
 use Phel\Lint\Application\Cache\LintCache;
 use Phel\Lint\Application\Config\RuleSettings;
+use Phel\Lint\Domain\Exception\LintSourceException;
 use Phel\Lint\Domain\FileAnalysis;
 use Phel\Lint\Transfer\LintResult;
 
@@ -34,6 +35,8 @@ final readonly class LintRunner
 
     /**
      * @param list<string> $paths
+     *
+     * @throws LintSourceException when a collected file cannot be read
      */
     public function run(array $paths, RuleSettings $settings): LintResult
     {
@@ -55,9 +58,11 @@ final readonly class LintRunner
                 continue;
             }
 
+            // Suppress the warning and raise instead: an unreadable file must
+            // not be skipped, or the run reports it as clean and exits 0.
             $source = @file_get_contents($file);
             if ($source === false) {
-                continue;
+                throw LintSourceException::cannotRead($file);
             }
 
             $read = $this->sourceReader->read($source, $file);

--- a/src/php/Lint/CLAUDE.md
+++ b/src/php/Lint/CLAUDE.md
@@ -6,7 +6,7 @@ Read-only semantic linter: emits diagnostics on Phel sources, never rewrites the
 
 | Method | Returns |
 |--------|---------|
-| `lint(list<string> $paths, RuleSettings $settings, ?LintCache $cache)` | `LintResult` |
+| `lint(list<string> $paths, RuleSettings $settings, ?LintCache $cache)` | `LintResult`; throws `LintSourceException` on an unreadable file |
 | `loadSettings(string $configPath, RuleSettings $defaults)` | `RuleSettings` |
 | `defaultSettings()` | `RuleSettings` |
 | `formatters()` | `FormatterRegistry` |
@@ -57,6 +57,7 @@ Enforces the positional comment convention (`.claude/rules/phel.md`, shared with
 - Severities: `:error`, `:warning`, `:info`, `:hint`, `:off`
 - Exclude patterns match file path (when they contain `/` or `.phel`) or namespace name, via `fnmatch`
 - A missing config file means defaults. A file that exists but is unreadable, unparseable, or not a map raises `Domain\Exception\LintConfigException` and `phel lint` exits 2 — never silently falls back to defaults
+- A collected `.phel` file that cannot be read raises `Domain\Exception\LintSourceException` — never skipped, which would report it as clean and exit 0
 
 ## Output Formats
 

--- a/src/php/Lint/Domain/Exception/LintSourceException.php
+++ b/src/php/Lint/Domain/Exception/LintSourceException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Domain\Exception;
+
+use RuntimeException;
+
+use function sprintf;
+
+/**
+ * Raised when a collected `.phel` file cannot be read. Skipping it instead
+ * would report the file as clean and let `phel lint` exit 0, so a permission
+ * problem or a file deleted mid-run would look like a passing lint.
+ */
+final class LintSourceException extends RuntimeException
+{
+    public static function cannotRead(string $path): self
+    {
+        return new self(sprintf('Cannot read file to lint: %s', $path));
+    }
+}

--- a/src/php/Lint/LintFacade.php
+++ b/src/php/Lint/LintFacade.php
@@ -9,6 +9,7 @@ use Phel\Lint\Application\Cache\LintCache;
 use Phel\Lint\Application\Config\RuleSettings;
 use Phel\Lint\Application\Formatter\FormatterRegistry;
 use Phel\Lint\Domain\Exception\LintConfigException;
+use Phel\Lint\Domain\Exception\LintSourceException;
 use Phel\Lint\Transfer\LintResult;
 
 /**
@@ -18,6 +19,8 @@ final class LintFacade extends AbstractFacade
 {
     /**
      * @param list<string> $paths
+     *
+     * @throws LintSourceException when a collected `.phel` file cannot be read
      */
     public function lint(array $paths, RuleSettings $settings, ?LintCache $cache = null): LintResult
     {

--- a/src/php/Shared/Exceptions/AbstractLocatedException.php
+++ b/src/php/Shared/Exceptions/AbstractLocatedException.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Exceptions;
 
-use Exception;
 use Phel\Lang\SourceLocation;
 use RuntimeException;
+use Throwable;
 
 abstract class AbstractLocatedException extends RuntimeException
 {
@@ -16,7 +16,7 @@ abstract class AbstractLocatedException extends RuntimeException
         string $message,
         private readonly ?SourceLocation $startLocation = null,
         private readonly ?SourceLocation $endLocation = null,
-        ?Exception $nestedException = null,
+        ?Throwable $nestedException = null,
     ) {
         parent::__construct($message, 0, $nestedException);
     }

--- a/tests/php/Integration/Compiler/Parser/ParserTest.php
+++ b/tests/php/Integration/Compiler/Parser/ParserTest.php
@@ -8,6 +8,8 @@ use Phel;
 use Phel\Compiler\Application\Parser;
 use Phel\Compiler\CompilerFacade;
 use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
+use Phel\Compiler\Domain\Parser\Exceptions\KeywordParserException;
+use Phel\Compiler\Domain\Parser\Exceptions\StringParserException;
 use Phel\Compiler\Domain\Parser\Exceptions\UnexpectedParserException;
 use Phel\Compiler\Domain\Parser\ExpressionParserFactory;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
@@ -767,6 +769,36 @@ final class ParserTest extends TestCase
         $this->expectExceptionMessage('not allowed at the top level');
 
         $this->parse('#?@(:phel [1 2])');
+    }
+
+    public function test_invalid_keyword_keeps_the_sub_parser_failure_as_previous(): void
+    {
+        try {
+            $this->parse(':');
+            self::fail('Expected an UnexpectedParserException');
+        } catch (UnexpectedParserException $unexpectedParserException) {
+            self::assertStringContainsString('not a valid keyword', $unexpectedParserException->getMessage());
+            // The located parser error is what the user sees; the sub-parser
+            // exception that produced the message stays reachable.
+            self::assertInstanceOf(
+                KeywordParserException::class,
+                $unexpectedParserException->getPrevious(),
+            );
+        }
+    }
+
+    public function test_invalid_string_escape_keeps_the_sub_parser_failure_as_previous(): void
+    {
+        try {
+            $this->parse('"\u{FFFFFFF}"');
+            self::fail('Expected an UnexpectedParserException');
+        } catch (UnexpectedParserException $unexpectedParserException) {
+            self::assertStringContainsString('Codepoint too large', $unexpectedParserException->getMessage());
+            self::assertInstanceOf(
+                StringParserException::class,
+                $unexpectedParserException->getPrevious(),
+            );
+        }
     }
 
     public function test_symbolic_number_inf(): void

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Phel;
 use Phel\Compiler\Application\Lexer;
 use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
 use Phel\Compiler\Domain\Parser\Exceptions\ZeroDenominatorRatioParserException;
 use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
@@ -17,6 +18,7 @@ use Phel\Lang\Keyword;
 use Phel\Lang\Ratio;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
+use Phel\Lang\TagHandlerException;
 use Phel\Lang\TagHandlers\BuiltinTagHandlers;
 use Phel\Lang\TagRegistry;
 use Phel\Lang\TypeInterface;
@@ -52,6 +54,11 @@ final class ReaderTest extends TestCase
         Phel::bootstrap(__DIR__);
         Symbol::resetGen();
         $this->compilerFacade = new CompilerFacade();
+    }
+
+    protected function tearDown(): void
+    {
+        DeprecationWarnings::reset();
     }
 
     public function test_read_number(): void
@@ -448,6 +455,9 @@ final class ReaderTest extends TestCase
 
     public function test_quasiquote_dollar_auto_gensym_emits_deprecation(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;
@@ -467,6 +477,9 @@ final class ReaderTest extends TestCase
 
     public function test_quasiquote_hash_auto_gensym_does_not_emit_deprecation(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;
@@ -1355,6 +1368,18 @@ final class ReaderTest extends TestCase
         $this->expectException(ReaderException::class);
         $this->expectExceptionMessage('is not a canonical UUID string');
         $this->read('#uuid "not-a-uuid"');
+    }
+
+    public function test_tag_handler_failure_stays_reachable_as_previous(): void
+    {
+        try {
+            $this->read('#uuid "not-a-uuid"');
+            self::fail('Expected a ReaderException');
+        } catch (ReaderException $readerException) {
+            // The located reader error carries the snippet the user sees; the
+            // handler's own exception stays reachable for the error log.
+            self::assertInstanceOf(TagHandlerException::class, $readerException->getPrevious());
+        }
     }
 
     public function test_uuid_tagged_literal_requires_string_form(): void

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/LoadSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/LoadSymbolTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm;
 
 use Generator;
+use InvalidArgumentException;
 use Phel;
 use Phel\Compiler\Application\Analyzer;
 use Phel\Compiler\Domain\Analyzer\Ast\LoadNode;
@@ -124,6 +125,24 @@ final class LoadSymbolTest extends TestCase
         yield 'explicit extension'    => ['util.phel',  'must not include'];
         yield 'dot-slash prefix'      => ['./util',     "must not start with './'"];
         yield 'parent-slash prefix'   => ['../util',    "must not start with './'"];
+    }
+
+    public function test_rejected_path_keeps_the_resolver_failure_as_previous(): void
+    {
+        $this->analyzer->setNamespace('test\\ns');
+
+        try {
+            $this->analyze($this->makeList(['./util']));
+            self::fail('Expected an AnalyzerException');
+        } catch (AnalyzerException $analyzerException) {
+            // The located error is what the user sees; the resolver's own
+            // exception stays reachable so the error log keeps the throw site.
+            self::assertInstanceOf(InvalidArgumentException::class, $analyzerException->getPrevious());
+            self::assertSame(
+                $analyzerException->getPrevious()->getMessage(),
+                $analyzerException->getMessage(),
+            );
+        }
     }
 
     /**

--- a/tests/php/Unit/Compiler/Deprecation/DeprecationWarningsTest.php
+++ b/tests/php/Unit/Compiler/Deprecation/DeprecationWarningsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Deprecation;
+
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_USER_DEPRECATED;
+
+final class DeprecationWarningsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        DeprecationWarnings::reset();
+    }
+
+    public function test_warn_is_silent_when_disabled(): void
+    {
+        DeprecationWarnings::disable();
+
+        self::assertSame([], $this->capture(static function (): void {
+            DeprecationWarnings::warn('should not surface');
+        }));
+    }
+
+    public function test_warn_emits_when_enabled(): void
+    {
+        DeprecationWarnings::enable();
+
+        self::assertSame(['surfaced'], $this->capture(static function (): void {
+            DeprecationWarnings::warn('surfaced');
+        }));
+    }
+
+    public function test_reset_restores_the_environment_driven_default(): void
+    {
+        DeprecationWarnings::enable();
+        DeprecationWarnings::reset();
+
+        // The suite runs without PHEL_WARN_DEPRECATIONS set, so the flag falls
+        // back to off rather than staying on from the previous call.
+        self::assertFalse(DeprecationWarnings::isEnabled());
+    }
+
+    public function test_source_gate_suppresses_bundled_stdlib(): void
+    {
+        DeprecationWarnings::enable();
+
+        $stdlibFile = dirname(__DIR__, 5) . '/src/phel/walk.phel';
+
+        self::assertTrue(DeprecationWarnings::isBundledStdlibSource($stdlibFile));
+        self::assertFalse(DeprecationWarnings::isEnabledForSource($stdlibFile));
+        self::assertSame([], $this->capture(static function () use ($stdlibFile): void {
+            DeprecationWarnings::warnForSource($stdlibFile, 'stdlib deprecation');
+        }));
+    }
+
+    public function test_source_gate_allows_user_sources_including_nested_src_phel(): void
+    {
+        DeprecationWarnings::enable();
+
+        self::assertTrue(DeprecationWarnings::isEnabledForSource('/app/src/phel/main.phel'));
+        self::assertSame(['user deprecation'], $this->capture(static function (): void {
+            DeprecationWarnings::warnForSource('/app/src/phel/main.phel', 'user deprecation');
+        }));
+    }
+
+    public function test_source_gate_suppresses_unknown_source(): void
+    {
+        DeprecationWarnings::enable();
+
+        self::assertFalse(DeprecationWarnings::isEnabledForSource(''));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function capture(callable $fn): array
+    {
+        $messages = [];
+        set_error_handler(
+            static function (int $errno, string $message) use (&$messages): bool {
+                $messages[] = $message;
+
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $fn();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $messages;
+    }
+}

--- a/tests/php/Unit/Compiler/Lexer/LexerTest.php
+++ b/tests/php/Unit/Compiler/Lexer/LexerTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Compiler\Lexer;
 
 use Phel\Compiler\CompilerFactory;
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
 use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use Phel\Shared\Parser\Node\Token;
 use PHPUnit\Framework\TestCase;
+
+use function dirname;
 
 final class LexerTest extends TestCase
 {
@@ -25,6 +28,11 @@ final class LexerTest extends TestCase
     protected function setUp(): void
     {
         $this->compilerFactory = new CompilerFactory();
+    }
+
+    protected function tearDown(): void
+    {
+        DeprecationWarnings::reset();
     }
 
     public function test_whitespace_with_newline(): void
@@ -357,6 +365,9 @@ final class LexerTest extends TestCase
 
     public function test_hash_comment_emits_deprecation(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;
@@ -377,6 +388,9 @@ final class LexerTest extends TestCase
 
     public function test_semicolon_comment_does_not_emit_deprecation(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;
@@ -394,6 +408,9 @@ final class LexerTest extends TestCase
 
     public function test_multiline_comment_emits_deprecation(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;
@@ -414,6 +431,9 @@ final class LexerTest extends TestCase
 
     public function test_pipe_fn_emits_deprecation(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;
@@ -432,6 +452,9 @@ final class LexerTest extends TestCase
 
     public function test_hash_fn_does_not_emit_deprecation(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;
@@ -449,6 +472,9 @@ final class LexerTest extends TestCase
 
     public function test_comma_unquote_emits_deprecation(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;
@@ -467,6 +493,9 @@ final class LexerTest extends TestCase
 
     public function test_comma_splicing_emits_deprecation(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;
@@ -483,8 +512,51 @@ final class LexerTest extends TestCase
         self::assertStringContainsString('"~@"', $warning);
     }
 
+    public function test_deprecated_syntax_is_silent_unless_warnings_are_enabled(): void
+    {
+        DeprecationWarnings::disable();
+
+        $warning = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
+            $warning = $errstr;
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $this->lex('#|test|# # comment');
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertNull($warning);
+    }
+
+    public function test_deprecated_syntax_in_bundled_stdlib_sources_is_never_reported(): void
+    {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
+        $warning = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
+            $warning = $errstr;
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $lexer = $this->compilerFactory->createLexer();
+            iterator_to_array($lexer->lexString('#|test|#', dirname(__DIR__, 5) . '/src/phel/walk.phel'));
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertNull($warning);
+    }
+
     public function test_tilde_unquote_does_not_emit_deprecation(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;
@@ -502,6 +574,9 @@ final class LexerTest extends TestCase
 
     public function test_tilde_splicing_does_not_emit_deprecation(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;
@@ -519,6 +594,9 @@ final class LexerTest extends TestCase
 
     public function test_non_deprecatable_token_stream_emits_no_deprecation(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;
@@ -805,6 +883,9 @@ final class LexerTest extends TestCase
 
     public function test_hash_pipe_multiline_comment_still_deprecated_but_works(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;
@@ -825,6 +906,9 @@ final class LexerTest extends TestCase
 
     public function test_bare_hash_line_comment_still_deprecated_but_works(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;

--- a/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
+++ b/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
@@ -6,14 +6,21 @@ namespace PhelTest\Unit\Compiler\Reader;
 
 use Phel;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
 use Phel\Compiler\Domain\Reader\QuasiquoteTransformer;
 use Phel\Lang\Keyword;
+use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 final class QuasiquoteTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        DeprecationWarnings::reset();
+    }
+
     public function test_transform_unquote(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
@@ -259,6 +266,9 @@ final class QuasiquoteTest extends TestCase
 
     public function test_dollar_auto_gensym_emits_deprecation(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;
@@ -267,7 +277,7 @@ final class QuasiquoteTest extends TestCase
 
         try {
             $q = new QuasiquoteTransformer(new GlobalEnvironment());
-            $q->transform(Symbol::create('foo$'));
+            $q->transform($this->locatedSymbol('foo$'));
         } finally {
             restore_error_handler();
         }
@@ -279,6 +289,9 @@ final class QuasiquoteTest extends TestCase
 
     public function test_hash_auto_gensym_does_not_emit_deprecation(): void
     {
+        // Syntax deprecations are opt-in (`--warn-deprecations`).
+        DeprecationWarnings::enable();
+
         $warning = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
             $warning = $errstr;
@@ -293,5 +306,35 @@ final class QuasiquoteTest extends TestCase
         }
 
         self::assertNull($warning);
+    }
+
+    public function test_dollar_auto_gensym_without_a_location_stays_silent(): void
+    {
+        // A symbol with no source location cannot be attributed to a line the
+        // user can edit, so it is not worth reporting.
+        DeprecationWarnings::enable();
+
+        $warning = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
+            $warning = $errstr;
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $q = new QuasiquoteTransformer(new GlobalEnvironment());
+            $q->transform(Symbol::create('foo$'));
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertNull($warning);
+    }
+
+    private function locatedSymbol(string $name): Symbol
+    {
+        $symbol = Symbol::create($name);
+        $symbol->setStartLocation(new SourceLocation('/app/user.phel', 3, 7));
+
+        return $symbol;
     }
 }

--- a/tests/php/Unit/Console/Application/WarnDeprecationsFlagTest.php
+++ b/tests/php/Unit/Console/Application/WarnDeprecationsFlagTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Console\Application;
 
 use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
 use Phel\Console\Application\WarnDeprecationsFlag;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
@@ -15,6 +16,27 @@ final class WarnDeprecationsFlagTest extends TestCase
     protected function tearDown(): void
     {
         BackslashSeparatorDeprecator::resetInstance();
+        // The flag is process-wide: leaving it on would make unrelated tests
+        // in this run start emitting syntax deprecations.
+        DeprecationWarnings::reset();
+    }
+
+    public function test_strips_plain_flag_and_enables_syntax_deprecations(): void
+    {
+        DeprecationWarnings::disable();
+
+        WarnDeprecationsFlag::applyAndStrip(['phel', 'run', '--warn-deprecations', 'src/main.phel']);
+
+        self::assertTrue(DeprecationWarnings::isEnabled());
+    }
+
+    public function test_leaves_syntax_deprecations_untouched_when_flag_absent(): void
+    {
+        DeprecationWarnings::disable();
+
+        WarnDeprecationsFlag::applyAndStrip(['phel', 'run', 'src/main.phel']);
+
+        self::assertFalse(DeprecationWarnings::isEnabled());
     }
 
     public function test_returns_argv_unchanged_when_flag_absent(): void

--- a/tests/php/Unit/Lang/Collections/Map/PersistentArrayMapTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/PersistentArrayMapTest.php
@@ -26,6 +26,9 @@ final class PersistentArrayMapTest extends TestCase
     public function test_can_not_create_from_array_with_uneven_values(): void
     {
         $this->expectException(RuntimeException::class);
+        // The message names the offending count: "odd number of elements" is
+        // the whole diagnosis, so a bare "invalid argument" would not do.
+        $this->expectExceptionMessage('An even number of elements must be provided to build a map, got 1');
         PersistentArrayMap::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['test']);
     }
 

--- a/tests/php/Unit/Lang/Collections/Map/PersistentHashMapTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/PersistentHashMapTest.php
@@ -10,9 +10,17 @@ use Phel\Lang\Hasher;
 use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 final class PersistentHashMapTest extends TestCase
 {
+    public function test_can_not_create_from_array_with_uneven_values(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('An even number of elements must be provided to build a map, got 3');
+        PersistentHashMap::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['a', 1, 'b']);
+    }
+
     public function test_empty(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer());

--- a/tests/php/Unit/Lang/Collections/SortedMap/PersistentSortedMapTest.php
+++ b/tests/php/Unit/Lang/Collections/SortedMap/PersistentSortedMapTest.php
@@ -26,6 +26,7 @@ final class PersistentSortedMapTest extends TestCase
     public function test_can_not_create_from_array_with_uneven_values(): void
     {
         $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('An even number of elements must be provided to build a sorted map, got 1');
         PersistentSortedMap::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['test']);
     }
 

--- a/tests/php/Unit/Lint/Application/LintRunnerTest.php
+++ b/tests/php/Unit/Lint/Application/LintRunnerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application;
+
+use Phel\Api\ApiFacade;
+use Phel\Lint\Application\Config\RuleSettings;
+use Phel\Lint\Application\FileCollector;
+use Phel\Lint\Application\LintRunner;
+use Phel\Lint\Application\RulePipeline;
+use Phel\Lint\Application\SourceReader;
+use Phel\Lint\Domain\Exception\LintSourceException;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+use PHPUnit\Framework\TestCase;
+
+use function chmod;
+use function file_get_contents;
+use function file_put_contents;
+use function mkdir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class LintRunnerTest extends TestCase
+{
+    private string $baseDir = '';
+
+    protected function setUp(): void
+    {
+        $this->baseDir = sys_get_temp_dir() . '/phel-lint-runner-' . uniqid();
+        mkdir($this->baseDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        @chmod($this->baseDir . '/unreadable.phel', 0644);
+        @unlink($this->baseDir . '/unreadable.phel');
+        @rmdir($this->baseDir);
+    }
+
+    public function test_it_raises_instead_of_reporting_an_unreadable_file_as_clean(): void
+    {
+        $file = $this->baseDir . '/unreadable.phel';
+        file_put_contents($file, "(ns unreadable)\n");
+        chmod($file, 0000);
+
+        if (@file_get_contents($file) !== false) {
+            self::markTestSkipped('chmod has no effect (running as root?)');
+        }
+
+        $this->expectException(LintSourceException::class);
+        // FileCollector realpath()s its input, so only the tail is asserted.
+        $this->expectExceptionMessage('Cannot read file to lint: ');
+        $this->expectExceptionMessageMatches('#unreadable\.phel$#');
+
+        $this->runner()->run([$file], new RuleSettings([]));
+    }
+
+    private function runner(): LintRunner
+    {
+        return new LintRunner(
+            new ApiFacade(),
+            new FileCollector(),
+            new SourceReader($this->createStub(CompilerFacadeInterface::class)),
+            new RulePipeline([]),
+        );
+    }
+}


### PR DESCRIPTION
## 🤔 Background

A follow-up error-handling audit went after what a catch-site census cannot see: the `@` suppression
operator, exception design quality, and error paths with no test.

The headline finding is that **every syntax deprecation notice the compiler raises has been invisible**.
Six sites used `@trigger_error(..., E_USER_DEPRECATED)`. `@` zeroes `error_reporting` for that call, so
PHP's default handler prints nothing, and Phel installs no error handler of its own. Bare `#` comments,
`#| ... |#` blocks, `|()` short fns, `,` / `,@` unquote and `$` auto-gensym were never reported to anyone:

```
$ phel run src/main.phel                     -> hi     (a file whose line 2 is `#| block |#`)
$ phel run --warn-deprecations src/main.phel -> hi     (should have warned)
```

Two things hid it. `set_error_handler` **is** still called for `@`-suppressed diagnostics, so the existing
`LexerTest` notice assertions passed — they exercised a mechanism the product does not use. And the sibling
`BackslashSeparatorDeprecator` calls the same `trigger_error` **without** `@`, gated on `warn-deprecations`,
so the two halves of one feature disagreed. #2783 reworded these messages three commits ago, which means
they are treated as user-facing text; they just had no path to a user.

## 💡 Goal

Make deprecation notices reachable, stop the linter reporting an unreadable file as clean, and keep the
original cause attached where a located exception replaces one.

No user-facing message changes except where a message was ungrammatical or missing the value at fault.

## 🔖 Changes

**Syntax deprecations are gated, not suppressed**

- New `Compiler\Domain\Deprecation\DeprecationWarnings`: one process-wide switch, off by default, turned on
  by `--warn-deprecations`, `PHEL_WARN_DEPRECATIONS`, or the `warn-deprecations` config key. All six sites
  call `warn()` / `warnForSource()`; no `@` remains.
- `BackslashSeparatorDeprecator` reads the same switch, dropping its duplicate env read and its duplicate
  stdlib-path check.
- Bundled-stdlib suppression now covers the lexer and reader too. Without it `--warn-deprecations` was
  unusable: phel's own `src/phel/core/protocols.phel` uses `,` for unquote, so the first run flooded stderr
  with notices about code the user cannot edit. The lexer resolves the per-source gate once per
  `lexString`, not per token, so the hot path is cheaper than before — previously every deprecatable token
  paid a `sprintf` plus a `trigger_error`.

**`phel lint` no longer calls an unreadable file clean**

- `LintRunner` skipped a `.phel` file it could not read and moved on, so the file produced no diagnostics
  and the run exited 0. It now raises the new `Lint\Domain\Exception\LintSourceException` naming the path.
  In practice the CLI usually trips `Build`'s `SystemFileIo` first; the silent skip was still reachable and
  is covered directly.

**Causes are chained**

- `Parser` (keyword and string sub-parser failures), `TaggedLiteralReader` (tag-handler failures) and
  `LoadSymbol` (path-resolver failures) forwarded only `->getMessage()`, dropping `$previous`.
  `AnalyzerException::withLocation()` already accepted a nested exception and the call site simply did not
  pass it; `ReaderException::forNode` and `UnexpectedParserException::forSnippet` gained an optional
  trailing parameter.
- `AbstractLocatedException` / `AbstractParserException` take `?Throwable` instead of `?Exception`.
- Located rendering is unchanged: `TextExceptionPrinter::getExceptionString` uses `$e->getMessage()`, and
  the `getPrevious()`-unwrapping call sites are scoped to `CompiledCodeIsMalformedException` or
  non-located throwables.

**Message quality**

- The three map constructors threw `A even number of elements must be provided` — bad grammar, no count,
  and no test anywhere in the repo. Now `An even number of elements must be provided to build a map, got 3`.

**Tests**

New `DeprecationWarningsTest` (6 cases) and `LintRunnerTest`; new cases in `LexerTest`, `QuasiquoteTest`,
`WarnDeprecationsFlagTest`, `LoadSymbolTest`, `ParserTest`, `ReaderTest` and the three map tests. The
thirteen existing deprecation-notice tests now enable the switch explicitly, which is what makes them
assert the shipped behaviour rather than an internal one.

Verified: `phpstan`, `psalm`, `phpunit --testsuite=unit,integration` (5 206), `test-core` (6 488), `csrun`,
`rector`, plus REPL and CLI smoke tests with and without `--warn-deprecations`.
