### PR TITLE
fix: `phel lint` no longer aborts with a bogus "already bound" error

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -43,6 +43,19 @@ jobs:
       - name: Run rector/rector
         run: ./vendor/bin/rector process --dry-run --config=rector.php
 
+  phel-lint:
+    name: Lint the Phel standard library
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-phel
+
+      # Phel's own stdlib must pass Phel's own linter. Exits non-zero only on
+      # `error`-severity rules, so today's remaining warnings do not gate the
+      # build while a regression to an error does.
+      - name: Run phel lint on src/phel
+        run: ./bin/phel lint --no-cache src/phel
+
   type-checker:
     name: Type Checker
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - New `phel lint` rule `phel/comment-style` (warning, on by default): flags a whole-line comment written with a single `;`, which the convention reserves for comments trailing code on the same line
+- New `phel lint` rule `phel/duplicate-def` (error, on by default): flags a top-level symbol defined twice in the same file, while a forward `(declare foo)` followed by its definition stays clean
 
 ### Fixed
 
+- `phel lint` no longer aborts with `Lint failed: Symbol ... is already bound` on any project whose files `:require` one another (or on phel's own stdlib): re-reading a source during analysis is no longer mistaken for a redefinition, a real duplicate definition is now reported by the new `phel/duplicate-def` rule, a `defstruct` implementing a `definterface` from the same file no longer crashes the run, and `php/->`/threading segments plus `for`/`dofor` heads and a bare `[&]` are no longer flagged
 - Syntax deprecation notices (bare `#` comments, `#| ... |#` blocks, `|()` short fns, `,`/`,@` unquote, `$` auto-gensym) are no longer suppressed with `@`, which hid them from every real run: `--warn-deprecations` printed nothing at all. They are now gated on the same switch as the backslash-separator warning, off by default and reported when asked for, and suppressed for phel's own bundled `src/phel` sources so only code the user can edit is flagged
 - `phel lint` no longer skips a `.phel` file it cannot read, which reported the file as clean and let the run exit 0; it now raises `LintSourceException` naming the path
 - Parser, reader and analyzer errors now chain the sub-parser, tag-handler or path-resolver exception that produced them as `getPrevious()`, so the error log keeps the original throw site. The located message shown to the user is unchanged

--- a/src/php/Api/Application/Analysis/ReadAndAnalyzeStage.php
+++ b/src/php/Api/Application/Analysis/ReadAndAnalyzeStage.php
@@ -30,8 +30,28 @@ final readonly class ReadAndAnalyzeStage implements AnalysisStageInterface
 
     public function run(string $source, string $uri, array &$context): array
     {
+        // The namespace under analysis is very likely already loaded in this
+        // process: `PreloadDependenciesStage` evaluates the bundled `phel.*`
+        // modules and the file's own dependencies, and a directory-wide run
+        // analyses files that required one another. Re-reading a source is
+        // not a redefinition, so suppress the `def` duplicate guard for the
+        // whole pass instead of letting it abort the file at its first `def`.
+        $globalEnv = $this->compilerFacade->getGlobalEnvironment();
+        $globalEnv->enterAnalysisMode();
+
+        try {
+            return $this->analyzeParseTrees($context['parseTrees'] ?? [], $uri);
+        } finally {
+            $globalEnv->leaveAnalysisMode();
+        }
+    }
+
+    /**
+     * @return list<Diagnostic>
+     */
+    private function analyzeParseTrees(mixed $parseTrees, string $uri): array
+    {
         $diagnostics = [];
-        $parseTrees = $context['parseTrees'] ?? [];
         if (!is_array($parseTrees)) {
             $parseTrees = [];
         }

--- a/src/php/Api/CLAUDE.md
+++ b/src/php/Api/CLAUDE.md
@@ -44,6 +44,7 @@ All collaborators degrade to empty/null on unknown types or reflection failure.
 ## Key Constraints
 
 - `SourceAnalyzer` runs a pipeline of `list<AnalysisStageInterface>` (`Application/Analysis/`: Preload → LexAndParse → ReadAndAnalyze); add/remove stages in `ApiFactory::createSourceAnalyzer()`.
+- `ReadAndAnalyzeStage` wraps its pass in `GlobalEnvironment::enterAnalysisMode()`/`leaveAnalysisMode()`. `PreloadDependenciesStage` really evaluates the bundled `phel.*` modules and the file's dependencies, so the namespace under analysis is usually already bound; without that guard every top-level `def` raises `DuplicateDefinitionException` and kills the run. Any new stage that re-analyzes loaded sources needs the same guard.
 - Analysis routes through `CompilerFacade` phases only — never bypass.
 - `Infrastructure/NativeSymbolCatalog`: static doc table for special forms / built-ins with no `.phel` source. Special forms (`load`, `in-ns`, `use`) need an entry here to appear in `phel doc`. `PhelFnLoader` merges it with runtime metadata.
 - `ProjectIndexer` re-indexes from scratch; caching hook is at the `SymbolExtractor` call-site.

--- a/src/php/Compiler/Application/Analyzer.php
+++ b/src/php/Compiler/Application/Analyzer.php
@@ -134,6 +134,22 @@ final class Analyzer implements AnalyzerInterface
         $this->globalEnvironment->addInterface($ns, $name);
     }
 
+    /**
+     * @param list<string> $methodNames
+     */
+    public function setInterfaceMethods(string $ns, Symbol $name, array $methodNames): void
+    {
+        $this->globalEnvironment->setInterfaceMethods($ns, $name, $methodNames);
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    public function getInterfaceMethods(string $ns, Symbol $name): ?array
+    {
+        return $this->globalEnvironment->getInterfaceMethods($ns, $name);
+    }
+
     public function getAvailableSymbols(): array
     {
         return $this->globalEnvironment->getAllDefinitions();

--- a/src/php/Compiler/Domain/Analyzer/AnalyzerInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/AnalyzerInterface.php
@@ -53,6 +53,20 @@ interface AnalyzerInterface
     public function addInterface(string $ns, Symbol $name): void;
 
     /**
+     * Record the method names declared by a `definterface`, so an inline
+     * implementation can be validated without the generated PHP interface
+     * having been evaluated (compile-only flows never evaluate).
+     *
+     * @param list<string> $methodNames
+     */
+    public function setInterfaceMethods(string $ns, Symbol $name, array $methodNames): void;
+
+    /**
+     * @return list<string>|null null when the interface was never analyzed here
+     */
+    public function getInterfaceMethods(string $ns, Symbol $name): ?array;
+
+    /**
      * Returns all available symbol names that can be resolved in the current namespace.
      *
      * @return array<string> List of available symbol names

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -59,7 +59,30 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     /** @var array<string, array<string, Symbol>> */
     private array $interfaces = [];
 
+    /**
+     * Method names declared by each `definterface`, in Phel spelling.
+     * `defstruct`/`defenum` normally read the expected method set off the
+     * generated PHP interface via reflection, but that class only exists
+     * once the `definterface` form has been emitted AND evaluated. A
+     * compile-only pass (linter, `phel analyze`, LSP) never evaluates, so
+     * this stash is the reflection-free fallback.
+     *
+     * @var array<string, array<string, list<string>>>
+     */
+    private array $interfaceMethods = [];
+
     private int $allowPrivateAccessCounter = 0;
+
+    /**
+     * Re-entrant counter guarding "static analysis" sections. While it is
+     * positive, `def` never raises {@see DuplicateDefinitionException}:
+     * analysis re-reads sources whose namespace may already be loaded in
+     * this very process (linter, `phel analyze`, LSP all pre-load
+     * dependencies before analysing), and re-reading a file is not a
+     * redefinition. Same escape hatch as `*build-mode*`/`*repl-mode*`,
+     * scoped to the environment instead of the runtime registry.
+     */
+    private int $analysisModeCounter = 0;
 
     private ?BundledNamespaceResolverInterface $bundledNamespaceResolver = null;
 
@@ -280,6 +303,23 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         return $this->allowPrivateAccessCounter > 0;
     }
 
+    public function enterAnalysisMode(): void
+    {
+        ++$this->analysisModeCounter;
+    }
+
+    public function leaveAnalysisMode(): void
+    {
+        if ($this->analysisModeCounter > 0) {
+            --$this->analysisModeCounter;
+        }
+    }
+
+    public function isAnalysisMode(): bool
+    {
+        return $this->analysisModeCounter > 0;
+    }
+
     public function addInterface(string $namespace, Symbol $name): void
     {
         if (!array_key_exists($namespace, $this->interfaces)) {
@@ -287,6 +327,22 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         }
 
         $this->interfaces[$namespace][$name->getName()] = $name;
+    }
+
+    /**
+     * @param list<string> $methodNames
+     */
+    public function setInterfaceMethods(string $namespace, Symbol $name, array $methodNames): void
+    {
+        $this->interfaceMethods[$namespace][$name->getName()] = $methodNames;
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    public function getInterfaceMethods(string $namespace, Symbol $name): ?array
+    {
+        return $this->interfaceMethods[$namespace][$name->getName()] ?? null;
     }
 
     public function snapshot(): array
@@ -368,7 +424,8 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
 
     private function shouldThrowOnDuplicateDefinition(string $namespace, Symbol $name): bool
     {
-        if (Phel::getDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, BuildConstants::BUILD_MODE)
+        if ($this->isAnalysisMode()
+            || Phel::getDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, BuildConstants::BUILD_MODE)
             || Phel::getDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, ReplConstants::REPL_MODE)
             || $namespace === CompilerConstants::PHEL_CORE_NAMESPACE
         ) {

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironmentInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironmentInterface.php
@@ -22,6 +22,18 @@ interface GlobalEnvironmentInterface
     public function addDefinition(string $namespace, Symbol $name, bool $allowRedefinition = false): void;
 
     /**
+     * Open a static-analysis section: `def` stops raising on a symbol that
+     * is already bound, because analysis re-reads sources whose namespace
+     * may already be loaded in this process. Re-entrant; always pair with
+     * {@see self::leaveAnalysisMode()} in a `finally`.
+     */
+    public function enterAnalysisMode(): void;
+
+    public function leaveAnalysisMode(): void;
+
+    public function isAnalysisMode(): bool;
+
+    /**
      * @param PersistentMapInterface<mixed, mixed> $meta
      */
     public function setCompileTimeMeta(string $namespace, Symbol $name, PersistentMapInterface $meta): void;
@@ -69,6 +81,20 @@ interface GlobalEnvironmentInterface
     public function resolveAsSymbol(Symbol $name, NodeEnvironment $env): ?Symbol;
 
     public function addInterface(string $namespace, Symbol $name): void;
+
+    /**
+     * Record the method names a `definterface` declares (Phel spelling), so
+     * `defstruct`/`defenum` can validate their inline implementations even
+     * when the generated PHP interface has not been evaluated yet.
+     *
+     * @param list<string> $methodNames
+     */
+    public function setInterfaceMethods(string $namespace, Symbol $name, array $methodNames): void;
+
+    /**
+     * @return list<string>|null null when the interface was never analyzed here
+     */
+    public function getInterfaceMethods(string $namespace, Symbol $name): ?array;
 
     public function addLevelToAllowPrivateAccess(): void;
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefInterfaceSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefInterfaceSymbol.php
@@ -15,6 +15,7 @@ use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 
+use function array_map;
 use function count;
 use function is_bool;
 use function is_float;
@@ -48,6 +49,12 @@ final class DefInterfaceSymbol implements SpecialFormAnalyzerInterface
         $bodyList = $rest->cdr();
 
         [$methods, $consts] = $this->methodsAndConsts($bodyList);
+
+        $this->analyzer->setInterfaceMethods(
+            $this->analyzer->getNamespace(),
+            $interfaceSymbol,
+            array_map(static fn(DefInterfaceMethod $method): string => $method->getName()->getName(), $methods),
+        );
 
         return new DefInterfaceNode(
             $env,

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InterfaceImplementationsAnalyzer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InterfaceImplementationsAnalyzer.php
@@ -13,9 +13,10 @@ use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
 use Phel\Shared\MungeInterface;
-use ReflectionMethod;
 
+use function class_exists;
 use function count;
+use function interface_exists;
 use function sprintf;
 
 /**
@@ -73,20 +74,11 @@ final readonly class InterfaceImplementationsAnalyzer
                 throw AnalyzerException::withLocation('Can not resolve interface ' . $first->getFullName(), $list);
             }
 
-            $reflectionClass = $classNode->getReflectionClass();
-            if (!$reflectionClass->isInterface()) {
-                throw AnalyzerException::withLocation('Given interface ' . $first->getFullName() . ' is not an interface', $list);
-            }
-
             $absoluteInterfaceName = $classNode->getAbsolutePhpName();
-            $expectedMethods = $reflectionClass->getMethods();
-            $expectedMethodIndex = [];
-            foreach ($expectedMethods as $method) {
-                $expectedMethodIndex[$method->getName()] = $method;
-            }
+            $expectedMethodIndex = $this->expectedMethodIndex($classNode, $first, $list);
 
             $methods = [];
-            $countExpectedMethods = count($expectedMethods);
+            $countExpectedMethods = count($expectedMethodIndex);
             for ($i = 0; $i < $countExpectedMethods; ++$i) {
                 $forms = $forms->cdr();
                 if (!$forms instanceof PersistentListInterface) {
@@ -101,7 +93,7 @@ final readonly class InterfaceImplementationsAnalyzer
                 $methods[] = $this->analyzeInterfaceMethod($method, $env, $expectedMethodIndex);
             }
 
-            if (count($methods) !== count($expectedMethods)) {
+            if (count($methods) !== $countExpectedMethods) {
                 throw AnalyzerException::withLocation('Missing method for interface ' . $absoluteInterfaceName . ' in ' . $context, $list);
             }
 
@@ -115,8 +107,64 @@ final readonly class InterfaceImplementationsAnalyzer
     }
 
     /**
-     * @param PersistentListInterface<mixed>  $list
-     * @param array<string, ReflectionMethod> $expectedMethodIndex
+     * The munged method names the interface expects, as a set.
+     *
+     * Reflection is the source of truth, but it only works once the PHP
+     * interface exists — which for a `definterface` in the very same file
+     * means the form must already have been emitted AND evaluated. Static
+     * analysis never evaluates, so fall back to what `definterface`
+     * recorded in the global environment during this pass.
+     *
+     * @param PersistentListInterface<mixed> $list
+     *
+     * @return array<string, true>
+     */
+    private function expectedMethodIndex(
+        PhpClassNameNode $classNode,
+        Symbol $interfaceSymbol,
+        PersistentListInterface $list,
+    ): array {
+        $resolved = $classNode->getName();
+        $namespace = $resolved->getNamespace();
+
+        if (!class_exists($classNode->getAbsolutePhpName())
+            && !interface_exists($classNode->getAbsolutePhpName())
+        ) {
+            $declared = $namespace === null
+                ? null
+                : $this->analyzer->getInterfaceMethods($namespace, $resolved);
+
+            if ($declared === null) {
+                throw AnalyzerException::withLocation(
+                    'Can not resolve interface ' . $interfaceSymbol->getFullName(),
+                    $list,
+                );
+            }
+
+            $index = [];
+            foreach ($declared as $methodName) {
+                $index[$this->munge->encode($methodName)] = true;
+            }
+
+            return $index;
+        }
+
+        $reflectionClass = $classNode->getReflectionClass();
+        if (!$reflectionClass->isInterface()) {
+            throw AnalyzerException::withLocation('Given interface ' . $interfaceSymbol->getFullName() . ' is not an interface', $list);
+        }
+
+        $index = [];
+        foreach ($reflectionClass->getMethods() as $method) {
+            $index[$method->getName()] = true;
+        }
+
+        return $index;
+    }
+
+    /**
+     * @param PersistentListInterface<mixed> $list
+     * @param array<string, true>            $expectedMethodIndex
      */
     private function analyzeInterfaceMethod(
         PersistentListInterface $list,

--- a/src/php/Lint/Application/Config/RuleRegistry.php
+++ b/src/php/Lint/Application/Config/RuleRegistry.php
@@ -26,6 +26,8 @@ final class RuleRegistry
 
     public const string DUPLICATE_KEY = 'phel/duplicate-key';
 
+    public const string DUPLICATE_DEF = 'phel/duplicate-def';
+
     public const string INVALID_DESTRUCTURING = 'phel/invalid-destructuring';
 
     public const string DISCOURAGED_VAR = 'phel/discouraged-var';
@@ -46,6 +48,7 @@ final class RuleRegistry
             self::SHADOWED_BINDING,
             self::REDUNDANT_DO,
             self::DUPLICATE_KEY,
+            self::DUPLICATE_DEF,
             self::INVALID_DESTRUCTURING,
             self::DISCOURAGED_VAR,
             self::COMMENT_STYLE,

--- a/src/php/Lint/Application/Rule/ArityMismatchRule.php
+++ b/src/php/Lint/Application/Rule/ArityMismatchRule.php
@@ -15,6 +15,7 @@ use Phel\Lint\Domain\LintRuleInterface;
 use Phel\Shared\Exceptions\ErrorCode;
 
 use function count;
+use function in_array;
 use function sprintf;
 
 /**
@@ -165,6 +166,12 @@ final readonly class ArityMismatchRule implements LintRuleInterface
     {
         if ($form instanceof PersistentListInterface && count($form) > 0) {
             $head = $form->get(0);
+            if ($head instanceof Symbol && $this->hasImplicitArgumentSegments($head)) {
+                $this->inspectSegmentedForm($form, $localFns, $uri, $result);
+
+                return;
+            }
+
             if ($head instanceof Symbol && $head->getNamespace() === null) {
                 $name = $head->getName();
                 if (isset($localFns[$name])) {
@@ -209,6 +216,70 @@ final readonly class ArityMismatchRule implements LintRuleInterface
             foreach ($form as $k => $v) {
                 $this->inspectCalls($k, $localFns, $uri, $result);
                 $this->inspectCalls($v, $localFns, $uri, $result);
+            }
+        }
+    }
+
+    /**
+     * Forms whose nested `(name args...)` segments are NOT complete calls:
+     *
+     * - `(php/-> obj (method a))` / `(php/:: Cls (method a))` name a PHP
+     *   method, never a Phel fn;
+     * - threading macros splice an extra argument into each segment, so the
+     *   literal argument count is always one short of the real one.
+     *
+     * Counting those segments as plain calls produces pure noise, so their
+     * heads are skipped and only their arguments are inspected.
+     */
+    private function hasImplicitArgumentSegments(Symbol $head): bool
+    {
+        return in_array(
+            $head->getFullName(),
+            [
+                Symbol::NAME_PHP_OBJECT_CALL,
+                Symbol::NAME_PHP_OBJECT_STATIC_CALL,
+                '->',
+                '->>',
+                'some->',
+                'some->>',
+                'cond->',
+                'cond->>',
+                'as->',
+                'doto',
+            ],
+            true,
+        );
+    }
+
+    /**
+     * Descends into the first operand and into each segment's *arguments*,
+     * skipping the head of every segment.
+     *
+     * @param PersistentListInterface<mixed> $form
+     * @param array<string, ArityRange>      $localFns
+     * @param list<Diagnostic>               $result
+     */
+    private function inspectSegmentedForm(
+        PersistentListInterface $form,
+        array $localFns,
+        string $uri,
+        array &$result,
+    ): void {
+        $count = count($form);
+        for ($i = 1; $i < $count; ++$i) {
+            $segment = $form->get($i);
+
+            // Index 1 is the receiver / threaded value: an ordinary
+            // expression. Every later segment is either a `(head args...)`
+            // list or a bare symbol.
+            if ($i === 1 || !$segment instanceof PersistentListInterface) {
+                $this->inspectCalls($segment, $localFns, $uri, $result);
+                continue;
+            }
+
+            $segmentCount = count($segment);
+            for ($j = 1; $j < $segmentCount; ++$j) {
+                $this->inspectCalls($segment->get($j), $localFns, $uri, $result);
             }
         }
     }

--- a/src/php/Lint/Application/Rule/DuplicateDefRule.php
+++ b/src/php/Lint/Application/Rule/DuplicateDefRule.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Symbol;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Domain\LintRuleInterface;
+
+use function count;
+use function in_array;
+use function sprintf;
+
+/**
+ * Flags a top-level symbol defined twice in the same file, e.g.
+ *
+ * ```phel
+ * (defn handle [x] x)
+ * (defn handle [x] (inc x)) ; the first definition is dead code
+ * ```
+ *
+ * The analyzer raises on this too, but only once the namespace has been
+ * evaluated, so a compile-only pass (which is all the linter does) never
+ * sees it. This rule works purely off the file's own read forms, so the
+ * verdict does not depend on what the linting process happens to have
+ * loaded.
+ *
+ * A forward `(declare foo)` followed by the real definition is the normal
+ * Lisp idiom and stays clean: `declare` only reserves the name.
+ */
+final readonly class DuplicateDefRule implements LintRuleInterface
+{
+    /**
+     * Heads that introduce exactly one new global, named by the form's
+     * second element. `defonce` is excluded on purpose (its whole point is
+     * to tolerate re-evaluation) and so is `defmethod`, which extends an
+     * existing `defmulti` rather than defining a new global.
+     */
+    private const array DEFINING_HEADS = [
+        'def',
+        'def-',
+        'defn',
+        'defn-',
+        'defmacro',
+        'defmacro-',
+        'definterface',
+        'defstruct',
+        'defexception',
+        'defenum',
+        'defprotocol',
+        'defrecord',
+        'deftype',
+        'defmulti',
+    ];
+
+    public function code(): string
+    {
+        return RuleRegistry::DUPLICATE_DEF;
+    }
+
+    public function apply(FileAnalysis $analysis): array
+    {
+        /** @var list<Diagnostic> $result */
+        $result = [];
+        /** @var array<string, true> $defined */
+        $defined = [];
+
+        foreach ($analysis->forms as $form) {
+            if (!$form instanceof PersistentListInterface) {
+                continue;
+            }
+
+            if (count($form) < 2) {
+                continue;
+            }
+
+            $head = $form->get(0);
+            if (!$head instanceof Symbol) {
+                continue;
+            }
+
+            if (!in_array($head->getName(), self::DEFINING_HEADS, true)) {
+                continue;
+            }
+
+            $name = $form->get(1);
+            if (!$name instanceof Symbol) {
+                continue;
+            }
+
+            $key = $name->getName();
+            if (isset($defined[$key])) {
+                $result[] = DiagnosticBuilder::fromForm(
+                    $this->code(),
+                    sprintf('Duplicate definition: %s is already defined in this file.', $key),
+                    $analysis->uri,
+                    $name,
+                );
+
+                continue;
+            }
+
+            $defined[$key] = true;
+        }
+
+        return $result;
+    }
+}

--- a/src/php/Lint/Application/Rule/InvalidDestructuringRule.php
+++ b/src/php/Lint/Application/Rule/InvalidDestructuringRule.php
@@ -7,6 +7,7 @@ namespace Phel\Lint\Application\Rule;
 use Phel\Api\Transfer\Diagnostic;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use Phel\Lint\Application\Config\RuleRegistry;
 use Phel\Lint\Domain\FileAnalysis;
@@ -25,9 +26,16 @@ use function in_array;
  */
 final readonly class InvalidDestructuringRule implements LintRuleInterface
 {
-    private const array LET_LIKE_FORMS = ['let', 'loop', 'for', 'if-let', 'when-let', 'binding'];
+    private const array LET_LIKE_FORMS = ['let', 'loop', 'if-let', 'when-let', 'binding'];
 
     private const array FN_FORMS = ['fn', 'defn', 'defn-', 'defmacro', 'defmacro-'];
+
+    /**
+     * `for`/`dofor` do NOT take name/value pairs. Their head is a sequence of
+     * `binding :verb expr` triples interleaved with `:modifier arg` pairs, so
+     * an odd element count is the normal case, not an error.
+     */
+    private const array FOR_FORMS = ['for', 'dofor'];
 
     public function code(): string
     {
@@ -52,6 +60,8 @@ final readonly class InvalidDestructuringRule implements LintRuleInterface
                 $name = $head->getName();
                 if (in_array($name, self::LET_LIKE_FORMS, true)) {
                     $this->inspectLet($node, $analysis->uri, $result);
+                } elseif (in_array($name, self::FOR_FORMS, true)) {
+                    $this->inspectFor($node, $analysis->uri, $result);
                 } elseif (in_array($name, self::FN_FORMS, true)) {
                     $this->inspectFn($node, $analysis->uri, $result);
                 }
@@ -94,6 +104,54 @@ final readonly class InvalidDestructuringRule implements LintRuleInterface
     }
 
     /**
+     * Validates a `for`/`dofor` head against its own grammar: a keyword
+     * starts a `:modifier arg` (or `:reduce [...]` option) pair, anything
+     * else starts a `binding :verb expr` triple. A head that runs out of
+     * forms mid-triple is the actual error worth reporting.
+     *
+     * @param PersistentListInterface<mixed> $form
+     * @param list<Diagnostic>               $result
+     */
+    private function inspectFor(PersistentListInterface $form, string $uri, array &$result): void
+    {
+        if (count($form) < 2) {
+            return;
+        }
+
+        $head = $form->get(1);
+        if (!$head instanceof PersistentVectorInterface) {
+            $result[] = DiagnosticBuilder::fromForm(
+                $this->code(),
+                'Binding form expects a vector of name/value pairs.',
+                $uri,
+                $form,
+            );
+
+            return;
+        }
+
+        $count = count($head);
+        $i = 0;
+        while ($i < $count) {
+            $step = $head->get($i) instanceof Keyword ? 2 : 3;
+            if ($i + $step > $count) {
+                $result[] = DiagnosticBuilder::fromForm(
+                    $this->code(),
+                    $step === 2
+                        ? 'Incomplete `for` head: a modifier keyword needs an argument.'
+                        : 'Incomplete `for` head: a binding needs a `:verb` and an expression.',
+                    $uri,
+                    $head,
+                );
+
+                return;
+            }
+
+            $i += $step;
+        }
+    }
+
+    /**
      * @param PersistentListInterface<mixed> $form
      * @param list<Diagnostic>               $result
      */
@@ -114,11 +172,13 @@ final readonly class InvalidDestructuringRule implements LintRuleInterface
         for ($i = 0; $i < $count; ++$i) {
             $item = $params->get($i);
             if ($item instanceof Symbol && $item->getName() === '&') {
+                // A bare trailing `&` is legal: it swallows the rest without
+                // binding it (`(defmacro comment [&])` in phel\core).
                 $remaining = $count - $i - 1;
-                if ($remaining !== 1) {
+                if ($remaining > 1) {
                     $result[] = DiagnosticBuilder::fromForm(
                         $this->code(),
-                        "Invalid destructuring: '&' must be followed by exactly one binding symbol.",
+                        "Invalid destructuring: '&' must be followed by at most one binding symbol.",
                         $uri,
                         $item,
                     );

--- a/src/php/Lint/CLAUDE.md
+++ b/src/php/Lint/CLAUDE.md
@@ -29,12 +29,24 @@ Exit codes: `0` clean/warnings only, `1` errors, `2` invocation error.
 
 ## Rule Set (v1)
 
-- Errors: `phel/unresolved-symbol`, `phel/arity-mismatch`, `phel/invalid-destructuring`, `phel/duplicate-key`
+- Errors: `phel/unresolved-symbol`, `phel/arity-mismatch`, `phel/invalid-destructuring`, `phel/duplicate-key`, `phel/duplicate-def`
 - Warnings: `phel/unused-binding`, `phel/unused-require`, `phel/unused-import`, `phel/shadowed-binding`, `phel/redundant-do`, `phel/discouraged-var`, `phel/comment-style`
 
 Every shipped rule is on by default (it has an entry in `LintConfig::defaultSeverities()`); a rule with no entry there is off until a config opts it in.
 
 Add a rule: implement `LintRuleInterface` in `Application/Rule/`, add a code constant to `RuleRegistry`, register it in `LintFactory::createRules()`, and give it a default severity in `LintConfig::defaultSeverities()`. Do not edit existing rules.
+
+### `phel/duplicate-def`
+
+Flags a top-level symbol defined twice in the same file. Works off the file's
+own read forms, never the runtime registry, so the verdict does not depend on
+what the linting process happens to have loaded. A forward `(declare foo)`
+followed by the real definition stays clean; `defonce` and `defmethod` are
+excluded by design.
+
+The analyzer's own `DuplicateDefinitionException` cannot cover this: it only
+fires once the namespace has actually been evaluated, which a compile-only
+lint pass never does.
 
 ### `phel/comment-style`
 

--- a/src/php/Lint/LintConfig.php
+++ b/src/php/Lint/LintConfig.php
@@ -28,6 +28,7 @@ final class LintConfig extends AbstractConfig
             RuleRegistry::ARITY_MISMATCH => Diagnostic::SEVERITY_ERROR,
             RuleRegistry::INVALID_DESTRUCTURING => Diagnostic::SEVERITY_ERROR,
             RuleRegistry::DUPLICATE_KEY => Diagnostic::SEVERITY_ERROR,
+            RuleRegistry::DUPLICATE_DEF => Diagnostic::SEVERITY_ERROR,
             RuleRegistry::UNUSED_BINDING => Diagnostic::SEVERITY_WARNING,
             RuleRegistry::UNUSED_REQUIRE => Diagnostic::SEVERITY_WARNING,
             RuleRegistry::UNUSED_IMPORT => Diagnostic::SEVERITY_WARNING,

--- a/src/php/Lint/LintFactory.php
+++ b/src/php/Lint/LintFactory.php
@@ -19,6 +19,7 @@ use Phel\Lint\Application\LintRunner;
 use Phel\Lint\Application\Rule\ArityMismatchRule;
 use Phel\Lint\Application\Rule\CommentStyleRule;
 use Phel\Lint\Application\Rule\DiscouragedVarRule;
+use Phel\Lint\Application\Rule\DuplicateDefRule;
 use Phel\Lint\Application\Rule\DuplicateKeyRule;
 use Phel\Lint\Application\Rule\InvalidDestructuringRule;
 use Phel\Lint\Application\Rule\RedundantDoRule;
@@ -73,6 +74,7 @@ final class LintFactory extends AbstractFactory
             new ShadowedBindingRule(),
             new RedundantDoRule(),
             new DuplicateKeyRule($this->getCompilerFacade()),
+            new DuplicateDefRule(),
             new InvalidDestructuringRule(),
             new DiscouragedVarRule(),
             new CommentStyleRule($this->getCompilerFacade()),

--- a/tests/php/Integration/Lint/Fixtures/CrossRequire/app.phel
+++ b/tests/php/Integration/Lint/Fixtures/CrossRequire/app.phel
@@ -1,0 +1,5 @@
+(ns fixtures.crossrequire.app
+  (:require fixtures.crossrequire.lib :as lib))
+
+(defn run [x]
+  (lib/helper x))

--- a/tests/php/Integration/Lint/Fixtures/CrossRequire/lib.phel
+++ b/tests/php/Integration/Lint/Fixtures/CrossRequire/lib.phel
@@ -1,0 +1,4 @@
+(ns fixtures.crossrequire.lib)
+
+(defn helper [x]
+  (inc x))

--- a/tests/php/Integration/Lint/Fixtures/local_interface.phel
+++ b/tests/php/Integration/Lint/Fixtures/local_interface.phel
@@ -1,0 +1,8 @@
+(ns fixtures.local-interface)
+
+(definterface Greeter
+  (greet [this]))
+
+(defstruct english [name]
+  Greeter
+  (greet [this] (str "Hello, " (get this :name))))

--- a/tests/php/Integration/Lint/LintCommandTest.php
+++ b/tests/php/Integration/Lint/LintCommandTest.php
@@ -215,6 +215,62 @@ final class LintCommandTest extends TestCase
         }
     }
 
+    /**
+     * A project file that another linted file `:require`s is evaluated for
+     * real while the requiring file is analyzed. Analyzing the required file
+     * afterwards used to abort the whole run with
+     * `Lint failed: Symbol ... is already bound`, because a re-read looked
+     * like a redefinition. Re-reading a source is not a redefinition.
+     */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_lints_a_directory_whose_files_require_each_other(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandTester(new LintCommand());
+        $exit = $tester->execute([
+            'paths' => [__DIR__ . '/Fixtures/CrossRequire'],
+            '--format' => 'json',
+            '--no-cache' => true,
+        ]);
+
+        $display = $tester->getDisplay();
+
+        self::assertStringNotContainsString('already bound', $display);
+        self::assertStringNotContainsString('Lint failed', $display);
+        self::assertNotSame(LintCommand::EXIT_INVOCATION_ERROR, $exit, 'Output: ' . $display);
+
+        $payload = json_decode(trim($display), true);
+        self::assertIsArray($payload);
+        self::assertSame([], $payload);
+    }
+
+    /**
+     * `definterface` implemented by a `defstruct` in the same file: the
+     * generated PHP interface only exists once the form has been emitted AND
+     * evaluated, which a lint pass never does.
+     */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_lints_a_defstruct_implementing_an_interface_from_the_same_file(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandTester(new LintCommand());
+        $exit = $tester->execute([
+            'paths' => [__DIR__ . '/Fixtures/local_interface.phel'],
+            '--format' => 'json',
+            '--no-cache' => true,
+        ]);
+
+        $display = $tester->getDisplay();
+
+        self::assertStringNotContainsString('Lint failed', $display);
+        self::assertStringNotContainsString('does not exist', $display);
+        self::assertSame(0, $exit, 'Output: ' . $display);
+    }
+
     private function bootstrap(): void
     {
         Phel::bootstrap(__DIR__);

--- a/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
@@ -469,6 +469,65 @@ final class GlobalEnvironmentTest extends TestCase
         $env->addDefinition('foo', $sym);
     }
 
+    public function test_analysis_mode_allows_redefining_an_already_bound_symbol(): void
+    {
+        $env = new GlobalEnvironment();
+        $sym = Symbol::create('x');
+
+        $env->addDefinition('foo', $sym);
+        Phel::addDefinition('foo', 'x', 1);
+
+        $env->enterAnalysisMode();
+        $env->addDefinition('foo', $sym);
+        $env->leaveAnalysisMode();
+
+        $this->assertTrue($env->hasDefinition('foo', $sym));
+    }
+
+    public function test_leaving_analysis_mode_restores_the_duplicate_definition_guard(): void
+    {
+        $env = new GlobalEnvironment();
+        $sym = Symbol::create('x');
+
+        $env->addDefinition('foo', $sym);
+        Phel::addDefinition('foo', 'x', 1);
+
+        $env->enterAnalysisMode();
+        $env->leaveAnalysisMode();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Symbol x is already bound in namespace foo');
+
+        $env->addDefinition('foo', $sym);
+    }
+
+    public function test_analysis_mode_is_reentrant(): void
+    {
+        $env = new GlobalEnvironment();
+
+        $env->enterAnalysisMode();
+        $env->enterAnalysisMode();
+        $env->leaveAnalysisMode();
+
+        $this->assertTrue($env->isAnalysisMode());
+
+        $env->leaveAnalysisMode();
+
+        $this->assertFalse($env->isAnalysisMode());
+    }
+
+    public function test_interface_methods_round_trip(): void
+    {
+        $env = new GlobalEnvironment();
+        $name = Symbol::create('IFoo');
+
+        $this->assertNull($env->getInterfaceMethods('test-ns', $name));
+
+        $env->setInterfaceMethods('test-ns', $name, ['do-it', 'undo-it']);
+
+        $this->assertSame(['do-it', 'undo-it'], $env->getInterfaceMethods('test-ns', $name));
+    }
+
     public function test_snapshot_captures_current_state(): void
     {
         $env = new GlobalEnvironment();

--- a/tests/php/Unit/Lint/Application/Rule/ArityMismatchRuleTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/ArityMismatchRuleTest.php
@@ -64,4 +64,72 @@ PHEL;
 
         self::assertSame([], $rule->apply($analysis));
     }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_a_php_method_sharing_a_local_fn_name(): void
+    {
+        $rule = new ArityMismatchRule();
+        $source = <<<'PHEL'
+(ns user)
+
+(defn persistent [coll] coll)
+
+(defn convert [coll] (php/-> coll (persistent)))
+PHEL;
+        $analysis = $this->buildAnalysis($source);
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_a_static_php_method_sharing_a_local_fn_name(): void
+    {
+        $rule = new ArityMismatchRule();
+        $source = <<<'PHEL'
+(ns user)
+
+(defn empty [coll] coll)
+
+(defn make [] (php/:: NodeEnvironment (empty)))
+PHEL;
+        $analysis = $this->buildAnalysis($source);
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_threaded_calls_whose_first_argument_is_spliced(): void
+    {
+        $rule = new ArityMismatchRule();
+        $source = <<<'PHEL'
+(ns user)
+
+(defn bump [s path] s)
+
+(defn run [s] (-> s (bump [:a]) (bump [:b])))
+PHEL;
+        $analysis = $this->buildAnalysis($source);
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_still_flags_a_wrong_arity_argument_inside_a_threaded_call(): void
+    {
+        $rule = new ArityMismatchRule();
+        $source = <<<'PHEL'
+(ns user)
+
+(defn add [x y] (+ x y))
+
+(defn run [s] (-> s (conj (add 1 2 3))))
+PHEL;
+        $analysis = $this->buildAnalysis($source);
+
+        self::assertCount(1, $rule->apply($analysis));
+    }
 }

--- a/tests/php/Unit/Lint/Application/Rule/DuplicateDefRuleTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/DuplicateDefRuleTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Rule;
+
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Application\Rule\DuplicateDefRule;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+final class DuplicateDefRuleTest extends RuleTestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_a_symbol_defined_twice(): void
+    {
+        $rule = new DuplicateDefRule();
+        $analysis = $this->buildAnalysis("(ns fixtures\\dup)\n(defn handle [x] x)\n(defn handle [x] (inc x))\n");
+
+        $diagnostics = $rule->apply($analysis);
+
+        self::assertCount(1, $diagnostics);
+        self::assertSame(RuleRegistry::DUPLICATE_DEF, $diagnostics[0]->code);
+        self::assertStringContainsString('handle', $diagnostics[0]->message);
+        self::assertSame(3, $diagnostics[0]->startLine);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_a_forward_declaration_followed_by_its_definition(): void
+    {
+        $rule = new DuplicateDefRule();
+        $analysis = $this->buildAnalysis(
+            "(ns fixtures\\fwd)\n(declare later-fn)\n(defn caller [x] (later-fn x))\n(defn later-fn [x] (inc x))\n",
+        );
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_private_definitions(): void
+    {
+        $rule = new DuplicateDefRule();
+        $analysis = $this->buildAnalysis("(ns fixtures\\priv)\n(def- a 1)\n(def- b 2)\n(defn- c [] (+ a b))\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_a_private_definition_repeated(): void
+    {
+        $rule = new DuplicateDefRule();
+        $analysis = $this->buildAnalysis("(ns fixtures\\priv2)\n(def- a 1)\n(def- a 2)\n");
+
+        self::assertCount(1, $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_the_same_name_across_different_def_flavours(): void
+    {
+        $rule = new DuplicateDefRule();
+        $analysis = $this->buildAnalysis("(ns fixtures\\mixed)\n(def thing 1)\n(defn thing [] 2)\n");
+
+        self::assertCount(1, $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_defonce_which_tolerates_re_evaluation(): void
+    {
+        $rule = new DuplicateDefRule();
+        $analysis = $this->buildAnalysis("(ns fixtures\\once)\n(defonce state (atom {}))\n(defonce state (atom {}))\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_a_local_shadowing_a_global_name(): void
+    {
+        $rule = new DuplicateDefRule();
+        $analysis = $this->buildAnalysis("(ns fixtures\\local)\n(def x 1)\n(defn f [] (let [x 2] x))\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+}

--- a/tests/php/Unit/Lint/Application/Rule/InvalidDestructuringRuleTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/InvalidDestructuringRuleTest.php
@@ -43,4 +43,69 @@ final class InvalidDestructuringRuleTest extends RuleTestCase
 
         self::assertSame([], $rule->apply($analysis));
     }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_accepts_a_bare_trailing_variadic_marker(): void
+    {
+        $rule = new InvalidDestructuringRule();
+        $analysis = $this->buildAnalysis("(defmacro comment [&])\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_accepts_a_for_head_which_is_not_a_pair_vector(): void
+    {
+        $rule = new InvalidDestructuringRule();
+        $analysis = $this->buildAnalysis("(for [x :in [1 2 3]] x)\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_accepts_a_for_head_with_destructuring_modifiers_and_options(): void
+    {
+        $rule = new InvalidDestructuringRule();
+        $analysis = $this->buildAnalysis(
+            "(for [[k v] :pairs m :when v :reduce [acc []]] (conj acc k))\n",
+        );
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_accepts_a_dofor_head(): void
+    {
+        $rule = new InvalidDestructuringRule();
+        $analysis = $this->buildAnalysis("(dofor [x :in [1 2 3]] (println x))\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_a_for_head_missing_its_expression(): void
+    {
+        $rule = new InvalidDestructuringRule();
+        $analysis = $this->buildAnalysis("(for [x :in] x)\n");
+
+        $diagnostics = $rule->apply($analysis);
+
+        self::assertCount(1, $diagnostics);
+        self::assertSame(RuleRegistry::INVALID_DESTRUCTURING, $diagnostics[0]->code);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_a_for_head_with_a_dangling_modifier(): void
+    {
+        $rule = new InvalidDestructuringRule();
+        $analysis = $this->buildAnalysis("(for [x :in xs :when] x)\n");
+
+        self::assertCount(1, $rule->apply($analysis));
+    }
 }


### PR DESCRIPTION
## 🤔 Background

`phel lint` aborts with a fatal `Lint failed: Symbol X is already bound` on
Phel's own standard library, and on **any** project whose files `:require` one
another:

```
$ ./bin/phel lint src/phel/repl.phel
Lint failed: Symbol build-facade is already bound in namespace phel.repl in .../repl.phel:17   # exit 2
$ ./bin/phel lint src/phel/json.phel
Lint failed: Symbol valid-key? is already bound in namespace phel.json in .../json.phel:4      # exit 2
$ ./bin/phel lint src/phel/router.phel
Lint failed: Class "\phel\router\Router" does not exist                                        # exit 2

# two ordinary files, app.phel requires lib.phel
$ ./bin/phel lint var/probe3
Lint failed: Symbol helper is already bound in namespace probe3.lib in .../lib.phel:3          # exit 2
```

The symbol is defined exactly once. The double registration comes from the
linter evaluating the code for real before analysing it, in the same process.

`LintRunner` calls `ApiFacade::analyzeSource()`, whose first stage
`PreloadDependenciesStage` **evaluates** the REPL startup namespace
(`phel\repl`), `phel.core` and every transitive dependency of the file under
analysis. That populates both `GlobalEnvironment::$definitions` and the runtime
registry. The third stage, `ReadAndAnalyzeStage`, then re-analyses the very same
source in that environment, so each top-level `def` reaches
`GlobalEnvironment::addDefinition()` with both conditions of
`shouldThrowOnDuplicateDefinition()` satisfied and raises
`DuplicateDefinitionException`. That class extends `RuntimeException`, not
`AnalyzerException`, so neither `catch` in the stage catches it: it escapes to
`LintCommand` as a fatal, aborting the whole run at the file's first `def`.

It is not `def-`-specific (`json.phel` has zero `def-`), not `declare`-specific
(`declare` expands to `(def x nil)` and `Registry::hasDefinition()` uses
`isset()`, so a stored `null` never trips the guard), and the low line numbers
were simply wherever each file's first definition sits. Only the nine
namespaces reachable from `phel.repl` failed; `phel.core` files are exempt via
the explicit `$namespace === PHEL_CORE_NAMESPACE` bypass.

`src/phel/router.phel` failed for a second, independent reason of the same
family: `(definterface Router ...)` only materialises a PHP interface once the
form has been emitted **and evaluated**, so `InterfaceImplementationsAnalyzer`'s
reflection call raised a bare `ReflectionException` during a compile-only pass.

There is already a workaround for a symptom of this bug in the repo:
`LintCommandTest::test_default_paths_exclude_phel_internal_stdlib` (#1541)
excludes the bundled stdlib from the default paths so `phel lint` with no
arguments does not explode. This PR fixes the cause.

## 💡 Goal

Make `phel lint` usable on any project that uses `:require` or forward
declarations, keep genuine duplicate definitions reported, and get Phel's own
standard library to pass Phel's own linter with a CI job holding that line.

## 🔖 Changes

**Root fix, analysis mode.** `GlobalEnvironment` gains a re-entrant
`enterAnalysisMode()` / `leaveAnalysisMode()` / `isAnalysisMode()`; while open,
`addDefinition()` does not raise. `ReadAndAnalyzeStage` opens it around its pass
and closes it in a `finally`. Same escape hatch that `*build-mode*` and
`*repl-mode*` already provide for flows that re-evaluate code in a live process,
scoped to the environment instead of the runtime registry. Nothing is
suppressed: re-reading a source simply is not a redefinition.

**Capability kept and strengthened, new `phel/duplicate-def` rule** (error, on
by default). The compiler guard was never usable as a lint signal: it needs the
namespace to have been evaluated, so on `main` a genuine duplicate `defn` in an
unloaded namespace was **silently missed**:

```
(ns probe.b) (defn dup [x] x) (defn dup [x] (+ x 1))
$ ./bin/phel lint var/probe/b.phel     # main
No lint issues found.
```

The new rule reads the file's own forms, so its verdict never depends on process
state. A forward `(declare foo)` followed by its definition stays clean;
`defonce` and `defmethod` are excluded by design. `phel run` / `phel build` keep
the compiler-level `DuplicateDefinitionException` unchanged.

**`definterface` without reflection.** `definterface` now records its declared
method names in `GlobalEnvironment` (`setInterfaceMethods` /
`getInterfaceMethods`, exposed through `AnalyzerInterface`).
`InterfaceImplementationsAnalyzer` uses reflection when the PHP interface
exists, falls back to that record when it does not, and raises a located
`AnalyzerException` rather than a bare `ReflectionException` when neither is
available.

**Two rule false positives that dominated the remaining errors.** With the
fatals gone, `src/phel` reported 154 errors, 153 of them bogus:

- `phel/arity-mismatch` (31) counted `(php/-> coll (persistent))`,
  `(php/:: Cls (empty))` and `(-> s (bump [:a]))` as plain calls against a
  same-named local `defn`. The heads of `php/->`, `php/::`, `->`, `->>`,
  `some->`, `some->>`, `cond->`, `cond->>`, `as->` and `doto` segments are now
  skipped while their arguments are still inspected.
- `phel/invalid-destructuring` (122) had `for` in the let-like list, so
  `(for [x :in xs] ...)` was reported as "odd number of forms". `for`/`dofor`
  heads are `binding :verb expr` triples interleaved with `:modifier arg` pairs
  and now get their own validator, which flags a genuinely truncated head
  instead. A bare trailing `&` is legal (`(defmacro comment [&])` in
  `phel\core`), so `&` now requires *at most* one following symbol.

**Tests.** `GlobalEnvironmentTest` covers analysis mode (suppression,
re-entrancy, and that leaving it **restores** the guard, i.e. a real
redefinition is still caught) plus the interface-method stash.
`LintCommandTest` gains two end-to-end regressions: a directory whose files
require each other (`Fixtures/CrossRequire/`) and a `defstruct` implementing a
`definterface` from the same file (`Fixtures/local_interface.phel`); the former
was confirmed to fail without the fix. New `DuplicateDefRuleTest` (7 cases)
covers duplicate flagged, `declare`-then-`def` clean, `def-` clean, `def-`
repeated flagged, mixed `def`/`defn` flagged, `defonce` clean, `let` local
clean. `ArityMismatchRuleTest` (+4) and `InvalidDestructuringRuleTest` (+6)
cover the interop/threading and `for`-head cases.

**CI.** New `phel-lint` job in `.github/workflows/quality.yml` running
`./bin/phel lint --no-cache src/phel`. Verified green locally: `phel lint` exits
non-zero only on error-severity rules, so the remaining warnings do not gate the
build while a regression to a fatal or an error does.

**Before / after**

```
# BEFORE (main): 10 of 62 stdlib files abort the run with exit 2
$ ./bin/phel lint src/phel/repl.phel
Lint failed: Symbol build-facade is already bound in namespace phel.repl in .../repl.phel:17
$ ./bin/phel lint src/phel/json.phel
Lint failed: Symbol valid-key? is already bound in namespace phel.json in .../json.phel:4
$ ./bin/phel lint src/phel/test.phel
Lint failed: Symbol fail-fast? is already bound in namespace phel.test in .../test.phel:14

# AFTER
$ ./bin/phel lint --no-cache src/phel
430 issue(s): 0 error(s), 430 warning(s), 0 info.     # exit 0
```

**Known remaining warnings (not fixed here, separate rule defects).** All
warning-severity, so the CI job stays green: `phel/shadowed-binding` (240) and
`phel/unused-binding` (99) misread `for` heads the same way
`invalid-destructuring` did and need the same grammar awareness;
`phel/unused-import` (58) does not see usages inside `for` heads or `:reduce`
option vectors; `phel/discouraged-var` (30) keys on the word "deprecated"
appearing anywhere in a docstring, so `phel.string/assert-string` (whose
docstring describes a **PHP** deprecation) accounts for 24 of them;
`phel/unused-require` (3) does not model the implicit last-segment alias, though
`(:require phel.core)` in `src/phel/string.phel` is a genuine finding left for a
maintainer call because that namespace sits in the bootstrap chain.

No `.phel` stdlib source is modified by this PR.
