### PR TITLE
ref: drop the unimported var-dumper dep and four stale surfaces

### DIFF
--- a/.agnostic-ai/rules/integration-tests.md
+++ b/.agnostic-ai/rules/integration-tests.md
@@ -34,7 +34,23 @@ Integration test fixtures use a two-section format separated by markers:
 
 ## REPL Fixtures
 
-REPL test fixtures in `tests/php/Integration/Run/Command/Repl/Fixtures/` use a different format with `--INPUT--` and `--EXPECT--` markers for interactive session testing.
+REPL test fixtures live in `tests/php/Integration/Run/Command/Repl/Fixtures/` (no core lib) and
+`.../FixturesWithCoreLib/` (core lib preloaded). They use no markers at all: a fixture is a literal
+REPL transcript, and the whole file is the expected output.
+
+```
+user:1> (php/+ 1 1)
+2
+```
+
+`ReplCommandTest::getInputs()` recovers the inputs by matching each line against the prompt regex
+`(?<prompt>(?:[\w\\.-]+|\.{4}):\d+> ?)(?<phel_code>.+)?`, so:
+
+- Every input line must carry a real prompt: `<ns>:<n>> ` for a new form, `....:<n>> ` for a
+  continuation line inside an unfinished form.
+- Everything without a prompt is expected output (results, error reports, code snippets).
+- Comparison is `assertSame` on the whole transcript after `trim()`, so blank leading/trailing lines
+  are ignored but interior whitespace is significant.
 
 ## Running
 

--- a/.github/actions/setup-phel/action.yml
+++ b/.github/actions/setup-phel/action.yml
@@ -1,5 +1,5 @@
 name: Setup Phel
-description: Checkout repo, install PHP, restore Composer cache, install dependencies.
+description: Install PHP, restore the Composer cache, install dependencies. Callers check out the repo first.
 
 inputs:
   php-version:

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
         "phpunit/phpunit": "^11.0|^12.0|^13.0",
         "psalm/plugin-phpunit": "^0.19|^0.20",
         "rector/rector": "^2.3",
-        "symfony/var-dumper": "^7.4|^8.0",
         "vimeo/psalm": "^6.16"
     },
     "autoload": {

--- a/src/php/Formatter/Infrastructure/Command/FormatCommand.php
+++ b/src/php/Formatter/Infrastructure/Command/FormatCommand.php
@@ -56,16 +56,15 @@ HELP)
         $dryRun = (bool) $input->getOption('dry-run');
 
         $result = $this->getFacade()->format($paths, $output, $dryRun);
-        $changedFilePaths = $result->changedPaths();
 
-        if ($changedFilePaths === []) {
-            $output->writeln($dryRun ? 'No files would be reformatted.' : 'No files were formatted.');
-        } else {
+        if ($result->hasChanges()) {
             $output->writeln($dryRun ? 'Would reformat:' : 'Formatted files:');
 
-            foreach ($changedFilePaths as $k => $filePath) {
+            foreach ($result->changedPaths() as $k => $filePath) {
                 $output->writeln(sprintf('  %d) %s', $k + 1, $filePath));
             }
+        } else {
+            $output->writeln($dryRun ? 'No files would be reformatted.' : 'No files were formatted.');
         }
 
         // A file the formatter could not even read or parse is a hard failure:
@@ -77,8 +76,8 @@ HELP)
             return self::FAILURE;
         }
 
-        if ($dryRun && $changedFilePaths !== []) {
-            $output->writeln(sprintf('%d file(s) need reformatting.', count($changedFilePaths)));
+        if ($dryRun && $result->hasChanges()) {
+            $output->writeln(sprintf('%d file(s) need reformatting.', count($result->changedPaths())));
 
             return self::FAILURE;
         }

--- a/src/php/Run/Domain/Repl/ReplHistory.php
+++ b/src/php/Run/Domain/Repl/ReplHistory.php
@@ -33,8 +33,6 @@ final class ReplHistory
 
     private mixed $result3 = null;
 
-    private ?Throwable $lastException = null;
-
     public function __construct(
         private readonly GlobalEnvironmentInterface $globalEnvironment,
     ) {}
@@ -66,17 +64,6 @@ final class ReplHistory
 
     public function recordException(Throwable $exception): void
     {
-        $this->lastException = $exception;
         Phel::addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, self::LAST_EXCEPTION, $exception);
-    }
-
-    public function lastResult(): mixed
-    {
-        return $this->result1;
-    }
-
-    public function lastException(): ?Throwable
-    {
-        return $this->lastException;
     }
 }

--- a/tests/php/Unit/Run/Domain/Repl/ReplHistoryTest.php
+++ b/tests/php/Unit/Run/Domain/Repl/ReplHistoryTest.php
@@ -74,12 +74,11 @@ final class ReplHistoryTest extends TestCase
         $history->recordResult(42);
         $history->recordResult(null);
 
-        self::assertNull($history->lastResult());
         self::assertNull(Registry::getInstance()->getDefinition(self::CORE_NS, ReplHistory::LAST_RESULT_1));
         self::assertSame(42, Registry::getInstance()->getDefinition(self::CORE_NS, ReplHistory::LAST_RESULT_2));
     }
 
-    public function test_record_exception_stores_in_registry_and_accessor(): void
+    public function test_record_exception_stores_in_registry(): void
     {
         $history = new ReplHistory(new GlobalEnvironment());
         $history->register();
@@ -88,7 +87,6 @@ final class ReplHistoryTest extends TestCase
 
         $history->recordException($exception);
 
-        self::assertSame($exception, $history->lastException());
         self::assertSame(
             $exception,
             Registry::getInstance()->getDefinition(self::CORE_NS, ReplHistory::LAST_EXCEPTION),


### PR DESCRIPTION
## 🤔 Background

Fourth pass over the codebase looking for genuinely unused code. Three earlier waves had already run Psalm `findUnusedCode`, PHPStan L9 and whole-repo scans, so this one went after the ground they had not covered: the dependency manifest, the 18 PRs that landed since, `.github/`, `docs/`, and `resources/agents/`.

Tooling was Psalm `--find-dead-code`, PHPStan level 9, and five custom whole-repo scanners: zero-external-reference types, uncalled private/protected methods, never-thrown exception classes, unreferenced class constants, config-file path literals checked with `file_exists`, `docs/`+`resources/` orphans, dead Phel `defn-`/`def-`, and public methods referenced only from `tests/`.

That produced roughly 597 raw candidates. Five survived triage. The near-zero yield is the real headline: there is no dead type (0 of 1046), no dead private method (0), and no dead Phel definition (0) left in the tree.

The most instructive false positive: **`AbstractFn::invokeArity2()`**. Psalm reports it unused and both text scanners agreed, because no source file contains the string `invokeArity2`. It is emitted by concatenation — `CallEmitter.php:257` builds `'->invokeArity' . $arity . '('` and `MultiFnAsClassEmitter.php:224` builds the matching declaration. Deleting it would have broken every 2-arity call in compiled output. Any `nameN`-shaped method needs a `'name' . $n` check before it is believed dead.

## 💡 Goal

Remove the five findings that are provably unreachable or provably wrong, and leave everything else documented rather than guessed at.

## 🔖 Changes

**`symfony/var-dumper` dropped from `require-dev`.** Nothing in the repo imports it: no `VarDumper`/`Dumper` reference anywhere under `src/`, `tests/`, `tools/`, `build/`, `.github/`, `docs/`, `resources/`, `.agents/`, `.claude/`, `.codex/`, and no `dump(`/`dd(` call site. Six packages name it in `composer.lock` (`gacela-project/container`, `gacela-project/gacela`, `symfony/console`, `friendsofphp/php-cs-fixer`, `phpbench/phpbench`, `staabm/side-effects-detector`) but **every one of them names it under its own `require-dev`**, which Composer never installs, so it was pulled in only by this direct entry.

> ⚠️ **`composer update --lock` still needs to run** from a checkout with a writable `vendor/` to drop the package from `composer.lock`. It could not run here. This is not urgent for CI: `quality.yml` already passes `--no-check-lock` to `composer validate` (verified against the edited file, exit 0), and `composer install` treats a stale content-hash as a warning, not an error.

**`FormatResult::hasChanges()` wired up.** `Formatter/CLAUDE.md` documents `hasChanges()`/`hasFailures()` as the pair of emptiness predicates, and states that `FormatCommand` returns `FAILURE` under `--dry-run` when `hasChanges()`. The command actually inlined `changedPaths() === []` at line 61 and `!== []` at line 80 and never called the predicate. Wiring it up was the right fix rather than deleting half a documented pair on a `Shared` DTO that library consumers see. `changedPaths()` still backs the file listing and the count. All five branches re-checked against a real `bin/phel`, output and exit codes byte-identical:

| Case | Output | Exit |
|---|---|---|
| already formatted, `--dry-run` | `No files would be reformatted.` | 0 |
| needs reformat, `--dry-run` | `Would reformat:` + list + `1 file(s) need reformatting.` | 1 |
| needs reformat, real run | `Formatted files:` + list | 0 |
| already formatted, real run | `No files were formatted.` | 0 |
| unparsable source | `1 file(s) could not be formatted.` | 1 |

**`ReplHistory::lastResult()` / `lastException()` removed.** Neither had a production caller. The class publishes its state the only way the REPL consumes it, `Phel::addDefinition(phel.core, '*1'|'*2'|'*3'|'*e', …)`, which is what `Run/CLAUDE.md` documents. The accessors existed so two unit assertions could peek at a field, and both sat immediately beside a `Registry::getDefinition(...)` assertion making the identical claim, so no coverage is lost. Dropping `lastException()` left `private ?Throwable $lastException` write-only, so the field and its assignment went with it. `$result1` stays — live state, read by the shift in `recordResult()`.

Every reference path was checked, not assumed: PHP call sites (grep + Psalm agree, tests only); Phel `php/->` interop via a **bare-name** grep over every `.phel` file (0 hits); emitter-generated strings in `src/Phel.php` via a string-literal grep (0); dynamic `'name' . $n` concatenation (not `nameN`-shaped); Gacela reflection (plain domain class, not Facade/Factory/Config/Provider); Symfony command registration (not a `Command`); and facade surface (`Phel\Run\Domain\Repl`, internal, absent from every `*FacadeInterface`).

**REPL fixture documentation corrected.** The integration-tests rule claimed REPL fixtures use `--INPUT--`/`--EXPECT--` markers. None of the 23 fixtures under `Repl/Fixtures/` and `Repl/FixturesWithCoreLib/` contain those markers, or any markers. They are literal REPL transcripts: the whole file is the expected output, and `ReplCommandTest::getInputs()` recovers the inputs by matching each line against the prompt regex. Replaced with the real format, including the `....:<n>>` continuation prompt and the `trim()`ed `assertSame` comparison. Edited in the `.agnostic-ai/` spec and re-synced, since `.claude/rules/` is generated and gitignored.

**`setup-phel` composite action description corrected.** It advertised "Checkout repo, install PHP, …" but contains no `actions/checkout`; all twelve call sites check out themselves first.

### Reported, deliberately not changed

- **`rector.php:51`** skips `.../NodeEmitter/DefEmitter` with no `.php` extension. Extensionless entries are live prefix matches, and this one prefix-matches exactly `DefEmitter.php`, so the skip works. Making it exact is cosmetic but touches emitter output, so it belongs in its own PR gated on a whole-project dry run.
- **Four of eight REPL test classes** still carry byte-duplicated copies of `ReplCommandTestTrait` (#2824 migrated only half of them). This is duplication, not dead code, and not a mechanical merge: the trait returns `Printer::readable()` while all four copies return `Printer::nonReadable()`, so adopting it changes what the REPL prints under test and can flip assertions.
- `announce-release.yml` re-runs the same `node --test` that `announce-release-tests.yml` already ran; `run-clojure-test-suite.yml` pins `actions/cache@v5` while the composite pins `@v4`.
- `ResponseBuilder::INVALID_PARAMS` / `SERVER_NOT_INITIALIZED` are unreferenced but complete the JSON-RPC 2.0 error-code set.
- ~62 further test-only public methods, all false positives: the public `PhelConfig` config DSL (29 of them, the surface downstream `phel-config.php` files are written against), complete-set library APIs (`LintResult::hintCount()`, the `AbstractZipper` movement/insertion API), emitter-generated call sites, and Gacela/Symfony reflection wiring.

### Audits that came back clean

Every path referenced by all 8 workflows and the composite action exists, and no job is a no-op; the new `phel-lint` job is wired correctly. `docs/` has zero orphans. `resources/` had one apparent orphan, `cli-wordcount/tests/counts_test.phel`, which `tools/validate-agents.sh` runs by directory discovery. `resources/agents/VERSION` matches `VersionFinder::LATEST_VERSION`. The `phel-config.php` entry for `src/phel/local.phel` looks dead but the file is gitignored on purpose.

No CHANGELOG entry: none of these five changes is user-facing. Removing a `require-dev` does not affect library consumers, since `require-dev` is never installed transitively.

### Verification

`composer phpstan` 0 · `composer psalm` 0 · `phpunit --testsuite=unit,integration` 5260 tests / 15017 assertions / 0 failures · `composer test-core` 6497 passed / 0 failed · `composer csrun` 0 of 1675 fixable · **`rector process --dry-run` across all 1675 files, `[OK]` with no diff** (the run that would expose a broken `DefEmitter` skip) · `composer validate --strict --no-check-lock` exit 0 · manual `bin/phel --help`, `debug:modules` (15 modules, 57 pillars, 0 unresolvable), `validate:config`, `doc map`.
