### PR TITLE
ref: close two architecture blind spots and align module docs with the graph

### DIFF
--- a/src/php/Api/CLAUDE.md
+++ b/src/php/Api/CLAUDE.md
@@ -29,6 +29,10 @@ Project-level transfers: `ProjectIndex`, `Definition`, `Location`, `Completion`,
 - Compiler (lex, parse, read, analyze phases) — `FACADE_COMPILER`.
 - `ApiConfig::allNamespaces()` lists the 25 documented Phel namespaces; `ApiConfig::githubRef()` returns `VersionFinder::LATEST_VERSION`.
 
+`Api <-> Run` is the codebase's only mutual Gacela provider pair, and the cycle is a wiring detail rather than a structural one: both sides consume each other through `Phel\Shared\Facade\*Interface`, and the concrete facades appear only in `ApiProvider` / `RunProvider`, because Gacela's locator has to name a class. `ModuleDependencyCycleTest` pins exactly those two files.
+
+Note that `ApiFacadeInterface` declares only 5 of the facade's methods, so Lint, Lsp and Watch still inject the **concrete** `ApiFacade` for `analyzeSource` / `indexProject` / symbol resolution. That is the one sanctioned exception to "inject the interface" in `src/php/CLAUDE.md`; it is pinned by `SatelliteFactoryFacadeInjectionTest`. Widening the contract is what would let those three bind the interface instead.
+
 ## PHP Interop Tooling (`Application/Php*`)
 
 All collaborators degrade to empty/null on unknown types or reflection failure.

--- a/src/php/Build/CLAUDE.md
+++ b/src/php/Build/CLAUDE.md
@@ -23,6 +23,10 @@ Compiles Phel projects to PHP: namespace extraction, dependency ordering, and ca
 | `FACADE_COMPILER` | Phel-to-PHP compilation |
 | `FACADE_COMMAND` | Output/source dirs, error formatting |
 
+Both are injected as their Shared `*FacadeInterface`. One non-facade edge: **Config** — `BuildConfig` reads `PhelConfig`/`PhelBuildConfig`, and `Domain/Compile/Output/EntryPointPhpFile` reads `PhelBuildConfig`.
+
+`EntryPointPhpFile` also *emits* the string `\Phel\Phel::setupRuntimeArgs(...)` into generated entry points. That is generated-code text, not an import: it creates no compile-time edge to the composition root, but it does make the root's signature part of the build ABI, so changing `setupRuntimeArgs()` breaks previously built artifacts.
+
 ## Structure
 
 | Path | Role |

--- a/src/php/CLAUDE.md
+++ b/src/php/CLAUDE.md
@@ -8,6 +8,16 @@ Unless a module says "No Gacela Pattern", it follows this wiring:
 
 - `XFacade implements XFacadeInterface` — `XFactory extends AbstractFactory<XConfig>`; `XConfig` reads module settings.
 - `XProvider` exposes cross-module facades via `FACADE_*` string constants (e.g. `RunProvider::FACADE_COMPILER`); the consuming Factory pulls them with `getProvidedDependency(...)`. Modules list these under "Dependencies".
+
+#### What a "Dependencies" section must list
+
+`Lang` and `Shared` are dependency-free leaves that nearly every module imports for types and pure utilities. They are **not** relisted per module; assume they are available. A module's "Dependencies" section covers everything else, whether or not it arrives through a facade:
+
+- every `FACADE_*` the Provider supplies,
+- any non-facade module import (e.g. `Config`, or a neighbour's exception type caught for formatting),
+- any edge that closes a documented cycle.
+
+Keeping non-facade edges out of the docs is how the graph erodes quietly, so they belong here even when there is no Provider entry to hang them on.
 - Layered layout: `Application/` (use cases), `Domain/` (interfaces, value objects, logic), `Infrastructure/` (I/O, CLI commands, adapters), `Transfer/` (DTOs); Gacela files (`Facade`, `Factory`, `Config`, `Provider`) at module root.
 
 ### Where the FacadeInterface lives

--- a/src/php/Command/CLAUDE.md
+++ b/src/php/Command/CLAUDE.md
@@ -23,8 +23,9 @@ Directory getters are `#[Cacheable]`.
 ## Dependencies
 
 - No facade dependencies. Provider exposes `PHP_CONFIG_READER` (Gacela `PhpConfigReader`).
-- Shared: `AbstractLocatedException`, `CodeSnippet`, `Printer`, `ColorStyle`, `Munge`, `Exceptions\Hint\*`.
+- Shared: `AbstractLocatedException`, `CodeSnippet`, `Printer`, `ColorStyle`, `Munge`, `Exceptions\Hint\*`, plus `SourceMap\SourceMapConsumer` to map a generated PHP line back to its Phel line.
 - Config: `PhelConfig`, `PhelBuildConfig`.
+- Compiler: one import, `Domain\Evaluator\Exceptions\EvaluatedCodeException`, tested with `instanceof` in `TextExceptionPrinter` so eval'd frames print with their Phel source. Type-only; Command never calls into the compiler and injects no compiler facade.
 
 ## Structure
 

--- a/src/php/Command/Domain/Exceptions/Extractor/FilePositionExtractor.php
+++ b/src/php/Command/Domain/Exceptions/Extractor/FilePositionExtractor.php
@@ -6,7 +6,7 @@ namespace Phel\Command\Domain\Exceptions\Extractor;
 
 use Phel\Command\Domain\Exceptions\Extractor\ReadModel\FilePosition;
 use Phel\Command\Domain\Exceptions\Extractor\ReadModel\SourceMapInformation;
-use Phel\Compiler\Domain\Emitter\OutputEmitter\SourceMap\SourceMapConsumer;
+use Phel\Shared\SourceMap\SourceMapConsumer;
 
 final readonly class FilePositionExtractor implements FilePositionExtractorInterface
 {

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -18,9 +18,12 @@ Core compilation pipeline: Phel source → tokens → AST → analyzed nodes →
 
 ## Dependencies
 
-- **Filesystem** — file I/O.
+- **Filesystem** — file I/O (`FACADE_FILESYSTEM`, the module's only Provider entry).
 - **Config** — `PhelConfig` data model, wrapped by `CompilerConfig` (`assertsEnabled()`, `warnDeprecationsEnabled()`, `isIntermediateCacheEnabled()`, `getCacheDir()`).
-- **Shared** — `Munge`, `Printer`, exceptions.
+- **Lang** — the compiler's widest edge by far (~200 files): every phase after the lexer reads and produces `Phel\Lang` values, and the emitter writes their FQNs into generated PHP.
+- **Shared** — `Munge`, `Printer`, exceptions, `SourceMap\VLQ`. Shared points back through `Facade/CompilerFacadeInterface`; see the "Compiler Back-Edge" section of `Shared/CLAUDE.md`.
+
+The source map is split across the boundary on purpose: the writer (`Domain/Emitter/OutputEmitter/SourceMap/SourceMapGenerator`, `SourceMapState`) is emitter state and stays here, while the reader (`Shared\SourceMap\SourceMapConsumer`) lives in Shared because Command decodes maps too and must not `new` a compiler-internal class.
 
 ## Phase Pipeline
 

--- a/src/php/Compiler/Domain/Evaluator/Exceptions/EvaluatedCodeException.php
+++ b/src/php/Compiler/Domain/Evaluator/Exceptions/EvaluatedCodeException.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Evaluator\Exceptions;
 
-use Phel\Compiler\Domain\Emitter\OutputEmitter\SourceMap\SourceMapConsumer;
 use Phel\Shared\SourceMap\InlineSourceMapComments;
+use Phel\Shared\SourceMap\SourceMapConsumer;
 use RuntimeException;
 use Throwable;
 

--- a/src/php/Console/CLAUDE.md
+++ b/src/php/Console/CLAUDE.md
@@ -15,6 +15,10 @@ CLI entry point: bootstraps Symfony Console, lazily registers every module's com
 |-------------------|--------|----------|
 | `FACADE_FILESYSTEM` | Filesystem | `clearAll()` cleanup after each run |
 
+`FACADE_FILESYSTEM` is the only *injected* dependency, but it is not the only edge. As the CLI entry point, `ConsoleFactory` also imports the command classes of twelve modules (Api, Build, Compiler, Filesystem, Formatter, Interop, Lint, Lsp, Nrepl, Profile, Run, Watch) to register them with Symfony Console.
+
+That makes Console the graph's sink: it depends on nearly everything and **nothing depends on it**. Keep it that way. A module importing `Phel\Console` would turn the widest fan-in in the codebase into a cycle, which is why `ConsoleFacadeInterface` exists in `Shared/Facade` for the rare case a module needs to describe console behaviour.
+
 ## Structure
 
 | Path | Role |

--- a/src/php/Fiber/CLAUDE.md
+++ b/src/php/Fiber/CLAUDE.md
@@ -13,7 +13,7 @@ Cooperative async primitives (promises, futures, single-threaded scheduler) back
 
 ## Dependencies
 
-- None. The module has no Provider; no cross-module facades.
+- None beyond the `Lang` leaf (`FnInterface`, in `Domain/Promise.php`). The module has no Provider and no cross-module facades.
 - `FiberConfig::defaultSleepMicroseconds()` = 500µs (top-level busy-poll sleep when awaiting outside a Fiber).
 
 ## Structure

--- a/src/php/Filesystem/CLAUDE.md
+++ b/src/php/Filesystem/CLAUDE.md
@@ -13,7 +13,7 @@ Temp dir management and compiled-artifact cleanup tracking.
 
 ## Dependencies
 
-None (no Provider). `FilesystemConfig` reads `PhelConfig::KEEP_GENERATED_TEMP_FILES` (bool, default false) and `PhelConfig::TEMP_DIR` (string, default `sys_get_temp_dir()`).
+No facades (no Provider). The one module import is **Config**: `FilesystemConfig` reads `PhelConfig::KEEP_GENERATED_TEMP_FILES` (bool, default false) and `PhelConfig::TEMP_DIR` (string, default `sys_get_temp_dir()`).
 
 ## Structure
 

--- a/src/php/Formatter/CLAUDE.md
+++ b/src/php/Formatter/CLAUDE.md
@@ -23,9 +23,11 @@ Each path lands in at most one bucket; an already-formatted file appears in neit
 
 ## Dependencies
 
-- `FACADE_COMPILER` — lex + parse to parse tree.
-- `FACADE_COMMAND` — CLI output.
-- `FormatterConfig.getFormatDirs()` reads `PhelConfig::FORMAT_DIRS`, defaults to `['src', 'tests']`.
+- `FACADE_COMPILER` — lex + parse to parse tree (`lexString`, `parseAll`). Injected as `CompilerFacadeInterface` via `FormatterFactory::getCompilerFacade()`.
+- `FACADE_COMMAND` — CLI output, as `CommandFacadeInterface`.
+- Config — `FormatterConfig.getFormatDirs()` reads `PhelConfig::FORMAT_DIRS`, defaults to `['src', 'tests']`.
+
+Both getters return the Shared contract, never a concrete facade, and `SatelliteFactoryFacadeInjectionTest` pins the return types. The residual `Formatter -> Compiler` imports are exception types named in `@throws` (`LexerValueException`, `AbstractParserException`), not behaviour.
 
 ## Rules (applied in this order)
 

--- a/src/php/Formatter/FormatterFactory.php
+++ b/src/php/Formatter/FormatterFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phel\Formatter;
 
 use Gacela\Framework\AbstractFactory;
-use Phel\Compiler\CompilerFacade;
 use Phel\Formatter\Application\Formatter;
 use Phel\Formatter\Application\PathsFormatter;
 use Phel\Formatter\Application\PhelPathFilter;
@@ -22,6 +21,7 @@ use Phel\Formatter\Domain\Rules\RemoveTrailingWhitespaceRule;
 use Phel\Formatter\Domain\Rules\UnindentRule;
 use Phel\Formatter\Infrastructure\IO\SystemFileIo;
 use Phel\Shared\Facade\CommandFacadeInterface;
+use Phel\Shared\Facade\CompilerFacadeInterface;
 
 /**
  * @extends AbstractFactory<FormatterConfig>
@@ -70,7 +70,7 @@ final class FormatterFactory extends AbstractFactory
     public function createFormatter(): FormatterInterface
     {
         return new Formatter(
-            $this->getFacadeCompiler(),
+            $this->getCompilerFacade(),
             [
                 $this->createRemoveSurroundingWhitespaceRule(),
                 $this->createUnindentRule(),
@@ -127,9 +127,9 @@ final class FormatterFactory extends AbstractFactory
         return new PhelPathFilter();
     }
 
-    private function getFacadeCompiler(): CompilerFacade
+    private function getCompilerFacade(): CompilerFacadeInterface
     {
-        /** @var CompilerFacade $facade */
+        /** @var CompilerFacadeInterface $facade */
         $facade = $this->getProvidedDependency(FormatterProvider::FACADE_COMPILER);
 
         return $facade;

--- a/src/php/Interop/CLAUDE.md
+++ b/src/php/Interop/CLAUDE.md
@@ -17,6 +17,8 @@ Generates PHP wrapper classes for Phel functions marked `^{:export true}`, so PH
 | `FACADE_COMMAND` | error / exception output |
 | `FACADE_BUILD` | namespace extraction, compilation, evaluation |
 
+One non-facade edge: **Config** — `InteropConfig` imports `PhelConfig` and `PhelExportConfig`.
+
 `InteropConfig` reads the `export` config: `getExportDirectories()`, `prefixNamespace()` (default `PhelGenerated`), `getExportTargetDirectory()` (default `src/PhelGenerated`).
 
 ## Structure

--- a/src/php/Lint/CLAUDE.md
+++ b/src/php/Lint/CLAUDE.md
@@ -14,12 +14,14 @@ Read-only semantic linter: emits diagnostics on Phel sources, never rewrites the
 
 ## Dependencies
 
-| Facade | Used for |
-|--------|----------|
-| Api | `analyzeSource` (semantic diagnostics), `indexProject` |
-| Compiler | `readFormsBestEffort` (`SourceReader`); `lexString`, `parseNext`, `read` (`ConfigLoader`, `DuplicateKeyRule` — both need the failures reported, not swallowed) |
-| Command | default source directories |
-| Run | `loadPhelNamespaces()` to ensure symbols resolve |
+| Facade | Injected as | Used for |
+|--------|-------------|----------|
+| Api | concrete `ApiFacade` | `analyzeSource` (semantic diagnostics), `indexProject` |
+| Compiler | `CompilerFacadeInterface` | `readFormsBestEffort` (`SourceReader`); `lexString`, `parseNext`, `read` (`ConfigLoader`, `DuplicateKeyRule` — both need the failures reported, not swallowed) |
+| Command | `CommandFacadeInterface` | default source directories |
+| Run | `RunFacadeInterface` | `loadPhelNamespaces()` to ensure symbols resolve |
+
+`ApiFacade` is bound concretely because `analyzeSource` and `indexProject` are not on `ApiFacadeInterface`; see `src/php/Api/CLAUDE.md`. `SatelliteFactoryFacadeInjectionTest` pins all four return types.
 
 ## CLI
 

--- a/src/php/Lsp/CLAUDE.md
+++ b/src/php/Lsp/CLAUDE.md
@@ -12,12 +12,14 @@ The facade is production surface only. `LspFactory::createDispatcher()` stays in
 
 ## Dependencies
 
-| Facade | Used for |
-|--------|----------|
-| Api | Semantic analysis, symbol resolve/references, completion, PHP interop |
-| Lint | Rule-based diagnostics |
-| Formatter | String formatting |
-| Run | Phel namespace loading |
+| Facade | Injected as | Used for |
+|--------|-------------|----------|
+| Api | concrete `ApiFacade` | Semantic analysis, symbol resolve/references, completion, PHP interop |
+| Lint | concrete `LintFacade` | Rule-based diagnostics |
+| Formatter | concrete `FormatterFacade` | String formatting (`formatString`) |
+| Run | `RunFacadeInterface` | Phel namespace loading |
+
+Lsp is the only module that binds three concrete facades, so it is worth being explicit about why: `ApiFacadeInterface` and `FormatterFacadeInterface` exist but declare a narrower surface than Lsp needs (`formatString` is not on the formatter contract), and Lint has no interface at all — `src/php/CLAUDE.md` lists it under "No interface — extend `AbstractFacade`". All three are pinned by `SatelliteFactoryFacadeInjectionTest`, which fails if a *fourth* appears. Narrowing them to interfaces means widening the contracts first.
 
 ## Supported LSP Methods
 

--- a/src/php/Profile/CLAUDE.md
+++ b/src/php/Profile/CLAUDE.md
@@ -19,6 +19,9 @@ Instrumentation profiler for `phel profile`. Reports per-fn call counts, self/to
 | `ProfileProvider::FACADE_RUN` → `RunFacade` | `runFile`, `runNamespace`, `autoDetectEntryPoint`, `writeLocatedException`, `writeStackTrace` |
 | `Phel\Shared\Munge` (direct) | `canonicalNs` for namespace targets |
 | `Phel\Lang` (types) | `AbstractFn`, `ProfilerHookInterface`, `Registry` |
+| `Phel\Phel` (composition root, direct) | `ProfileCommand` calls `setupRuntimeArgs()` before running the profiled entry point, exactly as `RunCommand` does |
+
+`Phel\Phel` is the only import that reaches *out* of the module graph into the composition root. It is not a cycle (the root never imports Profile), so `ModuleDependencyCycleTest` cannot see it; `CompositionRootBoundaryTest` pins it instead, along with the fact that `setupRuntimeArgs()` is the single root method used.
 
 ## How the hook works
 

--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -30,6 +30,15 @@ Most-connected module. 5 Provider facades:
 
 Version comes from `Shared\VersionResolver` directly — Run does **not** depend on Console.
 
+Two non-facade edges complete the picture:
+
+| Edge | Where | Why |
+|------|-------|-----|
+| **Config** | `PhelConfig` / `PhelBuildConfig` read by `RunConfig` and the REPL/test commands | plain data model, no facade exists |
+| **Phel** | `Infrastructure/Command/RunCommand.php` calls `Phel::setupRuntimeArgs()` | publishes the entry point's `$argv` before handing over control |
+
+The `Phel` import closes the `Phel <-> Run` cycle: the composition root wires `RunFacade`, and `RunCommand` calls back into the root. It is accepted because the root is where process-wide argv belongs, and it is deliberately one file wide on each side — `ModuleDependencyCycleTest` fails if a second Run file imports the root, and `CompositionRootBoundaryTest` fails if `RunCommand` starts calling more of it than `setupRuntimeArgs()`.
+
 ## Structure
 
 - `Infrastructure/Command/`: 10 user-facing Symfony commands (incl. `config` — dumps effective merged config) + 1 hidden `_test-worker` (`TestWorkerCommand`).

--- a/src/php/Shared/CLAUDE.md
+++ b/src/php/Shared/CLAUDE.md
@@ -94,7 +94,8 @@ Stateless strategy-pattern printer (see `Printer/CLAUDE.md`); consumers instanti
 
 | Class | Purpose / producer → consumer |
 |-------|-------------------------------|
-| `VLQ` | pure Base64-VLQ codec (`decode`, `encodeIntegers`, `encodeInteger`); used by Compiler's `SourceMapGenerator`/`SourceMapConsumer` |
+| `VLQ` | pure Base64-VLQ codec (`decode`, `encodeIntegers`, `encodeInteger`); used by Compiler's `SourceMapGenerator` and by `SourceMapConsumer` below |
+| `SourceMapConsumer` | read side of the codec: decodes a `mappings` string into `getOriginalLine()` / `getMappedLines()`. Lives here, not in the emitter, because both Compiler (`EvaluatedCodeException`) and Command (`FilePositionExtractor`) decode maps while only the emitter writes them. The writer (`SourceMapGenerator`, `SourceMapState`) stays in Compiler |
 | `SourceMapSiblings` | naming convention for `<file>.php.map` + `<file>.phel` artifacts. Written by Build (`FileCompiler`, `SecondaryFileHarvester`), read by Command (`SourceMapExtractor`) |
 | `BuiltFilePreamble` | fixed `<?php declare(strict_types=1);` line before generated code; `prepend()` (writer: `FileCompiler`), `codeStartLine()` (reader: `SourceMapExtractor`) |
 | `InlineSourceMapComments` | `// ` / `// ;;` metadata comment prefixes for inline maps in eval'd code. Written by Compiler's `EmitterResult`, parsed by `SourceMapExtractor` + `EvaluatedCodeException` |

--- a/src/php/Shared/SourceMap/SourceMapConsumer.php
+++ b/src/php/Shared/SourceMap/SourceMapConsumer.php
@@ -2,10 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Phel\Compiler\Domain\Emitter\OutputEmitter\SourceMap;
+namespace Phel\Shared\SourceMap;
 
-use Phel\Shared\SourceMap\VLQ;
-
+/**
+ * Read side of the source-map codec: decodes a VLQ `mappings` string into
+ * generated-line => original-Phel-line lookups.
+ *
+ * It lives beside {@see VLQ} rather than in the emitter because both the
+ * compiler (`EvaluatedCodeException`) and Command (`FilePositionExtractor`)
+ * decode maps, while only the emitter writes them. Keeping the writer
+ * (`SourceMapGenerator`, `SourceMapState`) in Compiler and the reader here
+ * spares Command a `new` on a compiler-internal class.
+ */
 final class SourceMapConsumer
 {
     /** @var array<int, list<int>> */

--- a/src/php/Watch/CLAUDE.md
+++ b/src/php/Watch/CLAUDE.md
@@ -15,12 +15,14 @@ CLI: `./bin/phel watch [paths]... [-b backend] [--poll=500] [--debounce=100]` (`
 
 ## Dependencies (Provider FACADE_* constants)
 
-| Facade | Used for |
-|--------|----------|
-| Run | `evalFile`, `structuredEval` (reload hooks) |
-| Build | `getDependenciesForNamespace` (dep-order reload) |
-| Api | `indexProject` — incremental re-index for tooling |
-| Command | source-directory defaults |
+| Facade | Injected as | Used for |
+|--------|-------------|----------|
+| Run | `RunFacadeInterface` | `evalFile`, `structuredEval` (reload hooks) |
+| Build | `BuildFacadeInterface` | `getDependenciesForNamespace` (dep-order reload) |
+| Api | concrete `ApiFacade` | `indexProject` — incremental re-index for tooling |
+| Command | `CommandFacadeInterface` | source-directory defaults |
+
+`ApiFacade` is bound concretely because `indexProject` is not on `ApiFacadeInterface`; see `src/php/Api/CLAUDE.md`. `SatelliteFactoryFacadeInjectionTest` pins all four return types.
 
 ## Structure
 

--- a/tests/php/Unit/Architecture/CompositionRootBoundaryTest.php
+++ b/tests/php/Unit/Architecture/CompositionRootBoundaryTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Architecture;
+
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function in_array;
+use function is_array;
+use function sprintf;
+
+/**
+ * `Phel\Phel` is the composition root: it owns `Gacela::bootstrap()`, the
+ * project-layout detection and the process-wide runtime argv.
+ *
+ * {@see ModuleDependencyCycleTest} pins the `Phel <-> Run` pair, but a cycle
+ * test can only see edges that point *both* ways. A module that merely reaches
+ * *into* the root is invisible there, and `Profile` already does exactly that.
+ * So the consumer set is pinned here instead: bootstrapping is a privilege of
+ * the entry point, and every module that helps itself to it should be a
+ * deliberate, listed decision rather than an accident nobody notices.
+ */
+final class CompositionRootBoundaryTest extends TestCase
+{
+    use ScansPhpSourcesTrait;
+
+    /**
+     * The modules allowed to import `Phel\Phel`, and why.
+     *
+     * Both call one method, `setupRuntimeArgs()`, because both launch a
+     * user-supplied entry point and must publish its `$argv` before handing
+     * control over. Neither bootstraps the container: that stays in `bin/phel`.
+     *
+     * @var array<string, string> relative file => the single root API it uses
+     */
+    private const array ALLOWED_ROOT_CONSUMERS = [
+        'Profile/Infrastructure/Command/ProfileCommand.php' => 'setupRuntimeArgs',
+        'Run/Infrastructure/Command/RunCommand.php' => 'setupRuntimeArgs',
+    ];
+
+    /**
+     * Bootstrapping the Gacela container is what makes something a composition
+     * root. Exactly one file in the repository may do it.
+     */
+    private const string BOOTSTRAP_ENTRY_POINT = 'bin/phel';
+
+    public function test_only_the_listed_modules_import_the_composition_root(): void
+    {
+        $importers = [];
+
+        foreach ($this->phpFilesIn('src/php') as $relative => $contents) {
+            if (preg_match('/^use\s+Phel\\\\Phel\s*;/m', $contents) !== 1) {
+                continue;
+            }
+
+            $importers[] = $relative;
+        }
+
+        sort($importers);
+
+        self::assertSame(
+            array_keys(self::ALLOWED_ROOT_CONSUMERS),
+            $importers,
+            "A new module imports the composition root Phel\\Phel.\n"
+            . "Reaching into the root couples a module to process-wide bootstrap state that a\n"
+            . "facade cannot mediate. Prefer taking what you need as a constructor argument.\n"
+            . 'If the dependency is genuinely warranted, list it in ALLOWED_ROOT_CONSUMERS with a reason.',
+        );
+    }
+
+    public function test_root_consumers_use_only_the_runtime_argv_entry_point(): void
+    {
+        foreach (self::ALLOWED_ROOT_CONSUMERS as $relative => $allowedMethod) {
+            $contents = $this->phpFilesIn('src/php')[$relative] ?? '';
+
+            preg_match_all('/(?<![\w\\\\])Phel::(\w+)\s*\(/', $contents, $matches);
+            $called = array_values(array_unique($matches[1]));
+
+            self::assertSame(
+                [$allowedMethod],
+                $called,
+                sprintf(
+                    "%s now calls more of the composition root than %s().\n"
+                    . 'Widening this is how a command quietly turns into a second composition root.',
+                    $relative,
+                    $allowedMethod,
+                ),
+            );
+        }
+    }
+
+    public function test_only_the_cli_entry_point_bootstraps_the_container(): void
+    {
+        $repositoryRoot = dirname(__DIR__, 4);
+        $bootstrappers = [];
+
+        foreach ($this->phpFilesIn('src/php') as $relative => $contents) {
+            // Root-namespace files (`Phel.php` and its helpers) *are* the
+            // composition root, so bootstrapping is their job by definition.
+            if (!str_contains($relative, '/')) {
+                continue;
+            }
+
+            if ($this->callsBootstrap($contents)) {
+                $bootstrappers[] = 'src/php/' . $relative;
+            }
+        }
+
+        foreach (['bin/phel', 'build/preload.php', 'build/build-phar.php'] as $script) {
+            $path = $repositoryRoot . '/' . $script;
+            if (!is_file($path)) {
+                continue;
+            }
+
+            if ($this->callsBootstrap((string) file_get_contents($path))) {
+                $bootstrappers[] = $script;
+            }
+        }
+
+        self::assertSame(
+            [self::BOOTSTRAP_ENTRY_POINT],
+            $bootstrappers,
+            "Something other than bin/phel now bootstraps the container.\n"
+            . 'Two composition roots means two different wirings of the same modules can exist at once.',
+        );
+    }
+
+    /**
+     * True when the file really calls `Gacela::bootstrap()` / `Phel::bootstrap()`.
+     *
+     * Comments are stripped first: `MergedConfigCacheInvalidator` documents the
+     * bootstrap contract in a docblock without invoking it, and a docblock that
+     * reads like a call is precisely the false positive the other architecture
+     * tests already refuse to count.
+     */
+    private function callsBootstrap(string $contents): bool
+    {
+        $code = '';
+
+        foreach (token_get_all($contents) as $token) {
+            if (is_array($token) && in_array($token[0], [T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            $code .= is_array($token) ? $token[1] : $token;
+        }
+
+        return preg_match('/(?:Gacela|Phel)::bootstrap\s*\(/', $code) === 1;
+    }
+}

--- a/tests/php/Unit/Architecture/SatelliteFactoryFacadeInjectionTest.php
+++ b/tests/php/Unit/Architecture/SatelliteFactoryFacadeInjectionTest.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Architecture;
 
 use Generator;
+use Phel\Api\ApiFacade;
+use Phel\Formatter\FormatterFacade;
+use Phel\Formatter\FormatterFactory;
+use Phel\Lint\LintFacade;
 use Phel\Lint\LintFactory;
 use Phel\Lsp\LspFactory;
 use Phel\Nrepl\NreplFactory;
@@ -19,6 +23,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use ReflectionNamedType;
+
+use function dirname;
 
 /**
  * Satellite modules must depend on the Shared facade *contracts*, not on a
@@ -55,6 +61,40 @@ final class SatelliteFactoryFacadeInjectionTest extends TestCase
         yield 'Nrepl api' => [NreplFactory::class, 'getApiFacade', ApiFacadeInterface::class];
 
         yield 'Profile run' => [ProfileFactory::class, 'getRunFacade', RunFacadeInterface::class];
+
+        yield 'Formatter compiler' => [FormatterFactory::class, 'getCompilerFacade', CompilerFacadeInterface::class];
+        yield 'Formatter command' => [FormatterFactory::class, 'getCommandFacade', CommandFacadeInterface::class];
+    }
+
+    /**
+     * The data provider above only sees getters somebody remembered to list, so
+     * it cannot notice a *new* factory binding a concrete facade. This walks
+     * every factory instead and fails on the difference.
+     *
+     * Three getters legitimately return a concrete facade: `Lint`, `Lsp` and
+     * `Watch` consume Api methods (`analyzeSource`, `indexProject`, symbol
+     * resolution) that `ApiFacadeInterface` does not declare, and `Lsp` consumes
+     * `LintFacade`, for which `src/php/CLAUDE.md` records that no interface
+     * exists. Narrowing those means widening the contracts first, so they are
+     * listed rather than silently allowed.
+     */
+    public function test_no_unlisted_factory_binds_a_concrete_facade(): void
+    {
+        $expected = [
+            'Lint/LintFactory.php::getApiFacade' => ApiFacade::class,
+            'Lsp/LspFactory.php::getApiFacade' => ApiFacade::class,
+            'Lsp/LspFactory.php::getFormatterFacade' => FormatterFacade::class,
+            'Lsp/LspFactory.php::getLintFacade' => LintFacade::class,
+            'Watch/WatchFactory.php::getApiFacade' => ApiFacade::class,
+        ];
+
+        self::assertSame(
+            $expected,
+            $this->concreteFacadeGetters(),
+            "A factory getter returns a concrete facade instead of a Shared *FacadeInterface.\n"
+            . "src/php/CLAUDE.md requires injecting the interface. Add the method to the contract\n"
+            . 'in Shared/Facade and widen the return type; only list it here if that is not yet possible.',
+        );
     }
 
     public function test_run_facade_interface_declares_auto_detect_entry_point(): void
@@ -63,5 +103,38 @@ final class SatelliteFactoryFacadeInjectionTest extends TestCase
             method_exists(RunFacadeInterface::class, 'autoDetectEntryPoint'),
             'Profile consumes RunFacade::autoDetectEntryPoint via the Shared contract.',
         );
+    }
+
+    /**
+     * @return array<string, string> `<relative factory>::<getter>` => concrete facade FQN
+     */
+    private function concreteFacadeGetters(): array
+    {
+        $srcDir = dirname(__DIR__, 4) . '/src/php';
+        $found = [];
+
+        foreach (glob($srcDir . '/*/*Factory.php') ?: [] as $path) {
+            $contents = (string) file_get_contents($path);
+            $relative = str_replace($srcDir . '/', '', $path);
+
+            preg_match_all(
+                '/function\s+(\w+)\s*\(\s*\)\s*:\s*(\w*Facade)\b/',
+                $contents,
+                $matches,
+                PREG_SET_ORDER,
+            );
+
+            foreach ($matches as [, $method, $shortName]) {
+                if (preg_match('/^use\s+(Phel\\\\[\w\\\\]*\\\\' . $shortName . ');$/m', $contents, $import) !== 1) {
+                    continue;
+                }
+
+                $found[$relative . '::' . $method] = $import[1];
+            }
+        }
+
+        ksort($found);
+
+        return $found;
     }
 }


### PR DESCRIPTION
## 🤔 Background

The module graph has been audited a few times now, and the result each time was a set of guards in `tests/php/Unit/Architecture/`. This pass re-ran the whole analysis against current `main` (module edges, Tarjan SCC over the class graph, provider-only and layer-rank passes) after 18 PRs had landed.

The good news first: **nothing regressed.** The four cyclic pairs are unchanged, there are zero factory boundary violations, zero class-level SCCs crossing a module boundary, Console is still a pure sink, and every guard's pinned set was still accurate without edits.

What the pass did turn up were two gaps *between* the guards rather than inside any of them, plus a question nobody had asked before: do the per-module `CLAUDE.md` dependency sections actually match the imports?

## 💡 Goal

Close the two blind spots, and make the module docs describe the graph that exists rather than the one that was intended. Behaviour is unchanged throughout.

## 🔖 Changes

### `SourceMapConsumer` moves to `Phel\Shared`

`Command\…\FilePositionExtractor` was calling `new SourceMapConsumer(...)` on a class living in `Phel\Compiler\Domain\Emitter\…` — one module constructing another's internals, with no facade in between. `Command` has no Provider at all, so nothing mediated it.

The class is a pure stateless VLQ decoder, and its only dependency, `VLQ`, already sits in `Phel\Shared\SourceMap`. That makes this the documented fix (move a pure stateless utility into `Phel\Shared`) rather than the tempting wrong one (add a `createX()` passthrough to `CompilerFacade`).

The split is deliberate and now written down: the **writer** (`SourceMapGenerator`, `SourceMapState`) is emitter state and stays in Compiler; only the **reader** moves, because both Compiler and Command decode maps. `Command -> Compiler` drops from 2 files to 1.

### `FormatterFactory` binds the interface

`getFacadeCompiler(): CompilerFacade` returned the concrete facade, which `src/php/CLAUDE.md` forbids. Its only consumer already accepted `CompilerFacadeInterface`, so this was pure needless narrowing — widened, and renamed to `getCompilerFacade` to match the other 25 getters. `Formatter -> Compiler` drops from 5 files to 4.

### Two new/extended guards

**`CompositionRootBoundaryTest`** (new). `ModuleDependencyCycleTest` can only detect edges pointing *both* ways, so `Profile -> Phel` was invisible to it: `Phel` never imports `Profile`, so it is not a cycle. `ProfileCommand` has been calling `Phel::setupRuntimeArgs()` alongside `RunCommand` with nothing watching. The new test pins the two allowed importers, holds each to that single method, and asserts `bin/phel` remains the only bootstrapper.

It is comment-aware via `token_get_all`: the naive version false-positived on a docblock in `MergedConfigCacheInvalidator` that merely *mentions* `Gacela::bootstrap()`, and ignoring docblocks is the policy the sibling guards already follow.

**`SatelliteFactoryFacadeInjectionTest`** gains a scan. It was a hand-maintained data provider, so it could only check getters someone remembered to list — it could never notice a *new* factory binding a concrete facade. It now walks every `src/php/*/*Factory.php` and pins the concrete set at exactly five.

Those five are contract gaps rather than oversights, and each is now documented where it lives: `ApiFacadeInterface` declares 5 of ~14 facade methods (which is why Lint, Lsp and Watch all bind concrete `ApiFacade`), `FormatterFacadeInterface` lacks the `formatString` that Lsp needs, and Lint has no interface at all. Widening those contracts is a sensible follow-up but it is real design work on public surface, so it is deliberately not in this PR.

### Module docs vs. the real import graph

Every module's `CLAUDE.md` was diffed against its actual imports. `Lang` and `Shared` are imported nearly everywhere, so rather than add two lines of noise to eighteen files, the convention is stated once in the root `src/php/CLAUDE.md`, along with what a "Dependencies" section is obliged to list.

The fixes then cover only the omissions that genuinely mislead:

- **Compiler** listed Shared but not **Lang**, its widest edge at 204 files.
- **Run** omitted the `Phel` back-edge, even though that edge is a *pinned cycle*.
- **Profile** omitted `Phel` entirely — the reach this PR adds a guard for.
- **Console** documented one dependency while importing thirteen modules; it is the graph's sink and the doc now says so, and says why nothing may depend on it.
- **Command** claimed "no facade dependencies" while `new`-ing a compiler class.
- **Api / Lint / Lsp / Watch** did not record that they bind concrete facades or why.
- **Filesystem** said "None", **Fiber** said "None", both had real edges.
- **Build / Interop** omitted their `Config` edge; Build also emits `\Phel\Phel::setupRuntimeArgs(...)` into generated entry points, which makes the root's signature part of the build ABI and is worth knowing.

`Config`, `Lang` and `Shared` have no `## Dependencies` heading but document their edges in prose already, so they were left alone.

### Verification

`unit,integration` 5266 passed / 14 skipped · `test-core` 6497 passed · `phpstan` (L9) OK · `psalm` OK · `csrun` 0 · `rector` OK.

No CHANGELOG entry: internal structure and docs only, nothing user-facing.
