### PR TITLE
ref: restore the generic key/value types the phpdoc fixer erased in Lang

### DIFF
--- a/src/php/Lang/Collections/HashSet/AbstractTransientSet.php
+++ b/src/php/Lang/Collections/HashSet/AbstractTransientSet.php
@@ -49,7 +49,7 @@ abstract readonly class AbstractTransientSet implements TransientHashSetInterfac
     }
 
     /**
-     * @param mixed $key
+     * @param TValue $key
      */
     public function contains($key): bool
     {

--- a/src/php/Lang/Collections/Map/ArrayNode.php
+++ b/src/php/Lang/Collections/Map/ArrayNode.php
@@ -43,8 +43,8 @@ final class ArrayNode implements HashMapNodeInterface, Countable
     }
 
     /**
-     * @param mixed $key
-     * @param mixed $value
+     * @param TKey   $key
+     * @param TValue $value
      *
      * @return HashMapNodeInterface<TKey, TValue>
      */
@@ -81,7 +81,7 @@ final class ArrayNode implements HashMapNodeInterface, Countable
     }
 
     /**
-     * @param mixed $key
+     * @param TKey $key
      *
      * @return HashMapNodeInterface<TKey, TValue>
      */
@@ -112,7 +112,7 @@ final class ArrayNode implements HashMapNodeInterface, Countable
     }
 
     /**
-     * @param mixed $key
+     * @param TKey  $key
      * @param mixed $notFound
      *
      * @return ?mixed

--- a/src/php/Lang/Collections/Map/HashCollisionNode.php
+++ b/src/php/Lang/Collections/Map/HashCollisionNode.php
@@ -72,7 +72,7 @@ final class HashCollisionNode implements HashMapNodeInterface
     }
 
     /**
-     * @param mixed $key
+     * @param TKey $key
      *
      * @return HashMapNodeInterface<TKey, TValue>|null
      */
@@ -93,7 +93,7 @@ final class HashCollisionNode implements HashMapNodeInterface
     }
 
     /**
-     * @param mixed $key
+     * @param TKey  $key
      * @param mixed $notFound
      *
      * @return ?mixed

--- a/src/php/Lang/Collections/Map/IndexedNode.php
+++ b/src/php/Lang/Collections/Map/IndexedNode.php
@@ -78,7 +78,7 @@ final readonly class IndexedNode implements HashMapNodeInterface
     }
 
     /**
-     * @param mixed $key
+     * @param TKey $key
      *
      * @return HashMapNodeInterface<TKey, TValue>|null
      */
@@ -135,7 +135,7 @@ final readonly class IndexedNode implements HashMapNodeInterface
     }
 
     /**
-     * @param mixed $key
+     * @param TKey  $key
      * @param mixed $notFound
      *
      * @return ?mixed

--- a/src/php/Lang/Collections/Map/PersistentArrayMap.php
+++ b/src/php/Lang/Collections/Map/PersistentArrayMap.php
@@ -119,7 +119,7 @@ final class PersistentArrayMap extends AbstractPersistentMap
     }
 
     /**
-     * @param mixed $key
+     * @param TKey $key
      *
      * @return self<TKey, TValue>
      */

--- a/src/php/Lang/Collections/Map/PersistentHashMap.php
+++ b/src/php/Lang/Collections/Map/PersistentHashMap.php
@@ -109,8 +109,8 @@ final class PersistentHashMap extends AbstractPersistentMap
     }
 
     /**
-     * @param mixed $key
-     * @param mixed $value
+     * @param TKey   $key
+     * @param TValue $value
      *
      * @return self<TKey, TValue>
      */
@@ -136,7 +136,7 @@ final class PersistentHashMap extends AbstractPersistentMap
     }
 
     /**
-     * @param mixed $key
+     * @param TKey $key
      *
      * @return self<TKey, TValue>
      */

--- a/src/php/Lang/Collections/Map/TransientArrayMap.php
+++ b/src/php/Lang/Collections/Map/TransientArrayMap.php
@@ -44,8 +44,8 @@ final class TransientArrayMap implements TransientMapInterface
     }
 
     /**
-     * @param mixed $key
-     * @param mixed $value
+     * @param TKey   $key
+     * @param TValue $value
      *
      * @return TransientMapInterface<TKey, TValue>
      */
@@ -80,7 +80,7 @@ final class TransientArrayMap implements TransientMapInterface
     }
 
     /**
-     * @param mixed $key
+     * @param TKey $key
      *
      * @return self<TKey, TValue>
      */

--- a/src/php/Lang/Collections/Map/TransientHashMap.php
+++ b/src/php/Lang/Collections/Map/TransientHashMap.php
@@ -66,8 +66,8 @@ final class TransientHashMap implements TransientMapInterface
     }
 
     /**
-     * @param mixed $key
-     * @param mixed $value
+     * @param TKey   $key
+     * @param TValue $value
      *
      * @return self<TKey, TValue>
      */
@@ -102,7 +102,7 @@ final class TransientHashMap implements TransientMapInterface
     }
 
     /**
-     * @param mixed $key
+     * @param TKey $key
      *
      * @return self<TKey, TValue>
      */

--- a/src/php/Lang/Collections/Map/TransientMapWrapper.php
+++ b/src/php/Lang/Collections/Map/TransientMapWrapper.php
@@ -47,8 +47,8 @@ final class TransientMapWrapper implements TransientMapInterface, Stringable
     }
 
     /**
-     * @param mixed $key
-     * @param mixed $value
+     * @param TKey   $key
+     * @param TValue $value
      *
      * @return self<TKey, TValue>
      */
@@ -61,7 +61,7 @@ final class TransientMapWrapper implements TransientMapInterface, Stringable
     }
 
     /**
-     * @param mixed $key
+     * @param TKey $key
      *
      * @return self<TKey, TValue>
      */

--- a/src/php/Lang/Collections/SortedMap/PersistentSortedMap.php
+++ b/src/php/Lang/Collections/SortedMap/PersistentSortedMap.php
@@ -133,7 +133,7 @@ final class PersistentSortedMap extends AbstractPersistentMap
     }
 
     /**
-     * @param mixed $key
+     * @param TKey $key
      *
      * @return self<TKey, TValue>
      */

--- a/src/php/Lang/Collections/SortedMap/TransientSortedMap.php
+++ b/src/php/Lang/Collections/SortedMap/TransientSortedMap.php
@@ -50,8 +50,8 @@ final class TransientSortedMap implements TransientMapInterface
     }
 
     /**
-     * @param mixed $key
-     * @param mixed $value
+     * @param TKey   $key
+     * @param TValue $value
      *
      * @return self<TKey, TValue>
      */
@@ -77,7 +77,7 @@ final class TransientSortedMap implements TransientMapInterface
     }
 
     /**
-     * @param mixed $key
+     * @param TKey $key
      *
      * @return self<TKey, TValue>
      */


### PR DESCRIPTION
## 🤔 Background

`.php-cs-fixer.dist.php` enables `phpdoc_add_missing_param_annotation`. That rule fills in `@param mixed $x` for **any untyped parameter of a method that already has a docblock**.

Every persistent/transient map method needs a docblock for its `@return self<TKey, TValue>`, so the fixer mechanically stamped `@param mixed $key` / `@param mixed $value` on top of them. A child `@param` **overrides** the interface's `@param TKey`, so PHPStan resolved those parameters as `mixed` at every concrete call site — the generic types were silently erased by our own formatter.

`PersistentArrayMap::put()` and `PersistentSortedMap::put()` are the tell: they carry **no** docblock at all, so the fixer never touched them, and they inherit `TKey`/`TValue` correctly on a green build. The HAMT nodes show the same split from the other side — someone hand-wrote `@param TKey`/`@param TValue` on `IndexedNode::put` and `HashCollisionNode::put`, while the neighbouring `remove`/`find` (never hand-written) kept the fixer's `mixed`.

Proof the erasure was real, with a throwaway probe under PHPStan L9:

```php
/** @param PersistentHashMap<string,int> $hash  @param PersistentArrayMap<string,int> $arr */
$hash->put(new stdClass(), 1);   // BEFORE: no error   <-- erased
$arr->put(new stdClass(), 1);    // BEFORE: error      <-- no docblock, inherits TKey
```

After this PR both lines error. The probe file was deleted; it is not part of the diff.

## 💡 Goal

Restore the key/value types the collection interfaces already declare, so a concretely parameterised map or set actually type-checks its arguments instead of accepting anything.

Deleting the `@param mixed` line does **not** work: the formatter re-injects it on the next write. The fix has to spell the real type out, which is also what the fixer leaves alone.

## 🔖 Changes

Docblock-only. No runtime change, nothing widened, no `assert()`/`instanceof` added.

**Map implementations** — `@param mixed` → `@param TKey` / `@param TValue`:

- `PersistentHashMap::put()`, `::remove()`
- `PersistentArrayMap::remove()`
- `PersistentSortedMap::remove()`
- `TransientHashMap::put()`, `::remove()`
- `TransientArrayMap::put()`, `::remove()`
- `TransientMapWrapper::put()`, `::remove()`
- `TransientSortedMap::put()`, `::remove()`

**HAMT nodes** — same, on the `$key` parameter:

- `IndexedNode::remove()`, `::find()`
- `ArrayNode::put()`, `::remove()`, `::find()`
- `HashCollisionNode::remove()`, `::find()`

**Sets**:

- `AbstractTransientSet::contains()` declared `@param mixed $key` against `ContainsInterface<TValue>`. Its deliberate mirror `AbstractPersistentSet::contains()` already said `@param TValue`, and the other eleven `contains()` implementations in `Lang` carry no docblock at all and inherit correctly — this was the single outlier.

Deliberately left alone, each for a reason:

- `PersistentHashMap`/`TransientHashMap` constructor `@param mixed $nullValue` — genuinely `mixed`: a literal `null` is passed whenever `hasNull` is false, so `TValue` would be wrong.
- `find()`'s `$notFound` and `@return` — `HashMapNodeInterface::find()` declares a method-level `@template TDefault`; restoring it in the three implementations means adding that template to each and re-checking the `self::$NOT_FOUND` sentinel call sites. Bigger than a docblock swap, so it wants its own pass.
- The four `offsetGet()` implementations with a hand-written `@return mixed|null` (`PersistentList`, `EmptyList`, `AbstractPersistentVector`, `TransientVector`) — same family, but each needs its own null-ability check against its own `get()`.

No CHANGELOG entry: this is internal type metadata with no user-facing effect.

### Verification

`vendor/bin/phpstan clear-result-cache` first, since the cache hides errors CI catches:

- `composer phpstan` — no errors
- `composer psalm` — no errors
- `composer csrun` — 0 of 1675 files need fixing
- `composer rector` — OK
- `vendor/bin/phpunit --testsuite=unit,integration` — 5260 tests, 15019 assertions, 14 skipped, 0 failures
- `composer test-core` — Passed 6497, Failed 0, Error 0
