### PR TITLE
chore: drop the orphaned symfony/var-dumper lock entry

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "791e5d88fe5b6f1ec47c4d490edcd69d",
+    "content-hash": "c9336acdbc414ef818dacf5b66a8d003",
     "packages": [
         {
             "name": "amphp/amp",
@@ -8146,93 +8146,6 @@
                 }
             ],
             "time": "2026-05-29T05:06:50+00:00"
-        },
-        {
-            "name": "symfony/var-dumper",
-            "version": "v8.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "40096a2515a979f3125c5c928603995b8664c62a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/40096a2515a979f3125c5c928603995b8664c62a",
-                "reference": "40096a2515a979f3125c5c928603995b8664c62a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4.1",
-                "symfony/polyfill-mbstring": "^1.0"
-            },
-            "conflict": {
-                "symfony/console": "<7.4",
-                "symfony/error-handler": "<7.4"
-            },
-            "require-dev": {
-                "symfony/console": "^7.4|^8.0",
-                "symfony/http-kernel": "^7.4|^8.0",
-                "symfony/process": "^7.4|^8.0",
-                "symfony/uid": "^7.4|^8.0",
-                "twig/twig": "^3.12"
-            },
-            "bin": [
-                "Resources/bin/var-dump-server"
-            ],
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "Resources/functions/dump.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Component\\VarDumper\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides mechanisms for walking through any arbitrary PHP variable",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "debug",
-                "dump"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v8.1.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-06-09T10:54:51+00:00"
         },
         {
             "name": "theseer/tokenizer",


### PR DESCRIPTION
## 🤔 Background

#2833 removed the unimported `symfony/var-dumper` from `require-dev`, but a lock refresh could not be run from that worktree (its `vendor/` was hardlinked to the primary checkout, so any writing composer command would have mutated the main repo). That left `composer.lock` stale: `composer validate --strict` failed, and because the package entry was still present, `composer install` kept installing a dependency nothing uses.

## 💡 Goal

Bring the lock back in sync and actually drop the orphan, without touching any other package version.

## 🔖 Changes

Ran `composer update symfony/var-dumper`, the narrowest command that re-resolves only that package. Since nothing requires it any more, it is removed.

- `composer.lock`: 1 insertion, 88 deletions
- The only package removed is `symfony/var-dumper` (v8.1.1)
- **Zero version changes to any other package** (verified: the diff contains no added `"version":` lines)

Note that `composer update --lock` alone was not sufficient. It refreshes the `content-hash` only, which silences `composer validate` while leaving the orphan installed.

## ✅ Verification

- `composer validate --strict` passes
- `composer why symfony/var-dumper` reports no dependents
- `vendor/symfony/var-dumper` is gone from the working tree, so the suite below ran with the package genuinely uninstalled: PHPStan L9 clean, 5307 unit+integration tests, 6497 core tests, all green