### PR TITLE
fix(compiler): declare the PHP namespace for in-ns files

### DIFF
--- a/src/php/Api/Infrastructure/NativeSymbolCatalog.php
+++ b/src/php/Api/Infrastructure/NativeSymbolCatalog.php
@@ -202,10 +202,10 @@ The test evaluates to false if its value is false or equal to nil. Every other v
             'doc' => '```phel
 (in-ns namespace)
 ```
-Switches to an existing namespace without creating it. Intended for REPL use, e.g. navigating into a namespace to inspect or test private functions interactively. Avoid in source files: the build system assumes one namespace per file, and `in-ns` causes collisions in the dependency resolver.',
+Switches to an existing namespace without creating it. Two uses: at the REPL, to navigate into a namespace and inspect or test private functions; and as the first form of a file pulled in with `(load ...)`, which must join its caller\'s namespace this way. Do not use it to switch namespace part-way through a file - the build system assumes one namespace per file.',
             'docUrl' => '/documentation/namespaces/',
             'signatures' => ['(in-ns namespace)'],
-            'desc' => 'Switches to an existing namespace without creating it (REPL-oriented).',
+            'desc' => 'Switches to an existing namespace without creating it (REPL, and `load`-ed files).',
             'example' => '(in-ns my-app\\core)',
         ],
         Symbol::NAME_LET => [

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InNsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InNsSymbol.php
@@ -19,11 +19,14 @@ use function str_replace;
 /**
  * (in-ns namespace)
  *
- * Switches to an existing namespace without creating it. Intended for
- * REPL use — e.g. navigating into a namespace to inspect or test private
- * functions interactively. Avoid using in source files: the build system
- * assumes one namespace per file, and in-ns causes namespace collisions
- * in the dependency resolver.
+ * Switches to an existing namespace without creating it. Two uses: at the
+ * REPL, navigating into a namespace to inspect or test private functions;
+ * and as the first form of a file pulled in with (load ...), which must
+ * join its caller's namespace this way - LoadEmitter enforces it at runtime.
+ *
+ * Do not use it to switch namespace part-way through a file: the build
+ * system assumes one namespace per file, and only the first declaration
+ * reaches the emitted PHP.
  */
 final class InNsSymbol implements SpecialFormAnalyzerInterface
 {

--- a/src/php/Compiler/Domain/Emitter/FileEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/FileEmitter.php
@@ -23,6 +23,7 @@ final class FileEmitter implements FileEmitterInterface
     {
         $this->outputEmitter->resetIndentLevel();
         $this->outputEmitter->resetSourceMapState();
+        $this->outputEmitter->resetPhpNamespaceDeclaration();
 
         $this->source = $source;
         $this->phpCode = '';

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter.php
@@ -38,6 +38,13 @@ final class OutputEmitter implements OutputEmitterInterface
     // are off (the common REPL / `compile --emit-only` path).
     private bool $atLineStart = true;
 
+    /**
+     * Whether this file already carries a PHP `namespace` declaration. PHP
+     * allows only one, and only as the first statement, so `ns` and `in-ns`
+     * share this flag rather than each emitting their own.
+     */
+    private bool $phpNamespaceDeclared = false;
+
     /** @var array<int, string> */
     private array $indentCache = [];
 
@@ -115,6 +122,40 @@ final class OutputEmitter implements OutputEmitterInterface
     {
         $this->indentLevel = 0;
         $this->atLineStart = true;
+    }
+
+    public function resetPhpNamespaceDeclaration(): void
+    {
+        $this->phpNamespaceDeclared = false;
+    }
+
+    /**
+     * Emits the file's PHP `namespace` declaration, at most once.
+     *
+     * Both `ns` and `in-ns` need it: FILE and CACHE mode emit struct, interface,
+     * enum and exception classes inline, relying on the file being namespaced.
+     * Without it a class is declared globally while call sites reference the
+     * qualified name.
+     *
+     * Only the first caller wins. A file may open with `ns` and later switch the
+     * analyzer namespace with `in-ns`; a second `namespace` statement there would
+     * be a PHP fatal, since it must be the very first statement in the file.
+     */
+    public function declarePhpNamespaceOnce(string $namespace, ?SourceLocation $sl = null): void
+    {
+        if ($this->phpNamespaceDeclared) {
+            return;
+        }
+
+        if (!$this->options->isFileEmitMode() && !$this->options->isCacheEmitMode()) {
+            return;
+        }
+
+        $this->phpNamespaceDeclared = true;
+
+        $this->emitStr('namespace ', $sl);
+        $this->emitStr($this->mungeEncodePhpNs($namespace), $sl);
+        $this->emitLine(';', $sl);
     }
 
     public function resetSourceMapState(): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/InNsEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/InNsEmitter.php
@@ -21,6 +21,8 @@ final class InNsEmitter implements NodeEmitterInterface
     {
         assert($node instanceof InNsNode);
 
+        $this->emitNamespace($node);
+
         $this->outputEmitter->emitLine(
             '\\' . GlobalEnvironmentSingleton::class . '::getInstance()->setNs("' . addslashes($node->getNamespace()) . '");',
             $node->getStartSourceLocation(),
@@ -30,6 +32,30 @@ final class InNsEmitter implements NodeEmitterInterface
         $this->emitFileAndNsDefinitions(
             $node->getNamespace(),
             $node->getStartSourceLocation()?->getFile() ?? '',
+        );
+    }
+
+    /**
+     * A file entered with `in-ns` needs the PHP namespace declaration for the
+     * same reason an `ns` file does: `DefStructEmitter` and its def-interface,
+     * def-enum and def-exception siblings emit their class inline in FILE and
+     * CACHE mode, relying on the file already being namespaced. Without it the
+     * class is declared globally while every call site references the qualified
+     * name, so it is "not found" on any run that reads the cache.
+     *
+     * `declarePhpNamespaceOnce` keeps a file that opens with `ns` and later
+     * switches with `in-ns` emitting exactly one declaration: PHP requires it to
+     * be the very first statement, so the `ns` form wins and this one is a no-op.
+     *
+     * Safe to emit first here because `LoadEmitter` never inlines a loaded file
+     * into its caller - it requires the compiled sibling or loads the source -
+     * so a file whose first form is `in-ns` always owns its output file.
+     */
+    private function emitNamespace(InNsNode $node): void
+    {
+        $this->outputEmitter->declarePhpNamespaceOnce(
+            $node->getNamespace(),
+            $node->getStartSourceLocation(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
@@ -29,14 +29,12 @@ final class NsEmitter implements NodeEmitterInterface
 
     private function emitNamespace(NsNode $node): void
     {
-        // Both FILE and CACHE modes need PHP namespace declaration for struct classes
-        if ($this->outputEmitter->getOptions()->isFileEmitMode()
-            || $this->outputEmitter->getOptions()->isCacheEmitMode()
-        ) {
-            $this->outputEmitter->emitStr('namespace ', $node->getStartSourceLocation());
-            $this->outputEmitter->emitStr($this->outputEmitter->mungeEncodePhpNs($node->getNamespace()), $node->getStartSourceLocation());
-            $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
-        }
+        // Both FILE and CACHE modes need the PHP namespace declaration for
+        // struct classes, which are emitted inline into the enclosing namespace.
+        $this->outputEmitter->declarePhpNamespaceOnce(
+            $node->getNamespace(),
+            $node->getStartSourceLocation(),
+        );
     }
 
     private function emitRequireFiles(NsNode $node): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
@@ -28,6 +28,13 @@ interface OutputEmitterInterface
 
     public function resetIndentLevel(): void;
 
+    public function resetPhpNamespaceDeclaration(): void;
+
+    /**
+     * Emits the file's PHP `namespace` declaration, at most once per file.
+     */
+    public function declarePhpNamespaceOnce(string $namespace, ?SourceLocation $sl = null): void;
+
     public function resetSourceMapState(): void;
 
     public function getSourceMapState(): SourceMapState;

--- a/src/php/Compiler/Domain/Emitter/StatementEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/StatementEmitter.php
@@ -20,6 +20,7 @@ final readonly class StatementEmitter implements StatementEmitterInterface
     {
         $this->outputEmitter->resetIndentLevel();
         $this->outputEmitter->resetSourceMapState();
+        $this->outputEmitter->resetPhpNamespaceDeclaration();
 
         return new EmitterResult(
             $enableSourceMaps,

--- a/tests/php/Integration/Fixtures/Ns/in-ns-as-first-form.test
+++ b/tests/php/Integration/Fixtures/Ns/in-ns-as-first-form.test
@@ -1,0 +1,15 @@
+--PHEL--
+(in-ns target\ns)
+--PHP--
+namespace target\ns;
+\Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton::getInstance()->setNs("target.ns");
+\Phel::addDefinition(
+  "phel.core",
+  "*file*",
+  "Ns/in-ns-as-first-form.test"
+);
+\Phel::addDefinition(
+  "phel.core",
+  "*ns*",
+  "target.ns"
+);


### PR DESCRIPTION
Closes #2834

## Problem

A `defstruct` in a file pulled in with `(load ...)` landed in the **global** namespace whenever the file was read from cache, while every call site referenced the qualified name. First run compiles in-process and works; second run reads the cache and fails.

```
Class "repro\lib\thing_b" not found
  at .phel/cache/compiled/repro.lib__8945a5cc.php:43
```

`NsEmitter::emitNamespace()` writes the `namespace` declaration and only runs for an `NsNode`. A `(load ...)`-ed file opens with `(in-ns ...)`, so nothing emitted it — while `DefStructEmitter::emitInline()` assumed the file was already namespaced, as its own docblock says:

```php
/**
 * In file/cache mode the NsEmitter already declared the namespace at the
 * top of the file, so the class is emitted inline without its own
 * namespace statement.
 */
```

## Fix

Both emitters now go through `OutputEmitter::declarePhpNamespaceOnce()`.

**The "once" is the whole subtlety.** My first attempt had `InNsEmitter` emit unconditionally, and the existing `Ns/in-ns*.test` fixtures caught it: a file may open with `(ns ...)` and later switch with `(in-ns ...)`, and a second `namespace` statement there is a PHP fatal — it has to be the very first statement in the file. Now the `ns` form wins and the `in-ns` call is a no-op, so those three fixtures are unchanged.

Emitting it first from `in-ns` is safe because `LoadEmitter` never inlines a loaded file into its caller — it `require_once`s the compiled sibling or loads the source — so a file whose first form is `in-ns` always owns its output file.

The flag resets per file in `FileEmitter::startFile()` and per statement in `StatementEmitter::emitNode()`.

## Docs

The issue flagged that `in-ns` was documented two ways. `LoadEmitter` settles it — a loaded file **must** use `in-ns`, and it throws at runtime otherwise:

```php
'File %s must use (in-ns %s) to join the caller namespace, but found (in-ns %s) or (ns ...)'
```

So the "avoid in source files" note was the wrong one. Corrected in `NativeSymbolCatalog` and `InNsSymbol`, keeping the genuine caveat: don't switch namespace part-way through a file.

## Verification

| | |
|---|---|
| `composer test-unit` | OK — 4204 tests, 9616 assertions |
| `composer test-integration:serial` | OK — 1094 tests (new fixture included) |
| `composer test-core` | OK — 6497 Phel tests |
| `composer phpstan` | No errors |
| `composer psalm` | No errors; identical output before/after |
| `php-cs-fixer --dry-run` | 0 of 1678 files |

New fixture `tests/php/Integration/Fixtures/Ns/in-ns-as-first-form.test` locks the declaration for a file whose first form is `in-ns`.

The four-file reproducer from the issue now prints correctly on every run instead of failing from the second onward.

### One note on the suite

`CompileCommandTest::test_compile_does_not_evaluate_side_effecting_forms` fails intermittently under `paratest`, and it is **pre-existing** — I reproduced it on clean `main` (3 runs: pass, error, pass) and it never fails serially or under `--filter`. Unrelated to this change, but it will occasionally trip the pre-commit hook.