### PR TITLE
ref: drop two orphans the recent test consolidations left behind

### DIFF
--- a/tests/php/Integration/Lint/Fixtures/let_sequential_binding.phel
+++ b/tests/php/Integration/Lint/Fixtures/let_sequential_binding.phel
@@ -1,6 +1,0 @@
-(ns fixtures\let-sequential-binding)
-
-(defn foo []
-  (let [n   (+ 1 2)
-        msg (str "n=" n)]
-    (println msg)))

--- a/tests/php/Integration/Run/Command/Repl/ReplTestIo.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplTestIo.php
@@ -142,20 +142,10 @@ final class ReplTestIo implements ReplCommandIoInterface
     }
 
     /**
-     * @return list<string>
-     */
-    public function getRawOutputs(): array
-    {
-        $this->finishCapture();
-
-        return $this->outputs;
-    }
-
-    /**
-     * Raw outputs with the line terminator stripped, for assertions that care
-     * about the logical line and not its framing. Prefer this over
-     * {@see self::getRawOutputs()} when matching a whole entry, so the
-     * assertion does not have to spell out `. PHP_EOL`.
+     * Every captured output with the line terminator stripped, for assertions
+     * that care about the logical line and not its framing, so they do not have
+     * to spell out `. PHP_EOL`. Unlike {@see self::getOutputs()} this keeps the
+     * banner and the trailing prompt.
      *
      * @return list<string>
      */


### PR DESCRIPTION
## 🤔 Background

A fresh dead-code sweep against current `main`, aimed specifically at what the last 25 PRs might have orphaned. The tooling run was Psalm `--find-dead-code` (428 raw issues), Psalm errorLevel 1, PHPStan L9, PHPStan L9 with `reportAlwaysTrueInLastCondition` / `checkBenevolentUnionTypes` / `checkUninitializedProperties` / `checkTooWideReturnTypesInProtectedAndPublicMethods`, plus six custom whole-repo scanners (zero-ref classes, uncalled private/protected methods, never-thrown exception types, unused class constants, never-`use`d traits, unread private properties, orphan fixtures, dangling `{@see}` targets, dead private Phel defs, and stale paths/globs in every config file).

Almost all of it came back clean, which is the expected result by now. `src/php` and `src/phel` yielded nothing: 0 exception types never thrown, 0 src classes with zero external references, 0 never-`use`d traits, 0 dead private Phel `defn-`/`def-`. The eight Psalm `UnusedClass` hits all resolved to the documented hiding mechanisms (`StreamTransport` via `php/::` interop from `src/phel/http-client.phel`, `PhelSourceLoader` via the literal FQN `LoadEmitter` writes into generated PHP, `NullNamespaceCache` via seven test references, the rest Gacela-wired or called from `bin/phel`). The 24 `UnusedConstructor` hits are all the `private function __construct()` no-instantiation idiom.

Two angles were explored that had not been before, and both produced nothing worth changing:

- **Unreachable branches.** All 54 `default:` / `default =>` arms in `src/php` were read individually and every one is reachable — the Lint formatters switch on `string $severity` rather than an enum, `DoctorCommand` uses `match (true)` over predicate methods, and `InitCommand`'s default collectively handles `ProjectLayout::Flat` and `::Nested`. PHPStan with the strict reachability flags on reported zero findings in that family, and Psalm at errorLevel 1 is clean, so there are no `RedundantCondition` / `TypeDoesNotContainType` / `UnevaluatedCode` results either.
- **CI configuration.** Nothing duplicated or superseded. Setup is already consolidated into the `setup-phel` composite action, used by all nine jobs that need PHP; the one job with inline `setup-php` (`composer-validate`) deliberately skips `composer install`. The new `phel-lint` job supersedes nothing, both PHP matrix entries add real coverage, and every path in `composer.json`, `rector.php`, `phpunit.xml.dist`, `psalm.xml`, `.php-cs-fixer.dist.php` and the workflows resolves.

What the sweep did find is one orphan of exactly the predicted shape — a helper whose last caller was deleted by a recent PR — plus a fixture that was never wired up in the first place.

## 💡 Goal

Remove the two dead test-tree symbols, with enough evidence in each case that emitted-code strings, Phel interop, and dynamic dispatch are all ruled out.

## 🔖 Changes

- **`ReplTestIo::getRawOutputs()` removed.** #2793 added `getOutputLines()` and moved every assertion onto it in the same commit, leaving the old accessor with no callers; `git log -S getRawOutputs` confirms none has appeared since. Repo-wide the name occurred exactly twice: the declaration, and the `{@see}` in `getOutputLines()`'s own docblock telling readers to prefer the replacement. It is not reachable through any of the hiding mechanisms — the class lives in a test namespace the emitter never names, `grep -rn getRawOutputs src/phel tests/phel docs resources` returns nothing, and there is no dynamic `->$method` anywhere under `Repl/`.

- **`getOutputLines()` docblock rewritten.** It would otherwise have been left with a dangling `{@see}`. It now states its own contract positively and contrasts against `getOutputs()`, which is the accessor that actually differs: `getOutputs()` slices off the banner and the trailing prompt, `getOutputLines()` keeps them.

- **`tests/php/Integration/Lint/Fixtures/let_sequential_binding.phel` removed.** It was added by `c841e12ec` with no accompanying test and never wired up. The three Lint integration tests name their fixtures one by one and none of them lints `Fixtures/` as a directory, so the file has never been read by anything; the `phel-lint` CI job covers `src/phel` only, and `phel test` never reaches `tests/php`. The regression it was meant to guard is already covered by `UnusedBindingRuleTest::test_it_does_not_flag_binding_consumed_only_by_later_sibling`, which asserts on the identical `(let [n 1 msg (str n)] msg)` form.

No CHANGELOG entry: both changes are confined to the test tree with no user-facing effect.

### Left for the maintainer to decide

- `Lsp\Application\Rpc\ResponseBuilder::INVALID_PARAMS` (-32602) and `::SERVER_NOT_INITIALIZED` (-32002) are the only two of six constants with no reference anywhere. They were left in place because the set is the standard JSON-RPC 2.0 / LSP error-code table, and `SERVER_NOT_INITIALIZED` names behaviour the LSP spec requires but the server does not implement yet. Deleting two rows from a spec table is a product call rather than a cleanup.
- Three parallel recursive-directory-removal helpers live in the test tree (`RemoveDirTrait::removeDir` with 21 users, `DirectoryUtil::removeDir` with 7, `tests/bootstrap.php::removeDirectory` with 2). All three are live, so it is duplication rather than dead code, and the bootstrap one genuinely cannot use a trait.
- `tests/php/Unit/Compiler/Analyzer/SpecialForm/IfSymbolTest.php:63` has a `{@see self::test_analyze_folds_literal_test()}` naming a method that was split in two and no longer exists.
- `tests/bootstrap.php:51` cleans the stale `out-load-e2e` build dir but not its sibling `out-load-e2e-no-cache`, which `BuildCommandLoadNoCompiledCacheE2ETest` produces.

### Verification

`phpstan` (no errors), `psalm` (no errors), `phpunit --testsuite=unit,integration` (5379 tests, 15246 assertions, 0 failures), `composer test-core` (6506 passed), `php-cs-fixer --dry-run` (0 of 1689), whole-project `rector --dry-run` (OK), plus `bin/phel --help`, `debug:modules` (15 modules, 57 pillars, 0 unresolvable), `validate:config` and `doc map`, all exit 0.
