### PR TITLE
ref: restore TDefault through the HAMT find() chain and say what offsetGet really returns

### DIFF
--- a/src/php/Lang/Collections/LinkedList/EmptyList.php
+++ b/src/php/Lang/Collections/LinkedList/EmptyList.php
@@ -182,7 +182,9 @@ final class EmptyList extends AbstractType implements PersistentListInterface
     /**
      * @param int $offset
      *
-     * @return mixed|null
+     * @throws IndexOutOfBoundsException always: the empty list holds no offset
+     *
+     * @return never
      */
     public function offsetGet($offset): mixed
     {

--- a/src/php/Lang/Collections/LinkedList/PersistentList.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentList.php
@@ -270,7 +270,9 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
     /**
      * @param int $offset
      *
-     * @return mixed|null
+     * @throws IndexOutOfBoundsException when $offset is outside [0, count)
+     *
+     * @return T never null for an absent offset: out of range throws
      */
     public function offsetGet($offset): mixed
     {

--- a/src/php/Lang/Collections/Map/ArrayNode.php
+++ b/src/php/Lang/Collections/Map/ArrayNode.php
@@ -112,10 +112,12 @@ final class ArrayNode implements HashMapNodeInterface, Countable
     }
 
     /**
-     * @param TKey  $key
-     * @param mixed $notFound
+     * @template TDefault
      *
-     * @return ?mixed
+     * @param TKey     $key
+     * @param TDefault $notFound
+     *
+     * @return TDefault|TValue
      */
     public function find(int $shift, int $hash, $key, $notFound)
     {

--- a/src/php/Lang/Collections/Map/HashCollisionNode.php
+++ b/src/php/Lang/Collections/Map/HashCollisionNode.php
@@ -93,10 +93,12 @@ final class HashCollisionNode implements HashMapNodeInterface
     }
 
     /**
-     * @param TKey  $key
-     * @param mixed $notFound
+     * @template TDefault
      *
-     * @return ?mixed
+     * @param TKey     $key
+     * @param TDefault $notFound
+     *
+     * @return TDefault|TValue
      */
     public function find(int $shift, int $hash, $key, $notFound)
     {
@@ -105,6 +107,9 @@ final class HashCollisionNode implements HashMapNodeInterface
             return $notFound;
         }
 
+        // findIndex only ever lands on a key slot of the flat [k, v, k, v, …]
+        // list, so $pair[1] is always the matching value; the coalesce is a
+        // defensive fallback that a well-formed node never reaches.
         $pair = array_slice($this->objects, $index, 2);
         /** @var TValue $value */
         $value = $pair[1] ?? $notFound;

--- a/src/php/Lang/Collections/Map/HashMapNodeInterface.php
+++ b/src/php/Lang/Collections/Map/HashMapNodeInterface.php
@@ -30,10 +30,18 @@ interface HashMapNodeInterface extends IteratorAggregate
     public function remove(int $shift, int $hash, mixed $key): ?self;
 
     /**
+     * Looks the key up, returning $notFound when it is absent.
+     *
+     * $notFound is a caller-chosen sentinel, so it must stay a distinct
+     * template parameter: `null` (the map's own default) and the
+     * `PersistentHashMap::getNotFound()` stdClass (used by `contains()` to
+     * tell "absent" from "present but null") have to survive as separate
+     * types in the return union.
+     *
      * @template TDefault
      *
-     * @param TKey      $key
-     * @param ?TDefault $notFound
+     * @param TKey     $key
+     * @param TDefault $notFound
      *
      * @return TDefault|TValue
      */

--- a/src/php/Lang/Collections/Map/IndexedNode.php
+++ b/src/php/Lang/Collections/Map/IndexedNode.php
@@ -135,10 +135,12 @@ final readonly class IndexedNode implements HashMapNodeInterface
     }
 
     /**
-     * @param TKey  $key
-     * @param mixed $notFound
+     * @template TDefault
      *
-     * @return ?mixed
+     * @param TKey     $key
+     * @param TDefault $notFound
+     *
+     * @return TDefault|TValue
      */
     public function find(int $shift, int $hash, $key, $notFound)
     {
@@ -157,7 +159,12 @@ final readonly class IndexedNode implements HashMapNodeInterface
         }
 
         if ($this->equalizer->equalsKey($key, $currentKey)) {
-            return $currentValue;
+            // Mirror of the $currentKey === null branch above: a non-null key
+            // means the slot holds a leaf value, never a child node.
+            /** @var TValue $value */
+            $value = $currentValue;
+
+            return $value;
         }
 
         return $notFound;

--- a/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
+++ b/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
@@ -6,6 +6,7 @@ namespace Phel\Lang\Collections\Vector;
 
 use InvalidArgumentException;
 use Phel\Lang\AbstractType;
+use Phel\Lang\Collections\Exceptions\IndexOutOfBoundsException;
 use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\Collections\LazySeq\LazySeqInterface;
 use Phel\Lang\Collections\Map\MapEntry;
@@ -143,7 +144,9 @@ abstract class AbstractPersistentVector extends AbstractType implements Persiste
     /**
      * @param int $offset
      *
-     * @return mixed|null
+     * @throws IndexOutOfBoundsException when $offset is outside [0, count)
+     *
+     * @return T never null for an absent offset: out of range throws
      */
     public function offsetGet($offset): mixed
     {

--- a/src/php/Lang/Collections/Vector/TransientVector.php
+++ b/src/php/Lang/Collections/Vector/TransientVector.php
@@ -239,7 +239,9 @@ final class TransientVector implements TransientVectorInterface, Stringable
     /**
      * @param int $offset
      *
-     * @return mixed|null
+     * @throws IndexOutOfBoundsException when $offset is outside [0, count)
+     *
+     * @return T never null for an absent offset: out of range throws
      */
     public function offsetGet($offset): mixed
     {


### PR DESCRIPTION
## 🤔 Background

Two families of weak phpdoc survived the earlier typing waves, both in `Lang/Collections`.

The HAMT node contract `HashMapNodeInterface::find()` already carried `@template TDefault`, but all three implementations (`ArrayNode`, `IndexedNode`, `HashCollisionNode`) overrode it with `@param mixed $notFound` / `@return ?mixed`. `?mixed` is not valid phpdoc and degenerates to `mixed`, and because PHPStan resolves a call against the *implementation* docblock when the concrete class is known, every node-level lookup collapsed to `mixed`.

Separately, four `offsetGet()` declared `@return mixed|null`. That is redundant (`mixed` already includes `null`) and, worse, misleading: it advertises a null-on-missing contract that none of the four honours.

## 💡 Goal

Make both say what they actually do, with no runtime change. `$notFound` is a caller-chosen sentinel and is precisely what separates "key absent" from "key present, value null", so this is the one place where a sloppy type is genuinely load-bearing.

## 🔖 Changes

**HAMT `find()`**

- `@template TDefault` + `@param TDefault $notFound` + `@return TDefault|TValue` on all three implementations.
- Interface: `@param ?TDefault` → `@param TDefault`. This is the load-bearing edit. With the `?`, passing the literal `null` matches the null arm, leaves `TDefault` uninferable, and PHPStan falls back to `mixed` — exactly the looseness the template existed to prevent. Without it, `find(…, null)` infers `TDefault = null` and returns `TValue|null`, which is what `PersistentMapInterface::find()` and `TransientMapInterface::find()` already promise. Not a weakening: `TDefault` is inferred from the argument, so `null` is still accepted.
- All four `self::$NOT_FOUND` call sites re-checked:

  | Site | `$notFound` | inferred `TDefault` | inferred return |
  |---|---|---|---|
  | `PersistentHashMap::contains()` | `self::getNotFound()` | `stdClass` | `stdClass\|TValue` |
  | `PersistentHashMap::find()` | `null` | `null` | `TValue\|null` |
  | `TransientHashMap::contains()` | `self::getNotFound()` | `stdClass` | `stdClass\|TValue` |
  | `TransientHashMap::find()` | `null` | `null` | `TValue\|null` |

  Both `contains()` sites compare `!== self::getNotFound()`; the sentinel type now survives into the return union instead of being flattened, so that identity comparison is type-visible rather than accidental. `getNotFound()` itself is untouched — still a lazily-built `stdClass` singleton, still identity-compared, never value-compared.
- Two inline `@var`s state an invariant the code already relied on, rather than adding a new claim. `IndexedNode::find()` gets `/** @var TValue $value */` as the exact mirror of the `/** @var HashMapNodeInterface<TKey, TValue> $node */` already sitting in the branch above it — one assertion per half of the `array{0: TKey|null, 1: HashMapNodeInterface|TValue}` slot union. `HashCollisionNode` keeps its existing narrow tag, now with a comment explaining why the `?? $notFound` fallback is unreachable in a well-formed node.

**`offsetGet()`**

Each of the four was checked against its own `get()`, not assumed to match its siblings:

| Class | actual behaviour | was | now |
|---|---|---|---|
| `PersistentList` | throws `IndexOutOfBoundsException` outside `[0, count)` | `mixed\|null` | `@return T` + `@throws` |
| `EmptyList` | `get(): never` — always throws; `offsetGet` has no `return` at all | `mixed\|null` | `@return never` + `@throws` |
| `AbstractPersistentVector` | `PersistentVector`/`SubVector` both throw | `mixed\|null` | `@return T` + `@throws` |
| `TransientVector` | `getArrayForIndex()` throws | `mixed\|null` | `@return T` + `@throws` |

All four throw; none returns null. `EmptyList` is the outlier — `@return never` is the only accurate answer, and it is a subtype of the native `ArrayAccess::offsetGet(): mixed`, so nothing is weakened. Added the missing `IndexOutOfBoundsException` import to `AbstractPersistentVector`, the only one of the four that lacked it.

The existing `PersistentListTest` / `EmptyListTest` / `PersistentVectorTest` / `TransientVectorTest` pass unchanged, and none of them ever expected `null` here — which is the evidence that the docblocks, not the code, were wrong.

**Scope note.** Docblocks only, plus one import and two behaviour-identical variable extractions. No CHANGELOG entry: nothing user-facing. A grep for `?mixed` / `mixed|null` / `null|mixed` across `src/php` returned exactly these seven sites and is now empty.

Verified with the result cache cleared: `composer phpstan` (L9, 1058 files) clean, `composer psalm` clean, `phpunit --testsuite=unit,integration` 5379 tests / 15246 assertions green, `composer test-core` 6506 passed, `composer csrun` and `composer rector` clean.
