### PR TITLE
fix(test): stop RunCommandTest writing a transient .phel into the test tree

### DIFF
--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -206,7 +206,15 @@ final class RunCommandTest extends AbstractTestCommand
 
     public function test_macro_expansion_error_includes_definition_location(): void
     {
-        $tmpFile = __DIR__ . '/macro-error-script.phel';
+        // Written to its own temp directory rather than next to this file: a
+        // transient `.phel` inside the test tree is visible to any *other*
+        // test process running a namespace scan, which then fails with
+        // "Unable to read file" the moment this test deletes it again. Under
+        // paratest that is a real, intermittent cross-process failure.
+        $tmpDir = sys_get_temp_dir() . '/phel-macro-error-' . bin2hex(random_bytes(8));
+        mkdir($tmpDir, 0o777, true);
+        $tmpFile = $tmpDir . '/macro-error-script.phel';
+
         file_put_contents($tmpFile, <<<'PHEL'
 (ns test\macro-error-script)
 
@@ -220,6 +228,7 @@ PHEL);
             $output = $this->captureRunOutput($tmpFile);
         } finally {
             unlink($tmpFile);
+            rmdir($tmpDir);
         }
 
         self::assertStringContainsString('Error in expanding macro', $output);


### PR DESCRIPTION
## Problem

`CompileCommandTest` fails intermittently under `paratest`:

```
RuntimeException: Unable to read file ".../tests/php/Integration/Run/Command/Run/macro-error-script.phel"
  src/php/Build/Application/NamespaceExtractor.php:54
```

The file it cannot read belongs to a **different test**. `RunCommandTest::test_macro_expansion_error_includes_definition_location` writes `macro-error-script.phel` next to itself, runs it, then `unlink`s it in a `finally`.

Any other test process doing a namespace scan can list that file and then fail the moment this test deletes it. Under `paratest` the two classes run in separate processes concurrently, so it is a genuine cross-process race — not test-order flakiness.

It surfaced on **different `CompileCommandTest` methods** on different runs (`test_compile_does_not_evaluate_side_effecting_forms`, `test_compile_known_core_call_uses_get_definition`), which is why it reads like a different bug each time. It is neither: it is whichever method happened to trigger the scan.

## Fix

Write the fixture to its own temp directory. Nothing scans there, so the race is removed rather than narrowed. The filename stays `macro-error-script.phel`, which the `~Defined: .*macro-error-script\.phel:3~` assertion depends on.

## Verification

Forced-race harness — the two classes hammered against each other in separate processes:

| | |
|---|---|
| before | **2/15** iterations failed |
| after | **0/30** |

Both failures before the fix were the exact error above.

- Full parallel integration: 1105 tests, no failures over three runs
- `composer test-unit`: OK, 4300 tests
- `composer test-core`: 6534 passed
- phpstan / psalm / php-cs-fixer / rector: clean

## Not done here

`NamespaceExtractor::extractFromFile()` hard-fails when a file vanishes between listing and reading. Arguably a scan should tolerate that, but making it silent could equally mask a real unreadable-file problem, and the root cause was a test polluting a scanned tree. Happy to follow up if you want the extractor hardened too.