### PR TITLE
fix(build): let a namespace scan skip a file that vanished mid-scan

### DIFF
--- a/src/php/Build/Application/NamespaceExtractor.php
+++ b/src/php/Build/Application/NamespaceExtractor.php
@@ -25,6 +25,7 @@ use Phel\Shared\Parser\Node\TriviaNodeInterface;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RegexIterator;
+use RuntimeException;
 use UnexpectedValueException;
 
 use function array_values;
@@ -51,7 +52,17 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
      */
     public function getNamespaceFromFile(string $path): NamespaceInformation
     {
-        $content = $this->fileIo->getContents($path);
+        try {
+            $content = $this->fileIo->getContents($path);
+        } catch (RuntimeException $runtimeException) {
+            // A file listed by a directory scan can be gone by the time it is
+            // read - another process writing a temp `.phel` and removing it
+            // again is enough. Raise the module's own exception so the scan in
+            // findAllNs() skips it, exactly as it already skips a file it
+            // cannot parse. A caller asking for one specific file still gets a
+            // thrown exception; only the scan swallows it.
+            throw ExtractorException::cannotReadFile($path, $runtimeException);
+        }
 
         try {
             $tokenStream = $this->compilerFacade->lexString($content);

--- a/src/php/Build/Domain/Extractor/ExtractorException.php
+++ b/src/php/Build/Domain/Extractor/ExtractorException.php
@@ -11,9 +11,22 @@ use function sprintf;
 
 final class ExtractorException extends RuntimeException
 {
-    public static function cannotReadFile(string $path): self
+    /**
+     * @param ?Throwable $previous the IO failure that caused this, when the file
+     *                             could not be read at all; its message is
+     *                             appended so the caller sees why
+     */
+    public static function cannotReadFile(string $path, ?Throwable $previous = null): self
     {
-        return new self('Cannot read file: ' . $path);
+        if (!$previous instanceof Throwable) {
+            return new self('Cannot read file: ' . $path);
+        }
+
+        return new self(
+            sprintf('Cannot read file: %s: %s', $path, $previous->getMessage()),
+            0,
+            $previous,
+        );
     }
 
     public static function cannotExtractNamespaceFromPath(string $path): self

--- a/tests/php/Unit/Build/Domain/Extractor/NamespaceExtractorTest.php
+++ b/tests/php/Unit/Build/Domain/Extractor/NamespaceExtractorTest.php
@@ -8,12 +8,17 @@ use Phel\Build\Application\NamespaceExtractor;
 use Phel\Build\Domain\Extractor\ExcludedScanPaths;
 use Phel\Build\Domain\Extractor\ExtractorException;
 use Phel\Build\Domain\Extractor\TopologicalNamespaceSorter;
+use Phel\Build\Domain\IO\FileContentsIoInterface;
 use Phel\Build\Infrastructure\IO\SystemFileIo;
 use Phel\Compiler\CompilerFacade;
 use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
 use Phel\Phel;
 use Phel\Shared\NamespaceInformation;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function basename;
+use function sprintf;
 
 final class NamespaceExtractorTest extends TestCase
 {
@@ -219,6 +224,85 @@ final class NamespaceExtractorTest extends TestCase
         unlink($excludedPath);
         rmdir($dir . '/vendor-build');
         rmdir($dir);
+    }
+
+    public function test_unreadable_file_raises_an_extractor_exception(): void
+    {
+        // Asking for one specific file must still fail loudly - only the
+        // directory scan is allowed to skip.
+        $this->expectException(ExtractorException::class);
+        $this->expectExceptionMessageMatches('~Cannot read file: .*does-not-exist\.phel~');
+
+        $this->newExtractor()->getNamespaceFromFile(
+            sys_get_temp_dir() . '/phel-does-not-exist.phel',
+        );
+    }
+
+    public function test_directory_scan_skips_a_file_that_vanished_mid_scan(): void
+    {
+        // A file listed by the scan can be deleted before it is read - another
+        // process writing a temp `.phel` and removing it is enough. The scan
+        // must skip it and still return the namespaces it could read.
+        $dir = sys_get_temp_dir() . '/phel-vanishing-' . bin2hex(random_bytes(8));
+        mkdir($dir, 0o777, true);
+        file_put_contents($dir . '/kept.phel', '(ns vanishing\\kept)');
+
+        $vanishing = $dir . '/vanishing.phel';
+        file_put_contents($vanishing, '(ns vanishing\\gone)');
+
+        $extractor = new NamespaceExtractor(
+            new CompilerFacade(),
+            new TopologicalNamespaceSorter(),
+            // Matched on basename: the scan realpaths the directory first, and
+            // on macOS sys_get_temp_dir() resolves /var -> /private/var, so the
+            // path the scan hands us is not the string we wrote.
+            new readonly class(basename($vanishing)) implements FileContentsIoInterface {
+                public function __construct(private string $vanishingName) {}
+
+                public function getContents(string $filename): string
+                {
+                    if (basename($filename) === $this->vanishingName) {
+                        throw new RuntimeException(sprintf('Unable to read file "%s".', $filename));
+                    }
+
+                    return new SystemFileIo()->getContents($filename);
+                }
+
+                public function putContents(string $filename, string $content): void
+                {
+                    new SystemFileIo()->putContents($filename, $content);
+                }
+
+                public function removeFile(string $filename): void
+                {
+                    new SystemFileIo()->removeFile($filename);
+                }
+            },
+        );
+
+        try {
+            $infos = $extractor->getNamespacesFromDirectories([$dir]);
+        } finally {
+            @unlink($dir . '/kept.phel');
+            @unlink($vanishing);
+            @rmdir($dir);
+        }
+
+        $namespaces = array_map(
+            static fn(NamespaceInformation $i): string => $i->getNamespace(),
+            $infos,
+        );
+
+        self::assertSame(['vanishing.kept'], $namespaces);
+    }
+
+    private function newExtractor(): NamespaceExtractor
+    {
+        return new NamespaceExtractor(
+            new CompilerFacade(),
+            new TopologicalNamespaceSorter(),
+            new SystemFileIo(),
+        );
     }
 
     private function extractNamespace(string $code): NamespaceInformation


### PR DESCRIPTION
Follow-up to #2851, which fixed this class of failure at the test level. This closes the hole in the scanner itself.

## Problem

`findAllNs()` already catches `ExtractorException` per file, so one malformed `.phel` in a scanned directory cannot abort the whole scan:

```php
} catch (ExtractorException) {
    // Skip files that cannot be parsed/lexed so one malformed
    // .phel file in a scanned directory does not abort the whole scan
    continue;
}
```

A file that disappears **between being listed and being read** escaped that net. `SystemFileIo::getContents()` throws a plain `RuntimeException`, which the loop does not catch:

```
RuntimeException: Unable to read file ".../macro-error-script.phel"
  src/php/Build/Application/NamespaceExtractor.php:54
```

Not hypothetical — that is exactly the intermittent CI failure #2851 addressed by stopping one test from writing a transient `.phel` into a scanned tree. Any concurrent process doing the same thing reopens it.

## Fix

Wrap the read so an IO failure becomes `ExtractorException::cannotReadFile()`, which the scan already knows how to skip.

**This does not widen what gets swallowed.** A caller asking for one specific file still gets a thrown exception — only the directory scan skips, which is its documented intent. And `ExtractorException extends RuntimeException`, so anything catching the broader type is unaffected.

`cannotReadFile()` gains an optional `$previous`, mirroring `cannotParseFile()`, so the underlying IO message survives into the message.

## Verification

Both new tests confirmed **red against the old code** first:

- `test_unreadable_file_raises_an_extractor_exception` — failed with *"exception of type RuntimeException matches expected ExtractorException"*
- `test_directory_scan_skips_a_file_that_vanished_mid_scan` — failed because the vanished namespace was still returned

Then green. Full suite:

| | |
|---|---|
| `test-unit` | OK — 4329 tests, 9817 assertions |
| integration (paratest) | 1108 tests, no failures |
| `test-core` | 6554 passed |
| phpstan / psalm / cs-fixer / rector | clean |

One wrinkle worth noting for anyone writing similar tests: the scan `realpath`s its directory, and on macOS `sys_get_temp_dir()` resolves `/var` → `/private/var`, so the path handed to the IO layer is not the string the test wrote. The fake IO matches on basename for that reason.