### PR TITLE
fix(lint): report a crashed rule instead of silently dropping its findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 - `phel/unused-import` and `phel/unused-require` now resolve the implicit alias of a dot-separated entry, so `(:require phel.json)` is no longer always "unused"
 - `phel/discouraged-var` keys off real `:deprecated` metadata instead of guessing from the docstring
 - An unreadable `phel-lint.phel`, source file or directory now fails loudly instead of silently linting with defaults or reporting the file as clean
+- A `phel lint` rule that crashes is now reported as a `phel/internal-error` diagnostic naming the rule, and the run exits 1. It used to be skipped in silence, so the report came back clean and exited 0 with that rule's findings missing. The other rules still report on the same file
 - Editor completion no longer offers a `for` head's collection expression as a binding, and now sees `foreach` bindings
 
 - `phel format` exits non-zero when a file cannot be parsed, so a `--dry-run` CI gate no longer passes over broken sources, and surfaces I/O failures instead of printing a trace and skipping

--- a/src/php/Lint/Application/Config/RuleRegistry.php
+++ b/src/php/Lint/Application/Config/RuleRegistry.php
@@ -35,6 +35,15 @@ final class RuleRegistry
     public const string COMMENT_STYLE = 'phel/comment-style';
 
     /**
+     * Not a rule: the code `RulePipeline` reports under when a rule itself
+     * throws. Deliberately absent from {@see self::allCodes()}: it has no
+     * configurable severity (a crash is always an error), nothing to
+     * contribute to the cache fingerprint, and keeping it out means it can
+     * never be switched off from `phel-lint.phel`.
+     */
+    public const string INTERNAL_ERROR = 'phel/internal-error';
+
+    /**
      * @return list<string>
      */
     public static function allCodes(): array

--- a/src/php/Lint/Application/LintRunner.php
+++ b/src/php/Lint/Application/LintRunner.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace Phel\Lint\Application;
 
 use Phel\Lint\Application\Cache\LintCache;
+use Phel\Lint\Application\Config\RuleRegistry;
 use Phel\Lint\Application\Config\RuleSettings;
 use Phel\Lint\Domain\Exception\LintSourceException;
 use Phel\Lint\Domain\FileAnalysis;
 use Phel\Lint\Transfer\LintResult;
+use Phel\Shared\Api\Diagnostic;
 use Phel\Shared\Api\ProjectIndex;
 use Phel\Shared\Facade\ApiFacadeInterface;
 
+use function array_any;
 use function file_get_contents;
 use function is_dir;
 
@@ -79,7 +82,14 @@ final readonly class LintRunner
             );
 
             $fileDiagnostics = $this->pipeline->run($analysis, $settings);
-            $this->cache?->put($file, $fileDiagnostics);
+
+            // A rule crash is a fact about the linter, not about the file, and
+            // fixing it changes neither the file hash nor the rule fingerprint.
+            // Caching it would replay a stale internal error until the source
+            // happens to change, so this file is simply re-linted next run.
+            if (!$this->hasInternalError($fileDiagnostics)) {
+                $this->cache?->put($file, $fileDiagnostics);
+            }
 
             foreach ($fileDiagnostics as $diagnostic) {
                 $allDiagnostics[] = $diagnostic;
@@ -89,6 +99,17 @@ final readonly class LintRunner
         $this->cache?->flush();
 
         return new LintResult($allDiagnostics);
+    }
+
+    /**
+     * @param list<Diagnostic> $diagnostics
+     */
+    private function hasInternalError(array $diagnostics): bool
+    {
+        return array_any(
+            $diagnostics,
+            static fn(Diagnostic $diagnostic): bool => $diagnostic->code === RuleRegistry::INTERNAL_ERROR,
+        );
     }
 
     /**

--- a/src/php/Lint/Application/RulePipeline.php
+++ b/src/php/Lint/Application/RulePipeline.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Phel\Lint\Application;
 
+use Phel\Lint\Application\Config\RuleRegistry;
 use Phel\Lint\Application\Config\RuleSettings;
+use Phel\Lint\Domain\Exception\LintRuleException;
 use Phel\Lint\Domain\FileAnalysis;
 use Phel\Lint\Domain\LintRuleInterface;
 use Phel\Shared\Api\Diagnostic;
@@ -15,8 +17,11 @@ use Throwable;
  * Runs every registered rule against a `FileAnalysis` and rewrites the
  * severity on each produced diagnostic based on the configured
  * `RuleSettings`. Rules set to `off` or excluded by glob are skipped
- * entirely; rules that throw are isolated so one bad rule cannot kill
- * the whole run.
+ * entirely.
+ *
+ * A rule that throws is isolated but never silenced: the pipeline records a
+ * `phel/internal-error` diagnostic naming it and carries on with the rest, so
+ * one bad rule neither kills the run nor lets it report the file as clean.
  */
 final readonly class RulePipeline
 {
@@ -45,8 +50,11 @@ final readonly class RulePipeline
 
             try {
                 $diagnostics = $rule->apply($analysis);
-            } catch (Throwable) {
-                // Isolate a failing rule so the rest of the pipeline keeps running.
+            } catch (Throwable $throwable) {
+                // Isolate the failing rule, but report it: the rest of the
+                // pipeline keeps running and the run cannot come back clean.
+                $result[] = $this->internalError($code, $analysis->uri, $throwable);
+
                 continue;
             }
 
@@ -66,5 +74,31 @@ final readonly class RulePipeline
         }
 
         return $result;
+    }
+
+    /**
+     * Severity is fixed at `error` instead of read from `RuleSettings`: the
+     * configured severity grades a finding about the linted code, and a crash
+     * is a finding about the linter. Honouring a `:warning` here would leave
+     * `phel lint` exiting 0 with the rule's real findings missing, which is
+     * the silent pass this diagnostic exists to prevent. The escape hatch is
+     * the explicit one, setting the rule to `:off`.
+     *
+     * The crash has no source location, so it is anchored at the start of the
+     * file it happened on; the message carries the rule code and chains the
+     * original throwable.
+     */
+    private function internalError(string $ruleCode, string $uri, Throwable $throwable): Diagnostic
+    {
+        return new Diagnostic(
+            code: RuleRegistry::INTERNAL_ERROR,
+            severity: Diagnostic::SEVERITY_ERROR,
+            message: LintRuleException::ruleCrashed($ruleCode, $throwable)->getMessage(),
+            uri: $uri,
+            startLine: 1,
+            startCol: 1,
+            endLine: 1,
+            endCol: 1,
+        );
     }
 }

--- a/src/php/Lint/CLAUDE.md
+++ b/src/php/Lint/CLAUDE.md
@@ -27,7 +27,7 @@ All four getters return the Shared contract, never a concrete facade, and `Satel
 
 `./bin/phel lint [paths]... [--format=human|json|github] [--config=path] [--no-cache]`
 
-Exit codes: `0` clean/warnings only, `1` errors, `2` invocation error.
+Exit codes: `0` clean/warnings only, `1` errors (including `phel/internal-error`), `2` invocation error.
 
 ## Rule Set (v1)
 
@@ -37,6 +37,29 @@ Exit codes: `0` clean/warnings only, `1` errors, `2` invocation error.
 Every shipped rule is on by default (it has an entry in `LintConfig::defaultSeverities()`); a rule with no entry there is off until a config opts it in.
 
 Add a rule: implement `LintRuleInterface` in `Application/Rule/`, add a code constant to `RuleRegistry`, register it in `LintFactory::createRules()`, and give it a default severity in `LintConfig::defaultSeverities()`. Do not edit existing rules.
+
+### `phel/internal-error` (not a rule)
+
+The code `RulePipeline` reports under when a rule's `apply()` throws. It is the
+one diagnostic the linter emits about itself, so it plays by different rules
+from the twelve above:
+
+- **Always `error` severity**, never `RuleSettings::severityFor()`. A configured
+  severity grades a finding about the linted code; a crash is a finding about
+  the linter. Honouring a `:warning` there would exit 0 with the rule's real
+  findings missing, which is exactly the silent pass it exists to prevent.
+- **Not in `RuleRegistry::allCodes()` and not in `defaultSeverities()`**, so it
+  has nothing to configure, contributes nothing to the cache fingerprint, and
+  cannot be switched off from `phel-lint.phel`.
+- **Anchored at line 1, col 1** of the file being analysed: a crash has no
+  source location. `Domain\Exception\LintRuleException::ruleCrashed()` owns the
+  wording, names the rule code, and chains the original throwable.
+- **Never cached** (`LintRunner`): fixing a rule changes neither the file hash
+  nor the rule fingerprint, so a cached internal error would outlive the bug.
+
+The rest of the pipeline still runs, so the other rules' findings for that file
+are reported alongside it. The escape hatch is the explicit one: set the
+crashing rule to `:off`, which skips it before `apply()` is ever reached.
 
 ### Shared rule helpers (`Application/Rule/`)
 
@@ -102,6 +125,8 @@ deprecating something does not flag its declaration.
 - Read-only: never rewrites source; Formatter module owns whitespace/indent
 - Semantic diagnostics (`unresolved-symbol`, `arity-mismatch`) come from `ApiFacadeInterface::analyzeSource` and are shared via `FileAnalysis::$semanticDiagnostics`, so the analyzer runs once per file
 - Open/closed: `LintFactory::createRules()` and `FormatterRegistry` are the ONLY edit points for new rules/formatters
-- `RulePipeline` isolates failing rules — one bad rule does not kill the run
+- `RulePipeline` isolates a failing rule without silencing it: the run continues, but a `phel/internal-error` diagnostic makes it exit 1 rather than report the file as clean (see above)
 - `DuplicateKeyRule` scans the parse tree, not read forms, because the reader silently deduplicates map literals
-- Cache (default on, `.phel/lint-cache/index.json`): keyed by MD5(file hash) + rule fingerprint (all rule codes + severities + exclude patterns); adding/removing rules or editing `phel-lint.phel` invalidates it
+- Cache (default on, `.phel/lint-cache/index.json`): keyed by MD5(file hash) + rule fingerprint (all rule codes + severities + exclude patterns); adding/removing rules or editing `phel-lint.phel` invalidates it. A file whose run produced a `phel/internal-error` is not cached at all
+- The rule-level `catch (Throwable)` in `CommentStyleRule` and `DuplicateKeyRule` exists for a source that does not lex or parse, not as a licence to swallow rule bugs. Because it catches `Throwable` around the whole `apply()` body, a genuine bug in either rule still bypasses `RulePipeline`'s guard; narrowing both to the documented lexer/parser exceptions is open work
+- Known gap: a `.phel` file that does not parse still lints clean and exits 0. `readFormsBestEffort` is best-effort by contract and nothing in Lint drives lex/parse to report the failure, so this is not the `RulePipeline` swallow and needs its own diagnostic code

--- a/src/php/Lint/Domain/Exception/LintRuleException.php
+++ b/src/php/Lint/Domain/Exception/LintRuleException.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Domain\Exception;
+
+use RuntimeException;
+use Throwable;
+
+use function sprintf;
+
+/**
+ * Built (never thrown) by `RulePipeline` when a lint rule throws while
+ * analysing a file: it chains the original throwable and owns the wording of
+ * the `phel/internal-error` diagnostic the pipeline reports instead.
+ *
+ * Skipping the rule silently would drop its findings for that file while the
+ * run still printed "No lint issues found." and exited 0, and a clean report
+ * is read as a guarantee the linter looked.
+ */
+final class LintRuleException extends RuntimeException
+{
+    public static function ruleCrashed(string $ruleCode, Throwable $previous): self
+    {
+        return new self(
+            sprintf(
+                "Lint rule '%s' crashed and reported nothing for this file: %s: %s at %s:%d."
+                . ' This is a linter bug, not a problem in the linted file;'
+                . ' set the rule to :off in phel-lint.phel to skip it.',
+                $ruleCode,
+                $previous::class,
+                $previous->getMessage(),
+                $previous->getFile(),
+                $previous->getLine(),
+            ),
+            0,
+            $previous,
+        );
+    }
+}

--- a/tests/php/Integration/Lint/LintRuleCrashTest.php
+++ b/tests/php/Integration/Lint/LintRuleCrashTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Lint;
+
+use Phel;
+use Phel\Api\ApiFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Lint\Application\Cache\LintCache;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Application\Config\RuleSettings;
+use Phel\Lint\Application\FileCollector;
+use Phel\Lint\Application\LintRunner;
+use Phel\Lint\Application\Rule\CommentStyleRule;
+use Phel\Lint\Application\RulePipeline;
+use Phel\Lint\Application\SourceReader;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Domain\LintRuleInterface;
+use Phel\Lint\Transfer\LintResult;
+use Phel\Shared\Api\Diagnostic;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function array_map;
+use function array_unshift;
+use function md5;
+use function realpath;
+use function sys_get_temp_dir;
+use function uniqid;
+
+/**
+ * A rule that throws used to be skipped in silence, so `phel lint` printed
+ * "No lint issues found." and exited 0 with that rule's findings missing.
+ * These cases pin the replacement contract end to end, over the real reader
+ * and analyzer, with a crashing test double standing in for a buggy rule.
+ */
+final class LintRuleCrashTest extends TestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_a_crashing_rule_surfaces_and_fails_the_run(): void
+    {
+        $result = new LintResult($this->lintFixture()->diagnostics);
+
+        $codes = array_map(static fn(Diagnostic $d): string => $d->code, $result->diagnostics);
+        self::assertContains(RuleRegistry::INTERNAL_ERROR, $codes);
+
+        self::assertTrue(
+            $result->hasErrors(),
+            'LintCommand maps hasErrors() onto exit code 1, so a crash must not exit 0',
+        );
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_the_internal_error_names_the_rule_and_chains_the_throwable(): void
+    {
+        $result = $this->lintFixture();
+
+        $message = '';
+        foreach ($result->diagnostics as $diagnostic) {
+            if ($diagnostic->code === RuleRegistry::INTERNAL_ERROR) {
+                $message = $diagnostic->message;
+            }
+        }
+
+        self::assertStringContainsString("Lint rule 'phel/duplicate-def' crashed", $message);
+        self::assertStringContainsString('RuntimeException: rule is broken', $message);
+    }
+
+    /**
+     * The sibling rule runs on the same file in the same pass: its findings
+     * must survive the crash, which is why the pipeline reports rather than
+     * aborting the whole run.
+     */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_sibling_rules_still_report_on_the_same_file(): void
+    {
+        $codes = array_map(
+            static fn(Diagnostic $d): string => $d->code,
+            $this->lintFixture()->diagnostics,
+        );
+
+        self::assertContains(RuleRegistry::COMMENT_STYLE, $codes);
+    }
+
+    /**
+     * Fixing a rule changes neither the file hash nor the rule fingerprint, so
+     * a cached internal error would be replayed long after the bug was gone.
+     */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_an_internal_error_is_never_written_to_the_cache(): void
+    {
+        $clean = $this->cache();
+        $this->lintFixture($clean, withCrashingRule: false);
+        self::assertNotNull($clean->get($this->fixture()), 'Control: an ordinary run does cache the file');
+
+        $crashed = $this->cache();
+        $this->lintFixture($crashed);
+
+        self::assertNull(
+            $crashed->get($this->fixture()),
+            'A file whose lint run crashed must be re-linted next time, not served from cache',
+        );
+    }
+
+    private function cache(): LintCache
+    {
+        return new LintCache(
+            sys_get_temp_dir() . '/phel-lint-crash-' . uniqid('', true),
+            md5('fingerprint'),
+        );
+    }
+
+    private function lintFixture(?LintCache $cache = null, bool $withCrashingRule = true): LintResult
+    {
+        Phel::bootstrap(__DIR__);
+        Phel::clear();
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+
+        $compilerFacade = new CompilerFacade();
+
+        $rules = [new CommentStyleRule($compilerFacade)];
+        if ($withCrashingRule) {
+            array_unshift($rules, $this->crashingRule());
+        }
+
+        $runner = new LintRunner(
+            new ApiFacade(),
+            new FileCollector(),
+            new SourceReader($compilerFacade),
+            new RulePipeline($rules),
+            $cache,
+        );
+
+        return $runner->run([$this->fixture()], new RuleSettings([
+            RuleRegistry::DUPLICATE_DEF => Diagnostic::SEVERITY_ERROR,
+            RuleRegistry::COMMENT_STYLE => Diagnostic::SEVERITY_WARNING,
+        ]));
+    }
+
+    private function fixture(): string
+    {
+        $path = realpath(__DIR__ . '/Fixtures/comment_style.phel');
+        self::assertIsString($path);
+
+        return $path;
+    }
+
+    /**
+     * Stands in for a rule with a bug in it. Borrowing a real rule code keeps
+     * the settings lookup realistic without touching a shipped rule.
+     */
+    private function crashingRule(): LintRuleInterface
+    {
+        return new class() implements LintRuleInterface {
+            public function code(): string
+            {
+                return RuleRegistry::DUPLICATE_DEF;
+            }
+
+            public function apply(FileAnalysis $analysis): array
+            {
+                throw new RuntimeException('rule is broken');
+            }
+        };
+    }
+}

--- a/tests/php/Unit/Lint/Application/RulePipelineTest.php
+++ b/tests/php/Unit/Lint/Application/RulePipelineTest.php
@@ -4,14 +4,20 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Lint\Application;
 
+use Phel\Lint\Application\Config\RuleRegistry;
 use Phel\Lint\Application\Config\RuleSettings;
 use Phel\Lint\Application\RulePipeline;
 use Phel\Lint\Domain\FileAnalysis;
 use Phel\Lint\Domain\LintRuleInterface;
+use Phel\Lint\Transfer\LintResult;
 use Phel\Shared\Api\Diagnostic;
 use Phel\Shared\Api\ProjectIndex;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+
+use function array_filter;
+use function array_map;
+use function array_values;
 
 final class RulePipelineTest extends TestCase
 {
@@ -48,35 +54,62 @@ final class RulePipelineTest extends TestCase
         self::assertSame(Diagnostic::SEVERITY_ERROR, $result[0]->severity);
     }
 
-    public function test_it_isolates_failing_rule(): void
+    public function test_it_reports_a_crashing_rule_as_an_internal_error(): void
     {
-        $bad = new class() implements LintRuleInterface {
-            public function code(): string
-            {
-                return 'phel/bad';
-            }
+        $result = $this->runWithCrashingRule(Diagnostic::SEVERITY_WARNING);
 
-            public function apply(FileAnalysis $analysis): array
-            {
-                throw new RuntimeException('boom');
-            }
-        };
-        $good = $this->ruleReturning('phel/good', [
-            $this->placeholder('phel/good', 'msg'),
-        ]);
+        $internal = $this->onlyInternalError($result);
 
-        $pipeline = new RulePipeline([$bad, $good]);
-        $settings = new RuleSettings(
-            severities: [
-                'phel/bad' => Diagnostic::SEVERITY_WARNING,
-                'phel/good' => Diagnostic::SEVERITY_WARNING,
-            ],
-        );
+        self::assertSame(RuleRegistry::INTERNAL_ERROR, $internal->code);
+        self::assertStringContainsString("Lint rule 'phel/bad' crashed", $internal->message);
+        self::assertStringContainsString('RuntimeException: boom', $internal->message);
+    }
 
-        $result = $pipeline->run($this->analysis(), $settings);
+    /**
+     * A crash is a fact about the linter, so the rule's configured severity
+     * must not grade it. Honouring `:warning` here would leave `phel lint`
+     * exiting 0 with the rule's real findings missing.
+     */
+    public function test_a_crash_is_an_error_whatever_severity_the_rule_is_configured_with(): void
+    {
+        foreach ([Diagnostic::SEVERITY_WARNING, Diagnostic::SEVERITY_INFO, Diagnostic::SEVERITY_HINT] as $configured) {
+            $internal = $this->onlyInternalError($this->runWithCrashingRule($configured));
 
-        self::assertCount(1, $result);
-        self::assertSame('phel/good', $result[0]->code);
+            self::assertSame(
+                Diagnostic::SEVERITY_ERROR,
+                $internal->severity,
+                'Configured severity: ' . $configured,
+            );
+        }
+    }
+
+    public function test_a_crashing_rule_does_not_suppress_its_siblings(): void
+    {
+        $result = $this->runWithCrashingRule(Diagnostic::SEVERITY_WARNING);
+
+        $codes = array_map(static fn(Diagnostic $d): string => $d->code, $result);
+
+        self::assertContains('phel/good', $codes);
+        self::assertContains(RuleRegistry::INTERNAL_ERROR, $codes);
+    }
+
+    /**
+     * `LintCommand` maps `hasErrors()` straight onto exit code 1, so this is
+     * the assertion that the run can no longer come back clean.
+     */
+    public function test_a_crash_makes_the_result_fail(): void
+    {
+        $result = new LintResult($this->runWithCrashingRule(Diagnostic::SEVERITY_WARNING));
+
+        self::assertTrue($result->hasErrors());
+    }
+
+    public function test_a_rule_switched_off_never_runs_so_it_cannot_crash(): void
+    {
+        $pipeline = new RulePipeline([$this->crashingRule()]);
+        $settings = new RuleSettings(severities: ['phel/bad' => RuleSettings::SEVERITY_OFF]);
+
+        self::assertSame([], $pipeline->run($this->analysis(), $settings));
     }
 
     public function test_it_respects_per_rule_excludes(): void
@@ -100,6 +133,54 @@ final class RulePipelineTest extends TestCase
         );
 
         self::assertSame([], $pipeline->run($analysis, $settings));
+    }
+
+    /**
+     * @return list<Diagnostic>
+     */
+    private function runWithCrashingRule(string $configuredSeverity): array
+    {
+        $pipeline = new RulePipeline([
+            $this->crashingRule(),
+            $this->ruleReturning('phel/good', [$this->placeholder('phel/good', 'msg')]),
+        ]);
+
+        return $pipeline->run($this->analysis(), new RuleSettings(
+            severities: [
+                'phel/bad' => $configuredSeverity,
+                'phel/good' => Diagnostic::SEVERITY_WARNING,
+            ],
+        ));
+    }
+
+    /**
+     * @param list<Diagnostic> $result
+     */
+    private function onlyInternalError(array $result): Diagnostic
+    {
+        $internal = array_values(array_filter(
+            $result,
+            static fn(Diagnostic $d): bool => $d->code === RuleRegistry::INTERNAL_ERROR,
+        ));
+
+        self::assertCount(1, $internal);
+
+        return $internal[0];
+    }
+
+    private function crashingRule(): LintRuleInterface
+    {
+        return new class() implements LintRuleInterface {
+            public function code(): string
+            {
+                return 'phel/bad';
+            }
+
+            public function apply(FileAnalysis $analysis): array
+            {
+                throw new RuntimeException('boom');
+            }
+        };
     }
 
     private function analysis(): FileAnalysis


### PR DESCRIPTION
## 🤔 Background

`RulePipeline` caught `Throwable` around each rule and `continue`d. A rule that crashed was skipped in silence, so `phel lint` printed `No lint issues found.` and exited 0 while that rule contributed nothing for the file.

That is the same failure mode already closed elsewhere in Lint this session: an unreadable config, an unreadable source file and an unreadable directory all used to pass quietly and now fail loudly. A clean report is read as a guarantee the linter looked, so a silently absent rule is worse than a failure.

## 💡 Goal

Make a crashed rule impossible to miss, without letting one broken rule abort an otherwise-lintable run.

## 🔖 Changes

- `RulePipeline` records a `phel/internal-error` diagnostic naming the rule and chaining the original throwable, then carries on with the remaining rules.
- **Severity is fixed at `error`, not read from `RuleSettings`.** The configured severity grades a finding about the linted *code*; a crash is a finding about the *linter*. Honouring a `:warning` would leave `phel lint` exiting 0 with that rule's real findings missing, which is exactly the silent pass this exists to prevent. The escape hatch stays explicit: set the rule to `:off`.
- `RuleRegistry::INTERNAL_ERROR` is deliberately **absent** from `allCodes()`. It has no configurable severity, nothing to contribute to the cache fingerprint, and keeping it out means it cannot be switched off from `phel-lint.phel`.
- A file whose diagnostics contain an internal error is **not cached**. A crash changes neither the file hash nor the rule fingerprint, so caching it would replay a stale error until the source happened to change.
- `src/php/Lint/CLAUDE.md` documents the contract.

## ✅ Verification

Reproduced first with a throwing rule: `phel lint` reported clean and exited 0. After the change it reports the internal error and exits non-zero, while sibling rules still report their findings.

PHPStan L9 clean, Psalm clean, cs-fixer 0/1695, 5462 unit+integration, 6554 core. The stdlib baseline is unchanged at **74 warnings, 0 errors, exit 0**, which is the check that no existing rule is quietly crashing today.

## 📋 Note for the reviewer

`LintRuleException` is built but never thrown. It exists to own the message wording and to chain `$previous` in one place, and its docblock says so. If you would rather that lived on the pipeline as a private formatter, it is a small change.
