### PR TITLE
fix(compiler): a namespace-qualified symbol no longer resolves to a local

### DIFF
--- a/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
@@ -77,6 +77,15 @@ final class NodeEnvironment implements NodeEnvironmentInterface
 
     public function hasLocal(Symbol $x): bool
     {
+        // A namespace-qualified symbol never names a local: locals are
+        // introduced by binding forms, which take bare names. Consulting the
+        // locals index by short name alone would let `(let [inc ...])` capture
+        // `phel.core/inc`, defeating the fully-qualified reference that macro
+        // expansions rely on.
+        if ($x->getNamespace() !== null) {
+            return false;
+        }
+
         return isset($this->localsByName[$x->getName()]);
     }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/BindingValidator.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/BindingValidator.php
@@ -23,6 +23,8 @@ final class BindingValidator implements BindingValidatorInterface
     public function assertSupportedBinding(mixed $form): void
     {
         if ($this->isSupportedBinding($form)) {
+            $this->assertUnqualifiedName($form);
+
             return;
         }
 
@@ -33,6 +35,30 @@ final class BindingValidator implements BindingValidatorInterface
         }
 
         throw new AnalyzerException('Cannot destructure ' . $type);
+    }
+
+    /**
+     * A binding form introduces a local, and locals are always bare names: a
+     * reference carrying a namespace resolves to the global definition, so a
+     * qualified binding name would bind a value nothing can read back. It
+     * mostly reaches the analyzer through a quasiquote, which qualifies any
+     * symbol that resolves globally, so `` `(let [count 0] count) `` arrives
+     * as `(let [phel.core/count 0] phel.core/count)`. Reject it here instead
+     * of letting the body pick up the core function.
+     *
+     * @throws AnalyzerException
+     */
+    private function assertUnqualifiedName(mixed $form): void
+    {
+        if (!$form instanceof Symbol || $form->getNamespace() === null) {
+            return;
+        }
+
+        throw AnalyzerException::withLocation(
+            "Can't bind qualified name: " . $form->getFullName()
+            . '. Use a bare name, or `' . $form->getName() . '#` for an auto-gensym inside a quasiquote.',
+            $form,
+        );
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReadModel/FnSymbolTuple.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReadModel/FnSymbolTuple.php
@@ -108,6 +108,16 @@ final class FnSymbolTuple
     private function checkAllVariablesStartWithALetterOrUnderscore(): void
     {
         foreach ($this->params as $param) {
+            // A qualified param would bind a local that no reference can read
+            // back: a namespaced symbol resolves to the global definition.
+            if ($param->getNamespace() !== null) {
+                throw AnalyzerException::withLocation(
+                    "Can't bind qualified name: " . $param->getFullName()
+                    . '. Use a bare name, or `' . $param->getName() . '#` for an auto-gensym inside a quasiquote.',
+                    $this->parentList,
+                );
+            }
+
             $matchesPattern = preg_match("/^(?:&[a-zA-Z_]|[a-zA-Z_\x80-\xff]).*$/", $param->getName());
 
             if ($matchesPattern === 0 || $matchesPattern === false) {

--- a/tests/phel/core/qualified-symbol-shadowing.phel
+++ b/tests/phel/core/qualified-symbol-shadowing.phel
@@ -1,0 +1,70 @@
+(ns phel-test.core.qualified-symbol-shadowing
+  (:require phel.string :as s)
+  (:require phel.test :refer [deftest is]))
+
+;; A namespace-qualified symbol names a global definition, so no local
+;; binding can shadow it. Only bare names participate in lexical scoping.
+;; This is what lets a macro defend itself by fully qualifying the globals
+;; it expands to, which is the guidance in `.claude/rules/macro-hygiene.md`.
+
+(def ^:private base 1)
+
+(defn own-fn [x] (+ x 100))
+
+(defn- defn-param-shadow [inc] (phel.core/inc 1))
+
+;; --- a local never captures a qualified reference ---
+
+(deftest test-let-does-not-shadow-qualified-core-fn
+  (is (= 2 (let [inc (fn [_] :hijacked)] (phel.core/inc 1)))))
+
+(deftest test-loop-does-not-shadow-qualified-core-fn
+  (is (= 2 (loop [inc (fn [_] :hijacked)] (phel.core/inc 1)))))
+
+(deftest test-fn-param-does-not-shadow-qualified-core-fn
+  (is (= 2 ((fn [inc] (phel.core/inc 1)) (fn [_] :hijacked)))))
+
+(deftest test-defn-param-does-not-shadow-qualified-core-fn
+  (is (= 2 (defn-param-shadow (fn [_] :hijacked)))))
+
+(deftest test-deprecated-backslash-separator-also-resolves-globally
+  (is (= 2 (let [inc (fn [_] :hijacked)] (phel\core/inc 1)))))
+
+(deftest test-require-alias-does-not-shadow
+  (is (= "AB" (let [upper-case (fn [_] :hijacked)] (s/upper-case "ab")))))
+
+(deftest test-own-namespace-qualified-name-does-not-shadow
+  (is (= 101 (let [own-fn (fn [_] :hijacked)] (phel-test.core.qualified-symbol-shadowing/own-fn 1)))))
+
+(deftest test-qualified-def-is-not-shadowed-by-a-local
+  (is (= 1 (let [base :hijacked] phel-test.core.qualified-symbol-shadowing/base))))
+
+;; --- bare names still shadow, exactly as every Lisp does ---
+
+(deftest test-unqualified-local-still-shadows-a-core-fn
+  (is (= :hijacked (let [inc (fn [_] :hijacked)] (inc 1)))))
+
+(deftest test-unqualified-local-still-shadows-a-definition-of-the-same-ns
+  (is (= :hijacked (let [own-fn (fn [_] :hijacked)] (own-fn 1)))))
+
+;; --- the real-world case: a macro whose expansion the caller has shadowed ---
+;; Quasiquote qualifies every symbol that resolves to a global, so this macro
+;; expands to `(phel.core/inc (phel.core/inc x))`. A caller that happens to
+;; bind `inc` locally must not change what the macro computes.
+
+(defmacro inc-twice [x]
+  `(inc (inc ~x)))
+
+(deftest test-macro-expansion-survives-a-shadowed-caller-scope
+  (is (= 7 (inc-twice 5)))
+  (let [inc (fn [_] :hijacked)]
+    (is (= 7 (inc-twice 5)))
+    (is (= :hijacked (inc 5)))))
+
+(defmacro sum-of [& xs]
+  `(apply + [~@xs]))
+
+(deftest test-macro-with-multiple-qualified-globals-survives-shadowing
+  (let [apply (fn [& _] :hijacked)
+        +     (fn [& _] :hijacked)]
+    (is (= 6 (sum-of 1 2 3)))))

--- a/tests/php/Integration/Fixtures/Let/let-does-not-shadow-qualified-symbol.test
+++ b/tests/php/Integration/Fixtures/Let/let-does-not-shadow-qualified-symbol.test
@@ -1,0 +1,6 @@
+--PHEL--
+(let [inc 1] (phel.core/inc inc))
+--PHP--
+/** @var int $inc_1 */
+$inc_1 = 1;
+($inc_1 + 1);

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
@@ -99,6 +99,36 @@ final class AnalyzeSymbolTest extends TestCase
         );
     }
 
+    public function test_qualified_symbol_is_not_shadowed_by_a_local_of_the_same_short_name(): void
+    {
+        $globalEnv = new GlobalEnvironment();
+        $globalEnv->setNs('test');
+        $globalEnv->addDefinition('other', Symbol::create('a'));
+
+        $symbolAnalyzer = new AnalyzeSymbol(new Analyzer($globalEnv));
+
+        $env = NodeEnvironment::empty()->withLocals([Symbol::create('a')]);
+        self::assertEquals(
+            new GlobalVarNode($env, 'other', Symbol::create('a'), Phel::map()),
+            $symbolAnalyzer->analyze(Symbol::createForNamespace('other', 'a'), $env),
+        );
+    }
+
+    public function test_qualified_symbol_of_the_current_ns_is_not_shadowed_by_a_local(): void
+    {
+        $globalEnv = new GlobalEnvironment();
+        $globalEnv->setNs('test');
+        $globalEnv->addDefinition('test', Symbol::create('a'));
+
+        $symbolAnalyzer = new AnalyzeSymbol(new Analyzer($globalEnv));
+
+        $env = NodeEnvironment::empty()->withLocals([Symbol::create('a')]);
+        self::assertEquals(
+            new GlobalVarNode($env, 'test', Symbol::create('a'), Phel::map()),
+            $symbolAnalyzer->analyze(Symbol::createForNamespace('test', 'a'), $env),
+        );
+    }
+
     public function test_undefined_symbol_with_did_you_mean_suggestion(): void
     {
         $globalEnv = new GlobalEnvironment();

--- a/tests/php/Unit/Compiler/Analyzer/Environment/NodeEnvironmentTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/NodeEnvironmentTest.php
@@ -28,6 +28,14 @@ final class NodeEnvironmentTest extends TestCase
         self::assertFalse($env->hasLocal(Symbol::create('c')));
     }
 
+    public function test_qualified_symbol_never_matches_a_local(): void
+    {
+        $env = NodeEnvironment::empty()->withLocals([Symbol::create('inc')]);
+
+        self::assertTrue($env->hasLocal(Symbol::create('inc')));
+        self::assertFalse($env->hasLocal(Symbol::createForNamespace('phel\core', 'inc')));
+    }
+
     public function test_with_locals_is_immutable(): void
     {
         $base = NodeEnvironment::empty()->withLocals([Symbol::create('a')]);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/BindingValidatorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/BindingValidatorTest.php
@@ -50,6 +50,13 @@ final class BindingValidatorTest extends TestCase
         $this->validator->assertSupportedBinding(Keyword::create('any'));
     }
 
+    public function test_qualified_symbol_binding_is_rejected(): void
+    {
+        $this->expectExceptionMessage("Can't bind qualified name: phel.core/count");
+
+        $this->validator->assertSupportedBinding(Symbol::createForNamespace('phel.core', 'count'));
+    }
+
     /**
      * @param AbstractType $type
      */


### PR DESCRIPTION
## 🤔 Background

A local shadowed a namespace-qualified reference:

```phel
(let [inc (fn [_] :hijacked)] (phel.core/inc 1))  ; => :hijacked, expected 2
```

Locals are introduced by binding forms, which take bare names, but resolution consulted the locals index by short name alone, so any local could capture a fully-qualified symbol.

This matters beyond the one-liner. `.claude/rules/macro-hygiene.md` leans on fully qualifying the globals a macro references, and that defence did not hold: every macro in the tree was exposed to whatever a caller happened to name locally. Clojure does not behave this way, a qualified symbol always resolves to the var.

## 💡 Goal

Make a qualified symbol always resolve to the global, while leaving unqualified shadowing exactly as it is, since that is how every Lisp works and is not the bug.

## 🔖 Changes

- `NodeEnvironment`: a symbol carrying a namespace is never matched against locals.
- `BindingValidator` and `FnSymbolTuple`: **a qualified binding name is now rejected.** This is the sibling defect. Quasiquote qualifies any symbol that resolves globally, so `` `(let [count 0] count) `` reaches the analyzer as `(let [phel.core/count 0] phel.core/count)`. Previously that bound the core name locally and the body read it back; with the resolution fix it would instead bind a value nothing can read. Erroring is the honest outcome, and the message points at `count#`.
- New integration fixture and a Phel-level test pinning both directions.

## ⚠️ Behaviour change worth reviewing

The qualified-binding-name rejection turns previously-accepted code into an analyzer error. Any macro writing `` `(let [foo 0] ...) `` with an unqualified `foo` that resolves globally was silently binding the qualified name and is now told to use `foo#`. That is the fix macro-hygiene already asks for, and `composer test-core` passes unchanged, so nothing in the stdlib relied on it. External macros doing this will need the auto-gensym.

## ✅ Verification

Reproduced first, then confirmed across the variants (`let`, `loop`, `fn` params, `binding`, `defn` params, aliased namespaces).

- `composer test-core`: 6568 passed, 0 failed (up 14 from the new Phel test), so **no stdlib macro depended on the old behaviour**
- `phpunit unit,integration`: 5459 tests, 0 failures
- PHPStan L9, Psalm, cs-fixer 0/1693, Rector all clean
- `phel lint src/phel` unchanged at 74 warnings, 0 errors

**Benchmark: no signal available.** `composer phpbench` fails with 15 erroring subjects on this machine, and it fails identically on unmodified `main` (same first failure, `TypedSignatureBench::bench_fib_untyped`), so it is a pre-existing environment problem rather than anything this introduces. The change adds one null check on a field the resolver already loads, so no measurable cost is expected, but I could not produce a number to prove it and would rather say so than imply one.

One compiled-output fixture is added, none changed.
