### PR TITLE
fix(cli): carry the user's ini flags across the opcache re-exec, and stop .gitignore hiding source dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,7 @@ build/out/
 build/workdir/
 tools/.upgrade-logs/
 
-# Test cache directories
-tests/**/cache/
-!tests/php/Unit/Lint/Application/Cache/
+# Generated test output (caches live under .phel/, already ignored above)
 tests/**/out/
 
 !PhelGenerated/.gitkeep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 - `phel ns <unknown>` exits 1 instead of printing a plausible `phel.core`-only listing and exiting 0
 - `phel doc <no-match>` says `No function matches "<search>"` instead of an empty table. Exit stays 0, and `--format=json` still answers `[]`
 - `phel config` ends with a `N configuration error(s) found.` summary and points at `phel doctor`. Exit stays 0, since it is a dump that succeeded
+- `php -d <ini>=<value> bin/phel …` no longer loses the setting. The OPcache re-exec rebuilt the child's argv from its own flags plus `$_SERVER['argv']`, which never contains interpreter flags, so every user `-d`/`-n`/`-c` was dropped and ini-based workarounds looked like they did nothing (`PHEL_NO_OPCACHE_REEXEC=1` was the only way to make them apply). The original flags are now read from the OS and passed through ahead of Phel's, which still win on `opcache.enable_cli`, `opcache.file_cache` and `opcache.file_cache_only`
 - `phel watch` no longer picks the `inotify` backend when `ext-inotify` is loaded but `inotifywait` is missing from PATH
 - A `data-readers.phel` whose reader bootstrap fails now names the file and the cause, instead of leaving every `(register-tag ...)` unregistered
 - Atom validator rejections name the value, bounded so a lazy seq shows as `#object[<type>]` and is never realized

--- a/bin/phel
+++ b/bin/phel
@@ -13,6 +13,8 @@ use Phel\Console\ConsoleFacade;
 use Phel\Shared\PhelProjectDirectory;
 use Phel\Shared\ProjectRootResolver;
 use Phel\Shared\Performance\OpcacheReexec;
+use Phel\Shared\Performance\ProcessCommandLine;
+use Phel\Shared\Performance\UserIniFlags;
 
 /**
  * Replace the current process with one that has an on-disk OPcache file cache,
@@ -53,9 +55,21 @@ function maybeReexecWithOpcacheFileCache(string $appRootDir): void
         return;
     }
 
+    $scriptArgv = array_values(array_map('strval', $argv));
+
+    // PHP hides the interpreter's own flags from $_SERVER['argv'], so ask the OS
+    // for the real command line and carry the user's `-d`/`-n`/`-c` across the
+    // exec. Without this, `php -d display_errors=stderr bin/phel …` runs the
+    // child under the default ini and the setting looks like it does nothing.
+    // Only paid on the invocation that actually re-execs (the child carries the
+    // breadcrumb and never reaches this point).
+    $decision = $decision->withUserIniFlags(
+        UserIniFlags::extract(ProcessCommandLine::current(), $scriptArgv),
+    );
+
     // argv[0] is the bin/phel script path; preserve the rest as user args. cwd
     // is unchanged across the exec, so a relative script path still resolves.
-    $args = array_merge($decision->flags, array_values(array_map('strval', $argv)));
+    $args = array_merge($decision->flags, $scriptArgv);
 
     // Breadcrumb the child inherits so it can never re-exec again, even if it
     // misreads opcache.file_cache back as empty on some build.

--- a/src/php/Shared/CLAUDE.md
+++ b/src/php/Shared/CLAUDE.md
@@ -89,7 +89,9 @@ Stateless strategy-pattern printer (see `Printer/CLAUDE.md`); consumers instanti
 | `Console/DeprecatedOptionWarner` | static `warn()` — one-line renamed-option deprecation notice to stderr (never corrupts machine-readable stdout like `phel config --json`) |
 | `Performance/OpcacheAdvisor` | pure `advise(...)` (caller passes ini flags) → `OpcacheAdvice` (`optimal`, `messages`); flags when OPcache won't persist the compiled-code cache across CLI runs |
 | `Performance/OpcacheWorkerFlags` | pure `forFileCache(loaded, dir)` → `-d opcache.enable_cli=1 -d opcache.file_cache=<dir>` flag pairs (or `[]`); shared by parallel test workers (`RunFactory`) and the CLI re-exec |
-| `Performance/OpcacheReexec` | pure `decide(...)` → `OpcacheReexecDecision` (`shouldReexec`, `flags`); whether `bin/phel` should `pcntl_exec` itself with a persistent file cache. Reuses `OpcacheWorkerFlags`; the actual exec is the thin edge in `bin/phel` |
+| `Performance/OpcacheReexec` | pure `decide(...)` → `OpcacheReexecDecision` (`shouldReexec`, `flags`); whether `bin/phel` should `pcntl_exec` itself with a persistent file cache. Reuses `OpcacheWorkerFlags`; the actual exec is the thin edge in `bin/phel`. `OpcacheReexecDecision::withUserIniFlags()` splices the user's flags **before** Phel's so PHP's last-wins `-d` order keeps `opcache.enable_cli` / `file_cache` / `file_cache_only` authoritative |
+| `Performance/ProcessCommandLine` | `current()` → the OS-reported argv of the running process (`/proc/self/cmdline`, else `ps -ww -o args=`), or `[]` when unknown. Exists because PHP strips interpreter flags from `$_SERVER['argv']` |
+| `Performance/UserIniFlags` | pure `extract(processArgs, scriptArgv)` → the user's `-d`/`-n`/`-c` flags, or `[]` when the two argv views do not reconstruct unambiguously. Lets the CLI re-exec carry ini overrides into the child instead of dropping them |
 
 ## SourceMap (`SourceMap/`)
 

--- a/src/php/Shared/Performance/OpcacheReexecDecision.php
+++ b/src/php/Shared/Performance/OpcacheReexecDecision.php
@@ -18,4 +18,36 @@ final readonly class OpcacheReexecDecision
         public bool $shouldReexec,
         public array $flags,
     ) {}
+
+    /**
+     * Splices the ini flags the user typed on the original command line in
+     * front of the ones Phel needs, so `php -d display_errors=stderr bin/phel …`
+     * still means what it says after the process replaces itself.
+     *
+     * Order is the whole point: PHP applies `-d` left to right and the last
+     * occurrence wins, so putting Phel's flags last makes them authoritative on
+     * the three directives it must control, while every other user override
+     * survives untouched. Phel forces exactly:
+     *
+     *  - `opcache.enable_cli=1`   — OPcache is inert on CLI without it, so the
+     *                               re-exec would cost a process start and buy
+     *                               nothing.
+     *  - `opcache.file_cache=<dir>` — the reason for the re-exec, and the flag
+     *                               the child reads back as its loop guard.
+     *  - `opcache.file_cache_only=1` — skips the SHM segment and the startup
+     *                               semaphore that can block on some CI hosts.
+     *
+     * Users who want their own OPcache settings honoured instead opt out of the
+     * re-exec entirely with `PHEL_NO_OPCACHE_REEXEC=1`.
+     *
+     * @param list<string> $userIniFlags
+     */
+    public function withUserIniFlags(array $userIniFlags): self
+    {
+        if ($userIniFlags === []) {
+            return $this;
+        }
+
+        return new self($this->shouldReexec, [...$userIniFlags, ...$this->flags]);
+    }
 }

--- a/src/php/Shared/Performance/ProcessCommandLine.php
+++ b/src/php/Shared/Performance/ProcessCommandLine.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared\Performance;
+
+use function count;
+use function function_exists;
+use function is_array;
+use function is_resource;
+
+/**
+ * Reads the full command line of the *running* process, interpreter flags
+ * included.
+ *
+ * PHP drops everything before the script from `$_SERVER['argv']`: a process
+ * started as `php -d display_errors=stderr bin/phel run x.phel` only ever sees
+ * `['bin/phel', 'run', 'x.phel']`. The `-d`/`-n`/`-c` flags are therefore
+ * unrecoverable from inside PHP, and any process the CLI replaces itself with
+ * would silently run under the default ini. Asking the OS for the real argv is
+ * the only way to carry them over.
+ *
+ * Best-effort by design: an empty list means "unknown", and every caller must
+ * degrade to today's behaviour rather than guess.
+ */
+final class ProcessCommandLine
+{
+    private const string PROC_SELF_CMDLINE = '/proc/self/cmdline';
+
+    /**
+     * @return list<string> the process argv (binary first), or `[]` when unknown
+     */
+    public static function current(): array
+    {
+        $fromProc = self::fromProcFilesystem();
+        if ($fromProc !== []) {
+            return $fromProc;
+        }
+
+        return self::fromPs();
+    }
+
+    /**
+     * Linux and friends: exact, NUL-separated, and free (a single file read).
+     *
+     * @return list<string>
+     */
+    private static function fromProcFilesystem(): array
+    {
+        if (!is_readable(self::PROC_SELF_CMDLINE)) {
+            return [];
+        }
+
+        $raw = @file_get_contents(self::PROC_SELF_CMDLINE);
+        if ($raw === false || $raw === '') {
+            return [];
+        }
+
+        $args = explode("\0", $raw);
+        // The buffer is NUL-terminated, so the split leaves one trailing empty
+        // entry. Only that last one is padding: an empty arg in the middle is a
+        // real (quoted-empty) argument.
+        if ($args[count($args) - 1] === '') {
+            array_pop($args);
+        }
+
+        return $args;
+    }
+
+    /**
+     * macOS/BSD have no procfs. `ps` is the portable fallback, at the cost of
+     * one fork (~3ms) and of losing argument quoting: the columns come back
+     * space-joined, so an argument containing a space is indistinguishable from
+     * two arguments. Callers cross-check the result against `$_SERVER['argv']`
+     * and bail when it does not line up, which turns that ambiguity into a
+     * clean "unknown" instead of a wrong reconstruction.
+     *
+     * @return list<string>
+     */
+    private static function fromPs(): array
+    {
+        if (DIRECTORY_SEPARATOR !== '/' || !function_exists('proc_open')) {
+            return [];
+        }
+
+        $pid = getmypid();
+        if ($pid === false) {
+            return [];
+        }
+
+        $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+        $pipes = [];
+        // Array form: executed directly, never through a shell.
+        $process = @proc_open(['ps', '-ww', '-o', 'args=', '-p', (string) $pid], $descriptors, $pipes);
+        if (!is_resource($process)) {
+            return [];
+        }
+
+        $stdout = stream_get_contents($pipes[1]);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+
+        $exitCode = proc_close($process);
+        if ($exitCode !== 0 || $stdout === false) {
+            return [];
+        }
+
+        $line = trim($stdout);
+        if ($line === '') {
+            return [];
+        }
+
+        $args = preg_split('/\s+/', $line);
+
+        return is_array($args) ? $args : [];
+    }
+}

--- a/src/php/Shared/Performance/UserIniFlags.php
+++ b/src/php/Shared/Performance/UserIniFlags.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared\Performance;
+
+use function array_slice;
+use function count;
+use function str_starts_with;
+
+/**
+ * Recovers the ini-affecting interpreter flags (`-d`, `-n`, `-c`) a user put on
+ * the `php` command line, so a process that replaces its own image can hand
+ * them to its successor instead of silently dropping them.
+ *
+ * Pure: the caller supplies the OS-reported process argv (see
+ * {@see ProcessCommandLine}) and PHP's own `$_SERVER['argv']`. The script and
+ * its arguments are the suffix common to both, so whatever sits between the
+ * binary and that suffix is the interpreter's own option list.
+ *
+ * Conservative: anything that does not reconstruct cleanly — a mismatching
+ * suffix (the `ps` fallback loses quoting around arguments with spaces), a
+ * dangling `-d`, an option we do not model — yields `[]`, i.e. "carry nothing
+ * over". Forwarding a misparsed token into the successor's argv would corrupt
+ * the command; forwarding nothing merely reproduces the previous behaviour.
+ */
+final class UserIniFlags
+{
+    /**
+     * @param list<string> $processArgs OS-reported argv, interpreter binary first
+     * @param list<string> $scriptArgv  PHP's `$_SERVER['argv']` (script path first)
+     *
+     * @return list<string> flags ready to splice into an `exec` argv, or `[]` when unknown
+     */
+    public static function extract(array $processArgs, array $scriptArgv): array
+    {
+        if ($processArgs === [] || $scriptArgv === []) {
+            return [];
+        }
+
+        // processArgs === [binary, ...options, ...scriptArgv]
+        $optionCount = count($processArgs) - count($scriptArgv) - 1;
+        if ($optionCount < 0) {
+            return [];
+        }
+
+        if (array_slice($processArgs, -count($scriptArgv)) !== $scriptArgv) {
+            return [];
+        }
+
+        return self::parseOptions(array_slice($processArgs, 1, $optionCount));
+    }
+
+    /**
+     * @param list<string> $options
+     *
+     * @return list<string>
+     */
+    private static function parseOptions(array $options): array
+    {
+        $flags = [];
+        $count = count($options);
+
+        for ($i = 0; $i < $count; ++$i) {
+            $option = $options[$i];
+
+            // `-n` (ignore php.ini) changes which ini files the successor reads,
+            // so it has to travel with the `-d` overrides to keep parity.
+            if ($option === '-n') {
+                $flags[] = $option;
+                continue;
+            }
+
+            // Detached form: `-d name=value`, `-c /path/php.ini`.
+            if ($option === '-d' || $option === '-c') {
+                if (!isset($options[$i + 1])) {
+                    return [];
+                }
+
+                $flags[] = $option;
+                $flags[] = $options[++$i];
+                continue;
+            }
+
+            // Glued form: `-dname=value`, `-c/path/php.ini`.
+            if (str_starts_with($option, '-d') || str_starts_with($option, '-c')) {
+                $flags[] = $option;
+                continue;
+            }
+
+            return [];
+        }
+
+        return $flags;
+    }
+}

--- a/tests/php/Integration/Run/Command/Run/OpcacheReexecTest.php
+++ b/tests/php/Integration/Run/Command/Run/OpcacheReexecTest.php
@@ -48,6 +48,13 @@ final class OpcacheReexecTest extends TestCase
             $this->projectDir . '/main.phel',
             "(ns local\\main)\n(println (+ 1 2 3))\n",
         );
+
+        file_put_contents(
+            $this->projectDir . '/ini.phel',
+            "(ns local\\ini)\n"
+            . "(println \"precision:\" (php/ini_get \"precision\"))\n"
+            . "(println \"reexeced:\" (php/getenv \"PHEL_OPCACHE_REEXEC_DONE\"))\n",
+        );
     }
 
     protected function tearDown(): void
@@ -70,21 +77,64 @@ final class OpcacheReexecTest extends TestCase
         self::assertStringContainsString('6', $warmOut);
     }
 
+    public function test_reexec_carries_the_user_ini_flags_into_the_child_process(): void
+    {
+        // `-d` never reaches $_SERVER['argv'], so the re-exec used to hand the
+        // child a bare argv and every user ini override vanished — which is what
+        // made ini-based workarounds look like they did nothing.
+        [$exitCode, $output] = $this->runPhel([], ['-d', 'precision=9'], 'ini.phel');
+
+        self::assertSame(0, $exitCode);
+
+        if (!str_contains($output, 'reexeced: 1')) {
+            self::markTestSkipped('OPcache re-exec did not fire on this host; nothing to carry over.');
+        }
+
+        self::assertStringContainsString('precision: 9', $output);
+    }
+
+    public function test_reexec_keeps_its_own_opcache_flags_authoritative(): void
+    {
+        // Phel forces opcache.enable_cli / file_cache / file_cache_only because a
+        // re-exec without them costs a process start and buys nothing, so a user
+        // flag on those directives must lose. Everything else on the same command
+        // line still has to survive.
+        [$exitCode, $output] = $this->runPhel(
+            [],
+            ['-d', 'opcache.enable_cli=0', '-d', 'precision=9'],
+            'ini.phel',
+        );
+
+        self::assertSame(0, $exitCode);
+
+        if (!str_contains($output, 'reexeced: 1')) {
+            self::markTestSkipped('OPcache re-exec did not fire on this host; nothing to carry over.');
+        }
+
+        self::assertStringContainsString('precision: 9', $output);
+    }
+
     /**
      * @param array<string, string> $env
+     * @param list<string>          $iniFlags
      *
      * @return array{0: int, 1: string} exit code and combined output
      */
-    private function runPhel(array $env): array
+    private function runPhel(array $env, array $iniFlags = [], string $script = 'main.phel'): array
     {
         $prefix = '';
         foreach ($env as $name => $value) {
             $prefix .= $name . '=' . escapeshellarg($value) . ' ';
         }
 
+        $flags = '';
+        foreach ($iniFlags as $flag) {
+            $flags .= escapeshellarg($flag) . ' ';
+        }
+
         $cmd = 'cd ' . escapeshellarg($this->projectDir)
-            . ' && ' . $prefix . 'php ' . escapeshellarg($this->repoRoot . '/bin/phel')
-            . ' run main.phel 2>&1';
+            . ' && ' . $prefix . 'php ' . $flags . escapeshellarg($this->repoRoot . '/bin/phel')
+            . ' run ' . escapeshellarg($script) . ' 2>&1';
 
         exec($cmd, $output, $exitCode);
 

--- a/tests/php/Unit/Shared/Performance/OpcacheReexecDecisionTest.php
+++ b/tests/php/Unit/Shared/Performance/OpcacheReexecDecisionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared\Performance;
+
+use Phel\Shared\Performance\OpcacheReexecDecision;
+use PHPUnit\Framework\TestCase;
+
+final class OpcacheReexecDecisionTest extends TestCase
+{
+    public function test_user_ini_flags_are_placed_before_the_forced_ones(): void
+    {
+        // PHP applies `-d` left to right with the last occurrence winning, so
+        // "user first" is what lets Phel's three OPcache directives stay
+        // authoritative while every other override survives.
+        $decision = new OpcacheReexecDecision(true, ['-d', 'opcache.enable_cli=1'])
+            ->withUserIniFlags(['-d', 'display_errors=stderr']);
+
+        self::assertTrue($decision->shouldReexec);
+        self::assertSame(
+            ['-d', 'display_errors=stderr', '-d', 'opcache.enable_cli=1'],
+            $decision->flags,
+        );
+    }
+
+    public function test_forced_opcache_flags_override_a_conflicting_user_flag(): void
+    {
+        $decision = new OpcacheReexecDecision(true, ['-d', 'opcache.enable_cli=1'])
+            ->withUserIniFlags(['-d', 'opcache.enable_cli=0']);
+
+        self::assertSame(
+            ['-d', 'opcache.enable_cli=0', '-d', 'opcache.enable_cli=1'],
+            $decision->flags,
+        );
+    }
+
+    public function test_returns_the_same_decision_when_there_is_nothing_to_carry_over(): void
+    {
+        $decision = new OpcacheReexecDecision(true, ['-d', 'opcache.enable_cli=1']);
+
+        self::assertSame($decision, $decision->withUserIniFlags([]));
+    }
+}

--- a/tests/php/Unit/Shared/Performance/UserIniFlagsTest.php
+++ b/tests/php/Unit/Shared/Performance/UserIniFlagsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared\Performance;
+
+use Phel\Shared\Performance\UserIniFlags;
+use PHPUnit\Framework\TestCase;
+
+final class UserIniFlagsTest extends TestCase
+{
+    public function test_extracts_detached_ini_flags(): void
+    {
+        self::assertSame(
+            ['-d', 'display_errors=stderr', '-d', 'precision=7'],
+            UserIniFlags::extract(
+                ['php', '-d', 'display_errors=stderr', '-d', 'precision=7', 'bin/phel', 'run', 'x.phel'],
+                ['bin/phel', 'run', 'x.phel'],
+            ),
+        );
+    }
+
+    public function test_extracts_glued_ini_flags(): void
+    {
+        self::assertSame(
+            ['-ddisplay_errors=stderr'],
+            UserIniFlags::extract(
+                ['php', '-ddisplay_errors=stderr', 'bin/phel', 'run', 'x.phel'],
+                ['bin/phel', 'run', 'x.phel'],
+            ),
+        );
+    }
+
+    public function test_extracts_ini_file_selection_flags(): void
+    {
+        // `-n` and `-c` decide which php.ini the successor reads, so they belong
+        // with the `-d` overrides: dropping them changes the effective config
+        // just as silently.
+        self::assertSame(
+            ['-n', '-c', '/etc/custom/php.ini', '-d', 'precision=7'],
+            UserIniFlags::extract(
+                ['php', '-n', '-c', '/etc/custom/php.ini', '-d', 'precision=7', 'bin/phel', 'run', 'x.phel'],
+                ['bin/phel', 'run', 'x.phel'],
+            ),
+        );
+    }
+
+    public function test_returns_no_flags_when_none_were_passed(): void
+    {
+        self::assertSame(
+            [],
+            UserIniFlags::extract(
+                ['php', 'bin/phel', 'run', 'x.phel'],
+                ['bin/phel', 'run', 'x.phel'],
+            ),
+        );
+    }
+
+    public function test_bails_out_when_the_script_arguments_do_not_line_up(): void
+    {
+        // The `ps` fallback joins arguments with spaces, so `-d error_log=/tmp/a b.log`
+        // comes back as two tokens and the suffix no longer matches argv. Guessing
+        // would splice a stray `b.log` into the child's argv; carrying nothing over
+        // just reproduces the old behaviour.
+        self::assertSame(
+            [],
+            UserIniFlags::extract(
+                ['php', '-d', 'error_log=/tmp/a', 'b.log', 'bin/phel', 'run', 'x.phel'],
+                ['bin/phel', 'run', 'x.phel'],
+            ),
+        );
+    }
+
+    public function test_bails_out_on_an_option_it_does_not_model(): void
+    {
+        self::assertSame(
+            [],
+            UserIniFlags::extract(
+                ['php', '-z', '/tmp/ext.so', '-d', 'precision=7', 'bin/phel', 'run', 'x.phel'],
+                ['bin/phel', 'run', 'x.phel'],
+            ),
+        );
+    }
+
+    public function test_bails_out_on_a_dangling_value_less_flag(): void
+    {
+        self::assertSame(
+            [],
+            UserIniFlags::extract(
+                ['php', '-d', 'bin/phel'],
+                ['bin/phel'],
+            ),
+        );
+    }
+
+    public function test_bails_out_when_the_process_command_line_is_unknown(): void
+    {
+        self::assertSame([], UserIniFlags::extract([], ['bin/phel', 'run', 'x.phel']));
+    }
+
+    public function test_bails_out_when_the_script_argv_is_unknown(): void
+    {
+        self::assertSame([], UserIniFlags::extract(['php', '-d', 'precision=7', 'bin/phel'], []));
+    }
+
+    public function test_bails_out_when_the_process_command_line_is_shorter_than_the_script_argv(): void
+    {
+        // `php -r` reports argv[0] as "Standard input code", which can never be a
+        // suffix of the real command line.
+        self::assertSame([], UserIniFlags::extract(['php', '-r', 'echo 1;'], ['Standard input code']));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Two developer-experience defects that each cost real debugging time and hid real work.

**1. `bin/phel` discarded the user's ini flags.** `maybeReexecWithOpcacheFileCache()` built the child argv from phel's own flags plus `$_SERVER['argv']`, and PHP hides the interpreter's own options from that array. So every `-d`, `-n` and `-c` the user typed was silently dropped on the re-exec.

**2. `.gitignore` hid source directories.** Git sets `core.ignorecase=true` on macOS and Windows, so `tests/**/cache/` also matched source directories named `Cache/`. A complete, passing 10-case `LintCacheTest` was never committed and never ran in CI. That was patched with a one-off negation; this removes the cause.

## 💡 Goal

Make `php -d ... bin/phel` mean what it says, and make the ignore rules match only what they exist for.

## 🔖 Changes

**Item 1.** The OS-reported process command line is read (via a new `ProcessCommandLine`) and the ini-affecting flags recovered from it (`UserIniFlags`), then spliced **ahead** of phel's own. Order is the point: PHP applies `-d` left to right and the last occurrence wins, so phel's flags stay authoritative while the user's survive. Anything that does not reconstruct cleanly (a mismatching suffix, a dangling `-d`, an unmodelled option) yields no flags at all, reproducing today's behaviour rather than risking a corrupted argv. Cost is paid only on the invocation that actually re-execs.

**Item 2.** `tests/**/cache/` is **deleted**, not narrowed. Every generated cache in this repo lives under `.phel/`, which `.gitignore:29` already ignores, so the rule was pure redundancy that only ever did harm. Its one-off negation goes with it. `tests/**/out/` is kept: its target has zero tracked files, so it is genuinely load-bearing, and it collides with no source directory today.

## ✅ Verification

Item 1, end to end against a real project, same command both times:

| | `display_errors` seen by the child |
|---|---|
| `main` | `"1"` (the `-d` was dropped) |
| this branch | `"stderr"` |

Item 2, verified by enumeration rather than by reading the pattern:

- generated caches still ignored, now via `.phel/` (`tests/php/Integration/Lint/.phel/cache`)
- `tests/**/out/` matches exactly as before (line moved, rule identical)
- all four source directories named `Cache/` are now visible: `Integration/Build/Cache`, `Unit/Build/Infrastructure/Cache`, `Unit/Compiler/Cache`, `Unit/Lint/Application/Cache`

Only the last had been caught so far, because the other three contain tracked files and gitignore cannot hide those. Any *new* file added to any of them would have vanished.

PHPStan L9 clean, cs-fixer 0/1697, Rector clean, 5469 unit+integration, 6554 core.

## 📋 Residual

`tests/**/out/` keeps the same case-insensitivity property, so a future source directory named `Out/` would be hidden. It collides with nothing today and its one target is genuinely generated, so pinning it to a single literal path felt like trading a real rule for a speculative one. Worth revisiting if an `Out/` ever appears.
