### PR TITLE
chore(deps): require gacela ^1.21 and answer its facade-interface drift rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ All notable changes to this project will be documented in this file.
 - (PHP API) `Phel\Shared\Api\Definition` gains an optional `deprecated` field plus `isDeprecated()`; existing call sites keep working
 - (PHP API) The `Phel\Compiler\Domain\{Parser,Reader}\Expression*` classes now depend on `ParserInterface`/`ReaderInterface` rather than the concrete `Application` classes, so `Domain` no longer reaches into `Application`. Both interfaces gain `readExpression()`, which the shipped implementations already had
 - (PHP API) `NullScanIndexCache` moved to `Phel\Build\Domain\Cache\`, and `Phel\Lsp\Domain\HandlerInterface` to `Phel\Lsp\Application\`. Behaviour unchanged
+- Requires `gacela-project/gacela` `^1.21` (was `^1.18`), which types the `#[ServiceMap]` pillar accessors instead of suppressing them and adds a facade/interface drift rule. No runtime change; Phel already uses the `AbstractProvider` shape 1.20 deprecates `AbstractDependencyProvider` in favour of
 
 ### Removed
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=8.4",
         "amphp/amp": "^3.1",
-        "gacela-project/gacela": "^1.18",
+        "gacela-project/gacela": "^1.21",
         "symfony/console": "^6.0|^7.0|^8.0",
         "symfony/polyfill-mbstring": "^1.30",
         "symfony/routing": "^7.3|^8.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c9336acdbc414ef818dacf5b66a8d003",
+    "content-hash": "8532263df9fd00ef1210ea7a2a8a7b2a",
     "packages": [
         {
             "name": "amphp/amp",
@@ -157,16 +157,16 @@
         },
         {
             "name": "gacela-project/gacela",
-            "version": "1.18.0",
+            "version": "1.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/gacela.git",
-                "reference": "d4f91871da18de2cdcc651c571d3932489436411"
+                "reference": "32fef1b9651f72e8006c4f0cf7b3bf618bf381be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/d4f91871da18de2cdcc651c571d3932489436411",
-                "reference": "d4f91871da18de2cdcc651c571d3932489436411",
+                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/32fef1b9651f72e8006c4f0cf7b3bf618bf381be",
+                "reference": "32fef1b9651f72e8006c4f0cf7b3bf618bf381be",
                 "shasum": ""
             },
             "require": {
@@ -177,6 +177,7 @@
                 "ergebnis/composer-normalize": "^2.50",
                 "friendsofphp/php-cs-fixer": "^3.95",
                 "infection/infection": "^0.29",
+                "nikic/php-parser": "^5.0",
                 "phpbench/phpbench": "^1.4",
                 "phpmetrics/phpmetrics": "^2.9",
                 "phpstan/phpstan": "^2.0",
@@ -231,7 +232,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/gacela/issues",
-                "source": "https://github.com/gacela-project/gacela/tree/1.18.0"
+                "source": "https://github.com/gacela-project/gacela/tree/1.21.0"
             },
             "funding": [
                 {
@@ -239,7 +240,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-07-20T05:33:57+00:00"
+            "time": "2026-07-26T01:29:08+00:00"
         },
         {
             "name": "psr/container",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -28,6 +28,48 @@ parameters:
         -
             identifier: gacela.facadeOnlyDelegates
             path: src/php/Build/BuildFacade.php
+        # A `Shared\Facade\*FacadeInterface` is the *cross-module* contract, not
+        # a mirror of the facade. `Shared/CLAUDE.md` says to keep its imports
+        # minimal, and every method below is called only from inside its own
+        # module (its own `Infrastructure/Command/`, or emitted PHP for the
+        # BuildMode trio), so no consumer type-hinting the interface is missing
+        # anything. Declaring them would drag `BuildOptions`, `ApiDaemon`,
+        # `CoverageDriver`, `CoverageReport`, `ParallelTestOrchestrator` and
+        # `CpuCountDetector` into the leaf layer and widen the public surface
+        # 1.0 has to freeze, for no caller's benefit.
+        #
+        # The counts are the point: a genuinely new cross-module method that
+        # skips the interface makes the count short by one and that one is
+        # reported. Re-count deliberately, never just to get back to green.
+        #
+        # `reportUnmatched: false` because the rule ships in gacela 1.21 but not
+        # on the 2.0 branch, where these entries would otherwise turn into
+        # non-ignorable `ignore.unmatched` errors on the version bump.
+        -
+            identifier: gacela.facadeInterfaceDrift
+            path: src/php/Api/ApiFacade.php
+            count: 1
+            reportUnmatched: false
+        -
+            identifier: gacela.facadeInterfaceDrift
+            path: src/php/Build/BuildFacade.php
+            count: 8
+            reportUnmatched: false
+        -
+            identifier: gacela.facadeInterfaceDrift
+            path: src/php/Compiler/CompilerFacade.php
+            count: 1
+            reportUnmatched: false
+        -
+            identifier: gacela.facadeInterfaceDrift
+            path: src/php/Interop/InteropFacade.php
+            count: 2
+            reportUnmatched: false
+        -
+            identifier: gacela.facadeInterfaceDrift
+            path: src/php/Run/RunFacade.php
+            count: 7
+            reportUnmatched: false
         # LazySeq::cdr() checks instanceof SeqInterface for runtime safety
         # even though PHPDoc inference says the type is already narrowed.
         -


### PR DESCRIPTION
## 🤔 Background

We were on `gacela-project/gacela: ^1.18`. Three releases have landed since (1.19, 1.20, 1.21), and 1.21 in particular ships static-analysis work that is worth having before anyone migrates to 2.0: PHPStan now **types** `getFacade()`/`getFactory()`/`getConfig()` from `#[ServiceMap]` instead of suppressing them, and a new `FacadeInterfaceInSyncRule` reports public facade methods that are missing from the facade's own `*FacadeInterface`.

Turning that on reports 19 methods across five facades. None of them is a bug in the sense the rule assumes.

## 💡 Goal

Take 1.21, keep the new rule switched on, and answer its 19 findings deliberately rather than by widening contracts we are about to freeze.

## 🔖 Changes

### 1. `gacela-project/gacela: ^1.18` → `^1.21`

Nothing in the runtime needed changing. The 1.20 `AbstractDependencyProvider` deprecation (which now always fires, since it no longer depends on `symfony/deprecation-contracts` being installed) does not touch us: all 13 providers already extend `AbstractProvider` and are already named `*Provider.php`, which is the part that is easy to miss because pillars resolve by *filename*.

`vendor/bin/gacela validate:config` is also newly able to detect circular dependencies (in 1.20 it matched the exception message with the wrong casing, so it never fired once). It reports none here.

### 2. Answering `FacadeInterfaceInSyncRule`

The 19 findings, by facade:

| Facade | Count | Methods |
|---|---|---|
| `BuildFacade` | 8 | `enableBuildMode`, `disableBuildMode`, `isBuildMode`, `compileProject`, `writeLocatedException`, `writeStackTrace`, `clearCache`, `getOutputDirectory` |
| `RunFacade` | 7 | `enableDebugLineTap`, `disableDebugLineTap`, `createParallelTestOrchestrator`, `createCpuCountDetector`, `runTestWatchLoop`, `detectCoverageDriver`, `buildCoverageReport` |
| `InteropFacade` | 2 | `writeLocatedException`, `writeStackTrace` |
| `ApiFacade` | 1 | `createApiDaemon` |
| `CompilerFacade` | 1 | `compileForm` |

I grepped every call site. **All 19 are called only from inside their own module** — almost entirely from that module's own `Infrastructure/Command/`. The BuildMode trio has no PHP caller at all: it is emitted into compiled PHP as `\Phel\Build\BuildFacade::enableBuildMode();` by `NsEmitter`/`LoadEmitter`.

So the rule's premise ("Consumers type-hinting the interface cannot reach it") has no such consumer here. A `Shared\Facade\*FacadeInterface` is the **cross-module** contract, not a mirror of the facade, and `src/php/Shared/CLAUDE.md` already says to keep its imports minimal. Declaring these would pull `BuildOptions`, `ApiDaemon`, `CoverageDriver`, `CoverageReport`, `ParallelTestOrchestrator` and `CpuCountDetector` into the leaf layer, which is exactly the shape `SharedCompilerBoundaryTest` exists to keep rare, and it would widen the public surface a 1.0 has to freeze for nobody's benefit.

They are therefore ignored per facade **with a pinned `count`**, so the ignore does not become a mute button: a genuinely new cross-module method that skips the interface makes the count short by one and that one is reported. Verified by temporarily setting Build's count to 7, which correctly surfaced the 8th method and failed the build.

`reportUnmatched: false` is set on those five entries for the reason in the next section.

### 3. Verified against `2.0.x-dev` ahead of the 2.0 release

Phel is **runtime-clean on gacela 2.0.x-dev** (commit `5ad9747`): unit 4364, integration 1118, core 6568, Psalm level 1 all green with no source changes.

Two things to know about the 2.0 branch as it stands, both static-analysis only:

- **`FacadeInterfaceInSyncRule` is not on the 2.0 branch.** `src/PHPStan/Rules/` there has `CrossModuleViaFacadeRule`, `FacadeOnlyDelegatesRule`, `FactoryDoesNotCallFacadeRule` and `SuffixExtendsRule`, but no facade/interface sync rule. It was added in 1.21 and looks like it has not been forward-ported.
- **The `#[ServiceMap]` accessor typing is not there either.** 2.0's `phpstan-gacela.neon` still carries the regex suppression for `getFacade|getFactory|getConfig`, which the 1.21 notes said would go away in 2.0 precisely because the accessors would be typed.

The `reportUnmatched: false` on the five new entries is what keeps this repo green either way: without it, the absent rule turns each entry into a non-ignorable `ignore.unmatched` the moment we bump to 2.0.

### Refactor pass

Nothing to extract or rename: the change is `composer.json`, `composer.lock`, `phpstan.neon` and a changelog line. Recorded here rather than pushed as an empty `ref(...)` commit.
