### PR TITLE
feat(run): sync the agent docs tree incrementally and uninstall only what we installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - New lint rule `phel/comment-style` (warning): flags a whole-line comment written with a single `;`, which the convention reserves for trailing comments
 - New lint rule `phel/duplicate-def` (error): flags a symbol defined twice in one file. A forward `(declare foo)` plus its definition stays clean
 - [Migration guide for the currently deprecated surface](docs/migration/deprecated-surface.md): every live deprecation, its replacement, and how it announces itself
+- `phel agent-install --check`: reports which skill files are installed and whether the `.agents/` docs are behind the bundled ones, exiting 1 when they are, so CI can gate on it. `resources/agents/skills/INSTALL.md` has documented this flag for a while without it existing
 
 ### Fixed
 
@@ -57,6 +58,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- `phel agent-install` now syncs the `.agents/` docs tree incrementally (#2809). It used to skip the whole tree when the directory existed and rewrite every file under `--force`, so there was no way to pull new docs without discarding your own edits. A re-run now writes only what is new or changed upstream, leaves a file you edited since the last install alone and names it in the summary, and under `--force` backs that file up to `<file>.pre-phel.bak` before overwriting. `--uninstall` removes only the paths we installed, so anything you added to `.agents/` survives. An install manifest at `.agents/.phel-agent-manifest.json` records the docs version and those paths; a tree from before it existed is treated as user-owned and is left intact
 - `phel\test/print-summary` is deprecated: `run-tests` already emits the `:summary` event, so calling it yourself double-reports. React to the event in a custom reporter instead
 - Every compiler deprecation notice now goes through one switch, one message factory and one dedup table, so notices read identically and cannot name a concrete removal version
 - **BREAKING** (PHP API, implementers only): `Phel\Shared\Facade\ApiFacadeInterface` now declares the whole semantic-analysis surface (adding `analyzeSource`, `indexProject`, `extractDefinitions`, `resolveSymbol`, `findReferences`, `completeAtPoint`, `phpInteropHoverAt`, `phpInteropSignatureAt`, `phelSignatureAt`), and `FormatterFacadeInterface` gains `formatString`. Callers are unaffected; implementers must add the new methods

--- a/docs/agent-docs.md
+++ b/docs/agent-docs.md
@@ -20,11 +20,12 @@ Platforms: `claude`, `cursor`, `codex`, `gemini`, `copilot`, `aider`. `--auto` i
 | (default) | Copies `.agents/` docs (rules, task recipes, quick-syntax) |
 | `--no-docs` | Skip the `.agents/` docs tree |
 | `--with-examples` | Also copy `.agents/examples/` (excluded by default) |
-| `--force` | Skip the `<path>.pre-phel.bak` backup; overwrite existing skill files and `.agents/` tree |
+| `--force` | Skip the skill file's `<path>.pre-phel.bak` backup, and overwrite locally modified docs (each backed up first) |
 | `--dry-run` | Preview without writing |
-| `--uninstall` | Remove skill file(s) (restoring any backup) and the `.agents/` tree |
+| `--check` | Report install state and docs version drift; exit 1 when stale |
+| `--uninstall` | Remove skill file(s) (restoring any backup) and the docs we installed |
 
-Re-run any time to pull the latest docs.
+Re-run any time to pull the latest docs. The `.agents/` tree syncs incrementally: only new and upstream-changed files are written, and a file you edited since the last install is left alone and reported (`--force` overwrites it after a backup). `.agents/.phel-agent-manifest.json` records the docs version and the installed paths, which is also what lets `--uninstall` leave files you added to `.agents/` in place.
 
 ## Destinations
 

--- a/resources/agents/skills/INSTALL.md
+++ b/resources/agents/skills/INSTALL.md
@@ -9,18 +9,19 @@
 ./vendor/bin/phel agent-install --dry-run claude     # preview
 ./vendor/bin/phel agent-install --force claude       # overwrite without backup
 ./vendor/bin/phel agent-install --check              # report install + version drift; exit 1 if stale
-./vendor/bin/phel agent-install --list               # list platforms with sources, targets, and state
 ./vendor/bin/phel agent-install --uninstall claude   # remove (restores .pre-phel.bak if present)
 ./vendor/bin/phel agent-install --uninstall --all    # full removal (skills + .agents/ docs)
 ```
 
-Existing targets back up to `<path>.pre-phel.bak`. `--force` skips backup.
+An existing **skill file** backs up to `<path>.pre-phel.bak`; `--force` skips that backup.
 
 The `.agents/` docs tree is copied by default; pass `--no-docs` for skill files only. Example apps are excluded by default; add `--with-examples` to include `.agents/examples/`.
 
-Each installed file gets a footer `<!-- phel-agents vX.Y.Z -->` stamped from `resources/agents/VERSION`. Re-running `agent-install` after `composer update phel-lang/phel-lang` refreshes the stamp.
+## Re-running is incremental
 
-`phel doctor` also reports installed agent skills and flags stale versions in one place, so no need to remember `--check`.
+The docs tree syncs file by file. A re-run writes only what is new or has changed upstream, and leaves alone anything you edited since the last install, so `agent-install` after `composer update phel-lang/phel-lang` pulls new docs without touching your notes. Locally modified files are listed at the end of the run; `--force` overwrites those too, backing each one up to `<file>.pre-phel.bak` first.
+
+`.agents/.phel-agent-manifest.json` records the docs version and what was installed. It is what makes the incremental sync and `--check` possible, and it is why `--uninstall` removes only the files we wrote, leaving anything you added to `.agents/` in place.
 
 ## Destinations
 

--- a/src/php/Run/Application/Agent/AgentDocsSynchronizer.php
+++ b/src/php/Run/Application/Agent/AgentDocsSynchronizer.php
@@ -133,6 +133,20 @@ final readonly class AgentDocsSynchronizer
     }
 
     /**
+     * The docs version recorded in $docsDir, or null when nothing there was
+     * installed by a release that writes a manifest.
+     */
+    public function installedVersion(string $docsDir): ?string
+    {
+        $manifest = $this->manifestStore->load($docsDir);
+        if (!$manifest instanceof AgentDocsManifest || $manifest->version === '') {
+            return null;
+        }
+
+        return $manifest->version;
+    }
+
+    /**
      * Relative path => absolute source path, for every file the sync covers.
      *
      * @return iterable<string, string>
@@ -186,12 +200,7 @@ final readonly class AgentDocsSynchronizer
 
     private function pruneEmptyDirectories(string $dir): void
     {
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST,
-        );
-
-        foreach ($iterator as $item) {
+        foreach ($this->deepestFirst($dir) as $item) {
             if ($item instanceof SplFileInfo && $item->isDir() && $this->isEmpty($item->getPathname())) {
                 AgentFileOperations::deleteDirectory($item->getPathname());
             }
@@ -204,12 +213,7 @@ final readonly class AgentDocsSynchronizer
 
     private function removeTree(string $dir): void
     {
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST,
-        );
-
-        foreach ($iterator as $item) {
+        foreach ($this->deepestFirst($dir) as $item) {
             if (!$item instanceof SplFileInfo) {
                 continue;
             }
@@ -222,6 +226,20 @@ final readonly class AgentDocsSynchronizer
         }
 
         AgentFileOperations::deleteDirectory($dir);
+    }
+
+    /**
+     * Children before their parent, so a directory is visited once everything
+     * inside it has already been dealt with.
+     *
+     * @return RecursiveIteratorIterator<RecursiveDirectoryIterator>
+     */
+    private function deepestFirst(string $dir): RecursiveIteratorIterator
+    {
+        return new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
     }
 
     private function isEmpty(string $dir): bool

--- a/src/php/Run/Application/Agent/AgentDocsSynchronizer.php
+++ b/src/php/Run/Application/Agent/AgentDocsSynchronizer.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application\Agent;
+
+use FilesystemIterator;
+use Phel\Run\Domain\Agent\AgentDocsManifest;
+use Phel\Run\Domain\Agent\AgentDocsSyncResult;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
+use SplFileInfo;
+
+use function dirname;
+use function explode;
+use function in_array;
+use function is_file;
+use function sort;
+use function sprintf;
+use function str_replace;
+
+/**
+ * Incremental `.agents/` sync.
+ *
+ * The old copy was all-or-nothing: the whole tree was skipped when it existed,
+ * and `--force` then rewrote every file. This walks the bundled tree file by
+ * file and classifies each one against the install manifest, so a re-run picks
+ * up new and updated docs while leaving anything the user edited exactly where
+ * it is.
+ */
+final readonly class AgentDocsSynchronizer
+{
+    private const string EXAMPLES_SUBDIR = 'examples';
+
+    /** Change detection only, never a security boundary. */
+    private const string HASH_ALGO = 'xxh128';
+
+    public function __construct(
+        private AgentManifestStore $manifestStore = new AgentManifestStore(),
+    ) {}
+
+    public function sync(
+        string $sourceRoot,
+        string $docsDir,
+        string $version,
+        bool $force,
+        bool $withExamples,
+        bool $dryRun,
+    ): AgentDocsSyncResult {
+        $previous = $this->manifestStore->load($docsDir) ?? AgentDocsManifest::empty();
+
+        $created = [];
+        $updated = [];
+        $unchanged = [];
+        $skipped = [];
+        $backedUp = [];
+        $shipped = [];
+
+        foreach ($this->sourceFiles($sourceRoot, $withExamples) as $relative => $sourcePath) {
+            $sourceHash = $this->hash($sourcePath);
+            $shipped[$relative] = $sourceHash;
+            $target = $docsDir . '/' . $relative;
+
+            if (!is_file($target)) {
+                $created[] = $relative;
+                $this->install($sourcePath, $target, $dryRun);
+                continue;
+            }
+
+            $targetHash = $this->hash($target);
+            if ($targetHash === $sourceHash) {
+                $unchanged[] = $relative;
+                continue;
+            }
+
+            if ($previous->shippedHash($relative) === $targetHash) {
+                // Byte-identical to what we last wrote, so nothing of the user's
+                // is at stake: refresh it.
+                $updated[] = $relative;
+                $this->install($sourcePath, $target, $dryRun);
+                continue;
+            }
+
+            if (!$force) {
+                $skipped[] = $relative;
+                continue;
+            }
+
+            $backedUp[] = $relative;
+            if (!$dryRun) {
+                AgentFileOperations::copy($target, $target . AgentInstaller::BACKUP_SUFFIX);
+            }
+
+            $this->install($sourcePath, $target, $dryRun);
+        }
+
+        if (!$dryRun && $shipped !== []) {
+            $this->manifestStore->save($docsDir, $previous->with($version, $shipped));
+        }
+
+        sort($created);
+        sort($updated);
+        sort($unchanged);
+        sort($skipped);
+        sort($backedUp);
+
+        return new AgentDocsSyncResult($created, $updated, $unchanged, $skipped, $backedUp);
+    }
+
+    /**
+     * Remove only the paths the manifest claims, then any directory that ends up
+     * empty. Without a manifest we cannot tell our files from the user's, so the
+     * whole tree goes, which is what every release before the manifest did.
+     */
+    public function remove(string $docsDir): void
+    {
+        $manifest = $this->manifestStore->load($docsDir);
+        if (!$manifest instanceof AgentDocsManifest) {
+            $this->removeTree($docsDir);
+            return;
+        }
+
+        foreach ($manifest->paths() as $relative) {
+            $path = $docsDir . '/' . $relative;
+            if (is_file($path)) {
+                AgentFileOperations::delete($path);
+            }
+        }
+
+        $this->manifestStore->delete($docsDir);
+        $this->pruneEmptyDirectories($docsDir);
+    }
+
+    /**
+     * Relative path => absolute source path, for every file the sync covers.
+     *
+     * @return iterable<string, string>
+     */
+    private function sourceFiles(string $sourceRoot, bool $withExamples): iterable
+    {
+        $skipTopLevel = $withExamples ? [] : [self::EXAMPLES_SUBDIR];
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($sourceRoot, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            if (!$item instanceof SplFileInfo) {
+                continue;
+            }
+
+            if ($item->isDir()) {
+                continue;
+            }
+
+            $relative = str_replace('\\', '/', $iterator->getSubPathname());
+            if (in_array(explode('/', $relative, 2)[0], $skipTopLevel, true)) {
+                continue;
+            }
+
+            yield $relative => $item->getPathname();
+        }
+    }
+
+    private function install(string $source, string $target, bool $dryRun): void
+    {
+        if ($dryRun) {
+            return;
+        }
+
+        AgentFileOperations::ensureDirectory(dirname($target));
+        AgentFileOperations::copy($source, $target);
+    }
+
+    private function hash(string $path): string
+    {
+        $hash = hash_file(self::HASH_ALGO, $path);
+        if ($hash === false) {
+            throw new RuntimeException(sprintf('Cannot read file: %s', $path));
+        }
+
+        return $hash;
+    }
+
+    private function pruneEmptyDirectories(string $dir): void
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            if ($item instanceof SplFileInfo && $item->isDir() && $this->isEmpty($item->getPathname())) {
+                AgentFileOperations::deleteDirectory($item->getPathname());
+            }
+        }
+
+        if ($this->isEmpty($dir)) {
+            AgentFileOperations::deleteDirectory($dir);
+        }
+    }
+
+    private function removeTree(string $dir): void
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            if (!$item instanceof SplFileInfo) {
+                continue;
+            }
+
+            if ($item->isDir()) {
+                AgentFileOperations::deleteDirectory($item->getPathname());
+            } else {
+                AgentFileOperations::delete($item->getPathname());
+            }
+        }
+
+        AgentFileOperations::deleteDirectory($dir);
+    }
+
+    private function isEmpty(string $dir): bool
+    {
+        return !new FilesystemIterator($dir, FilesystemIterator::SKIP_DOTS)->valid();
+    }
+}

--- a/src/php/Run/Application/Agent/AgentFileOperations.php
+++ b/src/php/Run/Application/Agent/AgentFileOperations.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application\Agent;
+
+use RuntimeException;
+
+use function is_dir;
+use function sprintf;
+
+/**
+ * Every filesystem write `agent-install` performs, with its return value
+ * checked. A failed `copy()` used to be reported to the user as a successful
+ * install, which is the worst outcome for a command whose whole job is putting
+ * files where someone expects to find them.
+ */
+final class AgentFileOperations
+{
+    public static function copy(string $source, string $target): void
+    {
+        if (!copy($source, $target)) {
+            throw new RuntimeException(sprintf('Cannot copy %s to %s', $source, $target));
+        }
+    }
+
+    public static function write(string $path, string $contents): void
+    {
+        if (file_put_contents($path, $contents) === false) {
+            throw new RuntimeException(sprintf('Cannot write file: %s', $path));
+        }
+    }
+
+    public static function rename(string $from, string $to): void
+    {
+        if (!rename($from, $to)) {
+            throw new RuntimeException(sprintf('Cannot move %s to %s', $from, $to));
+        }
+    }
+
+    public static function delete(string $path): void
+    {
+        if (!unlink($path)) {
+            throw new RuntimeException(sprintf('Cannot delete file: %s', $path));
+        }
+    }
+
+    public static function deleteDirectory(string $dir): void
+    {
+        if (!rmdir($dir)) {
+            throw new RuntimeException(sprintf('Cannot delete directory: %s', $dir));
+        }
+    }
+
+    public static function ensureDirectory(string $dir): void
+    {
+        if (is_dir($dir)) {
+            return;
+        }
+
+        if (!mkdir($dir, 0o755, true) && !is_dir($dir)) {
+            throw new RuntimeException(sprintf('Cannot create directory: %s', $dir));
+        }
+    }
+}

--- a/src/php/Run/Application/Agent/AgentInstaller.php
+++ b/src/php/Run/Application/Agent/AgentInstaller.php
@@ -4,18 +4,16 @@ declare(strict_types=1);
 
 namespace Phel\Run\Application\Agent;
 
-use FilesystemIterator;
+use Phel\Run\Domain\Agent\AgentDocsManifest;
+use Phel\Run\Domain\Agent\AgentDocsSyncResult;
 use Phel\Run\Domain\Agent\AgentPlatform;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 use RuntimeException;
-use SplFileInfo;
 
 use function dirname;
-use function in_array;
 use function is_dir;
 use function is_file;
 use function sprintf;
+use function trim;
 
 /**
  * Filesystem work behind `agent-install`: copy/remove a per-platform skill
@@ -23,7 +21,7 @@ use function sprintf;
  * dependency, so it can be unit-tested directly; the command renders the
  * outcome it returns.
  */
-final class AgentInstaller
+final readonly class AgentInstaller
 {
     public const string UNINSTALL_RESTORED = 'restored';
 
@@ -35,21 +33,32 @@ final class AgentInstaller
 
     public const string BACKUP_SUFFIX = '.pre-phel.bak';
 
-    private const string EXAMPLES_SUBDIR = 'examples';
+    private const string VERSION_FILE = 'VERSION';
 
     /**
-     * Locate the bundled `resources/agents/` directory. The levels differ by
-     * install layout: 5 = running from a Composer dependency (vendor/),
-     * 4 = running from this repo's own checkout, 6 = nested edge cases.
+     * How far up from this file to look for `resources/agents/`. The distance
+     * differs by install layout (this repo's own checkout, a Composer
+     * dependency under `vendor/`, a nested workspace), so walk instead of
+     * guessing a level.
+     */
+    private const int MAX_SOURCE_ROOT_LEVELS = 8;
+
+    public function __construct(
+        private AgentDocsSynchronizer $synchronizer = new AgentDocsSynchronizer(),
+        private AgentManifestStore $manifestStore = new AgentManifestStore(),
+    ) {}
+
+    /**
+     * Locate the bundled `resources/agents/` directory.
      */
     public function locateSourceRoot(): string
     {
-        foreach ([5, 4, 6] as $levels) {
+        for ($levels = 1; $levels <= self::MAX_SOURCE_ROOT_LEVELS; ++$levels) {
             $candidate = dirname(__DIR__, $levels) . '/resources/agents';
             // The VERSION marker ships only with the full agent docs tree, not
             // with the examples-only subtree bundled inside phel.phar, so this
             // keeps reporting the Composer-install hint when run from the PHAR.
-            if (is_file($candidate . '/VERSION')) {
+            if (is_file($candidate . '/' . self::VERSION_FILE)) {
                 return $candidate;
             }
         }
@@ -75,15 +84,15 @@ final class AgentInstaller
             throw new RuntimeException(sprintf('Source skill file not found: %s', $src));
         }
 
-        $this->ensureDir(dirname($dst));
+        AgentFileOperations::ensureDirectory(dirname($dst));
 
         $backedUp = false;
         if (is_file($dst) && !$force) {
-            copy($dst, $dst . self::BACKUP_SUFFIX);
+            AgentFileOperations::copy($dst, $dst . self::BACKUP_SUFFIX);
             $backedUp = true;
         }
 
-        copy($src, $dst);
+        AgentFileOperations::copy($src, $dst);
 
         return $backedUp;
     }
@@ -99,11 +108,11 @@ final class AgentInstaller
             return self::UNINSTALL_ABSENT;
         }
 
-        unlink($dst);
+        AgentFileOperations::delete($dst);
 
         $backup = $dst . self::BACKUP_SUFFIX;
         if (is_file($backup)) {
-            rename($backup, $dst);
+            AgentFileOperations::rename($backup, $dst);
             return self::UNINSTALL_RESTORED;
         }
 
@@ -111,95 +120,63 @@ final class AgentInstaller
     }
 
     /**
-     * Copy the docs tree. Returns false (skipped) when `.agents/` already
-     * exists and $force is off; true when the tree was written.
+     * Bring `.agents/` in line with the bundled tree, file by file. Writes only
+     * what is new or stale and never overwrites a local edit unless $force, in
+     * which case the edit is backed up first.
+     *
+     * $dryRun computes the same plan and writes nothing.
      */
-    public function copyDocs(string $sourceRoot, string $projectRoot, bool $force, bool $withExamples): bool
-    {
-        $dst = $projectRoot . '/' . self::AGENTS_DIR;
-        if (is_dir($dst) && !$force) {
-            return false;
-        }
-
-        $skipTopLevel = $withExamples ? [] : [self::EXAMPLES_SUBDIR];
-        $this->recursiveCopy($sourceRoot, $dst, $skipTopLevel);
-
-        return true;
+    public function syncDocs(
+        string $sourceRoot,
+        string $projectRoot,
+        bool $force,
+        bool $withExamples,
+        bool $dryRun = false,
+    ): AgentDocsSyncResult {
+        return $this->synchronizer->sync(
+            $sourceRoot,
+            $projectRoot . '/' . self::AGENTS_DIR,
+            $this->bundledDocsVersion($sourceRoot),
+            $force,
+            $withExamples,
+            $dryRun,
+        );
     }
 
+    /**
+     * Remove the docs we installed, leaving anything the user added in place.
+     * Returns false when there was no `.agents/` to begin with.
+     */
     public function removeDocs(string $projectRoot): bool
     {
-        $dst = $projectRoot . '/' . self::AGENTS_DIR;
-        if (!is_dir($dst)) {
+        $docsDir = $projectRoot . '/' . self::AGENTS_DIR;
+        if (!is_dir($docsDir)) {
             return false;
         }
 
-        $this->recursiveRemove($dst);
+        $this->synchronizer->remove($docsDir);
 
         return true;
     }
 
     /**
-     * @param list<string> $skipTopLevel
+     * The docs version recorded in the project, or null when `.agents/` was
+     * never installed by a release that writes a manifest.
      */
-    private function recursiveCopy(string $src, string $dst, array $skipTopLevel): void
+    public function installedDocsVersion(string $projectRoot): ?string
     {
-        $this->ensureDir($dst);
-
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($src, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::SELF_FIRST,
-        );
-
-        foreach ($iterator as $item) {
-            if (!$item instanceof SplFileInfo) {
-                continue;
-            }
-
-            $sub = $iterator->getSubPathname();
-            if (in_array(explode('/', $sub, 2)[0], $skipTopLevel, true)) {
-                continue;
-            }
-
-            $target = $dst . '/' . $sub;
-            if ($item->isDir()) {
-                $this->ensureDir($target);
-            } else {
-                copy($item->getPathname(), $target);
-            }
+        $manifest = $this->manifestStore->load($projectRoot . '/' . self::AGENTS_DIR);
+        if (!$manifest instanceof AgentDocsManifest || $manifest->version === '') {
+            return null;
         }
+
+        return $manifest->version;
     }
 
-    private function recursiveRemove(string $dir): void
+    public function bundledDocsVersion(string $sourceRoot): string
     {
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST,
-        );
+        $raw = @file_get_contents($sourceRoot . '/' . self::VERSION_FILE);
 
-        foreach ($iterator as $item) {
-            if (!$item instanceof SplFileInfo) {
-                continue;
-            }
-
-            if ($item->isDir()) {
-                rmdir($item->getPathname());
-            } else {
-                unlink($item->getPathname());
-            }
-        }
-
-        rmdir($dir);
-    }
-
-    private function ensureDir(string $dir): void
-    {
-        if (is_dir($dir)) {
-            return;
-        }
-
-        if (!mkdir($dir, 0o755, true) && !is_dir($dir)) {
-            throw new RuntimeException(sprintf('Cannot create directory: %s', $dir));
-        }
+        return $raw === false ? '' : trim($raw);
     }
 }

--- a/src/php/Run/Application/Agent/AgentInstaller.php
+++ b/src/php/Run/Application/Agent/AgentInstaller.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Run\Application\Agent;
 
-use Phel\Run\Domain\Agent\AgentDocsManifest;
 use Phel\Run\Domain\Agent\AgentDocsSyncResult;
 use Phel\Run\Domain\Agent\AgentPlatform;
 use RuntimeException;
@@ -45,7 +44,6 @@ final readonly class AgentInstaller
 
     public function __construct(
         private AgentDocsSynchronizer $synchronizer = new AgentDocsSynchronizer(),
-        private AgentManifestStore $manifestStore = new AgentManifestStore(),
     ) {}
 
     /**
@@ -165,12 +163,7 @@ final readonly class AgentInstaller
      */
     public function installedDocsVersion(string $projectRoot): ?string
     {
-        $manifest = $this->manifestStore->load($projectRoot . '/' . self::AGENTS_DIR);
-        if (!$manifest instanceof AgentDocsManifest || $manifest->version === '') {
-            return null;
-        }
-
-        return $manifest->version;
+        return $this->synchronizer->installedVersion($projectRoot . '/' . self::AGENTS_DIR);
     }
 
     public function bundledDocsVersion(string $sourceRoot): string

--- a/src/php/Run/Application/Agent/AgentManifestStore.php
+++ b/src/php/Run/Application/Agent/AgentManifestStore.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application\Agent;
+
+use JsonException;
+use Phel\Run\Domain\Agent\AgentDocsManifest;
+
+use function is_array;
+use function is_file;
+use function json_decode;
+use function json_encode;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+
+/**
+ * Reads and writes the install manifest that lives at the root of the installed
+ * `.agents/` tree. Absent manifest means "installed before this existed, or not
+ * by us", which callers treat as: touch nothing you cannot account for.
+ */
+final class AgentManifestStore
+{
+    public const string FILENAME = '.phel-agent-manifest.json';
+
+    public function load(string $docsDir): ?AgentDocsManifest
+    {
+        $path = $this->path($docsDir);
+        if (!is_file($path)) {
+            return null;
+        }
+
+        $raw = file_get_contents($path);
+        if ($raw === false) {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            // A hand-mangled manifest is indistinguishable from none: we still
+            // cannot prove what we shipped, so fall back to the cautious path
+            // rather than trusting half a file.
+            return null;
+        }
+
+        return is_array($decoded) ? AgentDocsManifest::fromArray($decoded) : null;
+    }
+
+    public function save(string $docsDir, AgentDocsManifest $manifest): void
+    {
+        AgentFileOperations::ensureDirectory($docsDir);
+        AgentFileOperations::write(
+            $this->path($docsDir),
+            json_encode(
+                $manifest->toArray(),
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+            ) . "\n",
+        );
+    }
+
+    public function delete(string $docsDir): void
+    {
+        $path = $this->path($docsDir);
+        if (is_file($path)) {
+            AgentFileOperations::delete($path);
+        }
+    }
+
+    public function path(string $docsDir): string
+    {
+        return $docsDir . '/' . self::FILENAME;
+    }
+}

--- a/src/php/Run/Application/Agent/AgentManifestStore.php
+++ b/src/php/Run/Application/Agent/AgentManifestStore.php
@@ -69,7 +69,7 @@ final class AgentManifestStore
         }
     }
 
-    public function path(string $docsDir): string
+    private function path(string $docsDir): string
     {
         return $docsDir . '/' . self::FILENAME;
     }

--- a/src/php/Run/Domain/Agent/AgentDocsManifest.php
+++ b/src/php/Run/Domain/Agent/AgentDocsManifest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Agent;
+
+use function array_keys;
+use function array_merge;
+use function is_array;
+use function is_string;
+use function ksort;
+
+/**
+ * Record of what `agent-install` last wrote into `.agents/`: the bundled docs
+ * version, plus each installed path against the hash of the file **as shipped**.
+ *
+ * The shipped hash is what makes an incremental sync possible. A file whose
+ * current contents still hash to the recorded value is untouched since we wrote
+ * it and is safe to refresh; anything else the user has edited.
+ */
+final readonly class AgentDocsManifest
+{
+    /**
+     * @param array<string, string> $files relative path => hash of the file as shipped
+     */
+    public function __construct(
+        public string $version,
+        public array $files,
+    ) {}
+
+    public static function empty(): self
+    {
+        return new self('', []);
+    }
+
+    /**
+     * @param array<array-key, mixed> $raw
+     */
+    public static function fromArray(array $raw): self
+    {
+        $version = $raw['version'] ?? '';
+        $rawFiles = $raw['files'] ?? [];
+
+        $files = [];
+        if (is_array($rawFiles)) {
+            foreach ($rawFiles as $path => $hash) {
+                if (is_string($path) && is_string($hash)) {
+                    $files[$path] = $hash;
+                }
+            }
+        }
+
+        return new self(is_string($version) ? $version : '', $files);
+    }
+
+    /**
+     * @return array{version: string, files: array<string, string>}
+     */
+    public function toArray(): array
+    {
+        $files = $this->files;
+        ksort($files);
+
+        return ['version' => $this->version, 'files' => $files];
+    }
+
+    /**
+     * The hash of $relativePath as we shipped it, or null when we never wrote it.
+     */
+    public function shippedHash(string $relativePath): ?string
+    {
+        return $this->files[$relativePath] ?? null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function paths(): array
+    {
+        return array_keys($this->files);
+    }
+
+    /**
+     * @param array<string, string> $files
+     */
+    public function with(string $version, array $files): self
+    {
+        // Merged, not replaced: a run without `--with-examples` must not forget
+        // that an earlier run installed `examples/`, or uninstall would orphan it.
+        return new self($version, array_merge($this->files, $files));
+    }
+}

--- a/src/php/Run/Domain/Agent/AgentDocsSyncResult.php
+++ b/src/php/Run/Domain/Agent/AgentDocsSyncResult.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Agent;
+
+use function array_merge;
+use function count;
+
+/**
+ * What one `.agents/` sync did, by relative path. Also describes a `--dry-run`,
+ * where the same plan is computed and nothing is written.
+ */
+final readonly class AgentDocsSyncResult
+{
+    /**
+     * @param list<string> $created   absent locally, now written
+     * @param list<string> $updated   ours and stale, now refreshed
+     * @param list<string> $unchanged already byte-identical to what we ship
+     * @param list<string> $skipped   edited locally since we installed it, left alone
+     * @param list<string> $backedUp  edited locally, overwritten under `--force` after a backup
+     */
+    public function __construct(
+        public array $created = [],
+        public array $updated = [],
+        public array $unchanged = [],
+        public array $skipped = [],
+        public array $backedUp = [],
+    ) {}
+
+    public function wroteNothing(): bool
+    {
+        return $this->created === [] && $this->updated === [] && $this->backedUp === [];
+    }
+
+    public function fileCount(): int
+    {
+        return count($this->created)
+            + count($this->updated)
+            + count($this->unchanged)
+            + count($this->skipped)
+            + count($this->backedUp);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function writtenPaths(): array
+    {
+        return array_merge($this->created, $this->updated, $this->backedUp);
+    }
+}

--- a/src/php/Run/Domain/Agent/AgentDocsSyncResult.php
+++ b/src/php/Run/Domain/Agent/AgentDocsSyncResult.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Run\Domain\Agent;
 
-use function array_merge;
-use function count;
-
 /**
  * What one `.agents/` sync did, by relative path. Also describes a `--dry-run`,
  * where the same plan is computed and nothing is written.
@@ -27,26 +24,4 @@ final readonly class AgentDocsSyncResult
         public array $skipped = [],
         public array $backedUp = [],
     ) {}
-
-    public function wroteNothing(): bool
-    {
-        return $this->created === [] && $this->updated === [] && $this->backedUp === [];
-    }
-
-    public function fileCount(): int
-    {
-        return count($this->created)
-            + count($this->updated)
-            + count($this->unchanged)
-            + count($this->skipped)
-            + count($this->backedUp);
-    }
-
-    /**
-     * @return list<string>
-     */
-    public function writtenPaths(): array
-    {
-        return array_merge($this->created, $this->updated, $this->backedUp);
-    }
 }

--- a/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
+++ b/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function count;
 use function implode;
 use function is_file;
 use function is_string;
@@ -37,6 +38,8 @@ final class AgentInstallCommand extends Command
 
     private const string OPT_UNINSTALL = 'uninstall';
 
+    private const string OPT_CHECK = 'check';
+
     private readonly AgentPlatformRegistry $registry;
 
     private readonly AgentInstaller $installer;
@@ -59,11 +62,16 @@ Copies a per-platform skill file plus a shared <comment>.agents/</comment> docs 
 (rules, recipes, quick-syntax reference) into the current project. Example
 projects are excluded by default; pass <comment>--with-examples</comment> to include them.
 
+The docs tree syncs incrementally: re-running writes only what is new or has
+changed upstream, and leaves any file you edited since the last install exactly
+as it is. <comment>--force</comment> overwrites those too, backing each one up first.
+
 <info>Common uses:</info>
   <comment>phel agent-install --auto</comment>             Install for agents detected in this project
   <comment>phel agent-install claude</comment>             Install only the Claude skill + docs
   <comment>phel agent-install --all --force</comment>      Reinstall every platform, overwriting
   <comment>phel agent-install claude --uninstall</comment> Remove the Claude skill (restore backup)
+  <comment>phel agent-install --check</comment>            Report docs version drift; exit 1 when stale
 
 Existing skill files are backed up to <comment>.pre-phel.bak</comment> unless <comment>--force</comment> is used.
 HELP)
@@ -72,15 +80,20 @@ HELP)
             ->addOption(self::OPT_AUTO, null, InputOption::VALUE_NONE, 'Install only for agents detected in this project (.claude/, .cursor/, AGENTS.md, ...)')
             ->addOption(self::OPT_NO_DOCS, null, InputOption::VALUE_NONE, 'Skip copying the .agents/ docs tree (copied by default)')
             ->addOption(self::OPT_WITH_EXAMPLES, null, InputOption::VALUE_NONE, 'Include example projects in .agents/examples/ (excluded by default)')
-            ->addOption(self::OPT_FORCE, null, InputOption::VALUE_NONE, 'Overwrite existing files without creating ' . AgentInstaller::BACKUP_SUFFIX . ' backups')
+            ->addOption(self::OPT_FORCE, null, InputOption::VALUE_NONE, 'Overwrite the skill file without a ' . AgentInstaller::BACKUP_SUFFIX . ' backup, and overwrite locally modified docs (backing those up)')
             ->addOption(self::OPT_DRY_RUN, null, InputOption::VALUE_NONE, 'Print what would be written without changing files')
-            ->addOption(self::OPT_UNINSTALL, null, InputOption::VALUE_NONE, 'Remove installed skill file(s); restores ' . AgentInstaller::BACKUP_SUFFIX . ' if present');
+            ->addOption(self::OPT_UNINSTALL, null, InputOption::VALUE_NONE, 'Remove installed skill file(s); restores ' . AgentInstaller::BACKUP_SUFFIX . ' if present')
+            ->addOption(self::OPT_CHECK, null, InputOption::VALUE_NONE, 'Report the installed docs version against the bundled one; exit 1 when they differ');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $sourceRoot = $this->installer->locateSourceRoot();
         $projectRoot = (string) getcwd();
+
+        if ((bool) $input->getOption(self::OPT_CHECK)) {
+            return $this->renderCheck($output, $sourceRoot, $projectRoot);
+        }
 
         $platforms = $this->selectPlatforms($input, $output);
         if ($platforms === null) {
@@ -114,7 +127,7 @@ HELP)
         }
 
         if ($copyDocs) {
-            $this->renderCopyDocs($output, $sourceRoot, $projectRoot, $force, $dryRun, $withExamples);
+            $this->renderSyncDocs($output, $sourceRoot, $projectRoot, $force, $dryRun, $withExamples);
         }
 
         if (!$dryRun) {
@@ -168,21 +181,82 @@ HELP)
         };
     }
 
-    private function renderCopyDocs(OutputInterface $output, string $sourceRoot, string $projectRoot, bool $force, bool $dryRun, bool $withExamples): void
+    /**
+     * Report install state and docs version drift without writing anything, so
+     * CI can gate on "your `.agents/` is behind the phel-lang you installed".
+     */
+    private function renderCheck(OutputInterface $output, string $sourceRoot, string $projectRoot): int
+    {
+        $bundled = $this->installer->bundledDocsVersion($sourceRoot);
+        $installed = $this->installer->installedDocsVersion($projectRoot);
+
+        foreach ($this->registry->keys() as $key) {
+            $target = $this->registry->get($key)->target;
+            $output->writeln(sprintf(
+                '  %-8s %s %s',
+                $key,
+                is_file($projectRoot . '/' . $target) ? '<info>installed</info>' : 'absent   ',
+                $target,
+            ));
+        }
+
+        if ($installed === null) {
+            $output->writeln(sprintf('<comment>No .agents/ docs installed (bundled: %s).</comment>', $bundled));
+            $output->writeln('Run <comment>phel agent-install --auto</comment> to install them.');
+            return Command::FAILURE;
+        }
+
+        if ($installed !== $bundled) {
+            $output->writeln(sprintf('<comment>Docs are stale: installed %s, bundled %s.</comment>', $installed, $bundled));
+            $output->writeln('Run <comment>phel agent-install</comment> again to sync the changed files.');
+            return Command::FAILURE;
+        }
+
+        $output->writeln(sprintf('<info>Docs are up to date</info> (%s).', $installed));
+
+        return Command::SUCCESS;
+    }
+
+    private function renderSyncDocs(OutputInterface $output, string $sourceRoot, string $projectRoot, bool $force, bool $dryRun, bool $withExamples): void
     {
         $dst = $projectRoot . '/' . AgentInstaller::AGENTS_DIR;
+        $installedVersion = $this->installer->installedDocsVersion($projectRoot);
+        $bundledVersion = $this->installer->bundledDocsVersion($sourceRoot);
+        $prefix = $dryRun ? '[dry-run] ' : '';
 
-        if ($dryRun) {
-            $output->writeln(sprintf('[dry-run] copy %s -> %s', $sourceRoot, $dst));
-            return;
+        if ($installedVersion !== null && $installedVersion !== $bundledVersion) {
+            $output->writeln(sprintf('Docs %s -> <info>%s</info>', $installedVersion, $bundledVersion));
         }
 
-        if (!$this->installer->copyDocs($sourceRoot, $projectRoot, $force, $withExamples)) {
-            $output->writeln('<comment>.agents/ already exists; skipping (use --force to overwrite)</comment>');
-            return;
+        $result = $this->installer->syncDocs($sourceRoot, $projectRoot, $force, $withExamples, $dryRun);
+
+        $output->writeln(sprintf(
+            '%s<info>Docs tree</info> %s: %d new, %d updated, %d unchanged',
+            $prefix,
+            $dst,
+            count($result->created),
+            count($result->updated) + count($result->backedUp),
+            count($result->unchanged),
+        ));
+
+        foreach ($result->backedUp as $relative) {
+            $output->writeln(sprintf(
+                '%sBacked up your %s -> %s',
+                $prefix,
+                $relative,
+                $relative . AgentInstaller::BACKUP_SUFFIX,
+            ));
         }
 
-        $output->writeln(sprintf('<info>Copied docs tree</info> -> %s', $dst));
+        if ($result->skipped !== []) {
+            $output->writeln(sprintf(
+                '<comment>Kept %d locally modified file(s): %s</comment>',
+                count($result->skipped),
+                implode(', ', $result->skipped),
+            ));
+            $output->writeln('<comment>Pass --force to overwrite them (your version is backed up first).</comment>');
+        }
+
         if (!$withExamples) {
             $output->writeln('<comment>Skipped examples/ (pass --with-examples to include sample apps).</comment>');
         }

--- a/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
+++ b/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
@@ -154,7 +154,7 @@ final class AgentInstallCommandTest extends TestCase
         self::assertDirectoryDoesNotExist($this->testDir . '/.agents');
     }
 
-    public function test_install_skips_docs_when_agents_dir_already_exists(): void
+    public function test_install_fills_in_an_existing_agents_dir_without_touching_what_is_there(): void
     {
         mkdir($this->testDir . '/.agents', 0o755, true);
         file_put_contents($this->testDir . '/.agents/marker.txt', 'keep me');
@@ -163,16 +163,60 @@ final class AgentInstallCommandTest extends TestCase
         $this->install(['platform' => 'claude'], $output);
 
         self::assertFileExists($this->testDir . '/.agents/marker.txt');
-        self::assertStringContainsString('.agents/ already exists', $output->fetch());
+        self::assertFileExists($this->testDir . '/.agents/RULES.md');
+        self::assertStringContainsString('new,', $output->fetch());
     }
 
-    public function test_force_overwrites_docs_tree(): void
+    public function test_reinstall_reports_everything_unchanged_and_rewrites_nothing(): void
     {
-        mkdir($this->testDir . '/.agents', 0o755, true);
+        $this->install(['platform' => 'claude']);
+        $before = (int) filemtime($this->testDir . '/.agents/RULES.md');
+
+        $output = new BufferedOutput();
+        $this->install(['platform' => 'claude'], $output);
+
+        self::assertStringContainsString('0 new, 0 updated,', $output->fetch());
+        self::assertSame($before, (int) filemtime($this->testDir . '/.agents/RULES.md'));
+    }
+
+    public function test_reinstall_keeps_a_locally_edited_doc_and_says_so(): void
+    {
+        $this->install(['platform' => 'claude']);
+        file_put_contents($this->testDir . '/.agents/RULES.md', 'my own rules');
+
+        $output = new BufferedOutput();
+        $this->install(['platform' => 'claude'], $output);
+
+        self::assertSame('my own rules', file_get_contents($this->testDir . '/.agents/RULES.md'));
+        self::assertStringContainsString('locally modified', $output->fetch());
+    }
+
+    public function test_force_overwrites_a_locally_edited_doc_after_backing_it_up(): void
+    {
+        $this->install(['platform' => 'claude']);
+        file_put_contents($this->testDir . '/.agents/RULES.md', 'my own rules');
 
         $this->install(['platform' => 'claude', '--force' => true]);
 
-        self::assertFileExists($this->testDir . '/.agents/RULES.md');
+        self::assertSame(
+            'my own rules',
+            file_get_contents($this->testDir . '/.agents/RULES.md.pre-phel.bak'),
+        );
+        self::assertStringNotContainsString(
+            'my own rules',
+            (string) file_get_contents($this->testDir . '/.agents/RULES.md'),
+        );
+    }
+
+    public function test_uninstall_keeps_files_the_user_added_to_the_agents_tree(): void
+    {
+        $this->install(['platform' => 'claude']);
+        file_put_contents($this->testDir . '/.agents/my-notes.md', 'mine');
+
+        $this->install(['platform' => 'claude', '--uninstall' => true]);
+
+        self::assertFileExists($this->testDir . '/.agents/my-notes.md');
+        self::assertFileDoesNotExist($this->testDir . '/.agents/RULES.md');
     }
 
     public function test_claude_skill_references_quick_syntax(): void
@@ -291,6 +335,36 @@ final class AgentInstallCommandTest extends TestCase
         // Nothing actually changed: skill + backup both still present.
         self::assertFileExists($this->testDir . '/CONVENTIONS.md');
         self::assertFileExists($this->testDir . '/CONVENTIONS.md.pre-phel.bak');
+    }
+
+    public function test_check_fails_when_no_docs_are_installed(): void
+    {
+        $output = new BufferedOutput();
+        $result = $this->install(['--check' => true], $output);
+
+        self::assertSame(Command::FAILURE, $result);
+        self::assertStringContainsString('No .agents/ docs installed', $output->fetch());
+    }
+
+    public function test_check_passes_right_after_an_install(): void
+    {
+        $this->install(['platform' => 'claude']);
+
+        $output = new BufferedOutput();
+        $result = $this->install(['--check' => true], $output);
+
+        self::assertSame(Command::SUCCESS, $result);
+        $rendered = $output->fetch();
+        self::assertStringContainsString('Docs are up to date', $rendered);
+        self::assertStringContainsString('claude', $rendered);
+    }
+
+    public function test_check_writes_nothing(): void
+    {
+        $this->install(['--check' => true]);
+
+        self::assertDirectoryDoesNotExist($this->testDir . '/.agents');
+        self::assertFileDoesNotExist($this->testDir . '/AGENTS.md');
     }
 
     public function test_uninstall_on_not_installed_platform_is_noop(): void

--- a/tests/php/Unit/Run/Application/Agent/AgentDocsSyncTest.php
+++ b/tests/php/Unit/Run/Application/Agent/AgentDocsSyncTest.php
@@ -1,0 +1,298 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Application\Agent;
+
+use Phel\Run\Application\Agent\AgentInstaller;
+use Phel\Run\Application\Agent\AgentManifestStore;
+use Phel\Run\Domain\Agent\AgentDocsSyncResult;
+use PhelTest\Support\RemoveDirTrait;
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function sprintf;
+
+/**
+ * The incremental `.agents/` sync: what it writes, what it leaves alone, and
+ * what it refuses to touch because the user changed it after we installed it.
+ */
+final class AgentDocsSyncTest extends TestCase
+{
+    use RemoveDirTrait;
+
+    private AgentInstaller $installer;
+
+    private string $sourceRoot;
+
+    private string $projectRoot;
+
+    protected function setUp(): void
+    {
+        $this->installer = new AgentInstaller();
+        $this->sourceRoot = $this->makeDir('source');
+        $this->projectRoot = $this->makeDir('project');
+
+        $this->writeFile($this->sourceRoot . '/VERSION', "1.0.0\n");
+        $this->writeFile($this->sourceRoot . '/RULES.md', 'rules v1');
+        $this->writeFile($this->sourceRoot . '/tasks/async.md', 'async v1');
+        $this->writeFile($this->sourceRoot . '/examples/app.md', 'example v1');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->sourceRoot);
+        $this->removeDir($this->projectRoot);
+    }
+
+    public function test_sync_creates_every_file_on_a_clean_project(): void
+    {
+        $result = $this->sync();
+
+        self::assertSame(['RULES.md', 'VERSION', 'tasks/async.md'], $result->created);
+        self::assertSame([], $result->updated);
+        self::assertSame([], $result->unchanged);
+        self::assertSame('rules v1', $this->read('.agents/RULES.md'));
+        self::assertSame('async v1', $this->read('.agents/tasks/async.md'));
+    }
+
+    public function test_sync_excludes_examples_unless_requested(): void
+    {
+        $this->sync();
+        self::assertFileDoesNotExist($this->projectRoot . '/.agents/examples/app.md');
+
+        $result = $this->sync(withExamples: true);
+
+        self::assertSame(['examples/app.md'], $result->created);
+    }
+
+    public function test_rerunning_an_unchanged_tree_writes_nothing(): void
+    {
+        $this->sync();
+        $before = $this->mtimes();
+
+        $result = $this->sync();
+
+        self::assertSame([], $result->created);
+        self::assertSame([], $result->updated);
+        self::assertSame(['RULES.md', 'VERSION', 'tasks/async.md'], $result->unchanged);
+        self::assertSame($before, $this->mtimes(), 'untouched files must keep their mtime');
+    }
+
+    public function test_sync_updates_only_the_file_whose_source_moved_on(): void
+    {
+        $this->sync();
+        $this->writeFile($this->sourceRoot . '/RULES.md', 'rules v2');
+
+        $result = $this->sync();
+
+        self::assertSame(['RULES.md'], $result->updated);
+        self::assertSame(['VERSION', 'tasks/async.md'], $result->unchanged);
+        self::assertSame([], $result->created);
+        self::assertSame('rules v2', $this->read('.agents/RULES.md'));
+    }
+
+    public function test_sync_adds_a_file_that_appeared_in_the_source_tree(): void
+    {
+        $this->sync();
+        $this->writeFile($this->sourceRoot . '/tasks/new-recipe.md', 'brand new');
+
+        $result = $this->sync();
+
+        self::assertSame(['tasks/new-recipe.md'], $result->created);
+        self::assertSame('brand new', $this->read('.agents/tasks/new-recipe.md'));
+    }
+
+    public function test_sync_leaves_a_locally_modified_file_alone(): void
+    {
+        $this->sync();
+        $this->writeFile($this->projectRoot . '/.agents/RULES.md', 'my own notes');
+        $this->writeFile($this->sourceRoot . '/RULES.md', 'rules v2');
+
+        $result = $this->sync();
+
+        self::assertSame(['RULES.md'], $result->skipped);
+        self::assertSame([], $result->updated);
+        self::assertSame('my own notes', $this->read('.agents/RULES.md'));
+    }
+
+    public function test_a_locally_modified_file_stays_skipped_on_every_later_run(): void
+    {
+        $this->sync();
+        $this->writeFile($this->projectRoot . '/.agents/RULES.md', 'my own notes');
+        $this->writeFile($this->sourceRoot . '/RULES.md', 'rules v2');
+        $this->sync();
+
+        $result = $this->sync();
+
+        self::assertSame(['RULES.md'], $result->skipped);
+        self::assertSame('my own notes', $this->read('.agents/RULES.md'));
+    }
+
+    public function test_force_backs_the_local_edit_up_before_overwriting_it(): void
+    {
+        $this->sync();
+        $this->writeFile($this->projectRoot . '/.agents/RULES.md', 'my own notes');
+        $this->writeFile($this->sourceRoot . '/RULES.md', 'rules v2');
+
+        $result = $this->sync(force: true);
+
+        self::assertSame(['RULES.md'], $result->backedUp);
+        self::assertSame([], $result->skipped);
+        self::assertSame('rules v2', $this->read('.agents/RULES.md'));
+        self::assertSame('my own notes', $this->read('.agents/RULES.md' . AgentInstaller::BACKUP_SUFFIX));
+    }
+
+    public function test_a_pre_manifest_tree_is_treated_as_locally_modified(): void
+    {
+        // What an install from before the manifest existed looks like: files on
+        // disk, nothing recording what we shipped.
+        $this->writeFile($this->projectRoot . '/.agents/RULES.md', 'ancient copy');
+
+        $result = $this->sync();
+
+        self::assertSame(['RULES.md'], $result->skipped);
+        self::assertSame(['VERSION', 'tasks/async.md'], $result->created);
+        self::assertSame('ancient copy', $this->read('.agents/RULES.md'));
+    }
+
+    public function test_dry_run_reports_the_same_plan_but_writes_nothing(): void
+    {
+        $this->sync();
+        $this->writeFile($this->sourceRoot . '/RULES.md', 'rules v2');
+        $this->writeFile($this->sourceRoot . '/tasks/extra.md', 'extra');
+
+        $result = $this->sync(dryRun: true);
+
+        self::assertSame(['tasks/extra.md'], $result->created);
+        self::assertSame(['RULES.md'], $result->updated);
+        self::assertSame('rules v1', $this->read('.agents/RULES.md'));
+        self::assertFileDoesNotExist($this->projectRoot . '/.agents/tasks/extra.md');
+    }
+
+    public function test_sync_records_the_bundled_version(): void
+    {
+        self::assertNull($this->installer->installedDocsVersion($this->projectRoot));
+
+        $this->sync();
+
+        self::assertSame('1.0.0', $this->installer->installedDocsVersion($this->projectRoot));
+    }
+
+    public function test_a_dry_run_does_not_record_a_version(): void
+    {
+        $this->sync(dryRun: true);
+
+        self::assertNull($this->installer->installedDocsVersion($this->projectRoot));
+        self::assertDirectoryDoesNotExist($this->projectRoot . '/.agents');
+    }
+
+    public function test_remove_docs_keeps_files_the_user_added(): void
+    {
+        $this->sync();
+        $this->writeFile($this->projectRoot . '/.agents/my-notes.md', 'mine');
+        $this->writeFile($this->projectRoot . '/.agents/tasks/my-task.md', 'mine too');
+
+        self::assertTrue($this->installer->removeDocs($this->projectRoot));
+
+        self::assertFileDoesNotExist($this->projectRoot . '/.agents/RULES.md');
+        self::assertFileDoesNotExist($this->projectRoot . '/.agents/tasks/async.md');
+        self::assertSame('mine', $this->read('.agents/my-notes.md'));
+        self::assertSame('mine too', $this->read('.agents/tasks/my-task.md'));
+    }
+
+    public function test_remove_docs_drops_the_whole_tree_when_nothing_of_the_user_is_left(): void
+    {
+        $this->sync();
+
+        self::assertTrue($this->installer->removeDocs($this->projectRoot));
+
+        self::assertDirectoryDoesNotExist($this->projectRoot . '/.agents');
+    }
+
+    public function test_remove_docs_removes_the_manifest_itself(): void
+    {
+        $this->sync();
+        $this->writeFile($this->projectRoot . '/.agents/my-notes.md', 'mine');
+
+        $this->installer->removeDocs($this->projectRoot);
+
+        self::assertFileDoesNotExist(
+            $this->projectRoot . '/.agents/' . AgentManifestStore::FILENAME,
+        );
+    }
+
+    public function test_remove_docs_falls_back_to_the_whole_tree_without_a_manifest(): void
+    {
+        $this->writeFile($this->projectRoot . '/.agents/legacy.md', 'from an old install');
+
+        self::assertTrue($this->installer->removeDocs($this->projectRoot));
+
+        self::assertDirectoryDoesNotExist($this->projectRoot . '/.agents');
+    }
+
+    public function test_remove_docs_is_a_noop_when_absent(): void
+    {
+        self::assertFalse($this->installer->removeDocs($this->projectRoot));
+    }
+
+    public function test_the_manifest_is_never_offered_back_as_a_synced_file(): void
+    {
+        $this->sync();
+
+        $result = $this->sync();
+
+        self::assertNotContains(AgentManifestStore::FILENAME, $result->unchanged);
+        self::assertNotContains(AgentManifestStore::FILENAME, $result->skipped);
+    }
+
+    private function sync(
+        bool $force = false,
+        bool $withExamples = false,
+        bool $dryRun = false,
+    ): AgentDocsSyncResult {
+        return $this->installer->syncDocs(
+            $this->sourceRoot,
+            $this->projectRoot,
+            $force,
+            $withExamples,
+            $dryRun,
+        );
+    }
+
+    private function read(string $relative): string
+    {
+        return (string) file_get_contents($this->projectRoot . '/' . $relative);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function mtimes(): array
+    {
+        $out = [];
+        foreach (['RULES.md', 'tasks/async.md'] as $rel) {
+            $path = $this->projectRoot . '/.agents/' . $rel;
+            $out[$rel] = (int) filemtime($path);
+        }
+
+        return $out;
+    }
+
+    private function makeDir(string $suffix): string
+    {
+        $dir = sprintf('%s/phel-docs-sync-%s-%s', sys_get_temp_dir(), uniqid(), $suffix);
+        mkdir($dir, 0o755, true);
+        return $dir;
+    }
+
+    private function writeFile(string $path, string $contents): void
+    {
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0o755, true);
+        }
+
+        file_put_contents($path, $contents);
+    }
+
+}

--- a/tests/php/Unit/Run/Application/Agent/AgentInstallerTest.php
+++ b/tests/php/Unit/Run/Application/Agent/AgentInstallerTest.php
@@ -31,9 +31,8 @@ final class AgentInstallerTest extends TestCase
         $this->projectRoot = $this->makeDir('project');
         $this->platform = new AgentPlatform('test', 'skills/test/SKILL.md', '.test/SKILL.md', ['.test']);
 
+        $this->writeFile($this->sourceRoot . '/VERSION', "9.9.9\n");
         $this->writeFile($this->sourceRoot . '/skills/test/SKILL.md', 'skill v2');
-        $this->writeFile($this->sourceRoot . '/RULES.md', 'rules');
-        $this->writeFile($this->sourceRoot . '/examples/app.md', 'example');
     }
 
     protected function tearDown(): void
@@ -111,53 +110,14 @@ final class AgentInstallerTest extends TestCase
         );
     }
 
-    public function test_copy_docs_writes_tree_and_skips_examples_by_default(): void
+    public function test_bundled_docs_version_reads_the_version_marker(): void
     {
-        $copied = $this->installer->copyDocs($this->sourceRoot, $this->projectRoot, false, false);
-
-        self::assertTrue($copied);
-        self::assertFileExists($this->projectRoot . '/.agents/RULES.md');
-        self::assertDirectoryDoesNotExist($this->projectRoot . '/.agents/examples');
+        self::assertSame('9.9.9', $this->installer->bundledDocsVersion($this->sourceRoot));
     }
 
-    public function test_copy_docs_includes_examples_when_requested(): void
+    public function test_bundled_docs_version_is_empty_when_the_marker_is_missing(): void
     {
-        $this->installer->copyDocs($this->sourceRoot, $this->projectRoot, false, true);
-
-        self::assertFileExists($this->projectRoot . '/.agents/examples/app.md');
-    }
-
-    public function test_copy_docs_skips_when_tree_exists_and_not_forced(): void
-    {
-        mkdir($this->projectRoot . '/.agents', 0o755, true);
-
-        $copied = $this->installer->copyDocs($this->sourceRoot, $this->projectRoot, false, false);
-
-        self::assertFalse($copied);
-        self::assertFileDoesNotExist($this->projectRoot . '/.agents/RULES.md');
-    }
-
-    public function test_copy_docs_overwrites_existing_tree_when_forced(): void
-    {
-        mkdir($this->projectRoot . '/.agents', 0o755, true);
-
-        $copied = $this->installer->copyDocs($this->sourceRoot, $this->projectRoot, true, false);
-
-        self::assertTrue($copied);
-        self::assertFileExists($this->projectRoot . '/.agents/RULES.md');
-    }
-
-    public function test_remove_docs_deletes_tree(): void
-    {
-        $this->installer->copyDocs($this->sourceRoot, $this->projectRoot, false, false);
-
-        self::assertTrue($this->installer->removeDocs($this->projectRoot));
-        self::assertDirectoryDoesNotExist($this->projectRoot . '/.agents');
-    }
-
-    public function test_remove_docs_is_noop_when_absent(): void
-    {
-        self::assertFalse($this->installer->removeDocs($this->projectRoot));
+        self::assertSame('', $this->installer->bundledDocsVersion($this->projectRoot));
     }
 
     public function test_locate_source_root_points_at_bundled_resources(): void


### PR DESCRIPTION
## 🤔 Background

`phel agent-install` copies a per-platform skill file plus the shared `.agents/` docs tree. The docs half was all-or-nothing: `copyDocs()` skipped the **entire** tree when `.agents/` already existed, and `--force` then rewrote **every** file. There was no middle ground, so you could not pull new docs after `composer update phel-lang/phel-lang` without discarding your own edits, and `--uninstall` deleted the whole directory including anything you had added to it.

Several filesystem calls also went unchecked, so a failed `copy()` reported a successful install.

Closes #2809

## 💡 Goal

Make re-running `agent-install` a normal, safe thing to do: pick up what changed upstream, never touch what you changed locally, and be able to say which of the two a file is.

## 🔖 Changes

### 1. Incremental sync (headline)

`syncDocs()` walks the bundled tree file by file and classifies each path against an install manifest, `.agents/.phel-agent-manifest.json`, which records the docs version and the hash of every file **as shipped**:

| On disk | Action |
|---|---|
| absent | written (`created`) |
| byte-identical to what we ship | left alone, mtime untouched (`unchanged`) |
| still identical to what we last wrote, but we ship something newer | refreshed (`updated`) |
| differs from both | kept and reported (`skipped`) |

The shipped hash is what makes the last two distinguishable. A file that still hashes to the recorded value cannot contain anything of yours, so refreshing it is free; anything else is an edit and stays.

A tree installed **before** the manifest existed hashes to nothing we recorded, so every file in it is treated as yours and left intact. Nobody's notes disappear on upgrade.

### 2. `--force` backs the local edit up

`installSkill()` already backed the skill file up to `.pre-phel.bak`; the docs tree had no equivalent. Now `--force` overwrites a locally modified doc only after copying it to `<file>.pre-phel.bak`, and the run says which files that happened to. Files that are merely stale are refreshed without a backup, because there is nothing there to lose.

### 3. Uninstall removes only what was installed

`removeDocs()` deletes the manifest's paths, then prunes the directories that end up empty, so `.agents/my-notes.md` survives an uninstall. Without a manifest it still drops the whole tree, which is exactly what every release before this one did.

### 4. Every filesystem write is checked

`AgentFileOperations` wraps `copy`/`rename`/`unlink`/`rmdir`/`mkdir`/`file_put_contents` and throws a `RuntimeException` naming the path when one fails. Previously a permissions or disk error left the command printing `Installed ...` and exiting 0.

### 5. Version awareness, and a flag that was documented but never existed

The manifest carries the docs version, so a re-run that crosses versions prints `Docs 0.48.0 -> 0.49.0`.

`resources/agents/skills/INSTALL.md` has been advertising `phel agent-install --check` ("report install + version drift; exit 1 if stale") for a while. It did not exist. It does now: it lists which platform skill files are installed, compares the recorded docs version against the bundled one, and exits 1 when they differ or when no docs are installed, so CI can gate on it.

The same file also claimed a `--list` flag and a `<!-- phel-agents vX.Y.Z -->` footer stamped into every installed file, and pointed at `phel doctor` for agent skill reporting. None of the three exists in the code. Those claims are removed rather than left to mislead.

### 6. `locateSourceRoot()` hardening

It tried `dirname(__DIR__, N)` for `N` in `[5, 4, 6]`, a list whose comment did not match what the levels actually mean. It now walks up looking for `resources/agents/VERSION`, which is layout-independent.

### Structure

| File | Role |
|---|---|
| `Domain/Agent/AgentDocsManifest` | the manifest as data: version + path => shipped hash, with a merging `with()` so a run without `--with-examples` does not forget an earlier run installed them |
| `Domain/Agent/AgentDocsSyncResult` | what one sync did, by relative path |
| `Application/Agent/AgentManifestStore` | manifest read/write; a corrupt file is treated as absent, which is the cautious branch |
| `Application/Agent/AgentDocsSynchronizer` | the classification and the removal walk |
| `Application/Agent/AgentFileOperations` | the checked filesystem writes |

`AgentInstaller` keeps its role as the command's single collaborator and delegates.

## 🧪 Tests

New `AgentDocsSyncTest` (18 cases) covers the paths the issue asked for and the ones that are easy to get wrong: unchanged file keeps its mtime, changed file updated, user-added file preserved on uninstall, a locally modified file skipped **and still skipped on every later run**, `--force` backing it up first, a pre-manifest tree treated as user-owned, dry-run producing the same plan while writing nothing, and the manifest never being offered back as one of its own synced files.

`AgentInstallCommandTest` gains the command-level equivalents plus the three `--check` cases. Two existing tests asserted the old all-or-nothing behaviour (`.agents/ already exists; skipping`) and are replaced by tests for what it does now.

Full gate green: PHPStan 9, Psalm 1, 4378 unit, 1124 integration, 6568 core.

### Refactor pass

Second commit: `AgentDocsSyncResult` shipped three helper methods nothing called, `AgentInstaller` and `AgentDocsSynchronizer` both held a manifest store so manifest reads had two owners, `AgentManifestStore::path()` had no external caller, and the two removal walks built the same `CHILD_FIRST` iterator inline.
