### PR TITLE
ci: move the coverage gate to a nightly run

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,71 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+
+# Line coverage for the compiler suites, published to the run summary and gated
+# on a floor.
+#
+# Nightly rather than per-pull-request. The run takes ~22 minutes while every
+# other check on a pull request finishes inside 8, so it alone set the wall clock
+# on every merge. What it produces ("this code is not exercised") is worth
+# knowing daily and is not worth making people wait on: coverage moves slowly,
+# and a drop is a conversation rather than a stop-the-line failure.
+#
+# Runs on a pull request only when the measurement itself changes, so a tweak to
+# the floor or the checker is still validated by the thing it configures.
+
+name: Coverage
+
+on:
+  schedule:
+    - cron: '30 3 * * *'
+  pull_request:
+    paths:
+      - 'tools/check-coverage.php'
+      - 'phpunit.xml.dist'
+      - '.github/workflows/coverage.yml'
+  workflow_dispatch:
+    inputs:
+      coverage-floor:
+        description: 'Override the coverage floor for this run'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # A ratchet: raise it when the real figure clears it comfortably, never
+      # lower it to turn a red build green.
+      #
+      # Measured at 86.90% (23550/27101 statements) on the first run that
+      # published a figure. 85 leaves room for ordinary movement without letting
+      # the number quietly slide. Every run prints the current value to its
+      # summary.
+      COVERAGE_FLOOR: '85'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-phel
+        with:
+          # pcov is several times faster than Xdebug for line coverage and is all
+          # this job needs; nothing here steps or inspects.
+          coverage: pcov
+
+      - name: Run the compiler suites with coverage
+        run: |
+          php -d memory_limit=2G vendor/bin/phpunit \
+            --testsuite=unit,integration \
+            --coverage-clover=data/clover.xml \
+            --do-not-cache-result
+
+      - name: Publish the figure and enforce the floor
+        run: |
+          php tools/check-coverage.php data/clover.xml \
+            "${{ github.event.inputs.coverage-floor || env.COVERAGE_FLOOR }}"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -56,39 +56,9 @@ jobs:
       - name: Run phel lint on src/phel
         run: ./bin/phel lint --no-cache src/phel
 
-  # `composer test-compiler:coverage` has always worked locally, but every CI job
-  # installs PHP with `coverage: none`, so no figure was ever published and nothing
-  # gated on one. This publishes it to the run summary and enforces a floor.
-  #
-  # COVERAGE_FLOOR is a ratchet: raise it when the real figure clears it
-  # comfortably, never lower it to turn a red build green.
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    env:
-      # Measured at 86.90% (23550/27101 statements) on the first run that
-      # published a figure. 85 leaves room for ordinary movement without letting
-      # the number quietly slide. Every run prints the current value to its
-      # summary; raise this when it clears the floor comfortably.
-      COVERAGE_FLOOR: '85'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-phel
-        with:
-          # pcov is several times faster than Xdebug for line coverage and is all
-          # this job needs; nothing here steps or inspects.
-          coverage: pcov
-
-      - name: Run the compiler suites with coverage
-        run: |
-          php -d memory_limit=2G vendor/bin/phpunit \
-            --testsuite=unit,integration \
-            --coverage-clover=data/clover.xml \
-            --do-not-cache-result
-
-      - name: Publish the figure and enforce the floor
-        run: php tools/check-coverage.php data/clover.xml "$COVERAGE_FLOOR"
+  # Coverage lives in its own nightly workflow (`.github/workflows/coverage.yml`).
+  # It took ~22 minutes while everything else here finishes inside 8, so on a
+  # pull request it was the only thing merges waited on.
 
   type-checker:
     name: Type Checker

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -195,7 +195,7 @@ CI.
 | Standard-library snapshot | `CoreApiSurfaceTest` | a definition or an arity disappears |
 | Special-form list | `LanguageSurfaceSpecTest` | the spec and the analyzer disagree |
 | Static analysis | `quality.yml` | PHPStan level 9 or Psalm level 1 reports anything |
-| Coverage floor | `quality.yml` | line coverage drops below the floor |
+| Coverage floor | `coverage.yml` (nightly) | line coverage drops below the floor |
 | Benchmark regression | `tests.yml` | a benchmark is more than 25% slower than the base revision (`phpbench.json` uses a tighter 17% locally, where the machine is quiet) |
 | Mutation score | `mutation.yml` (weekly) | MSI over `Lang/` and the analyzer drops below the floor |
 | Clojure divergences | `run-clojure-test-suite.yml` (nightly) | behaviour changes without the suite being updated |
@@ -205,6 +205,13 @@ clears them comfortably and never lowered to make a red build green. As of this
 writing line coverage is **86.9%** (floor 85) and the mutation score is **83%**
 (floor 80) over `Lang/` and the analyzer; both jobs print the current figure to
 their run summary.
+
+Neither runs on every pull request. Coverage takes around 22 minutes and mutation
+testing longer, so on a pull request they were the only checks a merge waited on,
+and both answer questions ("this code is not exercised", "this test asserts
+nothing") that are worth knowing on a schedule rather than within the hour. They
+still run against `main`, still gate on their floors, and both can be triggered on
+demand with `workflow_dispatch`, including a one-off floor override.
 
 ## See also
 


### PR DESCRIPTION
## 🤔 Background

The `Coverage` job takes **~22 minutes**, every run, on every branch:

| Run | Branch | Duration |
|---|---|---|
| 30210016134 | `main` | 21m48s |
| 30216228250 | `feat/gacela-2.0` | 21m03s |
| 30219999103 | `feat/gacela-2.0` | 22m09s |
| 30238944554 | `feat/gacela-2.0` | 21m52s |

Every other check on those runs finished inside 8 minutes (compiler tests 4m, type checker 1m). So this one job set the wall clock on every merge, and it was the only thing anyone waited on.

## 💡 Goal

Keep the gate, stop making merges wait for it.

## 🔖 Changes

Coverage moves out of `quality.yml` into its own `coverage.yml`, mirroring how `mutation.yml` already works:

- **nightly** at 03:30 UTC against `main`
- **on a pull request** only when the measurement itself changes: `tools/check-coverage.php`, `phpunit.xml.dist`, or the workflow. A tweak to the floor or the checker is still validated by the thing it configures.
- **`workflow_dispatch`** with an optional one-off floor override, same input shape as `mutation.yml`'s `min-msi`

Nothing about the measurement changes: same suites, same pcov driver, same `COVERAGE_FLOOR: 85`, same published figure.

`docs/stability.md` is updated in the same commit, since its quality-gates table named `quality.yml` and its ratchet paragraph implied both slow gates ran per pull request.

## 🧐 Why not just make it faster

Two real speedups exist and neither is in this PR:

- `pcov.directory` is unset, so pcov line-maps `vendor/` as well. `<source><include>src</include>` filters what gets *reported*, not what gets *collected*.
- the job runs `phpunit` serially, while `test-integration` normally uses `paratest --runner=WrapperRunner`.

Both are worth doing, but both change what is measured or how, and doing that in the same PR that changes the schedule would make the next figure unattributable. Nightly makes them optional rather than urgent.

## ✅ Merge safety

`Coverage` is not a required status check on `main`. The only one is `Run clojure-test-suite (PHP 8.4)`, so no open pull request will sit waiting for a check that no longer runs on it.

Related to #2859
