### PR TITLE
docs: add heredoc example for multi-line eval to phel eval -h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Add heredoc example to `phel eval -h` help output for reliable multi-line one-shot evaluation
+
 ### Added
 
 - `phel\test/with-isolated-stats` and `with-isolated-reporters`: run a body against a fresh statistics accumulator or reporter set and restore the caller's afterwards, rolling back even when the body throws

--- a/src/php/Run/Infrastructure/Command/EvalCommand.php
+++ b/src/php/Run/Infrastructure/Command/EvalCommand.php
@@ -46,6 +46,12 @@ Evaluates a Phel expression (or stdin) and prints its value.
 <info>Examples:</info>
   <comment>phel eval '(+ 1 2)'</comment>      Evaluate an inline expression
   <comment>echo '(* 6 7)' | phel eval -</comment>   Evaluate from stdin
+
+For reliable multi-line evaluation, use a quoted heredoc:
+<comment>phel eval - <<'PHEL'
+(ns app)
+(println (+ 40 2))
+PHEL</comment>
 HELP)
             ->addArgument(
                 'expression',


### PR DESCRIPTION
There's slight issue with the indented help output being not very copy-paste friendly in `/bin/phel eval -h` output:

<img width="595" height="349" alt="image" src="https://github.com/user-attachments/assets/a662f7fd-9df3-4ab6-bd3c-1ccda2add4f1" />

The heredoc closes only if the `PHEL` doesn't have whitespace before it which get's easily copied from the indented help output:

```
  phel eval - <<'PHEL'
  (ns app)
  (println (+ 40 2))
  PHEL    # <- invalid closing of heredoc
```

Following works:
```
  phel eval - <<'PHEL'
  (ns app)
  (println (+ 40 2))
PHEL 
```

It's bit tricky, should (A) the output be modified to make it easier to copy paste, or (B) should mention be added that it should be made sure that closing `PHEL` would not have whitespace before it... Or alternatively (C) leave as is and let user to discover it themselves, it's documented in the docs website in copy-paste friendly way anyways.

Resolving https://github.com/phel-lang/phel-lang/issues/2879

