### PR TITLE
feat(compiler): call static methods through a class name held in a value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- The dot syntax now reaches a static method through a class name held in a value: `(.cases enum-class)` works whether `enum-class` holds an object or a string like `"\\App\\Status"`, with no type annotation needed. `php/::` used to be the only spelling for this, and it was the last thing that form could do which the Clojure-style syntax could not (#2881). A receiver the compiler can prove is a class name emits `Class::m()` directly, one it can prove is an object emits `$o->m()`, and only an unprovable one carries a runtime check
 - `phel\test/with-isolated-stats` and `with-isolated-reporters`: run a body against a fresh statistics accumulator or reporter set and restore the caller's afterwards, rolling back even when the body throws
 - Deprecation warnings for your own code: any `def`/`defn` with `:deprecated` metadata now warns at every call site under `--warn-deprecations` (or `PHEL_WARN_DEPRECATIONS=1`), deduplicated per file and symbol
 - New lint rule `phel/comment-style` (warning): flags a whole-line comment written with a single `;`, which the convention reserves for trailing comments

--- a/src/phel/reflect.phel
+++ b/src/phel/reflect.phel
@@ -159,7 +159,7 @@
   [enum-class kw]
   (let [case-name (name kw)]
     (first (filter (fn [c] (= case-name (php/-> c name)))
-                   (php/:: enum-class (cases))))))
+                   (.cases enum-class)))))
 
 (defn enum-values
   "Returns a vector of keywords, one per case of the native PHP enum
@@ -167,5 +167,5 @@
   {:example "(enum-values \\App\\Status)"
    :see-also ["enum->keyword" "keyword->enum"]}
   [enum-class]
-  (vec (for [c :in (php/:: enum-class (cases))]
+  (vec (for [c :in (.cases enum-class)]
          (enum->keyword c))))

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectCallEmitter.php
@@ -14,6 +14,9 @@ use Phel\Compiler\Domain\Analyzer\Ast\PropertyOrConstantAccessNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\ByRefLocalCollector;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\ContextualWrapEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpObjectCallDispatch;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpObjectCallDispatchResolver;
+use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
 use Phel\Lang\Symbol;
 use RuntimeException;
 
@@ -22,9 +25,15 @@ use function assert;
 /**
  * @internal
  */
-final class PhpObjectCallEmitter implements NodeEmitterInterface
+final readonly class PhpObjectCallEmitter implements NodeEmitterInterface
 {
-    use WithOutputEmitterTrait;
+    private PhpObjectCallDispatchResolver $dispatchResolver;
+
+    public function __construct(
+        private OutputEmitterInterface $outputEmitter,
+    ) {
+        $this->dispatchResolver = new PhpObjectCallDispatchResolver();
+    }
 
     public function emit(AbstractNode $node): void
     {
@@ -70,9 +79,14 @@ final class PhpObjectCallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
 
         $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
-        $this->emitTarget($node);
-        $this->outputEmitter->emitStr($this->fnCode($node), $node->getStartSourceLocation());
-        $this->emitCall($node);
+        if ($this->dispatchResolver->resolve($node) === PhpObjectCallDispatch::Runtime) {
+            $this->emitRuntimeDispatch($node, fn(): null => $this->emitTarget($node));
+        } else {
+            $this->emitTarget($node);
+            $this->outputEmitter->emitStr($this->fnCode($node), $node->getStartSourceLocation());
+            $this->emitCall($node);
+        }
+
         $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
 
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
@@ -136,8 +150,45 @@ final class PhpObjectCallEmitter implements NodeEmitterInterface
 
     private function emitTargetCall(PhpObjectCallNode $node, Symbol $targetSym): void
     {
-        $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
+        $emitTarget = fn(): null => $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
+
+        if ($this->dispatchResolver->resolve($node) === PhpObjectCallDispatch::Runtime) {
+            $this->emitRuntimeDispatch($node, $emitTarget);
+
+            return;
+        }
+
+        $emitTarget();
         $this->outputEmitter->emitStr($this->fnCode($node), $node->getStartSourceLocation());
+        $this->emitCall($node);
+    }
+
+    /**
+     * `is_string($t) ? $t::m(...) : $t->m(...)`, for a receiver the analyzer
+     * could not classify. Measured at +7.8% on the object path without OPcache
+     * and inside noise with OPcache + JIT, which is why this is a ternary rather
+     * than a callable array (`[$t, 'm'](...)`, +179% even under JIT) or a helper
+     * call. `$emitTarget` is only ever a local or a `target_` temp, so emitting
+     * it three times cannot duplicate a side effect.
+     *
+     * @param callable(): null $emitTarget
+     */
+    private function emitRuntimeDispatch(PhpObjectCallNode $node, callable $emitTarget): void
+    {
+        $location = $node->getStartSourceLocation();
+
+        $this->outputEmitter->emitStr('is_string(', $location);
+        $emitTarget();
+        $this->outputEmitter->emitStr(') ? ', $location);
+
+        $emitTarget();
+        $this->outputEmitter->emitStr('::', $location);
+        $this->emitCall($node);
+
+        $this->outputEmitter->emitStr(' : ', $location);
+
+        $emitTarget();
+        $this->outputEmitter->emitStr('->', $location);
         $this->emitCall($node);
     }
 
@@ -203,6 +254,6 @@ final class PhpObjectCallEmitter implements NodeEmitterInterface
 
     private function fnCode(PhpObjectCallNode $node): string
     {
-        return $node->isStatic() ? '::' : '->';
+        return $this->dispatchResolver->resolve($node) === PhpObjectCallDispatch::StaticClass ? '::' : '->';
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/PhpObjectCallDispatch.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/PhpObjectCallDispatch.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+/**
+ * Which PHP member-access operator a `PhpObjectCallNode` emits.
+ *
+ * `Runtime` exists because a class name can be a value: `(.cases c)` with `c`
+ * bound to `"\\App\\Status"` has to reach `$c::cases()`, while the same form on
+ * an object has to reach `$c->cases()`. When the analyzer cannot prove which,
+ * the emitter defers to `is_string()`. That is safe in one direction only:
+ * `$string->m()` is never valid PHP, so no working program changes meaning.
+ *
+ * @internal
+ */
+enum PhpObjectCallDispatch
+{
+    case Instance;
+    case StaticClass;
+    case Runtime;
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/PhpObjectCallDispatchResolver.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/PhpObjectCallDispatchResolver.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpNewNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
+
+use function is_string;
+
+/**
+ * Picks the member-access operator for a `PhpObjectCallNode`.
+ *
+ * A class name can be a value in Phel, so `(.cases c)` has to reach
+ * `$c::cases()` when `c` holds `"\\App\\Status"` and `$c->cases()` when it holds
+ * an object. The written form cannot decide this, and neither can the analyzer:
+ * `LocalVarNode::getInferredType()` only reports a tag once the inferrers have
+ * grafted it, which is why every other consumer of it also lives here.
+ *
+ * @internal
+ */
+final readonly class PhpObjectCallDispatchResolver
+{
+    private const string STRING_TAG = 'string';
+
+    public function resolve(PhpObjectCallNode $node): PhpObjectCallDispatch
+    {
+        $target = $node->getTargetExpr();
+
+        // `Foo->BAR` is never valid PHP, so a class-name target is static
+        // whether it was written as `php/::` or `php/->`.
+        if ($node->isStatic() || $target instanceof PhpClassNameNode) {
+            return PhpObjectCallDispatch::StaticClass;
+        }
+
+        // `$t::x` reads a class constant while `$t->x` reads a property, so
+        // deferring this one to runtime would pick between two different
+        // members rather than two spellings of the same one.
+        if (!$node->isMethodCall()) {
+            return PhpObjectCallDispatch::Instance;
+        }
+
+        return match (true) {
+            $this->isClassNameString($target) => PhpObjectCallDispatch::StaticClass,
+            $this->isNeverClassNameString($target) => PhpObjectCallDispatch::Instance,
+            default => PhpObjectCallDispatch::Runtime,
+        };
+    }
+
+    private function isClassNameString(AbstractNode $target): bool
+    {
+        if ($target instanceof LiteralNode) {
+            return is_string($target->getValue());
+        }
+
+        return $target instanceof LocalVarNode
+            && TagNormalizer::normalise($target->getInferredType()) === self::STRING_TAG;
+    }
+
+    /**
+     * A target the emitter can prove is not a class-name string, so it keeps the
+     * plain `->` with no runtime check. A chained segment counts: its target is
+     * the previous call's return value, and threading `(-> o (.a) (.b))` must not
+     * pay for a test on every link.
+     */
+    private function isNeverClassNameString(AbstractNode $target): bool
+    {
+        if ($target instanceof PhpNewNode || $target instanceof PhpObjectCallNode) {
+            return true;
+        }
+
+        return $target instanceof LocalVarNode
+            && $target->getInferredType() !== null;
+    }
+}

--- a/tests/php/Integration/Fixtures/Call/php-method-call-by-ref.test
+++ b/tests/php/Integration/Fixtures/Call/php-method-call-by-ref.test
@@ -4,4 +4,4 @@
 /** @var int $x_1 */
 $x_1 = 1;
 $o_2 = (new \ArrayObject());
-($o_2->offsetSet(0, $x_1));
+(is_string($o_2) ? $o_2::offsetSet(0, $x_1) : $o_2->offsetSet(0, $x_1));

--- a/tests/php/Integration/Fixtures/Call/php-method-call-named-args.test
+++ b/tests/php/Integration/Fixtures/Call/php-method-call-named-args.test
@@ -2,4 +2,4 @@
 (let [o (php/new \ArrayObject)] (php/-> o (setFlags :& :flags 1)))
 --PHP--
 $o_1 = (new \ArrayObject());
-($o_1->setFlags(flags: 1));
+(is_string($o_1) ? $o_1::setFlags(flags: 1) : $o_1->setFlags(flags: 1));

--- a/tests/php/Integration/Fixtures/Call/php-object-call-local-target.test
+++ b/tests/php/Integration/Fixtures/Call/php-object-call-local-target.test
@@ -2,4 +2,4 @@
 (let [o (php/new \ArrayObject)] (php/-> o (count)))
 --PHP--
 $o_1 = (new \ArrayObject());
-($o_1->count());
+(is_string($o_1) ? $o_1::count() : $o_1->count());

--- a/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
@@ -34,7 +34,7 @@ interface IPlayer {
 
     public function __invoke($p) {
       if ((is_a($p, "interface_instance\\IPlayer"))) {
-        return ($p->choose());
+        return (is_string($p) ? $p::choose() : $p->choose());
       } else {
         throw (new \InvalidArgumentException("Value doesn't implement interface IPlayer"));
       }
@@ -61,7 +61,7 @@ interface IPlayer {
       if ((is_a($p, "interface_instance\\IPlayer"))) {
         return (function() use($p,$me,$you) {
           $target_1 = $p;
-          return $target_1->update_strategy($me, $you);
+          return is_string($target_1) ? $target_1::update_strategy($me, $you) : $target_1->update_strategy($me, $you);
         })();
       } else {
         throw (new \InvalidArgumentException("Value doesn't implement interface IPlayer"));

--- a/tests/php/Integration/Fixtures/Def/definterface.test
+++ b/tests/php/Integration/Fixtures/Def/definterface.test
@@ -32,7 +32,7 @@ interface IPlayer {
 
     public function __invoke($p) {
       if ((is_a($p, "user\\IPlayer"))) {
-        return ($p->choose());
+        return (is_string($p) ? $p::choose() : $p->choose());
       } else {
         throw (new \InvalidArgumentException("Value doesn't implement interface IPlayer"));
       }
@@ -59,7 +59,7 @@ interface IPlayer {
       if ((is_a($p, "user\\IPlayer"))) {
         return (function() use($p,$me,$you) {
           $target_1 = $p;
-          return $target_1->update_strategy($me, $you);
+          return is_string($target_1) ? $target_1::update_strategy($me, $you) : $target_1->update_strategy($me, $you);
         })();
       } else {
         throw (new \InvalidArgumentException("Value doesn't implement interface IPlayer"));

--- a/tests/php/Integration/Fixtures/Def/defstruct-two-interfaces.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-two-interfaces.test
@@ -53,7 +53,7 @@ final class my_type_with_two_interfaces extends \Phel\Lang\Collections\Struct\Ab
   public function foobar() {
     $v = $this->v;
     $this_3 = $this;
-    return ($this_3->foo());
+    return (is_string($this_3) ? $this_3::foo() : $this_3->foo());
   }
 }
 }

--- a/tests/php/Integration/Fixtures/PhpObjectCall/dot-call-on-inferred-string-class.test
+++ b/tests/php/Integration/Fixtures/PhpObjectCall/dot-call-on-inferred-string-class.test
@@ -1,0 +1,6 @@
+--PHEL--
+(let [cls "\\DateTimeImmutable"] (.createFromFormat cls "Y-m-d" "2024-03-10"))
+--PHP--
+/** @var string $cls_1 */
+$cls_1 = "\\DateTimeImmutable";
+($cls_1::createFromFormat("Y-m-d", "2024-03-10"));

--- a/tests/php/Integration/Fixtures/PhpObjectCall/dot-call-on-new-result-is-instance.test
+++ b/tests/php/Integration/Fixtures/PhpObjectCall/dot-call-on-new-result-is-instance.test
@@ -1,0 +1,5 @@
+--PHEL--
+(.format (php/new \DateTimeImmutable "2024-03-10") "Y")
+--PHP--
+$target_1 = (new \DateTimeImmutable("2024-03-10"));
+$target_1->format("Y");

--- a/tests/php/Integration/Fixtures/PhpObjectCall/dot-call-on-unknown-receiver.test
+++ b/tests/php/Integration/Fixtures/PhpObjectCall/dot-call-on-unknown-receiver.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [x] (.format x "Y"))
+--PHP--
+(function($x) {
+  return (is_string($x) ? $x::format("Y") : $x->format("Y"));
+});

--- a/tests/php/Integration/Fixtures/PhpObjectCall/static-call-on-class-name.test
+++ b/tests/php/Integration/Fixtures/PhpObjectCall/static-call-on-class-name.test
@@ -1,0 +1,4 @@
+--PHEL--
+(\DateTimeImmutable/createFromFormat "Y-m-d" "2024-03-10")
+--PHP--
+(\DateTimeImmutable::createFromFormat("Y-m-d", "2024-03-10"));

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/PhpObjectCallDispatchResolverTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/PhpObjectCallDispatchResolverTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MethodCallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpNewNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PropertyOrConstantAccessNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpObjectCallDispatch;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpObjectCallDispatchResolver;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Lang\TypeFactory;
+use PHPUnit\Framework\TestCase;
+
+final class PhpObjectCallDispatchResolverTest extends TestCase
+{
+    private PhpObjectCallDispatchResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new PhpObjectCallDispatchResolver();
+    }
+
+    public function test_static_form_dispatches_statically(): void
+    {
+        $node = $this->methodCallOn($this->untypedLocal(), isStatic: true);
+
+        self::assertSame(PhpObjectCallDispatch::StaticClass, $this->resolver->resolve($node));
+    }
+
+    /**
+     * `Foo->m()` is not valid PHP, so a class-name target is static even when the
+     * call was written as `php/->`.
+     */
+    public function test_class_name_target_dispatches_statically_even_when_written_as_instance_call(): void
+    {
+        $target = new PhpClassNameNode(
+            NodeEnvironment::empty(),
+            Symbol::create('\\DateTimeImmutable'),
+        );
+
+        $node = $this->methodCallOn($target, isStatic: false);
+
+        self::assertSame(PhpObjectCallDispatch::StaticClass, $this->resolver->resolve($node));
+    }
+
+    public function test_string_tagged_receiver_dispatches_statically(): void
+    {
+        $node = $this->methodCallOn($this->localTagged('string'), isStatic: false);
+
+        self::assertSame(PhpObjectCallDispatch::StaticClass, $this->resolver->resolve($node));
+    }
+
+    public function test_string_literal_receiver_dispatches_statically(): void
+    {
+        $target = new LiteralNode(NodeEnvironment::empty(), '\\DateTimeImmutable');
+
+        $node = $this->methodCallOn($target, isStatic: false);
+
+        self::assertSame(PhpObjectCallDispatch::StaticClass, $this->resolver->resolve($node));
+    }
+
+    /**
+     * A leading backslash must not defeat the string check, since `TagNormalizer`
+     * is what reconciles `string` with `\string`.
+     */
+    public function test_backslash_prefixed_string_tag_dispatches_statically(): void
+    {
+        $node = $this->methodCallOn($this->localTagged('\\string'), isStatic: false);
+
+        self::assertSame(PhpObjectCallDispatch::StaticClass, $this->resolver->resolve($node));
+    }
+
+    public function test_constructor_result_dispatches_as_instance(): void
+    {
+        $target = new PhpNewNode(
+            NodeEnvironment::empty(),
+            new PhpClassNameNode(NodeEnvironment::empty(), Symbol::create('\\DateTimeImmutable')),
+            [],
+        );
+
+        $node = $this->methodCallOn($target, isStatic: false);
+
+        self::assertSame(PhpObjectCallDispatch::Instance, $this->resolver->resolve($node));
+    }
+
+    public function test_chained_call_dispatches_as_instance(): void
+    {
+        $inner = $this->methodCallOn($this->untypedLocal(), isStatic: false);
+
+        $node = $this->methodCallOn($inner, isStatic: false);
+
+        self::assertSame(PhpObjectCallDispatch::Instance, $this->resolver->resolve($node));
+    }
+
+    /**
+     * A non-string tag proves the receiver is not a class name, so no runtime
+     * test is emitted even though the call will fail either way.
+     */
+    public function test_non_string_tagged_receiver_dispatches_as_instance(): void
+    {
+        $node = $this->methodCallOn($this->localTagged('int'), isStatic: false);
+
+        self::assertSame(PhpObjectCallDispatch::Instance, $this->resolver->resolve($node));
+    }
+
+    public function test_untyped_receiver_defers_to_runtime(): void
+    {
+        $node = $this->methodCallOn($this->untypedLocal(), isStatic: false);
+
+        self::assertSame(PhpObjectCallDispatch::Runtime, $this->resolver->resolve($node));
+    }
+
+    /**
+     * `$t::x` reads a class constant and `$t->x` a property, so a property access
+     * on an untyped receiver keeps `->` rather than choosing between two
+     * different members at runtime.
+     */
+    public function test_property_access_on_untyped_receiver_stays_an_instance_access(): void
+    {
+        $node = new PhpObjectCallNode(
+            NodeEnvironment::empty(),
+            $this->untypedLocal(),
+            new PropertyOrConstantAccessNode(NodeEnvironment::empty(), Symbol::create('prop')),
+            isStatic: false,
+            isMethodCall: false,
+        );
+
+        self::assertSame(PhpObjectCallDispatch::Instance, $this->resolver->resolve($node));
+    }
+
+    private function methodCallOn(AbstractNode $target, bool $isStatic): PhpObjectCallNode
+    {
+        return new PhpObjectCallNode(
+            NodeEnvironment::empty(),
+            $target,
+            new MethodCallNode(NodeEnvironment::empty(), Symbol::create('m'), []),
+            isStatic: $isStatic,
+            isMethodCall: true,
+        );
+    }
+
+    private function untypedLocal(): LocalVarNode
+    {
+        return new LocalVarNode(NodeEnvironment::empty(), Symbol::create('x'));
+    }
+
+    private function localTagged(string $tag): LocalVarNode
+    {
+        $symbol = Symbol::create('x')->withMeta(
+            TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('tag'), $tag),
+        );
+
+        return new LocalVarNode(NodeEnvironment::empty(), $symbol);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

A class name is a value in PHP, so `(.cases c)` with `c` holding `"\\App\\Status"` has to reach `$c::cases()`, while the same form on an object has to reach `$c->cases()`. Only `php/::` could do the first, which made it the last capability that form had over the Clojure-style syntax. That is the blocker #2881 was opened to remove, and the last real gap in the `php/*` audit in #2877.

Verified before this change, on `main`:

```bash
./bin/phel eval '(let [ec "\\Random\\IntervalBoundary"] (.cases ec))'
# Error: Call to a member function cases() on string
```

## 💡 Goal

Make the dot syntax total, so no program needs `php/::` for a runtime class name, **without asking anyone to annotate a type**. After this:

```bash
./bin/phel eval '(do (defn cases-of [c] (.cases c)) (count (cases-of "\\Random\\IntervalBoundary")))'
# => 4
```

## 🔖 Changes

**The operator is chosen from the receiver, not from the written form.** New `PhpObjectCallDispatchResolver` returns one of three dispatches:

| Receiver | Emits |
|---|---|
| provable class-name string (string literal, `string`-tagged local) | `$c::m(...)` |
| provable object (`php/new` result, a chained call's result, any non-string tag) | `$o->m(...)` |
| unprovable (an untagged fn param) | `is_string($t) ? $t::m(...) : $t->m(...)` |

Safe in one direction only, which is what makes it a non-breaking change: **`$string->m()` is never valid PHP**, so no program that compiles today changes meaning.

**It lives in the emitter, not the analyzer as #2881 proposed.** `LocalVarNode::getInferredType()` only reports a tag once the inferrers have grafted it, so an analyzer-side check reads `null` for every receiver. That is why `IterableTarget`, `TagNormalizer` and the `*Specialization` classes all consume it from the emitter too. `PhpObjectCallNode` and the analyzer are untouched, so the diff is smaller than the issue estimated.

**A coherence fix that came with it:** a `PhpClassNameNode` receiver now dispatches statically even when written as `php/->`. `Foo->BAR` was never valid PHP, so the written form cannot be what decides the operator. `PhpObjectCallEmitter`'s own comment already asserted this target was "inherently static" while `fnCode()` contradicted it.

**Property access is deliberately excluded.** `$t::x` reads a class constant and `$t->x` reads a property, so a runtime choice there would pick between two different members rather than two spellings of one. `(.-x c)` keeps `->`.

**`phel\reflect` migrated off `php/::`** (`keyword->enum`, `enum-values`). Those were the only two dynamic-class `php/::` calls in the repo, out of 313; the rest pass a literal class and are already covered by `(\C/m …)`.

### Why a ternary and not a callable array

`[$t, 'm'](...)` needs no duplicated argument list, so it was the first candidate. Measured against `$o->m()` on the object path, 5M iterations, best of 3:

| Shape | Plain CLI | OPcache + JIT |
|---|---|---|
| `is_string($t) ? :: : ->` | +7.8% | within noise |
| `[$t, 'm'](...)` | +240% | +179% |

### Perf, end to end

12 call sites in the compiled core gain the check, and they are the hot ones: `first`, `next`, `cdr`, `nextSeq`, `toPhpArray`, and map iteration. Measured with the resolver's fallback flipped in-tree so the only difference is this feature, median of 3 runs:

| Benchmark | Without | With |
|---|---|---|
| list traversal, 20k elements x20 | 68.0 ms | 69.8 ms |
| map iteration, 2k keys x50 | 326.3 ms | 319.2 ms |

Both inside run-to-run variance. Compiled core grows 76164 → 76593 bytes (+0.56%).

### Tests

- `PhpObjectCallDispatchResolverTest`: 10 cases, one per dispatch decision, including `\string` normalisation and the property-access carve-out
- 4 new fixtures under `Fixtures/PhpObjectCall/`, one per emitted shape
- 6 existing fixtures regenerated: they pin emitted PHP for receivers that are now unprovable

Suites: unit 4375 pass, integration 1117 pass, core 6564 pass. Psalm, cs-fixer, Rector and `validate:config` clean. PHPStan reports 34 errors, all in Gacela facades and factories and **identical on `main`** (verified in a clean worktree); none are in the files this PR touches.

### Known follow-up, deliberately not here

A `let`-bound constructor result is unprovable today, because `BindingTypeInferrer` infers primitives only:

```php
// (let [o (php/new \ArrayObject)] (.count o))
(is_string($o_1) ? $o_1::count() : $o_1->count());
```

Perf-neutral, but needless for a binding whose initialiser is `new \ArrayObject()`, and the reason 3 of the 6 fixtures churned. Teaching the inferrer to graft a class tag from `php/new` would remove it and revert those fixtures, but it reaches into a subsystem that documents itself as primitives-only and every `*Specialization` family consumes. Better reviewed on its own; tracked on #2881.

Refs #2881
