### PR TITLE
docs(spec): record the string-receiver interop divergence from #2881

### DIFF
--- a/docs/spec/clojure-divergences.md
+++ b/docs/spec/clojure-divergences.md
@@ -118,7 +118,29 @@ The one place Phel is *less* permissive. `phel.string` functions require a strin
 non-string rather than coercing through `str`. This matches ClojureScript, Basilisp and
 ClojureCLR; the JVM's coercing `:default` branch is the outlier.
 
-## 6. Absent concepts
+## 6. Host interop
+
+### A string receiver is a class name
+
+`(.m x)` reads a string `x` as a **class name**, so `(.cases "\\App\\Status")` reaches
+`App\Status::cases()`. Clojure reads the same receiver as the object, because a JVM
+`String` has methods and `(.length "abc")` has to work.
+
+The difference is forced by the host: PHP strings have no methods at all, so
+`$string->m()` is never valid PHP and there is no behaviour to preserve. Reading the
+receiver as a class name is therefore free here and impossible there. Clojure's own
+answer for a class known only at runtime is `clojure.lang.Reflector/invokeStaticMethod`,
+a function rather than syntax ([#2881](https://github.com/phel-lang/phel-lang/issues/2881)).
+
+A receiver the compiler can prove is an object still emits `->`, so only an unprovable
+one carries the runtime test.
+
+This is the one entry the suite does not pin, because no working program can observe it:
+a string receiver was an error before the change and is an error after it, and only the
+message differs. It is listed because the *capability* is a difference a Clojure reader
+will notice, not because a behaviour changed under them.
+
+## 7. Absent concepts
 
 | Clojure | Phel |
 |---|---|
@@ -126,7 +148,7 @@ ClojureCLR; the JVM's coercing `:default` branch is the outlier.
 | `special-symbol?` | Phel does not recognise the JVM special-symbol set |
 | Class objects (`string?` on a class) | classes are represented as strings |
 
-## 7. Known gap, not a decision
+## 8. Known gap, not a decision
 
 `case` returns `nil` when nothing matches and there is no default clause. Clojure
 throws. The suite marks this `:phel` with a note that it is arguably a real semantic


### PR DESCRIPTION
## 🤔 Background

#2885 made `(.m x)` reach a static method when `x` holds a class name. Its last acceptance item in #2881 was the matching entry in `docs/spec/clojure-divergences.md`, which did not ship with the code.

## 💡 Goal

Record it, so a Clojure reader meeting `(.cases "\\App\\Status")` finds a decision rather than a surprise.

## 🔖 Changes

New section 6, "Host interop", carrying the string-receiver entry. The former sections 6 and 7 renumber to 7 and 8; nothing links to numbered anchors on this page, so no other file moves.

The entry gives the host reason rather than only the behaviour: a JVM `String` has methods, so Clojure has to read `(.length "abc")` as the object, while PHP strings have none, so `$string->m()` is never valid PHP and reading the receiver as a class name costs nothing. It also names Clojure's own answer for a class known at runtime, `clojure.lang.Reflector/invokeStaticMethod`, which is a function rather than syntax.

**One honesty note, stated in the entry itself.** The page opens by claiming every entry is pinned by a `:phel` branch in `clojure-test-suite`. This one is not, so the entry says so and why: no working program can observe it, because a string receiver is an error both before and after the change and only the message differs. It is listed because the *capability* is a difference a Clojure reader will notice, not because behaviour changed under anyone. Adding an unpinned entry silently would have falsified the page's own contract.

Closes #2881
