### PR TITLE
fix(compiler): load project namespaces required under eval and nREPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `(:require my.ns)` of a project namespace now works under `phel eval` and the nREPL server, not only in the REPL. The source directories were resolved only when `*repl-mode*` was set, which only `phel repl` does, so everywhere else the require searched an empty path, silently loaded nothing, and the failure surfaced later as `Cannot resolve symbol` at the call site. Reported with a full repro in #2886
 - A multimethod's parameter list no longer renders as a gensym. `defmulti` named it with `(gensym)`, so `phel doc assert-expr` showed `(assert-expr & __phel_3167)`, with a different number on every run. It is `(assert-expr & args)` now. The generated `<name>-methods` and `<name>-prefers` tables also carry docstrings, since they are public (`defmethod` resolves them across namespaces) and were showing up undocumented
 - `filter`, `take-while` and `drop-while` now use Phel truthiness for the predicate result. A predicate returning `0`, `0.0`, `""`, `"0"` or `@[]` was silently dropping elements, so `(filter identity [0 1 2])` gave `@[1 2]` while the transducer arity gave all three. Only `nil` and `false` are false
 - `persistent!` now keeps the collection's metadata for maps, vectors and sets. Everything built through a transient inherits the fix, including the compiler's `assoc`/`conj` specialisation, where `(assoc (assoc m :b 2) :c 3)` lost `m`'s metadata as soon as `m` carried a type tag

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
@@ -7,7 +7,6 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\NsNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
-use Phel\Shared\BuildConstants;
 
 use function addslashes;
 use function assert;
@@ -79,14 +78,8 @@ final class NsEmitter implements NodeEmitterInterface
             // scanning again there picks the same namespace up twice.
             $this->outputEmitter->emitLine('$__phelBuildFacade = new \\Phel\\Build\\BuildFacade();');
             $this->outputEmitter->emitLine('$__phelSrcDirs = [];');
-            $this->outputEmitter->emitLine('if (!\\Phel::getDefinition(');
+            $this->outputEmitter->emitLine('if (!\\Phel\\Build\\BuildFacade::isBuildMode()) {');
             $this->outputEmitter->increaseIndentLevel();
-            $this->outputEmitter->emitStr('"');
-            $this->outputEmitter->emitStr(addslashes($this->outputEmitter->mungeEncodeRegistryKey('phel.core')));
-            $this->outputEmitter->emitLine('",');
-            $this->outputEmitter->emitStr('"');
-            $this->outputEmitter->emitStr(addslashes(BuildConstants::BUILD_MODE));
-            $this->outputEmitter->emitLine('")) {');
             $this->outputEmitter->emitLine('$__phelSrcDirs = (new \\Phel\\Command\\CommandFacade())->getAllPhelDirectories();');
             $this->outputEmitter->emitLine('$__phelCwd = getcwd();');
             $this->outputEmitter->emitLine('if ($__phelCwd !== false) { $__phelSrcDirs[] = $__phelCwd; }');

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\NsNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Shared\BuildConstants;
 
 use function addslashes;
 use function assert;
@@ -69,15 +70,22 @@ final class NsEmitter implements NodeEmitterInterface
             // In cache mode, don't emit any dependency loading code.
             // Dependencies are loaded in order by the test framework.
         } else {
+            // Resolve the project's source directories whenever this is *not* a
+            // build. The gate used to be `*repl-mode*`, which only `phel repl`
+            // sets, so `phel eval` and the nREPL server searched an empty path
+            // and every `(:require my.ns)` of a project namespace silently
+            // loaded nothing (#2886). Build mode is the right discriminator:
+            // Build resolves dependencies itself before evaluating each file, and
+            // scanning again there picks the same namespace up twice.
             $this->outputEmitter->emitLine('$__phelBuildFacade = new \\Phel\\Build\\BuildFacade();');
             $this->outputEmitter->emitLine('$__phelSrcDirs = [];');
-            $this->outputEmitter->emitLine('if (\\Phel::getDefinition(');
+            $this->outputEmitter->emitLine('if (!\\Phel::getDefinition(');
             $this->outputEmitter->increaseIndentLevel();
             $this->outputEmitter->emitStr('"');
             $this->outputEmitter->emitStr(addslashes($this->outputEmitter->mungeEncodeRegistryKey('phel.core')));
             $this->outputEmitter->emitLine('",');
             $this->outputEmitter->emitStr('"');
-            $this->outputEmitter->emitStr(addslashes('*repl-mode*'));
+            $this->outputEmitter->emitStr(addslashes(BuildConstants::BUILD_MODE));
             $this->outputEmitter->emitLine('")) {');
             $this->outputEmitter->emitLine('$__phelSrcDirs = (new \\Phel\\Command\\CommandFacade())->getAllPhelDirectories();');
             $this->outputEmitter->emitLine('$__phelCwd = getcwd();');

--- a/tests/php/Integration/Run/KebabNamespaceRequire/KebabNamespaceRequireTest.php
+++ b/tests/php/Integration/Run/KebabNamespaceRequire/KebabNamespaceRequireTest.php
@@ -51,6 +51,38 @@ final class KebabNamespaceRequireTest extends TestCase
         self::assertSame(1, LoadCounter::countFor('kebabns.plainlib'));
     }
 
+    /**
+     * The `phel eval` and nREPL case from #2886: a project namespace has to load
+     * from the configured source directories even though no REPL is running, so
+     * a definition it exports resolves at the call site.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function test_a_project_namespace_loads_outside_a_repl_session(): void
+    {
+        $this->bootRepl();
+
+        $this->evalCode('(ns consumer (:require kebabns.plainlib))');
+
+        self::assertSame(
+            1,
+            LoadCounter::countFor('kebabns.plainlib'),
+            'A project namespace must load without `*repl-mode*` being set.',
+        );
+        self::assertSame(
+            'hello',
+            $this->evalCode('(kebabns.plainlib/greet)'),
+            'The required namespace must export its definitions to the caller.',
+        );
+    }
+
+    /**
+     * No `*repl-mode*` is set here on purpose. The emitted require code used to
+     * resolve source directories only when that flag was on, which only `phel
+     * repl` sets, so `phel eval` and the nREPL server walked an empty directory
+     * list and loaded nothing (#2886). Booting without the flag is what keeps
+     * that fixed: if the gate returns, every test in this class fails.
+     */
     private function bootRepl(): void
     {
         Phel::bootstrap(__DIR__);
@@ -59,14 +91,10 @@ final class KebabNamespaceRequireTest extends TestCase
             __DIR__ . '/../../../../../src/phel/core.phel',
             tempnam(sys_get_temp_dir(), 'phel-core'),
         );
-
-        // The emitted require code only resolves source directories when the
-        // session is a REPL/eval one; without this it walks an empty dir list.
-        Phel::addDefinition('phel.core', '*repl-mode*', true);
     }
 
-    private function evalCode(string $phelCode): void
+    private function evalCode(string $phelCode): mixed
     {
-        new CompilerFacade()->eval($phelCode, new CompileOptions());
+        return new CompilerFacade()->eval($phelCode, new CompileOptions());
     }
 }

--- a/tests/php/Integration/Run/RequireBuildMode/Fixtures/example/game.phel
+++ b/tests/php/Integration/Run/RequireBuildMode/Fixtures/example/game.phel
@@ -1,6 +1,9 @@
 (ns buildmode\game)
 
-(def executed-file (str (php/constant "__DIR__") "/executed.txt"))
+; Not `(php/constant "__DIR__")`: PHP's `constant()` reads defined constants, not
+; compile-time magic ones, so that throws as soon as this file is really
+; evaluated. `*file*` is emitted per namespace and holds this file's path.
+(def executed-file (str (php/dirname *file*) "/executed.txt"))
 
 (when-not *build-mode*
   (php/file_put_contents executed-file "executed"))

--- a/tests/php/Integration/Run/RequireBuildMode/Fixtures/example/game.phel
+++ b/tests/php/Integration/Run/RequireBuildMode/Fixtures/example/game.phel
@@ -1,9 +1,9 @@
 (ns buildmode\game)
 
 ; Not `(php/constant "__DIR__")`: PHP's `constant()` reads defined constants, not
-; compile-time magic ones, so that throws as soon as this file is really
-; evaluated. `*file*` is emitted per namespace and holds this file's path.
-(def executed-file (str (php/dirname *file*) "/executed.txt"))
+; compile-time magic ones, so that threw as soon as this file was really
+; evaluated.
+(def executed-file (str __DIR__ "/executed.txt"))
 
 (when-not *build-mode*
   (php/file_put_contents executed-file "executed"))

--- a/tests/php/Integration/Run/RequireBuildMode/RequireBuildModeTest.php
+++ b/tests/php/Integration/Run/RequireBuildMode/RequireBuildModeTest.php
@@ -19,6 +19,15 @@ final class RequireBuildModeTest extends TestCase
         $fixtures = __DIR__ . '/Fixtures';
         Phel::bootstrap(__DIR__);
 
+        // `game.phel` calls `str` and reads `*build-mode*` at its top level, so
+        // the required file cannot compile without core in the registry. Until
+        // #2886 the require resolved nothing here, so the file was never loaded
+        // and this passed without ever exercising the path it names.
+        new BuildFacade()->compileFile(
+            __DIR__ . '/../../../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core'),
+        );
+
         Phel::addDefinition('phel\\repl', 'src-dirs', [$fixtures]);
 
         $executedFile = $fixtures . '/example/executed.txt';
@@ -28,6 +37,17 @@ final class RequireBuildModeTest extends TestCase
 
         new BuildFacade()->evalFile($fixtures . '/example/main.phel');
 
-        self::assertFileDoesNotExist($executedFile);
+        // Assert the require actually happened first. On its own, the
+        // file-absence assertion below is satisfied by never loading the
+        // dependency at all, which is how this test stayed green while loading
+        // nothing (#2886).
+        self::assertTrue(
+            Phel::isNamespaceLoaded('buildmode.game'),
+            'The required namespace must be loaded.',
+        );
+        self::assertFileDoesNotExist(
+            $executedFile,
+            'The dependency loads under build mode, so its non-build side effect must not run.',
+        );
     }
 }

--- a/tests/php/Integration/Run/RequireBuildMode/phel-config.php
+++ b/tests/php/Integration/Run/RequireBuildMode/phel-config.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'src-dirs' => [
+        '../../../../../src/phel/',
+        'Fixtures/',
+    ],
+    'test-dirs' => [],
+    'vendor' => '../../../../../../vendor/',
+    // Force a fresh compile on every run: on a warm compiled-code cache the
+    // cached file is required directly and cache-mode ns emission contains
+    // no runtime dependency loading (frameworks preload deps in order), so
+    // the require path under test would never fire.
+    'enable-compiled-code-cache' => false,
+];

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitterTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitterTest.php
@@ -54,7 +54,13 @@ final class NsEmitterTest extends TestCase
         self::assertStringContainsString('"app.module"', $output);
     }
 
-    public function test_ns_with_requires_emits_repl_gated_fallback(): void
+    /**
+     * Only `phel repl` sets `*repl-mode*`, so gating the source-directory lookup
+     * on it left `phel eval` and the nREPL server searching an empty path, and
+     * every `(:require my.ns)` of a project namespace silently loaded nothing
+     * (#2886).
+     */
+    public function test_ns_with_requires_resolves_source_directories_without_a_repl_gate(): void
     {
         $node = new NsNode('my\\app', [Symbol::create('phel\\string')], []);
 
@@ -62,13 +68,13 @@ final class NsEmitterTest extends TestCase
         $this->nsEmitter->emit($node);
         $output = (string) ob_get_clean();
 
-        self::assertStringContainsString(
+        self::assertStringNotContainsString(
             '*repl-mode*',
             $output,
-            'Fallback should be gated on REPL mode',
+            'The source-directory lookup must not be gated on REPL mode',
         );
         self::assertStringContainsString(
-            'CommandFacade',
+            'getAllPhelDirectories',
             $output,
             'Fallback should use CommandFacade to resolve directories',
         );

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitterTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitterTest.php
@@ -68,6 +68,11 @@ final class NsEmitterTest extends TestCase
         $this->nsEmitter->emit($node);
         $output = (string) ob_get_clean();
 
+        self::assertStringContainsString(
+            'BuildFacade::isBuildMode()',
+            $output,
+            'The lookup should be skipped during builds only, so eval and nREPL can load requires',
+        );
         self::assertStringNotContainsString(
             '*repl-mode*',
             $output,


### PR DESCRIPTION
## 🤔 Background

@jasalt reported in #2886 that `(:require ...)` of a project namespace works in the REPL but fails under `phel eval` and nREPL with `[PHEL001] Cannot resolve symbol 'plus'`.

It is not a `:refer` problem. All three spellings fail identically, and the same code in a file works, so the namespace was never loaded at all:

```bash
phel eval - <<'EOF'   # Cannot resolve symbol 'plus'
(ns demo.test (:require demo :refer [plus]))
(plus 1 2)
EOF

phel eval - <<'EOF'   # Cannot resolve symbol 'demo/plus'
(ns demo.test (:require demo))
(demo/plus 1 2)
EOF

phel run src/runner.phel   # => 3
```

## 💡 Goal

Make a project `:require` load under every interactive evaluation path, not just the REPL.

## 🔖 Changes

`NsEmitter::emitRequiredNamespaces()` resolved the project's source directories only when `*repl-mode*` was set, and `ReplCommand.php:127` is the only place that sets it. So `phel eval` and nREPL called `getDependenciesForNamespace([], ['demo'])`, resolved nothing, evaluated nothing, and reported nothing. The error appeared later at the first use of a definition that was never loaded, which is what made it look like `:refer`.

**Gate on build mode instead of REPL mode.** Build resolves dependencies itself before evaluating each file, so scanning again there discovers the same namespace twice; everything else that reaches this branch is interactive evaluation and wants the project's source directories.

I first tried removing the gate outright. That broke 19 `Build\Command\*` tests with `The last one will be used. Check your phel-config.php srcDirs/testDirs settings.`, which is what identified Build's `evalFile` as the other consumer of this branch. Worth recording, because "this branch is only the REPL" is the assumption that produced the original bug.

**Why not just set `*repl-mode*` from `EvalCommand` and the nREPL command.** That flag carries two other jobs: `GlobalEnvironment::shouldThrowOnDuplicateDefinition()` suppresses duplicate-definition errors under it, and `ReplReferInjector` injects the `phel.repl` refers (`doc`, `require`, `use`, ...). Setting it from two more commands would have widened both behaviours to `phel eval` as a side effect of fixing a require bug.

### Verified

All four spellings now work under `phel eval`, and nREPL answers over the wire:

```bash
CODE='(ns demo.test (:require demo :refer [plus])) (plus 1 2)'
printf 'd2:op4:eval4:code%s:%se' "${#CODE}" "$CODE" | nc -w 4 127.0.0.1 7899
# d2:ns4:user5:value1:3ed6:statusl4:doneee
```

`phel repl` and `phel run` are unchanged.

### Tests

- `NsEmitterTest`: the old test asserted the gate existed (`test_ns_with_requires_emits_repl_gated_fallback`), so it was inverted into a guard that the source-directory lookup is **not** gated on REPL mode.
- `KebabNamespaceRequireTest` no longer sets `*repl-mode*` by hand. Its own comment said "without this it walks an empty dir list", which was this bug observed from the inside. Removing that line makes the whole class a regression guard, plus one new test asserting a project namespace loads outside a REPL session and its definitions resolve.

Suites: unit 4375 pass, integration 1118 pass, core 6564 pass. Psalm and cs-fixer clean.

### Follow-up, filed separately

#2891: a `:require` that resolves to no file is silent, in every mode. That is why this bug surfaced at the call site instead of at the require, and it is a different cause (a missing check, not an empty path), so it is not bundled here.

Closes #2886
