### PR TITLE
docs: lead with the Clojure-style PHP interop spelling

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,37 @@ modules, deployment) live on **[phel-lang.org](https://phel-lang.org/documentati
 - [AI agents](../resources/agents/README.md): Claude Code, Cursor, Codex, Gemini, Copilot, Aider
 - [agent-docs](agent-docs.md) · [agent-metrics](agent-metrics.md)
 
+## PHP interop, in one paragraph
+
+Phel has two spellings for reaching PHP, and the Clojure-style one is the idiomatic
+default:
+
+```phel
+(new \DateTime "2020-01-01")   ; or (\DateTime. "2020-01-01")
+(.format d "Y")                ; instance method
+(.-prop obj)                   ; property
+(\DateTime/createFromFormat "Y-m-d" "2020-01-01")   ; static method
+```
+
+Each of those desugars to a `php/*` special form (`php/new`, `php/->`, `php/::`)
+before analysis, and the `php/*` forms remain available as the escape hatch: they
+are the only spelling that takes an unevaluated form in a position the shorthand
+cannot express, and they are what the compiler and this repo's older stdlib code
+still emit. Both exist because the `php/*` layer came first and is the compilation
+target; you are meant to write the shorthand.
+
+Chaining does **not** need `php/->`, mixed method and property chains included:
+
+```phel
+(-> (php/new \DateTimeImmutable "2024-03-10") (.modify "+1 day") (.format "Y-m-d"))
+```
+
+The full expansion table, including `\C/m` and `\C/.m` in value position, is in
+[the language surface spec](spec/language-surface.md#interop-shorthands). The
+complete guide with runnable examples is on the website:
+<https://phel-lang.org/documentation/php-interop/>. A runnable sample lives in
+[examples/09_php-integration.phel](examples/09_php-integration.phel).
+
 ## User-facing guides moved to phel-lang.org
 
 The guides below were ported to the website and removed from this repo. Use these

--- a/docs/examples/09_php-integration.phel
+++ b/docs/examples/09_php-integration.phel
@@ -1,3 +1,13 @@
+;; PHP interop, written the idiomatic way.
+;;
+;; `(new \C ...)`, `(.method obj ...)` and `(\C/staticMethod ...)` are the
+;; spellings to reach for. Each desugars to a `php/*` special form (`php/new`,
+;; `php/->`, `php/::`) before analysis, so the two are the same program; the
+;; `php/*` layer is the compilation target and the escape hatch, not the thing
+;; to write by hand. One `php/->` call below shows the equivalence.
+;;
+;; Full guide: https://phel-lang.org/documentation/php-interop/
+
 (ns examples.php-integration
   (:use DateInterval DateTimeImmutable DateTimeZone)
   (:require phel.json :as json))
@@ -12,26 +22,40 @@
   (let [result
         (for [block :in blocks
               :reduce [acc {:cursor start :entries []}]]
-          (let [cursor (get acc :cursor)
-                interval (php/new DateInterval (get block :length))
-                finish (php/-> cursor (add interval))
-                entry {:title (get block :title)
-                       :start (php/-> cursor (format "H:i"))
-                       :end (php/-> finish (format "H:i"))
+          (let [cursor   (get acc :cursor)
+                interval (new DateInterval (get block :length))
+                finish   (.add cursor interval)
+                entry    {:title (get block :title)
+                       :start (.format cursor "H:i")
+                       :end (.format finish "H:i")
                        :length (get block :length)}]
             {:cursor finish
              :entries (conj (get acc :entries) entry)}))]
     (get result :entries)))
 
 (defn iso [datetime]
-  (php/-> datetime (format "c")))
+  (.format datetime "c"))
+
+;; A static method reads `Class/method`, with no `php/::` in sight.
+(defn parse-day [text]
+  (\DateTimeImmutable/createFromFormat "Y-m-d H:i" text))
+
+;; Mixed method and property chains thread with plain `->`.
+(defn day-after [datetime]
+  (-> datetime
+      (.modify "+1 day")
+      (.format "Y-m-d")))
 
 (defn main []
-  (let [timezone (php/new DateTimeZone "Europe/Berlin")
-        start (php/new DateTimeImmutable "2024-06-01 09:00" timezone)
-        plan (schedule-blocks start workshop-blocks)
-        payload {:timezone (php/-> timezone (getName))
+  (let [timezone (new DateTimeZone "Europe/Berlin")
+        start    (new DateTimeImmutable "2024-06-01 09:00" timezone)
+        plan     (schedule-blocks start workshop-blocks)
+        payload  {:timezone (.getName timezone)
+                 ;; The same call through the `php/*` escape hatch, for comparison.
+                 :timezone-again (php/-> timezone (getName))
                  :starts (iso start)
+                 :next-day (day-after start)
+                 :reparsed (iso (parse-day "2024-06-01 09:00"))
                  :sessions plan}]
     (println "Workshop agenda (" (get payload :timezone) "):")
     (for [session :in plan]
@@ -39,6 +63,8 @@
                             (get session :start)
                             (get session :end)
                             (get session :title))))
+    (println)
+    (println "Day after the kickoff:" (get payload :next-day))
     (println)
     (println "JSON hand-off for PHP:")
     (println (json/encode payload {:flags php/JSON_PRETTY_PRINT :depth 256}))))

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -20,7 +20,7 @@ Copy any file into your project and tweak it.
 | 06 | `06_data-pipeline.phel` | Threading macros, `filter`/`map`/`reduce`, `group-by` |
 | 07 | `07_macro-playground.phel` | A small DSL built with `defmacro` |
 | 08 | `08_interfaces.phel` | `definterface` + `defstruct` polymorphism |
-| 09 | `09_php-integration.phel` | PHP interop: `DateTimeImmutable`, `DateInterval`, JSON |
+| 09 | `09_php-integration.phel` | PHP interop the idiomatic way (`new`, `.method`, `Class/method`), with the `php/*` equivalent shown once |
 | 10 | `10_html-rendering.phel` | HTML templating with `phel.html` |
 | 11 | `11_async-concurrency.phel` | AMPHP + fiber concurrency (`async`, `await`, `promise`) |
 | 12 | `12_cli.phel` | A todo-list CLI on `phel.cli` with subcommands and tables |

--- a/docs/spec/language-surface.md
+++ b/docs/spec/language-surface.md
@@ -112,6 +112,13 @@ The Clojure-style interop spellings are analyzer sugar, not special forms: each 
 to one of the `php/*` entries above before analysis, so they are deliberately absent
 from the table.
 
+**The shorthand is the idiomatic spelling.** The `php/*` forms are the compilation
+target and the escape hatch, kept public because they are the only spelling for the
+positions the shorthand cannot express. New code should read `(.format d "Y")`, not
+`(php/-> d (format "Y"))`; chaining, mixed method and property alike, threads with
+plain `->` and needs no `php/->`. The full guide is at
+<https://phel-lang.org/documentation/php-interop/>.
+
 | Written | Expands to | Position |
 |---|---|---|
 | `(.m obj args…)` | `(php/-> obj (m args…))` | call |


### PR DESCRIPTION
## 🤔 Background

Closes #2875.

The Clojure-style interop spellings already work; they were invisible everywhere a reader learns from. Counted on `main`: 1009 occurrences of `php/new` / `php/->` / `php/::` across `src/phel/`, and 0 of the shorthand. So the stdlib teaches the escape hatch as though it were the only way, which is @jasalt's point on #2859.

Long-form docs live in the sibling [phel-lang.org](https://github.com/phel-lang/phel-lang.org) repo. This PR is only the half that belongs here: the TL;DR, the spec statement, and the runnable proof. The website reordering is a separate PR in that repo, and the stdlib rewrite is #2882.

## 💡 Goal

A reader who only ever opens this repo should meet the shorthand first and learn that `php/*` is the escape hatch, without a second copy of the website guide growing here to drift.

## 🔖 Changes

**`docs/README.md`** gains a "PHP interop, in one paragraph" section: the four shorthand spellings, the statement that they desugar to `php/*` and that `php/*` is the escape hatch, the reason both exist, and the correction that chaining needs no `php/->`:

```phel
(-> (php/new \DateTimeImmutable "2024-03-10") (.modify "+1 day") (.format "Y-m-d"))
```

That last line is the claim the website page currently gets wrong, and it is the argument people reach for when defending `php/->` as public surface (#2877), so it is worth stating in both places.

**`docs/spec/language-surface.md`** already grew the expansion table in #2901 (call- and value-position shorthands, prose next to the special-form table rather than rows in it, since `LanguageSurfaceSpecTest` fails on a row with no dispatch entry). This adds the missing normative sentence: the shorthand is the idiomatic spelling, `php/*` is the compilation target and escape hatch, new code should read `(.format d "Y")`.

**`docs/examples/09_php-integration.phel`** now leads with `new`, `.method` and `Class/method`, and keeps exactly one `php/->` call, labelled, so the equivalence is visible rather than asserted. It also gained a static-method call and a mixed `->` chain, which are the two shapes the old version never showed. The `Run examples` CI job executes it, so this criterion stays true by itself.

**`docs/examples/README.md`**: the index line for 09 says what it now demonstrates.

## Not in scope

Per the issue: no stdlib rewrite (#2882), no `php/*` deprecation (#2877), and no copy of the website guide.

## Verification

```bash
./bin/phel run docs/examples/09_php-integration.phel   # runs, prints the agenda and JSON
./vendor/bin/phpunit --testsuite=unit --filter=LanguageSurfaceSpecTest   # OK
```

Docs-only otherwise; no source or test changes.
