### PR TITLE
ref(stdlib): write the standard library in the Clojure-style interop spelling

### DIFF
--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -73,10 +73,10 @@
         env-var  (provider-env-var provider)]
     (or (get cfg :api-key)
         (php/getenv env-var)
-        (throw (php/new RuntimeException
-                        (str "No API key configured for provider " provider
-                             ". Use (ai/configure {:api-key \"...\"}) or set "
-                             env-var " env var."))))))
+        (throw (new RuntimeException
+                    (str "No API key configured for provider " provider
+                         ". Use (ai/configure {:api-key \"...\"}) or set "
+                         env-var " env var."))))))
 
 ;; -----------
 ;; Provider-specific request builders
@@ -247,9 +247,9 @@
     (when (or (< status 200) (>= status 300))
       (let [body   (get response :body)
             parsed (try (json/decode body) (catch \Throwable _e nil))]
-        (throw (php/new RuntimeException
-                        (str "AI API error (HTTP " status "): "
-                             (provider-error-message parsed body))))))))
+        (throw (new RuntimeException
+                    (str "AI API error (HTTP " status "): "
+                         (provider-error-message parsed body))))))))
 
 (defn- send-request
   "Sends a prepared request map with retry + timeout."
@@ -307,7 +307,7 @@
                    (anthropic-request cfg messages system))
         body     (send-request cfg req)]
     (or (extract-text provider body)
-        (throw (php/new RuntimeException "No text content in AI response")))))
+        (throw (new RuntimeException "No text content in AI response")))))
 
 (defn complete
   "Sends a simple text completion request.
@@ -389,8 +389,8 @@ Useful for building multi-turn conversations."
         end   (php/strrpos trimmed close)]
     (if (and start end (>= end start))
       (php/substr trimmed start (+ (- end start) 1))
-      (throw (php/new RuntimeException
-                      (str error-prefix (truncate-for-error trimmed)))))))
+      (throw (new RuntimeException
+                  (str error-prefix (truncate-for-error trimmed)))))))
 
 (defn- extract-json-from-response
   "Extracts JSON from an AI response, handling markdown code blocks."
@@ -568,20 +568,20 @@ Similar to `extract`, but returns a vector of maps when the text contains multip
     (loop [msgs messages
            turn 0]
       (when (>= turn max-turns)
-        (throw (php/new RuntimeException
-                        (str "run-tools exceeded :max-turns (" max-turns ")"))))
+        (throw (new RuntimeException
+                    (str "run-tools exceeded :max-turns (" max-turns ")"))))
       (let [response (chat-with-tools msgs tools opts)
             calls    (get response :tool-calls)]
         (if (empty? calls)
           (or (get response :text)
-              (throw (php/new RuntimeException "run-tools: model returned no text and no tool calls")))
+              (throw (new RuntimeException "run-tools: model returned no text and no tool calls")))
           (let [assistant (assistant-message (get response :raw))
                 results   (for [c :in calls]
                             (let [name-str (get c :name)
                                   handler  (get handlers name-str)]
                               (when (nil? handler)
-                                (throw (php/new RuntimeException
-                                                (str "run-tools: no handler for tool '" name-str "'"))))
+                                (throw (new RuntimeException
+                                            (str "run-tools: no handler for tool '" name-str "'"))))
                               (tool-result (get c :id) (handler (get c :input)))))
                 next-msgs (concat msgs [assistant] results)]
             (recur next-msgs (+ turn 1))))))))
@@ -596,7 +596,7 @@ Similar to `extract`, but returns a vector of maps when the text contains multip
    :see-also ["cosine-similarity" "magnitude"]}
   [a b]
   (when (not= (count a) (count b))
-    (throw (php/new RuntimeException "Vectors must have the same length for dot product.")))
+    (throw (new RuntimeException "Vectors must have the same length for dot product.")))
   (apply + (map * a b)))
 
 (defn magnitude

--- a/src/phel/cli.phel
+++ b/src/phel/cli.phel
@@ -18,28 +18,28 @@
 ;; =============================================================================
 
 (def- arg-modes
-  {:required (php/:: InputArgument REQUIRED)
-   :optional (php/:: InputArgument OPTIONAL)
-   :array    (php/:: InputArgument IS_ARRAY)})
+  {:required InputArgument/REQUIRED
+   :optional InputArgument/OPTIONAL
+   :array    InputArgument/IS_ARRAY})
 
 (def- opt-modes
-  {:none      (php/:: InputOption VALUE_NONE)
-   :required  (php/:: InputOption VALUE_REQUIRED)
-   :optional  (php/:: InputOption VALUE_OPTIONAL)
-   :array     (php/:: InputOption VALUE_IS_ARRAY)
-   :negatable (php/:: InputOption VALUE_NEGATABLE)})
+  {:none      InputOption/VALUE_NONE
+   :required  InputOption/VALUE_REQUIRED
+   :optional  InputOption/VALUE_OPTIONAL
+   :array     InputOption/VALUE_IS_ARRAY
+   :negatable InputOption/VALUE_NEGATABLE})
 
 (defn- arg-mode [mode]
   (or (get arg-modes mode)
-      (throw (php/new InvalidArgumentException
-                      (str "phel\\cli: invalid :args :mode "
-                           mode ". Use one of :required :optional :array")))))
+      (throw (new InvalidArgumentException
+                  (str "phel\\cli: invalid :args :mode "
+                       mode ". Use one of :required :optional :array")))))
 
 (defn- opt-mode [mode]
   (or (get opt-modes mode)
-      (throw (php/new InvalidArgumentException
-                      (str "phel\\cli: invalid :opts :mode " mode
-                           ". Use one of :none :required :optional :array :negatable")))))
+      (throw (new InvalidArgumentException
+                  (str "phel\\cli: invalid :opts :mode " mode
+                       ". Use one of :none :required :optional :array :negatable")))))
 
 (defn- coerce-value [value coerce-kw]
   (cond
@@ -50,9 +50,9 @@
     (= coerce-kw :bool)    (boolean value)
     (= coerce-kw :keyword) (keyword value)
     (= coerce-kw :edn)     (read-string value)
-    true                   (throw (php/new InvalidArgumentException
-                                           (str "phel\\cli: invalid :coerce " coerce-kw
-                                                ". Use :int :float :bool :keyword :edn")))))
+    true                   (throw (new InvalidArgumentException
+                                       (str "phel\\cli: invalid :coerce " coerce-kw
+                                            ". Use :int :float :bool :keyword :edn")))))
 
 ;; =============================================================================
 ;; Spec validation
@@ -60,14 +60,14 @@
 
 (defn- assert-key! [m k pred msg]
   (when-not (pred (get m k))
-    (throw (php/new InvalidArgumentException (str "phel\\cli: " msg)))))
+    (throw (new InvalidArgumentException (str "phel\\cli: " msg)))))
 
 (defn- validate-arg [a]
   (assert-key! a :name string? ":args entries must have a string :name")
   (when (contains? a :mode)
     (when-not (contains? arg-modes (get a :mode))
-      (throw (php/new InvalidArgumentException
-                      (str "phel\\cli: invalid :args :mode " (get a :mode))))))
+      (throw (new InvalidArgumentException
+                  (str "phel\\cli: invalid :args :mode " (get a :mode))))))
   (when (contains? a :complete)
     (assert-key! a :complete fn? ":args :complete must be a fn (ctx -> vector)")))
 
@@ -75,14 +75,14 @@
   (assert-key! o :name string? ":opts entries must have a string :name")
   (when (contains? o :mode)
     (when-not (contains? opt-modes (get o :mode))
-      (throw (php/new InvalidArgumentException
-                      (str "phel\\cli: invalid :opts :mode " (get o :mode))))))
+      (throw (new InvalidArgumentException
+                  (str "phel\\cli: invalid :opts :mode " (get o :mode))))))
   (when (contains? o :complete)
     (assert-key! o :complete fn? ":opts :complete must be a fn (ctx -> vector)")))
 
 (defn- validate-command-spec [spec]
   (when-not (map? spec)
-    (throw (php/new InvalidArgumentException "phel\\cli: command spec must be a map")))
+    (throw (new InvalidArgumentException "phel\\cli: command spec must be a map")))
   (assert-key! spec :name string? "command :name is required (string)")
   (assert-key! spec :run  fn?     "command :run is required (fn)")
   (foreach [a (get spec :args [])] (validate-arg a))
@@ -104,7 +104,7 @@
   {:see-also ["opt" "argv"]
    :example  "(arg ctx \"port\") ; coerced when spec has :coerce :int"}
   [ctx name]
-  (coerce-value (php/-> (get ctx :input) (getArgument name))
+  (coerce-value (.getArgument (get ctx :input) name)
                 (get (find-arg-spec ctx name) :coerce)))
 
 (defn opt
@@ -112,7 +112,7 @@
   {:see-also ["arg"]
    :example  "(opt ctx \"verbose\") ; true when --verbose present and :mode :none"}
   [ctx name]
-  (coerce-value (php/-> (get ctx :input) (getOption name))
+  (coerce-value (.getOption (get ctx :input) name)
                 (get (find-opt-spec ctx name) :coerce)))
 
 (defn writeln
@@ -120,21 +120,21 @@
   {:see-also ["write" "info" "success"]
    :example  "(writeln ctx \"ready\")"}
   [ctx text]
-  (php/-> (get ctx :output) (writeln text)))
+  (.writeln (get ctx :output) text))
 
 (defn write
   "Write text without trailing newline."
   [ctx text]
-  (php/-> (get ctx :output) (write text)))
+  (.write (get ctx :output) text))
 
 (defn- write-at-verbosity [ctx level text]
   (let [out (get ctx :output)]
-    (when (>= (php/-> out (getVerbosity)) level)
-      (php/-> out (writeln text)))))
+    (when (>= (.getVerbosity out) level)
+      (.writeln out text))))
 
-(defn info-v  "Write only when -v or higher."  [ctx text] (write-at-verbosity ctx (php/:: OutputInterface VERBOSITY_VERBOSE) text))
-(defn info-vv "Write only when -vv or higher." [ctx text] (write-at-verbosity ctx (php/:: OutputInterface VERBOSITY_VERY_VERBOSE) text))
-(defn debug   "Write only when -vvv (debug)."  [ctx text] (write-at-verbosity ctx (php/:: OutputInterface VERBOSITY_DEBUG) text))
+(defn info-v  "Write only when -v or higher."  [ctx text] (write-at-verbosity ctx OutputInterface/VERBOSITY_VERBOSE text))
+(defn info-vv "Write only when -vv or higher." [ctx text] (write-at-verbosity ctx OutputInterface/VERBOSITY_VERY_VERBOSE text))
+(defn debug   "Write only when -vvv (debug)."  [ctx text] (write-at-verbosity ctx OutputInterface/VERBOSITY_DEBUG text))
 
 (defn- styled [ctx tag text]
   (writeln ctx (str "<" tag ">" text "</" tag ">")))
@@ -151,44 +151,44 @@
   "Return a cached `SymfonyStyle` bound to the context so successive
   `ask`/`confirm`/progress calls share state."
   {:see-also ["title" "success" "ask"]
-   :example  "(-> (style ctx) (php/-> (success \"Done!\")))"}
+   :example  "(-> (style ctx) (.success \"Done!\"))"}
   [ctx]
   (or (get ctx :style)
-      (php/new SymfonyStyle (get ctx :input) (get ctx :output))))
+      (new SymfonyStyle (get ctx :input) (get ctx :output))))
 
-(defn title    "Heavy heading."           [ctx text]  (php/-> (style ctx) (title text)))
-(defn section  "Sub-heading."             [ctx text]  (php/-> (style ctx) (section text)))
-(defn success  "Boxed success message."   [ctx text]  (php/-> (style ctx) (success text)))
-(defn warning  "Boxed warning message."   [ctx text]  (php/-> (style ctx) (warning text)))
-(defn note     "Boxed note."              [ctx text]  (php/-> (style ctx) (note text)))
-(defn caution  "Boxed caution message."   [ctx text]  (php/-> (style ctx) (caution text)))
-(defn listing  "Bulleted list of items."  [ctx items] (php/-> (style ctx) (listing (apply php/array items))))
+(defn title    "Heavy heading."           [ctx text]  (.title (style ctx) text))
+(defn section  "Sub-heading."             [ctx text]  (.section (style ctx) text))
+(defn success  "Boxed success message."   [ctx text]  (.success (style ctx) text))
+(defn warning  "Boxed warning message."   [ctx text]  (.warning (style ctx) text))
+(defn note     "Boxed note."              [ctx text]  (.note (style ctx) text))
+(defn caution  "Boxed caution message."   [ctx text]  (.caution (style ctx) text))
+(defn listing  "Bulleted list of items."  [ctx items] (.listing (style ctx) (apply php/array items)))
 
 (defn ask
   "Free-text prompt. `default` optional."
   {:see-also ["ask-hidden" "confirm" "choice"]
    :example  "(ask ctx \"Your name?\" \"alice\")"}
   [ctx question & [default]]
-  (php/-> (style ctx) (ask question default)))
+  (.ask (style ctx) question default))
 
 (defn ask-hidden
   "Prompt without echoing (passwords)."
   [ctx question]
-  (php/-> (style ctx) (askHidden question)))
+  (.askHidden (style ctx) question))
 
 (defn confirm
   "Yes/no prompt. `default?` defaults to true."
   {:see-also ["ask"]
    :example  "(when (confirm ctx \"Deploy?\") ...)"}
   [ctx question & [default?]]
-  (php/-> (style ctx) (confirm question (if (nil? default?) true default?))))
+  (.confirm (style ctx) question (if (nil? default?) true default?)))
 
 (defn choice
   "Single-choice prompt over a vector of options."
   {:see-also ["confirm"]
    :example  "(choice ctx \"Env?\" [\"dev\" \"stg\" \"prod\"] \"dev\")"}
   [ctx question choices & [default]]
-  (php/-> (style ctx) (choice question (apply php/array choices) default)))
+  (.choice (style ctx) question (apply php/array choices) default))
 
 ;; =============================================================================
 ;; Tables
@@ -212,15 +212,15 @@
   {:see-also ["listing"]
    :example  "(table ctx [\"id\" \"name\"] [[1 \"alice\"] [2 \"bob\"]])"}
   [ctx headers rows & [opts]]
-  (let [t (php/new Table (get ctx :output))]
+  (let [t (new Table (get ctx :output))]
     (when-let [s (get opts :style)]
       (when-let [name (get table-styles s)]
-        (php/-> t (setStyle name))))
+        (.setStyle t name)))
     (when-let [ws (get opts :widths)]
-      (php/-> t (setColumnWidths (apply php/array ws))))
-    (php/-> t (setHeaders (apply php/array headers)))
-    (php/-> t (setRows (apply php/array (for [r :in rows] (apply php/array r)))))
-    (php/-> t (render))))
+      (.setColumnWidths t (apply php/array ws)))
+    (.setHeaders t (apply php/array headers))
+    (.setRows t (apply php/array (for [r :in rows] (apply php/array r))))
+    (.render t)))
 
 ;; =============================================================================
 ;; Progress bar
@@ -240,16 +240,16 @@
     `:max`    total steps (0 = indeterminate)
     `:format` preset (:normal :verbose :very-verbose :debug :minimal) or custom string"
   [ctx & [opts]]
-  (let [bar (php/new ProgressBar (get ctx :output) (or (get opts :max) 0))]
+  (let [bar (new ProgressBar (get ctx :output) (or (get opts :max) 0))]
     (when-let [f (get opts :format)]
       (if-let [preset (get progress-formats f)]
-        (php/-> bar (setFormat preset))
-        (php/-> bar (setFormat f))))
+        (.setFormat bar preset)
+        (.setFormat bar f)))
     bar))
 
-(defn progress-start    "Start the bar."        [bar] (php/-> bar (start)))
-(defn progress-advance  "Advance by n."         [bar & [n]] (php/-> bar (advance (or n 1))))
-(defn progress-finish   "Finish + newline."     [bar] (php/-> bar (finish)) (println))
+(defn progress-start    "Start the bar."        [bar] (.start bar))
+(defn progress-advance  "Advance by n."         [bar & [n]] (.advance bar (or n 1)))
+(defn progress-finish   "Finish + newline."     [bar] (.finish bar) (println))
 
 (defn run-with-progress
   "Iterate `coll` and invoke `(step-fn item bar)` for each, handling start / advance / finish automatically."
@@ -287,36 +287,34 @@
 
 (defn- sugg-array [spec]
   (if (fn? (get spec :complete))
-    (php/:: \Closure (fromCallable (fn [input] (apply php/array ((get spec :complete) input)))))
+    (\Closure/fromCallable (fn [input] (apply php/array ((get spec :complete) input))))
     (php/array)))
 
 (defn- add-args [cmd args]
   (foreach [a args]
-    (php/-> cmd
-            (addArgument
-             (get a :name)
-             (arg-mode (get a :mode :optional))
-             (get a :doc "")
-             (get a :default)
-             (sugg-array a)))))
+    (.addArgument
+     cmd             (get a :name)
+     (arg-mode (get a :mode :optional))
+     (get a :doc "")
+     (get a :default)
+     (sugg-array a))))
 
 (defn- add-opts [cmd opts]
   (foreach [o opts]
-    (php/-> cmd
-            (addOption
-             (get o :name)
-             (get o :short)
-             (opt-mode (get o :mode :optional))
-             (get o :doc "")
-             (get o :default)
-             (sugg-array o)))))
+    (.addOption
+     cmd             (get o :name)
+     (get o :short)
+     (opt-mode (get o :mode :optional))
+     (get o :doc "")
+     (get o :default)
+     (sugg-array o))))
 
 (defn- build-ctx [input output spec]
   {:input     input
    :output    output
    :arg-specs (get spec :args [])
    :opt-specs (get spec :opts [])
-   :style     (php/new SymfonyStyle input output)})
+   :style     (new SymfonyStyle input output)})
 
 (defn- set-handler [cmd spec]
   ;; Symfony 8 (and 7.3 as a deprecation) requires named PHP types on
@@ -324,10 +322,8 @@
   ;; AbstractFn `__invoke` to a typed signature so Symfony's reflection
   ;; check passes on every supported version.
   (let [handler (get spec :run)]
-    (php/-> cmd
-            (setCode
-             (php/:: \Closure
-                     (fromCallable
+    (.setCode
+     cmd             (\Closure/fromCallable
                       (fn [^"\\Symfony\\Component\\Console\\Input\\InputInterface" input
                            ^"\\Symfony\\Component\\Console\\Output\\OutputInterface" output]
                         (let [ctx (build-ctx input output spec)]
@@ -335,11 +331,11 @@
                             (let [result (handler ctx)]
                               (if (int? result) result 0))
                             (catch \Throwable e
-                              (error ctx (str "Error: " (php/-> e (getMessage))))
-                              (when (>= (php/-> output (getVerbosity))
-                                        (php/:: OutputInterface VERBOSITY_VERBOSE))
-                                (writeln ctx (php/-> e (getTraceAsString))))
-                              1))))))))))
+                              (error ctx (str "Error: " (.getMessage e)))
+                              (when (>= (.getVerbosity output)
+                                        OutputInterface/VERBOSITY_VERBOSE)
+                                (writeln ctx (.getTraceAsString e)))
+                              1))))))))
 
 (defn command
   "Build a Symfony `Command` from a Phel spec map.
@@ -363,11 +359,11 @@
    :example  "(command {:name \"greet\" :run (fn [ctx] (success ctx \"Hi!\"))})"}
   [spec]
   (validate-command-spec spec)
-  (let [cmd (php/new Command (get spec :name))]
-    (php/-> cmd (setDescription (get spec :doc "")))
-    (when-let [h (get spec :help)] (php/-> cmd (setHelp h)))
-    (when-let [as (get spec :aliases)] (php/-> cmd (setAliases (apply php/array as))))
-    (when (get spec :hidden?) (php/-> cmd (setHidden true)))
+  (let [cmd (new Command (get spec :name))]
+    (.setDescription cmd (get spec :doc ""))
+    (when-let [h (get spec :help)] (.setHelp cmd h))
+    (when-let [as (get spec :aliases)] (.setAliases cmd (apply php/array as)))
+    (when (get spec :hidden?) (.setHidden cmd true))
     (add-args cmd (get spec :args []))
     (add-opts cmd (get spec :opts []))
     (set-handler cmd spec)
@@ -376,19 +372,19 @@
 ;; ---- Application --------------------------------------------------------
 
 (defn- build-dispatcher [spec]
-  (let [d      (php/new \Symfony\Component\EventDispatcher\EventDispatcher)
+  (let [d      (new \Symfony\Component\EventDispatcher\EventDispatcher)
         before (get spec :before)
         after  (get spec :after)
         on-err (get spec :on-error)]
     (when (fn? before)
-      (php/-> d (addListener (php/:: ConsoleEvents COMMAND)
-                             (php/:: \Closure (fromCallable (fn [e] (before e)))))))
+      (.addListener d ConsoleEvents/COMMAND
+                    (\Closure/fromCallable (fn [e] (before e)))))
     (when (fn? after)
-      (php/-> d (addListener (php/:: ConsoleEvents TERMINATE)
-                             (php/:: \Closure (fromCallable (fn [e] (after e)))))))
+      (.addListener d ConsoleEvents/TERMINATE
+                    (\Closure/fromCallable (fn [e] (after e)))))
     (when (fn? on-err)
-      (php/-> d (addListener (php/:: ConsoleEvents ERROR)
-                             (php/:: \Closure (fromCallable (fn [e] (on-err e)))))))
+      (.addListener d ConsoleEvents/ERROR
+                    (\Closure/fromCallable (fn [e] (on-err e)))))
     d))
 
 (def- signal-numbers {:sigint 2, :sigterm 15, :sighup 1, :sigquit 3})
@@ -399,10 +395,8 @@
           handler (second entry)
           num     (or (get signal-numbers k) k)]
       (when (fn? handler)
-        (php/-> (php/-> app (getSignalRegistry))
-                (register num
-                          (php/:: \Closure
-                                  (fromCallable (fn [s] (handler s))))))))))
+        (.register (.getSignalRegistry app) num
+                   (\Closure/fromCallable (fn [s] (handler s))))))))
 
 (defn application
   "Build a Symfony `Application`.
@@ -426,23 +420,23 @@
   (let [spec (if (map? name-or-spec)
                name-or-spec
                {:name name-or-spec, :commands commands})
-        app  (php/new Application
-                      (get spec :name "console")
-                      (or (get spec :version) "UNKNOWN"))]
-    (php/-> app (setAutoExit (get spec :auto-exit? false)))
+        app  (new Application
+                  (get spec :name "console")
+                  (or (get spec :version) "UNKNOWN"))]
+    (.setAutoExit app (get spec :auto-exit? false))
     (when (or (fn? (get spec :before))
               (fn? (get spec :after))
               (fn? (get spec :on-error)))
-      (php/-> app (setDispatcher (build-dispatcher spec))))
+      (.setDispatcher app (build-dispatcher spec)))
     (register-signals app (or (get spec :on-signal) {}))
     (let [has-add-command (php/method_exists app "addCommand")]
       (foreach [c (get spec :commands [])]
         (let [cmd (command c)]
           (if has-add-command
-            (php/-> app (addCommand cmd))
-            (php/-> app (add cmd))))))
+            (.addCommand app cmd)
+            (.add app cmd)))))
     (when-let [d (get spec :default)]
-      (php/-> app (setDefaultCommand d)))
+      (.setDefaultCommand app d))
     app))
 
 (defn run
@@ -455,9 +449,9 @@
    :example  "(run (application \"t\" [spec]))"}
   [app & [input output]]
   (cond
-    (and input output) (php/-> app (run input output))
-    input              (php/-> app (run input))
-    true               (php/-> app (run))))
+    (and input output) (.run app input output)
+    input              (.run app input)
+    true               (.run app)))
 
 ;; =============================================================================
 ;; Test helpers
@@ -468,7 +462,7 @@
   {:see-also ["argv-with-stdin" "buffered-output"]
    :example  "(argv [\"greet\" \"--loud\" \"alice\"])"}
   [args]
-  (php/new ArgvInput (apply php/array (cons "_" args))))
+  (new ArgvInput (apply php/array (cons "_" args))))
 
 (defn argv-with-stdin
   "Like `argv` but also wires a STDIN stream so `ask`/`confirm`/`choice` prompts can be tested with canned answers."
@@ -478,21 +472,21 @@
         stream (php/fopen "php://memory" "r+")]
     (php/fwrite stream stdin-string)
     (php/rewind stream)
-    (php/-> input (setStream stream))
+    (.setStream input stream)
     input))
 
 (defn buffered-output
   "Build a `BufferedOutput` that captures writes into a string."
-  [] (php/new BufferedOutput))
+  [] (new BufferedOutput))
 
 (defn null-output
   "Build a `NullOutput` that discards writes."
-  [] (php/new NullOutput))
+  [] (new NullOutput))
 
 (defn output->string
   "Drain a `BufferedOutput` into a string."
   [output]
-  (php/-> output (fetch)))
+  (.fetch output))
 
 (defn output-contains?
   "Test helper. Accepts a `BufferedOutput`, a string, or a map `{:out s}`."

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -32,32 +32,32 @@
   {:doc "Creates a new list. If no argument is provided, an empty list is created. Shortcut: '()"
    :example "(list 1 2 3) ; => '(1 2 3)"}
   (fn [& xs]
-    (php/:: Phel (list (apply php/array xs)))))
+    (Phel/list (apply php/array xs))))
 
 (def vector
   {:doc "Creates a new vector. If no argument is provided, an empty vector is created. Shortcut: []"
    :example "(vector 1 2 3) ; => [1 2 3]"}
   (fn [& xs]
-    (php/:: Phel (vector (apply php/array xs)))))
+    (Phel/vector (apply php/array xs))))
 
 (def queue
   {:doc "Creates a persistent FIFO queue. With no arguments returns an empty queue; with arguments returns a queue with the values pushed in order so that the first argument is at the front."
    :example "(queue 1 2 3) ; => <-(1 2 3)-<"}
   (fn [& xs]
-    (php/:: Phel (queue (apply php/array xs)))))
+    (Phel/queue (apply php/array xs))))
 
 (def hash-map
   {:doc "Creates a new hash map. If no argument is provided, an empty hash map is created. The number of parameters must be even. Shortcut: {}"
    :example "(hash-map :a 1 :b 2) ; => {:a 1, :b 2}"}
   (fn [& xs]
-    (php/:: Phel (map (apply php/array xs)))))
+    (Phel/map (apply php/array xs))))
 
 (def array-map
   {:doc "Constructs a map from the given key/value pairs. If any keys are equal, later values replace earlier ones, as if by repeated `assoc`. Phel has no distinct array-map type, so the result is the same persistent map as `hash-map` — `array-map` exists for `.cljc` interop with Clojure sources."
    :example "(array-map :a 1 :b 2) ; => {:a 1, :b 2}"
    :see-also ["hash-map"]}
   (fn [& xs]
-    (php/:: Phel (map (apply php/array xs)))))
+    (Phel/map (apply php/array xs))))
 
 (def next-vector-or-nil
   {:private true
@@ -66,13 +66,13 @@
     (let [sliced (php/array_slice values 1)]
       (if (php/empty sliced)
         nil
-        (php/:: Phel (vector sliced))))))
+        (Phel/vector sliced)))))
 
 (def next-of-set
   {:private true
    :doc "Returns all values after the first persistent set value, or nil."}
   (fn [s]
-    (next-vector-or-nil (php/-> s (toPhpArray)))))
+    (next-vector-or-nil (.toPhpArray s))))
 
 (def next-of-map
   {:private true
@@ -80,7 +80,7 @@
   (fn [m]
     (let [entries (php/array)]
       (foreach [k v m]
-        (php/apush entries (php/:: MapEntry (create k v))))
+        (php/apush entries (MapEntry/create k v)))
       (next-vector-or-nil entries))))
 
 (def next
@@ -90,16 +90,16 @@
     (if (php/=== xs nil)
       nil
       (if (php/instanceof xs LazySeqInterface)
-        (php/-> xs (nextSeq))
+        (.nextSeq xs)
         (if (php/instanceof xs Cons)
-          (php/-> xs (nextSeq))
+          (.nextSeq xs)
           (if (php/instanceof xs CdrInterface)
-            (php/-> xs (cdr))
+            (.cdr xs)
             (if (php/is_string xs)
               (let [chars (php/mb_str_split xs)]
                 (if (php/<= (php/count chars) 1)
                   nil
-                  (php/:: Phel (vector (php/array_slice chars 1)))))
+                  (Phel/vector (php/array_slice chars 1))))
               (if (php/is_array xs)
                 (let [sliced (php/array_slice xs 1)]
                   (if (php/empty sliced)
@@ -109,17 +109,17 @@
                   (next-of-set xs)
                   (if (php/instanceof xs PersistentMapInterface)
                     (next-of-map xs)
-                    (throw (php/new InvalidArgumentException
-                                    (php/. "cannot call 'next on " (php/gettype xs))))))))))))))
+                    (throw (new InvalidArgumentException
+                                (php/. "cannot call 'next on " (php/gettype xs))))))))))))))
 
 (def first-map-entry
   {:private true
    :doc "Returns the first entry of a persistent map as a typed `MapEntry`, or nil if empty."}
   (fn [m]
-    (let [it (php/-> m (getIterator))]
-      (php/-> it (rewind))
-      (if (php/-> it (valid))
-        (php/:: MapEntry (create (php/-> it (key)) (php/-> it (current))))
+    (let [it (.getIterator m)]
+      (.rewind it)
+      (if (.valid it)
+        (MapEntry/create (.key it) (.current it))
         nil))))
 
 (def first-of-string
@@ -132,7 +132,7 @@
   {:private true
    :doc "Returns the first value of a persistent set, or nil if empty."}
   (fn [s]
-    (let [values (php/-> s (toPhpArray))]
+    (let [values (.toPhpArray s)]
       (if (php/empty values) nil (php/aget values 0)))))
 
 (def first
@@ -143,11 +143,11 @@ Maps are treated as a sequence of entries: `(first {:a 1})` returns a typed `Map
 A lazily consumed source with no indexed access of its own (an `eduction` pipeline, a PHP generator, an iterator) is answered by pulling a single element, the same way `empty?` answers it. `count` is the one that refuses such a source, because counting means draining it."
    :example "(first [1 2 3]) ; => 1"}
   (fn [xs]
-    (if (php/instanceof xs FirstInterface)         (php/-> xs (first))
+    (if (php/instanceof xs FirstInterface)         (.first xs)
         (if (php/instanceof xs PersistentMapInterface) (first-map-entry xs)
             (if (php/is_string xs)                      (first-of-string xs)
                 (if (php/instanceof xs PersistentHashSetInterface) (first-of-set xs)
-                    (if (php/instanceof xs Traversable) (php/:: Seq (first xs))
+                    (if (php/instanceof xs Traversable) (Seq/first xs)
                         (php/aget xs 0))))))))
 
 (def concat1
@@ -157,7 +157,7 @@ A lazily consumed source with no indexed access of its own (an `eduction` pipeli
     (if (php/=== nil ys)
       xs
       (if (php/instanceof xs ConcatInterface)
-        (php/-> xs (concat ys))
+        (.concat xs ys)
         (do
           (foreach [y ys]
             (php/apush xs y))
@@ -199,7 +199,7 @@ A lazily consumed source with no indexed access of its own (an `eduction` pipeli
   (let [argv-raw (php/aget php/$GLOBALS "__phel_argv")]
     (if (php/=== argv-raw nil)
       []
-      (php/:: Phel (vector argv-raw)))))
+      (Phel/vector argv-raw))))
 
 ;; Metadata + macro machinery, then the primitive value constructors that
 ;; depend on `defn` / `defmacro`

--- a/src/phel/core/arrays.phel
+++ b/src/phel/core/arrays.phel
@@ -31,7 +31,7 @@
   (let [cnt (php/count xs)
         res (php/array)]
     (if (php/=== 1 (php/% cnt 2))
-      (throw (php/new InvalidArgumentException "An even number of parameters must be provided for 'php-associative-array'")))
+      (throw (new InvalidArgumentException "An even number of parameters must be provided for 'php-associative-array'")))
     (loop [i 0]
       (if (php/< i cnt)
         (do
@@ -50,7 +50,7 @@
   [size-or-seq]
   (if (php/is_int size-or-seq)
     (if (php/< size-or-seq 0)
-      (throw (php/new InvalidArgumentException "Size for 'object-array' must be non-negative"))
+      (throw (new InvalidArgumentException "Size for 'object-array' must be non-negative"))
       (if (php/=== 0 size-or-seq)
         (php/array)
         (php/array_fill 0 size-or-seq nil)))
@@ -84,7 +84,7 @@
   [op-name arr]
   (if (php/is_array arr)
     arr
-    (throw (php/new InvalidArgumentException (str op-name " expects a PHP array")))))
+    (throw (new InvalidArgumentException (str op-name " expects a PHP array")))))
 
 (defn aclone
   "Returns a shallow copy of a PHP array. The returned array is a distinct value — mutating the copy via `php/aset` does not affect the original, and vice versa. Matches Clojure's `aclone` for `.cljc` interop; raises `InvalidArgumentException` on non-array inputs since Phel's persistent collections are already immutable and don't need cloning."
@@ -121,7 +121,7 @@
 (defn- typed-array-with-size
   [coerce-fn default size init]
   (if (php/< size 0)
-    (throw (php/new InvalidArgumentException "Array size must be non-negative"))
+    (throw (new InvalidArgumentException "Array size must be non-negative"))
     (if (php/=== 0 size)
       (php/array)
       (if (php/=== nil init)
@@ -207,13 +207,13 @@
   {:example "(let [a (php/array 1 2 3)] (aset a 0 42) (aget a 0)) ; => 42"
    :see-also ["aget" "aclone" "object-array"]}
   [arr idx & more]
-  (let [n   (php/-> more (count))
-        val (php/-> more (get (php/- n 1)))]
+  (let [n   (.count more)
+        val (.get more (php/- n 1))]
     (if (php/=== 1 n)
       `(do (php/aset ~arr ~idx ~val) ~val)
       (let [extra-keys (loop [i  0
                               ks [idx]]
                          (if (php/< i (php/- n 1))
-                           (recur (php/+ i 1) (php/-> ks (push (php/-> more (get i)))))
+                           (recur (php/+ i 1) (.push ks (.get more i)))
                            ks))]
         `(do (php/aset-in ~arr ~extra-keys ~val) ~val)))))

--- a/src/phel/core/async.phel
+++ b/src/phel/core/async.phel
@@ -14,13 +14,13 @@
 (defn- fiber-facade
   "Lazily resolves the shared FiberFacade instance."
   []
-  (php/new \Phel\Fiber\FiberFacade))
+  (new \Phel\Fiber\FiberFacade))
 
 (defn ->closure
   "Converts a Phel function to a PHP Closure. Many PHP libraries (AMPHP, ReactPHP) type-hint `\\Closure` and reject Phel's `AbstractFn` even though it is callable. This bridges the gap."
   {:example "(->closure (fn [x] (* x 2)))"}
   [f]
-  (php/:: \Closure (fromCallable f)))
+  (\Closure/fromCallable f))
 
 (defmacro async
   "Runs body asynchronously in a new fiber. Returns an Amp\\Future.
@@ -31,16 +31,16 @@
   {:example "(async (do-something))"
    :see-also ["await" "await-all" "await-any" "future"]}
   [& body]
-  `(let [frame# (php/:: \Phel (snapshotDynamicBindings))]
+  `(let [frame# (\Phel/snapshotDynamicBindings)]
      (php/amp\async
       (fn []
-        (php/:: \Phel (withDynamicBindings frame# (fn [] ~@body)))))))
+        (\Phel/withDynamicBindings frame# (fn [] ~@body))))))
 
 (defn- unwrap-future
   "Returns the raw Amp\\Future for either a `Future` wrapper or a bare `Amp\\Future`."
   [future]
   (if (php/instanceof future \Phel\Lang\Future)
-    (php/-> future (unwrap))
+    (.unwrap future)
     future))
 
 (defn await
@@ -48,7 +48,7 @@
   {:example "(await (async (+ 1 2)))"
    :see-also ["async" "await-all" "await-any"]}
   [future]
-  (php/-> (unwrap-future future) (await)))
+  (.await (unwrap-future future)))
 
 (defn await-all
   "Awaits all Futures in the given collection. Returns a vector of results in the same order as the input collection, regardless of which Future resolves first. Accepts a mix of raw `Amp\\Future` and `Future` wrappers."
@@ -82,7 +82,7 @@ PHP fibers are cooperative on a single thread, so `pmap` overlaps IO-bound work 
    :see-also ["map" "async" "await-all"]}
   [f & colls]
   (case (count colls)
-    0 (throw (php/new \InvalidArgumentException "pmap expects at least one collection"))
+    0 (throw (new \InvalidArgumentException "pmap expects at least one collection"))
     1 (await-all (map #(async (f %)) (first colls)))
     (await-all (apply map (fn [& args] (async (apply f args))) colls))))
 
@@ -91,14 +91,14 @@ PHP fibers are cooperative on a single thread, so `pmap` overlaps IO-bound work 
   {:example "(future-cancel (future (expensive-call)))"
    :see-also ["future" "future-cancelled?" "future-done?" "deref"]}
   [f]
-  (php/-> f (cancel)))
+  (.cancel f))
 
 (defn future-cancelled?
   "Returns `true` if `future-cancel` was called on `f`, `false` otherwise."
   {:example "(future-cancelled? f)"
    :see-also ["future-cancel" "future-done?" "future"]}
   [f]
-  (php/-> f (isCancelled)))
+  (.isCancelled f))
 
 (defn future-done?
   "Returns `true` if the future is in a final state (completed, failed, or cancelled).
@@ -108,7 +108,7 @@ Dispatches on type: for a `\\Phel\\Fiber\\Domain\\Future` (fiber-backed) it call
    :see-also ["realized?" "future-cancel" "future" "future-fiber"]}
   [f]
   (cond
-    (php/instanceof f \Phel\Fiber\Domain\Future) (php/-> f (isDone))
+    (php/instanceof f \Phel\Fiber\Domain\Future) (.isDone f)
     true                                         (realized? f)))
 
 ;; -----------------------------------------------------------------
@@ -126,14 +126,14 @@ Once delivered the value is frozen; subsequent `deliver` calls are no-ops. `dere
   {:example "(let [p (promise)] (deliver p 42) @p) ; => 42"
    :see-also ["deliver" "deref" "realized?" "future-call" "future-fiber"]}
   []
-  (php/-> (fiber-facade) (createPromise)))
+  (.createPromise (fiber-facade)))
 
 (defn deliver
   "Delivers `value` to `p` if it is still unrealized. Returns `p` on first delivery, `nil` if `p` was already delivered."
   {:example "(deliver (promise) 7)"
    :see-also ["promise" "deref" "realized?"]}
   [p value]
-  (if (php/-> p (deliver value)) p nil))
+  (if (.deliver p value) p nil))
 
 (defn future-call
   "Invokes `f` (a zero-arg function) in a new fiber. Returns a
@@ -147,9 +147,9 @@ Once delivered the value is frozen; subsequent `deliver` calls are no-ops. `dere
    :see-also ["future-fiber" "deref" "future-done?" "future-cancel"
               "promise" "deliver"]}
   [f]
-  (let [frame   (php/:: \Phel (snapshotDynamicBindings))
-        wrapped (fn [] (php/:: \Phel (withDynamicBindings frame f)))]
-    (php/-> (fiber-facade) (future (->closure wrapped)))))
+  (let [frame   (\Phel/snapshotDynamicBindings)
+        wrapped (fn [] (\Phel/withDynamicBindings frame f))]
+    (.future (fiber-facade) (->closure wrapped))))
 
 (defmacro future-fiber
   "Runs `body` in a new fiber via the cooperative scheduler. Returns a

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -31,8 +31,8 @@ Optional `:meta` and `:validator` keyword arguments may follow the value in any 
   (let [pairs (apply hash-map opts)
         m     (get pairs :meta)
         vf    (get pairs :validator)
-        v     (php/:: Phel (atom value m))]
-    (when vf (php/-> v (setValidator vf)))
+        v     (Phel/atom value m)]
+    (when vf (.setValidator v vf))
     v))
 
 (defn atom?
@@ -53,14 +53,14 @@ Optional `:meta` and `:validator` keyword arguments may follow the value in any 
   "Throws `InvalidArgumentException` with `msg` unless `v` is a `Var`."
   [v msg]
   (when-not (var? v)
-    (throw (php/new \InvalidArgumentException msg))))
+    (throw (new \InvalidArgumentException msg))))
 
 (defn reset!
   "Sets a new value on the given atom. Returns the new value."
   {:example "(def x (atom 10))"
    :see-also ["atom" "deref" "swap!"]}
   [variable value]
-  (php/-> variable (set value)))
+  (.set variable value))
 
 (defn deref
   "Returns the current value inside an atom or var.
@@ -72,19 +72,19 @@ With three arguments, and when `variable` is a future or promise, blocks for at 
    :see-also ["atom" "reset!" "swap!" "future" "var-get"]}
   [variable & args]
   (case (count args)
-    0 (php/-> variable (deref))
+    0 (.deref variable)
     2 (cond
         (php/instanceof variable \Phel\Lang\Future)
-        (php/-> variable (derefWithTimeout (first args) (get args 1)))
+        (.derefWithTimeout variable (first args) (get args 1))
         (php/instanceof variable \Phel\Fiber\Domain\Future)
-        (php/-> variable (derefWithTimeout (first args) (get args 1)))
+        (.derefWithTimeout variable (first args) (get args 1))
         (php/instanceof variable \Phel\Fiber\Domain\Promise)
-        (php/-> variable (derefWithTimeout (first args) (get args 1)))
+        (.derefWithTimeout variable (first args) (get args 1))
         true
-        (throw (php/new \InvalidArgumentException
-                        "3-arg deref is only supported on futures and promises")))
-    (throw (php/new \InvalidArgumentException
-                    "deref expects 1 or 3 arguments"))))
+        (throw (new \InvalidArgumentException
+                    "3-arg deref is only supported on futures and promises")))
+    (throw (new \InvalidArgumentException
+                "deref expects 1 or 3 arguments"))))
 
 (defn swap!
   "Atomically swaps the value of the atom to `(apply f current-value args)`.
@@ -138,7 +138,7 @@ Returns the new value after the swap."
   {:example "(add-watch my-var :logger (fn [key ref old new] (println old \"->\" new)))"
    :see-also ["remove-watch" "atom" "swap!"]}
   [variable key f]
-  (php/-> variable (addWatch (name key) f))
+  (.addWatch variable (name key) f)
   variable)
 
 (defn alter-var-root
@@ -147,7 +147,7 @@ Returns the new value after the swap."
    :see-also ["var" "var?" "swap!"]}
   [v f & args]
   (assert-var! v "alter-var-root expects a Var as first argument; use swap! for atoms")
-  (php/-> v (alterRoot (fn [current] (apply f current args)))))
+  (.alterRoot v (fn [current] (apply f current args))))
 
 (defn bound?
   "Returns true when `v` has a current root binding in the namespace registry. `v` must be a `Var`."
@@ -155,8 +155,8 @@ Returns the new value after the swap."
    :see-also ["thread-bound?" "var-get" "find-var"]}
   [v]
   (assert-var! v "bound? expects a Var as its argument")
-  (php/:: Phel (isDefined (php/-> v (getNamespace))
-                          (php/-> v (getName)))))
+  (Phel/isDefined (.getNamespace v)
+                  (.getName v)))
 
 (defn thread-bound?
   "Returns true when a fiber-local `binding` (or `with-bindings`) frame currently overrides the value of `v` on the calling fiber."
@@ -164,9 +164,9 @@ Returns the new value after the swap."
    :see-also ["bound?" "binding" "var-set"]}
   [v]
   (assert-var! v "thread-bound? expects a Var as its argument")
-  (let [scope (php/:: DynamicScope (getInstance))]
-    (php/-> scope (hasBinding (php/-> v (getNamespace))
-                              (php/-> v (getName))))))
+  (let [scope (DynamicScope/getInstance)]
+    (.hasBinding scope (.getNamespace v)
+                 (.getName v))))
 
 (defn var-set
   "Sets the value of the topmost active fiber-local binding frame for
@@ -176,9 +176,9 @@ Returns the new value after the swap."
    :see-also ["binding" "thread-bound?" "alter-var-root"]}
   [v val]
   (assert-var! v "var-set expects a Var as its first argument")
-  (php/:: Phel (varSet (php/-> v (getNamespace))
-                       (php/-> v (getName))
-                       val)))
+  (Phel/varSet (.getNamespace v)
+               (.getName v)
+               val))
 
 (defn alter-meta!
   "Replaces the metadata on `r` with `(apply f current-meta args)`.
@@ -189,12 +189,12 @@ Returns the new value after the swap."
    :see-also ["reset-meta!" "meta" "with-meta"]}
   [r f & args]
   (cond
-    (var? r)  (php/-> r (alterMeta (fn [current] (apply f current args))))
-    (atom? r) (let [next (apply f (php/-> r (getMeta)) args)]
-                (php/-> r (withMeta next))
+    (var? r)  (.alterMeta r (fn [current] (apply f current args)))
+    (atom? r) (let [next (apply f (.getMeta r) args)]
+                (.withMeta r next)
                 next)
-    :else     (throw (php/new \InvalidArgumentException
-                              "alter-meta! expects a Var or atom as first argument"))))
+    :else     (throw (new \InvalidArgumentException
+                          "alter-meta! expects a Var or atom as first argument"))))
 
 (defn reset-meta!
   "Installs `meta-map` as the metadata on `r`, replacing any prior metadata. Works on `Var` handles and on atoms. Returns the installed map."
@@ -202,16 +202,16 @@ Returns the new value after the swap."
    :see-also ["alter-meta!" "meta" "with-meta"]}
   [r meta-map]
   (cond
-    (var? r)  (php/-> r (resetMeta meta-map))
-    (atom? r) (do (php/-> r (withMeta meta-map)) meta-map)
-    :else     (throw (php/new \InvalidArgumentException
-                              "reset-meta! expects a Var or atom as first argument"))))
+    (var? r)  (.resetMeta r meta-map)
+    (atom? r) (do (.withMeta r meta-map) meta-map)
+    :else     (throw (new \InvalidArgumentException
+                          "reset-meta! expects a Var or atom as first argument"))))
 
 (defn remove-watch
   "Removes a watch function from a variable by key."
   {:see-also ["add-watch"]}
   [variable key]
-  (php/-> variable (removeWatch (name key)))
+  (.removeWatch variable (name key))
   variable)
 
 (defn set-validator!
@@ -219,7 +219,7 @@ Returns the new value after the swap."
   {:example "(set-validator! my-var pos?)"
    :see-also ["get-validator" "atom"]}
   [variable f]
-  (php/-> variable (setValidator f))
+  (.setValidator variable f)
   variable)
 
 (defn get-validator
@@ -227,7 +227,7 @@ Returns the new value after the swap."
   {:example "(get-validator (atom 1)) ; => nil"
    :see-also ["set-validator!"]}
   [variable]
-  (php/-> variable (getValidator)))
+  (.getValidator variable))
 
 ;; --------
 ;; For loop
@@ -236,10 +236,10 @@ Returns the new value after the swap."
 (defn- lazy-seq-from-generator
   "Wraps a PHP Generator in a ChunkedSeq for efficient lazy evaluation. ChunkedSeq realizes elements in batches for better performance."
   [generator]
-  (php/:: ChunkedSeq (fromGenerator
-                      (php/new Hasher)
-                      (php/new Equalizer)
-                      generator)))
+  (ChunkedSeq/fromGenerator
+   (new Hasher)
+   (new Equalizer)
+   generator))
 
 (defn range
   "Creates a lazy sequence of numbers. With no arguments returns an infinite sequence starting at 0. With one argument returns (0..n). With two (start..end). With three (start..end step). Note: the infinite sequence is bounded by PHP_INT_MAX."
@@ -247,11 +247,11 @@ Returns the new value after the swap."
    :see-also ["iterate" "repeat"]}
   [& args]
   (case (count args)
-    0 (lazy-seq-from-generator (php/:: Seq (infiniteRange)))
-    1 (lazy-seq-from-generator (php/:: Seq (range 0 (get args 0) 1)))
-    2 (lazy-seq-from-generator (php/:: Seq (range (get args 0) (get args 1) 1)))
-    3 (lazy-seq-from-generator (php/:: Seq (range (get args 0) (get args 1) (get args 2))))
-    (throw (php/new InvalidArgumentException "Range function expects zero to three arguments"))))
+    0 (lazy-seq-from-generator (Seq/infiniteRange))
+    1 (lazy-seq-from-generator (Seq/range 0 (get args 0) 1))
+    2 (lazy-seq-from-generator (Seq/range (get args 0) (get args 1) 1))
+    3 (lazy-seq-from-generator (Seq/range (get args 0) (get args 1) (get args 2)))
+    (throw (new InvalidArgumentException "Range function expects zero to three arguments"))))
 
 (def- for-options (hash-set :reduce))
 
@@ -286,7 +286,7 @@ Returns the new value after the swap."
             :while `(if ~verb ~rest php/break)
             :let   `(let ~verb ~rest)
             :when  `(when ~verb ~rest)
-            (throw (php/new InvalidArgumentException (str "This modifier is not supported in for loop: " verb)))))
+            (throw (new InvalidArgumentException (str "This modifier is not supported in for loop: " verb)))))
 
         ;; Case 3: Verbs
         (let [object    (php/aget head (php/+ i 2))
@@ -300,7 +300,7 @@ Returns the new value after the swap."
             :pairs (let [key-sym (gensym)]
                      `(foreach [~key-sym ~value-sym ~object]
                         (let [~binding [~key-sym ~value-sym]] ~rest)))
-            (throw (php/new InvalidArgumentException (str "This verb is not supported in for loop " verb)))))))))
+            (throw (new InvalidArgumentException (str "This verb is not supported in for loop " verb)))))))))
 
 (defmacro for
   "List comprehension. The head of the loop is a vector that contains a

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -71,18 +71,18 @@
    (cond
      (php/=== nil x)            nil
      (php/instanceof x Keyword) x
-     (php/instanceof x Symbol)  (php/:: Keyword (createForNamespace (php/-> x (getNamespace))
-                                                                    (php/-> x (getName))))
-     (php/is_string x)          (php/:: Keyword (create x))
+     (php/instanceof x Symbol)  (Keyword/createForNamespace (.getNamespace x)
+                                                            (.getName x))
+     (php/is_string x)          (Keyword/create x)
      :else                      nil))
   ([ns nm]
    (when-not (php/=== nil nm)
-     (php/:: Keyword (createForNamespace (when-not (php/=== nil ns) (php/strval ns))
-                                         (php/strval nm))))))
+     (Keyword/createForNamespace (when-not (php/=== nil ns) (php/strval ns))
+                                 (php/strval nm)))))
 
 (defn- id2 [a b]
   (if (php/instanceof a IdenticalInterface)
-    (php/-> a (identical b))
+    (.identical a b)
     (php/=== a b)))
 
 (defn identical?
@@ -117,12 +117,12 @@
 
 (defn- num-equals1 [a b]
   (when-not (num? a)
-    (throw (php/new \InvalidArgumentException
-                    (str "Argument must be a number, got: " a))))
+    (throw (new \InvalidArgumentException
+                (str "Argument must be a number, got: " a))))
   (when-not (num? b)
-    (throw (php/new \InvalidArgumentException
-                    (str "Argument must be a number, got: " b))))
-  (php/:: NumericOperations (isEqual a b)))
+    (throw (new \InvalidArgumentException
+                (str "Argument must be a number, got: " b))))
+  (NumericOperations/isEqual a b))
 
 (defn ==
   "Numeric equality comparison. Returns true if all arguments have the same
@@ -165,30 +165,30 @@
   "Rejects `nil` operands so ordered comparisons fail loudly instead of silently coercing `nil` to 0. Mirrors the arithmetic functions, which already reject `nil`, and matches Clojure/JVM (which throws). Defined locally because `booleans` loads before the arithmetic module."
   [a b]
   (when (or (php/=== nil a) (php/=== nil b))
-    (throw (php/new InvalidArgumentException "Comparison functions do not accept nil values"))))
+    (throw (new InvalidArgumentException "Comparison functions do not accept nil values"))))
 
 (defn- lt2 [a b]
   (assert-non-nil a b)
   (if (or (numeric-object? a) (numeric-object? b))
-    (php/< (php/:: NumericOperations (compare a b)) 0)
+    (php/< (NumericOperations/compare a b) 0)
     (php/< a b)))
 
 (defn- lte2 [a b]
   (assert-non-nil a b)
   (if (or (numeric-object? a) (numeric-object? b))
-    (php/<= (php/:: NumericOperations (compare a b)) 0)
+    (php/<= (NumericOperations/compare a b) 0)
     (php/<= a b)))
 
 (defn- gt2 [a b]
   (assert-non-nil a b)
   (if (or (numeric-object? a) (numeric-object? b))
-    (php/> (php/:: NumericOperations (compare a b)) 0)
+    (php/> (NumericOperations/compare a b) 0)
     (php/> a b)))
 
 (defn- gte2 [a b]
   (assert-non-nil a b)
   (if (or (numeric-object? a) (numeric-object? b))
-    (php/>= (php/:: NumericOperations (compare a b)) 0)
+    (php/>= (NumericOperations/compare a b) 0)
     (php/>= a b)))
 
 (defn <
@@ -243,7 +243,7 @@
    :see-also ["compare" ">=<"]}
   [a b]
   (if (or (numeric-object? a) (numeric-object? b))
-    (php/:: NumericOperations (compare a b))
+    (NumericOperations/compare a b)
     (php/<=> a b)))
 
 (defn >=<
@@ -252,7 +252,7 @@
    :see-also ["compare" "<=>"]}
   [a b]
   (if (or (numeric-object? a) (numeric-object? b))
-    (php/:: NumericOperations (compare b a))
+    (NumericOperations/compare b a)
     (php/<=> b a)))
 
 (declare empty?)
@@ -322,7 +322,7 @@
   {:example "(truthy? 0) ; => true\n(truthy? nil) ; => false"
    :see-also ["true?" "false?" "nil?"]}
   [x]
-  (php/:: Truthy (isTruthy x)))
+  (Truthy/isTruthy x))
 
 (defn false?
   "Checks if value is exactly false (not just falsy)."
@@ -342,14 +342,14 @@
   [coll key]
   (cond
     (nil? coll) false
-    (php/instanceof coll ContainsInterface) (php/-> coll (contains key))
+    (php/instanceof coll ContainsInterface) (.contains coll key)
     (php/is_array coll) (php/array_key_exists key coll)
     (php/is_string coll) (and (php/is_int key) (php/>= key 0) (php/< key (php/mb_strlen coll)))
-    (throw (php/new InvalidArgumentException
-                    (str "cannot call 'contains?' on "
-                         (if (php/is_object coll)
-                           (php/get_class coll)
-                           (php/gettype coll)))))))
+    (throw (new InvalidArgumentException
+                (str "cannot call 'contains?' on "
+                     (if (php/is_object coll)
+                       (php/get_class coll)
+                       (php/gettype coll)))))))
 
 (defn- comparable-number?
   [x]
@@ -399,8 +399,8 @@
 
 (defn- compare-named
   [x y]
-  (let [ns-x   (php/-> x (getNamespace))
-        ns-y   (php/-> y (getNamespace))
+  (let [ns-x   (.getNamespace x)
+        ns-y   (.getNamespace y)
         ns-cmp (cond
                  (php/=== ns-x ns-y) 0
                  (php/=== ns-x nil)  -1
@@ -408,7 +408,7 @@
                  :else               (php/<=> ns-x ns-y))]
     (if (php/!== 0 ns-cmp)
       ns-cmp
-      (php/<=> (php/-> x (getName)) (php/-> y (getName))))))
+      (php/<=> (.getName x) (.getName y)))))
 
 (defn- compare-same-category [category x y]
   (cond
@@ -419,7 +419,7 @@
     (compare-sequential x y)
 
     (= category :number)
-    (php/:: NumericOperations (compare x y))
+    (NumericOperations/compare x y)
 
     :else
     (php/<=> x y)))
@@ -444,5 +444,5 @@
           cy (compare-category y)]
       (if (= cx cy)
         (compare-same-category cx x y)
-        (throw (php/new InvalidArgumentException
-                        (str "Cannot compare " cx " with " cy)))))))
+        (throw (new InvalidArgumentException
+                    (str "Cannot compare " cx " with " cy)))))))

--- a/src/phel/core/collections.phel
+++ b/src/phel/core/collections.phel
@@ -16,32 +16,32 @@
   "Creates a new Set from the given arguments. Shortcut: #{}"
   {:example "(hash-set 1 2 3) ; => #{1 2 3}"}
   [& xs]
-  (php/:: Phel (set (apply php/array xs))))
+  (Phel/set (apply php/array xs)))
 
 (defn sorted-map
   "Creates a new sorted map. Keys are in natural sorted order. The number of parameters must be even."
   {:example "(sorted-map :c 3 :a 1 :b 2) ; keys iterate as :a :b :c"
    :see-also ["sorted-map-by" "hash-map"]}
   [& xs]
-  (php/:: Phel (sortedMap (apply php/array xs))))
+  (Phel/sortedMap (apply php/array xs)))
 
 (defn sorted-map-by
   "Creates a new sorted map using the given comparator for key ordering. The comparator takes two arguments and returns a negative integer, zero, or a positive integer."
   {:example "(sorted-map-by (fn [a b] (compare b a)) :a 1 :b 2) ; keys iterate as :b :a"
    :see-also ["sorted-map" "compare"]}
   [comp & xs]
-  (php/:: Phel (sortedMapBy comp (apply php/array xs))))
+  (Phel/sortedMapBy comp (apply php/array xs)))
 
 (defn sorted-set
   "Creates a new sorted set. Elements are in natural sorted order."
   {:example "(sorted-set 3 1 2) ; iterates as 1 2 3"
    :see-also ["sorted-set-by" "hash-set"]}
   [& xs]
-  (php/:: Phel (sortedSet (apply php/array xs))))
+  (Phel/sortedSet (apply php/array xs)))
 
 (defn sorted-set-by
   "Creates a new sorted set using the given comparator for element ordering."
   {:example "(sorted-set-by (fn [a b] (compare b a)) 3 1 2) ; iterates as 3 2 1"
    :see-also ["sorted-set" "compare"]}
   [comp & xs]
-  (php/:: Phel (sortedSetBy comp (apply php/array xs))))
+  (Phel/sortedSetBy comp (apply php/array xs)))

--- a/src/phel/core/control.phel
+++ b/src/phel/core/control.phel
@@ -70,7 +70,7 @@
   (let [cnt (count clauses)]
     (cond
       (php/=== cnt 0)
-      (list 'throw (list 'php/new '\InvalidArgumentException
+      (list 'throw (list 'new '\InvalidArgumentException
                          "No matching clause in condp"))
       (php/=== cnt 1)
       (first clauses)

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -35,18 +35,18 @@
     ;; `catch (Exception)`, leaking core internals; throwing surfaces as `[PHEL005]`.
     (if (php/instanceof name Symbol)
       nil
-      (throw (php/new \InvalidArgumentException
-                      (php/. "First argument must be a symbol, but got: " (php/get_debug_type name)))))
-    (let [sym-meta        (php/-> name (getMeta))
-          meta            (if sym-meta (php/-> sym-meta (merge meta)) meta)
+      (throw (new \InvalidArgumentException
+                  (php/. "First argument must be a symbol, but got: " (php/get_debug_type name)))))
+    (let [sym-meta        (.getMeta name)
+          meta            (if sym-meta (.merge sym-meta meta) meta)
           meta            (if (php/is_string (first fdecl))
-                            (php/-> meta (put :doc (first fdecl)))
+                            (.put meta :doc (first fdecl))
                             meta)
           fdecl           (if (php/is_string (first fdecl))
                             (next fdecl)
                             fdecl)
           meta            (if (php/instanceof (first fdecl) PersistentMapInterface)
-                            (php/-> meta (merge (first fdecl)))
+                            (.merge meta (first fdecl))
                             meta)
           fdecl           (if (php/instanceof (first fdecl) PersistentMapInterface)
                             (next fdecl)
@@ -77,7 +77,7 @@
                                   nil))
                               (php/implode "\n" sigs)))
           docstring       (php/. "```phel\n" signatures "\n```\n" docstring)
-          meta            (php/-> meta (put :doc docstring))
+          meta            (.put meta :doc docstring)
           memoize-flag    (php/aget meta :memoize)
           memoize-lru-arg (php/aget meta :memoize-lru)
           async-flag      (php/aget meta :async)
@@ -124,13 +124,13 @@
 (defmacro defstruct
   "A Struct is a special kind of Map. It only supports a predefined number of keys and is associated to a global name. The Struct not only defines itself but also a predicate function."
   [name keys & implementations]
-  (let [name-str       (php/-> name (getName))
-        munge          (php/new Munge)
-        class-name-str (php/. (php/-> munge (encodePhpNs *ns*)) "\\" (php/-> munge (encode name-str)))
-        is-name        (php/:: Symbol (create (php/. name-str "?")))]
+  (let [name-str       (.getName name)
+        munge          (new Munge)
+        class-name-str (php/. (.encodePhpNs munge *ns*) "\\" (.encode munge name-str))
+        is-name        (Symbol/create (php/. name-str "?"))]
     `(do
        (defstruct* ~name ~keys ~@implementations)
-       (defn ~name ~(php/. "Creates a new " name " struct.") ~keys (php/new ~class-name-str ~@keys))
+       (defn ~name ~(php/. "Creates a new " name " struct.") ~keys (new ~class-name-str ~@keys))
        (swap! *type-tag-registry* assoc ~name ~class-name-str)
        (defn ~is-name ~(php/. "Checks if `x` is an instance of the " name " struct.") [x] (php/is_a x ~class-name-str)))))
 
@@ -139,15 +139,14 @@
   `\\Exception`), so frameworks can catch it by type, e.g.
   `(defexception ProductNotFound \\RuntimeException)`."
   [name & [parent]]
-  (let [name-str       (php/-> name (getName))
-        munge          (php/new Munge)
-        class-name-str (php/. (php/-> munge (encodePhpNs *ns*)) "\\" (php/-> munge (encode name-str)))
-        is-name        (php/:: Symbol (create (php/. name-str "?")))]
+  (let [name-str       (.getName name)
+        munge          (new Munge)
+        class-name-str (php/. (.encodePhpNs munge *ns*) "\\" (.encode munge name-str))
+        is-name        (Symbol/create (php/. name-str "?"))]
     `(do
        (defexception* ~name ~@(if parent [parent] []))
        (defn ~name ~(php/. "Creates a new " name " exception.") [& args]
-         (php/-> (php/new \ReflectionClass ~class-name-str)
-                 (newInstanceArgs (to-php-array args))))
+         (.newInstanceArgs (new \ReflectionClass ~class-name-str) (to-php-array args)))
        (defn ~is-name ~(php/. "Checks if `x` is an instance of the " name " exception.") [x] (php/is_a x ~class-name-str)))))
 
 (defmacro defenum
@@ -164,14 +163,14 @@
       (defenum Suit
         :hearts :spades :clubs :diamonds
         Describable
-        (describe [this] (php/-> this name))
+        (describe [this] (.-name this))
         :php
-        (label [this] (php/-> this name)))"
+        (label [this] (.-name this)))"
   [name & cases]
-  (let [name-str       (php/-> name (getName))
-        munge          (php/new Munge)
-        class-name-str (php/. (php/-> munge (encodePhpNs *ns*)) "\\" (php/-> munge (encode name-str)))
-        is-name        (php/:: Symbol (create (php/. name-str "?")))]
+  (let [name-str       (.getName name)
+        munge          (new Munge)
+        class-name-str (php/. (.encodePhpNs munge *ns*) "\\" (.encode munge name-str))
+        is-name        (Symbol/create (php/. name-str "?"))]
     `(do
        (defenum* ~name ~@cases)
        (defn ~is-name ~(php/. "Checks if `x` is a case of the " name " enum.") [x] (php/is_a x ~class-name-str)))))

--- a/src/phel/core/exceptions.phel
+++ b/src/phel/core/exceptions.phel
@@ -13,9 +13,9 @@
   {:example "(throw (ex-info \"Invalid input\" {:field :email}))"
    :see-also ["ex-data" "ex-message" "ex-cause"]}
   ([msg data]
-   (php/new \Phel\Lang\ExceptionInfo msg data))
+   (new \Phel\Lang\ExceptionInfo msg data))
   ([msg data cause]
-   (php/new \Phel\Lang\ExceptionInfo msg data cause)))
+   (new \Phel\Lang\ExceptionInfo msg data cause)))
 
 (defn ex-data
   "Returns the data map from an ex-info exception, or nil if not an ExceptionInfo."
@@ -23,18 +23,18 @@
    :see-also ["ex-info" "ex-message" "ex-cause"]}
   [ex]
   (when (php/instanceof ex ExceptionInfo)
-    (php/-> ex (getData))))
+    (.getData ex)))
 
 (defn ex-message
   "Returns the message of an exception."
   {:example "(ex-message (ex-info \"boom\" {})) ; => \"boom\""
    :see-also ["ex-info" "ex-data" "ex-cause"]}
   [ex]
-  (php/-> ex (getMessage)))
+  (.getMessage ex))
 
 (defn ex-cause
   "Returns the cause of an exception, or nil."
   {:example "(ex-cause (ex-info \"boom\" {})) ; => nil"
    :see-also ["ex-info" "ex-data" "ex-message"]}
   [ex]
-  (php/-> ex (getPrevious)))
+  (.getPrevious ex))

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -22,7 +22,7 @@
   (let [target (transient (hash-set))]
     (foreach [s sets]
       (foreach [v s]
-        (php/-> target (add v))))
+        (.add target v)))
     (persistent target)))
 
 (defn- intersection-pair
@@ -31,8 +31,8 @@
     (recur s2 s1)
     (let [result (transient s1)]
       (foreach [item s1]
-        (when-not (php/-> s2 (contains item))
-          (php/-> result (remove item))))
+        (when-not (.contains s2 item)
+          (.remove result item)))
       (persistent result))))
 
 (defn intersection
@@ -47,13 +47,13 @@
   (if (< (count s1) (count s2))
     (let [result (transient s1)]
       (foreach [item s1]
-        (when (php/-> s2 (contains item))
-          (php/-> result (remove item))))
+        (when (.contains s2 item)
+          (.remove result item)))
       (persistent result))
 
     (let [result (transient s1)]
       (foreach [item s2]
-        (php/-> result (remove item)))
+        (.remove result item))
       (persistent result))))
 
 (defn difference
@@ -76,7 +76,7 @@
   [s1 s2]
   (if (> (count s1) (count s2))
     false
-    (every? #(php/-> s2 (contains %)) s1)))
+    (every? #(.contains s2 %) s1)))
 
 (defn superset?
   "Returns true if `s1` is a superset of `s2`, i.e. every element in `s2` is also in `s1`."
@@ -149,28 +149,28 @@
 ;; `__invoke` signature is the single reflection point covering both.
 (defn- fn-reflection
   [f]
-  (php/new \ReflectionMethod f "__invoke"))
+  (new \ReflectionMethod f "__invoke"))
 
 (defn arity
   "Returns the number of required parameters of the function `f`. For a variadic function this is the number of parameters before `&`. A multi-arity function compiles to a single variadic dispatch, so it reports `0`."
   {:example "(arity inc) ; => 1\n(arity assoc) ; => 3"
    :see-also ["variadic?" "apply" "partial"]}
   [f]
-  (php/-> (fn-reflection f) (getNumberOfRequiredParameters)))
+  (.getNumberOfRequiredParameters (fn-reflection f)))
 
 (defn variadic?
   "Returns true if the function `f` accepts a variable number of arguments. A multi-arity function compiles to a single variadic dispatch, so it always reports `true`."
   {:example "(variadic? +) ; => true\n(variadic? inc) ; => false"
    :see-also ["arity" "apply"]}
   [f]
-  (php/-> (fn-reflection f) (isVariadic)))
+  (.isVariadic (fn-reflection f)))
 
 (defn some-fn
   "Takes a variadic set of predicates and returns a function `f` that, when called with any number of arguments, returns the first logical true value produced by applying any of the composing predicates to any of its arguments, and `false` when none match. The returned function short-circuits on the first truthy result: arguments after it are not inspected, and predicates after it are not tried. Predicates are consulted in the order supplied; for a given predicate, arguments are consulted left-to-right."
   {:example "((some-fn even? nil?) 1 2) ; => true\n((some-fn pos? even?) -3 -1) ; => false"
    :see-also ["some" "complement" "every?" "not-any?"]}
   ([]
-   (throw (php/new \InvalidArgumentException "some-fn expects at least one predicate")))
+   (throw (new \InvalidArgumentException "some-fn expects at least one predicate")))
   ([p & ps]
    (let [preds (cons p ps)]
      (fn [& args]
@@ -181,7 +181,7 @@
   {:example "((every-pred even? pos?) 2 4 6) ; => true\n((every-pred even? pos?) 2 -4) ; => false"
    :see-also ["some-fn" "complement" "every?" "not-every?"]}
   ([]
-   (throw (php/new \InvalidArgumentException "every-pred expects at least one predicate")))
+   (throw (new \InvalidArgumentException "every-pred expects at least one predicate")))
   ([p & ps]
    (let [preds (cons p ps)]
      (fn [& args]
@@ -312,7 +312,7 @@ Without arguments, uses a default cache size of 128 entries."
     (loop [stack (php/array root)]
       (if (> (count stack) 0)
         (let [node (pop stack)]
-          (php/-> ret (append node))
+          (.append ret node)
           (when (branch? node)
             (foreach [child (reverse (children node))]
               (php/apush stack child)))

--- a/src/phel/core/futures.phel
+++ b/src/phel/core/futures.phel
@@ -15,9 +15,9 @@ Must be called from inside a fiber context (e.g. the AMPHP event loop or an encl
   {:example "(let [f (future (expensive-computation))] @f)"
    :see-also ["realized?" "deref"]}
   [& body]
-  `(let [frame# (php/:: \Phel (snapshotDynamicBindings))]
-     (php/new \Phel\Lang\Future
-              (php/amp\async
-               (fn []
-                 (php/:: \Phel (withDynamicBindings frame# (fn [] ~@body)))))
-              (php/new \Amp\DeferredCancellation))))
+  `(let [frame# (\Phel/snapshotDynamicBindings)]
+     (new \Phel\Lang\Future
+          (php/amp\async
+           (fn []
+             (\Phel/withDynamicBindings frame# (fn [] ~@body))))
+          (new \Amp\DeferredCancellation))))

--- a/src/phel/core/interop.phel
+++ b/src/phel/core/interop.phel
@@ -21,13 +21,13 @@
   rather than a literal. `target` is either an object or a class-name string
   for a static method. Matches ClojureScript's `js-invoke`; use the dot
   syntax (`(.format d \"Y\")`) whenever the name is known at compile time."
-  {:example "(php-invoke (php/new \\DateTimeImmutable \"2024-03-10\") \"format\" \"Y\") ; => \"2024\"\n(let [m \"format\"] (php-invoke (php/new \\DateTimeImmutable \"2024-03-10\") m \"Y\")) ; => \"2024\""
+  {:example "(php-invoke (new \\DateTimeImmutable \"2024-03-10\") \"format\" \"Y\") ; => \"2024\"\n(let [m \"format\"] (php-invoke (new \\DateTimeImmutable \"2024-03-10\") m \"Y\")) ; => \"2024\""
    :see-also ["php/callable" "apply"]}
   [target method & args]
   (let [callable (php/array target method)]
     (if (php/is_callable callable)
       (php/call_user_func_array callable (to-php-array args))
-      (throw (php/new InvalidArgumentException
-                      (str "Call to undefined method "
-                           (invoke-target-name target)
-                           "::" method "()"))))))
+      (throw (new InvalidArgumentException
+                  (str "Call to undefined method "
+                       (invoke-target-name target)
+                       "::" method "()"))))))

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -32,7 +32,7 @@
 (defn- print-joined
   "Space-joins `xs`, stringifying each element with `printer`."
   [printer xs]
-  (let [pp #(php/-> printer (print %))]
+  (let [pp #(.print printer %)]
     (case (count xs)
       0 ""
       1 (pp (first xs))
@@ -47,14 +47,14 @@
   {:example "(print-str \"a\" 1) ; => \"a 1\""
    :see-also ["pr-str" "println-str" "str"]}
   ^string [& xs]
-  (print-joined (php/:: Printer (nonReadable)) xs))
+  (print-joined (Printer/nonReadable) xs))
 
 (defn pr-str
   "Same as `print-str`, but prints each value readably: strings are quoted and escaped so the output can be read back. Phel has no dedicated char type, so character literals such as `\\A` are single-character strings and print as `\"A\"` (ClojureScript-aligned; Clojure/JVM would print `\\A`)."
   {:example "(pr-str \"a\" 1) ; => \"\\\"a\\\" 1\""
    :see-also ["print-str" "prn-str" "prn"]}
   ^string [& xs]
-  (print-joined (php/:: Printer (readable)) xs))
+  (print-joined (Printer/readable) xs))
 
 (defn print
   "Prints the given values to the default output stream. Returns nil."
@@ -126,9 +126,9 @@
 
 (defn- dbg-location-str [form]
   (if (php/instanceof form SourceLocationInterface)
-    (let [start-loc (php/-> form (getStartLocation))]
+    (let [start-loc (.getStartLocation form)]
       (if start-loc
-        (str (php/-> start-loc (getFile)) ":" (php/-> start-loc (getLine)))
+        (str (.getFile start-loc) ":" (.getLine start-loc))
         "unknown"))
     "unknown"))
 
@@ -165,11 +165,11 @@
     ;; Validate for non-URLs
     (when-not is-url?
       (when (php/is_dir path)
-        (throw (php/new \InvalidArgumentException
-                        (str "Cannot read directory: " path))))
+        (throw (new \InvalidArgumentException
+                    (str "Cannot read directory: " path))))
       (when-not (php/is_file path)
-        (throw (php/new \InvalidArgumentException
-                        (str "File not found: " path)))))
+        (throw (new \InvalidArgumentException
+                    (str "File not found: " path)))))
     ;; Read content
     (let [opts             (or opts {})
           use-include-path (or (:use-include-path opts) false)
@@ -178,8 +178,8 @@
           length           (or (:length opts) nil)
           content          (file-get-contents-silenced path use-include-path context offset length)]
       (when (= content false)
-        (throw (php/new \InvalidArgumentException
-                        (str "Failed to read from: " path))))
+        (throw (new \InvalidArgumentException
+                    (str "Failed to read from: " path))))
       content)))
 
 (defn spit
@@ -188,8 +188,8 @@
 See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-contents.php) for more information."
   [filename data & [opts]]
   (when (php/is_dir filename)
-    (throw (php/new \InvalidArgumentException
-                    "Argument filename should be a valid path to a file, directory given.")))
+    (throw (new \InvalidArgumentException
+                "Argument filename should be a valid path to a file, directory given.")))
   (let [opts    (or opts {})
         flags   (or (:flags opts) 0)
         context (or (:context opts) nil)
@@ -259,7 +259,7 @@ See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-co
   (cond
     (nil? resource) nil
     (and (php/is_object resource) (php/method_exists resource "close"))
-    (php/-> resource (close))
+    (.close resource)
     (and (php/is_resource resource) (= "stream" (php/get_resource_type resource)))
     (php/fclose resource)
     nil))
@@ -272,7 +272,7 @@ See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-co
   {:example "(with-open [f (php/fopen \"data.txt\" \"r\")] (php/fgets f))"
    :see-also ["slurp" "spit" "line-seq"]}
   [bindings & body]
-  (let [err #(throw (php/new \InvalidArgumentException %))]
+  (let [err #(throw (new \InvalidArgumentException %))]
     (when-not (vector? bindings)
       (err (str "with-open requires a vector for its bindings, "
                 (type bindings) " given")))
@@ -490,14 +490,16 @@ See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-co
   fiber-local recording (`openBindingFrame` for dynamic-only,
   `openRedefsFrame` for any var)."
   [open-method bindings body]
+  ;; `php/::` stays: the static method name arrives as a symbol at
+  ;; expansion time, and `\Phel/m` needs the name written literally.
   `(do
      (php/:: \Phel (~open-method))
      (try
        (do
          ~@(emit-set-vars bindings)
-         (php/:: \Phel (commitAndRunBindingFrame (fn [] ~@body))))
+         (\Phel/commitAndRunBindingFrame (fn [] ~@body)))
        (finally
-         (php/:: \Phel (abortBindingFrameIfOpen))))))
+         (\Phel/abortBindingFrameIfOpen)))))
 
 (defmacro binding
   "Temporarily rebinds dynamic vars while executing `body`.
@@ -533,14 +535,13 @@ See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-co
         v-sym (gensym "v__")
         x-sym (gensym "x__")]
     `(let [~m-sym ~m]
-       (php/:: \Phel (openBindingFrame))
+       (\Phel/openBindingFrame)
        (try
          (do
            (foreach [~v-sym ~x-sym ~m-sym]
-             (php/:: \Phel
-                     (setVar (php/-> ~v-sym (getNamespace))
-                             (php/-> ~v-sym (getName))
-                             ~x-sym)))
-           (php/:: \Phel (commitAndRunBindingFrame (fn [] ~@body))))
+             (\Phel/setVar (.getNamespace ~v-sym)
+                           (.getName ~v-sym)
+                           ~x-sym))
+           (\Phel/commitAndRunBindingFrame (fn [] ~@body)))
          (finally
-           (php/:: \Phel (abortBindingFrameIfOpen)))))))
+           (\Phel/abortBindingFrameIfOpen))))))

--- a/src/phel/core/lazy.phel
+++ b/src/phel/core/lazy.phel
@@ -14,7 +14,7 @@
   {:example "(def d (delay (println \"computing\") 42))"
    :see-also ["force" "delay?" "realized?"]}
   [& body]
-  `(php/new \Phel\Lang\Delay (fn [] ~@body)))
+  `(new \Phel\Lang\Delay (fn [] ~@body)))
 
 (defn force
   "If x is a Delay, forces it and returns its cached value. Otherwise returns x."
@@ -22,7 +22,7 @@
    :see-also ["delay" "deref"]}
   [x]
   (if (php/instanceof x Delay)
-    (php/-> x (deref))
+    (.deref x)
     x))
 
 (defn delay?

--- a/src/phel/core/macroexpand.phel
+++ b/src/phel/core/macroexpand.phel
@@ -19,11 +19,11 @@
       (if (symbol? op)
         (let [node (get-global-var-node op)]
           (if (php/instanceof node GlobalVarNode)
-            (let [meta (php/-> node (getMeta))]
+            (let [meta (.getMeta node)]
               (if (:macro meta)
-                (let [ns       (php/-> node (getNamespace))
-                      name     (php/-> (php/-> node (getName)) (getName))
-                      macro-fn (php/:: Phel (getDefinition ns name))
+                (let [ns       (.getNamespace node)
+                      name     (.getName (.getName node))
+                      macro-fn (Phel/getDefinition ns name)
                       args     (rest form)]
                   (apply macro-fn form {} args))
                 form))

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -21,7 +21,7 @@
   [xs]
   (foreach [x xs]
     (when (php/=== nil x)
-      (throw (php/new \InvalidArgumentException "Arithmetic functions do not accept nil values")))))
+      (throw (new \InvalidArgumentException "Arithmetic functions do not accept nil values")))))
 
 (defn- assert-non-nil
   [& xs]
@@ -154,8 +154,8 @@
   (case (count xs)
     0 0
     1 (first xs)
-    2 (php/:: NumericOperations (add (first xs) (second xs)))
-    (reduce #(php/:: NumericOperations (add %1 %2)) xs)))
+    2 (NumericOperations/add (first xs) (second xs))
+    (reduce #(NumericOperations/add %1 %2) xs)))
 
 (defn -
   "Returns the difference of all elements in `xs`. If `xs` is empty, return 0. If `xs` has one element, return the negative value of that element."
@@ -165,9 +165,9 @@
   (assert-non-nil-coll xs)
   (case (count xs)
     0 0
-    1 (php/:: NumericOperations (negate (first xs)))
-    2 (php/:: NumericOperations (subtract (first xs) (second xs)))
-    (reduce #(php/:: NumericOperations (subtract %1 %2)) xs)))
+    1 (NumericOperations/negate (first xs))
+    2 (NumericOperations/subtract (first xs) (second xs))
+    (reduce #(NumericOperations/subtract %1 %2) xs)))
 
 (defn *
   "Returns the product of all elements in `xs`. All elements in `xs` must be numbers. If `xs` is empty, return 1."
@@ -178,8 +178,8 @@
   (case (count xs)
     0 1
     1 (first xs)
-    2 (php/:: NumericOperations (multiply (first xs) (second xs)))
-    (reduce #(php/:: NumericOperations (multiply %1 %2)) xs)))
+    2 (NumericOperations/multiply (first xs) (second xs))
+    (reduce #(NumericOperations/multiply %1 %2) xs)))
 
 (defn /
   "Returns the nominator divided by all the denominators. If `xs` is empty,
@@ -194,9 +194,9 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   (assert-non-nil-coll xs)
   (case (count xs)
     0 1
-    1 (php/:: NumericOperations (divide 1 (first xs)))
-    2 (php/:: NumericOperations (divide (first xs) (second xs)))
-    (reduce #(php/:: NumericOperations (divide %1 %2)) xs)))
+    1 (NumericOperations/divide 1 (first xs))
+    2 (NumericOperations/divide (first xs) (second xs))
+    (reduce #(NumericOperations/divide %1 %2) xs)))
 
 (defn quot
   "Returns the truncated integer quotient of `dividend` / `divisor`. Truncates toward zero. Throws `\\DivisionByZeroError` when `divisor` is zero."
@@ -204,7 +204,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
    :see-also ["rem" "mod" "/"]}
   [dividend divisor]
   (assert-non-nil dividend divisor)
-  (php/:: NumericOperations (quot dividend divisor)))
+  (NumericOperations/quot dividend divisor))
 
 (defn rem
   "Returns the truncated remainder of `dividend` / `divisor`. The result has the same sign as `dividend` (matches PHP's `%`)."
@@ -212,7 +212,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
    :see-also ["quot" "mod" "%"]}
   [dividend divisor]
   (assert-non-nil dividend divisor)
-  (php/:: NumericOperations (rem dividend divisor)))
+  (NumericOperations/rem dividend divisor))
 
 (defn mod
   "Returns the floor remainder of `dividend` / `divisor`. The result has
@@ -222,7 +222,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
    :see-also ["quot" "rem" "%"]}
   [dividend divisor]
   (assert-non-nil dividend divisor)
-  (php/:: NumericOperations (mod dividend divisor)))
+  (NumericOperations/mod dividend divisor))
 
 (defn %
   "Alias for `rem`. Returns the truncated remainder of `dividend` /
@@ -238,7 +238,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
    :see-also ["*" "sqrt"]}
   [a x]
   (assert-non-nil a x)
-  (php/:: NumericOperations (power a x)))
+  (NumericOperations/power a x))
 
 (defn inc
   "Increments `x` by one."
@@ -246,7 +246,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
    :see-also ["dec" "+"]}
   [x]
   (assert-non-nil x)
-  (php/:: NumericOperations (add x 1)))
+  (NumericOperations/add x 1))
 
 (defn dec
   "Decrements `x` by one."
@@ -254,12 +254,12 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
    :see-also ["inc" "-"]}
   [x]
   (assert-non-nil x)
-  (php/:: NumericOperations (subtract x 1)))
+  (NumericOperations/subtract x 1))
 
 (defn- promote-int->bigint
   [x]
   (if (php/is_int x)
-    (php/:: BigInt (fromInt x))
+    (BigInt/fromInt x)
     x))
 
 (defn +'
@@ -310,7 +310,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(even? 4) ; => true"
    :see-also ["odd?" "zero?"]}
   [x]
-  (php/:: NumericOperations (isZero (% x 2))))
+  (NumericOperations/isZero (% x 2)))
 
 (defn odd?
   "Checks if `x` is odd."
@@ -324,7 +324,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(zero? 0) ; => true"
    :see-also ["pos?" "neg?" "one?"]}
   [x]
-  (php/:: NumericOperations (isZero x)))
+  (NumericOperations/isZero x))
 
 (defn one?
   "Checks if `x` is one."
@@ -384,9 +384,9 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(abs -5) ; => 5"}
   [x]
   (if (number? x)
-    (php/:: NumericOperations (abs x))
-    (throw (php/new InvalidArgumentException
-                    (str "abs expects a number, got " (type x))))))
+    (NumericOperations/abs x)
+    (throw (new InvalidArgumentException
+                (str "abs expects a number, got " (type x))))))
 
 (defn gcd
   "Returns the greatest common divisor of `a` and `b`, computed with the
@@ -426,10 +426,10 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   (cond
     (or (php/instanceof x Ratio)
         (php/instanceof x BigInt)
-        (php/instanceof x BigDecimal)) (php/-> x (toInt))
-    (php/is_float x)                   (php/-> (php/:: BigInt (fromFloat x)) (toInt))
-    (php/is_object x)                  (throw (php/new InvalidArgumentException
-                                                       (str "int expects a number, numeric string, or nil, got " (type x))))
+        (php/instanceof x BigDecimal)) (.toInt x)
+    (php/is_float x)                   (.toInt (BigInt/fromFloat x))
+    (php/is_object x)                  (throw (new InvalidArgumentException
+                                                   (str "int expects a number, numeric string, or nil, got " (type x))))
     :else                             (php/intval x)))
 
 (defn float
@@ -444,11 +444,11 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
    :see-also ["double" "int?" "number?"]}
   [x]
   (cond
-    (php/instanceof x Ratio)      (php/-> x (toFloat))
+    (php/instanceof x Ratio)      (.toFloat x)
     (php/instanceof x BigInt)     (php/floatval (str x))
-    (php/instanceof x BigDecimal) (php/-> x (toFloat))
-    (php/is_object x)             (throw (php/new InvalidArgumentException
-                                                  (str "float expects a number, numeric string, or nil, got " (type x))))
+    (php/instanceof x BigDecimal) (.toFloat x)
+    (php/is_object x)             (throw (new InvalidArgumentException
+                                              (str "float expects a number, numeric string, or nil, got " (type x))))
     :else                         (php/floatval x)))
 
 (defn double
@@ -473,10 +473,10 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   (if (number? x)
     (let [truncated (int x)]
       (if (or (php/< truncated lo) (php/> truncated hi))
-        (throw (php/new InvalidArgumentException
-                        (php/. "Value out of range for " label ": " (php/strval truncated))))
+        (throw (new InvalidArgumentException
+                    (php/. "Value out of range for " label ": " (php/strval truncated))))
         truncated))
-    (throw (php/new InvalidArgumentException (php/. label " expects a numeric value")))))
+    (throw (new InvalidArgumentException (php/. label " expects a numeric value")))))
 
 (defn short
   "Coerces `x` to a signed 16-bit integer in the range `-32768..32767`. Decimal values are truncated toward zero. `Ratio` and `BigInt` values are accepted (truncate toward zero, then range-check). Values outside the range or non-numeric inputs raise `InvalidArgumentException`. Phel has no dedicated short type, so the result is a plain PHP int."
@@ -500,23 +500,23 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   (cond
     (int? x)
     (if (php/< x 0)
-      (throw (php/new InvalidArgumentException
-                      (php/. "Value out of range for char: " (php/strval x))))
+      (throw (new InvalidArgumentException
+                  (php/. "Value out of range for char: " (php/strval x))))
       (let [ch (php/mb_chr x "UTF-8")]
         (if (php/=== ch false)
-          (throw (php/new InvalidArgumentException
-                          (php/. "Invalid code point for char: " (php/strval x))))
+          (throw (new InvalidArgumentException
+                      (php/. "Invalid code point for char: " (php/strval x))))
           ch)))
 
     (string? x)
     (if (php/=== 1 (php/mb_strlen x "UTF-8"))
       x
-      (throw (php/new InvalidArgumentException
-                      "char expects a single-character string")))
+      (throw (new InvalidArgumentException
+                  "char expects a single-character string")))
 
     :else
-    (throw (php/new InvalidArgumentException
-                    "char expects a non-negative integer or a single-character string"))))
+    (throw (new InvalidArgumentException
+                "char expects a non-negative integer or a single-character string"))))
 
 (defn rand
   "Without arguments, returns a random number in `[0, 1)`. With one argument `n`, returns a random number in `[0, n)`."
@@ -616,7 +616,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
    :see-also ["min" "max"]}
   [v min max]
   (when (< max min)
-    (throw (php/new \InvalidArgumentException "Max values is bigger than min value")))
+    (throw (new \InvalidArgumentException "Max values is bigger than min value")))
   (php/max (php/min v max) min))
 
 (defn sum
@@ -641,7 +641,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   (let [arr (to-php-array xs)
         cnt (count arr)]
     (when (zero? cnt)
-      (throw (php/new \InvalidArgumentException "Cannot compute median of empty sequence")))
+      (throw (new \InvalidArgumentException "Cannot compute median of empty sequence")))
     (php/sort arr)
     (let [mid (php/intdiv cnt 2)]
       (if (odd? cnt)
@@ -654,7 +654,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn bigint?
   "Returns true when `x` is a `Phel\\Lang\\BigInt` value."
-  {:example "(bigint? (php/:: \\Phel\\Lang\\BigInt (fromInt 1))) ; => true"
+  {:example "(bigint? (\\Phel\\Lang\\BigInt/fromInt 1)) ; => true"
    :see-also ["int?" "ratio?" "number?"]}
   [x]
   (php/instanceof x BigInt))
@@ -680,16 +680,15 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   [x]
   (cond
     (php/instanceof x BigDecimal) x
-    (php/is_int x)                (php/:: BigDecimal (fromInt x))
-    (php/is_float x)              (php/:: BigDecimal (fromFloat x))
-    (php/instanceof x BigInt)     (php/:: BigDecimal (fromBigInt x))
-    (php/instanceof x Ratio)      (php/-> (php/:: BigDecimal (fromBigInt (php/-> x (numerator))))
-                                          (divideExact (php/:: BigDecimal (fromBigInt (php/-> x (denominator))))))
-    (string? x)                   (php/:: BigDecimal (fromString x))
+    (php/is_int x)                (BigDecimal/fromInt x)
+    (php/is_float x)              (BigDecimal/fromFloat x)
+    (php/instanceof x BigInt)     (BigDecimal/fromBigInt x)
+    (php/instanceof x Ratio)      (.divideExact (BigDecimal/fromBigInt (.numerator x)) (BigDecimal/fromBigInt (.denominator x)))
+    (string? x)                   (BigDecimal/fromString x)
     :else
-    (throw (php/new \InvalidArgumentException
-                    (php/. "bigdec expects a BigDecimal, int, float, BigInt, Ratio, or numeric string, got "
-                           (php/get_debug_type x))))))
+    (throw (new \InvalidArgumentException
+                (php/. "bigdec expects a BigDecimal, int, float, BigInt, Ratio, or numeric string, got "
+                       (php/get_debug_type x))))))
 
 (defn numerator
   "Returns the numerator of `r`. For rationals the numerator collapses to a PHP int when it fits; for plain ints and `BigInt` values `r` is returned unchanged."
@@ -698,18 +697,18 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   [r]
   (cond
     (php/instanceof r Ratio)
-    (let [n (php/-> r (numerator))]
-      (if (php/-> n (fitsInPhpInt))
-        (php/-> n (toInt))
+    (let [n (.numerator r)]
+      (if (.fitsInPhpInt n)
+        (.toInt n)
         n))
 
     (or (php/is_int r) (php/instanceof r BigInt))
     r
 
     :else
-    (throw (php/new InvalidArgumentException
-                    (str "numerator expects a rational, integer, or BigInt, got "
-                         (type r))))))
+    (throw (new InvalidArgumentException
+                (str "numerator expects a rational, integer, or BigInt, got "
+                     (type r))))))
 
 (defn denominator
   "Returns the denominator of `r`. For rationals the denominator collapses to a PHP int when it fits; integers and `BigInt` values report `1`."
@@ -718,18 +717,18 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   [r]
   (cond
     (php/instanceof r Ratio)
-    (let [d (php/-> r (denominator))]
-      (if (php/-> d (fitsInPhpInt))
-        (php/-> d (toInt))
+    (let [d (.denominator r)]
+      (if (.fitsInPhpInt d)
+        (.toInt d)
         d))
 
     (or (php/is_int r) (php/instanceof r BigInt))
     1
 
     :else
-    (throw (php/new InvalidArgumentException
-                    (str "denominator expects a rational, integer, or BigInt, got "
-                         (type r))))))
+    (throw (new InvalidArgumentException
+                (str "denominator expects a rational, integer, or BigInt, got "
+                     (type r))))))
 
 (defn- float-shortest-decimal
   "Shortest %g-formatted decimal that round-trips back to `x`. Tries increasing precision so 0.1 becomes \"0.1\", not \"0.10000000000000001\"."
@@ -760,20 +759,20 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
         stripped   (php/ltrim joined "0")
         digits     (if (php/=== "" stripped) "0" stripped)
         signed     (if negative? (php/. "-" digits) digits)
-        num        (php/:: BigInt (fromString signed))
+        num        (BigInt/fromString signed)
         eff-exp    (php/- exponent (php/strlen frac-part))]
     (if (php/>= eff-exp 0)
-      (let [scale (php/-> (php/:: BigInt (fromInt 10)) (pow eff-exp))]
-        (php/:: Ratio (create (php/-> num (multiply scale)) 1)))
-      (let [denom (php/-> (php/:: BigInt (fromInt 10)) (pow (php/- 0 eff-exp)))]
-        (php/:: Ratio (create num denom))))))
+      (let [scale (.pow (BigInt/fromInt 10) eff-exp)]
+        (Ratio/create (.multiply num scale) 1))
+      (let [denom (.pow (BigInt/fromInt 10) (php/- 0 eff-exp))]
+        (Ratio/create num denom)))))
 
 (defn- float->rational
   "Converts a finite float to a Ratio using its shortest round-trip decimal expansion. Non-finite floats are rejected."
   [x]
   (when (or (php/is_infinite x) (php/is_nan x))
-    (throw (php/new InvalidArgumentException
-                    "rationalize cannot convert ##Inf, ##-Inf, or ##NaN")))
+    (throw (new InvalidArgumentException
+                "rationalize cannot convert ##Inf, ##-Inf, or ##NaN")))
   (decimal-string->rational (float-shortest-decimal x)))
 
 (defn rationalize
@@ -786,10 +785,10 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
     (php/instanceof x BigInt)     x
     (php/is_int x)                x
     (php/is_float x)              (float->rational x)
-    (php/instanceof x BigDecimal) (decimal-string->rational (php/-> x (toPlainString)))
+    (php/instanceof x BigDecimal) (decimal-string->rational (.toPlainString x))
     :else
-    (throw (php/new InvalidArgumentException
-                    (str "rationalize expects a number, got " (type x))))))
+    (throw (new InvalidArgumentException
+                (str "rationalize expects a number, got " (type x))))))
 
 (defn bigint
   "Coerces `x` to a `Phel\\Lang\\BigInt`. Accepts ints, floats
@@ -800,12 +799,12 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   [x]
   (cond
     (php/instanceof x BigInt) x
-    (php/is_int x)            (php/:: BigInt (fromInt x))
-    (php/is_float x)          (php/:: BigInt (fromFloat x))
-    (string? x)               (php/:: BigInt (fromString x))
+    (php/is_int x)            (BigInt/fromInt x)
+    (php/is_float x)          (BigInt/fromFloat x)
+    (string? x)               (BigInt/fromString x)
     :else
-    (throw (php/new InvalidArgumentException
-                    (str "bigint expects an int, float, numeric string, or BigInt, got " (type x))))))
+    (throw (new InvalidArgumentException
+                (str "bigint expects an int, float, numeric string, or BigInt, got " (type x))))))
 
 (defn biginteger
   "Alias for `bigint`. Coerces `x` to a `Phel\\Lang\\BigInt`."
@@ -822,8 +821,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   [x]
   (if (number? x)
     (float x)
-    (throw (php/new InvalidArgumentException
-                    (str "expected a number, got " (type x))))))
+    (throw (new InvalidArgumentException
+                (str "expected a number, got " (type x))))))
 
 (defn- rational-floor
   ;; floor(n/d) = (n - mod(n,d)) / d; Ratio denominators are positive.
@@ -844,8 +843,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
     (php/instanceof x Ratio)  (rational-floor x)
     (php/is_float x)          (php/floor x)
     :else
-    (throw (php/new InvalidArgumentException
-                    (str "floor expects a number, got " (type x))))))
+    (throw (new InvalidArgumentException
+                (str "floor expects a number, got " (type x))))))
 
 (defn ceil
   "Returns the smallest integer not less than `x`. Ints and `BigInt` values are returned unchanged. Ratios collapse via ceiling division. Floats route through PHP's `ceil`."
@@ -859,8 +858,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
     (php/instanceof x Ratio)  (- (rational-floor (- x)))
     (php/is_float x)          (php/ceil x)
     :else
-    (throw (php/new InvalidArgumentException
-                    (str "ceil expects a number, got " (type x))))))
+    (throw (new InvalidArgumentException
+                (str "ceil expects a number, got " (type x))))))
 
 (defn round
   "Rounds `x` to the nearest integer using PHP's `round` (half away from zero). Ints and `BigInt` values are returned unchanged. Ratios and floats return floats."

--- a/src/phel/core/meta.phel
+++ b/src/phel/core/meta.phel
@@ -37,13 +37,13 @@
                          nil)
                        nil)]
       (if quoted-sym
-        (let [ns (php/-> quoted-sym (getNamespace))]
+        (let [ns (.getNamespace quoted-sym)]
           (if ns
-            `(php/:: \Phel (getDefinitionMetaData ~ns ~(php/-> quoted-sym (getName))))
-            `(php/:: \Phel (getDefinitionMetaData (php/str_replace "-" "_" *ns*) ~(php/-> quoted-sym (getName))))))
+            `(\Phel/getDefinitionMetaData ~ns ~(.getName quoted-sym))
+            `(\Phel/getDefinitionMetaData (php/str_replace "-" "_" *ns*) ~(.getName quoted-sym))))
         `(let [obj-meta ~obj]
            (if (php/instanceof obj-meta \Phel\Lang\MetaInterface)
-             (php/-> obj-meta (getMeta))
+             (.getMeta obj-meta)
              nil))))))
 
 (def copy-meta
@@ -52,9 +52,9 @@
   (fn [source target]
     (if (php/instanceof source MetaInterface)
       (if (php/instanceof target MetaInterface)
-        (let [src-meta (php/-> source (getMeta))]
+        (let [src-meta (.getMeta source)]
           (if src-meta
-            (php/-> target (withMeta src-meta))
+            (.withMeta target src-meta)
             target))
         target)
       target)))
@@ -63,13 +63,13 @@
   {:doc "Returns `obj` with the given metadata `meta` attached."
    :see-also ["meta" "vary-meta"]}
   (fn [obj meta]
-    (php/-> obj (withMeta meta))))
+    (.withMeta obj meta)))
 
 (def vary-meta
   {:doc "Returns an object with (apply f (meta obj) args) as its new metadata."
    :see-also ["meta" "with-meta"]}
   (fn [obj f & args]
     (let [m (if (php/instanceof obj MetaInterface)
-              (php/-> obj (getMeta))
+              (.getMeta obj)
               nil)]
-      (php/-> obj (withMeta (apply f m args))))))
+      (.withMeta obj (apply f m args)))))

--- a/src/phel/core/ns.phel
+++ b/src/phel/core/ns.phel
@@ -12,14 +12,14 @@
 
 (def ^:private munge-instance
   ;; Munge is a final readonly class; reuse a single instance to avoid per-call allocation.
-  (php/new Munge))
+  (new Munge))
 
 (defn canonical-ns
   "Returns the canonical (dot-separated) form of a namespace string. Pass user-supplied namespace strings through this before any registry lookup or write."
   {:example "(canonical-ns \"phel\\core\") ; => \"phel.core\""
    :see-also ["display-ns" "find-ns" "create-ns" "intern"]}
   [ns-str]
-  (php/:: Munge (canonicalNs ns-str)))
+  (Munge/canonicalNs ns-str))
 
 (defn display-ns
   "Returns the display (dot-separated) form of a namespace string. Equivalent to `canonical-ns`; kept as a separate name so call sites read intent (display vs. canonicalize)."
@@ -32,21 +32,21 @@
   "Returns all namespaces currently loaded, in dot-separated display form."
   {:example "(loaded-namespaces) ; => [\"phel.core\" \"phel.repl\"]"}
   []
-  (let [raw    (php/:: Phel (getNamespaces))
+  (let [raw    (Phel/getNamespaces)
         result (transient [])]
     (foreach [ns raw]
-      (conj result (php/-> munge-instance (decodeNs ns))))
+      (conj result (.decodeNs munge-instance ns)))
     (persistent result)))
 
 (defn- core-munge-ns
   "Encodes a namespace string for registry lookup."
   [ns-str]
-  (php/-> munge-instance (encodeRegistryKey ns-str)))
+  (.encodeRegistryKey munge-instance ns-str))
 
 (defn- core-munge-name
   "Encodes a definition name for registry lookup."
   [name-str]
-  (php/-> munge-instance (encode name-str)))
+  (.encode munge-instance name-str))
 
 (defn find-ns
   "Returns the namespace name in display form if it is loaded, or nil if no namespace of that name exists. Accepts dot or backslash separators on input."
@@ -54,7 +54,7 @@
    :see-also ["create-ns" "remove-ns" "loaded-namespaces"]}
   [ns-str]
   (let [canonical (canonical-ns ns-str)]
-    (when (php/:: Phel (hasNamespace (core-munge-ns canonical)))
+    (when (Phel/hasNamespace (core-munge-ns canonical))
       (display-ns canonical))))
 
 (defn create-ns
@@ -63,7 +63,7 @@
    :see-also ["find-ns" "remove-ns" "intern"]}
   [ns-str]
   (let [canonical (canonical-ns ns-str)]
-    (php/:: Phel (registerNamespace (core-munge-ns canonical)))
+    (Phel/registerNamespace (core-munge-ns canonical))
     (display-ns canonical)))
 
 (defn remove-ns
@@ -71,18 +71,18 @@
   {:example "(remove-ns \"my-app\\tmp\")"
    :see-also ["find-ns" "create-ns"]}
   [ns-str]
-  (php/:: Phel (removeNamespace (core-munge-ns ns-str)))
+  (Phel/removeNamespace (core-munge-ns ns-str))
   nil)
 
 (defn- defs->map
   "Builds a {decoded-name => value} map of the definitions in `encoded-ns`,
   keeping only those whose encoded `fn-name` satisfies `keep?`."
   [encoded-ns keep?]
-  (let [defs   (php/:: Phel (getDefinitionInNamespace encoded-ns))
+  (let [defs   (Phel/getDefinitionInNamespace encoded-ns)
         result (transient {})]
     (foreach [fn-name value defs]
       (when (keep? fn-name)
-        (assoc! result (php/-> munge-instance (decodeNs fn-name)) value)))
+        (assoc! result (.decodeNs munge-instance fn-name) value)))
     (persistent result)))
 
 (defn ns-interns
@@ -103,11 +103,11 @@
         encoded-ns   (core-munge-ns canonical)
         encoded-name (core-munge-name name-str)]
     (if (seq rest)
-      (php/:: Phel (addDefinition encoded-ns encoded-name (first rest)))
+      (Phel/addDefinition encoded-ns encoded-name (first rest))
       ;; skip when no value is provided and the definition already exists
-      (when-not (php/:: Phel (isDefined encoded-ns encoded-name))
-        (php/:: Phel (addDefinition encoded-ns encoded-name nil))))
-    (php/:: Symbol (createForNamespace (display-ns canonical) name-str))))
+      (when-not (Phel/isDefined encoded-ns encoded-name)
+        (Phel/addDefinition encoded-ns encoded-name nil)))
+    (Symbol/createForNamespace (display-ns canonical) name-str)))
 
 (defn var-get
   "Resolves the value bound to a `Var` or to a fully-qualified symbol.
@@ -128,19 +128,19 @@
   ([x not-found]
    (cond
      (php/instanceof x PhelVar)
-     (php/-> x (deref))
+     (.deref x)
 
      (and (symbol? x) (namespace x))
      (let [encoded-ns (core-munge-ns (namespace x))
            raw-name   (name x)]
        (cond
-         (php/:: Phel (isDefined encoded-ns raw-name))
-         (php/:: Phel (getDefinition encoded-ns raw-name))
+         (Phel/isDefined encoded-ns raw-name)
+         (Phel/getDefinition encoded-ns raw-name)
 
-         (php/:: Phel (isDefined encoded-ns (core-munge-name raw-name)))
-         (php/:: Phel (getDefinition encoded-ns (core-munge-name raw-name)))
+         (Phel/isDefined encoded-ns (core-munge-name raw-name))
+         (Phel/getDefinition encoded-ns (core-munge-name raw-name))
 
-         true                                                            not-found))
+         true                                                   not-found))
 
      true                            not-found)))
 
@@ -153,13 +153,13 @@
     (let [encoded-ns (core-munge-ns (namespace sym))
           raw-name   (name sym)]
       (cond
-        (php/:: Phel (isDefined encoded-ns raw-name))
-        (php/:: Phel (getVar encoded-ns raw-name))
+        (Phel/isDefined encoded-ns raw-name)
+        (Phel/getVar encoded-ns raw-name)
 
-        (php/:: Phel (isDefined encoded-ns (core-munge-name raw-name)))
-        (php/:: Phel (getVar encoded-ns (core-munge-name raw-name)))
+        (Phel/isDefined encoded-ns (core-munge-name raw-name))
+        (Phel/getVar encoded-ns (core-munge-name raw-name))
 
-        true                                                            nil))))
+        true                                                   nil))))
 
 (defn ns-publics
   "Returns a hash-map of {name => value} for all public definitions in the
@@ -170,7 +170,7 @@
   (let [encoded (core-munge-ns ns-str)]
     (defs->map encoded
                (fn [fn-name]
-                 (not (get (php/:: Phel (getDefinitionMetaData encoded fn-name)) :private))))))
+                 (not (get (Phel/getDefinitionMetaData encoded fn-name) :private))))))
 
 (defn ns-aliases
   "Returns a hash-map of {alias => namespace} for all require aliases in the
@@ -178,11 +178,11 @@
   {:example "(ns-aliases *ns*) ; => {\"repl\" \"phel.repl\" ...}"
    :see-also ["ns-publics" "ns-refers" "loaded-namespaces"]}
   [ns-str]
-  (let [env     (php/:: GlobalEnvironmentSingleton (getInstance))
-        aliases (php/-> env (getRequireAliases (canonical-ns ns-str)))
+  (let [env     (GlobalEnvironmentSingleton/getInstance)
+        aliases (.getRequireAliases env (canonical-ns ns-str))
         result  (transient {})]
     (foreach [alias-name target-sym aliases]
-      (assoc! result alias-name (display-ns (php/-> target-sym (getName)))))
+      (assoc! result alias-name (display-ns (.getName target-sym))))
     (persistent result)))
 
 (defn ns-refers
@@ -191,11 +191,11 @@
   {:example "(ns-refers *ns*) ; => {\"doc\" \"phel.repl\" ...}"
    :see-also ["ns-publics" "ns-aliases" "loaded-namespaces"]}
   [ns-str]
-  (let [env    (php/:: GlobalEnvironmentSingleton (getInstance))
-        refers (php/-> env (getRefers (canonical-ns ns-str)))
+  (let [env    (GlobalEnvironmentSingleton/getInstance)
+        refers (.getRefers env (canonical-ns ns-str))
         result (transient {})]
     (foreach [refer-name source-sym refers]
-      (assoc! result refer-name (display-ns (php/-> source-sym (getName)))))
+      (assoc! result refer-name (display-ns (.getName source-sym))))
     (persistent result)))
 
 (defn load-file
@@ -205,6 +205,6 @@
   [path]
   (let [content (php/file_get_contents path)]
     (when content
-      (let [cf   (php/new CompilerFacade)
-            opts (php/-> (php/new CompileOptions) (setSource path))]
-        (php/-> cf (eval content opts))))))
+      (let [cf   (new CompilerFacade)
+            opts (.setSource (new CompileOptions) path)]
+        (.eval cf content opts)))))

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -99,26 +99,26 @@
     :unknown))
 
 (defn- throw-class-type-error [op-name expected-suffix x]
-  (throw (php/new \InvalidArgumentException
-                  (php/. op-name " expects " expected-suffix ", got "
-                         (php/get_debug_type x)))))
+  (throw (new \InvalidArgumentException
+              (php/. op-name " expects " expected-suffix ", got "
+                     (php/get_debug_type x)))))
 
 (defn class?
   "Returns true if `x` is a `Phel\\Lang\\PhpClass` value."
-  {:example "(class? (class (php/new \\stdClass))) ; => true"
+  {:example "(class? (class (new \\stdClass))) ; => true"
    :see-also ["class" "class-name" "type"]}
   [x]
   (php/instanceof x PhpClass))
 
 (defn class
   "Returns a `Phel\\Lang\\PhpClass` for `x`. With an object argument returns the class of the object. With a string argument resolves the named class or interface FQN. Throws `InvalidArgumentException` for any other input."
-  {:example "(class (php/new \\stdClass)) ; => stdClass"
+  {:example "(class (new \\stdClass)) ; => stdClass"
    :see-also ["class?" "class-name" "type"]}
   [x]
   (cond
     (php/instanceof x PhpClass) x
-    (php/is_object x)           (php/:: PhpClass (ofValue x))
-    (php/is_string x)           (php/:: PhpClass (fromName x))
+    (php/is_object x)           (PhpClass/ofValue x)
+    (php/is_string x)           (PhpClass/fromName x)
     :else                       (throw-class-type-error "class" "an object or class-name string" x)))
 
 (defn class-name
@@ -127,7 +127,7 @@
    :see-also ["class" "class?"]}
   [c]
   (if (php/instanceof c PhpClass)
-    (php/-> c (name))
+    (.name c)
     (throw-class-type-error "class-name" "a Phel\\Lang\\PhpClass" c)))
 
 (defn float?
@@ -158,7 +158,7 @@
   (PHP int, BigInt, Ratio, float). Negative for x<0, 0 for x=0,
   positive for x>0."
   [x]
-  (php/:: NumericOperations (compare x 0)))
+  (NumericOperations/compare x 0))
 
 (defn neg-int?
   "Returns true if `x` is a negative integer. Accepts both fixed-precision PHP `int` and arbitrary-precision `BigInt` values."
@@ -259,14 +259,14 @@
   {:example "(simple-symbol? 'a) ; => true\n(simple-symbol? 'foo/bar) ; => false"
    :see-also ["symbol?" "simple-ident?"]}
   [x]
-  (and (symbol? x) (nil? (php/-> x (getNamespace)))))
+  (and (symbol? x) (nil? (.getNamespace x))))
 
 (defn simple-keyword?
   "Returns true if `x` is a keyword without a namespace."
   {:example "(simple-keyword? :a) ; => true\n(simple-keyword? :foo/bar) ; => false"
    :see-also ["keyword?" "simple-ident?"]}
   [x]
-  (and (keyword? x) (nil? (php/-> x (getNamespace)))))
+  (and (keyword? x) (nil? (.getNamespace x))))
 
 (defn simple-ident?
   "Returns true if `x` is a symbol or keyword without a namespace."
@@ -348,7 +348,7 @@
   ;; A seq view over a vector or a map is also a `PersistentListInterface`, so
   ;; dropping either half makes `(list? (seq [1 2]))` return true.
   (and (php/instanceof x PersistentListInterface)
-       (php/-> x (isList))))
+       (.isList x)))
 
 (defn queue?
   "Returns true if `x` is a `Phel\\Lang\\Collections\\Queue\\PersistentQueue` value."
@@ -384,7 +384,7 @@
   value second). `c` should be a literal class reference such as
   `DateTime` or a `:use`d short name; for runtime class names use
   `(php/is_a x class-name)`."
-  {:example "(instance? DateTime (php/new DateTime)) ; => true"
+  {:example "(instance? DateTime (new DateTime)) ; => true"
    :see-also ["type"]}
   [c x]
   `(php/instanceof ~x ~c))
@@ -403,7 +403,7 @@
 
 (defn php-object?
   "Returns true if `x` is a PHP object, false otherwise."
-  {:example "(php-object? (php/new \\stdClass)) ; => true"
+  {:example "(php-object? (new \\stdClass)) ; => true"
    :see-also ["php-array?" "php-resource?"]}
   [x]
   (= (type x) :php/object))
@@ -440,7 +440,7 @@ A non-countable iterable (an `eduction` pipeline, a PHP generator) is answered b
     (php/instanceof x LazySeqInterface) (nil? (first x))
     (php/instanceof x Cons)             false
     (php/instanceof x Countable)        (= 0 (count x))
-    (php/instanceof x Traversable)      (php/:: Seq (isEmpty x))
+    (php/instanceof x Traversable)      (Seq/isEmpty x)
     :else                               (= 0 (count x))))
 
 (defn not-empty
@@ -472,11 +472,11 @@ A non-countable iterable (an `eduction` pipeline, a PHP generator) is answered b
 
 (defn- seq-vector
   [values]
-  (if (php/empty values) nil (php/:: Phel (vector values))))
+  (if (php/empty values) nil (Phel/vector values)))
 
 (defn- seq-list
   [values]
-  (if (php/empty values) nil (php/:: Phel (seqList values))))
+  (if (php/empty values) nil (Phel/seqList values)))
 
 (defn seq
   "Returns a seq on the collection. Strings are converted to a vector of characters. Other non-empty collections (vectors, sets, sorted-maps, sorted-sets, PHP arrays) are converted to a non-list seq. Returns nil if `coll` is empty or nil.
@@ -494,7 +494,7 @@ This function is useful for explicitly converting strings to sequences of charac
 
     ;; For lazy sequences and lists, don't force them - just check if first element exists
     (seq? coll)
-    (if (php/=== nil (php/-> coll (first))) nil coll)
+    (if (php/=== nil (.first coll)) nil coll)
 
     ;; For other countable collections, check count (won't force lazy seqs)
     (and (php/instanceof coll Countable) (= 0 (count coll)))

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -25,20 +25,22 @@
   "An interface in Phel defines an abstract set of functions. It is directly mapped to a PHP interface. An interface can be defined by using the definterface macro."
   {:example "(definterface name & fns)"}
   [name & fns]
-  (let [name-str       (php/-> name (getName))
-        munge          (php/new Munge)
-        class-name-str (php/. (php/-> munge (encodePhpNs *ns*)) "\\" (php/-> munge (encode name-str)))
+  (let [name-str       (.getName name)
+        munge          (new Munge)
+        class-name-str (php/. (.encodePhpNs munge *ns*) "\\" (.encode munge name-str))
         ;; Only method forms get a Phel wrapper fn; a trailing `:php/const`
         ;; block (and its const forms) is passed through to `definterface*` only.
         method-forms   (take-while #(not= % :php/const) fns)
         defs           (for [[fn-name args doc] :in method-forms
-                             :let [fn-name-str (php/-> fn-name (getName))
-                                   munged-fn-name (php/-> munge (encode fn-name-str))
-                                   munged-fn-symbol (php/:: Symbol (create munged-fn-name))]]
+                             :let [fn-name-str (.getName fn-name)
+                                   munged-fn-name (.encode munge fn-name-str)
+                                   munged-fn-symbol (Symbol/create munged-fn-name)]]
                          `(defn ~fn-name {:doc ~doc} ~args
                             (if (php/is_a ~(first args) ~class-name-str)
+                              ;; `php/->` stays: the method name is a symbol
+                              ;; computed at expansion time, which `.m` cannot take.
                               (php/-> ~(first args) (~munged-fn-symbol ~@(rest args)))
-                              (throw (php/new \InvalidArgumentException ~(str "Value doesn't implement interface " name))))))]
+                              (throw (new \InvalidArgumentException ~(str "Value doesn't implement interface " name))))))]
     `(do
        (definterface* ~name ~@fns)
        ~@defs)))
@@ -97,7 +99,7 @@ Maintained in parallel with `derive`'s class -> proto-class-string entry so hier
 (defn- namespaced-ident?
   "Returns true when x is a keyword or symbol with a namespace."
   [x]
-  (and (ident? x) (php/-> x (getNamespace))))
+  (and (ident? x) (.getNamespace x)))
 
 (defn- valid-global-child-tag?
   "Returns true when tag is valid as a child in the global hierarchy."
@@ -113,11 +115,11 @@ Maintained in parallel with `derive`'s class -> proto-class-string entry so hier
 (defn- assert-global-derive-tags!
   [child parent]
   (when-not (valid-global-child-tag? child)
-    (throw (php/new \InvalidArgumentException
-                    (str "derive child must be a namespaced symbol/keyword or class tag, got: " child))))
+    (throw (new \InvalidArgumentException
+                (str "derive child must be a namespaced symbol/keyword or class tag, got: " child))))
   (when-not (valid-global-parent-tag? parent)
-    (throw (php/new \InvalidArgumentException
-                    (str "derive parent must be a namespaced symbol/keyword, got: " parent)))))
+    (throw (new \InvalidArgumentException
+                (str "derive parent must be a namespaced symbol/keyword, got: " parent)))))
 
 (defn- protocol-relations
   "Returns the set of protocol values registered for a PHP class tag. Hierarchy-independent: surfaced by every `parents`/`ancestors`/`descendants` call, mirroring PHP class inheritance."
@@ -240,7 +242,7 @@ Maintained in parallel with `derive`'s class -> proto-class-string entry so hier
 (defn- assert-hierarchy!
   [h]
   (when-not (valid-hierarchy-parents h)
-    (throw (php/new \InvalidArgumentException "Expected a hierarchy map")))
+    (throw (new \InvalidArgumentException "Expected a hierarchy map")))
   h)
 
 (defn isa?
@@ -260,8 +262,8 @@ Maintained in parallel with `derive`'s class -> proto-class-string entry so hier
   ([child parent]
    (assert-global-derive-tags! child parent)
    (when (isa? parent child)
-     (throw (php/new \InvalidArgumentException
-                     (str "Cyclic derivation: " parent " already isa " child))))
+     (throw (new \InvalidArgumentException
+                 (str "Cyclic derivation: " parent " already isa " child))))
    (swap! *hierarchy*
           (fn [h]
             (let [parents-map (get h :parents)
@@ -272,8 +274,8 @@ Maintained in parallel with `derive`'s class -> proto-class-string entry so hier
   ([h child parent]
    (assert-hierarchy! h)
    (when (isa? h parent child)
-     (throw (php/new \InvalidArgumentException
-                     (str "Cyclic derivation: " parent " already isa " child))))
+     (throw (new \InvalidArgumentException
+                 (str "Cyclic derivation: " parent " already isa " child))))
    (let [parents-map (get h :parents)
          old-parents (get parents-map child (hash-set))
          new-parents (union old-parents (hash-set parent))
@@ -395,10 +397,10 @@ Maintained in parallel with `derive`'s class -> proto-class-string entry so hier
                          (dominates? prefers-map parents-map k best) k
                          (dominates? prefers-map parents-map best k) best
                          :else
-                         (throw (php/new \InvalidArgumentException
-                                         (str "Multiple methods match dispatch value: "
-                                              dispatch-val " -> " k " and " best
-                                              ", and neither is preferred")))))
+                         (throw (new \InvalidArgumentException
+                                     (str "Multiple methods match dispatch value: "
+                                          dispatch-val " -> " k " and " best
+                                          ", and neither is preferred")))))
                      (first candidates)
                      (rest candidates))]
            (get methods best)))))))
@@ -438,17 +440,16 @@ A `:default` type can be registered via `extend-type` as a fallback when no spec
   {:example "(defprotocol Stringable (to-string [this]))"
    :see-also ["extend-type" "satisfies?" "extends?" "protocol-type-key"]}
   [protocol-name & method-specs]
-  (let [pname-str (php/-> protocol-name (getName))
+  (let [pname-str (.getName protocol-name)
         ;; `arglists` holds every declared arity vector, so a multi-arity
         ;; method like `(say [this] [this name])` dispatches on all of them.
         ;; Keep only the arity vectors: a spec may carry a trailing docstring
         ;; (`(bar [this a b] "doc")`), which must not be treated as an arity.
         methods   (for [spec :in method-specs
                         :let [mname (first spec)
-                              mname-str (php/-> mname (getName))
+                              mname-str (.getName mname)
                               arglists (filter vector? (rest spec))
-                              dsym (php/:: Symbol
-                                           (create (php/. pname-str "--" mname-str "--dispatch")))]]
+                              dsym (Symbol/create (php/. pname-str "--" mname-str "--dispatch"))]]
                     [mname mname-str arglists dsym])]
     `(do
        ~@(for [[_ _ _ dsym] :in methods]
@@ -468,9 +469,9 @@ A `:default` type can be registered via `extend-type` as a fallback when no spec
                         (let [default-impl (get dispatch-table :default)]
                           (if default-impl
                             (default-impl ~@margs)
-                            (throw (php/new \InvalidArgumentException
-                                            (str "No implementation of '" ~mname-str
-                                                 "' for type: " dk))))))))))))))
+                            (throw (new \InvalidArgumentException
+                                        (str "No implementation of '" ~mname-str
+                                             "' for type: " dk))))))))))))))
 
 (defn- group-protocol-specs
   "Splits a flat protocol spec list into `[[header [methods]] ...]` groups.
@@ -516,27 +517,27 @@ A `:default` type can be registered via `extend-type` as a fallback when no spec
   [type-spec & specs]
   (when (and (keyword? type-spec)
              (or (= type-spec :struct) (= type-spec :php/object)))
-    (throw (php/new \InvalidArgumentException
-                    (str "Cannot use " type-spec " as extend-type target. "
-                         "Protocol dispatch resolves structs/objects to their PHP class name. "
-                         "Use a struct symbol or PHP class name string instead."))))
+    (throw (new \InvalidArgumentException
+                (str "Cannot use " type-spec " as extend-type target. "
+                     "Protocol dispatch resolves structs/objects to their PHP class name. "
+                     "Use a struct symbol or PHP class name string instead."))))
   (let [type-key (cond
                    (nil? type-spec)                  :nil
                    (keyword? type-spec)              type-spec
                    (php/is_string type-spec)         type-spec
                    (php/instanceof type-spec Symbol)
-                   (let [munge    (php/new Munge)
-                         name-str (php/-> type-spec (getName))]
-                     (php/. (php/-> munge (encodePhpNs *ns*)) "\\" (php/-> munge (encode name-str)))))
+                   (let [munge    (new Munge)
+                         name-str (.getName type-spec)]
+                     (php/. (.encodePhpNs munge *ns*) "\\" (.encode munge name-str))))
         groups   (group-protocol-specs specs #(php/instanceof % Symbol))
         swaps    (reduce
                   (fn [acc group]
                     (let [proto-name (first group)
                           methods    (second group)
-                          proto-str  (php/-> proto-name (getName))
-                          proto-ns   (php/-> proto-name (getNamespace))
+                          proto-str  (.getName proto-name)
+                          proto-ns   (.getNamespace proto-name)
                           proto-tag  (if proto-ns
-                                       (php/-> proto-name (getFullName))
+                                       (.getFullName proto-name)
                                        (php/. *ns* "\\" proto-str))]
                       ;; Group the impls by method name so a method declared
                       ;; with several arities installs ONE multi-arity fn,
@@ -544,9 +545,8 @@ A `:default` type can be registered via `extend-type` as a fallback when no spec
                       (concat
                        (conj acc
                              `(register-protocol-implementor! ~type-key ~proto-name ~proto-tag))
-                       (for [[mname-str method-group] :pairs (group-by (fn [m] (php/-> (first m) (getName))) methods)]
-                         (let [dsym (php/:: Symbol
-                                            (create (php/. proto-str "--" mname-str "--dispatch")))]
+                       (for [[mname-str method-group] :pairs (group-by (fn [m] (.getName (first m))) methods)]
+                         (let [dsym (Symbol/create (php/. proto-str "--" mname-str "--dispatch"))]
                            `(swap! ~dsym assoc ~type-key
                                    (fn ~@(for [arity :in method-group]
                                            `(~(second arity) ~@(next (next arity)))))))))))
@@ -603,7 +603,7 @@ Equivalent to multiple `extend-type` calls."
   {:example "(reify Speakable (speak [this] \"hello\"))"
    :see-also ["defprotocol" "extend-type" "satisfies?"]}
   [& specs]
-  (let [munge                  (php/new Munge)
+  (let [munge                  (new Munge)
         instance-sym           (gensym "reify__")
         class-name-sym         (gensym "class__")
         ;; Group specs into [[ProtocolSym [method1 method2 ...]] ...]
@@ -621,20 +621,19 @@ Equivalent to multiple `extend-type` calls."
          (fn [acc group]
            (let [proto     (first group)
                  methods   (second group)
-                 proto-str (php/-> proto (getName))]
+                 proto-str (.getName proto)]
              (reduce
               (fn [inner method]
                 (let [mname          (first method)
-                      mname-str      (php/-> mname (getName))
+                      mname-str      (.getName mname)
                       margs          (second method)
                       rest-args      (next margs)
-                      dispatch-var   (php/:: Symbol
-                                             (create (php/. proto-str "--" mname-str "--dispatch")))
-                      php-method-sym (php/:: Symbol
-                                             (create (php/-> munge (encode mname-str))))]
+                      dispatch-var   (Symbol/create (php/. proto-str "--" mname-str "--dispatch"))
+                      php-method-sym (Symbol/create (.encode munge mname-str))]
                   (conj inner
                         `(swap! ~dispatch-var assoc ~class-name-sym
                                 (fn ~margs
+                                  ;; `php/->` stays: the method name is computed here too.
                                   (php/-> ~(first margs) (~php-method-sym ~@rest-args)))))))
               acc
               methods)))
@@ -661,12 +660,12 @@ Equivalent to multiple `extend-type` calls."
   {:example "(defrecord Point [x y] Drawable (draw [this canvas] ...))"
    :see-also ["deftype" "defstruct" "defprotocol" "extend-type"]}
   [name fields & impls]
-  (let [name-str   (php/-> name (getName))
-        arrow-ctor (php/:: Symbol (create (php/. "->" name-str)))
-        map-ctor   (php/:: Symbol (create (php/. "map->" name-str)))
+  (let [name-str   (.getName name)
+        arrow-ctor (Symbol/create (php/. "->" name-str))
+        map-ctor   (Symbol/create (php/. "map->" name-str))
         m-sym      (gensym "map__")
         get-calls  (for [f :in fields]
-                     `(get ~m-sym ~(keyword (php/-> f (getName)))))
+                     `(get ~m-sym ~(keyword (.getName f))))
         forms      [`(defstruct ~name ~fields)
                     `(defn ~arrow-ctor ~(php/. "Positional factory function for " name-str ".") ~fields (~name ~@fields))
                     `(defn ~map-ctor ~(php/. "Map factory function for " name-str ".") [~m-sym] (~name ~@get-calls))]
@@ -695,8 +694,8 @@ Equivalent to multiple `extend-type` calls."
   {:example "(deftype PointT [x y] Drawable (draw [this canvas] ...))"
    :see-also ["defrecord" "defstruct" "defprotocol" "extend-type"]}
   [name fields & impls]
-  (let [name-str   (php/-> name (getName))
-        arrow-ctor (php/:: Symbol (create (php/. "->" name-str)))
+  (let [name-str   (.getName name)
+        arrow-ctor (Symbol/create (php/. "->" name-str))
         forms      [`(defstruct ~name ~fields)
                     `(defn ~arrow-ctor ~(php/. "Positional factory function for " name-str ".") ~fields (~name ~@fields))]
         all-forms  (if (seq impls)
@@ -724,14 +723,14 @@ Equivalent to multiple `extend-type` calls."
         docstring   (when has-doc? (first args))
         dispatch-fn (if has-doc? (second args) (first args))]
     (when-not (or (= 1 arg-count) has-doc?)
-      (throw (php/new \InvalidArgumentException
-                      (str "defmulti '" (php/-> name (getName))
-                           "' expects (defmulti name docstring? dispatch-fn), got "
-                           (inc arg-count) " arguments."))))
-    (let [methods-name  (php/:: Symbol (create (php/. (php/-> name (getName)) "-methods")))
-          prefers-name  (php/:: Symbol (create (php/. (php/-> name (getName)) "-prefers")))
-          dispatch-name (php/:: Symbol (create (php/. (php/-> name (getName)) "-dispatch")))
-          name-str      (php/-> name (getName))
+      (throw (new \InvalidArgumentException
+                  (str "defmulti '" (.getName name)
+                       "' expects (defmulti name docstring? dispatch-fn), got "
+                       (inc arg-count) " arguments."))))
+    (let [methods-name  (Symbol/create (php/. (.getName name) "-methods"))
+          prefers-name  (Symbol/create (php/. (.getName name) "-prefers"))
+          dispatch-name (Symbol/create (php/. (.getName name) "-dispatch"))
+          name-str      (.getName name)
           df-sym        (gensym)
           ;; A stable name, not a gensym: this one is the multimethod's own
           ;; parameter list, so it shows up in `phel doc` and in the API
@@ -750,8 +749,8 @@ Equivalent to multiple `extend-type` calls."
                                  (let [default-method# (get methods# :default)]
                                    (if default-method#
                                      (apply default-method# ~args-sym)
-                                     (throw (php/new \InvalidArgumentException
-                                                     (str "No method for dispatch value: " dispatch-val#)))))))))]
+                                     (throw (new \InvalidArgumentException
+                                                 (str "No method for dispatch value: " dispatch-val#)))))))))]
       `(do
          ;; Both tables stay public: `defmethod` and `prefer-method` resolve them
          ;; in the multimethod's home namespace, so extending from another
@@ -768,10 +767,10 @@ Equivalent to multiple `extend-type` calls."
          (def ~dispatch-name {:private true}
            (let [~df-sym ~dispatch-fn]
              (when (and (string? ~df-sym) (not (php/is_callable ~df-sym)))
-               (throw (php/new \InvalidArgumentException
-                               (str "defmulti '" ~name-str
-                                    "' requires a callable dispatch-fn, got a string: "
-                                    (php/substr ~df-sym 0 60) "..."))))
+               (throw (new \InvalidArgumentException
+                           (str "defmulti '" ~name-str
+                                "' requires a callable dispatch-fn, got a string: "
+                                (php/substr ~df-sym 0 60) "..."))))
              ~df-sym))
          ~(if docstring
             `(defn ~name {:doc ~docstring} [& ~args-sym] ~body)
@@ -788,10 +787,10 @@ Equivalent to multiple `extend-type` calls."
   `args` and `body` define the function implementation."
   {:example "(defmethod area :circle [{:radius r}] (* 3.14159 r r))"}
   [multi-name dispatch-val & fn-tail]
-  (let [multi-ns     (php/-> multi-name (getNamespace))
-        methods-name (php/:: Symbol (createForNamespace
-                                     multi-ns
-                                     (php/. (php/-> multi-name (getName)) "-methods")))]
+  (let [multi-ns     (.getNamespace multi-name)
+        methods-name (Symbol/createForNamespace
+                      multi-ns
+                      (php/. (.getName multi-name) "-methods"))]
     `(swap! ~methods-name assoc ~dispatch-val (fn ~@fn-tail))))
 
 (defmacro prefer-method
@@ -804,21 +803,21 @@ Equivalent to multiple `extend-type` calls."
   {:example "(prefer-method draw :drawable :shape)"
    :see-also ["defmulti" "defmethod" "prefers"]}
   [multi-name dispatch-val-x dispatch-val-y]
-  (let [multi-ns     (php/-> multi-name (getNamespace))
-        multi-str    (php/-> multi-name (getName))
-        prefers-name (php/:: Symbol (createForNamespace
-                                     multi-ns
-                                     (php/. multi-str "-prefers")))]
+  (let [multi-ns     (.getNamespace multi-name)
+        multi-str    (.getName multi-name)
+        prefers-name (Symbol/createForNamespace
+                      multi-ns
+                      (php/. multi-str "-prefers"))]
     `(let [x#    ~dispatch-val-x
            y#    ~dispatch-val-y
            pmap# (deref ~prefers-name)]
        (when (= x# y#)
-         (throw (php/new \InvalidArgumentException
-                         (str "prefer-method: cannot prefer dispatch value to itself: " x#))))
+         (throw (new \InvalidArgumentException
+                     (str "prefer-method: cannot prefer dispatch value to itself: " x#))))
        (when (prefers? pmap# y# x#)
-         (throw (php/new \InvalidArgumentException
-                         (str "Preference conflict: " y# " is already preferred to " x#
-                              " in multimethod '" ~multi-str "'"))))
+         (throw (new \InvalidArgumentException
+                     (str "Preference conflict: " y# " is already preferred to " x#
+                          " in multimethod '" ~multi-str "'"))))
        (swap! ~prefers-name update x#
               (fn [s#] (if s# (conj s# y#) (hash-set y#))))
        nil)))
@@ -828,10 +827,10 @@ Equivalent to multiple `extend-type` calls."
   {:example "(prefers draw)"
    :see-also ["prefer-method" "defmulti"]}
   [multi-name]
-  (let [multi-ns     (php/-> multi-name (getNamespace))
-        prefers-name (php/:: Symbol (createForNamespace
-                                     multi-ns
-                                     (php/. (php/-> multi-name (getName)) "-prefers")))]
+  (let [multi-ns     (.getNamespace multi-name)
+        prefers-name (Symbol/createForNamespace
+                      multi-ns
+                      (php/. (.getName multi-name) "-prefers"))]
     `(deref ~prefers-name)))
 
 (defmacro if-let
@@ -839,7 +838,7 @@ Equivalent to multiple `extend-type` calls."
   {:example "(if-let [x (get {:a 1} :a)] x :none) ; => 1"
    :see-also ["when-let" "if-some"]}
   [bindings then & [else]]
-  (let [err #(throw (php/new \InvalidArgumentException %))]
+  (let [err #(throw (new \InvalidArgumentException %))]
     (when-not
       (vector? bindings)
       (err (str "if-let requires a vector for it's bindings, "
@@ -861,7 +860,7 @@ Equivalent to multiple `extend-type` calls."
   {:example "(when-let [x (get {:a 1} :a)] (* x 10)) ; => 10"
    :see-also ["if-let" "when-some"]}
   [bindings & body]
-  (let [err #(throw (php/new \InvalidArgumentException %))]
+  (let [err #(throw (new \InvalidArgumentException %))]
     (when-not
       (vector? bindings)
       (err (str "when-let requires a vector for it's bindings, "
@@ -882,7 +881,7 @@ Equivalent to multiple `extend-type` calls."
   {:example "(if-some [x false] :yes :no) ; => :yes"
    :see-also ["if-let" "when-some"]}
   [bindings then & [else]]
-  (let [err #(throw (php/new \InvalidArgumentException %))]
+  (let [err #(throw (new \InvalidArgumentException %))]
     (when-not
       (vector? bindings)
       (err (str "if-some requires a vector for its bindings, "
@@ -912,7 +911,7 @@ Equivalent to multiple `extend-type` calls."
   {:example "(when-first [x [1 2 3]] x) ; => 1"
    :see-also ["when-some" "first"]}
   [bindings & body]
-  (let [err #(throw (php/new \InvalidArgumentException %))]
+  (let [err #(throw (new \InvalidArgumentException %))]
     (when-not
       (vector? bindings)
       (err (str "when-first requires a vector for its bindings, "
@@ -973,63 +972,63 @@ bindings is a vector of function specs: (letfn [(f [params] body) (g [params] bo
                 `(str "Assert failed: " ~message)
                 `(str "Assert failed: " (quote ~expr)))]
       `(when (not ~expr)
-         (throw (php/new \InvalidArgumentException ~msg))))))
+         (throw (new \InvalidArgumentException ~msg))))))
 
 (defn name
   "Returns the name string of a string, keyword or symbol."
   {:example "(name :foo) ; => \"foo\"\n(name 'bar) ; => \"bar\""
    :see-also ["namespace" "full-name" "keyword"]}
   ^string [x]
-  (if (string? x) x (php/-> x (getName))))
+  (if (string? x) x (.getName x)))
 
 (defn namespace
   "Return the namespace string of a symbol or keyword. Nil if not present."
   {:example "(namespace :foo/bar) ; => \"foo\"\n(namespace :foo) ; => nil"
    :see-also ["name" "full-name"]}
   [x]
-  (php/-> x (getNamespace)))
+  (.getNamespace x))
 
 (defn full-name
   "Return the namespace and name string of a string, keyword or symbol."
   {:example "(full-name :foo/bar) ; => \"foo/bar\""
    :see-also ["name" "namespace"]}
   [x]
-  (if (string? x) x (php/-> x (getFullName))))
+  (if (string? x) x (.getFullName x)))
 
 (defn read-string
   "Reads the first phel expression from the string s."
   {:example "(read-string \"(+ 1 2)\") ; => (+ 1 2)"
    :see-also ["eval" "compile"]}
   [s]
-  (let [cf           (php/new CompilerFacade)
-        token-stream (php/-> cf (lexString s))
-        node         (php/-> cf (parseNext token-stream))]
+  (let [cf           (new CompilerFacade)
+        token-stream (.lexString cf s)
+        node         (.parseNext cf token-stream)]
     (when node
-      (php/-> (php/-> cf (read node)) (getAst)))))
+      (.getAst (.read cf node)))))
 
 (defn eval
   "Evaluates a form and return the evaluated results."
   {:example "(eval '(+ 1 2)) ; => 3"
    :see-also ["read-string" "compile"]}
   [form]
-  (let [cf (php/new CompilerFacade)]
-    (php/-> cf (evalForm form))))
+  (let [cf (new CompilerFacade)]
+    (.evalForm cf form)))
 
 (defn compile
   "Returns the compiled PHP code string for the given form."
   [form]
-  (let [cf (php/new CompilerFacade)]
-    (php/-> (php/-> cf (compileForm form)) (getPhpCode))))
+  (let [cf (new CompilerFacade)]
+    (.getPhpCode (.compileForm cf form))))
 
 (defn- get-global-env []
-  (php/:: GlobalEnvironmentSingleton (getInstance)))
+  (GlobalEnvironmentSingleton/getInstance))
 
 (defn- get-global-var-node [sym]
-  (php/-> (get-global-env) (resolve sym (php/:: NodeEnvironment (empty)))))
+  (.resolve (get-global-env) sym (NodeEnvironment/empty)))
 
 (defn resolve
   "Resolves the given symbol in the current environment and returns a resolved Symbol with the absolute namespace or nil if it cannot be resolved."
   {:example "(resolve 'map) ; => phel.core/map"}
   [sym]
   (-> (get-global-env)
-      (php/-> (resolveAsSymbol sym (php/:: NodeEnvironment (empty))))))
+      (.resolveAsSymbol sym (NodeEnvironment/empty))))

--- a/src/phel/core/seq-basics.phel
+++ b/src/phel/core/seq-basics.phel
@@ -25,32 +25,32 @@
   ;; `AbstractType` already implements `EqualsInterface` via `TypeInterface`,
   ;; so a single instanceof check per side is enough.
   (if (php/instanceof a \Phel\Lang\EqualsInterface)
-    (php/-> a (equals b))
+    (.equals a b)
     (if (php/instanceof b \Phel\Lang\EqualsInterface)
-      (php/-> b (equals a))
+      (.equals b a)
       (php/=== a b))))
 
 (defn- cons-string [x coll]
   (let [result (php/array x)]
     (foreach [char (php/mb_str_split coll)]
       (php/apush result char))
-    (php/:: Phel (vector result))))
+    (Phel/vector result)))
 
 (defn- cons-map [x coll]
   (let [result (php/array x)]
     (foreach [k v coll]
       (php/apush result [k v]))
-    (php/:: Phel (vector result))))
+    (Phel/vector result)))
 
 (defn- cons-iterable [x coll]
   (let [result (php/array x)]
     (foreach [v coll]
       (php/apush result v))
-    (php/:: Phel (vector result))))
+    (Phel/vector result)))
 
 (defn- cons-non-array [x coll]
   (if (php/instanceof coll ConsInterface)
-    (php/-> coll (cons x))
+    (.cons coll x)
     (if (php/=== coll nil)
       [x]
       (if (php/is_string coll)
@@ -59,8 +59,8 @@
           (cons-map x coll)
           (if (php/is_iterable coll)
             (cons-iterable x coll)
-            (throw (php/new InvalidArgumentException
-                            (php/. "cannot do cons " (php/print_r x true))))))))))
+            (throw (new InvalidArgumentException
+                        (php/. "cannot do cons " (php/print_r x true))))))))))
 
 (defn cons
   "Prepends an element to the beginning of a collection."
@@ -73,7 +73,7 @@
     (cons-non-array x coll)))
 
 (defn- rest-of-set [coll]
-  (php/:: Phel (vector (php/array_slice (php/-> coll (toPhpArray)) 1))))
+  (Phel/vector (php/array_slice (.toPhpArray coll) 1)))
 
 (defn ffirst
   "Same as `(first (first coll))`."
@@ -95,14 +95,14 @@
   (if (nil? coll)
     []
     (if (php/instanceof coll RestInterface)
-      (php/-> coll (rest))
+      (.rest coll)
       (if (php/is_string coll)
-        (php/:: Phel (vector (php/array_slice (php/mb_str_split coll) 1)))
+        (Phel/vector (php/array_slice (php/mb_str_split coll) 1))
         (if (php/instanceof coll PersistentHashSetInterface)
           (rest-of-set coll)
           (if (php/is_array coll)
             (php/array_slice coll 1)
-            (throw (php/new InvalidArgumentException "cannot do rest"))))))))
+            (throw (new InvalidArgumentException "cannot do rest"))))))))
 
 (defn nfirst
   "Same as `(next (first coll))`."
@@ -135,7 +135,7 @@ Throws for a lazily consumed source that has no size of its own — a transducer
    :see-also ["empty?" "seq"]}
   ^int [coll]
   (if (php/instanceof coll Countable)
-    (php/-> coll (count))
+    (.count coll)
     (if (php/is_array coll)
       (php/count coll)
       (if (php/is_string coll)
@@ -143,9 +143,9 @@ Throws for a lazily consumed source that has no size of its own — a transducer
         (if (php/=== coll nil)
           0
           (if (php/instanceof coll Traversable)
-            (throw (php/new InvalidArgumentException
-                            (str "count is not supported on a lazily consumed source: "
-                                 (php/get_debug_type coll)
-                                 ". Draining it re-runs the pipeline, so realize it first: (count (into [] coll)).")))
-            (throw (php/new InvalidArgumentException
-                            (str "count is not supported on this type: " (php/get_debug_type coll))))))))))
+            (throw (new InvalidArgumentException
+                        (str "count is not supported on a lazily consumed source: "
+                             (php/get_debug_type coll)
+                             ". Draining it re-runs the pipeline, so realize it first: (count (into [] coll)).")))
+            (throw (new InvalidArgumentException
+                        (str "count is not supported on this type: " (php/get_debug_type coll))))))))))

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -76,17 +76,17 @@
             ;; would eagerly materialise the first chunk. `Seq::map`
             ;; yields `[k v]` pairs when `coll` is a `PersistentMap`
             ;; (Clojure-aligned), otherwise it yields the elements.
-            result (php/:: LazySeq (fromGenerator
-                                    (php/new Hasher)
-                                    (php/new Equalizer)
-                                    (php/:: Seq (map f coll))))]
+            result (LazySeq/fromGenerator
+                    (new Hasher)
+                    (new Equalizer)
+                    (Seq/map f coll))]
         (copy-meta coll result))
-    (let [result (php/:: LazySeq (fromGenerator
-                                  (php/new Hasher)
-                                  (php/new Equalizer)
-                                  (php/call_user_func_array
-                                   (php/array "\\Phel\\Lang\\Seq" "mapMulti")
-                                   (php/array_merge (php/array f) (apply php/array colls)))))]
+    (let [result (LazySeq/fromGenerator
+                  (new Hasher)
+                  (new Equalizer)
+                  (php/call_user_func_array
+                   (php/array "\\Phel\\Lang\\Seq" "mapMulti")
+                   (php/array_merge (php/array f) (apply php/array colls))))]
       (copy-meta (first colls) result))))
 
 (defn comp
@@ -114,11 +114,11 @@
 (defn- assoc-into-entry
   [acc entry]
   (if (not (indexed? entry))
-    (throw (php/new InvalidArgumentException
-                    "into expects a collection of [key value] pairs"))
+    (throw (new InvalidArgumentException
+                "into expects a collection of [key value] pairs"))
     (if (php/!= (count entry) 2)
-      (throw (php/new InvalidArgumentException
-                      "into expects a collection of [key value] pairs"))
+      (throw (new InvalidArgumentException
+                  "into expects a collection of [key value] pairs"))
       (let [k (first entry)
             v (second entry)]
         (if (php/is_array acc)
@@ -189,14 +189,14 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
                 (conj acc value))
 
               (php/instanceof to ConcatInterface)
-              (php/-> to (concat (apply php/array entries)))
+              (.concat to (apply php/array entries))
 
               (php/is_array to)
               (concat to entries)
 
-              (throw (php/new InvalidArgumentException
-                              (php/. "Cannot convert into type " (type to))))))))
-    (throw (php/new InvalidArgumentException "into expects 1, 2, or 3 arguments"))))
+              (throw (new InvalidArgumentException
+                          (php/. "Cannot convert into type " (type to))))))))
+    (throw (new InvalidArgumentException "into expects 1, 2, or 3 arguments"))))
 
 (defn- conj-impl
   [coll value]
@@ -205,17 +205,17 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
     (php/instanceof coll PersistentListInterface) (cons value coll)
     (php/instanceof coll LazySeqInterface)        (cons value coll)
     (php/is_array coll)                           (do (php/apush coll value) coll)
-    (vector-target? coll)                         (php/-> coll (append value))
-    (set-target? coll)                            (php/-> coll (add value))
+    (vector-target? coll)                         (.append coll value)
+    (set-target? coll)                            (.add coll value)
     (map-target? coll)                            (conj-map-entry coll value)
     ;; MapEntry degrades to a 3-vector when grown; the result is no longer
     ;; an entry. Matches Clojure's MapEntry under conj.
     (php/instanceof coll MapEntry)
-    (php/-> [(php/-> coll (key)) (php/-> coll (value))] (append value))
-    (php/instanceof coll PushInterface)           (php/-> coll (push value))
+    (.append [(.key coll) (.value coll)] value)
+    (php/instanceof coll PushInterface)           (.push coll value)
     :else
-    (throw (php/new InvalidArgumentException
-                    (str "Cannot conj on type " (type coll))))))
+    (throw (new InvalidArgumentException
+                (str "Cannot conj on type " (type coll))))))
 
 (defn conj
   "Returns a new collection with values added. Appends to vectors/sets, prepends to lists."
@@ -231,10 +231,10 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
   [coll k]
   (cond
     (php/=== coll nil) nil
-    (set? coll)        (php/-> coll (remove k))
+    (set? coll)        (.remove coll k)
     :else
-    (throw (php/new InvalidArgumentException
-                    (str "Cannot disj on type " (type coll))))))
+    (throw (new InvalidArgumentException
+                (str "Cannot disj on type " (type coll))))))
 
 (defn disj
   "Returns a new set that does not contain the given key(s). Works on hash-sets and sorted-sets. Removing a non-existent key is a no-op. Returns `nil` when called on `nil`."
@@ -252,8 +252,8 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
   [coll & [offset & [length]]]
   (cond
     (php-array? coll) (php/array_slice coll offset length)
-    (php/instanceof coll SliceInterface) (php/-> coll (slice offset length))
-    (throw (php/new InvalidArgumentException "Cannot slice"))))
+    (php/instanceof coll SliceInterface) (.slice coll offset length)
+    (throw (new InvalidArgumentException "Cannot slice"))))
 
 ;; Clojure's subvec runs indices through RT.intCast: numbers truncate toward
 ;; zero, NaN counts as 0, ±Inf collapses to int min/max (then fails bounds),
@@ -268,9 +268,9 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
                        true                (php/intval x))
     (or (php/instanceof x Ratio)
         (php/instanceof x BigInt)
-        (php/instanceof x BigDecimal)) (php/-> x (toInt))
-    true (throw (php/new InvalidArgumentException
-                         (str "subvec index must be a number, got " (type x))))))
+        (php/instanceof x BigDecimal)) (.toInt x)
+    true (throw (new InvalidArgumentException
+                     (str "subvec index must be a number, got " (type x))))))
 
 (defn subvec
   "Returns a persistent vector of the items in `v` from `start` (inclusive) to `end` (exclusive). `end` defaults to `(count v)`. Non-integer indices truncate toward zero and `NaN` counts as `0`, matching Clojure. The result shares structure with `v`. Throws an OutOfBoundsException when `start` or `end` is out of range or `start` is greater than `end`."
@@ -279,14 +279,14 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
   ([v start] (subvec v start (count v)))
   ([v start end]
    (when-not (php/instanceof v PersistentVectorInterface)
-     (throw (php/new InvalidArgumentException (str "Cannot subvec on type " (type v)))))
+     (throw (new InvalidArgumentException (str "Cannot subvec on type " (type v)))))
    (let [cnt   (count v)
          start (subvec-index start)
          end   (subvec-index end)]
      (when (or (< start 0) (> end cnt) (> start end))
-       (throw (php/new OutOfBoundsException
-                       (str "subvec bounds [" start ", " end ") out of range for vector of count " cnt))))
-     (php/-> v (slice start (php/- end start))))))
+       (throw (new OutOfBoundsException
+                   (str "subvec bounds [" start ", " end ") out of range for vector of count " cnt))))
+     (.slice v start (php/- end start)))))
 
 (defn set
   "Coerces a collection to a set. Returns a set containing the distinct elements of `coll`. For creating sets from arguments, use `hash-set`."
@@ -399,9 +399,9 @@ Creates intermediate maps if they don't exist."
           (let [n (if (php/< n 0) 0 n)]
             (if (php/=== n 0)
               coll
-              (let [result (lazy-seq-from-generator (php/:: Seq (drop n coll)))]
+              (let [result (lazy-seq-from-generator (Seq/drop n coll))]
                 (copy-meta coll (or result [])))))))
-    (throw (php/new InvalidArgumentException "drop expects 1 or 2 arguments"))))
+    (throw (new InvalidArgumentException "drop expects 1 or 2 arguments"))))
 
 (defn drop-last
   "Drops the last `n` elements of `coll`. `n` defaults to `1` when omitted, matching Clojure's `(drop-last coll)` single-arity form. Returns an empty sequence when `coll` is `nil`. Works with any seqable collection including lazy sequences and ranges."
@@ -449,9 +449,9 @@ Creates intermediate maps if they don't exist."
     1 (let [coll (first args)]
         (if (nil? coll)
           []
-          (let [result (lazy-seq-from-generator (php/:: Seq (dropWhile pred coll)))]
+          (let [result (lazy-seq-from-generator (Seq/dropWhile pred coll))]
             (copy-meta coll (or result [])))))
-    (throw (php/new InvalidArgumentException "drop-while expects 1 or 2 arguments"))))
+    (throw (new InvalidArgumentException "drop-while expects 1 or 2 arguments"))))
 
 (defn take
   "Takes the first `n` elements of `coll`. When called with n only, returns a transducer."
@@ -471,12 +471,12 @@ Creates intermediate maps if they don't exist."
               n    (if (php/< n 0) 0 n)]
           (if (php/=== n 0)
             []
-            (let [result (lazy-seq-from-generator (php/:: Seq (take n coll)))]
+            (let [result (lazy-seq-from-generator (Seq/take n coll))]
               (if (nil? result)
                 []
                 (copy-meta coll result)))))
-        (throw (php/new InvalidArgumentException (str "take expects an integer count, got " (type n)))))
-    (throw (php/new InvalidArgumentException "take expects 1 or 2 arguments"))))
+        (throw (new InvalidArgumentException (str "take expects an integer count, got " (type n)))))
+    (throw (new InvalidArgumentException "take expects 1 or 2 arguments"))))
 
 (defn- take-last-buffered
   [n coll]
@@ -485,7 +485,7 @@ Creates intermediate maps if they don't exist."
       (php/apush buffer x)
       (when (php/> (php/count buffer) n)
         (php/array_shift buffer)))
-    (php/:: Phel (vector buffer))))
+    (Phel/vector buffer)))
 
 (defn take-last
   "Takes the last `n` elements of `coll`."
@@ -493,10 +493,10 @@ Creates intermediate maps if they don't exist."
    :see-also ["take" "drop-last"]}
   [n coll]
   (cond
-    (php/<= (php/:: NumericOperations (compare n 0)) 0) []
+    (php/<= (NumericOperations/compare n 0) 0) []
     (nil? coll)    nil
     (or (php-array? coll)
-        (php/instanceof coll SliceInterface)) (slice coll (php/:: NumericOperations (subtract 0 n)))
+        (php/instanceof coll SliceInterface)) (slice coll (NumericOperations/subtract 0 n))
     :else (take-last-buffered n coll)))
 
 (defn take-while
@@ -511,9 +511,9 @@ Creates intermediate maps if they don't exist."
     1 (let [coll (first args)]
         (if (nil? coll)
           []
-          (let [result (lazy-seq-from-generator (php/:: Seq (takeWhile pred coll)))]
+          (let [result (lazy-seq-from-generator (Seq/takeWhile pred coll))]
             (copy-meta coll (or result [])))))
-    (throw (php/new InvalidArgumentException "take-while expects 1 or 2 arguments"))))
+    (throw (new InvalidArgumentException "take-while expects 1 or 2 arguments"))))
 
 (defn take-nth
   "Returns every nth item in `coll`. Returns a lazy sequence. When called with n only, returns a transducer."
@@ -531,10 +531,10 @@ Creates intermediate maps if they don't exist."
             s    (seq coll)]
         (cond
           (nil? s)     []
-          (php/<= n 0) (copy-meta coll (lazy-seq-from-generator (php/:: Seq (repeat (first s)))))
-          :else        (let [result (lazy-seq-from-generator (php/:: Seq (takeNth n coll)))]
+          (php/<= n 0) (copy-meta coll (lazy-seq-from-generator (Seq/repeat (first s))))
+          :else        (let [result (lazy-seq-from-generator (Seq/takeNth n coll))]
                          (copy-meta coll (or result [])))))
-    (throw (php/new InvalidArgumentException "take-nth expects 1 or 2 arguments"))))
+    (throw (new InvalidArgumentException "take-nth expects 1 or 2 arguments"))))
 
 (defn filter
   "Returns a lazy sequence of elements where predicate returns true. When called with pred only, returns a transducer."
@@ -548,12 +548,12 @@ Creates intermediate maps if they don't exist."
             ;; Use LazySeq (not ChunkedSeq) so the first chunk isn't
             ;; pre-realized: a sparse predicate over an infinite source
             ;; would otherwise loop forever trying to fill 32 matches.
-            result (php/:: LazySeq (fromGenerator
-                                    (php/new Hasher)
-                                    (php/new Equalizer)
-                                    (php/:: Seq (filter pred coll))))]
+            result (LazySeq/fromGenerator
+                    (new Hasher)
+                    (new Equalizer)
+                    (Seq/filter pred coll))]
         (copy-meta coll result))
-    (throw (php/new InvalidArgumentException "filter expects 1 or 2 arguments"))))
+    (throw (new InvalidArgumentException "filter expects 1 or 2 arguments"))))
 
 (defn mapv
   "Returns a vector consisting of the result of applying `f` to the set of first items of each coll, followed by applying `f` to the set of second items in each coll, until any one of the colls is exhausted. Like `map`, but eager and returns a vector rather than a lazy sequence."
@@ -577,7 +577,7 @@ Creates intermediate maps if they don't exist."
   (case (count args)
     0 (filter #(not (pred %)))
     1 (filter #(not (pred %)) (first args))
-    (throw (php/new InvalidArgumentException "remove expects 1 or 2 arguments"))))
+    (throw (new InvalidArgumentException "remove expects 1 or 2 arguments"))))
 
 (defn keep
   "Returns a lazy sequence of non-nil results of applying function to elements. When called with f only, returns a transducer."
@@ -592,9 +592,9 @@ Creates intermediate maps if they don't exist."
     1 (let [coll (first args)]
         (if (nil? coll)
           []
-          (let [result (lazy-seq-from-generator (php/:: Seq (keep pred coll)))]
+          (let [result (lazy-seq-from-generator (Seq/keep pred coll))]
             (copy-meta coll (or result [])))))
-    (throw (php/new InvalidArgumentException "keep expects 1 or 2 arguments"))))
+    (throw (new InvalidArgumentException "keep expects 1 or 2 arguments"))))
 
 (defn keep-indexed
   "Returns a lazy sequence of non-nil results of `(pred i x)`. When called with f only, returns a transducer."
@@ -611,9 +611,9 @@ Creates intermediate maps if they don't exist."
     1 (let [coll (first args)]
         (if (nil? coll)
           []
-          (let [result (lazy-seq-from-generator (php/:: Seq (keepIndexed pred coll)))]
+          (let [result (lazy-seq-from-generator (Seq/keepIndexed pred coll))]
             (copy-meta coll (or result [])))))
-    (throw (php/new InvalidArgumentException "keep-indexed expects 1 or 2 arguments"))))
+    (throw (new InvalidArgumentException "keep-indexed expects 1 or 2 arguments"))))
 
 (defn- find-entry
   [coll key]
@@ -665,12 +665,12 @@ Creates intermediate maps if they don't exist."
           []
           ;; LazySeq keeps the seq unrealized until accessed; ChunkedSeq
           ;; would pre-pull 32 unique elements at construction.
-          (let [result (php/:: LazySeq (fromGenerator
-                                        (php/new Hasher)
-                                        (php/new Equalizer)
-                                        (php/:: Seq (distinct coll))))]
+          (let [result (LazySeq/fromGenerator
+                        (new Hasher)
+                        (new Equalizer)
+                        (Seq/distinct coll))]
             (copy-meta coll result))))
-    (throw (php/new InvalidArgumentException "distinct expects 0 or 1 arguments"))))
+    (throw (new InvalidArgumentException "distinct expects 0 or 1 arguments"))))
 
 (defn distinct?
   "Returns true if no two of the arguments are `=`. Requires at least one argument."
@@ -701,7 +701,7 @@ Creates intermediate maps if they don't exist."
   (let [arr    (if (string? coll)
                  (php/mb_str_split coll)
                  (to-php-array coll))
-        result (php/:: Phel (vector (php/array_reverse arr)))]
+        result (Phel/vector (php/array_reverse arr))]
     (copy-meta coll result)))
 
 (defn reversible?
@@ -718,10 +718,10 @@ Creates intermediate maps if they don't exist."
    :see-also ["reversible?" "reverse"]}
   [rev]
   (when-not (reversible? rev)
-    (throw (php/new InvalidArgumentException
-                    "rseq requires a reversible collection (vector, sorted-map, or sorted-set)")))
+    (throw (new InvalidArgumentException
+                "rseq requires a reversible collection (vector, sorted-map, or sorted-set)")))
   (when (php/> (count rev) 0)
-    (php/:: Phel (seqList (apply php/array (reverse (if (vector? rev) rev (vec rev))))))))
+    (Phel/seqList (apply php/array (reverse (if (vector? rev) rev (vec rev)))))))
 
 (defn frequencies
   "Returns a map from distinct items in `coll` to the number of times they appear.
@@ -755,7 +755,7 @@ Works with vectors, lists, sets, and strings."
   {:example "(map-entry :a 1) ; => [:a 1]"
    :see-also ["map-entry?" "key" "val"]}
   [k v]
-  (php/:: MapEntry (create k v)))
+  (MapEntry/create k v))
 
 (defn key
   "Returns the key of a map entry. Accepts a typed
@@ -765,7 +765,7 @@ Works with vectors, lists, sets, and strings."
    :see-also ["val" "keys" "pairs" "map-entry"]}
   [entry]
   (if (php/instanceof entry MapEntry)
-    (php/-> entry (key))
+    (.key entry)
     (first entry)))
 
 (defn val
@@ -776,21 +776,21 @@ Works with vectors, lists, sets, and strings."
    :see-also ["key" "vals" "pairs" "map-entry"]}
   [entry]
   (if (php/instanceof entry MapEntry)
-    (php/-> entry (value))
+    (.value entry)
     (second entry)))
 
 (defn- assert-sorted-coll
   [caller sc]
   (when-not (sorted? sc)
-    (throw (php/new InvalidArgumentException
-                    (str caller " expects a sorted collection (sorted-map or sorted-set), got " (type sc))))))
+    (throw (new InvalidArgumentException
+                (str caller " expects a sorted collection (sorted-map or sorted-set), got " (type sc))))))
 
 (defn- sorted-bound-fn
   "Boundary predicate for subseq/rsubseq: true when the element's key (for a
   sorted map) or the element itself (for a sorted set) satisfies
   `(test (cmp k bound-key) 0)` under the collection's own comparator."
   [sc test bound-key]
-  (let [cmp       (php/-> sc (getEffectiveComparator))
+  (let [cmp       (.getEffectiveComparator sc)
         entry-key (if (map? sc) key identity)]
     (fn [x] (test (cmp (entry-key x) bound-key) 0))))
 
@@ -841,8 +841,8 @@ Works with vectors, lists, sets, and strings."
   [coll]
   (let [res (transient [])]
     (foreach [k v coll]
-      (php/-> res (append k))
-      (php/-> res (append v)))
+      (.append res k)
+      (.append res v))
     (copy-meta coll (persistent res))))
 
 (defn php-array-to-map
@@ -852,7 +852,7 @@ Works with vectors, lists, sets, and strings."
   [arr]
   (let [res (transient {})]
     (foreach [k v arr]
-      (php/-> res (put k v)))
+      (.put res k v))
     (persistent res)))
 
 (defn- phel->php-key
@@ -934,10 +934,10 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps."
   {:example "(hydrate \"My\\\\Dto\" {:id 1 :name \"x\"})"
    :see-also ["bean"]}
   [class-name m]
-  (let [rc  (php/new \ReflectionClass class-name)
-        obj (php/-> rc (newInstanceWithoutConstructor))]
+  (let [rc  (new \ReflectionClass class-name)
+        obj (.newInstanceWithoutConstructor rc)]
     (foreach [k v m]
-      (php/-> (php/-> rc (getProperty (name k))) (setValue obj v)))
+      (.setValue (.getProperty rc (name k)) obj v))
     obj))
 
 (defn contains-value?
@@ -963,7 +963,7 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps."
   [coll comp]
   (let [php-array (to-php-array coll)]
     (php/usort php-array comp)
-    (copy-meta coll (php/:: Phel (vector php-array)))))
+    (copy-meta coll (Phel/vector php-array))))
 
 (defn- sort-with
   [coll comp]
@@ -1004,7 +1004,7 @@ If no comparator is supplied compare is used."
   [coll]
   (let [php-array (to-php-array coll)]
     (php/shuffle php-array)
-    (copy-meta coll (php/:: Phel (vector php-array)))))
+    (copy-meta coll (Phel/vector php-array))))
 
 (defn repeat
   "Returns a vector of length n where every element is x.
@@ -1014,9 +1014,9 @@ With one argument returns an infinite lazy sequence of x."
    :see-also ["repeatedly" "cycle"]}
   [a & rest]
   (case (count rest)
-    0 (lazy-seq-from-generator (php/:: Seq (repeat a)))
+    0 (lazy-seq-from-generator (Seq/repeat a))
     1 (for [_ :range [a]] (get rest 0))
-    (throw (php/new InvalidArgumentException "repeat expects one or two arguments"))))
+    (throw (new InvalidArgumentException "repeat expects one or two arguments"))))
 
 (defn repeatedly
   "Returns a vector of length n with values produced by repeatedly calling f.
@@ -1026,26 +1026,26 @@ With one argument returns an infinite lazy sequence of calls to f."
    :see-also ["repeat" "iterate"]}
   [a & rest]
   (case (count rest)
-    0 (php/:: LazySeq (fromGenerator
-                       (php/new Hasher)
-                       (php/new Equalizer)
-                       (php/:: Seq (repeatedly a))))
+    0 (LazySeq/fromGenerator
+       (new Hasher)
+       (new Equalizer)
+       (Seq/repeatedly a))
     1 (let [n a
             f (get rest 0)]
-        (php/new \Phel\Lang\Collections\LazySeq\LazySeq
-                 (php/new Hasher)
-                 (php/new Equalizer)
-                 (fn [] (for [_ :range [n]] (f)))))
-    (throw (php/new InvalidArgumentException "repeatedly expects one or two arguments"))))
+        (new \Phel\Lang\Collections\LazySeq\LazySeq
+             (new Hasher)
+             (new Equalizer)
+             (fn [] (for [_ :range [n]] (f)))))
+    (throw (new InvalidArgumentException "repeatedly expects one or two arguments"))))
 
 (defmacro lazy-seq
   "Creates a lazy sequence that evaluates the body only when accessed."
   {:example "(lazy-seq (cons 1 (lazy-seq nil))) ; => @[1]"}
   [& body]
-  `(php/new \Phel\Lang\Collections\LazySeq\LazySeq
-            (php/new \Phel\Lang\Hasher)
-            (php/new \Phel\Lang\Equalizer)
-            (fn [] ~@body)))
+  `(new \Phel\Lang\Collections\LazySeq\LazySeq
+        (new \Phel\Lang\Hasher)
+        (new \Phel\Lang\Equalizer)
+        (fn [] ~@body)))
 
 (defmacro lazy-cat
   "Concatenates collections into a lazy sequence (expands to concat)."
@@ -1058,7 +1058,7 @@ With one argument returns an infinite lazy sequence of calls to f."
   {:example "(take 5 (iterate inc 0)) ; => @[0 1 2 3 4]"
    :see-also ["repeatedly" "cycle"]}
   [f x]
-  (lazy-seq-from-generator (php/:: Seq (iterate f x))))
+  (lazy-seq-from-generator (Seq/iterate f x)))
 
 (defn reductions
   "Returns a lazy sequence of the intermediate values of the reduction (as per reduce) of coll by f, starting with init when supplied."
@@ -1081,10 +1081,10 @@ With one argument returns an infinite lazy sequence of calls to f."
 
 (defn iterator-seq
   "Returns a lazy sequence over a PHP `Traversable` (Iterator, Generator, IteratorAggregate, ...), pulling one element at a time. Unlike the eager coercion that materialises a `Traversable` via `iterator_to_array`, this streams a large or infinite source (DB cursor, stream reader, paginated API), so `take`/`map`/`filter` only pull what they consume."
-  {:example "(take 3 (iterator-seq (php/new \\ArrayIterator (php/array 1 2 3 4 5)))) ; => @[1 2 3]"
+  {:example "(take 3 (iterator-seq (new \\ArrayIterator (php/array 1 2 3 4 5)))) ; => @[1 2 3]"
    :see-also ["lazy-seq" "map" "take"]}
   [traversable]
-  (php/:: LazySeq (fromTraversable (php/new Hasher) (php/new Equalizer) traversable)))
+  (LazySeq/fromTraversable (new Hasher) (new Equalizer) traversable))
 
 (defn cycle
   "Returns an infinite lazy sequence that cycles through the elements of collection. Maps are iterated as `[key value]` pairs."
@@ -1093,7 +1093,7 @@ With one argument returns an infinite lazy sequence of calls to f."
   [coll]
   (if (or (php/=== nil coll) (empty? coll))
     []
-    (lazy-seq-from-generator (php/:: Seq (cycle (or (seq coll) coll))))))
+    (lazy-seq-from-generator (Seq/cycle (or (seq coll) coll)))))
 
 (defn concat
   "Concatenates multiple collections into a lazy sequence."
@@ -1103,12 +1103,12 @@ With one argument returns an infinite lazy sequence of calls to f."
     '()
     ;; Use LazySeq (not ChunkedSeq) so the head is not pre-realized:
     ;; the result must not satisfy `realized?` until accessed.
-    (php/:: LazySeq (fromGenerator
-                     (php/new Hasher)
-                     (php/new Equalizer)
-                     (php/call_user_func_array
-                      (php/array "\\Phel\\Lang\\Seq" "concat")
-                      (apply php/array colls))))))
+    (LazySeq/fromGenerator
+     (new Hasher)
+     (new Equalizer)
+     (php/call_user_func_array
+      (php/array "\\Phel\\Lang\\Seq" "concat")
+      (apply php/array colls)))))
 
 (defn cat
   "A transducer that concatenates the contents of each input into the reduction."
@@ -1136,7 +1136,7 @@ With one argument returns an infinite lazy sequence of calls to f."
           '()
           (let [input  (if (map? coll) (pairs coll) coll)
                 result (lazy-seq-from-generator
-                        (php/:: \Phel\Lang\Seq (mapcat f input)))]
+                        (\Phel\Lang\Seq/mapcat f input))]
             (if (php/=== nil result)
               '()
               (copy-meta coll result)))))
@@ -1166,11 +1166,11 @@ With one argument returns an infinite lazy sequence of calls to f."
           '()
           (let [seqd   (or (seq coll) coll)
                 result (lazy-seq-from-generator
-                        (php/:: \Phel\Lang\Seq (interpose sep seqd)))]
+                        (\Phel\Lang\Seq/interpose sep seqd))]
             (if (php/=== nil result)
               '()
               (copy-meta coll result)))))
-    (throw (php/new InvalidArgumentException "interpose expects 1 or 2 arguments"))))
+    (throw (new InvalidArgumentException "interpose expects 1 or 2 arguments"))))
 
 (defn map-indexed
   "Maps a function over a collection with index. Returns a lazy sequence.
@@ -1181,7 +1181,7 @@ Applies `f` to each element in `xs`. `f` is a two-argument function where the fi
   (if (php/=== nil coll)
     '()
     (let [result (lazy-seq-from-generator
-                  (php/:: \Phel\Lang\Seq (mapIndexed f coll)))]
+                  (\Phel\Lang\Seq/mapIndexed f coll))]
       (if (php/=== nil result)
         '()
         (copy-meta coll result)))))
@@ -1208,7 +1208,7 @@ Applies `f` to each element in `xs`. `f` is a two-argument function where the fi
   {:example "(doall (map println [1 2 3])) ; => [nil nil nil]"}
   [coll]
   (if (seq? coll)
-    (php/:: Phel (vector (php/-> coll (toArray))))
+    (Phel/vector (.toArray coll))
     coll))
 
 (defn dorun
@@ -1227,12 +1227,12 @@ Applies `f` to each element in `xs`. `f` is a two-argument function where the fi
    :see-also ["delay" "force" "lazy-seq" "future"]}
   [coll]
   (cond
-    (php/instanceof coll LazySeqInterface) (php/-> coll (isRealized))
+    (php/instanceof coll LazySeqInterface) (.isRealized coll)
     (php/instanceof coll PersistentListInterface) true
-    (php/instanceof coll Delay) (php/-> coll (isRealized))
-    (php/instanceof coll \Phel\Lang\Future) (php/-> coll (isRealized))
-    (php/instanceof coll \Phel\Fiber\Domain\Future) (php/-> coll (isRealized))
-    (php/instanceof coll \Phel\Fiber\Domain\Promise) (php/-> coll (isRealized))
+    (php/instanceof coll Delay) (.isRealized coll)
+    (php/instanceof coll \Phel\Lang\Future) (.isRealized coll)
+    (php/instanceof coll \Phel\Fiber\Domain\Future) (.isRealized coll)
+    (php/instanceof coll \Phel\Fiber\Domain\Promise) (.isRealized coll)
     true))
 
 (defn group-by
@@ -1354,7 +1354,7 @@ If map has duplicated values, some keys will be ignored."
   (cond
     (nil? coll)                              []
     (and (indexed? coll) (= 0 (count coll))) []
-    true                                     (lazy-seq-from-generator (php/:: Seq (partitionBy f coll)))))
+    true                                     (lazy-seq-from-generator (Seq/partitionBy f coll))))
 
 (defn dedupe
   "Returns a lazy sequence with consecutive duplicate values removed in `coll`. When called with no args, returns a transducer."
@@ -1372,8 +1372,8 @@ If map has duplicated values, some keys will be ignored."
         (cond
           (nil? coll)                              []
           (and (indexed? coll) (= 0 (count coll))) []
-          true                                     (lazy-seq-from-generator (php/:: Seq (dedupe coll)))))
-    (throw (php/new InvalidArgumentException "dedupe expects 0 or 1 arguments"))))
+          true                                     (lazy-seq-from-generator (Seq/dedupe coll))))
+    (throw (new InvalidArgumentException "dedupe expects 0 or 1 arguments"))))
 
 (defn sequence
   "Applies transducer `xform` to `coll`, returning a vector of results."
@@ -1395,7 +1395,7 @@ If map has duplicated values, some keys will be ignored."
         xform (if (or (nil? xs) (empty? xs))
                 identity
                 (apply comp xs))]
-    (php/new Eduction xform coll)))
+    (new Eduction xform coll)))
 
 (defn compact
   "Returns a lazy sequence with specified values removed from `coll`. If no values are specified, removes nil values by default."

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -53,8 +53,8 @@
   (cond
     (nil? coll) nil
     (php-array? coll) (php/array_pop coll)
-    (php/instanceof coll PopInterface) (php/-> coll (pop))
-    (throw (php/new InvalidArgumentException "Cannot pop"))))
+    (php/instanceof coll PopInterface) (.pop coll)
+    (throw (new InvalidArgumentException "Cannot pop"))))
 
 (defmacro pop
   "Removes the last element of a collection. Returns nil for nil."
@@ -94,7 +94,7 @@
     (or (set? ds)
         (php/instanceof ds PersistentHashSetInterface)
         (php/instanceof ds TransientHashSetInterface))
-    (if (php/-> ds (contains k))
+    (if (.contains ds k)
       k
       opt)
 
@@ -141,23 +141,23 @@
      nil
 
      (not (integer? index))
-     (throw (php/new OutOfBoundsException (str "Index " index " is not an integer")))
+     (throw (new OutOfBoundsException (str "Index " index " is not an integer")))
 
      (php/is_string coll)
      (if (in-bounds? index (php/mb_strlen coll "UTF-8"))
        (php/mb_substr coll index 1 "UTF-8")
-       (throw (php/new OutOfBoundsException (str "String index " index " out of bounds"))))
+       (throw (new OutOfBoundsException (str "String index " index " out of bounds"))))
 
      (indexed-vector? coll)
      (if (in-bounds? index (count coll))
        (get coll index)
-       (throw (php/new OutOfBoundsException (str "Vector index " index " out of bounds"))))
+       (throw (new OutOfBoundsException (str "Vector index " index " out of bounds"))))
 
      :else
      (loop [i index
             s coll]
        (cond
-         (nil? s)      (throw (php/new OutOfBoundsException (str "Index " index " out of bounds")))
+         (nil? s)      (throw (new OutOfBoundsException (str "Index " index " out of bounds")))
          (php/=== i 0) (first s)
          :else         (recur (php/- i 1) (next s))))))
 
@@ -191,12 +191,12 @@
   {:example "(nthrest [1 2 3 4 5] 2) ; => [3 4 5]\n(nthrest [1 2] 5) ; => ()\n(nthrest nil 0) ; => nil\n(nthrest nil 3) ; => ()"
    :see-also ["nth" "nthnext" "drop"]}
   [coll n]
-  (if (php/< (php/:: NumericOperations (compare n 1)) 0)
+  (if (php/< (NumericOperations/compare n 1) 0)
     coll
     (loop [i n
            s coll]
-      (if (and (php/> (php/:: NumericOperations (compare i 0)) 0) s)
-        (recur (php/:: NumericOperations (subtract i 1)) (next s))
+      (if (and (php/> (NumericOperations/compare i 0) 0) s)
+        (recur (NumericOperations/subtract i 1) (next s))
         (if (nil? s) '() s)))))
 
 (defn nthnext
@@ -236,9 +236,9 @@
   "Updates a vector at an integer index. Vectors index by int only; a non-integer key raises a clean `InvalidArgumentException` instead of leaking PHP's `update(): Argument #1 ($i) must be of type int` TypeError."
   [v key value]
   (if (integer? key)
-    (php/-> v (update key value))
-    (throw (php/new InvalidArgumentException
-                    (str "assoc on a vector expects an integer index, got " (type key))))))
+    (.update v key value)
+    (throw (new InvalidArgumentException
+                (str "assoc on a vector expects an integer index, got " (type key))))))
 
 (defn- assoc-pair
   "Associates a single key-value pair with a collection."
@@ -246,13 +246,13 @@
   (cond
     ;; Clojure-compat: (assoc nil k v) creates a fresh map instead of erroring.
     (nil? ds)
-    (php/-> {} (put key value))
+    (.put {} key value)
 
     (php-array? ds)
-    (throw (php/new InvalidArgumentException "Cannot call assoc on pure PHP arrays. Use (php/aset ds key value)"))
+    (throw (new InvalidArgumentException "Cannot call assoc on pure PHP arrays. Use (php/aset ds key value)"))
 
     (map-target? ds)
-    (php/-> ds (put key value))
+    (.put ds key value)
 
     (vector-target? ds)
     (vector-assoc ds key value)
@@ -261,23 +261,23 @@
     ;; longer represents a real map entry. Matches Clojure's MapEntry
     ;; behavior under assoc.
     (php/instanceof ds MapEntry)
-    (vector-assoc [(php/-> ds (key)) (php/-> ds (value))] key value)
+    (vector-assoc [(.key ds) (.value ds)] key value)
 
     ;; Explicit rejection for any other shape (string, list, set, sorted set,
     ;; number, …). Without this the old fall-through silently mutated strings
     ;; via `php/aset` and leaked raw PHP "offsetSet not supported" errors for
     ;; lists and sets.
-    (throw (php/new InvalidArgumentException
-                    (str "assoc expects a map, vector, struct, or nil; got " (type ds))))))
+    (throw (new InvalidArgumentException
+                (str "assoc expects a map, vector, struct, or nil; got " (type ds))))))
 
 (defn assoc
   "Associates one or more key-value pairs with a collection. Additional key-value pairs beyond the first are applied in order. Throws if an odd number of extra arguments is provided."
   {:example "(assoc {:a 1} :b 2) ; => {:a 1, :b 2}\n(assoc {:a 1} :b 2 :c 3) ; => {:a 1, :b 2, :c 3}"}
   [ds key value & more]
   (when (php/!== 0 (php/& (count more) 1))
-    (throw (php/new InvalidArgumentException
-                    (str "assoc expects an even number of extra arguments (key-value pairs), got "
-                         (count more)))))
+    (throw (new InvalidArgumentException
+                (str "assoc expects an even number of extra arguments (key-value pairs), got "
+                     (count more)))))
   (loop [acc       (assoc-pair ds key value)
          remaining more]
     (if (empty? remaining)
@@ -292,16 +292,16 @@
     nil
 
     (php/is_array ds)
-    (throw (php/new InvalidArgumentException "Cannot call dissoc on pure PHP arrays. Use (php/aunset ds key)"))
+    (throw (new InvalidArgumentException "Cannot call dissoc on pure PHP arrays. Use (php/aunset ds key)"))
 
     (map-target? ds)
-    (php/-> ds (remove key))
+    (.remove ds key)
 
     (set-target? ds)
-    (php/-> ds (remove key))
+    (.remove ds key)
 
-    (throw (php/new InvalidArgumentException
-                    (str "dissoc requires a map, set, or struct; got " (type ds))))))
+    (throw (new InvalidArgumentException
+                (str "dissoc requires a map, set, or struct; got " (type ds))))))
 
 (defn dissoc
   "Returns `ds` without the given keys. With no keys returns `ds` unchanged."

--- a/src/phel/core/strings.phel
+++ b/src/phel/core/strings.phel
@@ -7,7 +7,7 @@
 (def ^:private symbol-munge
   ;; Munge is a final readonly class; reuse one instance to decode var
   ;; namespaces back to their display form when constructing symbols.
-  (php/new Munge))
+  (new Munge))
 
 ;; Two families of primitive value constructors grouped together:
 ;;   - Symbol constructors: `symbol` (a runtime symbol from a string or
@@ -24,7 +24,7 @@
   (if (php/=== nil x)
     nil
     (if (php/instanceof x \Phel\Lang\NamedInterface)
-      (php/-> x (getName))
+      (.getName x)
       x)))
 
 (defn- valid-symbol-name? [x]
@@ -37,11 +37,11 @@
 (defn- assert-symbol-name [arg-name x]
   (if (valid-symbol-name? x)
     nil
-    (throw (php/new \InvalidArgumentException
-                    (php/. "symbol expects a string, keyword, or symbol for "
-                           arg-name
-                           ", got "
-                           (php/get_debug_type x))))))
+    (throw (new \InvalidArgumentException
+                (php/. "symbol expects a string, keyword, or symbol for "
+                       arg-name
+                       ", got "
+                       (php/get_debug_type x))))))
 
 (defn symbol
   "Returns a new symbol for the given name with an optional namespace.
@@ -55,28 +55,28 @@ Throws `InvalidArgumentException` for any other input (including functions, numb
     (do
       (assert-symbol-name "name" name)
       (if (php/=== nil name-or-ns)
-        (php/:: Symbol (create (to-symbol-part name)))
+        (Symbol/create (to-symbol-part name))
         (do
           (assert-symbol-name "namespace" name-or-ns)
-          (php/:: Symbol (createForNamespace
-                          (to-symbol-part name-or-ns)
-                          (to-symbol-part name))))))
+          (Symbol/createForNamespace
+           (to-symbol-part name-or-ns)
+           (to-symbol-part name)))))
     (if (php/instanceof name-or-ns Symbol)
       name-or-ns
       (if (php/instanceof name-or-ns PhelVar)
-        (php/:: Symbol (createForNamespace
-                        (php/-> symbol-munge (decodeNs (php/-> name-or-ns (getNamespace))))
-                        (php/-> name-or-ns (getName))))
+        (Symbol/createForNamespace
+         (.decodeNs symbol-munge (.getNamespace name-or-ns))
+         (.getName name-or-ns))
         (do
           (assert-symbol-name "name-or-ns" name-or-ns)
-          (php/:: Symbol (create (to-symbol-part name-or-ns))))))))
+          (Symbol/create (to-symbol-part name-or-ns)))))))
 
 (defn gensym
   "Generates a new unique symbol."
   {:example "(gensym) ; => __phel_1"
    :see-also ["symbol"]}
   []
-  (php/:: Symbol (gen)))
+  (Symbol/gen))
 
 (defn- float-to-str
   "Renders a float so integer-valued floats keep the trailing `.0`, while `NaN` and ±Infinity stringify readably."

--- a/src/phel/core/transducers.phel
+++ b/src/phel/core/transducers.phel
@@ -20,7 +20,7 @@
   {:example "(reduce (fn [acc x] (if (= x 3) (reduced acc) (+ acc x))) 0 [1 2 3 4]) ; => 3"
    :see-also ["reduced?" "unreduced"]}
   [x]
-  (php/new Reduced x))
+  (new Reduced x))
 
 (defn reduced?
   "Returns true if `x` is a Reduced value."
@@ -35,7 +35,7 @@
    :see-also ["reduced" "reduced?"]}
   [x]
   (if (reduced? x)
-    (php/-> x (deref))
+    (.deref x)
     x))
 
 (defn- ensure-reduced
@@ -67,31 +67,31 @@
           (reduce f (first s) (next s))))
     2 (let [init (first args)
             coll (second args)
-            acc  (php/new Volatile init)
-            done (php/new Volatile false)]
-        (dofor [x :in coll :while (not (php/-> done (deref)))]
-          (let [result (f (php/-> acc (deref)) x)]
+            acc  (new Volatile init)
+            done (new Volatile false)]
+        (dofor [x :in coll :while (not (.deref done))]
+          (let [result (f (.deref acc) x)]
             (if (reduced? result)
-              (do (php/-> acc (reset (php/-> result (deref))))
-                  (php/-> done (reset true)))
-              (php/-> acc (reset result)))))
-        (php/-> acc (deref)))
-    (throw (php/new InvalidArgumentException "expected 2 or 3 arguments in reduce"))))
+              (do (.reset acc (.deref result))
+                  (.reset done true))
+              (.reset acc result))))
+        (.deref acc))
+    (throw (new InvalidArgumentException "expected 2 or 3 arguments in reduce"))))
 
 (defn reduce-kv
   "Reduces an associative collection by applying `f` to the accumulator, key and value of each entry, starting with `init`. Vectors use the index as key. Respects early termination via `(reduced val)`."
   {:example "(reduce-kv (fn [m k v] (assoc m v k)) {} {:a 1 :b 2}) ; => {1 :a, 2 :b}"
    :see-also ["reduce" "update-keys" "update-vals" "reduced"]}
   [f init coll]
-  (let [acc  (php/new Volatile init)
-        done (php/new Volatile false)]
-    (dofor [[k v] :pairs coll :while (not (php/-> done (deref)))]
-      (let [result (f (php/-> acc (deref)) k v)]
+  (let [acc  (new Volatile init)
+        done (new Volatile false)]
+    (dofor [[k v] :pairs coll :while (not (.deref done))]
+      (let [result (f (.deref acc) k v)]
         (if (reduced? result)
-          (do (php/-> acc (reset (php/-> result (deref))))
-              (php/-> done (reset true)))
-          (php/-> acc (reset result)))))
-    (php/-> acc (deref))))
+          (do (.reset acc (.deref result))
+              (.reset done true))
+          (.reset acc result))))
+    (.deref acc)))
 
 (defn completing
   "Takes a reducing function `f` of 2 args and returns a fn suitable for transduce by adding a 1-arity (completion) that calls `cf` (default: identity)."
@@ -120,21 +120,21 @@
             f    (xform (completing f))
             ret  (reduce f init coll)]
         (f ret))
-    (throw (php/new InvalidArgumentException "transduce expects 3 or 4 arguments"))))
+    (throw (new InvalidArgumentException "transduce expects 3 or 4 arguments"))))
 
 (defn volatile!
   "Creates a volatile mutable reference with initial value `val`. Use for transducer state that needs fast mutation without watches."
   {:example "(let [v (volatile! 0)] (vreset! v 5) @v) ; => 5"
    :see-also ["vreset!" "vswap!" "var"]}
   [val]
-  (php/new Volatile val))
+  (new Volatile val))
 
 (defn vreset!
   "Sets the value of volatile `vol` to `val`. Returns `val`."
   {:example "(let [v (volatile! 0)] (vreset! v 9)) ; => 9"
    :see-also ["volatile!" "vswap!"]}
   [vol val]
-  (php/-> vol (reset val)))
+  (.reset vol val))
 
 (defn vswap!
   "Applies `f` to the current value of volatile `vol` plus `args`, and sets the new value. Returns the new value."

--- a/src/phel/core/transients.phel
+++ b/src/phel/core/transients.phel
@@ -22,14 +22,14 @@ Transient collections provide faster performance for multiple sequential updates
   {:example "(def t (transient []))"
    :see-also ["persistent"]}
   [coll]
-  (php/-> coll (asTransient)))
+  (.asTransient coll))
 
 (defn persistent
   "Converts a transient collection back to a persistent collection."
   {:example "(def t (transient {}))"
    :see-also ["transient"]}
   [coll]
-  (php/-> coll (persistent)))
+  (.persistent coll))
 
 (defn persistent!
   "Converts a transient collection back to a persistent collection. Alias for `persistent`, matching Clojure's `persistent!` naming."
@@ -47,15 +47,15 @@ Transient collections provide faster performance for multiple sequential updates
                      (do
                        (php/aset acc key value)
                        acc)
-                     (php/-> acc (put key value))))]
+                     (.put acc key value)))]
       (cond
         (php/instanceof entry MapEntry)
-        (assign coll (php/-> entry (key)) (php/-> entry (value)))
+        (assign coll (.key entry) (.value entry))
 
         (indexed? entry)
         (if (php/!= (count entry) 2)
-          (throw (php/new InvalidArgumentException
-                          "conj on a map expects entries of length 2"))
+          (throw (new InvalidArgumentException
+                      "conj on a map expects entries of length 2"))
           (assign coll (first entry) (second entry)))
 
         (associative? entry)
@@ -64,18 +64,18 @@ Transient collections provide faster performance for multiple sequential updates
           (assign acc key value))
 
         :else
-        (throw (php/new InvalidArgumentException
-                        "conj on a map expects a [key value] pair or an associative collection"))))))
+        (throw (new InvalidArgumentException
+                    "conj on a map expects a [key value] pair or an associative collection"))))))
 
 (defn- conj-bang-single
   [tcoll value]
   (cond
-    (php/instanceof tcoll TransientVectorInterface)  (php/-> tcoll (append value))
-    (php/instanceof tcoll TransientHashSetInterface) (php/-> tcoll (add value))
+    (php/instanceof tcoll TransientVectorInterface)  (.append tcoll value)
+    (php/instanceof tcoll TransientHashSetInterface) (.add tcoll value)
     (php/instanceof tcoll TransientMapInterface)     (conj-map-entry tcoll value)
     :else
-    (throw (php/new InvalidArgumentException
-                    (str "conj! expects a transient collection, got " (type tcoll))))))
+    (throw (new InvalidArgumentException
+                (str "conj! expects a transient collection, got " (type tcoll))))))
 
 (defn conj!
   "Adds `value` to the transient collection `tcoll`, mutating it in place, and returns `tcoll`. The 'addition' may happen at different 'places' depending on the concrete transient type: transient vectors append at the tail, transient hash-sets add the element (no-op if already present), and transient hash-maps treat `value` as a `[key value]` pair (or an associative collection of entries). With zero arguments returns a new empty transient vector. With one argument returns `tcoll` unchanged. Variadic forms reduce `conj!` over the remaining values. Raises `InvalidArgumentException` when `tcoll` is not a transient collection. Matches Clojure's `conj!` semantics."
@@ -91,14 +91,14 @@ Transient collections provide faster performance for multiple sequential updates
   [tcoll key value]
   (cond
     (php/instanceof tcoll TransientMapInterface)
-    (php/-> tcoll (put key value))
+    (.put tcoll key value)
 
     (php/instanceof tcoll TransientVectorInterface)
-    (php/-> tcoll (update key value))
+    (.update tcoll key value)
 
     :else
-    (throw (php/new InvalidArgumentException
-                    (str "assoc! expects a transient map or transient vector, got " (type tcoll))))))
+    (throw (new InvalidArgumentException
+                (str "assoc! expects a transient map or transient vector, got " (type tcoll))))))
 
 (defn assoc!
   "Associates one or more key-value pairs with a transient collection,
@@ -125,11 +125,11 @@ Transient collections provide faster performance for multiple sequential updates
   [tcoll key]
   (cond
     (php/instanceof tcoll TransientMapInterface)
-    (php/-> tcoll (remove key))
+    (.remove tcoll key)
 
     :else
-    (throw (php/new InvalidArgumentException
-                    (str "dissoc! expects a transient map, got " (type tcoll))))))
+    (throw (new InvalidArgumentException
+                (str "dissoc! expects a transient map, got " (type tcoll))))))
 
 (defn dissoc!
   "Dissociates one or more keys from a transient map, mutating it in place. Raises `InvalidArgumentException` when `tcoll` is not a transient map. Matches Clojure's `dissoc!` semantics."
@@ -144,11 +144,11 @@ Transient collections provide faster performance for multiple sequential updates
   [tcoll value]
   (cond
     (php/instanceof tcoll TransientHashSetInterface)
-    (php/-> tcoll (remove value))
+    (.remove tcoll value)
 
     :else
-    (throw (php/new InvalidArgumentException
-                    (str "disj! expects a transient set, got " (type tcoll))))))
+    (throw (new InvalidArgumentException
+                (str "disj! expects a transient set, got " (type tcoll))))))
 
 (defn disj!
   "Removes one or more elements from a transient set, mutating it in place. Raises `InvalidArgumentException` when `tcoll` is not a transient set. Matches Clojure's `disj!` semantics."
@@ -166,8 +166,8 @@ Transient collections provide faster performance for multiple sequential updates
   [tcoll]
   (cond
     (php/instanceof tcoll TransientVectorInterface)
-    (php/-> tcoll (pop))
+    (.pop tcoll)
 
     :else
-    (throw (php/new InvalidArgumentException
-                    (str "pop! expects a transient vector, got " (type tcoll))))))
+    (throw (new InvalidArgumentException
+                (str "pop! expects a transient vector, got " (type tcoll))))))

--- a/src/phel/core/uuid.phel
+++ b/src/phel/core/uuid.phel
@@ -22,7 +22,7 @@
   {:example "(random-uuid) ; => #uuid \"550e8400-e29b-41d4-a716-446655440000\""
    :see-also ["uuid?" "parse-uuid"]}
   []
-  (php/:: UUID (randomV4)))
+  (UUID/randomV4))
 
 (defn parse-uuid
   "Parses `s` as a canonical UUID string and returns a `Phel\\Lang\\UUID`
@@ -35,7 +35,7 @@
   (cond
     (php/instanceof s UUID) s
     (string? s)             (try
-                              (php/:: UUID (fromString s))
+                              (UUID/fromString s)
                               (catch \InvalidArgumentException _ nil))
     :else                   nil))
 
@@ -53,7 +53,7 @@
    :see-also ["uuid?"]}
   [x]
   (and (uuid? x)
-       (php/-> x (isNil))))
+       (.isNil x)))
 
 (defn uuid-version
   "Returns the version digit (1-5) encoded in UUID `x`, or nil if `x` is not a `UUID` value."
@@ -61,7 +61,7 @@
    :see-also ["uuid?" "uuid-variant"]}
   [x]
   (when (uuid? x)
-    (php/-> x (version))))
+    (.version x)))
 
 (defn uuid-variant
   "Returns a keyword describing the variant field of UUID `x`: `:ncs`,
@@ -71,4 +71,4 @@
    :see-also ["uuid?" "uuid-version"]}
   [x]
   (when (uuid? x)
-    (keyword (php/-> x (variant)))))
+    (keyword (.variant x))))

--- a/src/phel/edn.phel
+++ b/src/phel/edn.phel
@@ -26,10 +26,10 @@
 ;;                               (default nil)
 
 (defn- compiler-facade []
-  (php/new CompilerFacade))
+  (new CompilerFacade))
 
 (defn- tag-registry []
-  (php/:: TagRegistry (getInstance)))
+  (TagRegistry/getInstance))
 
 (defn- tag-key
   "Normalises a tag from a symbol, keyword, or string to the string key used by the global `TagRegistry`."
@@ -38,31 +38,31 @@
     (string? tag)  tag
     (symbol? tag)  (full-name tag)
     (keyword? tag) (name tag)
-    :else          (throw (php/new \InvalidArgumentException
-                                   (str "EDN reader tag must be a symbol, keyword, or string, got: "
-                                        (php/gettype tag))))))
+    :else          (throw (new \InvalidArgumentException
+                               (str "EDN reader tag must be a symbol, keyword, or string, got: "
+                                    (php/gettype tag))))))
 
 (defn- snapshot-tags
   "Captures the existing handler for each tag key so it can be restored after the call. Returns a map `{tag-key handler-or-nil}`."
   [reg tag-keys]
   (let [acc (transient {})]
     (foreach [k tag-keys]
-      (php/-> acc (put k (php/-> reg (get k)))))
+      (.put acc k (.get reg k)))
     (persistent acc)))
 
 (defn- install-readers
   "Registers each `tag -> fn` from `readers` on the registry."
   [reg readers]
   (foreach [tag handler readers]
-    (php/-> reg (register (tag-key tag) handler))))
+    (.register reg (tag-key tag) handler)))
 
 (defn- restore-tags
   "Reinstates the original handlers captured by `snapshot-tags`. When a tag had no prior handler, it is unregistered so the registry returns to its earlier shape."
   [reg snapshot]
   (foreach [k handler snapshot]
     (if (php/=== handler nil)
-      (php/-> reg (unregister k))
-      (php/-> reg (register k handler)))))
+      (.unregister reg k)
+      (.register reg k handler))))
 
 (defn- with-readers*
   "Runs `thunk` with `readers` temporarily installed on the tag registry. Restores prior state in a `finally` so exceptions still clean up."
@@ -82,20 +82,20 @@
   "Reads the next form from the open `token-stream` using `cf`. Skips whitespace, comments, and other trivia parser nodes that precede the next data form. Returns nil when the stream is exhausted."
   [cf token-stream]
   (loop []
-    (let [node (php/-> cf (parseNext token-stream))]
+    (let [node (.parseNext cf token-stream)]
       (cond
         (php/=== nil node)                        nil
         (php/instanceof node TriviaNodeInterface) (recur)
-        :else                                     (php/-> (php/-> cf (read node)) (getAst))))))
+        :else                                     (.getAst (.read cf node))))))
 
 (defn- parse-one [s]
   (let [cf           (compiler-facade)
-        token-stream (php/-> cf (lexString s))]
+        token-stream (.lexString cf s)]
     (read-next cf token-stream)))
 
 (defn- parse-all [s]
   (let [cf           (compiler-facade)
-        token-stream (php/-> cf (lexString s))]
+        token-stream (.lexString cf s)]
     (loop [acc (transient [])]
       (let [form (read-next cf token-stream)]
         (if (php/=== form nil)
@@ -132,14 +132,14 @@
    (let [readers (get opts :readers)]
      (with-readers* readers #(parse-all s)))))
 
-(def- readable-printer (php/:: Printer (readable)))
+(def- readable-printer (Printer/readable))
 
 (defn write-string
   "Serialises `value` to its EDN string representation. Uses Phel's readable printer so the output round-trips through `read-string` for all EDN-compatible values (nil, booleans, numbers, strings, keywords, symbols, lists, vectors, maps, sets, and built-in tagged literals such as `#uuid`)."
   {:example "(write-string {:a 1}) ; => \"{:a 1}\""
    :see-also ["read-string" "write-string-all"]}
   [value]
-  (php/-> readable-printer (print value)))
+  (.print readable-printer value))
 
 (defn write-string-all
   "Serialises a sequence of values to EDN, separating top-level forms with a single space. Inverse of `read-string-all`."

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -30,7 +30,7 @@
 (defn- normalize-element [[tag & content]]
   (do
     (when-not (or (keyword? tag) (string? tag))
-      (throw (php/new InvalidArgumentException (str tag " is not a valid element name."))))
+      (throw (new InvalidArgumentException (str tag " is not a valid element name."))))
     (let [tag         (to-str tag)
           elem        (first content)
           map-attrs   (if (map? elem) elem {})

--- a/src/phel/http-client.phel
+++ b/src/phel/http-client.phel
@@ -92,14 +92,13 @@
                          [headers body])
         url            (append-query-params url query-params)]
     (transport-result->response
-     (php/:: \Phel\HttpClient\StreamTransport
-             (send (php/strtoupper (key->string method))
-                   url
-                   (build-headers-array headers)
-                   body
-                   (build-options-array {:timeout timeout
-                                         :follow-redirects follow-redirects
-                                         :verify-ssl verify-ssl}))))))
+     (\Phel\HttpClient\StreamTransport/send (php/strtoupper (key->string method))
+                                            url
+                                            (build-headers-array headers)
+                                            body
+                                            (build-options-array {:timeout timeout
+                                                                  :follow-redirects follow-redirects
+                                                                  :verify-ssl verify-ssl})))))
 
 (defn get
   "Makes a GET request. See `request` for available options."

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -92,7 +92,7 @@
         parts        (php/parse_url (str prefix encodedUrl))
         parts        (php/array_map php/urldecode parts)]
     (when-not parts
-      (throw (php/new InvalidArgumentException (str "This is not a valid uri: " url))))
+      (throw (new InvalidArgumentException (str "This is not a valid uri: " url))))
     (uri
      (php/aget parts "scheme")
      (if (php/aget parts "pass")
@@ -145,7 +145,7 @@
         (indexed? v)
         (assoc res k (normalize-files v))
 
-        (throw (php/new InvalidArgumentException "Invalid value in files specification"))))
+        (throw (new InvalidArgumentException "Invalid value in files specification"))))
     (persistent res)))
 
 (defn files-from-globals
@@ -203,11 +203,11 @@
   (let [method (get (or server php/$_SERVER) "REQUEST_METHOD")]
     (if method
       method
-      (throw (php/new InvalidArgumentException
-                      (str "cannot determine HTTP Method: $_SERVER['REQUEST_METHOD'] is not set. "
-                           "request-from-globals requires a web request context (PHP-FPM, mod_php, or `php -S`); "
-                           "it cannot be used from the REPL or a CLI script. "
-                           "Build a request manually with `request-from-map` for testing."))))))
+      (throw (new InvalidArgumentException
+                  (str "cannot determine HTTP Method: $_SERVER['REQUEST_METHOD'] is not set. "
+                       "request-from-globals requires a web request context (PHP-FPM, mod_php, or `php -S`); "
+                       "it cannot be used from the REPL or a CLI script. "
+                       "Build a request manually with `request-from-map` for testing."))))))
 
 (defn- content-type-base
   "Lowercased media type from the `:content-type` header with any parameters
@@ -301,7 +301,7 @@
      (string? uri) (uri-from-string uri)
      (uri? uri) uri
      (nil? uri) nil
-     (throw (php/new InvalidArgumentException "Invalid :uri provided. Must be nil, string or uri")))
+     (throw (new InvalidArgumentException "Invalid :uri provided. Must be nil, string or uri")))
    (or headers {})
    parsed-body
    (or query-params {})
@@ -441,12 +441,12 @@
 (defn- assert-no-crlf [value]
   (when (and (string? value)
              (or (php/str_contains value "\r") (php/str_contains value "\n")))
-    (throw (php/new InvalidArgumentException "Header must not contain CR or LF characters")))
+    (throw (new InvalidArgumentException "Header must not contain CR or LF characters")))
   value)
 
 (defn- normalize-header-name [header-name]
   (when-not (or (keyword? header-name) (string? header-name))
-    (throw (php/new InvalidArgumentException (str "Header must be a keyword or string. Given: " header-name))))
+    (throw (new InvalidArgumentException (str "Header must be a keyword or string. Given: " header-name))))
   (assert-no-crlf (php/ucwords (name header-name) "-")))
 
 (defn- emit-headers [{:status status, :headers headers}]

--- a/src/phel/json.phel
+++ b/src/phel/json.phel
@@ -22,7 +22,7 @@
   (let [arr (php/array)]
     (foreach [k v x]
       (when-not (valid-key? k)
-        (throw (php/new JsonException "Key can only be an integer, float, symbol, keyword or a string.")))
+        (throw (new JsonException "Key can only be an integer, float, symbol, keyword or a string.")))
       (php/aset arr (encode-key k) (encode-value v)))
     arr))
 
@@ -34,7 +34,7 @@
   (cond
     ;; An empty map must encode as a JSON object `{}`, not the `[]` an empty
     ;; php/array would produce; a stdClass forces object encoding.
-    (and (map? x) (empty? x)) (php/new \stdClass)
+    (and (map? x) (empty? x)) (new \stdClass)
     (php/is_iterable x)       (encode-value-iterable x)
     (symbol? x)               (name x)
     (keyword? x)              (name x)
@@ -46,10 +46,10 @@
   [value & [{:flags flags, :depth depth}]]
   (let [flags (or flags 0)
         depth (or depth 512)]
-    (when (php/is_resource value) (throw (php/new JsonException "Value can be any type except a resource.")))
-    (when-not (int? flags) (throw (php/new JsonException "Flags must be an integer.")))
-    (when-not (int? depth) (throw (php/new JsonException "Depth must be an integer.")))
-    (when-not (> depth 0) (throw (php/new JsonException "Depth must be greater than zero.")))
+    (when (php/is_resource value) (throw (new JsonException "Value can be any type except a resource.")))
+    (when-not (int? flags) (throw (new JsonException "Flags must be an integer.")))
+    (when-not (int? depth) (throw (new JsonException "Depth must be an integer.")))
+    (when-not (> depth 0) (throw (new JsonException "Depth must be greater than zero.")))
     (php/json_encode (encode-value value) flags depth)))
 
 (defn decode-value
@@ -64,7 +64,7 @@
                        ;; JSON object keys are strings, but php/json_decode coerces
                        ;; numeric keys to ints; stringify first so `(keyword k)`
                        ;; never collapses them to a single nil key.
-                       (php/-> hashmap (put (keyword (str k)) (decode-value v))))
+                       (.put hashmap (keyword (str k)) (decode-value v)))
                      (persistent hashmap))
     true           x))
 
@@ -74,8 +74,8 @@
   [json & [{:flags flags, :depth depth}]]
   (let [flags (or flags 0)
         depth (or depth 512)]
-    (when-not (string? json) (throw (php/new JsonException "Json must be a string.")))
-    (when-not (int? flags) (throw (php/new JsonException "Flags must be an integer.")))
-    (when-not (int? depth) (throw (php/new JsonException "Depth must be an integer.")))
-    (when-not (> depth 0) (throw (php/new JsonException "Depth must be greater than zero.")))
+    (when-not (string? json) (throw (new JsonException "Json must be a string.")))
+    (when-not (int? flags) (throw (new JsonException "Flags must be an integer.")))
+    (when-not (int? depth) (throw (new JsonException "Depth must be an integer.")))
+    (when-not (> depth 0) (throw (new JsonException "Depth must be greater than zero.")))
     (decode-value (php/json_decode json true depth flags))))

--- a/src/phel/match.phel
+++ b/src/phel/match.phel
@@ -121,13 +121,13 @@
   [target pattern]
   (let [alts (vec (next pattern))]
     (when (empty? alts)
-      (throw (php/new \InvalidArgumentException
-                      "match :or pattern requires at least one alternative")))
+      (throw (new \InvalidArgumentException
+                  "match :or pattern requires at least one alternative")))
     (let [compiled (for [a :in alts] (compile-pattern target a))]
       (doseq [c :in compiled]
         (when-not (empty? (get c :bindings))
-          (throw (php/new \InvalidArgumentException
-                          "match :or alternatives must not introduce bindings"))))
+          (throw (new \InvalidArgumentException
+                      "match :or alternatives must not introduce bindings"))))
       (let [checks (for [c :in compiled] (get c :check))]
         {:check `(or ~@checks), :bindings []}))))
 
@@ -150,13 +150,13 @@
       [pattern nil]
       (do
         (when-not (= (+ idx 2) n)
-          (throw (php/new \InvalidArgumentException
-                          (str "match vector pattern: `&` must be followed by exactly one binding, got "
-                               pattern))))
+          (throw (new \InvalidArgumentException
+                      (str "match vector pattern: `&` must be followed by exactly one binding, got "
+                           pattern))))
         (let [tail (get pattern (+ idx 1))]
           (when-not (symbol? tail)
-            (throw (php/new \InvalidArgumentException
-                            (str "match vector pattern: `&` binding must be a symbol, got " tail))))
+            (throw (new \InvalidArgumentException
+                        (str "match vector pattern: `&` binding must be a symbol, got " tail))))
           [(vec (take idx pattern)) tail])))))
 
 (defn- compile-vector
@@ -225,17 +225,17 @@
     (vector? pattern)           (compile-vector target pattern)
     (map? pattern)              (compile-map target pattern)
     :else
-    (throw (php/new \InvalidArgumentException
-                    (str "match: unsupported pattern shape: " pattern)))))
+    (throw (new \InvalidArgumentException
+                (str "match: unsupported pattern shape: " pattern)))))
 
 (defn- compile-clause
   "Compiles one clause row into `[check bindings]`."
   [target-syms patterns]
   (when-not (= (count target-syms) (count patterns))
-    (throw (php/new \InvalidArgumentException
-                    (str "match: pattern count (" (count patterns)
-                         ") does not match target count (" (count target-syms)
-                         "): " patterns))))
+    (throw (new \InvalidArgumentException
+                (str "match: pattern count (" (count patterns)
+                     ") does not match target count (" (count target-syms)
+                     "): " patterns))))
   (let [subs     (vec
                   (for [i :range [0 (count patterns)]]
                     (compile-pattern (get target-syms i) (get patterns i))))
@@ -258,21 +258,21 @@
       (= (first remaining) else-keyword)
       (do
         (when-not (= (count remaining) 2)
-          (throw (php/new \InvalidArgumentException
-                          "match: :else must be followed by exactly one expression and must come last")))
+          (throw (new \InvalidArgumentException
+                      "match: :else must be followed by exactly one expression and must come last")))
         [clauses (get remaining 1)])
 
       :else
       (do
         (when (< (count remaining) 2)
-          (throw (php/new \InvalidArgumentException
-                          "match: every pattern must be paired with an expression")))
+          (throw (new \InvalidArgumentException
+                      "match: every pattern must be paired with an expression")))
         (let [pat  (first remaining)
               expr (get remaining 1)
               rest (vec (drop 2 remaining))]
           (when-not (vector? pat)
-            (throw (php/new \InvalidArgumentException
-                            (str "match: pattern must be a vector, got " pat))))
+            (throw (new \InvalidArgumentException
+                        (str "match: pattern must be a vector, got " pat))))
           (recur rest
                  (conj clauses [pat expr])
                  default))))))
@@ -298,8 +298,8 @@
    :example "(match [x y] [0 _] :zero-x [_ 0] :zero-y [a b] [:both a b])"}
   [targets & body]
   (when-not (vector? targets)
-    (throw (php/new \InvalidArgumentException
-                    (str "match: target list must be a vector, got " targets))))
+    (throw (new \InvalidArgumentException
+                (str "match: target list must be a vector, got " targets))))
   (let [n                 (count targets)
         target-syms       (vec
                            (for [_ :range [0 n]]
@@ -315,8 +315,8 @@
                                   [check bindings] (compile-clause target-syms pat)]
                               [check bindings expr]))
         no-match          (if (nil? default)
-                            `(throw (php/new \RuntimeException
-                                             (str "match: no matching clause for " [~@target-syms])))
+                            `(throw (new \RuntimeException
+                                         (str "match: no matching clause for " [~@target-syms])))
                             default)
         cond-body         (apply concat
                                  (concat

--- a/src/phel/mock.phel
+++ b/src/phel/mock.phel
@@ -77,7 +77,7 @@
 
 (defn mock-throwing
   "Creates a mock that throws an exception when called."
-  {:example "(def my-mock (mock-throwing (php/new \\RuntimeException \"API unavailable\")))"}
+  {:example "(def my-mock (mock-throwing (new \\RuntimeException \"API unavailable\")))"}
   [exception]
   (let [call-history (atom [])]
     (register-mock!

--- a/src/phel/pprint.phel
+++ b/src/phel/pprint.phel
@@ -6,12 +6,12 @@
 (defn- print-value
   "Prints a scalar or non-collection value using the standard readable printer."
   [x]
-  (php/-> (php/:: Printer (readable)) (print x)))
+  (.print (Printer/readable) x))
 
 (defn- render-value
   "Prints `x` with the given printer (plain or colored)."
   [printer x]
-  (php/-> printer (print x)))
+  (.print printer x))
 
 (defn- pp-str
   "Pretty-prints `form` to a string with the given indent level and max width.
@@ -95,7 +95,7 @@
    :example "(pprint-str {:a [1 2 3] :b {:c 4 :d 5}})"}
   [form & [width]]
   (let [w (or width *default-width*)]
-    (pp-str form 0 w (php/:: Printer (readable)))))
+    (pp-str form 0 w (Printer/readable))))
 
 (defn pprint
   "Pretty-prints `form` to stdout with optional `width` (default 72)."
@@ -124,8 +124,8 @@
   [x & [width]]
   (let [w       (or width *default-width*)
         printer (if (color-output?)
-                  (php/:: Printer (readableWithColor))
-                  (php/:: Printer (readable)))]
+                  (Printer/readableWithColor)
+                  (Printer/readable))]
     (php/print (pp-str x 0 w printer))
     (php/print "\n")
     x))

--- a/src/phel/reader.phel
+++ b/src/phel/reader.phel
@@ -14,7 +14,7 @@
 (defn- registry
   "Returns the shared TagRegistry singleton."
   []
-  (php/:: TagRegistry (getInstance)))
+  (TagRegistry/getInstance))
 
 (defn register-tag
   "Registers a handler for reader tag `tag-name` (a string without the leading `#`). The handler `f` is a 1-arg function receiving the already-read form value and returning the value that should replace the tagged literal.
@@ -24,7 +24,7 @@ Re-registering an existing tag overwrites the previous handler."
   ; later: #date \"2026-04-20\" => (my-ns/parse-date \"2026-04-20\")"
    :see-also ["tag-registered?" "unregister-tag" "registered-tags"]}
   [tag-name f]
-  (php/-> (registry) (register tag-name f))
+  (.register (registry) tag-name f)
   nil)
 
 (defn tag-registered?
@@ -32,14 +32,14 @@ Re-registering an existing tag overwrites the previous handler."
   {:example "(tag-registered? \"inst\") ; => true"
    :see-also ["register-tag" "unregister-tag" "registered-tags"]}
   [tag-name]
-  (php/-> (registry) (has tag-name)))
+  (.has (registry) tag-name))
 
 (defn unregister-tag
   "Removes any handler registered for reader tag `tag-name`. Built-in tags can be unregistered but are re-installed on the next reader bootstrap."
   {:example "(unregister-tag \"date\")"
    :see-also ["register-tag" "tag-registered?" "registered-tags"]}
   [tag-name]
-  (php/-> (registry) (unregister tag-name))
+  (.unregister (registry) tag-name)
   nil)
 
 (defn registered-tags
@@ -47,4 +47,4 @@ Re-registering an existing tag overwrites the previous handler."
   {:example "(registered-tags) ; => [\"inst\" \"regex\" \"uuid\"]"
    :see-also ["register-tag" "tag-registered?" "unregister-tag"]}
   []
-  (php/:: Phel (vector (php/-> (registry) (tags)))))
+  (Phel/vector (.tags (registry))))

--- a/src/phel/reflect.phel
+++ b/src/phel/reflect.phel
@@ -9,38 +9,38 @@
 (defn- reflection-class
   "Returns a ReflectionClass for `class-or-name` (string FQN or object)."
   [class-or-name]
-  (php/new ReflectionClass class-or-name))
+  (new ReflectionClass class-or-name))
 
 (defn- type-string
   "Renders a ReflectionType (named, union, or intersection) as a string. Returns nil when the reflection type itself is nil (no declaration)."
   [rt]
-  (when rt (php/-> rt (__toString))))
+  (when rt (.__toString rt)))
 
 (defn- visibility-of [m]
   (cond
-    (php/-> m (isPrivate))   :private
-    (php/-> m (isProtected)) :protected
-    true                     :public))
+    (.isPrivate m)   :private
+    (.isProtected m) :protected
+    true             :public))
 
 (defn- parameter->map [p]
-  {:name     (php/-> p (getName))
-   :type     (type-string (php/-> p (getType)))
-   :optional (php/-> p (isOptional))
-   :variadic (php/-> p (isVariadic))})
+  {:name     (.getName p)
+   :type     (type-string (.getType p))
+   :optional (.isOptional p)
+   :variadic (.isVariadic p)})
 
 (defn- method->map [m]
-  {:name        (php/-> m (getName))
-   :params      (vec (for [p :in (php/-> m (getParameters))]
+  {:name        (.getName m)
+   :params      (vec (for [p :in (.getParameters m)]
                        (parameter->map p)))
-   :return-type (type-string (php/-> m (getReturnType)))
-   :static?     (php/-> m (isStatic))
+   :return-type (type-string (.getReturnType m))
+   :static?     (.isStatic m)
    :visibility  (visibility-of m)})
 
 (defn- property->map [p]
-  {:name       (php/-> p (getName))
-   :type       (type-string (php/-> p (getType)))
-   :static?    (php/-> p (isStatic))
-   :readonly?  (php/-> p (isReadonly))
+  {:name       (.getName p)
+   :type       (type-string (.getType p))
+   :static?    (.isStatic p)
+   :readonly?  (.isReadonly p)
    :visibility (visibility-of p)})
 
 (defn methods
@@ -49,7 +49,7 @@
   {:example "(methods DateTime)"}
   [class-or-name]
   (let [rc (reflection-class class-or-name)]
-    (vec (for [m :in (php/-> rc (getMethods))]
+    (vec (for [m :in (.getMethods rc)]
            (method->map m)))))
 
 (defn properties
@@ -58,7 +58,7 @@
   {:example "(properties \\DateInterval)"}
   [class-or-name]
   (let [rc (reflection-class class-or-name)]
-    (vec (for [p :in (php/-> rc (getProperties))]
+    (vec (for [p :in (.getProperties rc)]
            (property->map p)))))
 
 (defn supers
@@ -67,13 +67,13 @@
   [class-or-name]
   (let [rc    (reflection-class class-or-name)
         names (transient (hash-set))
-        names (loop [parent (php/-> rc (getParentClass))
+        names (loop [parent (.getParentClass rc)
                      acc    names]
                 (if parent
-                  (recur (php/-> parent (getParentClass))
-                         (conj! acc (php/-> parent (getName))))
+                  (recur (.getParentClass parent)
+                         (conj! acc (.getName parent)))
                   acc))]
-    (foreach [iface (php/-> rc (getInterfaceNames))]
+    (foreach [iface (.getInterfaceNames rc)]
       (conj! names iface))
     (persistent! names)))
 
@@ -81,16 +81,16 @@
   "Builds the `:args` map for a `ReflectionAttribute`: named arguments become keyword keys, positional arguments keep their integer index."
   [a]
   (let [res (transient {})]
-    (foreach [k v (php/-> a (getArguments))]
-      (php/-> res (put (if (string? k) (keyword k) k) v)))
+    (foreach [k v (.getArguments a)]
+      (.put res (if (string? k) (keyword k) k) v))
     (persistent res)))
 
 (defn- attribute->map [a]
-  {:name (php/-> a (getName))
+  {:name (.getName a)
    :args (attribute-args a)})
 
 (defn- attributes-of [reflectable]
-  (vec (for [a :in (php/-> reflectable (getAttributes))]
+  (vec (for [a :in (.getAttributes reflectable)]
          (attribute->map a))))
 
 (defn class-attributes
@@ -105,14 +105,14 @@
   {:example "(method-attributes \\App\\Foo \"handle\")"
    :see-also ["class-attributes" "property-attributes"]}
   [class-or-name method-name]
-  (attributes-of (php/-> (reflection-class class-or-name) (getMethod method-name))))
+  (attributes-of (.getMethod (reflection-class class-or-name) method-name)))
 
 (defn property-attributes
   "Returns a vector of attribute maps for property `property-name` on `class-or-name`."
   {:example "(property-attributes \\App\\Foo \"id\")"
    :see-also ["class-attributes" "method-attributes"]}
   [class-or-name property-name]
-  (attributes-of (php/-> (reflection-class class-or-name) (getProperty property-name))))
+  (attributes-of (.getProperty (reflection-class class-or-name) property-name)))
 
 (defn attributes
   "Returns the class-level attribute maps for `obj-or-class`; an instance uses its class. Convenience alias of `class-attributes`."
@@ -128,17 +128,17 @@
    :see-also ["methods" "properties" "supers"]}
   [class-or-name]
   (let [rc     (reflection-class class-or-name)
-        parent (php/-> rc (getParentClass))]
-    {:name       (php/-> rc (getName))
+        parent (.getParentClass rc)]
+    {:name       (.getName rc)
      :methods    (methods class-or-name)
      :properties (properties class-or-name)
      :parents    (vec (loop [p   parent
                              acc []]
                         (if p
-                          (recur (php/-> p (getParentClass))
-                                 (conj acc (php/-> p (getName))))
+                          (recur (.getParentClass p)
+                                 (conj acc (.getName p)))
                           acc)))
-     :interfaces (vec (php/-> rc (getInterfaceNames)))}))
+     :interfaces (vec (.getInterfaceNames rc))}))
 
 ;; Bridge native PHP enums (Symfony/Doctrine column enums, library enums)
 ;; to Phel keywords and back. Works with `defenum`-generated enums and any
@@ -150,7 +150,7 @@
   {:example "(enum->keyword Status/Active)"
    :see-also ["keyword->enum" "enum-values"]}
   [enum-case]
-  (keyword (php/-> enum-case name)))
+  (keyword (.-name enum-case)))
 
 (defn keyword->enum
   "Returns the case of the native PHP enum `enum-class` (string FQN) whose name matches keyword `kw`, or nil when no case matches. Inverse of `enum->keyword`."
@@ -158,7 +158,7 @@
    :see-also ["enum->keyword" "enum-values"]}
   [enum-class kw]
   (let [case-name (name kw)]
-    (first (filter (fn [c] (= case-name (php/-> c name)))
+    (first (filter (fn [c] (= case-name (.-name c)))
                    (.cases enum-class)))))
 
 (defn enum-values

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -13,24 +13,24 @@
   (:require phel.ai :as ai)
   (:require phel.test :as t))
 
-(def- build-facade (php/new BuildFacade))
+(def- build-facade (new BuildFacade))
 
 (def- munge-instance
   ;; Munge is a final readonly class; reuse one instance to avoid per-call allocation.
-  (php/new Munge))
+  (new Munge))
 
 (defn- get-global-env []
-  (php/:: GlobalEnvironmentSingleton (getInstance)))
+  (GlobalEnvironmentSingleton/getInstance))
 
 (defn loaded-namespaces
   "Returns all namespaces currently loaded in the REPL, in dot-separated display form."
   {:example "(loaded-namespaces) ; => [\"phel.core\" \"phel.repl\"]"}
   []
-  (let [raw    (php/:: Phel (getNamespaces))
+  (let [raw    (Phel/getNamespaces)
         munge  munge-instance
         result (transient [])]
     (foreach [ns raw]
-      (conj result (php/:: Munge (displayNs (php/-> munge (decodeNs ns))))))
+      (conj result (Munge/displayNs (.decodeNs munge ns))))
     (persistent result)))
 
 (defn ns-list
@@ -41,12 +41,12 @@
   (sort (loaded-namespaces)))
 
 (defn- eval-file [file]
-  (php/-> build-facade (evalFile file)))
+  (.evalFile build-facade file))
 
 (defn- get-src-dirs
   "Returns source directories for namespace resolution: the configured Phel directories plus the current working directory."
   []
-  (let [dirs (php/-> (php/new CommandFacade) (getAllPhelDirectories))
+  (let [dirs (.getAllPhelDirectories (new CommandFacade))
         cwd  (php/getcwd)]
     (when cwd
       (php/array_push dirs cwd))
@@ -54,20 +54,20 @@
 
 (defn- eval-namespace [namespace]
   (let [canonical    (canonical-ns namespace)
-        dependencies (php/-> build-facade (getDependenciesForNamespace (get-src-dirs) (php/array canonical)))
+        dependencies (.getDependenciesForNamespace build-facade (get-src-dirs) (php/array canonical))
         found        (php/> (php/count dependencies) 0)]
     (when-not found
-      (throw (php/new \RuntimeException
-                      (str "Could not locate namespace '" canonical "' on the source paths."))))
+      (throw (new \RuntimeException
+                  (str "Could not locate namespace '" canonical "' on the source paths."))))
     (foreach [dep dependencies]
-      (when-not (php/in_array (php/-> dep (getNamespace)) (php/:: Phel (getNamespaces)))
-        (eval-file (php/-> dep (getFile)))))))
+      (when-not (php/in_array (.getNamespace dep) (Phel/getNamespaces))
+        (eval-file (.getFile dep))))))
 
 (defn- clean-doc [str]
   (php/trim (php/str_replace (php/array "```phel\n" "```") "" str)))
 
 (defn- find-doc [namespace name]
-  (let [meta (php/:: Phel (getDefinitionMetaData namespace name))]
+  (let [meta (Phel/getDefinitionMetaData namespace name)]
     (when meta
       (let [doc        (or (get meta :doc) "")
             deprecated (get meta :deprecated)
@@ -99,7 +99,7 @@
     (let [normalized (php/str_replace "\\" "." (name sym))
           parts      (php/explode "." normalized)
           last       (php/array_pop parts)]
-      (php/:: Symbol (create last)))))
+      (Symbol/create last))))
 
 (defn- set-ns [namespace]
   (set-var *ns* namespace))
@@ -112,7 +112,7 @@
       ns-str
       (let [target (str "phel." (php/substr ns-str 8))
             munged (php/str_replace "-" "_" target)
-            exists (not (php/empty (php/-> (php/:: Registry (getInstance)) (getDefinitionInNamespace munged))))]
+            exists (not (php/empty (.getDefinitionInNamespace (Registry/getInstance) munged)))]
         (if exists target ns-str)))))
 
 (defn- normalize-require-symbol
@@ -121,18 +121,18 @@
   (let [normalized (normalize-ns-str (name sym))]
     (if (php/=== normalized (name sym))
       sym
-      (php/:: Symbol (create normalized)))))
+      (Symbol/create normalized))))
 
 (defn- require-namespace
   [namespace alias refers]
   (let [namespace  (normalize-require-symbol namespace)
         env        (get-global-env)
         current-ns *ns*]
-    (php/-> env (addRequireAlias current-ns alias namespace))
+    (.addRequireAlias env current-ns alias namespace)
     (foreach [r refers]
-      (php/-> env (addRefer current-ns r namespace)))
+      (.addRefer env current-ns r namespace))
     (eval-namespace namespace)
-    (php/-> (get-global-env) (setNs current-ns))
+    (.setNs (get-global-env) current-ns)
     (set-ns current-ns)
     namespace))
 
@@ -155,7 +155,7 @@
 
 (defn- use-namespace
   [namespace alias]
-  (php/-> (get-global-env) (addUseAlias *ns* alias namespace))
+  (.addUseAlias (get-global-env) *ns* alias namespace)
   namespace)
 
 (defmacro use
@@ -170,8 +170,8 @@
 (defn- print-colorful-str
   "Same as print-str from core, but with color."
   [& xs]
-  (let [printer (php/:: Printer (readableWithColor))
-        pp      #(php/-> printer (print %))]
+  (let [printer (Printer/readableWithColor)
+        pp      #(.print printer %)]
     (case (count xs)
       0 ""
       1 (pp (first xs))
@@ -211,23 +211,23 @@ Compilation happens in expression context, so a bare top-level expression yields
   {:example "(compile-str \"(+ 1 2)\") ; => \"3\"\n(compile-str \"[1 2 3]\") ; => \"\\\\Phel::vector([1, 2, 3])\""
    :see-also ["eval-str" "load-file"]}
   [s]
-  (let [cf   (php/new CompilerFacade)
-        opts (php/new CompileOptions)]
+  (let [cf   (new CompilerFacade)
+        opts (new CompileOptions)]
     ;; `setEmitOnly` keeps this a pure read of the generated PHP: without it the
     ;; compiler evaluates what it emits, so asking to see `(def x 1)` would define
     ;; `x`. It is also required by `setEmitAsExpression`, whose output has no
     ;; trailing `;` and therefore cannot be evaluated as a statement.
-    (php/-> opts (setEmitOnly true) (setEmitAsExpression true))
-    (php/trim (php/-> cf (compile s opts) (getPhpCode)))))
+    (-> opts (.setEmitOnly true) (.setEmitAsExpression true))
+    (php/trim (-> cf (.compile s opts) (.getPhpCode)))))
 
 (defn eval-str
   "Evaluates a string of Phel code and returns the result. If the string contains multiple expressions, returns the result of the last one."
   {:example "(eval-str \"(+ 1 2)\") ; => 3"
    :see-also ["compile-str" "load-file"]}
   [s]
-  (let [cf   (php/new CompilerFacade)
-        opts (php/new CompileOptions)]
-    (php/-> cf (eval s opts))))
+  (let [cf   (new CompilerFacade)
+        opts (new CompileOptions)]
+    (.eval cf s opts)))
 
 (defn load-file
   "Loads and evaluates a Phel source file in the current REPL session. Reads the file content and evaluates it using the compiler, preserving the current REPL namespace context. Returns the result of the last expression."
@@ -235,15 +235,15 @@ Compilation happens in expression context, so a bare top-level expression yields
   [path]
   (let [content (php/file_get_contents path)]
     (when content
-      (let [cf   (php/new CompilerFacade)
-            opts (php/-> (php/new CompileOptions) (setSource path))]
-        (php/-> cf (eval content opts))))))
+      (let [cf   (new CompilerFacade)
+            opts (.setSource (new CompileOptions) path)]
+        (.eval cf content opts)))))
 
 (defn- munge-ns
   "Encodes a namespace string for registry lookup."
   [ns-str]
   (let [munge munge-instance]
-    (php/-> munge (encodeRegistryKey ns-str))))
+    (.encodeRegistryKey munge ns-str)))
 
 (defn get-symbol-info
   "Returns a hash-map of structured metadata for the definition identified by
@@ -256,8 +256,8 @@ Compilation happens in expression context, so a bare top-level expression yields
   (let [canonical    (canonical-ns ns-str)
         encoded-ns   (munge-ns canonical)
         munge        munge-instance
-        encoded-name (php/-> munge (encode name-str))
-        meta         (php/:: Phel (getDefinitionMetaData encoded-ns encoded-name))]
+        encoded-name (.encode munge name-str)
+        meta         (Phel/getDefinitionMetaData encoded-ns encoded-name)]
     (when meta
       (let [start-loc (get meta :start-location)
             end-loc   (get meta :end-location)]
@@ -272,7 +272,7 @@ Compilation happens in expression context, so a bare top-level expression yields
          :min-arity (get meta "min-arity")
          :max-arity (get meta "max-arity")
          :is-variadic (or (get meta "is-variadic") false)
-         :ns (php/:: Munge (displayNs canonical))
+         :ns (Munge/displayNs canonical)
          :name name-str}))))
 
 (defmacro symbol-info
@@ -295,12 +295,12 @@ Returns nil. Prints one name per line, sorted alphabetically."
   [ns]
   (let [ns-str  (name ns)
         encoded (munge-ns ns-str)
-        defs    (php/:: Phel (getDefinitionInNamespace encoded))
+        defs    (Phel/getDefinitionInNamespace encoded)
         munge   munge-instance
         names   (for [fn-name :keys defs
-                      :let [meta (php/:: Phel (getDefinitionMetaData encoded fn-name))]
+                      :let [meta (Phel/getDefinitionMetaData encoded fn-name)]
                       :when (not (get meta :private))]
-                  (php/-> munge (decodeNs fn-name)))]
+                  (.decodeNs munge fn-name))]
     (foreach [n (sort names)]
       (println n))
     nil))
@@ -321,15 +321,15 @@ Returns nil. Prints one name per line, sorted alphabetically."
   [search]
   (let [munge   munge-instance
         results (transient [])]
-    (foreach [ns (php/:: Phel (getNamespaces))]
-      (let [defs     (php/:: Phel (getDefinitionInNamespace ns))
+    (foreach [ns (Phel/getNamespaces)]
+      (let [defs     (Phel/getDefinitionInNamespace ns)
             fn-names (php/array_keys defs)]
         (foreach [fn-name fn-names]
-          (let [decoded (php/-> munge (decodeNs fn-name))
-                meta    (php/:: Phel (getDefinitionMetaData ns fn-name))]
+          (let [decoded (.decodeNs munge fn-name)
+                meta    (Phel/getDefinitionMetaData ns fn-name)]
             (when (and (not (get meta :private))
                        (php/str_contains decoded search))
-              (conj results (str (php/:: Munge (displayNs (php/-> munge (decodeNs ns))))
+              (conj results (str (Munge/displayNs (.decodeNs munge ns))
                                  "/" decoded)))))))
     (sort (persistent results))))
 
@@ -341,15 +341,15 @@ Returns nil. Prints one name per line, sorted alphabetically."
   (let [munge        munge-instance
         search-lower (php/strtolower search)
         results      (transient [])]
-    (foreach [ns (php/:: Phel (getNamespaces))]
-      (let [defs     (php/:: Phel (getDefinitionInNamespace ns))
+    (foreach [ns (Phel/getNamespaces)]
+      (let [defs     (Phel/getDefinitionInNamespace ns)
             fn-names (php/array_keys defs)]
         (foreach [fn-name fn-names]
-          (let [definition (php/:: Phel (getDefinition ns fn-name))]
+          (let [definition (Phel/getDefinition ns fn-name)]
             (when (php/instanceof definition FnInterface)
-              (let [meta         (php/:: Phel (getDefinitionMetaData ns fn-name))
-                    decoded-name (php/-> munge (decodeNs fn-name))
-                    decoded-ns   (php/:: Munge (displayNs (php/-> munge (decodeNs ns))))
+              (let [meta         (Phel/getDefinitionMetaData ns fn-name)
+                    decoded-name (.decodeNs munge fn-name)
+                    decoded-ns   (Munge/displayNs (.decodeNs munge ns))
                     doc          (or (get meta :doc) "")
                     name-lower   (php/strtolower decoded-name)
                     doc-lower    (php/strtolower doc)]
@@ -395,8 +395,8 @@ Returns nil. Prints one name per line, sorted alphabetically."
    :see-also ["create-ns" "remove-ns" "loaded-namespaces"]}
   [ns-str]
   (let [canonical (canonical-ns ns-str)]
-    (when (php/:: Phel (hasNamespace (munge-ns canonical)))
-      (php/:: Munge (displayNs canonical)))))
+    (when (Phel/hasNamespace (munge-ns canonical))
+      (Munge/displayNs canonical))))
 
 (defn create-ns
   "Creates the given namespace if it does not already exist. Returns the namespace name in display form. Existing namespaces are left untouched."
@@ -404,15 +404,15 @@ Returns nil. Prints one name per line, sorted alphabetically."
    :see-also ["find-ns" "remove-ns" "intern"]}
   [ns-str]
   (let [canonical (canonical-ns ns-str)]
-    (php/:: Phel (registerNamespace (munge-ns canonical)))
-    (php/:: Munge (displayNs canonical))))
+    (Phel/registerNamespace (munge-ns canonical))
+    (Munge/displayNs canonical)))
 
 (defn remove-ns
   "Removes the namespace and all of its definitions from the registry. Use with caution. Returns nil."
   {:example "(remove-ns \"my-app.tmp\")"
    :see-also ["find-ns" "create-ns"]}
   [ns-str]
-  (php/:: Phel (removeNamespace (munge-ns ns-str)))
+  (Phel/removeNamespace (munge-ns ns-str))
   nil)
 
 (defn intern
@@ -422,10 +422,10 @@ Returns nil. Prints one name per line, sorted alphabetically."
   [ns-str name-str & rest]
   (let [canonical    (canonical-ns ns-str)
         encoded-ns   (munge-ns canonical)
-        encoded-name (php/-> munge-instance (encode name-str))
+        encoded-name (.encode munge-instance name-str)
         value        (first rest)]
-    (php/:: Phel (addDefinition encoded-ns encoded-name value))
-    (php/:: Symbol (createForNamespace (php/:: Munge (displayNs canonical)) name-str))))
+    (Phel/addDefinition encoded-ns encoded-name value)
+    (Symbol/createForNamespace (Munge/displayNs canonical) name-str)))
 
 (defn ns-interns
   "Returns a hash-map of {name => value} for every definition in the
@@ -434,11 +434,11 @@ Returns nil. Prints one name per line, sorted alphabetically."
   {:example "(ns-interns \"phel\\core\")"
    :see-also ["ns-publics" "intern" "find-ns"]}
   [ns-str]
-  (let [defs   (php/:: Phel (getDefinitionInNamespace (munge-ns ns-str)))
+  (let [defs   (Phel/getDefinitionInNamespace (munge-ns ns-str))
         munge  munge-instance
         result (transient {})]
     (foreach [fn-name value defs]
-      (assoc! result (php/-> munge (decodeNs fn-name)) value))
+      (assoc! result (.decodeNs munge fn-name) value))
     (persistent result)))
 
 (defn ns-publics
@@ -448,13 +448,13 @@ Returns nil. Prints one name per line, sorted alphabetically."
    :see-also ["ns-aliases" "ns-refers" "dir" "loaded-namespaces"]}
   [ns-str]
   (let [encoded (munge-ns ns-str)
-        defs    (php/:: Phel (getDefinitionInNamespace encoded))
+        defs    (Phel/getDefinitionInNamespace encoded)
         munge   munge-instance
         result  (transient {})]
     (foreach [fn-name value defs]
-      (let [meta (php/:: Phel (getDefinitionMetaData encoded fn-name))]
+      (let [meta (Phel/getDefinitionMetaData encoded fn-name)]
         (when-not (get meta :private)
-          (assoc! result (php/-> munge (decodeNs fn-name)) value))))
+          (assoc! result (.decodeNs munge fn-name) value))))
     (persistent result)))
 
 (defn ns-aliases
@@ -464,10 +464,10 @@ Returns nil. Prints one name per line, sorted alphabetically."
    :see-also ["ns-publics" "ns-refers" "loaded-namespaces"]}
   [ns-str]
   (let [env     (get-global-env)
-        aliases (php/-> env (getRequireAliases (canonical-ns ns-str)))
+        aliases (.getRequireAliases env (canonical-ns ns-str))
         result  (transient {})]
     (foreach [alias-name target-sym aliases]
-      (assoc! result alias-name (php/:: Munge (displayNs (php/-> target-sym (getName))))))
+      (assoc! result alias-name (Munge/displayNs (.getName target-sym))))
     (persistent result)))
 
 (defn ns-refers
@@ -477,10 +477,10 @@ Returns nil. Prints one name per line, sorted alphabetically."
    :see-also ["ns-publics" "ns-aliases" "loaded-namespaces"]}
   [ns-str]
   (let [env    (get-global-env)
-        refers (php/-> env (getRefers (canonical-ns ns-str)))
+        refers (.getRefers env (canonical-ns ns-str))
         result (transient {})]
     (foreach [refer-name source-sym refers]
-      (assoc! result refer-name (php/:: Munge (displayNs (php/-> source-sym (getName))))))
+      (assoc! result refer-name (Munge/displayNs (.getName source-sym))))
     (persistent result)))
 
 (defn search-doc
@@ -489,16 +489,16 @@ Returns nil. Prints one name per line, sorted alphabetically."
   [search]
   (let [munge        munge-instance
         search-lower (php/strtolower search)]
-    (foreach [ns (php/:: Phel (getNamespaces))]
-      (let [defs     (php/:: Phel (getDefinitionInNamespace ns))
+    (foreach [ns (Phel/getNamespaces)]
+      (let [defs     (Phel/getDefinitionInNamespace ns)
             fn-names (php/array_keys defs)]
         (foreach [fn-name fn-names]
-          (let [meta (php/:: Phel (getDefinitionMetaData ns fn-name))]
+          (let [meta (Phel/getDefinitionMetaData ns fn-name)]
             (when meta
               (let [doc          (or (get meta :doc) "")
                     doc-lower    (php/strtolower doc)
-                    decoded-name (php/-> munge (decodeNs fn-name))
-                    decoded-ns   (php/:: Munge (displayNs (php/-> munge (decodeNs ns))))]
+                    decoded-name (.decodeNs munge fn-name)
+                    decoded-ns   (Munge/displayNs (.decodeNs munge ns))]
                 (when (and (not (get meta :private))
                            (php/str_contains doc-lower search-lower))
                   (println (str "--- " decoded-ns "/" decoded-name " ---"))
@@ -518,9 +518,9 @@ Returns nil. Prints one name per line, sorted alphabetically."
   [code-str]
   (php/ob_start)
   (try
-    (let [cf    (php/new CompilerFacade)
-          opts  (php/new CompileOptions)
-          value (php/-> cf (eval code-str opts))
+    (let [cf    (new CompilerFacade)
+          opts  (new CompileOptions)
+          value (.eval cf code-str opts)
           out   (php/ob_get_clean)]
       {:value value
        :out out
@@ -531,7 +531,7 @@ Returns nil. Prints one name per line, sorted alphabetically."
         {:value nil
          :out out
          :success false
-         :error (php/-> e (getMessage))}))))
+         :error (.getMessage e)}))))
 
 ;; -------------------------------------------------------------------
 ;; Namespace reloading
@@ -559,8 +559,8 @@ Returns nil. Prints one name per line, sorted alphabetically."
         ns-array (apply php/array (map canonical-ns project))]
     (if (php/empty ns-array)
       (php/array)
-      (filter (fn [info] (reloadable? (php/-> info (getNamespace))))
-              (php/-> build-facade (getDependenciesForNamespace (get-src-dirs) ns-array))))))
+      (filter (fn [info] (reloadable? (.getNamespace info)))
+              (.getDependenciesForNamespace build-facade (get-src-dirs) ns-array)))))
 
 (defn- with-interactive-mode
   "Runs `thunk` with `*interactive-mode*` enabled so re-evaluating a definition
@@ -568,12 +568,12 @@ Returns nil. Prints one name per line, sorted alphabetically."
   after. Not `*repl-mode*`: that one also injects the `phel.repl` refers, which
   a reloaded project namespace must not silently gain."
   [thunk]
-  (let [previous (php/:: Phel (getDefinition "phel.core" "*interactive-mode*"))]
-    (php/:: Phel (addDefinition "phel.core" "*interactive-mode*" true))
+  (let [previous (Phel/getDefinition "phel.core" "*interactive-mode*")]
+    (Phel/addDefinition "phel.core" "*interactive-mode*" true)
     (try
       (thunk)
       (finally
-        (php/:: Phel (addDefinition "phel.core" "*interactive-mode*" previous))))))
+        (Phel/addDefinition "phel.core" "*interactive-mode*" previous)))))
 
 (defn- reload-infos!
   "Reloads the given namespace infos (topologically sorted) when their source
@@ -587,9 +587,9 @@ Returns nil. Prints one name per line, sorted alphabetically."
     (with-interactive-mode
      (fn []
        (foreach [info infos]
-         (let [ns-name   (canonical-ns (php/-> info (getNamespace)))
-               file      (php/-> info (getFile))
-               deps      (map canonical-ns (php/-> info (getDependencies)))
+         (let [ns-name   (canonical-ns (.getNamespace info))
+               file      (.getFile info)
+               deps      (map canonical-ns (.getDependencies info))
                cur-hash  (file-hash file)
                prev-hash (get (deref reload-state) ns-name)
                self?     (or force? (not= cur-hash prev-hash))
@@ -602,7 +602,7 @@ Returns nil. Prints one name per line, sorted alphabetically."
              (swap! reloaded conj ns-name))
            (swap! reload-state assoc ns-name cur-hash)))))
     ;; Re-evaluating files switches the current namespace; restore the caller's.
-    (php/-> (get-global-env) (setNs current-ns))
+    (.setNs (get-global-env) current-ns)
     (set-ns current-ns)
     (deref reloaded)))
 
@@ -640,7 +640,7 @@ Returns nil. Prints one name per line, sorted alphabetically."
   (when-not (find-ns ns-str)
     (let [current *ns*]
       (eval-namespace ns-str)
-      (php/-> (get-global-env) (setNs current))
+      (.setNs (get-global-env) current)
       (set-ns current))))
 
 (defn- run-tests-collecting
@@ -665,7 +665,7 @@ Returns nil. Prints one name per line, sorted alphabetically."
   {:example "(run-tests 'my-app.foo-test 'my-app.bar-test)"
    :see-also ["run-test" "test-ns" "reload!"]}
   [& namespaces]
-  (let [ns-syms (map (fn [n] (php/:: Symbol (create (canonical-ns (name n))))) namespaces)]
+  (let [ns-syms (map (fn [n] (Symbol/create (canonical-ns (name n)))) namespaces)]
     (foreach [n ns-syms]
       (load-namespace! (name n)))
     (run-tests-collecting {} ns-syms)))
@@ -679,7 +679,7 @@ Returns nil. Prints one name per line, sorted alphabetically."
   [test-sym]
   (let [ns-str    (canonical-ns (namespace test-sym))
         test-name (name test-sym)
-        ns-symbol (php/:: Symbol (create ns-str))]
+        ns-symbol (Symbol/create ns-str)]
     (load-namespace! ns-str)
     (run-tests-collecting {:only-tests [(str ns-str "/" test-name)]} [ns-symbol])))
 
@@ -689,23 +689,23 @@ Returns nil. Prints one name per line, sorted alphabetically."
    :see-also ["run-tests" "run-test" "dir" "loaded-namespaces"]}
   [ns-str]
   (load-namespace! ns-str)
-  (run-tests-collecting {} [(php/:: Symbol (create (canonical-ns ns-str)))]))
+  (run-tests-collecting {} [(Symbol/create (canonical-ns ns-str))]))
 
 (defn macroexpand-1-form
   "Expands the given form once if it is a macro call. Takes a quoted form and returns the expanded form, or the original form unchanged if it is not a macro call. Uses the CompilerFacade to perform the expansion without going through analyze+emit."
   {:example "(macroexpand-1-form '(defn foo [x] x))"
    :see-also ["macroexpand-form" "macroexpand-1" "macroexpand"]}
   [form]
-  (let [cf (php/new CompilerFacade)]
-    (php/-> cf (macroexpand1 form))))
+  (let [cf (new CompilerFacade)]
+    (.macroexpand1 cf form)))
 
 (defn macroexpand-form
   "Recursively expands the given form until it is no longer a macro call. Takes a quoted form and returns the fully expanded form. Uses the CompilerFacade to perform the expansion without going through analyze+emit."
   {:example "(macroexpand-form '(defn foo [x] x))"
    :see-also ["macroexpand-1-form" "macroexpand-1" "macroexpand"]}
   [form]
-  (let [cf (php/new CompilerFacade)]
-    (php/-> cf (macroexpand form))))
+  (let [cf (new CompilerFacade)]
+    (.macroexpand cf form)))
 
 (defn macroexpand-1
   "Expands the given form once if it is a macro call. The form must be quoted to prevent evaluation, matching Clojure semantics."

--- a/src/phel/router.phel
+++ b/src/phel/router.phel
@@ -20,9 +20,9 @@
 
 (defn- walk-one [routes prefix-path prev-data]
   (when (string? routes)
-    (throw (php/new \InvalidArgumentException
-                    (str "router expects a route vector `[path data? children*]` or a vector of such routes, got a bare string: \""
-                         routes "\". Wrap it like [\"" routes "\"]."))))
+    (throw (new \InvalidArgumentException
+                (str "router expects a route vector `[path data? children*]` or a vector of such routes, got a bare string: \""
+                     routes "\". Wrap it like [\"" routes "\"]."))))
   (let [head (first routes)]
     (cond
       (empty? routes)
@@ -44,9 +44,9 @@
           (walk-many (keep identity childs) full-path next-data)))
 
       :else
-      (throw (php/new \InvalidArgumentException
-                      (str "router route must start with a string path, got: "
-                           (type head) " in route " (print-str routes)))))))
+      (throw (new \InvalidArgumentException
+                  (str "router route must start with a string path, got: "
+                       (type head) " in route " (print-str routes)))))))
 
 (defn flatten-routes
   "Flattens nested routes to a vector of `[path data]` tuples.
@@ -143,9 +143,9 @@
 (defn- build-route-collection [normalized-routes]
   (for [route :in normalized-routes
         :let [[path data] route
-              symfony-route (php/new Route path (php/array) (php/array) (php-associative-array "data" data "template" path))]
-        :reduce [coll (php/new RouteCollection)]]
-    (php/-> coll (add (route-name-of route) symfony-route))
+              symfony-route (new Route path (php/array) (php/array) (php-associative-array "data" data "template" path))]
+        :reduce [coll (new RouteCollection)]]
+    (.add coll (route-name-of route) symfony-route)
     coll))
 
 (defn- params->php-array
@@ -171,7 +171,7 @@
    Returns nil when no route matches."
   [matcher path lookup-fn]
   (try
-    (let [parameters      (php/-> matcher (match path))
+    (let [parameters      (.match matcher path)
           route-name      (php/aget parameters "_route")
           [template data] (lookup-fn route-name)]
       {:route-name  route-name
@@ -186,7 +186,7 @@
 (defn- generate-with
   "Generates a URL using the given Symfony generator."
   [generator route-name parameters]
-  (php/-> generator (generate (full-name route-name) (params->php-array parameters))))
+  (.generate generator (full-name route-name) (params->php-array parameters)))
 
 (defn- indexed-route->match
   "Converts an `[path data]` tuple from the compiled router's index into a by-name match response. Returns nil when the tuple is nil."
@@ -200,13 +200,13 @@
   (match-by-path [this path]
                  (match-with matcher path
                              (fn [route-name]
-                               (let [route (php/-> route-collection (get route-name))]
-                                 [(php/-> route (getOption "template"))
-                                  (php/-> route (getOption "data"))]))))
+                               (let [route (.get route-collection route-name)]
+                                 [(.getOption route "template")
+                                  (.getOption route "data")]))))
   (match-by-name [this route-name]
-                 (when-let [route (php/-> route-collection (get (full-name route-name)))]
-                   {:template (php/-> route (getOption "template"))
-                    :data     (php/-> route (getOption "data"))}))
+                 (when-let [route (.get route-collection (full-name route-name))]
+                   {:template (.getOption route "template")
+                    :data     (.getOption route "data")}))
   (generate [this route-name parameters]
             (generate-with generator route-name parameters)))
 
@@ -230,10 +230,10 @@
   [raw-routes & [options]]
   (let [normalized (normalize-routes raw-routes options)
         coll       (build-route-collection normalized)
-        ctx        (php/new RequestContext)]
+        ctx        (new RequestContext)]
     (SymfonyRouter normalized coll
-                   (php/new UrlMatcher coll ctx)
-                   (php/new UrlGenerator coll ctx))))
+                   (new UrlMatcher coll ctx)
+                   (new UrlGenerator coll ctx))))
 
 (defstruct CompiledSymfonyRouter [normalized-routes matcher generator indexed-routes]
   Router
@@ -256,11 +256,11 @@
                     (for [route :in normalized
                           :reduce [acc (transient {})]]
                       (assoc! acc (route-name-of route) route)))
-        ctx        (php/new RequestContext)]
+        ctx        (new RequestContext)]
     (CompiledSymfonyRouter
      normalized
-     (php/new CompiledUrlMatcher compiled-matcher-routes ctx)
-     (php/new CompiledUrlGenerator compiled-generator-routes ctx)
+     (new CompiledUrlMatcher compiled-matcher-routes ctx)
+     (new CompiledUrlGenerator compiled-generator-routes ctx)
      indexed)))
 
 (defmacro compiled-router
@@ -276,8 +276,8 @@ Because compilation runs during macro expansion, `raw-routes` must be a literal 
   ;; are rebuilt at runtime from the `raw-routes`/`options` forms.
   (let [flattened-routes          (normalize-routes (eval raw-routes) (eval options))
         route-collection          (build-route-collection flattened-routes)
-        compiled-matcher-routes   (php/-> (php/new CompiledUrlMatcherDumper route-collection) (getCompiledRoutes))
-        compiled-generator-routes (php/-> (php/new CompiledUrlGeneratorDumper route-collection) (getCompiledRoutes))]
+        compiled-matcher-routes   (.getCompiledRoutes (new CompiledUrlMatcherDumper route-collection))
+        compiled-generator-routes (.getCompiledRoutes (new CompiledUrlGeneratorDumper route-collection))]
     `(build-compiled-router ~raw-routes ~options ~compiled-matcher-routes ~compiled-generator-routes)))
 
 (defn handler

--- a/src/phel/schema/coercer.phel
+++ b/src/phel/schema/coercer.phel
@@ -94,11 +94,11 @@
     (php/instanceof value \DateTimeInterface) value
     (string? value)
     (try
-      (php/new \DateTimeImmutable value)
+      (new \DateTimeImmutable value)
       (catch \Throwable _ value))
     (int? value)
     (try
-      (php/:: \DateTimeImmutable (createFromFormat "U" (str value)))
+      (\DateTimeImmutable/createFromFormat "U" (str value))
       (catch \Throwable _ value))
     :else                                     value))
 

--- a/src/phel/schema/generator.phel
+++ b/src/phel/schema/generator.phel
@@ -15,7 +15,7 @@
 (declare schema->gen)
 
 (defn- inst-gen []
-  (g/fmap (fn [secs] (php/:: \DateTimeImmutable (createFromFormat "U" (str secs))))
+  (g/fmap (fn [secs] (\DateTimeImmutable/createFromFormat "U" (str secs)))
           (g/choose 0 2147483647)))
 
 (defn- uuid-gen []
@@ -131,8 +131,8 @@
 (defn- ref-gen [args]
   (let [target (reg/deref-ref (first args))]
     (when (nil? target)
-      (throw (php/new \InvalidArgumentException
-                      (str "schema ref not registered: " (first args)))))
+      (throw (new \InvalidArgumentException
+                  (str "schema ref not registered: " (first args)))))
     (schema->gen target)))
 
 (defn- vector-kind->gen
@@ -153,8 +153,8 @@
       :re     (re-gen args)
       :fn     (fn-gen args)
       :ref    (ref-gen args)
-      :=>     (throw (php/new \InvalidArgumentException
-                              "cannot generate function schemas"))
+      :=>     (throw (new \InvalidArgumentException
+                          "cannot generate function schemas"))
       (v/resolve-or-throw "no generator for schema kind" head
                           (fn [target] (schema->gen target))))))
 
@@ -172,8 +172,8 @@
       (if custom custom (vector-kind->gen schema)))
 
     :else
-    (throw (php/new \InvalidArgumentException
-                    (str "unsupported schema shape: " (print-str schema))))))
+    (throw (new \InvalidArgumentException
+                (str "unsupported schema shape: " (print-str schema))))))
 
 (defn generate
   "Generates one random value conforming to `schema`. Accepts the same

--- a/src/phel/schema/instrument.phel
+++ b/src/phel/schema/instrument.phel
@@ -70,18 +70,18 @@
 (defn- schema-violation!
   [label schema value]
   (let [result (e/explain schema value)]
-    (throw (php/new \InvalidArgumentException
-                    (str label "\n"
-                         (e/human-readable-explain result))))))
+    (throw (new \InvalidArgumentException
+                (str label "\n"
+                     (e/human-readable-explain result))))))
 
 (defn- validate-args!
   [arg-schemas args]
   (let [expected (if (vector? arg-schemas) arg-schemas [arg-schemas])
         actual   (into [] args)]
     (when (not= (count actual) (count expected))
-      (throw (php/new \InvalidArgumentException
-                      (str "schema arity mismatch: expected "
-                           (count expected) " args, got " (count actual)))))
+      (throw (new \InvalidArgumentException
+                  (str "schema arity mismatch: expected "
+                       (count expected) " args, got " (count actual)))))
     (loop [i 0]
       (when (< i (count expected))
         (let [s (get expected i)
@@ -120,9 +120,9 @@
    :see-also ["wrap-with-schema"]}
   [f schema]
   (when-not (function-schema? schema)
-    (throw (php/new \InvalidArgumentException
-                    (str "expected function schema `[:=> args ret]`, got "
-                         (print-str schema)))))
+    (throw (new \InvalidArgumentException
+                (str "expected function schema `[:=> args ret]`, got "
+                     (print-str schema)))))
   (wrap-with-schema f (get schema 1) (get schema 2)))
 
 (defn instrument!

--- a/src/phel/schema/validator.phel
+++ b/src/phel/schema/validator.phel
@@ -32,8 +32,8 @@
   [label head f]
   (if (reg/registered? head)
     (f (reg/deref-ref head))
-    (throw (php/new \InvalidArgumentException
-                    (str label ": " head)))))
+    (throw (new \InvalidArgumentException
+                (str label ": " head)))))
 
 (defn resolve-or-default
   "Like `resolve-or-throw`, but returns `default` when `head` is not registered instead of throwing. Used by `coerce` where unknown heads are intentionally passed through unchanged for downstream validation to flag."
@@ -266,8 +266,8 @@
                 (catch \Throwable _ false))
       :ref    (let [target (reg/deref-ref (get args 0))]
                 (when (nil? target)
-                  (throw (php/new \InvalidArgumentException
-                                  (str "schema ref not registered: " (get args 0)))))
+                  (throw (new \InvalidArgumentException
+                              (str "schema ref not registered: " (get args 0)))))
                 (valid? target value))
       :=>     true
       (resolve-or-throw "unknown schema kind" head
@@ -290,5 +290,5 @@
     (validate-vector-kind schema value)
 
     :else
-    (throw (php/new \InvalidArgumentException
-                    (str "unsupported schema shape: " (print-str schema))))))
+    (throw (new \InvalidArgumentException
+                (str "unsupported schema shape: " (print-str schema))))))

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -9,7 +9,7 @@
   (a hard `TypeError` in PHP 9) and return nonsense on non-string input."
   [x]
   (when-not (string? x)
-    (throw (php/new InvalidArgumentException (str "Expected a string, got " (type x))))))
+    (throw (new InvalidArgumentException (str "Expected a string, got " (type x))))))
 
 (defn split
   "Splits string on a regular expression, returning a vector of parts."
@@ -26,7 +26,7 @@ This is a convenience function for converting strings to character sequences. Pr
    :see-also ["seq"]}
   [s]
   (assert-string s)
-  (php/:: \Phel (vector (php/mb_str_split s))))
+  (\Phel/vector (php/mb_str_split s)))
 
 (defn join
   "Returns a string of all elements in coll, separated by an optional separator."
@@ -42,7 +42,7 @@ This is a convenience function for converting strings to character sequences. Pr
   (let [len (php/mb_strlen s)
         end (or end len)]
     (when (or (php/< start 0) (php/< end start) (php/> end len))
-      (throw (php/new InvalidArgumentException "Invalid start or end index for subs")))
+      (throw (new InvalidArgumentException "Invalid start or end index for subs")))
     (php/mb_substr s start (- end start))))
 
 (defn reverse
@@ -161,7 +161,7 @@ This is a convenience function for converting strings to character sequences. Pr
     (string? s) (not= 0 (php/preg_match
                          "/^[\\t\\n\\x0B\\f\\r\\x1C-\\x1F \\x{1680}\\x{2000}-\\x{2006}\\x{2008}-\\x{200A}\\x{2028}\\x{2029}\\x{205F}\\x{3000}]*$/u"
                          s))
-    :else       (throw (php/new InvalidArgumentException (str "blank? expects a string or nil, got " (type s))))))
+    :else       (throw (new InvalidArgumentException (str "blank? expects a string or nil, got " (type s))))))
 
 (defn starts-with?
   "True if s starts with substr."

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -196,11 +196,11 @@
 
 (defn- location [form]
   (when (php/instanceof form SourceLocationInterface)
-    (let [loc (php/-> form (getStartLocation))]
+    (let [loc (.getStartLocation form)]
       (when loc
-        {:file (php/-> loc (getFile))
-         :line (php/-> loc (getLine))
-         :column (php/-> loc (getColumn))}))))
+        {:file (.getFile loc)
+         :line (.getLine loc)
+         :column (.getColumn loc)}))))
 
 (defn- assert-predicate [form message negated]
   (let [pred            (first form)
@@ -294,7 +294,7 @@
          ~@body
          (report (merge ~report-data {:state :failed :actual-message nil}))
          (catch ~exception-symbol ~e
-           (let [~actual-message (php/-> ~e (getMessage))]
+           (let [~actual-message (.getMessage ~e)]
              (if (= ~expected-message ~actual-message)
                (report (merge ~report-data {:state :pass :actual-message ~actual-message}))
                (report (merge ~report-data {:state :failed :actual-message ~actual-message})))))))))
@@ -388,10 +388,10 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
   {:example "(deftest test-add)"}
   [test-name & body]
   (when-not (symbol? test-name)
-    (throw (php/new \InvalidArgumentException
-                    (str "deftest requires a symbol name as its first argument, got "
-                         (type test-name) ". Example: (deftest test-add ...)."))))
-  (let [sym-meta (or (php/-> test-name (getMeta)) {})
+    (throw (new \InvalidArgumentException
+                (str "deftest requires a symbol name as its first argument, got "
+                     (type test-name) ". Example: (deftest test-add ...)."))))
+  (let [sym-meta (or (.getMeta test-name) {})
         base     {:test true, :test-name (name test-name)}
         merged   (merge sym-meta base)]
     `(defn ~test-name ~merged []
@@ -462,10 +462,10 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
 (defn- print-error-headline [data]
   (print-headline "ERROR" data))
 
-(def- readable-printer (php/:: Printer (readable)))
+(def- readable-printer (Printer/readable))
 
 (defn- readable-str [value]
-  (php/-> readable-printer (print value)))
+  (.print readable-printer value))
 
 (defn- print-label
   "Prints `label:`, the readable form of `value`, then any extra trailing words on a single line. Used by the built-in failure printers to keep the right-aligned two-column layout consistent."
@@ -634,14 +634,14 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
 (defn- print-error [data]
   (print-error-headline data)
   (let [{:exception exception, :form form} data
-        command-facade                     (php/new CommandFacade)
-        printer                            (php/-> command-facade (getExceptionPrinter))]
+        command-facade                     (new CommandFacade)
+        printer                            (.getExceptionPrinter command-facade)]
     (print-label "              Form" form)
     (println "             threw:" (php/get_class exception))
     (when-let [exception-message (ex-message exception)]
       (println "      with message:" exception-message))
     (when (deref print-stack-trace?)
-      (php/-> printer (printStackTrace exception)))))
+      (.printStackTrace printer exception))))
 
 (defn- print-predicate-failure [{:pred pred, :value value, :result result}]
   (print-form-evaluated "                 Form" value
@@ -1071,8 +1071,8 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
   [name reporter-fn]
   (let [kw (reporter-key name)]
     (when (nil? kw)
-      (throw (php/new \InvalidArgumentException
-                      "register-reporter! name must be a keyword or string")))
+      (throw (new \InvalidArgumentException
+                  "register-reporter! name must be a keyword or string")))
     (swap! custom-reporters assoc kw reporter-fn)
     kw))
 
@@ -1136,14 +1136,14 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
    :see-also ["deftest" "run-tests"]}
   [fixture-type & fns]
   (when (some (fn [f] (not (fn? f))) fns)
-    (throw (php/new \InvalidArgumentException
-                    "All arguments to use-fixtures must be functions")))
+    (throw (new \InvalidArgumentException
+                "All arguments to use-fixtures must be functions")))
   (let [key     (case fixture-type
                   :each :each-fixtures
                   :once :once-fixtures
-                  (throw (php/new \InvalidArgumentException
-                                  (str "use-fixtures: invalid fixture-type "
-                                       fixture-type ", expected :each or :once"))))
+                  (throw (new \InvalidArgumentException
+                              (str "use-fixtures: invalid fixture-type "
+                                   fixture-type ", expected :each or :once"))))
         ns-name *ns*]
     (swap! fixtures-by-ns
            (fn [m]
@@ -1167,12 +1167,12 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
 (defn- find-test-vars
   "Discovers every `deftest`-defined function in `ns` and returns a vector of `{:fn <callable> :meta <map>}` entries. The caller is responsible for applying selectors."
   [ns]
-  (let [munge    (php/new Munge)
-        munge-ns (php/-> munge (encodeRegistryKey ns))]
-    (vec (for [fn-name :keys (php/:: Phel (getDefinitionInNamespace munge-ns))
-               :let [meta (php/:: Phel (getDefinitionMetaData munge-ns fn-name))]
+  (let [munge    (new Munge)
+        munge-ns (.encodeRegistryKey munge ns)]
+    (vec (for [fn-name :keys (Phel/getDefinitionInNamespace munge-ns)
+               :let [meta (Phel/getDefinitionMetaData munge-ns fn-name)]
                :when (:test meta)]
-           {:fn   (php/:: Phel (getDefinition munge-ns fn-name))
+           {:fn   (Phel/getDefinition munge-ns fn-name)
             :meta meta}))))
 
 (defn- selector-options
@@ -1303,12 +1303,12 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
 
     (or (keyword? r) (string? r))
     (or (resolve-reporter r)
-        (throw (php/new \InvalidArgumentException
-                        (str "Unknown reporter: " r))))
+        (throw (new \InvalidArgumentException
+                    (str "Unknown reporter: " r))))
 
     :else
-    (throw (php/new \InvalidArgumentException
-                    (str "Invalid reporter value: " r)))))
+    (throw (new \InvalidArgumentException
+                (str "Invalid reporter value: " r)))))
 
 (defn- requested-reporters
   "Returns the user-selected reporter identifiers, honouring the

--- a/src/phel/test/gen.phel
+++ b/src/phel/test/gen.phel
@@ -86,8 +86,8 @@
   {:example "((choose 1 6) 100) ; => 1..6"}
   [lo hi]
   (when (> lo hi)
-    (throw (php/new InvalidArgumentException
-                    (str "gen/choose requires lo <= hi, got " lo ", " hi))))
+    (throw (new InvalidArgumentException
+                (str "gen/choose requires lo <= hi, got " lo ", " hi))))
   (fn [_size] (rand-int* lo hi)))
 
 ;; -----------------
@@ -192,8 +192,8 @@
    (fn [size]
      (loop [i 0]
        (when (>= i max-tries)
-         (throw (php/new RuntimeException
-                         (str "gen/such-that exceeded " max-tries " retries"))))
+         (throw (new RuntimeException
+                     (str "gen/such-that exceeded " max-tries " retries"))))
        (let [v (g size)]
          (if (pred v) v (recur (inc i))))))))
 
@@ -215,8 +215,8 @@
   [coll]
   (let [v (into [] coll)]
     (when (zero? (count v))
-      (throw (php/new InvalidArgumentException
-                      "gen/elements requires a non-empty collection")))
+      (throw (new InvalidArgumentException
+                  "gen/elements requires a non-empty collection")))
     (fn [_size] (rand-elem v))))
 
 (defn one-of
@@ -225,8 +225,8 @@
   [gens]
   (let [v (into [] gens)]
     (when (zero? (count v))
-      (throw (php/new InvalidArgumentException
-                      "gen/one-of requires at least one generator")))
+      (throw (new InvalidArgumentException
+                  "gen/one-of requires at least one generator")))
     (fn [size] ((rand-elem v) size))))
 
 (defn frequency
@@ -236,8 +236,8 @@
   (let [v     (into [] pairs)
         total (reduce + 0 (map (fn [p] (get p 0)) v))]
     (when (<= total 0)
-      (throw (php/new InvalidArgumentException
-                      "gen/frequency requires at least one pair with positive weight")))
+      (throw (new InvalidArgumentException
+                  "gen/frequency requires at least one pair with positive weight")))
     (fn [size]
       (loop [i 0 remaining (rand-int* 1 total)]
         (let [pair           (get v i)
@@ -406,7 +406,7 @@
                   parts)
         parts   (if ex
                   (conj parts (str ", threw " (php/get_class ex) ": "
-                                   (php/-> ex (getMessage))))
+                                   (.getMessage ex)))
                   parts)]
     (apply str (conj parts ")"))))
 
@@ -449,7 +449,7 @@
         n-sym      (gensym)
         res-sym    (gensym)
         final-opts (gensym)
-        name-meta  (or (php/-> name (getMeta)) {})
+        name-meta  (or (.getMeta name) {})
         no-shrink? (true? (get name-meta :no-shrink))
         name-str   (str name)]
     `(t/deftest ~name

--- a/src/phel/transit.phel
+++ b/src/phel/transit.phel
@@ -86,8 +86,8 @@
     (case marker
       ":" (keyword rep)
       "$" (symbol rep)
-      "u" (php/:: UUID (fromString rep))
-      "t" (php/new \DateTimeImmutable rep)
+      "u" (UUID/fromString rep)
+      "t" (new \DateTimeImmutable rep)
       "?" (php/=== rep "t")
       "i" (php/intval rep)
       "d" (php/floatval rep)
@@ -100,8 +100,8 @@
       (let [default (get opts :default-handler)]
         (if default
           (default (str marker) rep)
-          (throw (php/new \InvalidArgumentException
-                          (str "Unknown Transit scalar tag '~" marker "'"))))))))
+          (throw (new \InvalidArgumentException
+                      (str "Unknown Transit scalar tag '~" marker "'"))))))))
 
 (defn- decode-cmap
   "Decodes a `~#cmap` payload — a flat sequence of alternating key/value representations — into a persistent map."
@@ -112,7 +112,7 @@
         (persistent acc)
         (let [k (decode (first items) opts)
               v (decode (first (next items)) opts)]
-          (php/-> acc (put k v))
+          (.put acc k v)
           (recur (next (next items))))))))
 
 (defn- decode-tagged-array
@@ -130,8 +130,8 @@
         handler (handler (decode rep opts))
         default (default tag (decode rep opts))
         :else
-        (throw (php/new \InvalidArgumentException
-                        (str "Unknown Transit tag '~#" tag "'")))))))
+        (throw (new \InvalidArgumentException
+                    (str "Unknown Transit tag '~#" tag "'")))))))
 
 (defn- decode-array
   "Decodes a JSON array. Detects `[\"~#tag\", rep]` markers before falling back to a positional vector decode."
@@ -154,7 +154,7 @@
       ;; numeric ones to ints; restore the string so a key like "1" decodes
       ;; to the string "1" rather than the int 1.
       (let [k (if (php/is_int k) (php/strval k) k)]
-        (php/-> acc (put (decode k opts) (decode v opts)))))
+        (.put acc (decode k opts) (decode v opts))))
     (persistent acc)))
 
 (defn- decode
@@ -173,9 +173,9 @@
          (php/array_is_list x))  (decode-array x opts)
     (php/is_array x)             (decode-object x opts)
     :else
-    (throw (php/new \InvalidArgumentException
-                    (str "Cannot decode Transit value of type "
-                         (php/gettype x))))))
+    (throw (new \InvalidArgumentException
+                (str "Cannot decode Transit value of type "
+                     (php/gettype x))))))
 
 (defn read-string
   "Reads one Transit+JSON-Verbose value from string `s`.
@@ -193,8 +193,8 @@
    (let [raw (php/json_decode s true)
          err (php/json_last_error)]
      (when-not (zero? err)
-       (throw (php/new \InvalidArgumentException
-                       (str "Invalid Transit JSON: " (php/json_last_error_msg)))))
+       (throw (new \InvalidArgumentException
+                   (str "Invalid Transit JSON: " (php/json_last_error_msg)))))
      (decode raw opts))))
 
 ;; ---------------------------------------------------------------------------
@@ -221,7 +221,7 @@
   (str "~u" (str u)))
 
 (defn- encode-datetime [d]
-  (str "~t" (php/-> d (format "Y-m-d\\TH:i:s.vP"))))
+  (str "~t" (.format d "Y-m-d\\TH:i:s.vP")))
 
 (defn- string-keys?
   "True when `m` is non-empty and every key is a plain Phel string. An empty
@@ -275,8 +275,8 @@
     (list? x)                             (encode-list x)
     (map? x)                              (encode-map x)
     :else
-    (throw (php/new \InvalidArgumentException
-                    (str "Cannot encode value of type " (php/gettype x) " to Transit")))))
+    (throw (new \InvalidArgumentException
+                (str "Cannot encode value of type " (php/gettype x) " to Transit")))))
 
 (defn write-string
   "Serialises `value` to a Transit+JSON-Verbose string."

--- a/src/phel/watch.phel
+++ b/src/phel/watch.phel
@@ -33,7 +33,7 @@
   "Starts the file watcher on the given vector of paths. Blocks until the watcher is stopped (e.g. Ctrl+C). Reloads changed namespaces in dependency order and runs any hooks registered with `register-on-reload`."
   {:example "(watch! [\"src/\" \"tests/\"])"}
   [paths & [opts]]
-  (let [facade  (php/new WatchFacade)
+  (let [facade  (new WatchFacade)
         phpOpts (php/array)]
     (when (and opts (get opts :backend))
       (php/aset phpOpts "backend" (get opts :backend)))
@@ -41,5 +41,5 @@
       (php/aset phpOpts "poll" (get opts :poll)))
     (when (and opts (get opts :debounce))
       (php/aset phpOpts "debounce" (get opts :debounce)))
-    (php/-> facade (watch (to-php-array paths) phpOpts))
+    (.watch facade (to-php-array paths) phpOpts)
     nil))

--- a/tests/phel/ai.phel
+++ b/tests/phel/ai.phel
@@ -38,7 +38,7 @@
   (let [original @ai/config]
     (try
       (ai/with-config {:provider :openai}
-                      (throw (php/new \RuntimeException "boom")))
+                      (throw (new \RuntimeException "boom")))
       (catch \RuntimeException _e nil))
     (is (= (get original :provider) (get @ai/config :provider)) "config restored after throw")))
 
@@ -749,8 +749,8 @@
         (ai/complete "hi" {:api-key "k"})
         (is false "should have thrown")
         (catch \RuntimeException e
-          (is (php/str_contains (php/-> e (getMessage)) "bad prompt") "error surfaces provider message")
-          (is (php/str_contains (php/-> e (getMessage)) "400") "error includes status code"))))))
+          (is (php/str_contains (.getMessage e) "bad prompt") "error surfaces provider message")
+          (is (php/str_contains (.getMessage e) "400") "error includes status code"))))))
 
 ;; --- Embeddings ---
 ;; Note: responses use raw JSON strings because phel.json stringifies floats

--- a/tests/phel/are.phel
+++ b/tests/phel/are.phel
@@ -60,12 +60,12 @@
 
 (deftest test-are-records-individual-failures
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer
-                           (are [x y] (= x y)
-                                1 1
-                                2 3
-                                4 4
-                                5 6))))]
+                          (with-output-buffer
+                            (are [x y] (= x y)
+                                 1 1
+                                 2 3
+                                 4 4
+                                 5 6))))]
     (is (= 2 (:pass counts)) "two groups pass")
     (is (= 2 (:failed counts)) "two groups fail")))
 
@@ -75,11 +75,11 @@
 
 (deftest test-are-drops-incomplete-trailing-group
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer
-                           (are [x y] (= x y)
-                                1 1
-                                2 2
-                                3))))]
+                          (with-output-buffer
+                            (are [x y] (= x y)
+                                 1 1
+                                 2 2
+                                 3))))]
     (is (= 2 (:pass counts)) "only complete groups are asserted")
     (is (= 0 (:failed counts)) "no failures from dropped group")))
 
@@ -108,8 +108,8 @@
 
 (deftest test-are-zero-args
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer
-                           (are [x y] (= x y)))))]
+                          (with-output-buffer
+                            (are [x y] (= x y)))))]
     (is (= 0 (:total counts)) "no assertions generated")))
 
 ;; ---------------------------------------------------------------------------

--- a/tests/phel/assert-expr-extensibility.phel
+++ b/tests/phel/assert-expr-extensibility.phel
@@ -32,7 +32,7 @@
 
 (deftest test-approx-equal-fails-outside-epsilon
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer (is (approx= 1.0 2.0)))))]
+                          (with-output-buffer (is (approx= 1.0 2.0)))))]
     (is (= 1 (:failed counts)) "approx= records a failure when outside epsilon")))
 
 ;; ---------------------------------------------------------------------------
@@ -51,7 +51,7 @@
 
 (deftest test-divisible-fails-when-not-divisible
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer (is (divisible? 10 3)))))]
+                          (with-output-buffer (is (divisible? 10 3)))))]
     (is (= 1 (:failed counts)) "non-divisible records a failure")))
 
 ;; ---------------------------------------------------------------------------
@@ -68,9 +68,9 @@
 
 (deftest test-even-positive-fails-for-odd-or-non-positive
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer (is (even-positive? 3)))
-                         (with-output-buffer (is (even-positive? -2)))
-                         (with-output-buffer (is (even-positive? 0)))))]
+                          (with-output-buffer (is (even-positive? 3)))
+                          (with-output-buffer (is (even-positive? -2)))
+                          (with-output-buffer (is (even-positive? 0)))))]
     (is (= 3 (:failed counts)) "odd, negative, and zero all fail")))
 
 ;; ---------------------------------------------------------------------------
@@ -80,11 +80,11 @@
 ;; ---------------------------------------------------------------------------
 
 (defmethod phel.test/assert-expr 'always-throws [_message _form]
-  `(throw (php/new \RuntimeException "boom from custom assertion")))
+  `(throw (new \RuntimeException "boom from custom assertion")))
 
 (deftest test-custom-method-exception-is-reported-as-error
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer (is (always-throws)))))]
+                          (with-output-buffer (is (always-throws)))))]
     (is (= 1 (:error counts)) "throw from custom method is reported as :error")
     (is (= 0 (:failed counts)) "not reported as :failed")
     (is (= 0 (:pass counts)) "not reported as :pass")))
@@ -133,6 +133,6 @@
 
 (deftest test-custom-clojure-style-thrown-symbol-dispatches-through-new-method
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer
-                           (t/is (p/thrown? (throw (php/new \RuntimeException "boom")))))))]
+                          (with-output-buffer
+                            (t/is (p/thrown? (throw (new \RuntimeException "boom")))))))]
     (is (= 1 (:pass counts)) "namespaced custom assert dispatch values do not require a resolved function")))

--- a/tests/phel/async-fiber.phel
+++ b/tests/phel/async-fiber.phel
@@ -57,7 +57,7 @@
     (is (= true (realized? f)) "future is realized after deref")))
 
 (deftest test-future-fiber-propagates-exceptions
-  (let [f (future-fiber (throw (php/new \RuntimeException "boom")))]
+  (let [f (future-fiber (throw (new \RuntimeException "boom")))]
     (is (thrown? \RuntimeException @f)
         "deref on a failed fiber-future rethrows")))
 

--- a/tests/phel/async.phel
+++ b/tests/phel/async.phel
@@ -62,7 +62,7 @@
     (is (< elapsed 0.15) "concurrent execution is faster than sequential")))
 
 (deftest test-async-error-propagation
-  (let [future (async (throw (php/new \RuntimeException "boom")))]
+  (let [future (async (throw (new \RuntimeException "boom")))]
     (is (thrown? \RuntimeException (await future))
         "exceptions in async body propagate through await")))
 
@@ -137,7 +137,7 @@
 (deftest test-future-exception-propagation
   (let [raised? (await (async
                         (try
-                          (deref (future (throw (php/new \RuntimeException "boom"))))
+                          (deref (future (throw (new \RuntimeException "boom"))))
                           false
                           (catch \RuntimeException _e true))))]
     (is (= true raised?) "deref re-raises the future's exception")))

--- a/tests/phel/auto-refer.phel
+++ b/tests/phel/auto-refer.phel
@@ -17,7 +17,7 @@
 
 (deftest test-persistent-map-alias
   (is (php/instanceof {:a 1} PersistentMap))
-  (is (php/instanceof (php/:: \Phel\Lang\Collections\Map\MapEntry (create :k :v)) MapEntry)))
+  (is (php/instanceof (\Phel\Lang\Collections\Map\MapEntry/create :k :v) MapEntry)))
 
 (deftest test-persistent-hash-set-alias
   (is (php/instanceof (hash-set 1 2 3) PersistentHashSet)))

--- a/tests/phel/cli.phel
+++ b/tests/phel/cli.phel
@@ -75,7 +75,7 @@
 
 (deftest test-handler-exception-becomes-exit-1
   (let [res (run-cmd {:name "boom"
-                      :run  (fn [ctx] (throw (php/new \RuntimeException "kaboom")))}
+                      :run  (fn [ctx] (throw (new \RuntimeException "kaboom")))}
                      ["boom"])]
     (is (= 1 (get res :code)))
     (is (cli/output-contains? res "kaboom"))))
@@ -152,7 +152,7 @@
 
 (deftest test-hidden-flag
   (let [cmd (cli/command {:name "secret" :hidden? true :run (fn [_] 0)})]
-    (is (true? (php/-> cmd (isHidden))))))
+    (is (true? (.isHidden cmd)))))
 
 (deftest test-output-contains-with-string
   (is (cli/output-contains? "foo bar baz" "bar"))
@@ -184,14 +184,14 @@
   ;; Extract the Closure registered via Command::setCode across all supported
   ;; Symfony versions. Symfony 6 stores the raw Closure on `Command::$code`;
   ;; 7+ wraps it in an InvokableCommand whose own `$code` holds the Closure.
-  (let [rc  (php/new \ReflectionClass cmd)
-        cp  (php/-> rc (getProperty "code"))
-        raw (php/-> cp (getValue cmd))]
+  (let [rc  (new \ReflectionClass cmd)
+        cp  (.getProperty rc "code")
+        raw (.getValue cp cmd)]
     (if (php/instanceof raw \Closure)
       raw
-      (let [icrc (php/new \ReflectionClass raw)
-            icp  (php/-> icrc (getProperty "code"))]
-        (php/-> icp (getValue raw))))))
+      (let [icrc (new \ReflectionClass raw)
+            icp  (.getProperty icrc "code")]
+        (.getValue icp raw)))))
 
 (deftest test-handler-closure-has-typed-symfony-params
   ;; Symfony 8 enforces named types on Command::setCode closure params.
@@ -200,15 +200,15 @@
   ;; Symfony interface as a named type. Works on Symfony 6, 7, and 8.
   (let [cmd     (cli/command {:name "x" :run (fn [_] 0)})
         closure (handler-closure cmd)
-        rf      (php/new \ReflectionFunction closure)
-        params  (php/-> rf (getParameters))
+        rf      (new \ReflectionFunction closure)
+        params  (.getParameters rf)
         p0      (php/aget params 0)
         p1      (php/aget params 1)
-        t0      (php/-> p0 (getType))
-        t1      (php/-> p1 (getType))]
+        t0      (.getType p0)
+        t1      (.getType p1)]
     (is (not (nil? t0)) "input param must declare a named type")
     (is (not (nil? t1)) "output param must declare a named type")
     (is (= "Symfony\\Component\\Console\\Input\\InputInterface"
-           (php/-> t0 (getName))))
+           (.getName t0)))
     (is (= "Symfony\\Component\\Console\\Output\\OutputInterface"
-           (php/-> t1 (getName))))))
+           (.getName t1)))))

--- a/tests/phel/core/assert.phel
+++ b/tests/phel/core/assert.phel
@@ -22,14 +22,14 @@
 ;; Toggle phel.core/*assert* at file load time so the forms below are
 ;; macroexpanded while the flag is false. The macro must read the current
 ;; value of *assert* from the core namespace on each expansion.
-(php/:: \Phel (addDefinition "phel.core" "*assert*" false))
+(\Phel/addDefinition "phel.core" "*assert*" false)
 
 (defn- assert-while-disabled-returns-nil []
   (list (assert false)
         (assert nil "boom")
         (assert (= 1 2) "not equal")))
 
-(php/:: \Phel (addDefinition "phel.core" "*assert*" true))
+(\Phel/addDefinition "phel.core" "*assert*" true)
 
 (deftest test-assert-disabled-at-expansion-time
   (is (= '(nil nil nil) (assert-while-disabled-returns-nil))

--- a/tests/phel/core/basic-constructors.phel
+++ b/tests/phel/core/basic-constructors.phel
@@ -394,13 +394,13 @@
 
 (deftest test-defexception
   (let [ex (my-exception "test message" 42)]
-    (is (= "test message" (php/-> ex (getMessage))) "exception: get message")
-    (is (= 42 (php/-> ex (getCode))) "exception: get code")
+    (is (= "test message" (.getMessage ex)) "exception: get message")
+    (is (= 42 (.getCode ex)) "exception: get code")
     (is (true? (my-exception? ex)) "exception: predicate returns true")
     (is (false? (my-exception? "not an exception")) "exception: predicate returns false for non-exception"))
   (let [ex (my-exception)]
-    (is (= "" (php/-> ex (getMessage))) "exception: default message is empty string")
-    (is (= 0 (php/-> ex (getCode))) "exception: default code is 0")))
+    (is (= "" (.getMessage ex)) "exception: default message is empty string")
+    (is (= 0 (.getCode ex)) "exception: default code is 0")))
 
 (deftest list-as-function
   (let [xs (list 1 2 3)]

--- a/tests/phel/core/binding.phel
+++ b/tests/phel/core/binding.phel
@@ -30,7 +30,7 @@
 (deftest test-with-redefs-restores-on-throw
   (let [threw? (try
                  (with-redefs [*my-redef-target* 42]
-                   (throw (php/new \RuntimeException "boom")))
+                   (throw (new \RuntimeException "boom")))
                  false
                  (catch \Throwable _ true))]
     (is threw? "with-redefs lets the body's exception propagate")
@@ -47,15 +47,15 @@
 (deftest test-if-let
   (is (= 1 (if-let [a 1] a)))
   (is (= 2 (if-let [[a b] '(1 2)] b)))
-  (is (= nil (if-let [a false] (throw (php/new \Exception)))))
+  (is (= nil (if-let [a false] (throw (new \Exception)))))
   (is (= 1 (if-let [a false] a 1)))
   (is (= 1 (if-let [[a b] nil] b 1)))
-  (is (= 1 (if-let [a false] (throw (php/new \Exception)) 1))))
+  (is (= 1 (if-let [a false] (throw (new \Exception)) 1))))
 
 (deftest test-when-let
   (is (= 1 (when-let [a 1] a)))
   (is (= 2 (when-let [[a b] '(1 2)] b)))
-  (is (= nil (when-let [a false] (throw (php/new \Exception))))))
+  (is (= nil (when-let [a false] (throw (new \Exception))))))
 
 (deftest test-if-some
   (is (= "found" (if-some [x 1] "found" "missing"))

--- a/tests/phel/core/boolean-operation.phel
+++ b/tests/phel/core/boolean-operation.phel
@@ -169,7 +169,7 @@
   (is (false? (all? pos? [1 -1 3])) "all pos? in list"))
 
 (deftest test-all?-empty-element
-  (is (true? (all? #(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
+  (is (true? (all? #(throw (new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
 
 (deftest test-every?
   (is (true? (every? pos? [1 2 3])) "every? pos? in list")
@@ -188,7 +188,7 @@
   (is (false? (some? pos? [-1 -1 -3])) "some pos? in list"))
 
 (deftest test-some?-empty-element
-  (is (false? (some? #(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
+  (is (false? (some? #(throw (new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
 
 (deftest test-some?-1-arg-clojure-semantics
   (is (true? (some? 0))           "0 is not nil")

--- a/tests/phel/core/defenum.phel
+++ b/tests/phel/core/defenum.phel
@@ -11,19 +11,19 @@
 (defenum Color :red :green :blue)
 
 (deftest string-backed-enum
-  (let [active (php/:: \phel_test\core\defenum\Status (from "active"))]
-    (is (= "active" (php/-> active value)) "case carries its string value")
-    (is (= "active" (php/-> active name)) "case name matches the keyword")
+  (let [active (\phel_test\core\defenum\Status/from "active")]
+    (is (= "active" (.-value active)) "case carries its string value")
+    (is (= "active" (.-name active)) "case name matches the keyword")
     (is (true? (Status? active)) "predicate recognises its own case")
     (is (false? (Status? :active)) "predicate rejects a plain keyword")))
 
 (deftest int-backed-enum
-  (let [high (php/:: \phel_test\core\defenum\Priority (from 10))]
-    (is (= 10 (php/-> high value)) "int case carries its value")
+  (let [high (\phel_test\core\defenum\Priority/from 10)]
+    (is (= 10 (.-value high)) "int case carries its value")
     (is (true? (Priority? high)) "int predicate works")))
 
 (deftest pure-enum
-  (let [cases (php/:: \phel_test\core\defenum\Color (cases))]
+  (let [cases (\phel_test\core\defenum\Color/cases)]
     (is (= 3 (count cases)) "pure enum exposes all cases")
     (is (true? (Color? (php/aget cases 0))) "pure case satisfies predicate")))
 
@@ -31,7 +31,7 @@
   ;; The enum's bare name resolves to the namespaced PHP class, so the
   ;; documented `EnumName/case` access form works (issue #2358).
   (is (true? (Status? Status/active)) "Status/active resolves to a case")
-  (is (= "active" (php/-> Status/active value)) "the resolved case carries its value")
+  (is (= "active" (.-value Status/active)) "the resolved case carries its value")
   (is (true? (Color? Color/red)) "pure-enum case access works too"))
 
 ;; Enum with an implemented interface and a `:php` block of plain methods.
@@ -42,27 +42,27 @@
   :hearts :spades :clubs :diamonds
   Describable
   (describe [this]
-            (let [n (php/-> this name)]
+            (let [n (.-name this)]
               (if (or (= n "hearts") (= n "diamonds")) "red" "black")))
   :php
-  (label [this] (php/-> this name)))
+  (label [this] (.-name this)))
 
 ;; Backed enum carrying a `:php` method that reads its own value.
 (defenum Coin
   :penny 1 :nickel 5
   :php
-  (doubled [this] (* 2 (php/-> this value))))
+  (doubled [this] (* 2 (.-value this))))
 
 (deftest enum-implements-interface
-  (let [hearts (php/:: \phel_test\core\defenum\Suit hearts)]
+  (let [hearts \phel_test\core\defenum\Suit/hearts]
     (is (php/is_a hearts "phel_test\\core\\defenum\\Describable") "enum implements the declared interface")
-    (is (= "red" (php/-> hearts (describe))) "interface method runs on a red suit")
-    (is (= "black" (php/-> (php/:: \phel_test\core\defenum\Suit spades) (describe))) "interface method runs on a black suit")))
+    (is (= "red" (.describe hearts)) "interface method runs on a red suit")
+    (is (= "black" (.describe \phel_test\core\defenum\Suit/spades)) "interface method runs on a black suit")))
 
 (deftest enum-php-block-method
-  (let [hearts (php/:: \phel_test\core\defenum\Suit hearts)]
-    (is (= "hearts" (php/-> hearts (label))) "a :php block method runs on a pure enum case")))
+  (let [hearts \phel_test\core\defenum\Suit/hearts]
+    (is (= "hearts" (.label hearts)) "a :php block method runs on a pure enum case")))
 
 (deftest backed-enum-php-method
-  (let [nickel (php/:: \phel_test\core\defenum\Coin (from 5))]
-    (is (= 10 (php/-> nickel (doubled))) "a :php method can read the backed value")))
+  (let [nickel (\phel_test\core\defenum\Coin/from 5)]
+    (is (= 10 (.doubled nickel)) "a :php method can read the backed value")))

--- a/tests/phel/core/defexception-parent.phel
+++ b/tests/phel/core/defexception-parent.phel
@@ -8,7 +8,7 @@
   (is (= "boom"
          (try
            (throw (NotFound "boom"))
-           (catch \RuntimeException e (php/-> e (getMessage)))))
+           (catch \RuntimeException e (.getMessage e))))
       "an exception with :extends parent is caught as that parent")
   (is (instance? \RuntimeException (NotFound "x")) "instance of the custom parent")
   (is (NotFound? (NotFound "x")) "its own predicate still works"))

--- a/tests/phel/core/definterface-consts.phel
+++ b/tests/phel/core/definterface-consts.phel
@@ -11,16 +11,16 @@
   (DEFAULT nil))
 
 (deftest typed-constants-are-readable
-  (is (= 100 (php/:: \phel_test\core\definterface_consts\HasLimits MAX)) "int const is reachable")
-  (is (= "limit" (php/:: \phel_test\core\definterface_consts\HasLimits LABEL)) "string const is reachable"))
+  (is (= 100 \phel_test\core\definterface_consts\HasLimits/MAX) "int const is reachable")
+  (is (= "limit" \phel_test\core\definterface_consts\HasLimits/LABEL) "string const is reachable"))
 
 (deftest scalar-constant-values-are-supported
-  (is (= 1.5 (php/:: \phel_test\core\definterface_consts\HasLimits RATE)) "float const value")
-  (is (= true (php/:: \phel_test\core\definterface_consts\HasLimits ENABLED)) "bool const value")
-  (is (nil? (php/:: \phel_test\core\definterface_consts\HasLimits DEFAULT)) "nil const value"))
+  (is (= 1.5 \phel_test\core\definterface_consts\HasLimits/RATE) "float const value")
+  (is (= true \phel_test\core\definterface_consts\HasLimits/ENABLED) "bool const value")
+  (is (nil? \phel_test\core\definterface_consts\HasLimits/DEFAULT) "nil const value"))
 
 (deftest constant-is-typed
-  (let [rc   (php/new \ReflectionClassConstant
-                      "phel_test\\core\\definterface_consts\\HasLimits" "MAX")
-        type (php/-> rc (getType))]
-    (is (= "int" (php/-> type (getName))) "the constant carries its declared PHP type")))
+  (let [rc   (new \ReflectionClassConstant
+                  "phel_test\\core\\definterface_consts\\HasLimits" "MAX")
+        type (.getType rc)]
+    (is (= "int" (.getName type)) "the constant carries its declared PHP type")))

--- a/tests/phel/core/defstruct-php-override.phel
+++ b/tests/phel/core/defstruct-php-override.phel
@@ -9,8 +9,8 @@
   (^:php/override greet [this] (php/. "hi " (get this :name))))
 
 (defn- method-has-override? [class-fqn method]
-  (let [rm    (php/new \ReflectionMethod class-fqn method)
-        attrs (php/-> rm (getAttributes "Override"))]
+  (let [rm    (new \ReflectionMethod class-fqn method)
+        attrs (.getAttributes rm "Override")]
     (php/< 0 (php/count attrs))))
 
 (deftest override-method-still-runs

--- a/tests/phel/core/defstruct-readonly.phel
+++ b/tests/phel/core/defstruct-readonly.phel
@@ -6,8 +6,8 @@
 (defstruct plain-point [a b])
 
 (defn- readonly-prop? [class-fqn prop]
-  (let [rp (php/new \ReflectionProperty class-fqn prop)]
-    (php/-> rp (isReadonly))))
+  (let [rp (new \ReflectionProperty class-fqn prop)]
+    (.isReadonly rp)))
 
 (deftest readonly-struct-constructs-and-reads
   (let [p (point 1 2)]

--- a/tests/phel/core/ex-info.phel
+++ b/tests/phel/core/ex-info.phel
@@ -8,7 +8,7 @@
     (is (nil? (ex-cause ex)) "ex-cause is nil when no cause")))
 
 (deftest test-ex-info-with-cause
-  (let [cause (php/new \Exception "root cause")
+  (let [cause (new \Exception "root cause")
         ex    (ex-info "wrapped" {:code 42} cause)]
     (is (= "wrapped" (ex-message ex)) "ex-message on wrapped exception")
     (is (= {:code 42} (ex-data ex)) "ex-data on wrapped exception")
@@ -31,11 +31,11 @@
       "ex-data works inside catch block"))
 
 (deftest test-ex-data-on-regular-exception
-  (let [ex (php/new \Exception "plain")]
+  (let [ex (new \Exception "plain")]
     (is (nil? (ex-data ex)) "ex-data returns nil for non-ExceptionInfo")))
 
 (deftest test-ex-message-on-regular-exception
-  (let [ex (php/new \Exception "hello")]
+  (let [ex (new \Exception "hello")]
     (is (= "hello" (ex-message ex)) "ex-message works on regular exceptions")))
 
 (deftest test-ex-info-with-empty-data

--- a/tests/phel/core/exotic-literals.phel
+++ b/tests/phel/core/exotic-literals.phel
@@ -1,15 +1,15 @@
 (ns phel-test.core.exotic-literals
   (:require phel\test :refer [deftest is]))
 
-(defn- make-inst [] #inst "2024-01-15T10:30:00Z")
+(defn- make-inst [] #inst"2024-01-15T10:30:00Z")
 
 (deftest defn-body-exotic-literals
   ;; #2778: a raw DateTimeImmutable literal inside a defn body crashed
   ;; the macroexpansion location walk at compile time.
-  (is (= "2024-01-15" (php/-> (make-inst) (format "Y-m-d")))
+  (is (= "2024-01-15" (.format (make-inst) "Y-m-d"))
       "defn body with #inst literal compiles and evaluates")
   (is (= 2/3 ((fn [] 2/3))) "ratio literal in fn body")
   (is (= 1.5M ((fn [] 1.5M))) "big decimal literal in fn body")
-  (is (= #uuid "123e4567-e89b-12d3-a456-426614174000"
-         ((fn [] #uuid "123e4567-e89b-12d3-a456-426614174000")))
+  (is (= #uuid"123e4567-e89b-12d3-a456-426614174000"
+         ((fn [] #uuid"123e4567-e89b-12d3-a456-426614174000")))
       "uuid literal in fn body"))

--- a/tests/phel/core/file-operation.phel
+++ b/tests/phel/core/file-operation.phel
@@ -464,7 +464,7 @@
     (let [handle (php/fopen target-file "r")]
       (is (thrown? \RuntimeException
                    (with-open [f handle]
-                     (throw (php/new \RuntimeException "boom"))))
+                     (throw (new \RuntimeException "boom"))))
           "exception propagates out of with-open")
       (is (false? (php/is_resource handle)) "stream is closed even when the body throws"))
     (php/unlink target-file)))
@@ -474,7 +474,7 @@
         r       (reify Closable (close [this] (reset! closed? true)))]
     (is (thrown? \RuntimeException
                  (with-open [x r]
-                   (throw (php/new \RuntimeException "boom"))))
+                   (throw (new \RuntimeException "boom"))))
         "exception propagates out of with-open")
     (is (true? (deref closed?)) "object close method is called when the body throws")))
 

--- a/tests/phel/core/function-operation.phel
+++ b/tests/phel/core/function-operation.phel
@@ -68,7 +68,7 @@
 (deftest test-some-fn-short-circuits-preds
   (let [calls (atom 0)
         p1    (fn [x] (swap! calls inc) (even? x))
-        p2    (fn [_] (throw (php/new \Exception "should not be called")))]
+        p2    (fn [_] (throw (new \Exception "should not be called")))]
     (is (true? ((some-fn p1 p2) 2)) "some-fn short-circuits on first truthy pred")
     (is (= 1 (deref calls)) "second pred was not invoked")))
 
@@ -112,7 +112,7 @@
 (deftest test-every-pred-short-circuits-preds
   (let [calls (atom 0)
         p1    (fn [x] (swap! calls inc) (even? x))
-        p2    (fn [_] (throw (php/new \Exception "should not be called")))]
+        p2    (fn [_] (throw (new \Exception "should not be called")))]
     (is (false? ((every-pred p1 p2) 3)) "every-pred short-circuits on first false pred")
     (is (= 1 (deref calls)) "second pred was not invoked")))
 

--- a/tests/phel/core/hydration.phel
+++ b/tests/phel/core/hydration.phel
@@ -7,8 +7,8 @@
   (let [t (hydrate target {:id 7 :name "kb"})]
     (is (instance? \PhelTest\Fixtures\Interop\HydrationTarget t)
         "hydrate returns an instance of the target class")
-    (is (= 7 (php/-> t id)) "id property is set")
-    (is (= "kb" (php/-> t name)) "name property is set")))
+    (is (= 7 (.-id t)) "id property is set")
+    (is (= "kb" (.-name t)) "name property is set")))
 
 (deftest bean-reads-public-properties
   (is (= {:id 7 :name "kb"} (bean (hydrate target {:id 7 :name "kb"})))

--- a/tests/phel/core/interface-param-attributes.phel
+++ b/tests/phel/core/interface-param-attributes.phel
@@ -5,12 +5,12 @@
   (^{:php/attr [:Route "/x"]} act [this ^{:php/attr [:Autowire]} dep]))
 
 (defn- attr-names [attrs]
-  (map #(php/-> % (getName)) attrs))
+  (map #(.getName %) attrs))
 
 (deftest method-and-param-attributes-are-emitted
-  (let [rm    (php/new \ReflectionMethod "phel_test\\core\\interface_param_attributes\\Ctrl" "act")
-        p0    (php/aget (php/-> rm (getParameters)) 0)
-        margs (attr-names (php/-> rm (getAttributes)))
-        pargs (attr-names (php/-> p0 (getAttributes)))]
+  (let [rm    (new \ReflectionMethod "phel_test\\core\\interface_param_attributes\\Ctrl" "act")
+        p0    (php/aget (.getParameters rm) 0)
+        margs (attr-names (.getAttributes rm))
+        pargs (attr-names (.getAttributes p0))]
     (is (= ["Route"] margs) "method carries its #[Route] attribute")
     (is (= ["Autowire"] pargs) "parameter carries its #[Autowire] attribute")))

--- a/tests/phel/core/interop-by-ref.phel
+++ b/tests/phel/core/interop-by-ref.phel
@@ -4,15 +4,15 @@
 (def- target "PhelTest\\Fixtures\\Interop\\ByRefTarget")
 
 (deftest php-ref-observes-by-reference-write
-  (let [t   (php/new target)
+  (let [t   (new target)
         out "init"]
-    (php/-> t (writeInto (php/ref out) "written"))
+    (.writeInto t (php/ref out) "written")
     (is (= "written" out) "a by-ref method writes back into the Phel local")))
 
 (deftest without-php-ref-the-write-is-not-observed
-  (let [t   (php/new target)
+  (let [t   (new target)
         out "init"]
-    (php/-> t (writeInto out "written"))
+    (.writeInto t out "written")
     (is (= "init" out) "a value-captured local is unaffected by the by-ref write")))
 
 (deftest php-ref-on-a-plain-function-call
@@ -34,7 +34,7 @@
     (is (= "123" (php/aget m 1)) "by-ref survives an enclosing IIFE wrap")))
 
 (deftest php-method-ref-survives-an-enclosing-closure-wrap
-  (let [t   (php/new target)
+  (let [t   (new target)
         out "init"]
-    (php/intval (do (php/-> t (writeInto (php/ref out) "written")) 0))
+    (php/intval (do (.writeInto t (php/ref out) "written") 0))
     (is (= "written" out) "method by-ref survives an enclosing IIFE wrap")))

--- a/tests/phel/core/interop-named-args.phel
+++ b/tests/phel/core/interop-named-args.phel
@@ -4,24 +4,24 @@
 (def- by-ref-target "PhelTest\\Fixtures\\Interop\\ByRefTarget")
 
 (deftest php-new-with-named-args
-  (let [ao (php/new \ArrayObject :& :array (php/array 1 2 3))]
-    (is (= 3 (php/-> ao (count))) "named args bind to the constructor parameters")))
+  (let [ao (new \ArrayObject :& :array (php/array 1 2 3))]
+    (is (= 3 (.count ao)) "named args bind to the constructor parameters")))
 
 (deftest php-new-with-positional-then-named-args
-  (let [dt (php/new \DateTime "2024-01-15 00:00:00" :& :timezone nil)]
-    (is (= "2024-01-15" (php/-> dt (format "Y-m-d"))) "positional args mix with trailing named args")))
+  (let [dt (new \DateTime "2024-01-15 00:00:00" :& :timezone nil)]
+    (is (= "2024-01-15" (.format dt "Y-m-d")) "positional args mix with trailing named args")))
 
 (deftest php-static-call-with-named-args
-  (let [dt (php/:: \DateTime (createFromFormat :& :format "Y-m-d" :datetime "2024-01-15"))]
-    (is (= "2024-01-15" (php/-> dt (format "Y-m-d"))) "static interop calls accept named args")))
+  (let [dt (\DateTime/createFromFormat :& :format "Y-m-d" :datetime "2024-01-15")]
+    (is (= "2024-01-15" (.format dt "Y-m-d")) "static interop calls accept named args")))
 
 (deftest php-method-call-with-named-args
-  (let [ao (php/new \ArrayObject (php/array 1 2))]
-    (php/-> ao (setFlags :& :flags \ArrayObject/ARRAY_AS_PROPS))
-    (is (= 2 (php/-> ao (count))) "method interop calls accept named args")))
+  (let [ao (new \ArrayObject (php/array 1 2))]
+    (.setFlags ao :& :flags \ArrayObject/ARRAY_AS_PROPS)
+    (is (= 2 (.count ao)) "method interop calls accept named args")))
 
 (deftest php-ref-inside-a-named-arg-writes-back
-  (let [t   (php/new by-ref-target)
+  (let [t   (new by-ref-target)
         out "init"]
-    (php/-> t (writeInto :& :out (php/ref out) :value "written"))
+    (.writeInto t :& :out (php/ref out) :value "written")
     (is (= "written" out) "php/ref still writes back when passed as a named argument")))

--- a/tests/phel/core/iterator-seq.phel
+++ b/tests/phel/core/iterator-seq.phel
@@ -2,7 +2,7 @@
   (:require phel.test :refer [deftest is]))
 
 (defn- array-iterator [& xs]
-  (php/new \ArrayIterator (apply php/array xs)))
+  (new \ArrayIterator (apply php/array xs)))
 
 (defn- naturals []
   (loop [i 0]

--- a/tests/phel/core/math-operation.phel
+++ b/tests/phel/core/math-operation.phel
@@ -79,11 +79,11 @@
   (is (thrown? \DivisionByZeroError (mod 1 0)) "mod by zero throws"))
 
 (deftest test-quot-rem-mod-bigint
-  (let [big (php/:: \Phel\Lang\BigInt (fromString "1000000000000000000"))]
+  (let [big (\Phel\Lang\BigInt/fromString "1000000000000000000")]
     (is (= 333333333333333333 (quot big 3)) "quot on BigInt collapses to int when fits")
     (is (= 1 (rem big 3)) "rem on BigInt collapses to int when fits")
     (is (= 1 (mod big 3)) "mod on BigInt collapses to int when fits"))
-  (let [huge (php/:: \Phel\Lang\BigInt (fromString "100000000000000000000"))]
+  (let [huge (\Phel\Lang\BigInt/fromString "100000000000000000000")]
     (is (bigint? (quot huge 3)) "quot stays BigInt when result overflows int")))
 
 (deftest test-gcd
@@ -536,14 +536,14 @@
   (is (int? -1N) "(int? -1N)"))
 
 (deftest test-equality-bigint-int-symmetric
-  (let [b (php/:: \Phel\Lang\BigInt (fromString "5"))]
+  (let [b (\Phel\Lang\BigInt/fromString "5")]
     (is (= b 5) "(= bigint int) is true when values match")
     (is (= 5 b) "(= int bigint) is true when values match")
     (is (false? (= b 6)) "(= bigint int) is false on mismatch")
     (is (false? (= 6 b)) "(= int bigint) is false on mismatch")))
 
 (deftest test-equality-bigint-large-symmetric
-  (let [big     (php/:: \Phel\Lang\BigInt (fromString "1000000000000000000000000"))
+  (let [big     (\Phel\Lang\BigInt/fromString "1000000000000000000000000")
         product (* 100000000 100000000 100000000)]
     (is (= big product) "(= bigint product) is true when values match")
     (is (= product big) "(= product bigint) is true when values match")))
@@ -682,7 +682,7 @@
   (is (bigint? (bigint 42)) "(bigint 42) is BigInt")
   (is (bigint? (bigint "1000000000000000000000000")) "(bigint string) parses")
   (is (= "1000000000000000000000000" (str (bigint "1000000000000000000000000"))) "(bigint big-string)")
-  (let [b (php/:: \Phel\Lang\BigInt (fromInt 5))]
+  (let [b (\Phel\Lang\BigInt/fromInt 5)]
     (is (= b (bigint b)) "(bigint BigInt) is identity"))
   (is (thrown? \InvalidArgumentException (bigint nil)) "(bigint nil) rejects nil"))
 
@@ -758,7 +758,7 @@
 (deftest test-rationalize-passes-through-exact
   (is (= 1/3 (rationalize 1/3)) "(rationalize 1/3) is identity")
   (is (= 7 (rationalize 7)) "(rationalize 7) is identity for ints")
-  (let [b (php/:: \Phel\Lang\BigInt (fromString "100000000000000000000"))]
+  (let [b (\Phel\Lang\BigInt/fromString "100000000000000000000")]
     (is (= b (rationalize b)) "(rationalize BigInt) is identity")))
 
 (deftest test-rationalize-rejects-non-finite
@@ -774,4 +774,4 @@
   (let [x (/ 1.0 3.0)
         r (rationalize x)]
     (is (true? (ratio? r)) "rationalize on 1/3-as-double yields a Ratio")
-    (is (= x (php/-> r (toFloat))) "rationalize round-trips back to the same float")))
+    (is (= x (.toFloat r)) "rationalize round-trips back to the same float")))

--- a/tests/phel/core/multi-arity-fn.phel
+++ b/tests/phel/core/multi-arity-fn.phel
@@ -64,9 +64,9 @@
 
 (deftest multi-arity-fn-returned-from-fn
   (let [make  (fn [x]
-               (fn
-                 ([a] (+ a x))
-                 ([a b] (+ a b x))))
+                (fn
+                  ([a] (+ a x))
+                  ([a b] (+ a b x))))
         add10 (make 10)]
     (is (= 15 (add10 5)) "returned multi-arity fn: one-arg overload with captured local")
     (is (= 16 (add10 5 1)) "returned multi-arity fn: two-arg overload with captured local"))

--- a/tests/phel/core/multimethods.phel
+++ b/tests/phel/core/multimethods.phel
@@ -92,7 +92,7 @@
   (let [err (try
               (eval '(defmulti broken "stray string as dispatch-fn"))
               false
-              (catch \Throwable e (php/-> e (getMessage))))]
+              (catch \Throwable e (.getMessage e)))]
     (is (not (= false err)) "throws when dispatch-fn missing (string as dispatch)")
     (is (php/str_contains err "requires a callable dispatch-fn")
         "error mentions callable dispatch-fn")))
@@ -112,7 +112,7 @@
 
 (deftest test-prefer-method-ambiguity-throws-without-preference
   (let [err (try (pm1-render ::pm1-rect) false
-                 (catch \InvalidArgumentException e (php/-> e (getMessage))))]
+                 (catch \InvalidArgumentException e (.getMessage e)))]
     (is (not (= false err)) "ambiguous dispatch throws")
     (is (php/str_contains err "Multiple methods match dispatch value")
         "error message identifies ambiguity")))
@@ -157,14 +157,14 @@
 (deftest test-prefer-method-cycle-throws
   (prefer-method pm3-cycle ::pm3-a ::pm3-b)
   (let [err (try (prefer-method pm3-cycle ::pm3-b ::pm3-a) false
-                 (catch \InvalidArgumentException e (php/-> e (getMessage))))]
+                 (catch \InvalidArgumentException e (.getMessage e)))]
     (is (not (= false err)) "cycle creation throws")
     (is (php/str_contains err "already preferred")
         "error explains the cycle")))
 
 (deftest test-prefer-method-self-throws
   (let [err (try (prefer-method pm3-cycle ::pm3-a ::pm3-a) false
-                 (catch \InvalidArgumentException e (php/-> e (getMessage))))]
+                 (catch \InvalidArgumentException e (.getMessage e)))]
     (is (not (= false err)) "preferring value to itself throws")
     (is (php/str_contains err "cannot prefer dispatch value to itself")
         "error explains self-preference")))

--- a/tests/phel/core/php-callable.phel
+++ b/tests/phel/core/php-callable.phel
@@ -8,7 +8,7 @@
 (def make-kw (php/callable \Phel\Lang\Keyword create))
 
 ;; Instance method: emits `($dt->format(...))`.
-(def formatter (php/callable (php/new \DateTime "2020-03-04") format))
+(def formatter (php/callable (new \DateTime "2020-03-04") format))
 
 (deftest free-function-callable-runs
   (is (= "HI" (upper "hi")) "the free-function callable invokes the PHP function")

--- a/tests/phel/core/php-invoke.phel
+++ b/tests/phel/core/php-invoke.phel
@@ -3,7 +3,7 @@
   (:use \DateTimeImmutable))
 
 (deftest invokes-a-method-named-by-a-value
-  (let [d (php/new DateTimeImmutable "2024-03-10")]
+  (let [d (new DateTimeImmutable "2024-03-10")]
     (is (= "2024" (php-invoke d "format" "Y"))
         "the method name comes from a runtime value")
     (is (= "2024-03-10" (php-invoke d "format" "Y-m-d"))
@@ -11,12 +11,12 @@
 
 (deftest invokes-a-method-held-in-a-binding
   (let [m "format"
-        d (php/new DateTimeImmutable "2024-03-10")]
+        d (new DateTimeImmutable "2024-03-10")]
     (is (= "03" (php-invoke d m "m"))
         "the name may be any expression, not only a literal")))
 
 (deftest invokes-a-method-without-arguments
-  (let [d (php/new DateTimeImmutable "2024-03-10")]
+  (let [d (new DateTimeImmutable "2024-03-10")]
     (is (= 2024 (php/intval (php-invoke d "format" "Y")))
         "a call with one argument still works")
     (is (php/is_int (php-invoke d "getTimestamp"))
@@ -31,25 +31,25 @@
       "Phel values are PHP objects, so their methods are reachable too"))
 
 (deftest unknown-method-raises-a-clear-error
-  (let [d   (php/new DateTimeImmutable "2024-03-10")
+  (let [d   (new DateTimeImmutable "2024-03-10")
         err (try (php-invoke d "nope" 1)
                  (catch \InvalidArgumentException e e))]
     (is (php/instanceof err \InvalidArgumentException)
         "an undefined method throws instead of a PHP TypeError")
     (is (= "Call to undefined method DateTimeImmutable::nope()"
-           (php/-> err (getMessage)))
+           (.getMessage err))
         "the message matches what a literal method call reports")))
 
 (deftest unknown-static-method-names-the-class
   (let [err (try (php-invoke "\\Phel\\Lang\\Keyword" "nope")
                  (catch \InvalidArgumentException e e))]
     (is (= "Call to undefined method \\Phel\\Lang\\Keyword::nope()"
-           (php/-> err (getMessage)))
+           (.getMessage err))
         "the class name is reported as given")))
 
 (deftest non-object-target-raises
   (let [err (try (php-invoke 42 "format")
                  (catch \InvalidArgumentException e e))]
     (is (= "Call to undefined method integer::format()"
-           (php/-> err (getMessage)))
+           (.getMessage err))
         "a non-object target reports its type instead of crashing")))

--- a/tests/phel/core/phpdoc-emission.phel
+++ b/tests/phel/core/phpdoc-emission.phel
@@ -5,9 +5,9 @@
   [^{:php/doc "@var list<int>"} items])
 
 (deftest class-and-property-docblocks-are-emitted
-  (let [rc        (php/new \ReflectionClass "phel_test\\core\\phpdoc_emission\\bag")
-        class-doc (php/-> rc (getDocComment))
-        prop-doc  (php/-> (php/-> rc (getProperty "items")) (getDocComment))]
+  (let [rc        (new \ReflectionClass "phel_test\\core\\phpdoc_emission\\bag")
+        class-doc (.getDocComment rc)
+        prop-doc  (.getDocComment (.getProperty rc "items"))]
     (is (php/str_contains class-doc "@implements \\IteratorAggregate<int, string>")
         "class docblock carries the :php/doc string")
     (is (php/str_contains prop-doc "@var list<int>")

--- a/tests/phel/core/sequence-functions.phel
+++ b/tests/phel/core/sequence-functions.phel
@@ -22,7 +22,7 @@
   (is (= [[0 "a"] [1 "b"] [2 "c"]] (map-indexed vector ["a" "b" "c"])) "map-indexed"))
 
 (deftest test-map-empty-element
-  (is (= [] (map #(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
+  (is (= [] (map #(throw (new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
 
 (deftest test-mapv
   (is (= [2 3 4] (mapv inc [1 2 3])) "mapv applies f eagerly")
@@ -176,7 +176,7 @@
   (is (= [1 2 3 4 -1 -2 -3] (doall (drop-while neg? (php/array -1 -2 -3 1 2 3 4 -1 -2 -3)))) "drop-while: php array (returns lazy seq)"))
 
 (deftest test-drop-while-empty-element
-  (is (= [] (drop-while #(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
+  (is (= [] (drop-while #(throw (new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
 
 (deftest test-take
   (is (= ["a" "b"] (take 2 ["a" "b" "c"])) "take two elements")
@@ -237,7 +237,7 @@
   (is (= [-1 -2 -3] (filter neg? (php/array -1 2 3 -2 -3 4 5))) "filter on php array"))
 
 (deftest test-filter-empty-element
-  (is (= [] (filter #(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
+  (is (= [] (filter #(throw (new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
 
 ;; A Phel predicate returns an arbitrary value, and only nil/false are logically
 ;; false. The lazy `filter` used to apply PHP truthiness, so 0, "" and friends
@@ -277,7 +277,7 @@
   (is (nil? (find {:a 1 :b 2 :c 3} :d)) "find returns nil for missing key"))
 
 (deftest test-find-empty-element
-  (is (nil? (find #(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
+  (is (nil? (find #(throw (new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
 
 (deftest test-find-index?
   (is (= 3 (find-index neg? [1 2 3 -1 2 3])) "find-index first neg number")
@@ -285,7 +285,7 @@
   (is (nil? (find-index neg? [])) "find-index on empty array"))
 
 (deftest test-find-index-empty-element
-  (is (nil? (find-index #(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
+  (is (nil? (find-index #(throw (new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
 
 ;; =============================================================================
 ;; Collection Utilities (distinct, dedupe, reverse, interleave, etc.)

--- a/tests/phel/core/sorted-collections.phel
+++ b/tests/phel/core/sorted-collections.phel
@@ -35,7 +35,7 @@
 (deftest test-sorted-map-merge
   (let [m1     (sorted-map 1 "a" 3 "c")
         m2     (sorted-map 2 "b" 4 "d")
-        merged (php/-> m1 (merge m2))]
+        merged (.merge m1 m2)]
     (is (= [1 2 3 4] (keys merged)) "map merge maintains order")))
 
 (deftest test-sorted-map-persistent

--- a/tests/phel/core/special-forms.phel
+++ b/tests/phel/core/special-forms.phel
@@ -2,33 +2,33 @@
   (:require phel.test :refer [deftest is]))
 
 (deftest test-set-object-property
-  (is (= "foo" (php/-> (php/oset (php/-> (php/new \stdClass) name) "foo") name)) "set value to stdClass"))
+  (is (= "foo" (.-name (php/oset (.-name (new \stdClass)) "foo"))) "set value to stdClass"))
 
 (deftest test-oset-expression-returns-target-object
   ;; `php/oset` as an expression must evaluate to the *target object*, not
   ;; the assigned value (a bare PHP `$o->p = v` would yield `v`). Reading the
   ;; property back off the result proves the target object flowed out.
-  (let [o   (php/new \stdClass)
-        ret (php/oset (php/-> o name) "bar")]
+  (let [o   (new \stdClass)
+        ret (php/oset (.-name o) "bar")]
     (is (php/=== o ret) "oset expression returns the same target object")
-    (is (= "bar" (php/-> ret name)) "the property was set on the returned object")))
+    (is (= "bar" (.-name ret)) "the property was set on the returned object")))
 
 (deftest test-nested-php-object-call
   (let [xml-string "<root><user id='1'><name>John</name></user></root>"
-        xml        (php/new \SimpleXMLElement xml-string)]
-    (is (= "John" (str (php/-> xml user name))))))
+        xml        (new \SimpleXMLElement xml-string)]
+    (is (= "John" (str (-> xml (.-user) (.-name)))))))
 
 (deftest test-php-new-dynamic-class-from-variable
   (let [cls "\\DateTimeZone"
-        tz  (php/new cls "Europe/Berlin")]
-    (is (= "Europe/Berlin" (php/-> tz (getName)))
-        "php/new with a class held in a variable resolves at runtime")))
+        tz  (new cls "Europe/Berlin")]
+    (is (= "Europe/Berlin" (.getName tz))
+        "new with a class held in a variable resolves at runtime")))
 
 (deftest test-php-new-dynamic-invalid-class-throws
   (is (thrown? \InvalidArgumentException
-        (let [cls 42]
-          (php/new cls)))
-      "php/new with a non-string, non-object class value throws InvalidArgumentException"))
+               (let [cls 42]
+                 (new cls)))
+      "new with a non-string, non-object class value throws InvalidArgumentException"))
 
 (deftest test-def-duplication
   (let [form (read-string "(do (def a \"first\") (def a \"second\") a)")]

--- a/tests/phel/core/tap.phel
+++ b/tests/phel/core/tap.phel
@@ -27,7 +27,7 @@
 
 (deftest tap-swallows-exceptions
   (let [seen (atom 0)
-        bad  (fn [_] (throw (php/new \RuntimeException "boom")))
+        bad  (fn [_] (throw (new \RuntimeException "boom")))
         good (fn [_] (swap! seen inc))]
     (add-tap bad)
     (add-tap good)

--- a/tests/phel/core/threading-macros.phel
+++ b/tests/phel/core/threading-macros.phel
@@ -29,19 +29,19 @@
 (deftest test-as->
   (is (= 1 (as-> 1 v)))
   (is (= -3 (as-> 5 v (+ 3 v) (/ v 2) (- 1 v))))
-  (is (= "oo" (as-> [:foo :bar] v (map #(php/-> % (getName)) v) (first v) (php/substr v 1))))
+  (is (= "oo" (as-> [:foo :bar] v (map #(.getName %) v) (first v) (php/substr v 1))))
   (let [animals [{:name "Rex" :type :dog} {:name "Kitty" :type :cat}]]
     (is (= :cat (as-> animals o (o 1) (o :type))))
     (is (= :cat (as-> animals $ ($ 1) ($ :type))))))
 
 (deftest test-doto
-  (let [dt (doto (php/new DateTime "2025-02-02 12:00:00")
-                 (php/-> (modify "+1 hour"))
-                 (php/-> (modify "+1 week"))
-                 (php/-> (modify "+1 year")))]
+  (let [dt (doto (new DateTime "2025-02-02 12:00:00")
+                 (.modify "+1 hour")
+                 (.modify "+1 week")
+                 (.modify "+1 year"))]
     (is (= :php/object (type dt)))
     (is (= "DateTime" (php/get_class dt)))
-    (is (= "2026-02-09 13:00:00" (php/-> dt (format "Y-m-d H:i:s"))))))
+    (is (= "2026-02-09 13:00:00" (.format dt "Y-m-d H:i:s")))))
 
 (deftest test-cond->
   (is (= 1 (cond-> 1)) "identity when no clauses")

--- a/tests/phel/core/transducers.phel
+++ b/tests/phel/core/transducers.phel
@@ -333,7 +333,7 @@
         "an eduction re-runs its pipeline, so first is not consuming")))
 
 (deftest test-first-of-a-php-generator
-  (is (= 6 (first (php/:: \Phel\Lang\Seq (map inc [5 6]))))
+  (is (= 6 (first (\Phel\Lang\Seq/map inc [5 6])))
       "first pulls one element from a bare PHP generator"))
 
 (deftest test-eduction-count-is-a-deliberate-error

--- a/tests/phel/core/type-operation.phel
+++ b/tests/phel/core/type-operation.phel
@@ -20,12 +20,12 @@
   (is (= :function (type concat)) "type of function")
   (is (= :php/array (type (php/array))) "type of php array")
   (is (= :php/resource (type (php/tmpfile))) "type of php resource")
-  (is (= :php/object (type (php/new DateTime))) "type of php object"))
+  (is (= :php/object (type (new DateTime))) "type of php object"))
 
 (deftest test-constructor-shorthand
   (is (= :php/object (type (\DateTime.)))
       "(ClassName.) behaves like (php/new ClassName)")
-  (is (= "msg" (php/-> (\RuntimeException. "msg") (getMessage)))
+  (is (= "msg" (.getMessage (\RuntimeException. "msg")))
       "(ClassName. args) forwards args to the constructor")
   (is (= "ab" (php/. "a" "b"))
       "php/. string concatenation is unaffected by the shorthand"))
@@ -124,7 +124,7 @@
       "(symbol vector) throws InvalidArgumentException"))
 
 (deftest test-class-and-class?
-  (let [c (class (php/new \stdClass))]
+  (let [c (class (new \stdClass))]
     (is (class? c) "(class? (class obj)) returns true")
     (is (= :php/class (type c)) "type of PhpClass is :php/class")
     (is (= "stdClass" (class-name c)) "class-name returns the FQN")
@@ -374,7 +374,7 @@
        {:a 1}))
 
 (deftest test-bigint?
-  (is (true? (bigint? (php/:: \Phel\Lang\BigInt (fromString "100000000000000000000000"))))
+  (is (true? (bigint? (\Phel\Lang\BigInt/fromString "100000000000000000000000")))
       "bigint? on a BigInt value")
   (are [x] (false? (bigint? x))
        1
@@ -408,8 +408,8 @@
       "rationalize rejects ##NaN"))
 
 (deftest test-instance?
-  (let [now (php/new DateTime)
-        err (php/new \RuntimeException "x")]
+  (let [now (new DateTime)
+        err (new \RuntimeException "x")]
     (are [c x] (true? (instance? c x))
          \DateTime  now
          DateTime   now            ;; :use'd short name resolves the same as the FQN
@@ -438,7 +438,7 @@
   (is (true? (php-resource? (php/tmpfile))) "php-resource?"))
 
 (deftest test-php-object?
-  (is (true? (php-object? (php/new DateTime))) "php-object?"))
+  (is (true? (php-object? (new DateTime))) "php-object?"))
 
 (deftest test-empty?
   (is (true? (empty? [])) "empty? on empty vector")
@@ -586,9 +586,9 @@
   (is (= 'abc (symbol "abc")) "symbol on simple string")
   (is (= '*_.%;!:+-? (symbol "*_.%;!:+-?")) "symbol on complex string")
   (is (= 'foo/bar (symbol "foo" "bar")) "symbol on string with namespace")
-  (is (= "foo" (php/-> (symbol "foo" "bar") (getNamespace))) "symbol on string with namespace using getNamespace")
-  (is (= nil (php/-> (symbol "bar") (getNamespace))) "symbol on string without namespace using getNamespace")
-  (is (= 'foo (php/:: (symbol (str "\Phel" "\Lang" "\Symbol")) (create "foo"))) "symbol on PHP class identifier string")
+  (is (= "foo" (.getNamespace (symbol "foo" "bar"))) "symbol on string with namespace using getNamespace")
+  (is (= nil (.getNamespace (symbol "bar"))) "symbol on string without namespace using getNamespace")
+  (is (= 'foo (.create (symbol (str "\Phel" "\Lang" "\Symbol")) "foo")) "symbol on PHP class identifier string")
   (is (= 'abc (symbol :abc)) "symbol on a keyword extracts the name")
   (is (= '+ (symbol :+)) "symbol on a single-character keyword")
   (is (= 'a/b (symbol :a :b)) "symbol with keyword namespace and keyword name")
@@ -599,12 +599,12 @@
 (deftest test-namespace
   (is (= nil (namespace 'symbol)) "namespace on symbol without ns")
   (is (= nil (namespace :keyword)) "namespace of keyword without ns")
-  (is (= "test" (namespace (php/:: Symbol (createForNamespace "test" "symbol")))) "namespace on symbol with ns")
+  (is (= "test" (namespace (Symbol/createForNamespace "test" "symbol"))) "namespace on symbol with ns")
   (is (= "phel-test.core.type-operation" (namespace ::keyword)) "namespace of keyword with ns"))
 
 (deftest test-full-name
   (is (= "string" (name "string")) "full-name on string")
   (is (= "symbol" (full-name 'symbol)) "full-name on symbol without ns")
   (is (= "keyword" (full-name :keyword)) "full-name of keyword without ns")
-  (is (= "test/symbol" (full-name (php/:: Symbol (createForNamespace "test" "symbol")))) "full-name on symbol with ns")
+  (is (= "test/symbol" (full-name (Symbol/createForNamespace "test" "symbol"))) "full-name on symbol with ns")
   (is (= "phel-test.core.type-operation/keyword" (full-name ::keyword)) "full-name of keyword with ns"))

--- a/tests/phel/defspec-shrink.phel
+++ b/tests/phel/defspec-shrink.phel
@@ -17,8 +17,8 @@
                  (when (= :defspec-failed (:type ev))
                    (swap! events conj ev)))]
     (t/with-isolated-reporters [rep]
-                               (t/with-isolated-stats
-                                (with-output-buffer (spec-thunk))))
+      (t/with-isolated-stats
+        (with-output-buffer (spec-thunk))))
     (first (deref events))))
 
 (defn- emit-failure-event! [outcome name-str]

--- a/tests/phel/edn/read.phel
+++ b/tests/phel/edn/read.phel
@@ -65,7 +65,7 @@
 (deftest test-read-builtin-tags
   (let [uuid (edn/read-string "#uuid \"550e8400-e29b-41d4-a716-446655440000\"")]
     (is (php/instanceof uuid \Phel\Lang\UUID) "#uuid returns UUID")
-    (is (= "550e8400-e29b-41d4-a716-446655440000" (php/-> uuid (__toString))))))
+    (is (= "550e8400-e29b-41d4-a716-446655440000" (.__toString uuid)))))
 
 (deftest test-read-custom-tag
   (is (= 84
@@ -85,6 +85,5 @@
 (deftest test-read-readers-restored-after-call
   (edn/read-string "1" {:readers {'myapp/x (fn [v] v)}})
   (is (false?
-       (php/-> (php/:: \Phel\Lang\TagRegistry (getInstance))
-               (has "myapp/x")))
+       (.has (\Phel\Lang\TagRegistry/getInstance) "myapp/x"))
       "custom reader unregistered after call"))

--- a/tests/phel/edn/write.phel
+++ b/tests/phel/edn/write.phel
@@ -49,7 +49,7 @@
          (edn/read-string (edn/write-string #{1 2 3})))))
 
 (deftest test-write-uuid-round-trip
-  (let [u             (php/:: \Phel\Lang\UUID (fromString "550e8400-e29b-41d4-a716-446655440000"))
+  (let [u             (\Phel\Lang\UUID/fromString "550e8400-e29b-41d4-a716-446655440000")
         round-tripped (edn/read-string (edn/write-string u))]
     (is (php/instanceof round-tripped \Phel\Lang\UUID))
     (is (= (str u) (str round-tripped)) "UUID round-trips through EDN")))

--- a/tests/phel/fixtures/run-harness.phel
+++ b/tests/phel/fixtures/run-harness.phel
@@ -22,8 +22,8 @@ run's output, restores the outer suite's reporters and stats, and returns
         run-options     (assoc options :reporters
                                (conj (vec (:reporters options)) capture))
         snapshot        (t/with-isolated-stats
-                         (with-output-buffer
-                           (t/run-tests run-options test-ns)))]
+                          (with-output-buffer
+                            (t/run-tests run-options test-ns)))]
     ;; `run-tests` installs its own reporters from `run-options`, so there is
     ;; nothing to hand to `with-isolated-reporters`; only the restore is ours.
     (t/set-reporters! saved-reporters)

--- a/tests/phel/gen.phel
+++ b/tests/phel/gen.phel
@@ -143,7 +143,7 @@
 
 (deftest test-quick-check-error
   (let [res (g/quick-check 10 (g/tuple (g/return 0))
-                           (fn [_] (throw (php/new \RuntimeException "boom")))
+                           (fn [_] (throw (new \RuntimeException "boom")))
                            {:seed fixed-seed})]
     (is (= :error (:result res)))
     (is (some? (:exception res)))))

--- a/tests/phel/http-client.phel
+++ b/tests/phel/http-client.phel
@@ -6,10 +6,9 @@
 ;; --- Response parser integration (via PHP static call) ---
 
 (deftest test-response-parser-basic
-  (let [parsed (php/:: \Phel\HttpClient\ResponseParser
-                       (parse (php/array "HTTP/1.1 200 OK"
-                                         "Content-Type: application/json"
-                                         "X-Request-Id: abc-123")))]
+  (let [parsed (\Phel\HttpClient\ResponseParser/parse (php/array "HTTP/1.1 200 OK"
+                                                                 "Content-Type: application/json"
+                                                                 "X-Request-Id: abc-123"))]
     (is (= 200 (php/aget parsed "status")) "parses status code")
     (is (= "1.1" (php/aget parsed "version")) "parses HTTP version")
     (is (= "OK" (php/aget parsed "reason")) "parses reason phrase")
@@ -18,30 +17,27 @@
       (is (= "abc-123" (php/aget headers "x-request-id")) "parses custom header"))))
 
 (deftest test-response-parser-empty-headers
-  (let [parsed (php/:: \Phel\HttpClient\ResponseParser (parse (php/array)))]
+  (let [parsed (\Phel\HttpClient\ResponseParser/parse (php/array))]
     (is (= 200 (php/aget parsed "status")) "defaults to 200 when no status line")
     (is (= "1.1" (php/aget parsed "version")) "defaults to HTTP/1.1")))
 
 (deftest test-response-parser-404
-  (let [parsed (php/:: \Phel\HttpClient\ResponseParser
-                       (parse (php/array "HTTP/1.1 404 Not Found")))]
+  (let [parsed (\Phel\HttpClient\ResponseParser/parse (php/array "HTTP/1.1 404 Not Found"))]
     (is (= 404 (php/aget parsed "status")) "parses 404 status")
     (is (= "Not Found" (php/aget parsed "reason")) "parses reason phrase")))
 
 (deftest test-response-parser-redirect-chain
-  (let [parsed (php/:: \Phel\HttpClient\ResponseParser
-                       (parse (php/array "HTTP/1.1 301 Moved"
-                                         "Location: /new"
-                                         "HTTP/1.1 200 OK"
-                                         "Content-Type: text/html")))]
+  (let [parsed (\Phel\HttpClient\ResponseParser/parse (php/array "HTTP/1.1 301 Moved"
+                                                                 "Location: /new"
+                                                                 "HTTP/1.1 200 OK"
+                                                                 "Content-Type: text/html"))]
     (is (= 200 (php/aget parsed "status")) "uses final status after redirect")
     (is (= "text/html" (php/aget (php/aget parsed "headers") "content-type"))
         "parses headers from final response")))
 
 (deftest test-response-parser-colon-in-value
-  (let [parsed (php/:: \Phel\HttpClient\ResponseParser
-                       (parse (php/array "HTTP/1.1 200 OK"
-                                         "Location: https://example.com:8080/path")))]
+  (let [parsed (\Phel\HttpClient\ResponseParser/parse (php/array "HTTP/1.1 200 OK"
+                                                                 "Location: https://example.com:8080/path"))]
     (is (= "https://example.com:8080/path"
            (php/aget (php/aget parsed "headers") "location"))
         "preserves colons in header values")))

--- a/tests/phel/json/encode/keys.phel
+++ b/tests/phel/json/encode/keys.phel
@@ -44,10 +44,10 @@
   (is
    (thrown-with-msg?
     Exception "Key can only be an integer, float, symbol, keyword or a string."
-    (json/encode {(php/new \stdClass) "stdClass"}))
+    (json/encode {(new \stdClass) "stdClass"}))
    "It tests if stdClass is a valid key.")
   (is
    (thrown-with-msg?
     Exception "Key can only be an integer, float, symbol, keyword or a string."
-    (json/encode {(php/new \DateTime) "DateTime"}))
+    (json/encode {(new \DateTime) "DateTime"}))
    "It tests if DateTime is a valid key."))

--- a/tests/phel/mock.phel
+++ b/tests/phel/mock.phel
@@ -55,7 +55,7 @@
     (is (= 2 (my-mock)) "second call after reset returns 2")))
 
 (deftest test-mock-throwing
-  (let [my-mock (mock-throwing (php/new \Exception "API error"))]
+  (let [my-mock (mock-throwing (new \Exception "API error"))]
     (is (thrown? \Exception (my-mock)) "throws exception when called")
     (is (= 1 (call-count my-mock)) "tracks call even when throwing")))
 
@@ -296,7 +296,7 @@
   {:url url :status 200})
 
 (deftest test-api-failure-with-mock-throwing
-  (let [mock-api (mock-throwing (php/new \RuntimeException "API unavailable"))]
+  (let [mock-api (mock-throwing (new \RuntimeException "API unavailable"))]
     (with-redefs [fetch-from-api (fn [url] (mock-api url))]
       (is (thrown? \RuntimeException (fetch-from-api "http://api.example.com"))
           "throws when API fails")
@@ -316,7 +316,7 @@
     (with-redefs [fetch-from-api (fn [url]
                                    (let [result (mock-api url)]
                                      (when (nil? result)
-                                       (throw (php/new \Exception "Failed")))
+                                       (throw (new \Exception "Failed")))
                                      result))]
       (is (= {:status 200} (retry-fetch fetch-from-api "http://api.example.com" 3))
           "succeeds after retries")

--- a/tests/phel/reader.phel
+++ b/tests/phel/reader.phel
@@ -8,11 +8,11 @@
 (deftest test-inst-returns-datetime
   (let [dt #inst"2026-04-20T12:00:00Z"]
     (is (datetime? dt))
-    (is (= "2026-04-20T12:00:00+00:00" (php/-> dt (format "c"))))))
+    (is (= "2026-04-20T12:00:00+00:00" (.format dt "c")))))
 
 (deftest test-inst-defaults-to-utc
   (let [dt #inst"2026-04-20T12:00:00"]
-    (is (= "+00:00" (php/-> dt (format "P"))))))
+    (is (= "+00:00" (.format dt "P")))))
 
 (deftest test-uuid-regression
   (is (= "550e8400-e29b-41d4-a716-446655440000"

--- a/tests/phel/reflect.phel
+++ b/tests/phel/reflect.phel
@@ -8,7 +8,7 @@
 
 (deftest class-info-by-string-or-object
   (let [from-string (r/class-info "DateTime")
-        from-object (r/class-info (php/new DateTime))]
+        from-object (r/class-info (new DateTime))]
     (is (= "DateTime" (get from-string :name))
         "class-info accepts class name string")
     (is (= "DateTime" (get from-object :name))
@@ -77,11 +77,11 @@
     (is (= "/products/{id}" (get-in attr [:args 0])) "property attribute positional arg")))
 
 (deftest attributes-alias-works-on-an-instance
-  (let [attr (first (r/attributes (php/new annotated)))]
+  (let [attr (first (r/attributes (new annotated)))]
     (is (= route-attr (get attr :name)) "an instance reflects its class' attributes")))
 
 (def- status-class "PhelTest\\Fixtures\\Enum\\Status")
-(def- status-active (php/:: \PhelTest\Fixtures\Enum\Status Active))
+(def- status-active \PhelTest\Fixtures\Enum\Status/Active)
 
 (deftest enum->keyword-uses-the-case-name
   (is (= :Active (r/enum->keyword status-active))

--- a/tests/phel/repeat-seed.phel
+++ b/tests/phel/repeat-seed.phel
@@ -40,8 +40,8 @@
                             (swap! counter inc)))
         saved-reporters (t/get-reporters)]
     (t/with-isolated-stats
-     (with-output-buffer
-       (t/run-tests {:reporters [bump-reporter] :repeat 4} fixture-ns)))
+      (with-output-buffer
+        (t/run-tests {:reporters [bump-reporter] :repeat 4} fixture-ns)))
     ;; `run-tests` installs its own reporters, so only the restore is ours.
     (t/set-reporters! saved-reporters)
     ;; 3 fixtures × 4 iterations = 12 pass events.
@@ -59,11 +59,11 @@
                             (swap! order conj (:test-name e))))
         saved-reporters (t/get-reporters)]
     (t/with-isolated-stats
-     (with-output-buffer
-       (t/run-tests {:reporters [capture]
-                     :random-order true
-                     :seed seed}
-                    fixture-ns)))
+      (with-output-buffer
+        (t/run-tests {:reporters [capture]
+                      :random-order true
+                      :seed seed}
+                     fixture-ns)))
     ;; `run-tests` installs its own reporters, so only the restore is ours.
     (t/set-reporters! saved-reporters)
     (deref order)))

--- a/tests/phel/repl.phel
+++ b/tests/phel/repl.phel
@@ -233,7 +233,7 @@
         (eval-str (str "(ns " original-ns ")"))))))
 
 (deftest test-eval-capturing-error-case
-  (let [result (eval-capturing "(throw (php/new \\Exception \"boom\"))")]
+  (let [result (eval-capturing "(throw (new \\Exception \"boom\"))")]
     (is (= false (get result :success)) "eval-capturing reports failure on error")
     (is (= nil (get result :value)) "eval-capturing has nil value on error")
     (is (string? (get result :error)) "eval-capturing has error message string")
@@ -256,7 +256,7 @@
       "a top-level def still compiles to its definition call"))
 
 (deftest test-compile-str-does-not-evaluate
-  (is (s/contains? (compile-str "(throw (php/new \\Exception \"compile-str must not run this\"))")
+  (is (s/contains? (compile-str "(throw (new \\Exception \"compile-str must not run this\"))")
                    "compile-str must not run this")
       "compile-str returns the emitted PHP without executing it"))
 
@@ -346,7 +346,7 @@
   (let [original *ns*]
     (eval-str "(ns test-ns-propagation)")
     (is (= "test-ns-propagation" *ns*) "*ns* propagates after eval-str returns")
-    (is (= *ns* (php/-> (php/:: \Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton (getInstance)) (getNs)))
+    (is (= *ns* (.getNs (\Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton/getInstance)))
         "GlobalEnvironment.ns matches *ns*")
     (eval-str (str "(ns " original ")"))))
 
@@ -578,9 +578,9 @@
 (deftest test-intern-returns-fully-qualified-symbol
   (let [ns  "phel-test-repl.intern-return"
         sym (intern ns "pointer" 1)]
-    (is (= "pointer" (php/-> sym (getName))) "symbol name matches")
-    (is (= ns (php/-> sym (getNamespace))) "symbol namespace matches")
-    (is (= (str ns "/pointer") (php/-> sym (getFullName)))
+    (is (= "pointer" (.getName sym)) "symbol name matches")
+    (is (= ns (.getNamespace sym)) "symbol namespace matches")
+    (is (= (str ns "/pointer") (.getFullName sym))
         "symbol full name is ns/name")
     (remove-ns ns)))
 
@@ -641,7 +641,7 @@
   the outer test stats afterwards. Returns the thunk's value."
   (let [result (atom nil)]
     (t/with-isolated-stats
-     (with-output-buffer (reset! result (thunk))))
+      (with-output-buffer (reset! result (thunk))))
     (deref result)))
 
 (deftest test-run-tests-returns-summary-map

--- a/tests/phel/reporter-diff.phel
+++ b/tests/phel/reporter-diff.phel
@@ -194,7 +194,7 @@
 (deftest test-error-headline-shows-test-name
   (let [out (run-default-reporter-event
              (named-failure-event {:state :error
-                                   :exception (php/new \RuntimeException "kaput")}))]
+                                   :exception (new \RuntimeException "kaput")}))]
     (is (php/preg_match "/ERROR my-test \\(diff\\.phel:7\\)/" out)
         "error headline carries the deftest name before the location")))
 

--- a/tests/phel/reporters.phel
+++ b/tests/phel/reporters.phel
@@ -15,7 +15,7 @@
   builder private, so a test that needs to drive a reporter through a summary
   mid-run assembles the event from the public `get-stats` snapshot."
   []
-  (let [{:failed failures :skipped skips :counts counts} (t/get-stats)
+  (let [{:failed failures :skipped skips :counts counts}          (t/get-stats)
         {:failed failed :error error :pass pass :skipped skipped} counts]
     {:type :summary
      :failures failures
@@ -60,9 +60,9 @@
 (deftest test-report-fans-out-to-active-reporters
   (let [events (atom [])]
     (t/with-isolated-reporters [(fn [e] (swap! events conj e))]
-                               (t/with-isolated-stats
-                                (t/report {:type :pass :state :pass :message "ok"})
-                                (t/report {:type :failed :state :failed :message "boom"})))
+      (t/with-isolated-stats
+        (t/report {:type :pass :state :pass :message "ok"})
+        (t/report {:type :failed :state :failed :message "boom"})))
     (is (= 2 (count (deref events))) "both events fanned out")
     (is (= :pass (:state (first (deref events)))) "pass state preserved")
     (is (= :failed (:state (nth (deref events) 1))) "failed state preserved")))
@@ -71,15 +71,15 @@
   (let [order (atom [])]
     (t/with-isolated-reporters [(fn [_] (swap! order conj :a))
                                 (fn [_] (swap! order conj :b))]
-                               (t/with-isolated-stats
-                                (t/report {:type :pass :state :pass})))
+      (t/with-isolated-stats
+        (t/report {:type :pass :state :pass})))
     (is (= [:a :b] (deref order)) "reporters invoked in registration order")))
 
 (deftest test-default-report-method-preserves-event
   (let [captured (atom nil)]
     (t/with-isolated-reporters [(fn [e] (reset! captured e))]
-                               (t/with-isolated-stats
-                                (t/report {:type :my-custom-type :payload 42})))
+      (t/with-isolated-stats
+        (t/report {:type :my-custom-type :payload 42})))
     (is (= :my-custom-type (:type (deref captured)))
         "unknown event types reach reporters via :default method")
     (is (= 42 (:payload (deref captured))) "payload flows through untouched")))
@@ -194,10 +194,10 @@
   (let [rep (t/resolve-reporter :default)
         out (with-output-buffer
               (t/with-isolated-reporters [rep]
-                                         (t/with-isolated-stats
-                                          (rep {:type :begin-test-run})
-                                          (is (= 0 (apply + "")))
-                                          (rep (summary-of-current-stats)))))]
+                (t/with-isolated-stats
+                  (rep {:type :begin-test-run})
+                  (is (= 0 (apply + "")))
+                  (rep (summary-of-current-stats)))))]
     (is (php/preg_match "/Test: \\(= 0 \\(apply \\+ \"\"\\)\\)/" out)
         "error output renders empty strings with quotes")))
 
@@ -274,8 +274,8 @@
 (deftest test-assertion-like-state-error-is-recorded
   (let [events   (atom [])
         snapshot (t/with-isolated-reporters [(fn [e] (swap! events conj e))]
-                                            (t/with-isolated-stats
-                                             (t/report {:type :predicate :state :error :message "threw"})))]
+                   (t/with-isolated-stats
+                     (t/report {:type :predicate :state :error :message "threw"})))]
     (is (= 1 (count (deref events))) "event reached the reporter")
     (is (= 1 (:error (:counts snapshot)))
         ":predicate with :state :error increments :error count")))
@@ -283,8 +283,8 @@
 (deftest test-assertion-like-without-state-flows-through
   (let [events   (atom [])
         snapshot (t/with-isolated-reporters [(fn [e] (swap! events conj e))]
-                                            (t/with-isolated-stats
-                                             (t/report {:type :binary :payload "no state"})))]
+                   (t/with-isolated-stats
+                     (t/report {:type :binary :payload "no state"})))]
     (is (= 1 (count (deref events))) "event still fans out")
     (is (= 0 (:pass (:counts snapshot)))
         "event without :state does not touch stats")))
@@ -492,8 +492,8 @@
   (let [events (atom [])
         prev   (t/get-reporters)]
     (t/with-isolated-stats
-     (with-output-buffer
-       (t/run-tests {:reporters [(fn [e] (swap! events conj (:type e)))]})))
+      (with-output-buffer
+        (t/run-tests {:reporters [(fn [e] (swap! events conj (:type e)))]})))
     ;; `run-tests` installs its own reporters, so only the restore is ours.
     (t/set-reporters! prev)
     (is (contains? (into (hash-set) (deref events)) :begin-test-run)

--- a/tests/phel/schema/coerce.phel
+++ b/tests/phel/schema/coerce.phel
@@ -59,10 +59,10 @@
   (testing "epoch boundary timestamps coerce to a DateTime"
            (let [zero (s/coerce :inst 0)]
              (is (= true (php/instanceof zero \DateTimeInterface)) "epoch 0 coerces")
-             (is (= "1970-01-01" (php/-> zero (format "Y-m-d"))) "epoch 0 is 1970-01-01"))
+             (is (= "1970-01-01" (.format zero "Y-m-d")) "epoch 0 is 1970-01-01"))
            (let [neg (s/coerce :inst -1000000)]
              (is (= true (php/instanceof neg \DateTimeInterface)) "negative epoch coerces")
-             (is (= "1969-12-20" (php/-> neg (format "Y-m-d"))) "negative epoch is before 1970"))))
+             (is (= "1969-12-20" (.format neg "Y-m-d")) "negative epoch is before 1970"))))
 
 (deftest test-coerce-string
   (is (= "42" (s/coerce :string 42)))

--- a/tests/phel/schema/instrument.phel
+++ b/tests/phel/schema/instrument.phel
@@ -89,7 +89,7 @@
   (s/set-schema-check! true)
   (let [caught (try
                  (s/with-schema-check false
-                                      (fn [] (throw (php/new \RuntimeException "oops"))))
+                                      (fn [] (throw (new \RuntimeException "oops"))))
                  :no-throw
                  (catch \RuntimeException _ :caught))]
     (is (= :caught caught))

--- a/tests/phel/schema/validate.phel
+++ b/tests/phel/schema/validate.phel
@@ -41,7 +41,7 @@
 
 (deftest test-inst
   (testing ":inst matches DateTime instances"
-           (let [now (php/new \DateTimeImmutable)]
+           (let [now (new \DateTimeImmutable)]
              (is (s/validate :inst now))))
   (testing ":inst rejects strings"
            (is (not (s/validate :inst "2026-01-01")))))

--- a/tests/phel/selectors-runtime.phel
+++ b/tests/phel/selectors-runtime.phel
@@ -39,9 +39,9 @@
         events          (atom [])
         capture         (fn [e] (swap! events conj e))]
     (t/with-isolated-stats
-     (with-output-buffer
-       (t/run-tests {:reporters [capture]} fixture-ns)
-       (t/run-tests {:reporters [capture]} fixture-ns)))
+      (with-output-buffer
+        (t/run-tests {:reporters [capture]} fixture-ns)
+        (t/run-tests {:reporters [capture]} fixture-ns)))
     ;; `run-tests` installs its own reporters, so only the restore is ours.
     (t/set-reporters! saved-reporters)
     (let [summaries (events-of (deref events) :summary)]

--- a/tests/phel/shrink.phel
+++ b/tests/phel/shrink.phel
@@ -105,7 +105,7 @@
   (testing "a predicate that throws is treated as a failing trial"
            (let [res (shrink/shrink-args
                       (fn [n]
-                        (when (> n 0) (throw (php/new \RuntimeException "boom")))
+                        (when (> n 0) (throw (new \RuntimeException "boom")))
                         true)
                       [100])]
              (is (= [1] (:smallest res)) "shrinks to the smallest throwing value")

--- a/tests/phel/test-framework.phel
+++ b/tests/phel/test-framework.phel
@@ -26,7 +26,7 @@
 
 (deftest test-is-not-predicate-fails-when-predicate-is-true
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer (is (not (nil? nil))))))]
+                          (with-output-buffer (is (not (nil? nil))))))]
     (is (= 1 (:failed counts)) "not nil? on nil records a failure")
     (is (= 0 (:pass counts)) "no pass recorded")))
 
@@ -42,7 +42,7 @@
 
 (deftest test-is-not-binary-fails-when-predicate-is-true
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer (is (not (= 1 1))))))]
+                          (with-output-buffer (is (not (= 1 1))))))]
     (is (= 1 (:failed counts)) "not (= 1 1) records a failure")))
 
 ;; ---------------------------------------------------------------------------
@@ -51,16 +51,16 @@
 
 (deftest test-is-thrown-passes-when-exception-type-matches
   (is (thrown? \InvalidArgumentException
-               (throw (php/new \InvalidArgumentException "boom")))
+               (throw (new \InvalidArgumentException "boom")))
       "thrown? passes when matching exception is thrown")
   (is (thrown? \Exception
-               (throw (php/new \RuntimeException "boom")))
+               (throw (new \RuntimeException "boom")))
       "thrown? passes for subclass of expected exception"))
 
 (deftest test-is-thrown-fails-when-no-exception-thrown
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer
-                           (is (thrown? \InvalidArgumentException (+ 1 1))))))]
+                          (with-output-buffer
+                            (is (thrown? \InvalidArgumentException (+ 1 1))))))]
     (is (= 1 (:failed counts)) "thrown? without throw records a failure")))
 
 ;; ---------------------------------------------------------------------------
@@ -69,27 +69,27 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest test-is-thrown-single-arg-passes-for-any-exception
-  (is (thrown? (throw (php/new \Exception "boom")))
+  (is (thrown? (throw (new \Exception "boom")))
       "single-arg thrown? catches a bare \\Exception")
-  (is (thrown? (throw (php/new \RuntimeException "runtime")))
+  (is (thrown? (throw (new \RuntimeException "runtime")))
       "single-arg thrown? catches a \\RuntimeException")
-  (is (thrown? (throw (php/new \InvalidArgumentException "bad")))
+  (is (thrown? (throw (new \InvalidArgumentException "bad")))
       "single-arg thrown? catches an \\InvalidArgumentException")
-  (is (thrown? (throw (php/new \DivisionByZeroError "divzero")))
+  (is (thrown? (throw (new \DivisionByZeroError "divzero")))
       "single-arg thrown? catches an \\Error subclass"))
 
 (deftest test-is-thrown-single-arg-fails-when-body-does-not-throw
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer
-                           (is (thrown? (+ 1 2))))))]
+                          (with-output-buffer
+                            (is (thrown? (+ 1 2))))))]
     (is (= 1 (:failed counts))
         "single-arg thrown? without throw records a failure")
     (is (= 0 (:pass counts)) "no pass recorded")))
 
 (deftest test-is-thrown-two-arg-still-works-alongside-single-arg
-  (is (thrown? \Exception (throw (php/new \Exception "still works")))
+  (is (thrown? \Exception (throw (new \Exception "still works")))
       "two-arg thrown? keeps working when single-arg is supported")
-  (is (thrown? \RuntimeException (throw (php/new \RuntimeException "ok")))
+  (is (thrown? \RuntimeException (throw (new \RuntimeException "ok")))
       "two-arg thrown? with explicit class still catches the right type"))
 
 ;; ---------------------------------------------------------------------------
@@ -98,20 +98,20 @@
 
 (deftest test-is-thrown-with-msg-passes-when-message-matches
   (is (thrown-with-msg? \InvalidArgumentException "boom"
-                        (throw (php/new \InvalidArgumentException "boom")))
+                        (throw (new \InvalidArgumentException "boom")))
       "thrown-with-msg? passes when message matches exactly"))
 
 (deftest test-is-thrown-with-msg-fails-when-no-exception
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer
-                           (is (thrown-with-msg? \InvalidArgumentException "boom" (+ 1 1))))))]
+                          (with-output-buffer
+                            (is (thrown-with-msg? \InvalidArgumentException "boom" (+ 1 1))))))]
     (is (= 1 (:failed counts)) "thrown-with-msg? without throw records a failure")))
 
 (deftest test-is-thrown-with-msg-fails-when-message-differs
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer
-                           (is (thrown-with-msg? \InvalidArgumentException "expected"
-                                                 (throw (php/new \InvalidArgumentException "different")))))))]
+                          (with-output-buffer
+                            (is (thrown-with-msg? \InvalidArgumentException "expected"
+                                                  (throw (new \InvalidArgumentException "different")))))))]
     (is (= 1 (:failed counts)) "thrown-with-msg? with wrong message records a failure")))
 
 ;; ---------------------------------------------------------------------------
@@ -123,8 +123,8 @@
 
 (deftest test-is-output-fails-when-output-differs
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer
-                           (is (output? "expected" (print "actual"))))))]
+                          (with-output-buffer
+                            (is (output? "expected" (print "actual"))))))]
     (is (= 1 (:failed counts)) "output? mismatch records a failure")))
 
 ;; ---------------------------------------------------------------------------
@@ -156,7 +156,7 @@
 
 (deftest test-is-binary-default-fails
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer (is (= 1 2)))))]
+                          (with-output-buffer (is (= 1 2)))))]
     (is (= 1 (:failed counts)) "= on unequal values records a failure")))
 
 ;; ---------------------------------------------------------------------------
@@ -170,7 +170,7 @@
 
 (deftest test-is-predicate-default-fails
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer (is (nil? 1)))))]
+                          (with-output-buffer (is (nil? 1)))))]
     (is (= 1 (:failed counts)) "nil? on non-nil records a failure")))
 
 ;; ---------------------------------------------------------------------------
@@ -183,8 +183,8 @@
 
 (deftest test-is-any-fails-when-list-result-is-falsy
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer (is (and true false 1 2)))
-                         (with-output-buffer (is (or false nil false nil)))))]
+                          (with-output-buffer (is (and true false 1 2)))
+                          (with-output-buffer (is (or false nil false nil)))))]
     (is (= 2 (:failed counts)) "falsy and/or expressions both record failures")))
 
 (deftest test-is-accepts-scalar-literal-arguments
@@ -194,8 +194,8 @@
 
 (deftest test-is-scalar-literal-failures-record-failure
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer (is false "false literal"))
-                         (with-output-buffer (is nil "nil literal"))))]
+                          (with-output-buffer (is false "false literal"))
+                          (with-output-buffer (is nil "nil literal"))))]
     (is (= 2 (:failed counts)) "scalar false/nil record failures without error")
     (is (= 0 (:error counts)) "scalar literals do not raise an internal error")))
 
@@ -206,8 +206,8 @@
 
 (deftest test-is-records-error-when-body-throws
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer
-                           (is (= 1 (throw (php/new \RuntimeException "boom inside is")))))))]
+                          (with-output-buffer
+                            (is (= 1 (throw (new \RuntimeException "boom inside is")))))))]
     (is (= 1 (:error counts)) "uncaught exception in assertion is reported as :error")
     (is (= 0 (:failed counts)) "not counted as a failure")))
 
@@ -217,7 +217,7 @@
 
 (deftest test-passing-assertion-increments-pass-and-total-only
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer (is (= 1 1)))))]
+                          (with-output-buffer (is (= 1 1)))))]
     (is (= 1 (:pass counts)) "pass count incremented")
     (is (= 0 (:failed counts)) "failed count untouched")
     (is (= 0 (:error counts)) "error count untouched")
@@ -229,7 +229,7 @@
 
 (deftest test-failing-assertion-records-failure-data
   (let [snapshot (with-isolated-stats
-                  (with-output-buffer (is (= 1 2) "intentional failure")))]
+                   (with-output-buffer (is (= 1 2) "intentional failure")))]
     (is (= 1 (count (get snapshot :failed))) "one failure recorded in :failed list")
     (let [failure (first (get snapshot :failed))]
       (is (= "intentional failure" (get failure :message))
@@ -250,9 +250,9 @@
 
 (deftest test-testing-context-in-failure-message
   (let [snapshot (with-isolated-stats
-                  (with-output-buffer
-                    (testing "math basics"
-                             (is (= 1 2) "addition"))))]
+                   (with-output-buffer
+                     (testing "math basics"
+                              (is (= 1 2) "addition"))))]
     (let [failure (first (get snapshot :failed))]
       (is (= "math basics - addition" (get failure :message))
           "testing context is prepended to failure message"))))
@@ -263,14 +263,14 @@
 
 (deftest test-do-report-pass-increments-pass-count
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer (do-report {:state :pass :type :any :message "ok"}))))]
+                          (with-output-buffer (do-report {:state :pass :type :any :message "ok"}))))]
     (is (= 1 (:pass counts)) "do-report with :pass increments pass count")
     (is (= 1 (:total counts)) "do-report with :pass increments total")
     (is (= 0 (:failed counts)) "do-report with :pass does not increment failed")))
 
 (deftest test-do-report-failure-records-failure
   (let [snapshot (with-isolated-stats
-                  (with-output-buffer (do-report {:state :failed :type :any :message "nope"})))]
+                   (with-output-buffer (do-report {:state :failed :type :any :message "nope"})))]
     (is (= 1 (:failed (get snapshot :counts))) "do-report with :failed increments failed count")
     (is (= 1 (count (get snapshot :failed))) "do-report with :failed records failure data")
     (let [failure (first (get snapshot :failed))]
@@ -279,11 +279,11 @@
 (deftest test-do-report-preserves-location
   (let [loc      {:file "test.phel" :line 42 :column 1}
         snapshot (with-isolated-stats
-                  (with-output-buffer (do-report {:state :failed :type :any :location loc})))]
+                   (with-output-buffer (do-report {:state :failed :type :any :location loc})))]
     (let [failure (first (get snapshot :failed))]
       (is (= loc (get failure :location)) "do-report preserves :location in result"))))
 
 (deftest test-do-report-works-without-location
   (let [counts (:counts (with-isolated-stats
-                         (with-output-buffer (do-report {:state :pass :type :any}))))]
+                          (with-output-buffer (do-report {:state :pass :type :any}))))]
     (is (= 1 (:pass counts)) "do-report works without :location key")))

--- a/tests/phel/test-isolation.phel
+++ b/tests/phel/test-isolation.phel
@@ -21,9 +21,9 @@
 
 (deftest test-with-isolated-stats-returns-the-body-stats
   (let [counts (:counts (t/with-isolated-stats
-                         (with-output-buffer
-                           (is (= 1 1))
-                           (is (= 1 2)))))]
+                          (with-output-buffer
+                            (is (= 1 1))
+                            (is (= 1 2)))))]
     (is (= 1 (:pass counts)) "the passing inner assertion is counted")
     (is (= 1 (:failed counts)) "the failing inner assertion is counted")
     (is (= 2 (:total counts)) "both inner assertions reach the total")))
@@ -31,7 +31,7 @@
 (deftest test-with-isolated-stats-restores-the-caller-stats
   (let [before (t/get-stats)
         _      (t/with-isolated-stats
-                (with-output-buffer (is (= 1 2))))
+                 (with-output-buffer (is (= 1 2))))
         after  (t/get-stats)]
     (is (= (:counts before) (:counts after))
         "the failure inside the body never reaches the outer counts")
@@ -42,9 +42,9 @@
   (let [before (t/get-stats)
         caught (try
                  (t/with-isolated-stats
-                  (with-output-buffer (is (= 1 2)))
-                  (throw (php/new \RuntimeException "boom")))
-                 (catch \RuntimeException e (php/-> e (getMessage))))
+                   (with-output-buffer (is (= 1 2)))
+                   (throw (new \RuntimeException "boom")))
+                 (catch \RuntimeException e (.getMessage e)))
         after  (t/get-stats)]
     (is (= "boom" caught) "the body's exception propagates to the caller")
     (is (= (:counts before) (:counts after))
@@ -53,9 +53,9 @@
 (deftest test-with-isolated-stats-nests
   (let [inner  (atom nil)
         outer  (t/with-isolated-stats
-                (with-output-buffer (is (= 1 1)))
-                (reset! inner (t/with-isolated-stats
-                               (with-output-buffer (is (= 1 2))))))
+                 (with-output-buffer (is (= 1 1)))
+                 (reset! inner (t/with-isolated-stats
+                                 (with-output-buffer (is (= 1 2))))))
         icount (:counts (deref inner))
         ocount (:counts outer)]
     (is (= 1 (:failed icount)) "the inner block sees only its own failure")
@@ -72,9 +72,9 @@
         events (atom [])
         active (atom nil)]
     (t/with-isolated-reporters [(fn [event] (swap! events conj (:type event)))]
-                               (reset! active (t/get-reporters))
-                               (t/with-isolated-stats
-                                (t/report {:type :pass :state :pass})))
+      (reset! active (t/get-reporters))
+      (t/with-isolated-stats
+        (t/report {:type :pass :state :pass})))
     (is (= 1 (count (deref active))) "only the given reporter is active in the body")
     (is (= [:pass] (deref events)) "the installed reporter received the event")
     (is (= before (t/get-reporters)) "the previous reporter set is restored")))
@@ -82,16 +82,16 @@
 (deftest test-with-isolated-reporters-returns-the-body-value
   (is (= :body-value
          (t/with-isolated-reporters []
-                                    :ignored
-                                    :body-value))
+           :ignored
+           :body-value))
       "the value of the last body form is returned"))
 
 (deftest test-with-isolated-reporters-restores-when-the-body-throws
   (let [before (t/get-reporters)
         caught (try
                  (t/with-isolated-reporters [(fn [_] nil)]
-                                            (throw (php/new \RuntimeException "boom")))
-                 (catch \RuntimeException e (php/-> e (getMessage))))]
+                   (throw (new \RuntimeException "boom")))
+                 (catch \RuntimeException e (.getMessage e)))]
     (is (= "boom" caught) "the body's exception propagates to the caller")
     (is (= before (t/get-reporters))
         "the previous reporter set is restored on the exceptional path too")))
@@ -100,7 +100,7 @@
   (let [before (t/get-reporters)
         active (atom nil)]
     (t/with-isolated-reporters (vec (cons (fn [_] nil) before))
-                               (reset! active (t/get-reporters)))
+      (reset! active (t/get-reporters)))
     (is (= (inc (count before)) (count (deref active)))
         "the reporter expression is evaluated against the outer set")
     (is (= before (t/get-reporters)) "the previous reporter set is restored")))
@@ -116,7 +116,7 @@
            (let [outer-stats :caller-value
                  saved       :also-mine
                  counts      (:counts (t/with-isolated-stats
-                                       (with-output-buffer (is (= 1 2)))))]
+                                        (with-output-buffer (is (= 1 2)))))]
              (is (= :caller-value outer-stats) "a caller local named outer-stats survives")
              (is (= :also-mine saved) "a caller local named saved survives")
              (is (= 1 (:failed counts)) "the macro still reports the inner failure")))
@@ -125,6 +125,6 @@
                  prev            :also-mine
                  seen            (atom nil)]
              (t/with-isolated-reporters []
-                                        (reset! seen [outer-reporters prev]))
+               (reset! seen [outer-reporters prev]))
              (is (= [:caller-value :also-mine] (deref seen))
                  "caller locals named outer-reporters and prev survive the expansion"))))

--- a/tests/phel/trace.phel
+++ b/tests/phel/trace.phel
@@ -56,7 +56,7 @@
         "nested calls are indented and returns align with their call")))
 
 (deftest test-trace-fn-depth-restored-after-throw
-  (let [boom           (t/trace-fn "boom" (fn [] (throw (php/new \Exception "no"))))
+  (let [boom           (t/trace-fn "boom" (fn [] (throw (new \Exception "no"))))
         [result lines] (capture-trace
                         (fn []
                           (try (boom) (catch \Exception _ :caught))))]

--- a/tests/phel/transit/read.phel
+++ b/tests/phel/transit/read.phel
@@ -26,7 +26,7 @@
 (deftest test-read-instant
   (let [d (transit/read-string "\"~t2026-05-19T12:00:00+00:00\"")]
     (is (php/instanceof d \DateTimeImmutable))
-    (is (= "2026-05-19T12:00:00+00:00" (php/-> d (format "c"))))))
+    (is (= "2026-05-19T12:00:00+00:00" (.format d "c")))))
 
 (deftest test-read-vector
   (is (= [1 2 3] (transit/read-string "[1,2,3]")))

--- a/tests/phel/transit/write.phel
+++ b/tests/phel/transit/write.phel
@@ -18,7 +18,7 @@
   (is (= "\"~$bar\"" (transit/write-string 'bar))))
 
 (deftest test-write-uuid
-  (let [u (php/:: \Phel\Lang\UUID (fromString "550e8400-e29b-41d4-a716-446655440000"))]
+  (let [u (\Phel\Lang\UUID/fromString "550e8400-e29b-41d4-a716-446655440000")]
     (is (= "\"~u550e8400-e29b-41d4-a716-446655440000\"" (transit/write-string u)))))
 
 (deftest test-write-vector


### PR DESCRIPTION
## 🤔 Background

Closes #2882.

Measured on `main` before this branch: 1225 occurrences of `php/new`, `php/->` and `php/::` across `src/phel/` and `tests/phel/`, and zero of the dot syntax. A Clojure developer reading the standard library to learn Phel meets `php/->` hundreds of times and concludes the `php/` forms are the only way to reach PHP, which is the complaint behind #2875 and something documentation alone cannot fix while the library contradicts it.

It also unblocks #2877: deprecating these forms would fire on our own compile unless `phel.*` were exempted, and exempting it ships a two-tier language.

#2881 was the hard prerequisite (the dot syntax reaching a class held in a value) and is merged, so the two `src/phel/reflect.phel` sites the issue called out are rewritten here like the rest.

## 💡 Goal

Mechanical, no behaviour change. `composer test` is the whole safety argument.

## 🔖 Changes

```
(php/new C a)      -> (new C a)
(php/-> o (m a))   -> (.m o a)
(php/-> o p)       -> (.-p o)
(php/:: C (m a))   -> (C/m a)
```

Multi-segment forms become `->` chains: `(php/-> o (m a) (n b))` reads `(-> o (.m a) (.n b))`.

The rewrite was done with a small s-expression rewriter rather than regexes: each file is parsed into forms with source spans and rewritten innermost-first, so nested occurrences are handled, strings and comments are never touched, and every byte outside a rewritten head is preserved. `phel format` then normalised the touched lines. Two things it deliberately refuses to rewrite:

- **`php/oset` places.** Its first argument is a location, and the static place form (`(php/:: C prop)`) has no dot-syntax equivalent, so places are left alone. There are none of the instance kind left after the sweep.
- **A `php/::` whose class is a runtime value.** `(C/m …)` would read `C` as a class name. Those become `(.m value …)` instead, which is exactly what #2881 made possible.

## What is left, and why

Eleven grep hits remain. None is a call site that could read better:

| Site | Why |
|---|---|
| `core/protocols.phel:42`, `:637` | inside a quasiquote, the method name is a **symbol computed at expansion time** (`~munged-fn-symbol`); `.m` needs the name written literally. Comment added |
| `core/io.phel:496` | same, for a `\Phel` static (`~open-method`). Comment added |
| `core/predicates.phel:285` | the special-symbol catalogue: these are the data, not calls |
| `tests/phel/core/type-operation.phel:27`, `:279` | tests that name the forms on purpose (`special-symbol?`, and the assertion message comparing `(ClassName.)` with `php/new`) |

## Also swept: documentation examples

`:example` metadata is user-facing (it feeds `phel doc` and the website API reference), so the examples in `predicates`, `math`, `seq-fns`, `mock`, `cli`, `defs` and `interop` were rewritten too. Each stays runnable and the documentation gate still passes.

## Verification

- `composer test`: full gate green, **6575** core assertions, 0 failed, static analysis clean.
- `grep -rE "php/new|php/->|php/::" src/phel/ tests/phel/` returns the eleven sites above and nothing else.
- No CHANGELOG entry: no user-facing behaviour changes, per the issue's third acceptance criterion.

## Notes for the reviewer

- **Read it as "does every hunk still say the same thing"**, since that is the only risk. The emitted PHP is unchanged in kind: `(.m o a)` and `(php/-> o (m a))` produce the same `PhpObjectCallNode`.
- The diff is large (112 files) but uniform. `git diff --stat` and a spot check of `src/phel/core/io.phel` and `src/phel/protocols.phel` covers the shapes.
- One pre-existing oddity found while sweeping: `tests/phel/keyword-alias-resolution.phel` cannot be run through `phel format` at all (auto-resolved `::alias/kw`). Untouched here, worth its own issue.
