### PR TITLE
feat: nREPL sessions keep their own namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- nREPL sessions each keep their own namespace, as reference nREPL does. Two editors on one server no longer walk over each other: client A evaluating `(ns foo)` used to move where client B's next form compiled, and B's prompt jumped namespace with nobody having asked. Definitions stay shared, since the registry is global; only the current namespace is per session (#2906)
 - A namespace's own `def`/`defn` beats a `:refer` of the same name, and redefining a referred name warns instead of silently keeping the refer. A recursive self-call used to resolve to the refer and never recurse; at the prompt, `(def doc 1)` then `doc` printed `<function:doc>` (#2897)
 - A `(:require ...)` resolving to no source file fails at the require, naming both namespaces, instead of loading nothing silently and surfacing as `Cannot resolve symbol` lines later (#2891, #2886)
 - `(:require my.ns)` of a project namespace works under `phel eval` and the nREPL server, not only in the REPL (#2886)

--- a/src/php/Nrepl/Application/Op/EvalOp.php
+++ b/src/php/Nrepl/Application/Op/EvalOp.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Nrepl\Application\Op;
 
+use Phel\Nrepl\Application\Session\SessionNamespaceBinder;
 use Phel\Nrepl\Domain\Op\OpHandlerInterface;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Op\OpResponse;
@@ -21,6 +22,7 @@ final readonly class EvalOp implements OpHandlerInterface
     public function __construct(
         private RunFacadeInterface $runFacade,
         private EvalResultResponder $responder,
+        private SessionNamespaceBinder $namespaceBinder,
     ) {}
 
     public function name(): string
@@ -46,10 +48,13 @@ final readonly class EvalOp implements OpHandlerInterface
             return $this->responder->respondEmptyCode($request);
         }
 
-        // structuredEval compiles and evaluates the code in the compiler's
-        // current namespace, which every session shares. CompileOptions is
-        // left empty: there is currently no nREPL-specific tuning (no
-        // optimization flags) to pass through.
+        // The compiler's namespace is process-wide, so point it at this
+        // session's before compiling: without it another session's `(ns ...)`
+        // decides where this code lands.
+        $this->namespaceBinder->bind($request);
+
+        // CompileOptions is left empty: there is currently no nREPL-specific
+        // tuning (no optimization flags) to pass through.
         $result = $this->runFacade->structuredEval($code, new CompileOptions());
 
         return $this->responder->respond($request, $result, 'Evaluation failed.');

--- a/src/php/Nrepl/Application/Op/EvalResultResponder.php
+++ b/src/php/Nrepl/Application/Op/EvalResultResponder.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace Phel\Nrepl\Application\Op;
 
+use Phel\Nrepl\Application\Session\SessionNamespaceBinder;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Op\OpResponse;
 use Phel\Nrepl\Domain\Op\OpStatus;
 use Phel\Nrepl\Domain\Session\Session;
-use Phel\Nrepl\Domain\Session\SessionRegistry;
 use Phel\Shared\Eval\EvalError;
 use Phel\Shared\Eval\EvalResult;
-use Phel\Shared\Facade\CompilerFacadeInterface;
-use Phel\Shared\Munge;
 use Phel\Shared\Printer\PrinterInterface;
 
 use function sprintf;
@@ -29,8 +27,7 @@ final readonly class EvalResultResponder
 {
     public function __construct(
         private PrinterInterface $printer,
-        private SessionRegistry $sessions,
-        private CompilerFacadeInterface $compilerFacade,
+        private SessionNamespaceBinder $namespaceBinder,
     ) {}
 
     /**
@@ -67,8 +64,8 @@ final readonly class EvalResultResponder
             return $responses;
         }
 
-        $session = $this->sessionFor($request);
-        $ns = $this->syncNamespace($session);
+        $session = $this->namespaceBinder->sessionFor($request);
+        $ns = $this->namespaceBinder->sync($session);
 
         if ($result->success) {
             $session?->recordValue($result->value);
@@ -97,39 +94,9 @@ final readonly class EvalResultResponder
      */
     public function respondEmptyCode(OpRequest $request): array
     {
-        $ns = $this->syncNamespace($this->sessionFor($request));
+        $ns = $this->namespaceBinder->sync($this->namespaceBinder->sessionFor($request));
 
         return [OpResponse::forRequest($request, ['ns' => $ns], [OpStatus::DONE])];
-    }
-
-    private function sessionFor(OpRequest $request): ?Session
-    {
-        return $request->session !== null
-            ? $this->sessions->get($request->session)
-            : null;
-    }
-
-    /**
-     * Mirror the compiler's current namespace into the session and return it:
-     * the `ns` field of eval responses then tracks `ns`/`in-ns` forms as they
-     * evaluate — editor prompts (CIDER, Calva, ...) are driven by that field.
-     * This is the same source of truth the terminal REPL prompt reads. A failed
-     * or incomplete eval restores the environment snapshot, so after one this
-     * simply yields the pre-eval namespace. Falls back to what the session
-     * already knows while the global environment is still uninitialized.
-     */
-    private function syncNamespace(?Session $session): string
-    {
-        if ($this->compilerFacade->isGlobalEnvironmentInitialized()) {
-            $ns = Munge::displayNs($this->compilerFacade->getGlobalEnvironment()->getNs());
-            if ($ns !== '') {
-                $session?->setNamespace($ns);
-
-                return $ns;
-            }
-        }
-
-        return $session instanceof Session ? $session->namespace() : Session::DEFAULT_NAMESPACE;
     }
 
     /**

--- a/src/php/Nrepl/Application/Op/LoadFileOp.php
+++ b/src/php/Nrepl/Application/Op/LoadFileOp.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Nrepl\Application\Op;
 
+use Phel\Nrepl\Application\Session\SessionNamespaceBinder;
 use Phel\Nrepl\Domain\Op\OpHandlerInterface;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Op\OpResponse;
@@ -19,6 +20,7 @@ final readonly class LoadFileOp implements OpHandlerInterface
     public function __construct(
         private RunFacadeInterface $runFacade,
         private EvalResultResponder $responder,
+        private SessionNamespaceBinder $namespaceBinder,
     ) {}
 
     public function name(): string
@@ -38,6 +40,10 @@ final readonly class LoadFileOp implements OpHandlerInterface
                 [OpStatus::LOAD_FILE_ERROR],
             )];
         }
+
+        // A file without its own `(ns ...)` header loads into the ambient
+        // namespace, so it has to be this session's, not another's.
+        $this->namespaceBinder->bind($request);
 
         $result = $this->runFacade->structuredEval($fileContent, new CompileOptions());
 

--- a/src/php/Nrepl/Application/Session/SessionNamespaceBinder.php
+++ b/src/php/Nrepl/Application/Session/SessionNamespaceBinder.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Application\Session;
+
+use Phel;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Session\Session;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+use Phel\Shared\CompilerConstants;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+use Phel\Shared\Munge;
+
+/**
+ * Both directions of the one piece of evaluation state nREPL keeps per session:
+ * the current namespace.
+ *
+ * Evaluation runs in a single process-wide `GlobalEnvironment` that every
+ * session shares, so without this two editors on one server walk over each
+ * other: client A evaluates `(ns foo)`, and client B's next eval compiles in
+ * `foo` and reports `ns foo` back, moving its prompt with nobody having asked
+ * (#2906). Reference nREPL binds `*ns*` per session, and `*1`/`*2`/`*3` are
+ * already per-session here, which made the namespace the odd one out.
+ *
+ * Definitions stay shared either way: the registry is global, so a `def` in one
+ * session is visible from the other. Only the *current* namespace is isolated.
+ *
+ * @internal
+ */
+final readonly class SessionNamespaceBinder
+{
+    public function __construct(
+        private CompilerFacadeInterface $compilerFacade,
+        private SessionRegistry $sessions,
+    ) {}
+
+    public function sessionFor(OpRequest $request): ?Session
+    {
+        return $request->session !== null
+            ? $this->sessions->get($request->session)
+            : null;
+    }
+
+    /**
+     * Point the shared environment at the session's namespace, so the code
+     * about to be evaluated compiles where that session left off rather than
+     * wherever another session last went.
+     *
+     * A session-less request is left alone: it has no namespace of its own, so
+     * the only sensible ambient namespace is the one already in place.
+     *
+     * The namespace can only be one this process created — a session starts at
+     * `user` and moves only by evaluating an `ns`/`in-ns` form — so this never
+     * points the environment at something that does not exist.
+     *
+     * "The current namespace" is two pieces of state, and both have to move
+     * together or `*ns*` disagrees with where the code actually compiled:
+     * the analyzer's `GlobalEnvironment::ns` and the runtime `phel.core/*ns*`
+     * var. `NamespaceLoader::restoreStartupNamespace()` writes the same pair.
+     */
+    public function bind(OpRequest $request): void
+    {
+        $session = $this->sessionFor($request);
+        if (!$session instanceof Session) {
+            return;
+        }
+
+        if (!$this->compilerFacade->isGlobalEnvironmentInitialized()) {
+            return;
+        }
+
+        $namespace = $session->namespace();
+        $this->compilerFacade->getGlobalEnvironment()->setNs($namespace);
+        Phel::setVar(CompilerConstants::PHEL_CORE_NAMESPACE, '*ns*', $namespace);
+    }
+
+    /**
+     * Mirror the post-eval namespace back into the session and return it: the
+     * `ns` field of eval responses then tracks `ns`/`in-ns` forms as they
+     * evaluate, which is what drives editor prompts (CIDER, Calva, ...). This
+     * is the same source of truth the terminal REPL prompt reads.
+     *
+     * A failed or incomplete eval restores the environment snapshot, so after
+     * one this yields the pre-eval namespace and the session does not move.
+     * Falls back to what the session already knows while the global
+     * environment is still uninitialized.
+     */
+    public function sync(?Session $session): string
+    {
+        if ($this->compilerFacade->isGlobalEnvironmentInitialized()) {
+            $ns = Munge::displayNs($this->compilerFacade->getGlobalEnvironment()->getNs());
+            if ($ns !== '') {
+                $session?->setNamespace($ns);
+
+                return $ns;
+            }
+        }
+
+        return $session instanceof Session ? $session->namespace() : Session::DEFAULT_NAMESPACE;
+    }
+}

--- a/src/php/Nrepl/CLAUDE.md
+++ b/src/php/Nrepl/CLAUDE.md
@@ -27,7 +27,7 @@ The facade is production surface only. `NreplFactory::createOpDispatcher()` stay
 |----------|--------|----------|
 | `FACADE_RUN` | RunFacade | `structuredEval`, version, `loadPhelNamespaces` |
 | `FACADE_API` | ApiFacade | completion, symbol metadata |
-| `FACADE_COMPILER` | CompilerFacade | reading the current namespace from the global environment after eval |
+| `FACADE_COMPILER` | CompilerFacade | reading and writing the current namespace on the global environment around each eval |
 
 ## Structure
 
@@ -36,6 +36,7 @@ The facade is production surface only. `NreplFactory::createOpDispatcher()` stay
 - `Domain/Session/` — `Session`, `SessionRegistry`
 - `Domain/Transport/` — `ClientConnection`
 - `Application/Op/` — one class per op (+ `EvalResultResponder`)
+- `Application/Session/` — `SessionNamespaceBinder`
 - `Infrastructure/` — `NreplSocketServer`, `ClientFiberPool`, `NreplPortFile`, `Command/NreplCommand`
 
 ## Key Constraints
@@ -46,6 +47,8 @@ The facade is production surface only. `NreplFactory::createOpDispatcher()` stay
 - Eval always via RunFacade — no inline compilation.
 - `LookupOp` resolves namespace: explicit param, else session, else `"user"`.
 - `Session` tracks id, namespace, and a 3-deep value ring (`value(1..3)`; `lastValue()` is `value(1)`). `EvalResultResponder` surfaces it as `*1`/`*2`/`*3` in each successful eval response (session-scoped; absent for session-less evals). `*e` stays REPL-only.
-- `EvalResultResponder` syncs the session namespace from the compiler's `GlobalEnvironment` after every eval (same source of truth as the terminal REPL prompt), so the `ns` response field — which editor clients use for their prompt — tracks `(ns ...)`/`in-ns` forms. The `ns` is also attached to eval error frames, and `EvalOp` answers empty `code` with a no-op `done` frame carrying the `ns`: clients (CIDER's `cider-repl-init-code`) prime their initial prompt namespace from the first eval response on connect, whatever its outcome.
+- **The namespace is per session; definitions are not.** `SessionNamespaceBinder` owns both directions. `EvalOp`/`LoadFileOp` call `bind()` before evaluating, so the code compiles where *that* session left off rather than wherever another session last went; `EvalResultResponder` calls `sync()` afterwards to mirror the result back and fill the `ns` response field that drives editor prompts. Without the bind half, two editors on one server walk over each other: A evaluates `(ns foo)` and B's next form silently compiles in `foo` (#2906). The registry stays global, so a `def` in one session is still visible from the other — only the *current* namespace is isolated.
+- **"The current namespace" is two pieces of state**, and `bind()` writes both: the analyzer's `GlobalEnvironment::ns` (where code compiles, and what `sync()` reads back) and the runtime `phel.core/*ns*` var via `Phel::setVar`. Setting only the first leaves `*ns*` reporting the other session's namespace. `NamespaceLoader::restoreStartupNamespace()` writes the same pair.
+- The `ns` is also attached to eval error frames, and `EvalOp` answers empty `code` with a no-op `done` frame carrying the `ns`: clients (CIDER's `cider-repl-init-code`) prime their initial prompt namespace from the first eval response on connect, whatever its outcome. A failed or incomplete eval restores the evaluator's environment snapshot, so the session does not move.
 - `NreplSocketServer::run(int $maxIterations = 0)` bounds test runs; `0` = unbounded.
 - `NreplCommand` writes the bound port to `.nrepl-port` in the working directory (the Clojure-standard discovery file editors read) once the socket is listening, so `--port=0` records the real port. It is removed on every exit path: `finally` around `run()`, a `register_shutdown_function` backstop for fatal exits, and SIGINT/SIGTERM handlers that call `stop()` so the accept loop returns (no-op without ext-pcntl, i.e. on Windows). `NreplPortFile::delete()` only removes a file the same instance wrote, so a server that failed before writing never deletes the file another server is advertising.

--- a/src/php/Nrepl/NreplFactory.php
+++ b/src/php/Nrepl/NreplFactory.php
@@ -16,6 +16,7 @@ use Phel\Nrepl\Application\Op\LoadFileOp;
 use Phel\Nrepl\Application\Op\LookupOp;
 use Phel\Nrepl\Application\Op\ReloadOp;
 use Phel\Nrepl\Application\Op\RunTestsOp;
+use Phel\Nrepl\Application\Session\SessionNamespaceBinder;
 use Phel\Nrepl\Domain\Op\OpDispatcher;
 use Phel\Nrepl\Domain\Session\SessionRegistry;
 use Phel\Nrepl\Infrastructure\NreplPortFile;
@@ -57,13 +58,14 @@ final class NreplFactory extends AbstractFactory
     public function createOpDispatcher(): OpDispatcher
     {
         $sessions = $this->createSessionRegistry();
-        $responder = new EvalResultResponder($this->createPrinter(), $sessions, $this->getCompilerFacade());
+        $namespaceBinder = new SessionNamespaceBinder($this->getCompilerFacade(), $sessions);
+        $responder = new EvalResultResponder($this->createPrinter(), $namespaceBinder);
         $dispatcher = new OpDispatcher();
 
         $dispatcher->register(new CloneOp($sessions));
         $dispatcher->register(new CloseOp($sessions));
-        $dispatcher->register(new EvalOp($this->getRunFacade(), $responder));
-        $dispatcher->register(new LoadFileOp($this->getRunFacade(), $responder));
+        $dispatcher->register(new EvalOp($this->getRunFacade(), $responder, $namespaceBinder));
+        $dispatcher->register(new LoadFileOp($this->getRunFacade(), $responder, $namespaceBinder));
         $dispatcher->register(new ReloadOp($this->getRunFacade(), $responder));
         $dispatcher->register(new RunTestsOp($this->getRunFacade(), $responder));
         $dispatcher->register(new InterruptOp());

--- a/tests/php/Integration/Nrepl/NreplServerTest.php
+++ b/tests/php/Integration/Nrepl/NreplServerTest.php
@@ -231,6 +231,99 @@ final class NreplServerTest extends TestCase
         $server->stop();
     }
 
+    /**
+     * Two editors on one server. Evaluation runs in a single process-wide
+     * environment, so before #2906 client A's `(ns foo)` silently moved where
+     * client B's next form compiled, and B's prompt jumped namespace with
+     * nobody having asked.
+     *
+     * Definitions stay shared, which is the other half of the contract: the
+     * registry is global, so B still sees a `def` A made.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function test_two_sessions_keep_independent_namespaces(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Phel::clear();
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+
+        $facade = new NreplFacade();
+        $facade->loadPhelNamespaces();
+
+        $server = $facade->createSocketServer(0, '127.0.0.1');
+        $server->start();
+
+        $alice = $this->connect($server);
+        $bob = $this->connect($server);
+
+        $encoder = new BencodeEncoder();
+        $aliceDecoder = new BencodeStreamDecoder();
+        $bobDecoder = new BencodeStreamDecoder();
+
+        $this->writeMessage($alice, $encoder->encode(['op' => 'clone', 'id' => 'ca']));
+        $aliceSession = $this->readUntil($alice, $aliceDecoder, $server, 1)[0]['new-session'];
+
+        $this->writeMessage($bob, $encoder->encode(['op' => 'clone', 'id' => 'cb']));
+        $bobSession = $this->readUntil($bob, $bobDecoder, $server, 1)[0]['new-session'];
+
+        self::assertNotSame($aliceSession, $bobSession);
+
+        // Alice moves to her own namespace and defines something there.
+        $this->writeMessage($alice, $encoder->encode([
+            'op' => 'eval',
+            'id' => 'a1',
+            'session' => $aliceSession,
+            'code' => '(ns alice.scratch) (def shared 42)',
+        ]));
+        $aliceNs = $this->firstWithKey($this->readUntil($alice, $aliceDecoder, $server, 2), 'value');
+        self::assertNotNull($aliceNs);
+        self::assertSame('alice.scratch', $aliceNs['ns']);
+
+        // Bob never asked to leave `user`, so his eval must still land there.
+        $this->writeMessage($bob, $encoder->encode([
+            'op' => 'eval',
+            'id' => 'b1',
+            'session' => $bobSession,
+            'code' => '*ns*',
+        ]));
+        $bobNs = $this->firstWithKey($this->readUntil($bob, $bobDecoder, $server, 2), 'value');
+        self::assertNotNull($bobNs);
+        self::assertSame('user', $bobNs['ns'], "Alice's (ns ...) must not move Bob's session");
+        self::assertSame('"user"', $bobNs['value']);
+
+        // Definitions are global, so Bob resolves Alice's `def` by its
+        // qualified name even though he is in a different namespace.
+        $this->writeMessage($bob, $encoder->encode([
+            'op' => 'eval',
+            'id' => 'b2',
+            'session' => $bobSession,
+            'code' => 'alice.scratch/shared',
+        ]));
+        $bobRead = $this->firstWithKey($this->readUntil($bob, $bobDecoder, $server, 2), 'value');
+        self::assertNotNull($bobRead);
+        self::assertSame('42', $bobRead['value']);
+        self::assertSame('user', $bobRead['ns']);
+
+        // Alice is still where she left off, after Bob's two evals ran in
+        // `user` in between.
+        $this->writeMessage($alice, $encoder->encode([
+            'op' => 'eval',
+            'id' => 'a2',
+            'session' => $aliceSession,
+            'code' => '*ns*',
+        ]));
+        $aliceAgain = $this->firstWithKey($this->readUntil($alice, $aliceDecoder, $server, 2), 'value');
+        self::assertNotNull($aliceAgain);
+        self::assertSame('alice.scratch', $aliceAgain['ns']);
+        self::assertSame('"alice.scratch"', $aliceAgain['value']);
+
+        fclose($alice);
+        fclose($bob);
+        $server->stop();
+    }
+
     #[RunInSeparateProcess]
     #[PreserveGlobalState(false)]
     public function test_it_returns_lookup_info_for_session_defined_symbols(): void
@@ -507,8 +600,27 @@ final class NreplServerTest extends TestCase
     }
 
     /**
-     * @param resource $client
+     * @return resource
      */
+    private function connect(NreplSocketServer $server)
+    {
+        $client = @stream_socket_client(
+            sprintf('tcp://127.0.0.1:%d', $server->port()),
+            $errno,
+            $errstr,
+            2.0,
+        );
+        if ($client === false) {
+            $server->stop();
+            self::fail(sprintf('Could not connect to server: %s', $errstr));
+        }
+
+        stream_set_blocking($client, false);
+        stream_set_timeout($client, 2);
+
+        return $client;
+    }
+
     private function writeMessage($client, string $message): void
     {
         $written = 0;

--- a/tests/php/Unit/Nrepl/Application/Op/EvalResultResponderTest.php
+++ b/tests/php/Unit/Nrepl/Application/Op/EvalResultResponderTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Unit\Nrepl\Application\Op;
 
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
 use Phel\Nrepl\Application\Op\EvalResultResponder;
+use Phel\Nrepl\Application\Session\SessionNamespaceBinder;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Session\SessionRegistry;
 use Phel\Shared\Eval\EvalError;
@@ -20,7 +21,7 @@ final class EvalResultResponderTest extends TestCase
     {
         $registry = new SessionRegistry();
         $session = $registry->create();
-        $responder = new EvalResultResponder($this->printerReturning('42'), $registry, $this->uninitializedCompiler());
+        $responder = new EvalResultResponder($this->printerReturning('42'), new SessionNamespaceBinder($this->uninitializedCompiler(), $registry));
 
         $responses = $responder->respond(
             new OpRequest('eval', 'req-1', $session->id, []),
@@ -39,7 +40,7 @@ final class EvalResultResponderTest extends TestCase
     {
         $registry = new SessionRegistry();
         $session = $registry->create();
-        $responder = new EvalResultResponder($this->printerReturning('nil'), $registry, $this->compilerInNamespace('foo.bar'));
+        $responder = new EvalResultResponder($this->printerReturning('nil'), new SessionNamespaceBinder($this->compilerInNamespace('foo.bar'), $registry));
 
         $responses = $responder->respond(
             new OpRequest('eval', 'req-1', $session->id, []),
@@ -55,7 +56,7 @@ final class EvalResultResponderTest extends TestCase
     {
         $registry = new SessionRegistry();
         $session = $registry->create();
-        $responder = new EvalResultResponder($this->printerReturning('nil'), $registry, $this->compilerInNamespace('foo\\bar-baz'));
+        $responder = new EvalResultResponder($this->printerReturning('nil'), new SessionNamespaceBinder($this->compilerInNamespace('foo\\bar-baz'), $registry));
 
         $responses = $responder->respond(
             new OpRequest('eval', 'req-1', $session->id, []),
@@ -70,7 +71,7 @@ final class EvalResultResponderTest extends TestCase
     {
         $registry = new SessionRegistry();
         $session = $registry->create();
-        $responder = new EvalResultResponder($this->printerReturning('nil'), $registry, $this->uninitializedCompiler());
+        $responder = new EvalResultResponder($this->printerReturning('nil'), new SessionNamespaceBinder($this->uninitializedCompiler(), $registry));
 
         $responses = $responder->respond(
             new OpRequest('eval', 'req-1', $session->id, []),
@@ -88,7 +89,7 @@ final class EvalResultResponderTest extends TestCase
         $session = $registry->create();
         $session->setNamespace('foo');
 
-        $responder = new EvalResultResponder($this->printerReturning('nil'), $registry, $this->compilerInNamespace(''));
+        $responder = new EvalResultResponder($this->printerReturning('nil'), new SessionNamespaceBinder($this->compilerInNamespace(''), $registry));
 
         $responses = $responder->respond(
             new OpRequest('eval', 'req-1', $session->id, []),
@@ -102,7 +103,7 @@ final class EvalResultResponderTest extends TestCase
 
     public function test_success_uses_user_namespace_when_session_missing(): void
     {
-        $responder = new EvalResultResponder($this->printerReturning('nil'), new SessionRegistry(), $this->uninitializedCompiler());
+        $responder = new EvalResultResponder($this->printerReturning('nil'), new SessionNamespaceBinder($this->uninitializedCompiler(), new SessionRegistry()));
 
         $responses = $responder->respond(
             new OpRequest('eval', null, null, []),
@@ -120,7 +121,7 @@ final class EvalResultResponderTest extends TestCase
 
         $registry = new SessionRegistry();
         $session = $registry->create();
-        $responder = new EvalResultResponder($printer, $registry, $this->uninitializedCompiler());
+        $responder = new EvalResultResponder($printer, new SessionNamespaceBinder($this->uninitializedCompiler(), $registry));
 
         $responder->respond(new OpRequest('eval', 'r1', $session->id, []), EvalResult::success(1), 'fallback');
         $responder->respond(new OpRequest('eval', 'r2', $session->id, []), EvalResult::success(2), 'fallback');
@@ -135,7 +136,7 @@ final class EvalResultResponderTest extends TestCase
 
     public function test_no_history_keys_without_a_session(): void
     {
-        $responder = new EvalResultResponder($this->printerReturning('nil'), new SessionRegistry(), $this->uninitializedCompiler());
+        $responder = new EvalResultResponder($this->printerReturning('nil'), new SessionNamespaceBinder($this->uninitializedCompiler(), new SessionRegistry()));
 
         $responses = $responder->respond(
             new OpRequest('eval', null, null, []),
@@ -148,7 +149,7 @@ final class EvalResultResponderTest extends TestCase
 
     public function test_success_prepends_out_frame_when_output_present(): void
     {
-        $responder = new EvalResultResponder($this->printerReturning('nil'), new SessionRegistry(), $this->uninitializedCompiler());
+        $responder = new EvalResultResponder($this->printerReturning('nil'), new SessionNamespaceBinder($this->uninitializedCompiler(), new SessionRegistry()));
 
         $responses = $responder->respond(
             new OpRequest('eval', null, null, []),
@@ -164,8 +165,7 @@ final class EvalResultResponderTest extends TestCase
     {
         $responder = new EvalResultResponder(
             $this->createStub(PrinterInterface::class),
-            new SessionRegistry(),
-            $this->uninitializedCompiler(),
+            new SessionNamespaceBinder($this->uninitializedCompiler(), new SessionRegistry()),
         );
 
         $responses = $responder->respond(
@@ -185,8 +185,7 @@ final class EvalResultResponderTest extends TestCase
         $session = $registry->create();
         $responder = new EvalResultResponder(
             $this->createStub(PrinterInterface::class),
-            $registry,
-            $this->compilerInNamespace('foo.bar'),
+            new SessionNamespaceBinder($this->compilerInNamespace('foo.bar'), $registry),
         );
 
         $responses = $responder->respond(
@@ -208,8 +207,7 @@ final class EvalResultResponderTest extends TestCase
     {
         $responder = new EvalResultResponder(
             $this->createStub(PrinterInterface::class),
-            new SessionRegistry(),
-            $this->uninitializedCompiler(),
+            new SessionNamespaceBinder($this->uninitializedCompiler(), new SessionRegistry()),
         );
 
         $responses = $responder->respond(
@@ -230,8 +228,7 @@ final class EvalResultResponderTest extends TestCase
         $session = $registry->create();
         $responder = new EvalResultResponder(
             $this->createStub(PrinterInterface::class),
-            $registry,
-            $this->compilerInNamespace('foo'),
+            new SessionNamespaceBinder($this->compilerInNamespace('foo'), $registry),
         );
 
         $responses = $responder->respond(
@@ -252,8 +249,7 @@ final class EvalResultResponderTest extends TestCase
 
         $responder = new EvalResultResponder(
             $this->createStub(PrinterInterface::class),
-            $registry,
-            $this->uninitializedCompiler(),
+            new SessionNamespaceBinder($this->uninitializedCompiler(), $registry),
         );
 
         $responses = $responder->respondEmptyCode(new OpRequest('eval', 'req-1', $session->id, []));
@@ -270,8 +266,7 @@ final class EvalResultResponderTest extends TestCase
 
         $responder = new EvalResultResponder(
             $this->createStub(PrinterInterface::class),
-            $registry,
-            $this->compilerInNamespace('foo.bar'),
+            new SessionNamespaceBinder($this->compilerInNamespace('foo.bar'), $registry),
         );
 
         $responses = $responder->respondEmptyCode(new OpRequest('eval', 'req-1', $session->id, []));
@@ -284,8 +279,7 @@ final class EvalResultResponderTest extends TestCase
     {
         $responder = new EvalResultResponder(
             $this->createStub(PrinterInterface::class),
-            new SessionRegistry(),
-            $this->uninitializedCompiler(),
+            new SessionNamespaceBinder($this->uninitializedCompiler(), new SessionRegistry()),
         );
 
         $responses = $responder->respondEmptyCode(new OpRequest('eval', 'req-1', null, []));
@@ -297,8 +291,7 @@ final class EvalResultResponderTest extends TestCase
     {
         $responder = new EvalResultResponder(
             $this->createStub(PrinterInterface::class),
-            new SessionRegistry(),
-            $this->uninitializedCompiler(),
+            new SessionNamespaceBinder($this->uninitializedCompiler(), new SessionRegistry()),
         );
 
         $responses = $responder->respond(
@@ -317,8 +310,7 @@ final class EvalResultResponderTest extends TestCase
     {
         $responder = new EvalResultResponder(
             $this->createStub(PrinterInterface::class),
-            new SessionRegistry(),
-            $this->uninitializedCompiler(),
+            new SessionNamespaceBinder($this->uninitializedCompiler(), new SessionRegistry()),
         );
 
         // An explicit "non-success, non-incomplete, no error" case (defensive);

--- a/tests/php/Unit/Nrepl/Application/Session/SessionNamespaceBinderTest.php
+++ b/tests/php/Unit/Nrepl/Application/Session/SessionNamespaceBinderTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Application\Session;
+
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
+use Phel\Nrepl\Application\Session\SessionNamespaceBinder;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Session\Session;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class SessionNamespaceBinderTest extends TestCase
+{
+    public function test_bind_points_the_environment_at_the_session_namespace(): void
+    {
+        $sessions = new SessionRegistry();
+        $session = $sessions->create();
+        $session->setNamespace('alice.scratch');
+
+        $env = $this->createMock(GlobalEnvironmentInterface::class);
+        $env->expects(self::once())->method('setNs')->with('alice.scratch');
+
+        new SessionNamespaceBinder($this->compilerWith($env), $sessions)
+            ->bind($this->request($session->id));
+    }
+
+    /**
+     * A session-less request has no namespace of its own, so the only sensible
+     * ambient namespace is the one already in place. Moving it would be
+     * inventing state the client never asked for.
+     */
+    public function test_bind_leaves_a_session_less_request_alone(): void
+    {
+        $env = $this->createMock(GlobalEnvironmentInterface::class);
+        $env->expects(self::never())->method('setNs');
+
+        new SessionNamespaceBinder($this->compilerWith($env), new SessionRegistry())
+            ->bind($this->request(null));
+    }
+
+    public function test_bind_ignores_a_session_id_that_no_longer_exists(): void
+    {
+        $env = $this->createMock(GlobalEnvironmentInterface::class);
+        $env->expects(self::never())->method('setNs');
+
+        new SessionNamespaceBinder($this->compilerWith($env), new SessionRegistry())
+            ->bind($this->request('closed-session'));
+    }
+
+    public function test_bind_is_a_no_op_before_the_global_environment_exists(): void
+    {
+        $sessions = new SessionRegistry();
+        $session = $sessions->create();
+
+        $compiler = $this->createMock(CompilerFacadeInterface::class);
+        $compiler->method('isGlobalEnvironmentInitialized')->willReturn(false);
+        $compiler->expects(self::never())->method('getGlobalEnvironment');
+
+        new SessionNamespaceBinder($compiler, $sessions)->bind($this->request($session->id));
+    }
+
+    public function test_sync_records_the_post_eval_namespace_on_the_session(): void
+    {
+        $sessions = new SessionRegistry();
+        $session = $sessions->create();
+
+        $ns = new SessionNamespaceBinder($this->compilerInNamespace('foo.bar'), $sessions)->sync($session);
+
+        self::assertSame('foo.bar', $ns);
+        self::assertSame('foo.bar', $session->namespace());
+    }
+
+    /**
+     * The analyzer stores a namespace in whatever separator form it was written
+     * with; clients get the canonical dot form.
+     */
+    public function test_sync_reports_the_display_form_of_the_namespace(): void
+    {
+        $sessions = new SessionRegistry();
+        $session = $sessions->create();
+
+        $ns = new SessionNamespaceBinder($this->compilerInNamespace('foo\\bar-baz'), $sessions)->sync($session);
+
+        self::assertSame('foo.bar-baz', $ns);
+    }
+
+    public function test_sync_falls_back_to_the_session_namespace_when_the_environment_reports_nothing(): void
+    {
+        $sessions = new SessionRegistry();
+        $session = $sessions->create();
+        $session->setNamespace('kept.ns');
+
+        $ns = new SessionNamespaceBinder($this->compilerInNamespace(''), $sessions)->sync($session);
+
+        self::assertSame('kept.ns', $ns);
+    }
+
+    public function test_sync_without_a_session_falls_back_to_the_default_namespace(): void
+    {
+        $compiler = $this->createStub(CompilerFacadeInterface::class);
+
+        $ns = new SessionNamespaceBinder($compiler, new SessionRegistry())->sync(null);
+
+        self::assertSame(Session::DEFAULT_NAMESPACE, $ns);
+    }
+
+    private function request(?string $session): OpRequest
+    {
+        return new OpRequest('eval', 'r1', $session, ['op' => 'eval']);
+    }
+
+    private function compilerWith(GlobalEnvironmentInterface $env): CompilerFacadeInterface
+    {
+        $compiler = $this->createStub(CompilerFacadeInterface::class);
+        $compiler->method('isGlobalEnvironmentInitialized')->willReturn(true);
+        $compiler->method('getGlobalEnvironment')->willReturn($env);
+
+        return $compiler;
+    }
+
+    private function compilerInNamespace(string $ns): CompilerFacadeInterface
+    {
+        $env = $this->createStub(GlobalEnvironmentInterface::class);
+        $env->method('getNs')->willReturn($ns);
+
+        return $this->compilerWith($env);
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Op/EvalOpTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/EvalOpTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Unit\Nrepl\Domain\Op;
 
 use Phel\Nrepl\Application\Op\EvalOp;
 use Phel\Nrepl\Application\Op\EvalResultResponder;
+use Phel\Nrepl\Application\Session\SessionNamespaceBinder;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Session\SessionRegistry;
 use Phel\Shared\CompileOptions;
@@ -29,7 +30,7 @@ final class EvalOpTest extends TestCase
         $registry = new SessionRegistry();
         $session = $registry->create();
 
-        $op = new EvalOp($run, $this->responder($printer, $registry));
+        $op = $this->evalOp($run, $printer, $registry);
         $responses = $op->handle(new OpRequest('eval', 'r1', $session->id, [
             'op' => 'eval',
             'code' => '(+ 1 2)',
@@ -52,7 +53,7 @@ final class EvalOpTest extends TestCase
         $printer->method('print')->willReturn('nil');
 
         $registry = new SessionRegistry();
-        $op = new EvalOp($run, $this->responder($printer, $registry));
+        $op = $this->evalOp($run, $printer, $registry);
         $responses = $op->handle(new OpRequest('eval', 'r1', null, [
             'op' => 'eval',
             'code' => '(println "x")',
@@ -87,7 +88,7 @@ final class EvalOpTest extends TestCase
         $printer = $this->createStub(PrinterInterface::class);
 
         $registry = new SessionRegistry();
-        $op = new EvalOp($run, $this->responder($printer, $registry));
+        $op = $this->evalOp($run, $printer, $registry);
         $responses = $op->handle(new OpRequest('eval', 'r1', null, [
             'op' => 'eval',
             'code' => 'xx',
@@ -108,7 +109,7 @@ final class EvalOpTest extends TestCase
         $run->method('structuredEval')->willReturn(EvalResult::incomplete());
 
         $registry = new SessionRegistry();
-        $op = new EvalOp($run, $this->responder(registry: $registry));
+        $op = $this->evalOp($run, registry: $registry);
         $responses = $op->handle(new OpRequest('eval', 'r1', null, [
             'op' => 'eval',
             'code' => '(+ 1',
@@ -123,7 +124,7 @@ final class EvalOpTest extends TestCase
         $run = $this->createStub(RunFacadeInterface::class);
         $run->method('structuredEval')->willReturn(EvalResult::incomplete());
 
-        $op = new EvalOp($run, $this->responder());
+        $op = $this->evalOp($run);
         $responses = $op->handle(new OpRequest('eval', 'r1', null, [
             'op' => 'eval',
             'code' => '(+ 1',
@@ -134,10 +135,7 @@ final class EvalOpTest extends TestCase
 
     public function test_it_rejects_missing_code_param(): void
     {
-        $op = new EvalOp(
-            $this->createStub(RunFacadeInterface::class),
-            $this->responder(),
-        );
+        $op = $this->evalOp($this->createStub(RunFacadeInterface::class));
         $responses = $op->handle(new OpRequest('eval', 'r1', null, ['op' => 'eval']));
 
         self::assertContains('no-code', $responses[0]->payload['status']);
@@ -149,7 +147,7 @@ final class EvalOpTest extends TestCase
         $run = $this->createMock(RunFacadeInterface::class);
         $run->expects(self::never())->method('structuredEval');
 
-        $op = new EvalOp($run, $this->responder());
+        $op = $this->evalOp($run);
         $responses = $op->handle(new OpRequest('eval', 'r1', null, ['op' => 'eval', 'code' => 42]));
 
         self::assertContains('no-code', $responses[0]->payload['status']);
@@ -163,7 +161,7 @@ final class EvalOpTest extends TestCase
         $registry = new SessionRegistry();
         $session = $registry->create();
 
-        $op = new EvalOp($run, $this->responder(registry: $registry));
+        $op = $this->evalOp($run, registry: $registry);
         $responses = $op->handle(new OpRequest('eval', 'r1', $session->id, [
             'op' => 'eval',
             'code' => '',
@@ -180,7 +178,7 @@ final class EvalOpTest extends TestCase
         $run = $this->createMock(RunFacadeInterface::class);
         $run->expects(self::never())->method('structuredEval');
 
-        $op = new EvalOp($run, $this->responder());
+        $op = $this->evalOp($run);
         $responses = $op->handle(new OpRequest('eval', 'r1', null, [
             'op' => 'eval',
             'code' => "  \n ",
@@ -201,21 +199,33 @@ final class EvalOpTest extends TestCase
         $printer = $this->createStub(PrinterInterface::class);
         $printer->method('print')->willReturn('3');
 
-        $op = new EvalOp($run, $this->responder($printer));
+        $op = $this->evalOp($run, $printer);
         $op->handle(new OpRequest('eval', 'r1', null, ['op' => 'eval', 'code' => '(+ 1 2)']));
     }
 
     /**
+     * The op and its responder share one namespace binder, as they do in
+     * production: the op binds the session's namespace before evaluating and
+     * the responder reads the result back out of the same place.
+     *
      * The responder is exercised on its own in `EvalResultResponderTest`; here
-     * it only has to translate results, so its compiler facade stays a stub
-     * with no global environment (namespaces fall back to `user`).
+     * it only has to translate results, so the binder's compiler facade stays
+     * a stub with no global environment (namespaces fall back to `user`).
      */
-    private function responder(?PrinterInterface $printer = null, ?SessionRegistry $registry = null): EvalResultResponder
-    {
-        return new EvalResultResponder(
-            $printer ?? $this->createStub(PrinterInterface::class),
-            $registry ?? new SessionRegistry(),
+    private function evalOp(
+        RunFacadeInterface $run,
+        ?PrinterInterface $printer = null,
+        ?SessionRegistry $registry = null,
+    ): EvalOp {
+        $binder = new SessionNamespaceBinder(
             $this->createStub(CompilerFacadeInterface::class),
+            $registry ?? new SessionRegistry(),
+        );
+
+        return new EvalOp(
+            $run,
+            new EvalResultResponder($printer ?? $this->createStub(PrinterInterface::class), $binder),
+            $binder,
         );
     }
 }

--- a/tests/php/Unit/Nrepl/Domain/Op/LoadFileOpTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/LoadFileOpTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Unit\Nrepl\Domain\Op;
 
 use Phel\Nrepl\Application\Op\EvalResultResponder;
 use Phel\Nrepl\Application\Op\LoadFileOp;
+use Phel\Nrepl\Application\Session\SessionNamespaceBinder;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Session\SessionRegistry;
 use Phel\Shared\Eval\EvalError;
@@ -25,7 +26,7 @@ final class LoadFileOpTest extends TestCase
         $printer = $this->createStub(PrinterInterface::class);
         $printer->method('print')->willReturn('42');
 
-        $op = new LoadFileOp($run, $this->responder($printer));
+        $op = $this->loadFileOp($run, $printer);
         $responses = $op->handle(new OpRequest('load-file', 'r1', null, [
             'op' => 'load-file',
             'file' => '(def x 42) x',
@@ -39,10 +40,7 @@ final class LoadFileOpTest extends TestCase
 
     public function test_it_rejects_missing_file_param(): void
     {
-        $op = new LoadFileOp(
-            $this->createStub(RunFacadeInterface::class),
-            $this->responder(),
-        );
+        $op = $this->loadFileOp($this->createStub(RunFacadeInterface::class));
         $responses = $op->handle(new OpRequest('load-file', 'r1', null, ['op' => 'load-file']));
 
         self::assertContains('load-file-error', $responses[0]->payload['status']);
@@ -50,10 +48,7 @@ final class LoadFileOpTest extends TestCase
 
     public function test_op_name_is_load_file(): void
     {
-        $op = new LoadFileOp(
-            $this->createStub(RunFacadeInterface::class),
-            $this->responder(),
-        );
+        $op = $this->loadFileOp($this->createStub(RunFacadeInterface::class));
         self::assertSame('load-file', $op->name());
     }
 
@@ -77,10 +72,7 @@ final class LoadFileOpTest extends TestCase
         $run = $this->createStub(RunFacadeInterface::class);
         $run->method('structuredEval')->willReturn(EvalResult::failure($error));
 
-        $op = new LoadFileOp(
-            $run,
-            $this->responder(),
-        );
+        $op = $this->loadFileOp($run);
         $responses = $op->handle(new OpRequest('load-file', 'r1', null, [
             'op' => 'load-file',
             'file' => '(broken form)',
@@ -94,16 +86,25 @@ final class LoadFileOpTest extends TestCase
     }
 
     /**
+     * The op and its responder share one namespace binder, as they do in
+     * production: the op binds the session's namespace before evaluating and
+     * the responder reads the result back out of the same place.
+     *
      * The responder is exercised on its own in `EvalResultResponderTest`; here
-     * it only has to translate results, so its compiler facade stays a stub
-     * with no global environment (namespaces fall back to `user`).
+     * it only has to translate results, so the binder's compiler facade stays
+     * a stub with no global environment (namespaces fall back to `user`).
      */
-    private function responder(?PrinterInterface $printer = null): EvalResultResponder
+    private function loadFileOp(RunFacadeInterface $run, ?PrinterInterface $printer = null): LoadFileOp
     {
-        return new EvalResultResponder(
-            $printer ?? $this->createStub(PrinterInterface::class),
-            new SessionRegistry(),
+        $binder = new SessionNamespaceBinder(
             $this->createStub(CompilerFacadeInterface::class),
+            new SessionRegistry(),
+        );
+
+        return new LoadFileOp(
+            $run,
+            new EvalResultResponder($printer ?? $this->createStub(PrinterInterface::class), $binder),
+            $binder,
         );
     }
 }


### PR DESCRIPTION
## 🤔 Background

nREPL sessions carry an id, a namespace and a 3-deep value ring, but evaluation itself
runs in one process-wide `GlobalEnvironment` that every session shares. Nothing pushed a
session's namespace into that environment before an eval, and since #2895 every session
reads its `ns` back out of it.

With two editors on one server:

1. Client A evaluates `(ns foo)`. The global environment moves to `foo`.
2. Client B evaluates anything at all. Its code compiles in `foo`, its response reports
   `ns foo`, and its prompt jumps namespace with nobody having asked.

Not a regression from #2895 — evaluation was always shared, and B's code always ran in
whatever namespace A had left behind. #2895 only made it visible. `*1`/`*2`/`*3` were
already per-session, which made the namespace the odd one out.

## 💡 Goal

Isolate it, as reference nREPL does by binding `*ns*` per session.

**Definitions stay shared.** The registry is global, so a `def` in one session is still
visible from the other; only the *current* namespace becomes per session. The test
asserts both halves.

## 🔖 Changes

### `SessionNamespaceBinder`

New in `Application/Session/`, owning both directions of the one piece of evaluation
state a session keeps:

- `bind(OpRequest)` — point the shared environment at the session's namespace before
  evaluating. Called by `EvalOp` and `LoadFileOp`.
- `sync(?Session)` — mirror the post-eval namespace back and return it for the `ns`
  response field. Moved here from `EvalResultResponder`, which now delegates.

A session-less request is deliberately left alone: it has no namespace of its own, so
the only sensible ambient namespace is the one already in place. The bound namespace can
only ever be one this process created — a session starts at `user` and moves only by
evaluating an `ns`/`in-ns` form — so this never points the environment at something that
does not exist.

`reload` and `run-tests` are left unbound: both take an explicit namespace and do not
depend on the ambient one.

### "The current namespace" is two pieces of state

The part worth writing down. Binding `GlobalEnvironment::ns` alone was not enough:

- `GlobalEnvironment::ns` decides where code **compiles** (and is what `sync()` reads
  back), while
- the runtime `phel.core/*ns*` var is what `*ns*` **evaluates to**.

With only the first bound, the integration test compiled `*ns*` in the right namespace
and got the *other session's* name back as its value. `bind()` now writes both, the same
pair `NamespaceLoader::restoreStartupNamespace()` writes.

### Tests

- `NreplServerTest::test_two_sessions_keep_independent_namespaces` — two live sockets,
  two sessions. Alice does `(ns alice.scratch)` and a `def`; Bob's next eval must still
  report and evaluate in `user`, must still resolve `alice.scratch/shared` (definitions
  are shared), and Alice must still be in `alice.scratch` afterwards. This test fails on
  `main` and failed again mid-implementation on the `*ns*` half, which is how that was
  caught.
- `SessionNamespaceBinderTest` — 8 unit cases: the bind write, the session-less and
  unknown-session no-ops, the uninitialized-environment no-op, and the four sync paths
  moved over from the responder.
- The `EvalOp`/`LoadFileOp` unit tests now build the op and its responder from **one**
  shared binder, as production does, instead of constructing the responder alone.

`Nrepl/CLAUDE.md` records the isolation rule and the two-pieces-of-state gotcha.

## ✅ Verified

`unit` 4444 ✓ · `integration` 1153 ✓ · `test-core` 6586 ✓ · cs-fixer, rector, psalm ✓

Closes #2906
