### PR TITLE
ref: scaffolds and agent docs use the dot namespace separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `phel init` scaffolds projects with the dot namespace separator (`my-app.main`) instead of the deprecated backslash. The three bundled example apps, the task recipes installed as `.agents/`, and the `--template=` scaffolds they back were all still written with `\`, so an agent reading them or a project generated from them started out on syntax the compiler warns about (#2827)
 - nREPL sessions each keep their own namespace, as reference nREPL does. Two editors on one server no longer walk over each other: client A evaluating `(ns foo)` used to move where client B's next form compiled, and B's prompt jumped namespace with nobody having asked. Definitions stay shared, since the registry is global; only the current namespace is per session (#2906)
 - A namespace's own `def`/`defn` beats a `:refer` of the same name, and redefining a referred name warns instead of silently keeping the refer. A recursive self-call used to resolve to the refer and never recurse; at the prompt, `(def doc 1)` then `doc` printed `<function:doc>` (#2897)
 - A `(:require ...)` resolving to no source file fails at the require, naming both namespaces, instead of loading nothing silently and surfacing as `Cannot resolve symbol` lines later (#2891, #2886)

--- a/resources/agents/examples/cli-wordcount/bin/wordcount
+++ b/resources/agents/examples/cli-wordcount/bin/wordcount
@@ -3,4 +3,4 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-\Phel::run(__DIR__ . '/..', 'cli-wordcount\\main', array_slice($argv, 1));
+\Phel::run(__DIR__ . '/..', 'cli-wordcount.main', array_slice($argv, 1));

--- a/resources/agents/examples/cli-wordcount/src/counts.phel
+++ b/resources/agents/examples/cli-wordcount/src/counts.phel
@@ -1,5 +1,5 @@
-(ns cli-wordcount\counts
-  (:require phel\string :as str))
+(ns cli-wordcount.counts
+  (:require phel.string :as str))
 
 (defn count-text [text]
   {:lines (if (php/empty text) 0 (count (str/split text #"\n")))

--- a/resources/agents/examples/cli-wordcount/src/main.phel
+++ b/resources/agents/examples/cli-wordcount/src/main.phel
@@ -1,5 +1,5 @@
-(ns cli-wordcount\main
-  (:require cli-wordcount\counts :as c))
+(ns cli-wordcount.main
+  (:require cli-wordcount.counts :as c))
 
 (defn- read-stdin []
   (let [h (php/fopen "php://stdin" "r")]

--- a/resources/agents/examples/cli-wordcount/tests/counts_test.phel
+++ b/resources/agents/examples/cli-wordcount/tests/counts_test.phel
@@ -1,6 +1,6 @@
-(ns tests\counts-test
-  (:require phel\test :refer [deftest is])
-  (:require cli-wordcount\counts :as c))
+(ns tests.counts-test
+  (:require phel.test :refer [deftest is])
+  (:require cli-wordcount.counts :as c))
 
 (deftest counts-empty
   (let [r (c/count-text "")]

--- a/resources/agents/examples/http-json-api/public/index.php
+++ b/resources/agents/examples/http-json-api/public/index.php
@@ -2,4 +2,4 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-\Phel::run(__DIR__ . '/..', 'http-json-api\\entry');
+\Phel::run(__DIR__ . '/..', 'http-json-api.entry');

--- a/resources/agents/examples/http-json-api/src/entry.phel
+++ b/resources/agents/examples/http-json-api/src/entry.phel
@@ -1,6 +1,6 @@
-(ns http-json-api\entry
-  (:require phel\http :as h)
-  (:require http-json-api\routes :refer [app-handler]))
+(ns http-json-api.entry
+  (:require phel.http :as h)
+  (:require http-json-api.routes :refer [app-handler]))
 
 (when-not *build-mode*
   (-> (h/request-from-globals)

--- a/resources/agents/examples/http-json-api/src/handlers.phel
+++ b/resources/agents/examples/http-json-api/src/handlers.phel
@@ -1,5 +1,5 @@
-(ns http-json-api\handlers
-  (:require phel\http :as h))
+(ns http-json-api.handlers
+  (:require phel.http :as h))
 
 (defn health [_request]
   (h/json-response 200 {:status "ok" :ts (php/time)}))

--- a/resources/agents/examples/http-json-api/src/main.phel
+++ b/resources/agents/examples/http-json-api/src/main.phel
@@ -1,2 +1,2 @@
-(ns http-json-api\main
-  (:require http-json-api\routes))
+(ns http-json-api.main
+  (:require http-json-api.routes))

--- a/resources/agents/examples/http-json-api/src/routes.phel
+++ b/resources/agents/examples/http-json-api/src/routes.phel
@@ -1,6 +1,6 @@
-(ns http-json-api\routes
-  (:require phel\router :as r)
-  (:require http-json-api\handlers :as h))
+(ns http-json-api.routes
+  (:require phel.router :as r)
+  (:require http-json-api.handlers :as h))
 
 (def app-router
   (r/router

--- a/resources/agents/examples/http-json-api/tests/handlers_test.phel
+++ b/resources/agents/examples/http-json-api/tests/handlers_test.phel
@@ -1,8 +1,8 @@
-(ns tests\handlers-test
-  (:require phel\test :refer [deftest is])
-  (:require phel\http :as h)
-  (:require phel\json :as json)
-  (:require http-json-api\handlers :as hdl))
+(ns tests.handlers-test
+  (:require phel.test :refer [deftest is])
+  (:require phel.http :as h)
+  (:require phel.json :as json)
+  (:require http-json-api.handlers :as hdl))
 
 (defn- body-of [resp] (json/decode (get resp :body)))
 

--- a/resources/agents/examples/todo-app/public/index.php
+++ b/resources/agents/examples/todo-app/public/index.php
@@ -2,4 +2,4 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-\Phel::run(__DIR__ . '/..', 'todo-app\\entry');
+\Phel::run(__DIR__ . '/..', 'todo-app.entry');

--- a/resources/agents/examples/todo-app/src/entry.phel
+++ b/resources/agents/examples/todo-app/src/entry.phel
@@ -1,6 +1,6 @@
-(ns todo-app\entry
-  (:require phel\http :as h)
-  (:require todo-app\routes :refer [app-handler]))
+(ns todo-app.entry
+  (:require phel.http :as h)
+  (:require todo-app.routes :refer [app-handler]))
 
 (when-not *build-mode*
   (-> (h/request-from-globals)

--- a/resources/agents/examples/todo-app/src/handlers.phel
+++ b/resources/agents/examples/todo-app/src/handlers.phel
@@ -1,7 +1,7 @@
-(ns todo-app\handlers
-  (:require phel\http :as h)
-  (:require phel\json :as json)
-  (:require todo-app\store :as s))
+(ns todo-app.handlers
+  (:require phel.http :as h)
+  (:require phel.json :as json)
+  (:require todo-app.store :as s))
 
 (defn- json-response [status data]
   (h/response-from-map

--- a/resources/agents/examples/todo-app/src/main.phel
+++ b/resources/agents/examples/todo-app/src/main.phel
@@ -1,2 +1,2 @@
-(ns todo-app\main
-  (:require todo-app\routes))
+(ns todo-app.main
+  (:require todo-app.routes))

--- a/resources/agents/examples/todo-app/src/routes.phel
+++ b/resources/agents/examples/todo-app/src/routes.phel
@@ -1,6 +1,6 @@
-(ns todo-app\routes
-  (:require phel\router :as r)
-  (:require todo-app\handlers :as h))
+(ns todo-app.routes
+  (:require phel.router :as r)
+  (:require todo-app.handlers :as h))
 
 (defn- logging-mw [handler request]
   (let [response (handler request)]

--- a/resources/agents/examples/todo-app/src/store.phel
+++ b/resources/agents/examples/todo-app/src/store.phel
@@ -1,4 +1,4 @@
-(ns todo-app\store)
+(ns todo-app.store)
 
 (def store (atom {:next 1 :items {}}))
 

--- a/resources/agents/examples/todo-app/tests/handlers_test.phel
+++ b/resources/agents/examples/todo-app/tests/handlers_test.phel
@@ -1,9 +1,9 @@
-(ns tests\handlers-test
-  (:require phel\test :refer [deftest is use-fixtures])
-  (:require phel\http :as h)
-  (:require phel\json :as json)
-  (:require todo-app\store :as s)
-  (:require todo-app\handlers :as hdl))
+(ns tests.handlers-test
+  (:require phel.test :refer [deftest is use-fixtures])
+  (:require phel.http :as h)
+  (:require phel.json :as json)
+  (:require todo-app.store :as s)
+  (:require todo-app.handlers :as hdl))
 
 (use-fixtures :each
   (fn [t]

--- a/resources/agents/examples/todo-app/tests/store_test.phel
+++ b/resources/agents/examples/todo-app/tests/store_test.phel
@@ -1,6 +1,6 @@
-(ns tests\store-test
-  (:require phel\test :refer [deftest is use-fixtures])
-  (:require todo-app\store :as s))
+(ns tests.store-test
+  (:require phel.test :refer [deftest is use-fixtures])
+  (:require todo-app.store :as s))
 
 (use-fixtures :each
   (fn [t]

--- a/resources/agents/tasks/add-tests.md
+++ b/resources/agents/tasks/add-tests.md
@@ -17,7 +17,7 @@ Namespace: `tests\<name>-test`.
 `src/math.phel`:
 
 ```phel
-(ns my-app\math)
+(ns my-app.math)
 
 (defn ^int add [^int a ^int b] (+ a b))
 
@@ -30,9 +30,9 @@ Namespace: `tests\<name>-test`.
 `tests/math_test.phel`:
 
 ```phel
-(ns tests\math-test
-  (:require phel\test :refer [deftest is are testing])
-  (:require my-app\math :refer [add divide]))
+(ns tests.math-test
+  (:require phel.test :refer [deftest is are testing])
+  (:require my-app.math :refer [add divide]))
 
 (deftest test-add
   (is (= 4 (add 2 2))))
@@ -81,7 +81,7 @@ Compose outer-to-inner. Keyed by `*ns*`.
 ## Mocking
 
 ```phel
-(:require phel\mock :refer [with-mocks mock mock-fn mock-returning mock-throwing spy
+(:require phel.mock :refer [with-mocks mock mock-fn mock-returning mock-throwing spy
                             called? called-with? called-once? never-called?
                             call-count calls reset-mock!])
 

--- a/resources/agents/tasks/async.md
+++ b/resources/agents/tasks/async.md
@@ -5,8 +5,8 @@
 ## Basic
 
 ```phel
-(ns my-app\main
-  (:require phel\async :refer [async await delay future]))
+(ns my-app.main
+  (:require phel.async :refer [async await delay future]))
 
 (defn fetch-slow [url]
   (delay 200)                          ; simulate latency

--- a/resources/agents/tasks/cli-tool.md
+++ b/resources/agents/tasks/cli-tool.md
@@ -9,8 +9,8 @@ Full reference: <https://phel-lang.org/documentation/tooling/cli-commands/>. Mod
 `src/main.phel`:
 
 ```phel
-(ns my-tool\main
-  (:require phel\cli :as cli))
+(ns my-tool.main
+  (:require phel.cli :as cli))
 
 (defn- greet [ctx]
   (let [name (or (cli/arg ctx "name")
@@ -162,7 +162,7 @@ Composer bin shim `bin/greet`:
 #!/usr/bin/env php
 <?php
 require __DIR__ . '/../vendor/autoload.php';
-\Phel::run(__DIR__ . '/..', 'my-tool\\main');
+\Phel::run(__DIR__ . '/..', 'my-tool.main');
 ```
 
 `composer.json`: `{ "bin": ["bin/greet"] }`, then `chmod +x bin/greet`.
@@ -170,10 +170,10 @@ require __DIR__ . '/../vendor/autoload.php';
 ## Tests
 
 ```phel
-(ns tests\main-test
-  (:require phel\test :refer [deftest is])
-  (:require phel\cli  :as cli)
-  (:require my-tool\main :refer [app]))
+(ns tests.main-test
+  (:require phel.test :refer [deftest is])
+  (:require phel.cli  :as cli)
+  (:require my-tool.main :refer [app]))
 
 (deftest greets
   (let [input  (cli/argv ["greet" "alice"])
@@ -203,7 +203,7 @@ require __DIR__ . '/../vendor/autoload.php';
 For a trivial script without subcommands, drop `phel\cli`:
 
 ```phel
-(ns my-tool\main)
+(ns my-tool.main)
 
 (defn -main [& args]
   (println (str "Hello, " (or (first args) "World") "!"))

--- a/resources/agents/tasks/http-app.md
+++ b/resources/agents/tasks/http-app.md
@@ -9,9 +9,9 @@ Runnable: `.agents/examples/todo-app/`.
 `src/handlers.phel`:
 
 ```phel
-(ns my-api\handlers
-  (:require phel\http :as h)
-  (:require phel\json :as json))
+(ns my-api.handlers
+  (:require phel.http :as h)
+  (:require phel.json :as json))
 
 (defn- json-response [status data]
   (h/response-from-map
@@ -31,9 +31,9 @@ Runnable: `.agents/examples/todo-app/`.
 `src/routes.phel`:
 
 ```phel
-(ns my-api\routes
-  (:require phel\router :as r)
-  (:require my-api\handlers :as h))
+(ns my-api.routes
+  (:require phel.router :as r)
+  (:require my-api.handlers :as h))
 
 (def app-router
   (r/router
@@ -57,9 +57,9 @@ Nested children inherit path prefix and deep-merged data.
 `src/entry.phel`:
 
 ```phel
-(ns my-api\entry
-  (:require phel\http :as h)
-  (:require my-api\routes :refer [app-handler]))
+(ns my-api.entry
+  (:require phel.http :as h)
+  (:require my-api.routes :refer [app-handler]))
 
 (when-not *build-mode*
   (-> (h/request-from-globals) app-handler h/emit-response))
@@ -70,7 +70,7 @@ Nested children inherit path prefix and deep-merged data.
 ```php
 <?php
 require __DIR__ . '/../vendor/autoload.php';
-\Phel::run(__DIR__ . '/..', 'my-api\\entry');
+\Phel::run(__DIR__ . '/..', 'my-api.entry');
 ```
 
 ```bash
@@ -106,7 +106,7 @@ Route-level: `{:middleware [auth-mw] :get {:handler ...}}`. Method-level goes in
 ## URL generation
 
 ```phel
-(:require phel\router :as r :refer [generate match-by-name])
+(:require phel.router :as r :refer [generate match-by-name])
 
 (def app-router
   (r/router [["/users/{id}" {:name :user-show :get {:handler show}}]]))
@@ -128,7 +128,7 @@ Macro — routes must be literal at call site. ~3x faster matching + URL gen.
 ## Outbound HTTP
 
 ```phel
-(:require phel\http-client :as hc)
+(:require phel.http-client :as hc)
 
 (hc/get  "https://api.example.com/users/42")
 (hc/post "https://api.example.com/users"
@@ -142,11 +142,11 @@ Returns `h/response` struct. Opts: `:headers` `:body` `:json` `:query-params` `:
 ## Tests
 
 ```phel
-(ns tests\handlers-test
-  (:require phel\test :refer [deftest is])
-  (:require phel\http :as h)
-  (:require phel\json :as json)
-  (:require my-api\handlers :refer [health greet]))
+(ns tests.handlers-test
+  (:require phel.test :refer [deftest is])
+  (:require phel.http :as h)
+  (:require phel.json :as json)
+  (:require my-api.handlers :refer [health greet]))
 
 (deftest health-ok
   (is (= 200 (get (health (h/request-from-map {})) :status))))

--- a/resources/agents/tasks/pattern-match.md
+++ b/resources/agents/tasks/pattern-match.md
@@ -16,8 +16,8 @@ Each pattern is a vector whose length must equal the target count.
 ## Basic example
 
 ```phel
-(ns my-app\main
-  (:require phel\match :refer [match]))
+(ns my-app.main
+  (:require phel.match :refer [match]))
 
 (defn describe [x]
   (match [x]

--- a/resources/agents/tasks/repl-workflow.md
+++ b/resources/agents/tasks/repl-workflow.md
@@ -36,7 +36,7 @@ Shell: `./vendor/bin/phel doc <fn>`.
 (require 'phel\test :refer [run-tests])
 (require 'tests\math-test)
 (run-tests {} 'tests\math-test)
-(tests\math-test/test-add)
+(tests.math-test/test-add)
 ```
 
 Each `deftest` is a zero-arg fn tagged `{:test true}`.

--- a/resources/agents/tasks/use-php-libs.md
+++ b/resources/agents/tasks/use-php-libs.md
@@ -26,9 +26,9 @@ composer require guzzlehttp/guzzle
 ```
 
 ```phel
-(ns my-app\http
+(ns my-app.http
   (:use GuzzleHttp\Client)
-  (:require phel\json :as json))
+  (:require phel.json :as json))
 
 (def client
   (new Client
@@ -42,7 +42,7 @@ composer require guzzlehttp/guzzle
 ## PDO
 
 ```phel
-(ns my-app\db
+(ns my-app.db
   (:use PDO PDOException))
 
 (defn connect [dsn user pass]

--- a/resources/agents/tasks/validate-with-schema.md
+++ b/resources/agents/tasks/validate-with-schema.md
@@ -5,8 +5,8 @@
 ## Define a schema
 
 ```phel
-(ns my-app\main
-  (:require phel\schema :as s))
+(ns my-app.main
+  (:require phel.schema :as s))
 
 (def User
   [:map {:closed? true}

--- a/src/php/Run/Domain/Init/NamespaceNormalizer.php
+++ b/src/php/Run/Domain/Init/NamespaceNormalizer.php
@@ -14,12 +14,12 @@ final class NamespaceNormalizer
      *
      * - Removes all non-alphanumeric characters (hyphens, underscores, etc.)
      * - Converts to lowercase for consistency
-     * - Appends `\main` as the entry module (matches the generated `main.phel`)
+     * - Appends `.main` as the entry module (matches the generated `main.phel`)
      */
     public function normalize(string $projectName): string
     {
         $clean = preg_replace('/[^a-zA-Z0-9]/', '', $projectName);
 
-        return strtolower((string) $clean) . '\\main';
+        return strtolower((string) $clean) . '.main';
     }
 }

--- a/src/php/Run/Domain/Init/ProjectTemplateGenerator.php
+++ b/src/php/Run/Domain/Init/ProjectTemplateGenerator.php
@@ -59,7 +59,7 @@ PHEL;
 
         return <<<PHEL
 (ns {$testNamespace}
-  (:require phel\\test :refer [deftest is])
+  (:require phel.test :refer [deftest is])
   (:require {$namespace} :refer [greet]))
 
 (deftest test-greet

--- a/tests/phel/core/exotic-literals.phel
+++ b/tests/phel/core/exotic-literals.phel
@@ -1,5 +1,5 @@
 (ns phel-test.core.exotic-literals
-  (:require phel\test :refer [deftest is]))
+  (:require phel.test :refer [deftest is]))
 
 (defn- make-inst [] #inst"2024-01-15T10:30:00Z")
 

--- a/tests/php/Integration/Run/Command/Init/InitCommandTest.php
+++ b/tests/php/Integration/Run/Command/Init/InitCommandTest.php
@@ -102,7 +102,7 @@ final class InitCommandTest extends TestCase
         $configContent = (string) file_get_contents($this->testDir . '/phel-config.php');
 
         self::assertStringContainsString('PhelConfig::forProject(ProjectLayout::Root)', $configContent);
-        self::assertStringContainsString("->withMainPhelNamespace('sandbox\\main')", $configContent);
+        self::assertStringContainsString("->withMainPhelNamespace('sandbox.main')", $configContent);
     }
 
     public function test_minimal_main_file_uses_main_namespace(): void
@@ -118,7 +118,7 @@ final class InitCommandTest extends TestCase
 
         $mainContent = (string) file_get_contents($this->testDir . '/main.phel');
 
-        self::assertStringContainsString('(ns sandbox\\main)', $mainContent);
+        self::assertStringContainsString('(ns sandbox.main)', $mainContent);
         self::assertStringContainsString('(defn greet [name]', $mainContent);
     }
 
@@ -135,8 +135,8 @@ final class InitCommandTest extends TestCase
 
         $testContent = (string) file_get_contents($this->testDir . '/main_test.phel');
 
-        self::assertStringContainsString('(ns sandbox\\main-test', $testContent);
-        self::assertStringContainsString('sandbox\\main :refer [greet]', $testContent);
+        self::assertStringContainsString('(ns sandbox.main-test', $testContent);
+        self::assertStringContainsString('sandbox.main :refer [greet]', $testContent);
         self::assertStringContainsString('deftest test-greet', $testContent);
     }
 
@@ -202,9 +202,9 @@ final class InitCommandTest extends TestCase
         self::assertStringContainsString('use Phel\\Config\\PhelConfig;', $configContent);
         self::assertStringContainsString('use Phel\\Config\\ProjectLayout;', $configContent);
         self::assertStringContainsString('PhelConfig::forProject(ProjectLayout::Flat)', $configContent);
-        self::assertStringContainsString("->withMainPhelNamespace('myapp\\main')", $configContent);
+        self::assertStringContainsString("->withMainPhelNamespace('myapp.main')", $configContent);
         // New projects ship -O2 as an active chained call, not the commented hint (#2631).
-        self::assertStringContainsString("->withMainPhelNamespace('myapp\\main')\n    ->withOptimizationLevel(2);", $configContent);
+        self::assertStringContainsString("->withMainPhelNamespace('myapp.main')\n    ->withOptimizationLevel(2);", $configContent);
     }
 
     public function test_generated_config_uses_nested_layout(): void
@@ -221,7 +221,7 @@ final class InitCommandTest extends TestCase
         $configContent = (string) file_get_contents($this->testDir . '/phel-config.php');
 
         self::assertStringContainsString('PhelConfig::forProject(ProjectLayout::Nested)', $configContent);
-        self::assertStringContainsString("->withMainPhelNamespace('testproject\\main')", $configContent);
+        self::assertStringContainsString("->withMainPhelNamespace('testproject.main')", $configContent);
     }
 
     public function test_generated_main_file_contains_namespace(): void
@@ -234,7 +234,7 @@ final class InitCommandTest extends TestCase
 
         $mainContent = file_get_contents($this->testDir . '/src/main.phel');
 
-        self::assertStringContainsString('(ns myapp\\main)', (string) $mainContent);
+        self::assertStringContainsString('(ns myapp.main)', (string) $mainContent);
         self::assertStringContainsString('(defn main []', (string) $mainContent);
         self::assertStringContainsString('greet', (string) $mainContent);
     }
@@ -283,10 +283,10 @@ final class InitCommandTest extends TestCase
 
         $configContent = (string) file_get_contents($this->testDir . '/phel-config.php');
         self::assertStringContainsString('PhelConfig::forProject(ProjectLayout::Flat)', $configContent);
-        self::assertStringContainsString("->withMainPhelNamespace('app\\main')", $configContent);
+        self::assertStringContainsString("->withMainPhelNamespace('app.main')", $configContent);
 
         $mainContent = file_get_contents($this->testDir . '/src/main.phel');
-        self::assertStringContainsString('(ns app\\main)', (string) $mainContent);
+        self::assertStringContainsString('(ns app.main)', (string) $mainContent);
     }
 
     public function test_namespace_conversion_removes_hyphens(): void
@@ -299,7 +299,7 @@ final class InitCommandTest extends TestCase
 
         $mainContent = file_get_contents($this->testDir . '/src/main.phel');
 
-        self::assertStringContainsString('(ns mycoolapp\\main)', (string) $mainContent);
+        self::assertStringContainsString('(ns mycoolapp.main)', (string) $mainContent);
     }
 
     public function test_gitignore_contains_standard_entries(): void
@@ -456,14 +456,14 @@ final class InitCommandTest extends TestCase
         self::assertFileExists($this->testDir . '/composer.json');
 
         $entry = (string) file_get_contents($this->testDir . '/src/entry.phel');
-        self::assertStringContainsString('(ns my-api\\entry', $entry);
+        self::assertStringContainsString('(ns my-api.entry', $entry);
         self::assertStringNotContainsString('http-json-api', $entry);
 
         $composer = (string) file_get_contents($this->testDir . '/composer.json');
         self::assertStringContainsString('my-api', $composer);
 
         $index = (string) file_get_contents($this->testDir . '/public/index.php');
-        self::assertStringContainsString("'my-api\\\\entry'", $index);
+        self::assertStringContainsString("'my-api.entry'", $index);
     }
 
     /**

--- a/tests/php/Unit/Run/Domain/Init/NamespaceNormalizerTest.php
+++ b/tests/php/Unit/Run/Domain/Init/NamespaceNormalizerTest.php
@@ -28,15 +28,15 @@ final class NamespaceNormalizerTest extends TestCase
      */
     public static function namespaceProvider(): iterable
     {
-        yield 'simple name' => ['app', 'app\\main'];
-        yield 'with hyphens' => ['my-app', 'myapp\\main'];
-        yield 'with underscores' => ['my_app', 'myapp\\main'];
-        yield 'with multiple hyphens' => ['my-cool-app', 'mycoolapp\\main'];
-        yield 'mixed separators' => ['my-cool_app', 'mycoolapp\\main'];
-        yield 'uppercase' => ['MyApp', 'myapp\\main'];
-        yield 'mixed case with hyphens' => ['My-Cool-App', 'mycoolapp\\main'];
-        yield 'with numbers' => ['app123', 'app123\\main'];
-        yield 'with special chars' => ['my.app!', 'myapp\\main'];
-        yield 'empty becomes just main' => ['', '\\main'];
+        yield 'simple name' => ['app', 'app.main'];
+        yield 'with hyphens' => ['my-app', 'myapp.main'];
+        yield 'with underscores' => ['my_app', 'myapp.main'];
+        yield 'with multiple hyphens' => ['my-cool-app', 'mycoolapp.main'];
+        yield 'mixed separators' => ['my-cool_app', 'mycoolapp.main'];
+        yield 'uppercase' => ['MyApp', 'myapp.main'];
+        yield 'mixed case with hyphens' => ['My-Cool-App', 'mycoolapp.main'];
+        yield 'with numbers' => ['app123', 'app123.main'];
+        yield 'with special chars' => ['my.app!', 'myapp.main'];
+        yield 'empty becomes just main' => ['', '.main'];
     }
 }

--- a/tests/php/Unit/Run/Domain/Init/ProjectTemplateGeneratorTest.php
+++ b/tests/php/Unit/Run/Domain/Init/ProjectTemplateGeneratorTest.php
@@ -19,50 +19,50 @@ final class ProjectTemplateGeneratorTest extends TestCase
 
     public function test_generate_config_flat_layout(): void
     {
-        $config = $this->generator->generateConfig('myapp\\main', ProjectLayout::Flat);
+        $config = $this->generator->generateConfig('myapp.main', ProjectLayout::Flat);
 
         self::assertStringContainsString('declare(strict_types=1);', $config);
         self::assertStringContainsString('use Phel\\Config\\PhelConfig;', $config);
         self::assertStringContainsString('use Phel\\Config\\ProjectLayout;', $config);
         self::assertStringContainsString('PhelConfig::forProject(ProjectLayout::Flat)', $config);
-        self::assertStringContainsString("->withMainPhelNamespace('myapp\\main')", $config);
+        self::assertStringContainsString("->withMainPhelNamespace('myapp.main')", $config);
     }
 
     public function test_generate_config_enables_optimization_by_default(): void
     {
         // New projects ship -O2 so compute-heavy code gets inlined arithmetic
         // and elided nil-guards out of the box (#2631); the runtime default is 0.
-        $config = $this->generator->generateConfig('myapp\\main', ProjectLayout::Flat);
+        $config = $this->generator->generateConfig('myapp.main', ProjectLayout::Flat);
 
         // Must be an active chained call (trailing `;`), not the commented example.
-        self::assertStringContainsString("->withMainPhelNamespace('myapp\\main')\n    ->withOptimizationLevel(2);", $config);
+        self::assertStringContainsString("->withMainPhelNamespace('myapp.main')\n    ->withOptimizationLevel(2);", $config);
     }
 
     public function test_generate_config_nested_layout(): void
     {
-        $config = $this->generator->generateConfig('myapp\\main', ProjectLayout::Nested);
+        $config = $this->generator->generateConfig('myapp.main', ProjectLayout::Nested);
 
         self::assertStringContainsString('use Phel\\Config\\PhelConfig;', $config);
         self::assertStringContainsString('use Phel\\Config\\ProjectLayout;', $config);
         self::assertStringContainsString('PhelConfig::forProject(ProjectLayout::Nested)', $config);
-        self::assertStringContainsString("->withMainPhelNamespace('myapp\\main')", $config);
+        self::assertStringContainsString("->withMainPhelNamespace('myapp.main')", $config);
     }
 
     public function test_generate_config_root_layout(): void
     {
-        $config = $this->generator->generateConfig('sandbox\\main', ProjectLayout::Root);
+        $config = $this->generator->generateConfig('sandbox.main', ProjectLayout::Root);
 
         self::assertStringContainsString('use Phel\\Config\\PhelConfig;', $config);
         self::assertStringContainsString('use Phel\\Config\\ProjectLayout;', $config);
         self::assertStringContainsString('PhelConfig::forProject(ProjectLayout::Root)', $config);
-        self::assertStringContainsString("->withMainPhelNamespace('sandbox\\main')", $config);
+        self::assertStringContainsString("->withMainPhelNamespace('sandbox.main')", $config);
     }
 
     public function test_generate_main_file(): void
     {
-        $main = $this->generator->generateMainFile('myapp\\main');
+        $main = $this->generator->generateMainFile('myapp.main');
 
-        self::assertStringContainsString('(ns myapp\\main)', $main);
+        self::assertStringContainsString('(ns myapp.main)', $main);
         self::assertStringContainsString('(defn greet [name]', $main);
         self::assertStringContainsString('(defn main []', $main);
         self::assertStringContainsString('println', $main);
@@ -71,10 +71,10 @@ final class ProjectTemplateGeneratorTest extends TestCase
 
     public function test_generate_test_file(): void
     {
-        $test = $this->generator->generateTestFile('myapp\\main');
+        $test = $this->generator->generateTestFile('myapp.main');
 
-        self::assertStringContainsString('(ns myapp\\main-test', $test);
-        self::assertStringContainsString('phel\\test', $test);
+        self::assertStringContainsString('(ns myapp.main-test', $test);
+        self::assertStringContainsString('phel.test', $test);
         self::assertStringContainsString(':refer [deftest is]', $test);
         self::assertStringContainsString(':refer [greet]', $test);
         self::assertStringContainsString('(deftest test-greet', $test);

--- a/tests/php/Unit/Run/Domain/Init/ProjectTemplateScaffolderTest.php
+++ b/tests/php/Unit/Run/Domain/Init/ProjectTemplateScaffolderTest.php
@@ -40,7 +40,7 @@ final class ProjectTemplateScaffolderTest extends TestCase
         self::assertArrayHasKey('composer.json', $files);
 
         $main = $files['src/main.phel'];
-        self::assertStringContainsString('(ns my-tool\\main', $main);
+        self::assertStringContainsString('(ns my-tool.main', $main);
         self::assertStringNotContainsString('cli-wordcount', $main);
         self::assertStringContainsString('my-tool', $files['composer.json']);
     }
@@ -49,7 +49,7 @@ final class ProjectTemplateScaffolderTest extends TestCase
     {
         $files = $this->scaffolder->files('cli-wordcount', 'My Cool API!');
 
-        self::assertStringContainsString('(ns my-cool-api\\main', $files['src/main.phel']);
+        self::assertStringContainsString('(ns my-cool-api.main', $files['src/main.phel']);
     }
 
     public function test_files_throws_for_unknown_template(): void


### PR DESCRIPTION
## 🤔 Background

`\` as a namespace separator was deprecated by #1567 back in April, and #2827 is still
deciding whether it goes at the next major. That decision is open, but this is not:
**phel was still teaching the deprecated form, and still generating it.**

Turned up while gathering evidence for #2827 — the question "how much code would a
removal break?" ran straight into the fact that we are one of the sources of it.

## 💡 Goal

Stop emitting `\` from anything phel ships, so the #2827 decision is about *other
people's* code rather than our own output.

Three places, all reached from `phel init`:

| | |
|---|---|
| `NamespaceNormalizer` | hardcoded `. '\main'`, so **every** scaffolded project began on the deprecated form |
| `ProjectTemplateGenerator` | the generated test file required `phel\test` |
| `resources/agents/examples/` | the three example apps, which are also the `--template=` scaffolds (`ProjectTemplateScaffolder` reads them as its single source of truth) |

Plus `resources/agents/tasks/*.md`, the recipes installed into user projects as
`.agents/` — so an agent reading them learned the deprecated spelling and wrote more of
it.

## 🔖 Changes

Every Phel namespace moves to `.`:

```diff
-(ns todo-app\handlers
-  (:require phel\http :as h)
-  (:require phel\json :as json)
-  (:require todo-app\store :as s))
+(ns todo-app.handlers
+  (:require phel.http :as h)
+  (:require phel.json :as json)
+  (:require todo-app.store :as s))
```

**A leading `\` on a PHP class or constant is a different meaning and is untouched** —
that one is #2876's question, not this one:

```phel
(:use \stdClass)              ; unchanged
(:use GuzzleHttp\Client)      ; unchanged
(:use \JSON_PRETTY_PRINT)     ; unchanged
```

Also covered: the examples' PHP entry points, where the namespace lives inside a string
(`\Phel::run(__DIR__ . '/..', 'todo-app\entry')`), which a `.phel`-only sweep misses.

`tests/phel/core/qualified-symbol-shadowing.phel` deliberately keeps its backslash — its
test is named `test-deprecated-backslash-separator-also-resolves-globally`.

## ✅ Verified

`composer test` fully green (quality + unit 4444 + integration 1153 + core 6586), and
`composer test-agents` validates all three example apps end to end after the rewrite.

Note on `.codex/agents/tdd-coach.toml`, which has the same two lines: it is
`.gitignore`d, so the fix cannot ship here.

Part of #2827 — this is the cross-cutting checklist item, not the removal decision.
