### PR TITLE
docs: simplify the docs tree, and stop the PHAR build copying local caches

### DIFF
--- a/build/phar.sh
+++ b/build/phar.sh
@@ -98,6 +98,8 @@ mkdir -p "$WORK_DIR" "$CACHE_DIR" "$OUTPUT_DIR"
 rsync -a "$REPO_ROOT/" "$WORK_DIR/" \
   --include='resources/' \
   --include='resources/agents/' \
+  --exclude='resources/agents/examples/*/vendor/' \
+  --exclude='resources/agents/examples/*/.phel/' \
   --include='resources/agents/examples/***' \
   --exclude='resources/agents/**' \
   --exclude='.git' \
@@ -109,6 +111,7 @@ rsync -a "$REPO_ROOT/" "$WORK_DIR/" \
   --exclude='.agents' \
   --exclude='.phpbench' \
   --exclude='.phpunit.cache' \
+  --exclude='/.phel/' \
   --exclude='/.phel-cache' \
   --exclude='docs' \
   --exclude='tests' \

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,31 +25,25 @@ modules, deployment) live on **[phel-lang.org](https://phel-lang.org/documentati
 
 ## PHP interop, in one paragraph
 
-Phel has two spellings for reaching PHP, and the Clojure-style one is the idiomatic
-default:
+Write the Clojure-style spelling:
 
 ```phel
 (new \DateTime "2020-01-01")   ; or (\DateTime. "2020-01-01")
 (.format d "Y")                ; instance method
 (.-prop obj)                   ; property
 (\DateTime/createFromFormat "Y-m-d" "2020-01-01")   ; static method
-```
 
-Each of those desugars to a `php/*` special form (`php/new`, `php/->`, `php/::`)
-before analysis. That layer is the compilation target, and it came first, which is
-why older code is written in it — but it is **deprecated as source**: every position
-it once had to itself now has a shorthand. Write the shorthand.
-
-Chaining threads with plain `->`, mixed method and property chains included:
-
-```phel
 (-> (new \DateTimeImmutable "2024-03-10") (.modify "+1 day") (.format "Y-m-d"))
 ```
 
-The full expansion table, including `\C/m` and `\C/.m` in value position, is in
-[the language surface spec](spec/language-surface.md#interop-shorthands). The
-complete guide with runnable examples is on the website:
-<https://phel-lang.org/documentation/php-interop/>. A runnable sample lives in
+Each desugars to a `php/*` special form (`php/new`, `php/->`, `php/::`) before
+analysis. That layer is the compilation target and came first, which is why older
+code uses it, but it is **deprecated as source**: every position it once had to
+itself now has a shorthand ([ADR 0007](adr/0007-clojure-style-interop-is-the-source-spelling.md)).
+
+Expansion table including `\C/m` and `\C/.m` in value position:
+[the language surface spec](spec/language-surface.md#interop-shorthands). Full
+guide: <https://phel-lang.org/documentation/php-interop/>. Runnable sample:
 [examples/09_php-integration.phel](examples/09_php-integration.phel).
 
 ## User-facing guides moved to phel-lang.org

--- a/docs/adr/0006-one-opt-in-deprecation-channel.md
+++ b/docs/adr/0006-one-opt-in-deprecation-channel.md
@@ -40,8 +40,10 @@ nothing else.
    against the macro's file with the call site appended, a stdlib origin is
    suppressed, an unknown origin stays silent rather than misattributed.
 
-CLI-option deprecations are the one exception, always printing on stderr through
-`Phel\Shared\Console\DeprecatedOptionWarner`.
+CLI-option deprecations are the one exception and print on stderr
+unconditionally. No rename is in flight, so no shared helper exists today;
+[cli-flag-conventions.md](../internals/cli-flag-conventions.md#renaming-an-option)
+carries the procedure.
 
 Every live deprecation also appears in
 [the deprecated surface map](../migration/deprecated-surface.md) and moves to the

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,12 +1,11 @@
 # CLI Reference & DX Guide
 
-A single map of every `phel` command, the common workflows, and the
-edit→test dev loop. Run `phel <command> --help` for the full options of any
-command (each ships a usage example), and `phel completion bash|zsh|fish` to
-enable tab-completion (see the [README](../README.md#enable-shell-completion-optional)).
+Every `phel` command, the common workflows, and the dev loop. `phel <command>
+--help` gives full options and a usage example; `phel completion bash|zsh|fish`
+enables tab-completion (setup in the [README](../README.md)).
 
-> User-facing tutorials live on [phel-lang.org](https://phel-lang.org/documentation/tooling/cli-commands/);
-> this page is the quick reference kept next to the code.
+> Tutorials live on [phel-lang.org](https://phel-lang.org/documentation/tooling/cli-commands/);
+> this is the quick reference kept next to the code.
 
 ## Commands
 
@@ -48,22 +47,17 @@ Phel into your editor. Per-editor setup lives on the website:
 
 ## compile vs eval vs run vs build
 
-These four overlap; pick by what you want back:
+Pick by what you want back:
 
 | Command | Input | Runs the code? | Output |
 |---|---|---|---|
 | `compile` | snippet / file / stdin | no | emitted **PHP source** (honors `optimizationLevel`) |
 | `eval` | expression / stdin | yes | the **value** of the last form |
 | `run` | file / namespace | yes | whatever the script prints / its side effects |
-| `build` | the whole project | compiles (no run) | **PHP files** written to the output dir, for deployment |
+| `build` | the whole project | compiles (no run) | **PHP files** in the output dir, for deployment |
 
-Rule of thumb: `eval` to check a value, `run` to execute a script, `compile`
-to inspect generated PHP for one form, `build` to produce deployable PHP for
-the entire project.
-
-`eval` is a developer tool with full host access, not a sandbox. For using it
-as a playground eval primitive (and why that needs isolation), see
-[playground.md](playground.md).
+`eval` is a developer tool with full host access, not a sandbox. On using it as a
+playground primitive, and why that needs isolation: [playground.md](playground.md).
 
 ## Common workflows
 
@@ -78,13 +72,12 @@ phel completion zsh       # (optional) enable tab-completion
 ### The dev loop
 
 ```sh
-phel test --watch         # re-run tests on every change (incremental cache reuse)
-# or, for hot-reloading namespaces:
-phel watch
+phel test --watch         # re-run tests on change
+phel watch                # hot-reload namespaces instead
 ```
 
 Both reuse the compiled-code cache, so a one-file edit recompiles only the
-affected namespaces. Use `phel repl` (or `phel nrepl` from your editor) for
+affected namespaces. `phel repl` (or `phel nrepl` from your editor) for
 interactive exploration.
 
 ### Ship it

--- a/docs/internals/benchmarks.md
+++ b/docs/internals/benchmarks.md
@@ -1,48 +1,38 @@
 # Benchmarking Phel
 
-[PHPBench](https://phpbench.readthedocs.io/) (in `require-dev`) measures the runtime cost of developer workflows and core data structures. Run the suite to spot regressions before release.
-
-It covers three areas:
-
-- **CLI commands**: `phel run` and `phel test` end-to-end.
-- **Persistent collections**: vectors and hash maps for hot ops like `append`, `update`, `put`.
-- **Core bootstrap**: loading and executing the bundled `phel.core` namespace, to track compiler startup time.
-
-## Running the suite
+[PHPBench](https://phpbench.readthedocs.io/) (in `require-dev`) measures three
+areas: CLI commands (`phel run`, `phel test` end to end), persistent collections
+(vector and hash-map hot ops), and core bootstrap (loading and executing
+`phel.core`, tracking compiler startup).
 
 ```bash
 composer phpbench
-```
-
-Override iterations and revolutions for quick local checks:
-
-```bash
-composer phpbench -- --iterations=2 --revs=10
+composer phpbench -- --iterations=2 --revs=10   # quick local check
 ```
 
 ## Comparing against a baseline
 
 ```bash
-composer phpbench-base   # record/update baseline (stored under the `baseline` tag)
-composer phpbench-ref    # compare current state with baseline
+composer phpbench-base   # record/update the `baseline` tag
+composer phpbench-ref    # compare current state against it
 ```
 
-The assertion in [`phpbench.json`](../../phpbench.json) fails the comparison when the measured mode deviates beyond the configured threshold.
+The assertion in [`phpbench.json`](../../phpbench.json) fails the comparison when
+the measured mode deviates beyond the threshold.
 
-## Measuring JIT gains
+## JIT gains
 
-`TypedSignatureBench` measures the JIT specialization wins on `:tag`-annotated fns. Compare the two runs to see what typed signatures unlock at runtime:
+`TypedSignatureBench` measures JIT specialization on `:tag`-annotated fns:
 
 ```bash
 composer bench-jit-baseline   # opcache off, no JIT
 composer bench-jit-tracing    # opcache on, tracing JIT
 ```
 
-See the [PHPBench docs](https://phpbench.readthedocs.io/) for advanced reporting.
+## Compiler phases
 
-## Measuring compiler phases
-
-To quantify a compiler-phase change (lexer, parser, analyzer, emitter), build the project with `--timing`. It sums each phase's wall-clock across every compiled namespace. Pair it with `--no-cache` so the whole project recompiles and the numbers are comparable run to run:
+`--timing` sums each phase's wall-clock across every compiled namespace. Pair it
+with `--no-cache` so the whole project recompiles and runs are comparable:
 
 ```bash
 ./vendor/bin/phel build --no-cache --timing
@@ -60,36 +50,43 @@ Compile-phase timing
   (33 namespaces compiled)
 ```
 
-Run it before and after a change and quote the before/after totals (and the affected phase's share) in the PR. This is compile-only — it never executes the built program, so the analyzer/emitter cost is isolated from runtime. `--timing` composes with `--report` (per-namespace sizes + build time). Without `--no-cache` only freshly compiled namespaces contribute; if everything is served from cache the report says so and tells you to re-run with `--no-cache`.
+Quote before/after totals and the affected phase's share in the PR. Compile-only:
+it never executes the built program, so analyzer and emitter cost are isolated
+from runtime. Composes with `--report` (per-namespace sizes + build time). Without
+`--no-cache` only freshly compiled namespaces contribute, and a fully cached run
+says so.
 
-## Speeding up CLI runs with OPcache
+## OPcache for CLI runs
 
-Phel compiles each `.phel` file to PHP and caches the result under the Phel cache dir (`.phel/cache/compiled/` by default). A warm `phel run` then just `require`s the cached PHP instead of recompiling. The remaining gap versus native PHP comes from PHP re-parsing those cached files on every process, because **OPcache is disabled on the CLI by default** (`opcache.enable_cli=0`).
-
-To let the compiled cache survive across CLI invocations, enable OPcache with its file cache:
+Phel caches compiled PHP under `.phel/cache/compiled/`, so a warm `phel run` just
+`require`s it. The remaining gap versus native PHP is PHP re-parsing those files
+every process, because **OPcache is off on the CLI by default**
+(`opcache.enable_cli=0`):
 
 ```ini
-; php.ini (or a -d flag on the CLI)
 opcache.enable_cli=1
 opcache.file_cache=/tmp/phel-opcache   ; any writable directory
 opcache.file_cache_only=1              ; persist across short-lived CLI processes
 ```
 
-`opcache.enable_cli` and `opcache.file_cache` are `PHP_INI_SYSTEM` settings, so they must be set in `php.ini` or via `php -d ...` before the process starts (they cannot be changed at runtime).
+Both are `PHP_INI_SYSTEM`, so they must be set in `php.ini` or via `php -d …`
+before the process starts. `phel doctor` reports whether CLI caching is fully
+configured.
 
-Run `phel doctor` to check the current configuration: its "Checking performance" section reports whether OPcache CLI caching is fully configured and prints tips otherwise.
+## Ahead-of-time builds
 
-## Ahead-of-time builds vs runtime compilation
-
-For the fastest, closest-to-native execution, compile the project ahead of time and run the generated PHP directly, so the Phel compiler never runs:
+Fastest path: compile ahead of time and run the generated PHP, so the compiler
+never runs.
 
 ```bash
 composer install --no-dev --optimize-autoloader
 ./vendor/bin/phel build          # writes plain PHP to out/
-php out/index.php                 # runs the built entry, zero runtime compilation
+php out/index.php                # zero runtime compilation
 ```
 
-The built entry (`out/index.php`) requires the compiled namespace tree, which require-chains the precompiled `phel.core`. No lexer/parser/analyzer/emitter runs on the request path. Indicative CLI process-startup, best-of-5 on a trivial script (your numbers depend on how much stdlib the entry touches and on OPcache):
+`out/index.php` require-chains the compiled namespace tree, including the
+precompiled `phel.core`. No pipeline phase runs on the request path. Indicative
+process startup, best-of-5 on a trivial script:
 
 | Execution mode | Startup |
 |---|---|
@@ -97,4 +94,6 @@ The built entry (`out/index.php`) requires the compiled namespace tree, which re
 | `phel run` (warm cache) | ~0.20s |
 | native PHP equivalent | ~0.05s |
 
-The ahead-of-time artifact roughly halves the gap to native versus a warm `phel run`. See the example deployment guide (`resources/agents/examples/http-json-api/DEPLOYMENT.md`) for the full production flow (Docker, OPcache preload, php-fpm, worker mode).
+Roughly halves the gap to native versus a warm `phel run`. Full production flow
+(Docker, OPcache preload, php-fpm, worker mode):
+`resources/agents/examples/http-json-api/DEPLOYMENT.md`.

--- a/docs/internals/testing-performance.md
+++ b/docs/internals/testing-performance.md
@@ -1,51 +1,43 @@
 # Testing Performance &amp; DX
 
-How the test suites are wired, where the wall-clock goes, and the fast paths
-for local work. Numbers below are from a 10-core dev machine (June 2026) and
-are indicative, not a benchmark — re-measure before acting on them.
+How the suites are wired, where wall-clock goes, and the fast paths for local
+work. Numbers are from a 10-core dev machine (June 2026), indicative rather than
+a benchmark. Re-measure before acting on them.
 
 ## The three suites
 
-| Suite | Command | Count | Wall-clock | Parallel today |
-|-------|---------|-------|-----------|----------------|
+| Suite | Command | Count | Wall-clock | Parallel |
+|-------|---------|-------|-----------|----------|
 | PHPUnit `unit` | `composer test-unit` | 3850 tests | ~4 s | no (not needed) |
 | PHPUnit `integration` | `composer test-integration` | 984 tests | ~37 s | yes (paratest) |
 | Phel core | `composer test-core` | ~6100 tests | ~6 s warm serial | opt-in (`--parallel`) |
 
 The full gate is `composer test` → `test-all`: `test-quality` (cs-fixer, psalm,
-phpstan, rector), `test-compiler` (unit + integration), and `test-core`. It
-reuses the psalm/phpstan result caches; `composer test-all:fresh` clears them
-first for a cold run.
+phpstan, rector), `test-compiler` (unit + integration), `test-core`. It reuses the
+psalm/phpstan result caches; `composer test-all:fresh` clears them first.
 
-> `test-core` wall-clock swings with the compiled-PHP cache state: a cold first
-> run after a checkout pays the full compile, warm runs are several times
-> faster. Numbers below are warm.
+`test-core` wall-clock swings with the compiled-PHP cache: a cold first run after
+a checkout pays the full compile. Numbers above are warm.
 
 ## Where the time goes
 
 - **`unit` is already fast** (~1 ms/test). Leave it alone.
-- **`integration` was the bottleneck, now parallelized.** 421 `.test` fixtures
-  (plus the other integration cases) expand to 984 PHPUnit invocations via data
-  providers, each driving the full lexer → parser → analyzer → emitter pipeline
-  (~92 ms per invocation). `composer test-integration` now runs them across
-  paratest workers (see #1 below); `composer test-integration:serial` keeps the
-  single-process path for debugging.
-- **`test-core --parallel` now reuses per-worker state.** Workers are
-  long-lived and used to re-evaluate their whole dependency closure (mostly the
-  shared `phel.*` stdlib) on every namespace frame — re-executing already-loaded
-  code dominated each frame, so `--parallel=2` was *slower* than serial and
-  4-vs-8 workers plateaued. Each dependency is now evaluated once per worker
-  (like the serial runner). Warm local figures: serial ~5.9 s, `--parallel=auto`
-  ~4.4 s before → ~3.9 s after. The relative win is modest on this small core
-  suite (real per-frame work is only ~20 ms) but grows with the number of
-  namespaces in a project, since the removed re-eval is fixed-cost per frame.
+- **`integration` was the bottleneck.** 421 `.test` fixtures expand to 984 PHPUnit
+  invocations via data providers, each driving the full lexer → parser → analyzer
+  → emitter pipeline (~92 ms per invocation). Now parallelized (see below);
+  `composer test-integration:serial` keeps the single-process path for debugging.
+- **`test-core --parallel` reuses per-worker state.** Workers are long-lived and
+  used to re-evaluate their whole dependency closure (mostly the shared `phel.*`
+  stdlib) on every namespace frame, so `--parallel=2` was *slower* than serial and
+  4-vs-8 workers plateaued. Each dependency is now evaluated once per worker.
+  Warm: serial ~5.9 s, `--parallel=auto` ~4.4 s before → ~3.9 s after. Modest on
+  this small core suite (~20 ms real work per frame) but grows with the number of
+  namespaces, since the removed re-eval is fixed-cost per frame.
 
 ## Fast local workflows
 
-You rarely need the whole gate while iterating:
-
 ```bash
-composer test-unit                      # ~4 s — pure PHP logic
+composer test-unit                      # ~4 s, pure PHP logic
 composer test-integration               # compiler fixtures only
 composer test-core:parallel             # core lib across workers
 
@@ -56,58 +48,52 @@ composer test-core:parallel             # core lib across workers
 ./bin/phel test --slowest=10            # surface the slow tests
 ```
 
-`phel test` already supports `--filter`, `--ns`, `--include`/`--exclude` tags,
-`--last-failed`, `--watch`, `--repeat`, `--seed`/`--random-order`, `--slowest`,
-multiple reporters, and `--coverage` — see `phel test --help`.
+`phel test` also supports `--include`/`--exclude` tags, `--repeat`,
+`--seed`/`--random-order`, multiple reporters and `--coverage`. See
+`phel test --help`.
 
-## Remaining improvements (not yet adopted)
+## Parallel isolation (adopted, #2630)
 
-### 1. Parallelize `integration` with paratest — adopted (#2630)
+`composer test-integration` runs `brianium/paratest` with the `WrapperRunner`
+(`-p auto`): ~37 s vs ~91 s serial on 10 cores, scaling with them.
 
-`composer test-integration` now runs `brianium/paratest` with the
-`WrapperRunner` (`-p auto`): ~37 s vs ~91 s serial on a 10-core machine, and it
-scales with cores. `composer test-integration:serial` is the single-process
-fallback for debugging.
-
-The win was gated on cross-worker isolation, since paratest workers are
-separate processes that share the filesystem. Three couplings had to be removed:
+The win was gated on cross-worker isolation, since paratest workers are separate
+processes sharing a filesystem. Three couplings had to go:
 
 - **Per-worker temp.** `tests/bootstrap.php` points each worker at its own
-  `sys_get_temp_dir()` keyed by `TEST_TOKEN`, so every `sys_get_temp_dir()`-derived
-  path (compiled-code cache, Gacela merged-config cache, parallel-runner opcache
-  dir) — in-process and in spawned `bin/phel` subprocesses — is worker-private.
-  It reads `getenv('TMPDIR')` rather than `sys_get_temp_dir()`, which PHP caches
-  on first call.
-- **Build tests off the repo tree.** The `Build/Command` tests used to compile
-  into fixed in-repo `out*/` dirs and mutate in-repo fixtures (`src-load-e2e`
-  rename, `src-cascade` rewrite). `NamespaceLoader` scans `getcwd()` (the repo
-  root), so a sibling worker mid-build surfaced this test's `out/phel/core.phel`
-  as a duplicate of the real core and loaded the wrong file. `BuildCommandWorkspace`
-  now gives each test an isolated project root under the worker-private temp.
+  `sys_get_temp_dir()` keyed by `TEST_TOKEN`, so every derived path (compiled-code
+  cache, Gacela merged-config cache, parallel-runner opcache dir), in-process and
+  in spawned `bin/phel` subprocesses, is worker-private. It reads
+  `getenv('TMPDIR')` rather than `sys_get_temp_dir()`, which PHP caches on first
+  call.
+- **Build tests off the repo tree.** The `Build/Command` tests compiled into fixed
+  in-repo `out*/` dirs and mutated in-repo fixtures. `NamespaceLoader` scans
+  `getcwd()`, so a sibling worker mid-build surfaced this test's
+  `out/phel/core.phel` as a duplicate of the real core and loaded the wrong file.
+  `BuildCommandWorkspace` now gives each test an isolated project root under the
+  worker-private temp.
 - **`phel doc` temp file.** `PhelFunctionRuntimeLoader` wrote its generated
-  `doc.phel` to a fixed path inside the package (`Api/Infrastructure/phel/`);
-  concurrent `phel doc`/completion runs clobbered it. It now uses a unique
-  per-call temp dir (the PHAR path already did), which also unblocks read-only
-  installs.
+  `doc.phel` to a fixed path inside the package; concurrent `phel doc` runs
+  clobbered it. It now uses a unique per-call temp dir, which also unblocks
+  read-only installs.
 
-### 2. Drop CLI-opcache cost in `--parallel` workers — adopted (#2628)
+## Worker opcache (adopted, #2628)
 
-With per-frame re-eval removed (see "Where the time goes"), the next parallel
-ceiling was that CLI opcache is off, so each worker re-parsed every compiled
-`.php` it requires. Workers are now spawned with a shared on-disk opcache
-file-cache (`-d opcache.enable_cli=1 -d opcache.file_cache=<temp-dir>/opcache-workers`)
-so worker N reuses what worker 1 compiled. `RunFactory` enables it only when the
-Zend OPcache extension is loaded (a graceful no-op otherwise) and pre-creates the
-cache dir, which PHP requires to exist at startup. The serial path stays
-opcache-off by design.
+With per-frame re-eval removed, the next parallel ceiling was CLI opcache being
+off, so each worker re-parsed every compiled `.php` it requires. Workers are now
+spawned with a shared on-disk file cache
+(`-d opcache.enable_cli=1 -d opcache.file_cache=<temp-dir>/opcache-workers`), so
+worker N reuses what worker 1 compiled. `RunFactory` enables it only when the Zend
+OPcache extension is loaded and pre-creates the dir, which PHP requires to exist
+at startup. The serial path stays opcache-off by design.
 
-### 3. Convert passive mocks to stubs (the 98 `unit` notices)
+## Open: convert passive mocks to stubs
 
 All 98 PHPUnit notices in the `unit` suite are one category: *"No expectations
 were configured for the mock object … use a test stub instead."* They come from
-`createMock()` used as a passive stub (no `->expects()`). The fix is mechanical
-but wide — `createMock(X::class)` → `createStub(X::class)` at the no-expectation
-sites across ~17 files (interfaces: `CompilerFacadeInterface`,
-`NamespaceExtractorInterface`, `BuildFacadeInterface`, `CommandFacadeInterface`,
-`PhelFnLoaderInterface`, `PrinterInterface`). Each site must be checked for an
-absent `->expects()` before converting, so it warrants its own focused PR.
+`createMock()` used as a passive stub. The fix is mechanical but wide,
+`createMock(X::class)` → `createStub(X::class)` at the no-expectation sites across
+~17 files (`CompilerFacadeInterface`, `NamespaceExtractorInterface`,
+`BuildFacadeInterface`, `CommandFacadeInterface`, `PhelFnLoaderInterface`,
+`PrinterInterface`). Each site needs checking for an absent `->expects()` first,
+so it warrants its own PR.

--- a/docs/migration/deprecated-surface.md
+++ b/docs/migration/deprecated-surface.md
@@ -17,10 +17,11 @@ Everything the **compiler** knows about, syntax and definitions alike, goes
 through one switch: `Phel\Compiler\Domain\Deprecation\DeprecationWarnings`. It
 is off by default and reports when you ask for it.
 
-CLI-option deprecations are the one thing outside it: they always print a
-one-line notice on stderr through `Phel\Shared\Console\DeprecatedOptionWarner`,
-because a renamed flag is a single unmissable event rather than something
-scattered through your source.
+CLI-option deprecations are the one thing outside it: a renamed flag prints a
+one-line notice on stderr unconditionally, because it is a single unmissable
+event rather than something scattered through your source. No rename is in
+flight today, so there is no shared helper for it; see
+[cli-flag-conventions.md](../internals/cli-flag-conventions.md#renaming-an-option).
 
 Turn compiler deprecation warnings on with any of:
 

--- a/docs/migration/removed-deprecated-core-fns.md
+++ b/docs/migration/removed-deprecated-core-fns.md
@@ -1,6 +1,12 @@
 # Migration: Removed Long-Deprecated Core Functions
 
-The core functions below were deprecated for many releases and are now **removed** ([#2784](https://github.com/phel-lang/phel-lang/issues/2784)). Each was a thin alias, so replace every call site with the canonical function; arguments and behavior are unchanged.
+Everything here is **removed**. The step-by-step upgrade path is
+[upgrade-0.49-to-1.0.md](upgrade-0.49-to-1.0.md); this page is the full record.
+
+## Core aliases ([#2784](https://github.com/phel-lang/phel-lang/issues/2784))
+
+Each was a thin alias, so the replacement takes the same arguments and behaves
+the same way.
 
 | Removed | Deprecated since | Replacement |
 |---------|------------------|-------------|
@@ -13,95 +19,25 @@ The core functions below were deprecated for many releases and are now **removed
 | `function?` | 0.32.0 | `fn?` |
 | `hash-map?` | 0.32.0 | `map?` |
 | `id` | 0.32.0 | `identical?` |
-| `str-contains?` | long-deprecated | `phel\string\contains?` |
+| `str-contains?` | long-deprecated | `phel.string/contains?` |
+| `set-meta!` | 0.32.0 | `with-meta` |
+| `phel.test/print-summary` | 0.49.0 | react to the `:summary` event |
 
-## How to migrate
-
-The replacement keeps the same signature:
-
-```phel
-(push coll x)      ; -> (conj coll x)
-(put m :k v)       ; -> (assoc m :k v)
-(unset m :k)       ; -> (dissoc m :k)
-(put-in m ks v)    ; -> (assoc-in m ks v)
-(unset-in m ks)    ; -> (dissoc-in m ks)
-(values m)         ; -> (vals m)
-(function? x)      ; -> (fn? x)
-(hash-map? x)      ; -> (map? x)
-(id a b)           ; -> (identical? a b)
-```
-
-`str-contains?` now lives in the `phel\string` namespace:
+`str-contains?` moved namespace, so it needs a require:
 
 ```phel
-(ns my-app (:require phel\string :as s))
+(ns my-app (:require phel.string :as s))
 
 (str-contains? haystack needle)   ; -> (s/contains? haystack needle)
 ```
 
-## Removed CLI option aliases
+`run-tests` already emits `:summary` at the end of a run, so calling
+`print-summary` double-reported. A custom reporter reacts to the event instead of
+triggering it. A harness needing a summary for stats it assembled itself builds
+the event from the public `get-stats` snapshot; `phel.test` keeps its own builder
+private so the event shape stays free to change.
 
-Two renamed options kept a deprecated alias; the aliases are now removed ([#2827](https://github.com/phel-lang/phel-lang/issues/2827)).
-
-| Removed | Replacement |
-|---------|-------------|
-| `phel index --out=PATH` | `phel index --output=PATH` (`-o`) |
-| `phel config --json` | `phel config --format=json` (`-f json`) |
-
-```bash
-phel index --out=index.json      # -> phel index --output=index.json
-phel config --json               # -> phel config --format=json
-```
-
-Passing a removed alias now fails with Symfony's own `The "--out" option does not exist.`, so a stale CI invocation surfaces immediately rather than silently. The conventions these were aligned to are in [../internals/cli-flag-conventions.md](../internals/cli-flag-conventions.md).
-
-## Removed REPL history migration
-
-The REPL history file moved from `<project>/.phel-repl-history` to `<project>/.phel/repl-history` in `0.37.0`, and every REPL start since then migrated a legacy file automatically. That migration is now removed, along with the `PHEL_QUIET_MIGRATION` environment variable that silenced its notice.
-
-A project that upgraded through any release from `0.37.0` onwards has already been migrated and needs to do nothing. A project jumping straight from before `0.37.0` keeps its old file untouched and simply starts a fresh history; move it by hand to keep it:
-
-```bash
-mkdir -p .phel && mv .phel-repl-history .phel/repl-history
-```
-
-Replace any literal `.phel-repl-history` in a `.gitignore` or CI cache key with `.phel/`.
-## Removed function-parameter metadata
-
-`^:reference` marked a by-reference fn parameter. `^:by-ref` was always the canonical spelling and the two were exactly equivalent, so the alias is removed ([#2827](https://github.com/phel-lang/phel-lang/issues/2827)).
-
-```phel
-(defn fill [^:reference buffer]       (defn fill [^:by-ref buffer]
-  (php/array_push buffer 1))            (php/array_push buffer 1))
-```
-
-`^:reference` is now simply not a by-reference marker: the parameter compiles by value, and a function relying on the mutation stops propagating it to the caller. Grep for the literal `:reference` in parameter metadata, since a symbol rename will not find it.
-
-## Removed core definitions
-
-| Removed | Deprecated since | Replacement |
-|---------|------------------|-------------|
-| `set-meta!` | 0.32.0 | `with-meta` |
-| `phel\test/print-summary` | 0.49.0 | react to the `:summary` event |
-
-`set-meta!` was a thin alias with the same arguments and return value:
-
-```phel
-(set-meta! [] {:a 1})   ; -> (with-meta [] {:a 1})
-```
-
-`run-tests` already emits the `:summary` event at the end of a run, so calling `print-summary` yourself double-reported:
-
-```phel
-(t/run-tests {} 'my-app.core-test)    (t/run-tests {} 'my-app.core-test)
-(t/print-summary)                     ;; nothing else needed
-```
-
-A custom reporter reacts to the `:summary` event instead of triggering it. A test harness that needs a summary for stats it assembled itself builds the event from the public `get-stats` snapshot and hands it to the reporter; `phel.test` keeps its own builder private on purpose, so the event shape stays free to change.
-
-## Removed reader syntax
-
-Six spellings are removed ([#2827](https://github.com/phel-lang/phel-lang/issues/2827)).
+## Reader syntax ([#2827](https://github.com/phel-lang/phel-lang/issues/2827))
 
 | Removed | Replacement |
 |---|---|
@@ -115,10 +51,6 @@ Six spellings are removed ([#2827](https://github.com/phel-lang/phel-lang/issues
 ```phel
 # old line comment                    ;; new line comment
 
-#|
-  old block comment
-|#                                    ;; new block comment, one line at a time
-
 (map |(inc $) xs)                     (map #(inc %) xs)
 (map |(+ $1 $2) xs ys)                (map #(+ %1 %2) xs ys)
 
@@ -126,26 +58,67 @@ Six spellings are removed ([#2827](https://github.com/phel-lang/phel-lang/issues
 `(let [v$ ,x] (+ v$ v$))              `(let [v# ~x] (+ v# v#))
 ```
 
-### Most of these now fail loudly
+`#`, `#|` and `|(` are no longer tokens, so a file using them fails to lex or
+reports an unresolvable symbol `|`.
 
-`#`, `#|` and `|(` are simply not tokens any more, so a file still using them fails to lex or reports an unresolvable symbol `|`. You will know immediately.
-
-**`,` is the exception, and it is the one to grep for.** A comma is now plain whitespace *everywhere*, syntax-quote included. `` `(foo ,x) `` still parses; it just quotes the symbol `x` instead of unquoting it, so a macro keeps compiling and starts producing the wrong expansion. Phel's own stdlib had three of these (`aset`, `aset-in` and `router/compiled-router`), which is a fair warning about how easy they are to miss.
-
-Grep for a comma directly followed by the start of a form:
+**`,` is the exception and the one to grep for.** A comma is plain whitespace
+everywhere now, syntax-quote included: `` `(foo ,x) `` still parses and quotes
+`x` instead of unquoting it, so a macro keeps compiling and starts producing the
+wrong expansion. Phel's own stdlib had three (`aset`, `aset-in`,
+`router/compiled-router`).
 
 ```bash
 grep -rnE ",[A-Za-z0-9_(\[{'\`~@:*+-]" --include='*.phel' src/ tests/
 ```
 
-A comma between map pairs (`{:a 1, :b 2}`) is followed by a space and is unaffected. `phel format` keeps preserving commas and still never inserts them.
+A comma between map pairs (`{:a 1, :b 2}`) is followed by a space and is
+unaffected. `phel format` preserves commas and never inserts them.
 
-### `$` is still a symbol
+Only the auto-gensym meaning of a trailing `$` is gone. `$` is still the return
+value inside an `fn` `:post` condition, and an ordinary character in a name.
 
-Only the *auto-gensym* meaning of a trailing `$` is gone. `$` remains the return value inside an `fn` `:post` condition, and a `$` anywhere in a name is an ordinary character.
+## Function-parameter metadata ([#2827](https://github.com/phel-lang/phel-lang/issues/2827))
 
-## Still deprecated (not removed)
+`^:reference` and `^:by-ref` marked the same thing; the alias is removed.
 
-The `warn-deprecations` infrastructure stays, since it still serves live deprecations such as the deprecated reader syntax and the `\` namespace separator (see [backslash-to-dot.md](backslash-to-dot.md)). `DeprecatedDefinitionWarner` stays too: it is a general facility that project code uses for its own `:deprecated` definitions.
+```phel
+(defn fill [^:reference buffer]       (defn fill [^:by-ref buffer]
+  (php/array_push buffer 1))            (php/array_push buffer 1))
+```
 
-[deprecated-surface.md](deprecated-surface.md) maps the whole set of deprecations that are still shipped, with a before/after for each.
+`^:reference` is no longer a by-reference marker: the parameter compiles by
+value and a function relying on the mutation stops propagating it. Grep for the
+literal `:reference`, since a symbol rename will not find it.
+
+## CLI option aliases ([#2827](https://github.com/phel-lang/phel-lang/issues/2827))
+
+| Removed | Replacement |
+|---------|-------------|
+| `phel index --out=PATH` | `phel index --output=PATH` (`-o`) |
+| `phel config --json` | `phel config --format=json` (`-f json`) |
+
+A removed alias now fails with Symfony's `The "--out" option does not exist.`, so
+a stale CI invocation surfaces immediately. Conventions:
+[cli-flag-conventions.md](../internals/cli-flag-conventions.md).
+
+## REPL history migration
+
+History moved from `<project>/.phel-repl-history` to `<project>/.phel/repl-history`
+in `0.37.0`, and every REPL start since migrated a legacy file automatically. That
+migration is removed, along with `PHEL_QUIET_MIGRATION`.
+
+A project that upgraded through any release from `0.37.0` on is already migrated.
+One jumping straight from before `0.37.0` starts a fresh history; move it by hand
+to keep it, and replace any literal `.phel-repl-history` in `.gitignore` or a CI
+cache key with `.phel/`:
+
+```bash
+mkdir -p .phel && mv .phel-repl-history .phel/repl-history
+```
+
+## Still deprecated
+
+The `warn-deprecations` infrastructure stays: it serves live deprecations such as
+the `\` namespace separator, and `DeprecatedDefinitionWarner` is a general
+facility project code uses for its own `:deprecated` definitions.
+[deprecated-surface.md](deprecated-surface.md) maps everything still shipped.

--- a/docs/migration/upgrade-0.49-to-1.0.md
+++ b/docs/migration/upgrade-0.49-to-1.0.md
@@ -1,78 +1,59 @@
 # Upgrading from 0.49 to 1.0
 
-`1.0.0` is a stability commitment, not a feature release. Almost nothing new
-arrives with it; what arrives is a promise that what already exists stops moving.
-See [the stability policy](../stability.md) for exactly what that promise covers.
+`1.0.0` is a stability commitment, not a feature release: what arrives is a
+promise that what exists stops moving. See
+[the stability policy](../stability.md) for what it covers.
 
-The upgrade is therefore small, and most projects need nothing at all. The work,
-where there is any, is removing calls to things that have been printing
-deprecation notices for several releases.
+Most projects need nothing. Where there is work, it is removing calls to things
+that have been printing deprecation notices for several releases.
 
 ## Step 1: find out whether you are affected
 
-Deprecation warnings are off by default. Turn them on for one run:
+Warnings are off by default. Turn them on for one run:
 
 ```bash
 vendor/bin/phel run --warn-deprecations src/main.phel
 PHEL_WARN_DEPRECATIONS=1 vendor/bin/phel test
 ```
 
-or, project-wide:
-
 ```php
 return PhelConfig::forProject()->withWarnDeprecations(true);
 ```
 
-Uses inside Phel's own bundled standard library are suppressed, so the output
-lists only code you own. **A clean run on 0.49 means the upgrade is a version
-bump.** Everything below is a fix for something that run reported.
-
-Deprecation notices go to stderr and never corrupt program output; a notice
-cannot break a build.
+Uses inside Phel's own stdlib are suppressed, so the output lists only code you
+own. **A clean run on 0.49 means the upgrade is a version bump.** Notices go to
+stderr and cannot break a build.
 
 ## Step 2: reader syntax
 
-These parse today and are removed in 1.0.
+`#| |#`, bare `#` comments, `|(x)` short fns, `,` / `,@` unquote and `foo$`
+auto-gensym are gone. Full table and replacements:
+[removed-deprecated-core-fns.md](removed-deprecated-core-fns.md#reader-syntax-2827).
 
-| Old | New |
-|---|---|
-| `#\| block comment \|#` | `;` line comments, or `#_` to discard a form |
-| `# bare comment` | `;` (or `;;` for a whole-line comment) |
-| `\|(x)` short function | `#(x)` |
-| `` `(f ,x) `` | `` `(f ~x) `` |
-| `` `(f ,@xs) `` | `` `(f ~@xs) `` |
-| `foo$` auto-gensym | `foo#` |
-
-**`,` is the dangerous one.** Every other item above stops parsing, so the
-compiler finds it for you. `,` is now plain whitespace, which means
-`` `(f ,x) `` still parses and quietly *quotes* `x` instead of unquoting it. There
-is no error, only a wrong expansion.
-
-Find it with:
+**`,` is the dangerous one.** Everything else stops parsing, so the compiler
+finds it. `,` is now plain whitespace, so `` `(f ,x) `` still parses and quietly
+*quotes* `x`. No error, only a wrong expansion.
 
 ```bash
 grep -rnE ",[A-Za-z0-9_(\[{'\`~@:*+-]" --include='*.phel' src/ tests/
 ```
 
 A comma followed by whitespace is fine and always was: `{:a 1, :b 2}` is
-idiomatic and `phel format` preserves it.
-
-Do not restrict the sweep to your `.phel` files. Anything that *generates* Phel
-(a PHP heredoc, a template, a scaffold) needs the same pass. Phel's own repository
-had two such cases and both were invisible to a `.phel` grep.
+idiomatic. Do not restrict the sweep to `.phel` files: anything that *generates*
+Phel (a PHP heredoc, a template, a scaffold) needs the same pass. Phel's own
+repository had two such cases, both invisible to a `.phel` grep.
 
 ## Step 3: definitions and metadata
 
 | Old | New |
 |---|---|
-| `(set-meta! v m)` | `(with-meta v m)`, or attach the metadata at definition |
-| `(phel\test/print-summary)` | `(phel\test/successful?)` plus your own reporting, or the default reporter |
-| `^:reference` parameters | pass and return values; use an `atom` where you need shared mutable state |
+| `(set-meta! v m)` | `(with-meta v m)`, or attach metadata at definition |
+| `(phel.test/print-summary)` | `(phel.test/successful?)` plus your own reporting, or the default reporter |
+| `^:reference` parameters | pass and return values; use an `atom` for shared mutable state |
 
-`^:reference` deserves a note: it emitted a PHP by-reference parameter, which is
-a PHP concept rather than a Phel one, and it interacted badly with the rest of the
-language. `php/ref` remains for genuine interop with a PHP function that takes an
-output parameter.
+`^:reference` emitted a PHP by-reference parameter, a PHP concept rather than a
+Phel one, and interacted badly with the rest of the language. `php/ref` remains
+for genuine interop with a function taking an output parameter.
 
 ## Step 4: CLI flags
 
@@ -81,13 +62,12 @@ output parameter.
 | `phel index --out <dir>` | `phel index --output <dir>` |
 | `phel config --json` | `phel config --format=json` |
 
-The old spellings printed a one-line notice on stderr on every run.
+Both printed a one-line stderr notice on every run before removal.
 
 ## Step 5: the REPL history file
 
 `.phel-repl-history` in the project root is no longer read or migrated. History
-lives at `.phel/repl-history`. Nothing is lost: the old file is left where it is
-and simply ignored. Move it if you want the history back:
+lives at `.phel/repl-history`. The old file is left where it is and ignored:
 
 ```bash
 mkdir -p .phel && mv .phel-repl-history .phel/repl-history
@@ -95,47 +75,43 @@ mkdir -p .phel && mv .phel-repl-history .phel/repl-history
 
 ## Step 6: if you embed Phel in PHP
 
-Two things changed for code that calls Phel's PHP classes directly, both already
-shipped in 0.49 and both marked **BREAKING** in the changelog:
+Two changes for code calling Phel's PHP classes directly, both shipped in 0.49
+and marked **BREAKING** in the changelog:
 
 - The five transfers named by `ApiFacadeInterface` moved from `Phel\Api\Transfer\`
-  to `Phel\Shared\Api\`: `Diagnostic`, `ProjectIndex`, `Definition`, `Location`,
-  `Completion`. The class shapes did not change.
-- The four unrelated interfaces all named `FileIoInterface` were renamed after
-  what each does: `DirectoryWritabilityCheckerInterface`, `FileContentsIoInterface`,
+  to `Phel\Shared\Api\` (`Diagnostic`, `ProjectIndex`, `Definition`, `Location`,
+  `Completion`). Shapes unchanged.
+- The four unrelated `FileIoInterface` interfaces were renamed after what each
+  does: `DirectoryWritabilityCheckerInterface`, `FileContentsIoInterface`,
   `ValidatedFileIoInterface`, `FileWriterInterface`.
 
-From 1.0 on, changes like these can only happen in a major, and every class in
-`src/php/` outside the [public surface](../stability.md#public-php-api) carries
-`@internal`, so your IDE and static analyser will tell you when you reach for one.
-
-If you find yourself depending on an internal class, that is worth
+From 1.0 on such changes need a major, and everything outside the
+[public surface](../stability.md#public-php-api) carries `@internal`, so an IDE
+and a static analyser will tell you when you reach for one. Depending on an
+internal class is worth
 [an issue](https://github.com/phel-lang/phel-lang/issues): it usually means a
 facade is missing a method.
 
 ## What is *not* changing
 
-- **The `\` namespace separator still works.** `(ns my-app\core)` and
-  `phel\string/join` keep parsing. It is deprecated in favour of `.` and has its
-  own tracking issue ([#1567](https://github.com/phel-lang/phel-lang/issues/1567)),
-  but it is not removed in 1.0. Migrate at your own pace;
-  [backslash-to-dot.md](backslash-to-dot.md) has the details.
-- **Every other public `phel.*` function.** The full list is pinned in
-  `tests/php/Integration/Api/core-api.snapshot.txt` and a test fails if any
-  definition or arity disappears.
-- **`phel-config.php`.** Its keys and the `with*()` builder are frozen.
+- **The `\` namespace separator still works.** Deprecated in favour of `.`, not
+  removed in 1.0 ([#1567](https://github.com/phel-lang/phel-lang/issues/1567)).
+  Details in [backslash-to-dot.md](backslash-to-dot.md).
+- **Every other public `phel.*` function.** Pinned in
+  `tests/php/Integration/Api/core-api.snapshot.txt`; a test fails if a definition
+  or arity disappears.
+- **`phel-config.php`** keys and its `with*()` builder.
 - **The `.phel/` directory layout.**
 
 ## After upgrading
 
-Run `phel doctor` to confirm the environment, then your own suite. If something
-behaves differently from Clojure and you are not sure whether it is a bug, check
-[the divergence catalogue](../spec/clojure-divergences.md) first: everything listed
-there is deliberate.
+Run `phel doctor`, then your own suite. If something behaves differently from
+Clojure, check [the divergence catalogue](../spec/clojure-divergences.md) first:
+everything listed there is deliberate.
 
 ## See also
 
-- [Stability policy](../stability.md): what 1.x promises, and for how long
-- [Language surface spec](../spec/language-surface.md): the frozen language
-- [The currently deprecated surface](deprecated-surface.md): what is still shipped and still deprecated
-- [Removed deprecated core functions](removed-deprecated-core-fns.md): the full removal record
+[Stability policy](../stability.md) ·
+[Language surface spec](../spec/language-surface.md) ·
+[Currently deprecated](deprecated-surface.md) ·
+[Removed](removed-deprecated-core-fns.md)

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -1,127 +1,95 @@
-# Web Playground — Language-Side Design & Spike
+# Web Playground: language-side design and spike
 
-Design notes and investigation for a "try Phel in the browser" playground
-(issue [#2696](https://github.com/phel-lang/phel-lang/issues/2696)).
-
-> The playground **UI** (editor, output pane, permalinks, doc "try it" widgets)
-> belongs in the [phel-lang.org](https://phel-lang.org) repo. This page tracks
-> the **language-side prerequisites**: the eval entry point, what a sandbox
-> would need, and whether a PHP-in-WASM build is feasible. It is a spike, not a
-> shipped feature.
+Design notes for a "try Phel in the browser" playground
+([#2696](https://github.com/phel-lang/phel-lang/issues/2696)). The **UI** (editor,
+output pane, permalinks, doc "try it" widgets) belongs in the
+[phel-lang.org](https://phel-lang.org) repo. This page tracks the language-side
+prerequisites. It is a spike, not a shipped feature.
 
 ## The eval building block
 
-Phel already ships a one-shot evaluator: the `eval` command (alias `e`), in
-`src/php/Run/Infrastructure/Command/EvalCommand.php`. It loads the core
-namespaces, compiles the input string through the normal
-lex → parse → analyze → emit pipeline, evaluates the emitted PHP in-memory
-(`InMemoryEvaluator`, which calls PHP `eval()`), and prints the result.
-
-It accepts an inline argument or reads from stdin with `-`:
+`phel eval` (alias `e`, `src/php/Run/Infrastructure/Command/EvalCommand.php`)
+loads the core namespaces, compiles the input through the normal pipeline,
+evaluates the emitted PHP in memory (`InMemoryEvaluator`, PHP `eval()`), and
+prints the result. Inline argument or stdin with `-`:
 
 ```console
 $ phel eval '(+ 1 2)'
 3
-
 $ echo '(* 6 7)' | phel eval -
 42
 ```
 
-This is ~80% of the "server-side sandbox" building block: a stateless
-string-in / value-out primitive an API endpoint could call per request. What it
-does **not** do is isolate anything — see the gap below.
+That is ~80% of a server-side sandbox primitive: stateless, string in, value out.
+What it does not do is isolate anything.
 
 ## The gap to a safe playground
 
-`phel eval` runs with the full power of the host process. It is a developer
-tool, not a sandbox. Two categories of escape hatch matter:
+`phel eval` runs with the full power of the host process. Two categories of escape
+hatch:
 
-1. **`php/*` interop special forms** — `php/new`, `php/->`, `php/::`,
-   `php/aget`, etc. (see `NAME_PHP_*` in `src/php/Lang/Symbol.php`). These reach
-   arbitrary PHP:
-
-   ```console
-   $ phel eval '(php/getenv "HOME")'
-   "/Users/you"
-   ```
-
-2. **Core functions that do I/O without any `php/*` form** — this is the
-   important finding. File and code-loading primitives are plain corelib
-   functions, reachable with no interop syntax at all:
+1. **`php/*` interop forms** (`NAME_PHP_*` in `src/php/Lang/Symbol.php`) reach
+   arbitrary PHP: `phel eval '(php/getenv "HOME")'`.
+2. **Core functions that do I/O with no `php/*` form at all.** This is the
+   important finding: `slurp` / `spit` (`src/phel/core/io.phel`), `load-file`
+   (`ns.phel`), `eval` / `read-string` (`protocols.phel`) are plain corelib
+   functions.
 
    ```console
    $ phel eval '(take 20 (slurp "/etc/hosts"))'
    @["#" "#" "\n" "#" " " "H" "o" "s" "t" ...]
    ```
 
-   - `slurp` / `spit` — read/write files (`src/phel/core/io.phel`)
-   - `load-file` — load and run a file (`src/phel/core/ns.phel`)
-   - `eval` / `read-string` — evaluate arbitrary code (`src/phel/core/protocols.phel`)
-
 ### Why a `--no-interop` flag is not enough
 
-An obvious first move is a flag that rejects `php/*` forms at analysis time. It
-was considered and **deliberately not shipped**: because `slurp`, `spit`,
-`load-file`, and `eval` are ordinary core functions (not `php/*` interop), a
-flag that only blocks `php/*` would leave the biggest escape hatches open. It
-would read as a safety feature while providing no boundary — false confidence is
-worse than none for a security-sensitive surface. Any real allowlist has to
-operate on the *effective set of callable symbols*, not just interop syntax.
+A flag rejecting `php/*` at analysis time was considered and **deliberately not
+shipped**. Because `slurp`, `spit`, `load-file` and `eval` are ordinary core
+functions, such a flag leaves the biggest escape hatches open while reading as a
+safety feature. False confidence is worse than none here. A real allowlist has to
+operate on the effective set of callable symbols, not on interop syntax.
 
-### What a real server-side sandbox needs (out of scope for one PR)
+### What a real server-side sandbox needs
 
-A trustworthy sandbox is a dedicated security project, not a compiler flag. It
-needs, at minimum:
+A dedicated security project, not a compiler flag. At minimum:
 
-- **Symbol allowlist** — restrict the callable corelib surface (drop `slurp`,
-  `spit`, `load-file`, `eval`, `read-string`, `sh`-style helpers) *and* reject
-  `php/*` interop, enforced at analysis time so nothing dangerous reaches the
-  emitter.
-- **OS-level isolation** — the process still runs PHP `eval()`, so the allowlist
-  is only defence-in-depth. The real boundary must be the container: no
-  filesystem writes, no network, seccomp/gVisor-style syscall filtering, a
-  read-only root, and a fresh short-lived process per request.
-- **Resource limits** — CPU/wall-clock timeout, memory cap, output-size cap,
-  recursion/stack guard (an infinite loop or huge allocation must be killed).
-- **Abuse prevention** — rate limiting, request-size limits, per-IP quotas.
+- **Symbol allowlist** restricting the callable corelib surface (drop `slurp`,
+  `spit`, `load-file`, `eval`, `read-string`, `sh`-style helpers) *and* rejecting
+  `php/*`, enforced at analysis time so nothing dangerous reaches the emitter.
+- **OS-level isolation**, since the process still runs PHP `eval()`: container
+  boundary, no filesystem writes, no network, syscall filtering, read-only root, a
+  fresh short-lived process per request.
+- **Resource limits**: CPU/wall-clock timeout, memory cap, output-size cap,
+  recursion guard.
+- **Abuse prevention**: rate limiting, request-size limits, per-IP quotas.
 
-This surface deserves its own PR with a dedicated security review. It should not
-be bolted onto `phel eval`.
+Its own PR with a dedicated security review. Not bolted onto `phel eval`.
 
-## PHP-in-WASM path — feasibility (GO, pending PoC)
+## PHP-in-WASM path: GO, pending PoC
 
-Running the compiler + runtime client-side via [php-wasm](https://github.com/seanmorris/php-wasm)
-sidesteps the server sandbox entirely (nothing runs on our infra; the browser
-tab is the sandbox). The language-side blockers were checked:
+Running compiler and runtime client-side via
+[php-wasm](https://github.com/seanmorris/php-wasm) sidesteps the server sandbox
+entirely: the browser tab is the sandbox. Language-side blockers checked:
 
 - **No hard PHP extension dependencies.** `composer.json` `require` is
   `php >=8.4`, `amphp/amp`, `gacela-project/gacela`, `symfony/console`,
-  `symfony/routing` — all pure PHP, no `ext-*`. The only `ext-*` entry
-  (`ext-readline`) is in `require-dev` and is used solely by the interactive
-  REPL, not by eval.
-- **Eval uses `eval()`, not `proc_open`.** The default `InMemoryEvaluator` calls
-  PHP `eval()`, which php-wasm supports. `proc_open`/`pcntl`/`posix`/Fibers
-  appear only in the parallel test runner, nREPL server, watcher, and async
-  paths — none are on the compile-and-eval path a playground uses.
+  `symfony/routing`, all pure PHP. The only `ext-*` entry (`ext-readline`) is
+  `require-dev` and used solely by the interactive REPL.
+- **Eval uses `eval()`, not `proc_open`.** `proc_open`/`pcntl`/`posix`/Fibers
+  appear only in the parallel test runner, nREPL server, watcher and async paths,
+  none on the compile-and-eval path.
 
-**Verdict: GO for a proof of concept.** No language-side hard blocker was found.
-Open items a PoC must verify (not assumed here):
-
-- php-wasm's bundled PHP version actually satisfies `>=8.4`.
-- Initial payload size once the compiler + core `.phel` library are bundled, and
-  cold-start compile time in the browser.
-- That the pure-PHP runtime deps (amp, gacela, symfony) load cleanly under
-  php-wasm's filesystem shim.
+Open items a PoC must verify: that php-wasm's bundled PHP satisfies `>=8.4`; the
+payload size once compiler plus core `.phel` are bundled, and cold-start compile
+time in the browser; that amp, gacela and symfony load cleanly under php-wasm's
+filesystem shim.
 
 ## Recommendation
 
-- **Short term:** embed non-interactive, pre-rendered `:example` output in docs
-  from the corelib metadata (no live eval, zero risk) while the playground is
-  built.
-- **Interactive playground:** prefer the **WASM path**. It removes the entire
-  server-sandbox surface (isolation, resource limits, abuse prevention) that
-  would otherwise each need building and reviewing. Gate it on a PoC that
-  confirms the three open items above.
+- **Short term:** embed pre-rendered `:example` output in docs from the corelib
+  metadata. No live eval, zero risk.
+- **Interactive playground:** prefer the WASM path. It removes the entire
+  server-sandbox surface that would otherwise each need building and reviewing.
+  Gate on the PoC above.
 - **If a server API is chosen instead:** treat the sandbox as a standalone,
-  security-reviewed project — symbol allowlist *plus* container isolation *plus*
-  resource limits — and do not present a compiler flag alone as a boundary.
+  security-reviewed project (allowlist *plus* container isolation *plus* resource
+  limits) and never present a compiler flag alone as a boundary.

--- a/docs/spec/clojure-divergences.md
+++ b/docs/spec/clojure-divergences.md
@@ -1,13 +1,13 @@
 # Deliberate Divergences from Clojure
 
-Phel follows Clojure semantics where it can. Where it does not, the difference is a
-decision, and this page is the record of it. **If a behaviour is listed here, it is not
-a bug.** Anything not listed that differs from Clojure is worth
+Phel follows Clojure semantics where it can. Where it does not, the difference is
+a decision, and this page is the record. **If a behaviour is listed here, it is
+not a bug.** Anything unlisted that differs is worth
 [an issue](https://github.com/phel-lang/phel-lang/issues).
 
 Every entry is pinned by a `:phel` reader conditional in
-[phel-lang/clojure-test-suite](https://github.com/phel-lang/clojure-test-suite), which
-runs against `main` nightly. That suite characterises Clojure JVM behaviour across
+[phel-lang/clojure-test-suite](https://github.com/phel-lang/clojure-test-suite),
+run against `main` nightly. That suite characterises Clojure JVM behaviour across
 dialects; a `:phel` branch is Phel saying "here, deliberately, something else".
 
 ## Why they exist
@@ -15,18 +15,18 @@ dialects; a `:phel` branch is Phel saying "here, deliberately, something else".
 Five forces produce nearly all of them:
 
 1. **PHP has no character type.** `\a` reads as the one-character string `"a"`.
-2. **PHP integers are 64-bit and promote rather than overflow.** There is no 32-bit
-   `int`, no `ArithmeticException`, and no JVM float overflow.
-3. **PHP comparison is total where Java's is not.** Strings, vectors, maps and sets are
-   all structurally comparable, so ordering functions return a value where Clojure
-   throws.
-4. **Throwing on bad input is expensive in a language with no static types**, so many
-   predicates and accessors are lenient and return `nil` or `false` instead.
-5. **PHP's own type coercion leaks through the numeric casts**, which parse numeric
+2. **PHP integers are 64-bit and promote rather than overflow.** No 32-bit `int`,
+   no `ArithmeticException`, no JVM float overflow.
+3. **PHP comparison is total where Java's is not.** Strings, vectors, maps and
+   sets are all structurally comparable, so ordering functions return a value
+   where Clojure throws.
+4. **Throwing on bad input is expensive without static types,** so many
+   predicates and accessors are lenient and return `nil` or `false`.
+5. **PHP's own coercion leaks through the numeric casts,** which parse numeric
    strings the way PHP does.
 
-Where Phel is lenient it usually lands where ClojureScript, Basilisp or ClojureCLR
-already are; the catalogue notes it when so.
+Where Phel is lenient it usually lands where ClojureScript, Basilisp or
+ClojureCLR already are; the catalogue notes it when so.
 
 ## 1. No character type
 
@@ -53,28 +53,25 @@ already are; the catalogue notes it when so.
 | `long` | parses numeric strings, treats `nil` as `0`; still throws on `:0` / `[0]` |
 | `double`, `float` | parse numeric strings (PHP float cast); `##Inf` casting is a no-op |
 | `byte` | truncates toward zero *before* the range check, so `-128.000001` passes |
-| `quot`, `rem`, `mod` | IEEE-754 semantics: an infinite or NaN operand yields NaN rather than throwing. Integer division by zero still throws |
+| `quot`, `rem`, `mod` | IEEE-754: an infinite or NaN operand yields NaN rather than throwing. Integer division by zero still throws |
 | `/` | `(/)` is `1`, the multiplicative identity, mirroring `(*)`. Clojure throws on zero args |
 | `numerator`, `denominator` | accept plain integers, treating `n` as `n/1` (matches Basilisp) |
 
-### Lenient numeric predicates
-
-`even?`, `odd?`, `neg?` and `zero?` do not validate that their argument is an integer.
-Floats, infinities and NaN return a boolean instead of throwing. `zero?` returns
-`false` for non-numeric input rather than throwing (matches Basilisp and
-ClojureScript). `neg?` coerces `false`/`true` to `0`/`1`. Only `nil` is rejected by
-`even?`, `odd?` and `neg?`.
+`even?`, `odd?`, `neg?` and `zero?` do not validate that their argument is an
+integer: floats, infinities and NaN return a boolean. `zero?` returns `false` for
+non-numeric input (matches Basilisp and ClojureScript), `neg?` coerces
+`false`/`true` to `0`/`1`, and only `nil` is rejected by `even?`, `odd?`, `neg?`.
 
 ## 3. Comparison is total
 
-Clojure throws when asked to order values that are not `Comparable`. Phel compares them
-structurally.
+Clojure throws when asked to order values that are not `Comparable`. Phel
+compares them structurally.
 
 | Function | Behaviour |
 |---|---|
-| `compare` | vectors, lists, sets, maps and ranges compare element-wise or by count. Comparing across *kinds* (vector vs map) still throws |
+| `compare` | vectors, lists, sets, maps and ranges compare element-wise or by count. Comparing across *kinds* still throws |
 | `min`, `max` | strings compare lexicographically; `nil` is still rejected |
-| `min-key`, `max-key` | strings, vectors, maps and sets are all comparable, so a value comes back instead of a throw |
+| `min-key`, `max-key` | strings, vectors, maps and sets are comparable, so a value comes back instead of a throw |
 | `sort-by` | a non-callable comparator yields an empty result instead of throwing |
 
 ## 4. Lenient accessors and predicates
@@ -88,151 +85,142 @@ These return `nil` or a benign value where Clojure throws.
 | `nth` | `(nth nil _)` is `nil` for any index. Out of bounds on a real vector still throws |
 | `key` | `nil` for empty or non-pair collections; the first element for sequential pairs |
 | `val` | calls `next` and returns the second element; only a non-seqable scalar like `0` throws |
-| `keys`, `vals` | `nil` for a non-associative scalar instead of throwing |
-| `peek` | lenient on maps (`nil`), lists, cons and lazy seqs (head), and strings (last char). Throws only for sets and non-seqable scalars |
+| `keys`, `vals` | `nil` for a non-associative scalar |
+| `peek` | lenient on maps (`nil`), lists, cons and lazy seqs (head), strings (last char). Throws only for sets and non-seqable scalars |
 | `empty?` | `(not (seq x))` over a lenient `count`; `(empty? 0)` is `true` |
 | `dissoc` | accepts a set and removes the element |
-| `select-keys` | an empty string behaves as an empty associative source and yields `{}` |
+| `select-keys` | an empty string behaves as an empty associative source, yielding `{}` |
 | `shuffle` | coerces any seqable; `nil` and `{}` yield `[]`, a string shuffles its characters |
 | `remove` | regexes and strings are iterable, so a regex yields its pattern characters |
 | `realized?` | anything not a pending delay, promise or future is "realized", including `nil` |
-| `intern` | auto-creates an unknown target namespace instead of throwing |
-| `keyword`, `symbol` | accept symbols and keywords for the ns/name arguments and coerce to their string names |
-
-### `nil`-punned counts
+| `intern` | auto-creates an unknown target namespace |
+| `keyword`, `symbol` | accept symbols and keywords for the ns/name arguments, coercing to their string names |
 
 `drop`, `take`, `nthnext` and `take-nth` treat a `nil` count as `0` rather than
-throwing, matching ClojureScript. For `take` this is the transducer arity only; the
-lazy-seq arity still throws.
+throwing, matching ClojureScript. For `take` this is the transducer arity only;
+the lazy-seq arity still throws.
 
-### `nil`-safe parsers
-
-`parse-boolean`, `parse-double`, `parse-long` and `parse-uuid` return `nil` for any
-input they cannot parse, including non-strings, so they chain inside `when` and
-`if-let` without a guard. Clojure throws on a non-string.
+`parse-boolean`, `parse-double`, `parse-long` and `parse-uuid` return `nil` for
+anything they cannot parse, including non-strings, so they chain inside `when`
+and `if-let` without a guard. Clojure throws on a non-string.
 
 ## 5. Stricter than Clojure
 
-The one place Phel is *less* permissive. `phel.string` functions require a string:
-`capitalize`, `lower-case`, `upper-case`, `starts-with?` and `ends-with?` throw on a
-non-string rather than coercing through `str`. This matches ClojureScript, Basilisp and
-ClojureCLR; the JVM's coercing `:default` branch is the outlier.
+The one place Phel is *less* permissive. `phel.string` functions require a
+string: `capitalize`, `lower-case`, `upper-case`, `starts-with?` and `ends-with?`
+throw on a non-string rather than coercing through `str`. This matches
+ClojureScript, Basilisp and ClojureCLR; the JVM's coercing `:default` branch is
+the outlier.
 
 ## 6. Host interop
 
 ### A string receiver is a class name
 
-`(.m x)` reads a string `x` as a **class name**, so `(.cases "\\App\\Status")` reaches
-`App\Status::cases()`. Clojure reads the same receiver as the object, because a JVM
-`String` has methods and `(.length "abc")` has to work.
+`(.m x)` reads a string `x` as a **class name**, so `(.cases "\\App\\Status")`
+reaches `App\Status::cases()`. Clojure reads the same receiver as the object,
+because a JVM `String` has methods and `(.length "abc")` has to work.
 
-The difference is forced by the host: PHP strings have no methods at all, so
-`$string->m()` is never valid PHP and there is no behaviour to preserve. Reading the
-receiver as a class name is therefore free here and impossible there. Clojure's own
-answer for a class known only at runtime is `clojure.lang.Reflector/invokeStaticMethod`,
-a function rather than syntax ([#2881](https://github.com/phel-lang/phel-lang/issues/2881)).
-
-A receiver the compiler can prove is an object still emits `->`, so only an unprovable
-one carries the runtime test.
+The host forces it: PHP strings have no methods, so `$string->m()` is never valid
+PHP and there is no behaviour to preserve. Clojure's own answer for a class known
+only at runtime is `clojure.lang.Reflector/invokeStaticMethod`, a function rather
+than syntax ([#2881](https://github.com/phel-lang/phel-lang/issues/2881)). A
+receiver the compiler can prove is an object still emits `->`, so only an
+unprovable one carries the runtime test.
 
 ### `Class/new` is not a constructor
 
-Clojure 1.12 reads `File/new` in value position as the constructor. Phel does not, and
+Clojure 1.12 reads `File/new` in value position as the constructor. Phel does not:
 `\C/new` keeps meaning the class constant `new`.
 
-PHP 7 lifted the ban on reserved words as member names, so `Foo::new()` is both legal
-and a common named-constructor idiom, and a single class can carry a constant `new` and
-a static method `new` at once. Claiming the name would silently change what existing
-code reads: `(\League\Uri\Urn/new "urn:isbn:1234")` already calls a real `::new()`
-factory, and `league/uri` and `phpbench` both ship one. Java forbids the name outright,
-which is what let Clojure take it safely;
+PHP 7 lifted the ban on reserved words as member names, so `Foo::new()` is both
+legal and a common named-constructor idiom, and one class can carry a constant
+`new` and a static method `new` at once. Claiming the name would silently change
+what existing code reads: `(\League\Uri\Urn/new "urn:isbn:1234")` already calls a
+real `::new()` factory, and `league/uri` and `phpbench` both ship one. Java
+forbids the name outright, which is what let Clojure take it safely;
 [Basilisp declined it](https://docs.basilisp.org/en/latest/differencesfromclojure.html#host-interop)
 for the same reason Python does not.
 
-A constructor as a value stays `(fn [x] (new \C x))`. The two safe halves of the Clojure
-1.12 syntax are supported: `\C/m` is a static method as a value and `\C/.m` is an
-instance method as a function of its receiver
-([#2883](https://github.com/phel-lang/phel-lang/issues/2883)).
+A constructor as a value stays `(fn [x] (new \C x))`. The two safe halves of the
+Clojure 1.12 syntax are supported: `\C/m` is a static method as a value, `\C/.m`
+an instance method as a function of its receiver
+([#2883](https://github.com/phel-lang/phel-lang/issues/2883)). Where a class
+carries a constant *and* a static method under one name the constant wins, as it
+did before the value-position forms existed; the shadowed method stays reachable
+as `(\C/m x)`.
 
-Where a class carries a constant *and* a static method under one name, the constant
-wins, which is what happened before the value-position forms existed. The shadowed
-method stays reachable in call position, `(\C/m x)`, and as `(fn [x] (\C/m x))`.
-
-This is the one entry the suite does not pin, because no working program can observe it:
-a string receiver was an error before the change and is an error after it, and only the
-message differs. It is listed because the *capability* is a difference a Clojure reader
-will notice, not because a behaviour changed under them.
+The suite does not pin this one, because no working program can observe it: a
+string receiver was an error before and after, and only the message differs. It is
+listed because the *capability* is a difference a Clojure reader will notice.
 
 ### `aset` and `set!` are macros, not functions
 
-Clojure's `aset` is a function, so `(map (partial aset arr) …)` and any other
-higher-order use works. Phel's is a **macro**, and so is `set!`.
+Clojure's `aset` is a function, so `(map (partial aset arr) …)` works. Phel's is a
+**macro**, and so is `set!`.
 
-PHP arrays are value types: a function receiving one receives a copy, so a function
-`aset` would mutate the copy and drop the write. `set!` is a macro for the usual reason
-a place-setting form is: its first argument is a location (`(.-field o)`), not a value.
+PHP arrays are value types: a function receiving one receives a copy, so a
+function `aset` would mutate the copy and drop the write. `set!` is a macro
+because its first argument is a location (`(.-field o)`), not a value.
 
-The practical consequence is that neither can be passed to a higher-order function.
-Where Clojure would use `(partial aset arr)`, wrap it: `(fn [i v] (aset arr i v))`.
+Neither can be passed to a higher-order function. Where Clojure would use
+`(partial aset arr)`, wrap it: `(fn [i v] (aset arr i v))`.
 
 ### Mutation naming: which forms got Clojure names
 
-`set!` is the one mutating `php/*` form with a Clojure spelling, and it has it
-([#2884](https://github.com/phel-lang/phel-lang/issues/2884)). The rest keep the `php/`
+`set!` is the one mutating `php/*` form with a Clojure spelling
+([#2884](https://github.com/phel-lang/phel-lang/issues/2884)). The rest keep the
 prefix, deliberately:
 
 | Form | Decision | Why |
 |---|---|---|
 | `php/oset` | `set!` in `phel.core` | Clojure spells this exact operation `(set! (.-field o) v)` |
 | `php/aset`, `php/aget`, `php/aclone`, `php/alength` | core names since [#1411](https://github.com/phel-lang/phel-lang/issues/1411) | same names Clojure uses |
-| `php/apush`, `php/aunset` | stay `php/*` | JVM arrays are fixed size, so Clojure has no counterpart and any core name would be invented. 1.0 freezes whatever ships, so an invented name is the expensive kind of guess; revisit when a concrete need names it |
-| `php/ref`, `php/callable` | stay `php/*` | both take an **unevaluated** form (a variable to reference, a call target), so neither can be a plain function, and both name a host mechanism with no Clojure analogue |
+| `php/apush`, `php/aunset` | stay `php/*` | JVM arrays are fixed size, so Clojure has no counterpart and any core name would be invented. 1.0 freezes whatever ships, so an invented name is the expensive kind of guess |
+| `php/ref`, `php/callable` | stay `php/*` | both take an **unevaluated** form, so neither can be a plain function, and both name a host mechanism with no Clojure analogue |
 
 ### Var mutation: three operations, three names
 
-Clojure overloads `set!` across a field and a thread-local var binding, and gives root
-mutation its own name. Phel matches that, with one extra name it inherited:
+Clojure overloads `set!` across a field and a thread-local binding, and gives root
+mutation its own name. Phel matches that, plus one name it inherited:
 
 | Operation | Clojure | Phel |
 |---|---|---|
 | assign an object field | `(set! (.-f o) v)` | `(set! (.-f o) v)` |
 | assign the current thread-local binding | `(set! *x* v)` | `(set! *x* v)`, or `(var-set #'*x* v)` |
 | change the root | `(alter-var-root #'*x* f)` | `(alter-var-root #'*x* f)` |
-| *(no Clojure counterpart)* | | `(set-var *x* v)`, a special form that writes the root directly — **deprecated** |
+| *(no Clojure counterpart)* | | `(set-var *x* v)`, a special form writing the root directly, **deprecated** |
 
-`set!` on a symbol writes only the binding frame and **throws when none is active**, so
-it can never change a root by accident, exactly as in Clojure.
+`set!` on a symbol writes only the binding frame and **throws when none is
+active**, so it can never change a root by accident, exactly as in Clojure.
 
-`set-var` is the odd one out: it is a special form, it takes a value rather than a
-function, and its name reads like Clojure's `set!` while behaving like
-`alter-var-root`. A name that points a Clojure reader at the wrong operation is the
-failure mode this page exists to prevent, so it is **deprecated** in favour of
-`alter-var-root` ([#2888](https://github.com/phel-lang/phel-lang/issues/2888)). It is
-on the closed special-form list, so it still works throughout `1.x`, warns under
-`--warn-deprecations`, and can only be removed at a major:
+`set-var` is the odd one out: a special form, taking a value rather than a
+function, with a name that reads like Clojure's `set!` while behaving like
+`alter-var-root`. A name pointing a Clojure reader at the wrong operation is the
+failure mode this page exists to prevent, so it is deprecated
+([#2888](https://github.com/phel-lang/phel-lang/issues/2888)). It is on the closed
+special-form list, so it works throughout `1.x` and can only be removed at a
+major.
 
 ```phel
 (set-var *x* 3)                        (alter-var-root #'*x* (constantly 3))
 ```
 
-The two do not have the same call shape, which is why this is a deprecation and not a
-rename: `set-var` takes the symbol and a value, `alter-var-root` takes a var and a
-function. Wrap a plain value in `constantly`.
+The call shapes differ, which is why this is a deprecation and not a rename:
+`set-var` takes a symbol and a value, `alter-var-root` a var and a function.
 
 ## 7. Absent concepts
 
 | Clojure | Phel |
 |---|---|
-| `aclone`, reference identity | PHP arrays are value types; there is nothing to alias ([#1735](https://github.com/phel-lang/phel-lang/issues/1735)) |
+| `aclone`, reference identity | PHP arrays are value types; nothing to alias ([#1735](https://github.com/phel-lang/phel-lang/issues/1735)) |
 | `special-symbol?` | Phel does not recognise the JVM special-symbol set |
 | Class objects (`string?` on a class) | classes are represented as strings |
 
 ## 8. Known gap, not a decision
 
-`case` returns `nil` when nothing matches and there is no default clause. Clojure
-throws. The suite marks this `:phel` with a note that it is arguably a real semantic
-gap rather than an intended divergence. It is the one entry on this page that may yet
-change; everything else is settled.
+`case` returns `nil` when nothing matches and there is no default clause; Clojure
+throws. The suite marks it `:phel` with a note that it is arguably a real semantic
+gap. It is the one entry here that may yet change.
 
 ## Keeping this page honest
 
@@ -243,5 +231,5 @@ git clone --depth 1 https://github.com/phel-lang/clojure-test-suite
 grep -rn -B4 ':phel' clojure-test-suite/test --include='*.cljc'
 ```
 
-Each `:phel` branch carries a comment explaining the divergence. A new one that is not
-represented here means this page is stale.
+Each `:phel` branch carries a comment explaining the divergence. A new one absent
+from this page means the page is stale.

--- a/docs/spec/language-surface.md
+++ b/docs/spec/language-surface.md
@@ -1,20 +1,17 @@
 # Language Surface Specification
 
-This page is **normative**. It enumerates the part of the Phel language that
-[the stability policy](../stability.md) freezes: Phel source that compiles on
-`1.0.0` compiles on every later `1.x`.
+**Normative.** The part of the language [the stability policy](../stability.md)
+freezes: Phel source that compiles on `1.0.0` compiles on every later `1.x`.
 
-Anything listed here can change only in a major release, and only after the
-[deprecation policy](../stability.md#deprecation-policy-for-1x) has run its course.
-Anything not listed is not frozen.
-
-[special-forms.md](../internals/special-forms.md) explains how these are dispatched
-and how to add one. This page says which ones exist and that the list is closed.
+Anything listed here changes only in a major, and only after the
+[deprecation policy](../stability.md#deprecation-policy-for-1x) has run its
+course. Anything not listed is not frozen.
+[special-forms.md](../internals/special-forms.md) explains dispatch; this page
+says which forms exist and that the list is closed.
 
 ## 1. Reader syntax
 
-The lexer's token set is the outermost contract: it decides whether a file parses at
-all. Every entry below is frozen.
+The lexer's token set decides whether a file parses at all. Every entry is frozen.
 
 | Syntax | Meaning |
 |---|---|
@@ -39,23 +36,23 @@ all. Every entry below is frozen.
 | `"…"` | string, with `\` escapes |
 | `foo#` | auto-gensym inside a quasiquote |
 
-Removed in the run-up to 1.0 and **not** coming back: `#\| \|#` block comments, a bare
-`#` comment, `\|()` short functions, `,` and `,@` as unquote, and `foo$` as auto-gensym.
-See [removed-deprecated-core-fns.md](../migration/removed-deprecated-core-fns.md).
+Removed in the run-up to 1.0 and **not** coming back: `#| |#` block comments, a
+bare `#` comment, `|()` short functions, `,` and `,@` as unquote, `foo$`
+auto-gensym. See
+[removed-deprecated-core-fns.md](../migration/removed-deprecated-core-fns.md).
 
-Still shipped and still deprecated: `\` as a namespace separator, tracked in
-[#1567](https://github.com/phel-lang/phel-lang/issues/1567). It is the only reader-level
-item whose fate is not yet settled; see
-[the deprecated surface map](../migration/deprecated-surface.md).
+Still shipped and still deprecated: `\` as a namespace separator
+([#1567](https://github.com/phel-lang/phel-lang/issues/1567)). The only
+reader-level item whose fate is unsettled.
 
 ## 2. Special forms
 
-A list whose head is one of these routes to a dedicated analyzer instead of being a
-function call. **The list is closed for 1.x**: entries are not removed and not renamed.
-Adding one is a minor-release feature, since existing source cannot be using it.
+A list whose head is one of these routes to a dedicated analyzer instead of being
+a function call. **The list is closed for 1.x**: entries are not removed and not
+renamed. Adding one is a minor feature, since existing source cannot use it.
 
-Trailing `*` marks a low-level form users are not expected to write directly; the
-macro that expands into it is named in the last column.
+Trailing `*` marks a low-level form users are not expected to write; the macro
+that expands into it is in the last column.
 
 | Form | Kind | Written directly as |
 |---|---|---|
@@ -101,19 +98,19 @@ macro that expands into it is named in the last column.
 | `var` | core | |
 
 `tests/php/Unit/Architecture/LanguageSurfaceSpecTest.php` parses this table and
-compares it against the analyzer's own dispatch registry, so the spec cannot drift
-from the compiler. A form added or removed in the analyzer fails the build until this
-page is updated too, which is the point at which somebody has to decide whether the
-change is allowed inside the major.
+compares it against the analyzer's dispatch registry, so the spec cannot drift
+from the compiler. A form added or removed in the analyzer fails the build until
+this page is updated, which is when somebody decides whether the change is
+allowed inside the major.
 
 ### Deprecated inside 1.x
 
-Four of the forms above are frozen but superseded. They keep working for every `1.x`,
-they warn under `--warn-deprecations`, and they are the candidates for removal at the
-next major. One rule puts them here:
+Four forms above are frozen but superseded. They keep working for every `1.x`,
+warn under `--warn-deprecations`, and are the candidates for removal at the next
+major. One rule puts them here:
 
-> **`php/` means host access. It is never a second spelling for something Phel already
-> says the Clojure way.**
+> **`php/` means host access. It is never a second spelling for something Phel
+> already says the Clojure way.**
 
 | Deprecated | Write instead |
 |---|---|
@@ -122,39 +119,37 @@ next major. One rule puts them here:
 | `php/::` | `(\Foo/method arg)` and `\Foo/CONST` |
 | `set-var` | `(alter-var-root #'v f)`, or `(set! v x)` for the current binding frame |
 
-One position is still open: an **assignable static property**. Neither spelling works
-today — `(php/oset (php/:: \Foo slot) v)` emits invalid PHP and `(set! \Foo/slot v)`
-routes to the var branch — so `php/::` is not the answer for it either. Tracked in
-[#2907](https://github.com/phel-lang/phel-lang/issues/2907).
+One position is still open: an **assignable static property**. Neither spelling
+works today (`(php/oset (php/:: \Foo slot) v)` emits invalid PHP and
+`(set! \Foo/slot v)` routes to the var branch), so `php/::` is not the answer for
+it either ([#2907](https://github.com/phel-lang/phel-lang/issues/2907)).
 
-The remaining `php/*` forms stay, because each reaches a PHP capability Phel has no
-other word for: `php/aget`, `php/aset`, `php/apush`, `php/aunset` and `php/oset` mutate
-in place, `php/ref` takes a PHP reference, and `php/callable` makes a PHP callable.
-`phel.core` already spells the common ones at top level (`aget`, `aset`, `aclone`,
-`alength`, `set!`), which is what a Clojure reader should reach for first.
+The remaining `php/*` forms stay, because each reaches a PHP capability Phel has
+no other word for: `php/aget`, `php/aset`, `php/apush`, `php/aunset` and
+`php/oset` mutate in place, `php/ref` takes a PHP reference, `php/callable` makes
+a PHP callable. `phel.core` spells the common ones at top level (`aget`, `aset`,
+`aclone`, `alength`, `set!`).
 
-`set-var` carries one extra constraint that its removal has to solve first: `binding`
-and `with-redefs` expand into it, because an emitted `set-var` inside an open frame is
-what records a rebinding. Removing the public form therefore needs a non-public
-primitive to take over that job.
+`set-var` carries one extra constraint its removal has to solve first: `binding`
+and `with-redefs` expand into it, because an emitted `set-var` inside an open
+frame is what records a rebinding. Removing the public form needs a non-public
+primitive to take that job.
 
-`tests/php/Unit/Architecture/LanguageSurfaceSpecTest.php` checks this table against
-`SupersededFormDeprecator` too, so the page and the compiler cannot disagree about
-which forms warn.
+`LanguageSurfaceSpecTest` checks this table against `SupersededFormDeprecator`
+too, so the page and the compiler cannot disagree about which forms warn.
+Rationale: [ADR 0007](../adr/0007-clojure-style-interop-is-the-source-spelling.md).
 
 ### Interop shorthands
 
-The Clojure-style interop spellings are analyzer sugar, not special forms: each expands
-to one of the `php/*` entries above before analysis, so they are deliberately absent
+Clojure-style interop spellings are analyzer sugar, not special forms: each
+expands to a `php/*` entry above before analysis, which is why they are absent
 from the table.
 
 **The shorthand is the only spelling.** The `php/*` forms it expands to are the
-compilation target, and they are deprecated as source (see above): every position they
-once had to themselves now has a shorthand. A method or class name computed at
-expansion time is reached by building the head symbol, `(symbol (str "." name))` or
-`(symbol "\\Foo" name)`, not by falling back to `php/->`. New code reads
-`(.format d "Y")`; chaining, mixed method and property alike, threads with plain `->`.
-The full guide is at <https://phel-lang.org/documentation/php-interop/>.
+compilation target and are deprecated as source. A method or class name computed
+at expansion time is reached by building the head symbol,
+`(symbol (str "." name))` or `(symbol "\\Foo" name)`, not by falling back to
+`php/->`. Full guide: <https://phel-lang.org/documentation/php-interop/>.
 
 | Written | Expands to | Position |
 |---|---|---|
@@ -166,46 +161,42 @@ The full guide is at <https://phel-lang.org/documentation/php-interop/>.
 | `\C/m` | `(php/callable \C m)` | value |
 | `\C/.m` | `(fn [o & args] (apply (php/callable o m) args))` | value |
 
-A root PHP class does not need a leading backslash: `PDO/ATTR_ERRMODE` reads the
-class constant, and `(.-ATTR_ERRMODE PDO)` is the equivalent dot-member spelling.
-Namespaced classes have the Clojure-readable dotted form, for example
+A root PHP class needs no leading backslash: `PDO/ATTR_ERRMODE` reads the class
+constant, `(.-ATTR_ERRMODE PDO)` is the dot-member equivalent. Namespaced classes
+have the dotted form, for example
 `Symfony.Component.Console.Command.Command/SUCCESS`.
 
 At host-symbol fallback an existing PHP class, interface, trait or enum takes
-precedence over the global-constant reading of the same bare name, so a class and a
-global constant sharing a name resolve to the class. `php/NAME` bypasses the fallback
-and stays the explicit constant escape hatch. Phel locals and definitions still
-resolve before this host fallback.
+precedence over the global-constant reading of the same bare name. `php/NAME`
+bypasses the fallback and stays the explicit constant escape hatch. Phel locals
+and definitions still resolve first.
 
-In value position a qualified member is a class constant unless the class carries no
-constant of that name and does carry a public static method, decided by reflection at
-analysis time. A class with both keeps the constant. `\C/new` is therefore never a
+In value position a qualified member is a class constant unless the class has no
+constant of that name and does have a public static method, decided by reflection
+at analysis time. A class with both keeps the constant, so `\C/new` is never a
 constructor; see [clojure-divergences.md](clojure-divergences.md).
 
 ## 3. The standard library
 
-Every public definition in a `phel.*` namespace is frozen: it keeps its name, and it
-keeps every arity it has. A definition may **gain** an arity in a minor; it may not
-lose one, and it may not gain a required parameter.
+Every public definition in a `phel.*` namespace is frozen: it keeps its name and
+every arity it has. A definition may **gain** an arity in a minor; it may not lose
+one, and may not gain a required parameter.
 
-The full list lives in `tests/php/Integration/Api/core-api.snapshot.txt`, one line per
-definition with its arities, and `CoreApiSurfaceTest` fails when it drifts. Regenerate
-it with:
+The full list is `tests/php/Integration/Api/core-api.snapshot.txt`, one line per
+definition with its arities, and `CoreApiSurfaceTest` fails on drift. Regenerate:
 
 ```bash
 composer core-api:update
 ```
 
-Private definitions (`defn-`, `def-`) are not part of the surface. Neither is anything
-under `phel-internal.*`.
+Private definitions (`defn-`, `def-`) are not part of the surface. Neither is
+anything under `phel-internal.*`.
 
-### Deliberate divergences from Clojure
-
-Phel tracks Clojure semantics where it can and diverges where PHP makes the Clojure
-behaviour wrong or pointless. Those divergences are catalogued in
+Phel tracks Clojure semantics where it can and diverges where PHP makes the
+Clojure behaviour wrong or pointless. Those divergences are catalogued in
 [clojure-divergences.md](clojure-divergences.md) and marked `:phel` in the
-[clojure-test-suite](https://github.com/phel-lang/clojure-test-suite), which runs
-nightly. A behaviour listed there is a decision, not a bug.
+nightly [clojure-test-suite](https://github.com/phel-lang/clojure-test-suite). A
+behaviour listed there is a decision, not a bug.
 
 ## 4. Namespaces and project layout
 
@@ -218,23 +209,22 @@ nightly. A behaviour listed there is a decision, not a bug.
 
 ## 5. Not frozen
 
-- The PHP source text the emitter produces. Only its behaviour is promised.
+- The PHP source the emitter produces. Only its behaviour is promised.
 - Diagnostic wording and error-output shape.
-- Macro *expansions*. A macro's expansion may change freely as long as the behaviour
-  of the macro does not. Only forms that are themselves special forms are pinned.
-- Performance characteristics, beyond the complexity classes documented for the
+- Macro *expansions*. A macro's expansion may change freely as long as its
+  behaviour does not; only forms that are themselves special forms are pinned.
+- Performance characteristics, beyond the documented complexity classes of the
   persistent collections.
 - Anything reachable only through `phel-internal.*`.
 
 ## Stated non-goals
 
-These will not arrive in 1.x, and asking for them is answered with the alternative
-rather than a roadmap entry:
+Not arriving in 1.x. Asking is answered with the alternative, not a roadmap entry.
 
 | Absent | Use instead |
 |---|---|
-| Software transactional memory, refs | `atom` with `swap!` / `reset!`, and `binding` for dynamic scope |
-| Agents | `future` (see the [async guide](https://phel-lang.org/documentation/language/async/)) |
+| Software transactional memory, refs | `atom` with `swap!` / `reset!`, `binding` for dynamic scope |
+| Agents | `future` ([async guide](https://phel-lang.org/documentation/language/async/)) |
 | `core.async`, channels, `go` blocks | PHP fibers and futures under `Fiber/` |
 | A self-hosted compiler | The PHP compiler is the only implementation |
 | A character type | Character literals read as one-character strings |
@@ -242,7 +232,7 @@ rather than a roadmap entry:
 
 ## See also
 
-- [Stability policy](../stability.md): the PHP half of the same promise
-- [Clojure divergences](clojure-divergences.md)
-- [Special forms internals](../internals/special-forms.md): dispatch, and how to add one
-- [Macros](../internals/macros.md)
+[Stability policy](../stability.md) ·
+[Clojure divergences](clojure-divergences.md) ·
+[Special forms internals](../internals/special-forms.md) ·
+[Macros](../internals/macros.md)

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,31 +1,30 @@
 # Stability Policy
 
-This page is **normative**. It defines what a Phel version number promises, which
-symbols that promise covers, and how something covered by it is allowed to change.
+**Normative.** What a Phel version number promises, which symbols it covers, and
+how those are allowed to change.
 
-Until `1.0.0` ships, the policy below describes the *target*: it is what `1.x` will
-guarantee, and the gates in CI already enforce the parts that can be enforced today.
-`0.x` releases remain free to break, and the changelog marks every such change
-**BREAKING**.
+Until `1.0.0` ships this describes the *target*: what `1.x` will guarantee, with
+the enforceable parts already gated in CI. `0.x` remains free to break, and the
+changelog marks every such change **BREAKING**.
 
 ## Two promises
 
 1. **Language stability.** Phel source that compiles on `1.0.0` compiles on every
-   later `1.x`. Reader syntax, special forms and the public `phel.*` core API do not
-   break inside the major. The frozen surface is listed in
+   later `1.x`. Reader syntax, special forms and the public `phel.*` core API do
+   not break inside the major. Frozen surface:
    [the language surface spec](spec/language-surface.md).
-2. **Embedding stability.** The PHP surface listed under
-   [Public PHP API](#public-php-api) follows semver, so a project wiring Phel into
-   its own tooling can take `1.x` updates without reading a diff.
+2. **Embedding stability.** The PHP surface under [Public PHP API](#public-php-api)
+   follows semver, so a project wiring Phel into its own tooling can take `1.x`
+   updates without reading a diff.
 
-Anything not covered by one of those two is explicitly not promised. That is not a
-gap to be filled later; it is the boundary that makes the promise affordable.
+Anything else is explicitly not promised. That is the boundary that makes the
+promise affordable, not a gap to fill later.
 
 ## Public PHP API
 
-A symbol is public if and only if it matches one of the rules below. Everything else
-in `src/php/` is internal, carries an `@internal` annotation, and may change in any
-release including a patch.
+A symbol is public if and only if it matches a rule below. Everything else in
+`src/php/` is internal, carries `@internal`, and may change in any release
+including a patch.
 
 | # | Rule | Examples |
 |---|------|----------|
@@ -37,190 +36,172 @@ release including a patch.
 | 6 | Everything under `Phel\Config\` | `Phel\Config\PhelConfig`, `Phel\Config\ProjectLayout` |
 
 Rule 1 exists because emitted PHP calls into it: every compiled `.phel` file is a
-consumer, so `\Phel` is load-bearing for build artifacts produced by older versions.
-Its `Phel\Phel` base stays internal ("use `\Phel` instead"), but the members it
-declares, `bootstrap()`, `run()` and `configFn()` among them, are reachable through
-the child and are therefore covered as part of `\Phel`.
+consumer, so `\Phel` is load-bearing for build artifacts from older versions. Its
+`Phel\Phel` base stays internal, but the members it declares (`bootstrap()`,
+`run()`, `configFn()` among them) are reachable through the child and covered as
+part of `\Phel`.
 
-Rules 4 to 6 are whole namespaces rather than hand-picked lists because they are the
-namespaces a consumer cannot avoid: values that cross the facade boundary (`Lang`),
-the contracts and transfers those facades speak in (`Shared`), and the object a
-project's own `phel-config.php` constructs (`Config`).
+Rules 4 to 6 are whole namespaces rather than curated lists because they are what
+a consumer cannot avoid: values crossing the facade boundary (`Lang`), the
+contracts those facades speak in (`Shared`), and the object a project's
+`phel-config.php` constructs (`Config`).
+
+Why the rules take this shape:
+[ADR 0005](adr/0005-public-php-api-by-rule-and-snapshot.md).
 
 ### Internal by construction
 
-Everything below is internal even when a public class happens to return it:
+Internal even when a public class returns it:
 
-- `Phel\<Module>\Domain\`, `Phel\<Module>\Application\`, `Phel\<Module>\Infrastructure\`
+- `Phel\<Module>\Domain\`, `…\Application\`, `…\Infrastructure\`
 - `*Factory`, `*Config`, `*Provider` (the Gacela plumbing)
-- `Phel\<Module>\Transfer\` (module-local transfers; the cross-module ones live in `Phel\Shared\Api\`)
+- `Phel\<Module>\Transfer\` (cross-module transfers live in `Phel\Shared\Api\`)
 
-Depending on an internal symbol is not forbidden, it is unsupported. Reaching for one
-is a signal the facade is missing a method, and that is worth an issue.
+Depending on an internal symbol is not forbidden, it is unsupported. Reaching for
+one signals a missing facade method, which is worth an issue.
 
 ### What counts as a break
 
-For a public symbol, all of the following are breaking and may only land in a major:
+Breaking for a public symbol, major only:
 
 - removing a class, interface, method, constant or public property
-- narrowing a parameter type, adding a required parameter, or reordering parameters
+- narrowing a parameter type, adding a required parameter, reordering parameters
 - widening a return type, or changing it to an unrelated type
 - adding a method to an interface, or making an existing method abstract
 - changing a class from non-`final` to `final`, or removing a public constructor
 
-The following are **not** breaks and may land in a minor or patch:
+Not breaking, fine in a minor or patch:
 
-- adding a class, or adding a method to a `final` class
+- adding a class, or a method to a `final` class
 - adding an optional parameter at the end of a signature
-- widening a parameter type or narrowing a return type
-- any change to a symbol marked `@internal`
+- widening a parameter type, narrowing a return type
+- any change to an `@internal` symbol
 
-Interfaces under `Phel\Shared\Facade\` are the one place where "adding a method" bites
-implementers rather than callers. The changelog labels those
-**BREAKING (PHP API, implementers only)** so the two cases stay distinguishable.
+Interfaces under `Phel\Shared\Facade\` are the one place where adding a method
+bites implementers rather than callers. The changelog labels those
+**BREAKING (PHP API, implementers only)**.
 
 ### How it is enforced
 
 `tests/php/Unit/Architecture/PublicApiSurfaceTest.php` reflects over every symbol
-matched by the rules above and compares the result against the committed snapshot at
-`tests/php/Unit/Architecture/public-api.snapshot.txt`. The rules themselves are code,
-in `tests/php/Support/PublicApiSurface.php`, so this table and the gate cannot drift
-apart. Any signature change to a public symbol fails the build until the snapshot is
-regenerated:
+the rules match and compares against
+`tests/php/Unit/Architecture/public-api.snapshot.txt`. The rules themselves are
+code, in `tests/php/Support/PublicApiSurface.php`, so this table and the gate
+cannot drift apart. Any signature change fails the build until:
 
 ```bash
 composer api-surface:update
 ```
 
-The regenerated diff is the backward-compatibility review. A change that shows up
-there needs a changelog entry, and inside `1.x` it needs to be one of the non-breaking
-shapes listed above.
+That regenerated diff is the backward-compatibility review. The gate is on the
+pull request introducing the change, not a comparison against the last release
+tag: a break is cheapest to discuss while its diff is open.
 
-The snapshot is deliberately a gate on the pull request that introduces the change,
-not a comparison against the last release tag: a break is cheapest to discuss while
-the diff that causes it is still open.
+`InternalAnnotationTest` pins the complement, so the split reaches an IDE and a
+static analyser rather than living only here.
 
-`tests/php/Unit/Architecture/InternalAnnotationTest.php` pins the complement. Every
-class the rules reject carries `@internal`, so the split reaches an IDE and a static
-analyser rather than living only in this page.
-
-One gap is worth naming: a public class inheriting from a *vendor* base is rendered
-without that base's members, so a dependency upgrade that changes an inherited
-signature is a real break the snapshot cannot see. Phel ancestors are folded in and
-do not have this problem. Dependency upgrades are the place to look for it.
+One gap: a public class inheriting a *vendor* base is rendered without that
+base's members, so a dependency upgrade changing an inherited signature is a real
+break the snapshot cannot see. Phel ancestors are folded in. Dependency upgrades
+are where to look.
 
 ## Deprecation policy for 1.x
 
-1. **Announce before removing.** A deprecated symbol ships with a notice for at least
-   one full minor release before it can be removed. It is then removed only in a major.
-2. **One channel.** Everything the compiler knows about, syntax and definitions alike,
-   reports through `Phel\Compiler\Domain\Deprecation\DeprecationWarnings`, off by
-   default and enabled with `--warn-deprecations` or `PHEL_WARN_DEPRECATIONS=1`. CLI
-   option renames are the documented exception and always print on stderr, because a
-   renamed flag is a single unmissable event rather than something scattered through
-   source.
-3. **No version promises in the message.** Deprecation notices never name a concrete
-   removal version: the release such a message promises inevitably ships and the text
-   goes stale. The tracking issue carries the schedule instead.
+1. **Announce before removing.** A deprecated symbol ships with a notice for at
+   least one full minor, and is removed only in a major.
+2. **One channel.** Everything the compiler knows about reports through
+   `Phel\Compiler\Domain\Deprecation\DeprecationWarnings`, off by default,
+   enabled with `--warn-deprecations` or `PHEL_WARN_DEPRECATIONS=1`. CLI option
+   renames are the documented exception and always print on stderr, because a
+   renamed flag is one unmissable event.
+   ([ADR 0006](adr/0006-one-opt-in-deprecation-channel.md).)
+3. **No version promises in the message.** The release such a message names
+   inevitably ships and the text goes stale. The tracking issue carries the
+   schedule.
 4. **A migration page, always.** Every live deprecation appears in
-   [the deprecated surface map](migration/deprecated-surface.md) with its replacement
-   and a mechanical before/after. When it is removed it moves to
-   [removed](migration/removed-deprecated-core-fns.md), so the "still deprecated" page
-   shrinks to exactly what is still shipped.
-5. **PHP-side deprecations** use the native `#[\Deprecated]` attribute or a
-   `@deprecated` annotation so `phpstan/phpstan-deprecation-rules` reports them
-   downstream.
+   [the deprecated surface map](migration/deprecated-surface.md) with its
+   replacement and a before/after, moving to
+   [removed](migration/removed-deprecated-core-fns.md) once gone.
+5. **PHP-side deprecations** use `#[\Deprecated]` or `@deprecated`, so
+   `phpstan/phpstan-deprecation-rules` reports them downstream.
 
 ## PHP support policy
 
-- `1.x` requires **PHP >= 8.4**. Raising that minimum is a breaking change and can only
-  happen in a major.
-- Every PHP minor from the minimum up to the newest stable release runs the full
-  compiler and core suites in CI. A new PHP minor is added to the matrix within one
-  Phel minor of its release.
-- Support for a PHP minor is never dropped inside a major, including after that minor
-  leaves the PHP project's own security-support window. Phel keeps testing it; the
-  security posture of the runtime is the deploying project's call.
+- `1.x` requires **PHP >= 8.4**. Raising the minimum is breaking, major only.
+- Every PHP minor from the minimum to the newest stable runs the full compiler
+  and core suites in CI, added within one Phel minor of its release.
+- Support for a PHP minor is never dropped inside a major, including after it
+  leaves PHP's own security window. Phel keeps testing it; the security posture
+  of the runtime is the deploying project's call.
 
 ## Platform support
 
 | Tier | Platforms | Meaning |
 |---|---|---|
-| Supported | Linux, macOS | Full compiler, core and PHAR suites run in CI on every push. A failure here blocks a release. |
-| Best effort | Windows | A reduced suite runs in CI. Bugs are accepted and fixed, but a Windows-only failure does not block a release. |
+| Supported | Linux, macOS | Full compiler, core and PHAR suites run in CI on every push. A failure blocks a release. |
+| Best effort | Windows | A reduced suite runs in CI. Bugs are fixed, but a Windows-only failure does not block a release. |
 
-The distinction is about what the project commits to, not about what works. Phel is
-plain PHP and the parts that are platform-sensitive are narrow: path separators,
-`readline` availability in the REPL, and the file-watching backends in
-`phel watch`, which fall back to polling wherever the native backend is missing.
+The distinction is about what the project commits to, not about what works. The
+platform-sensitive parts are narrow: path separators, `readline` in the REPL, and
+the `phel watch` backends, which fall back to polling.
 
 ## Configuration surface
 
-`phel-config.php` returns a `Phel\Config\PhelConfig`. Two things about it are frozen
-for `1.x`:
+`phel-config.php` returns a `Phel\Config\PhelConfig`. Two things are frozen:
 
 - **The wire keys.** `PhelConfig::SRC_DIRS` is the string `'src-dirs'`, and every
-  sibling constant is likewise the literal key Gacela reads. Renaming one silently
-  changes the meaning of an existing project's config file, so the constants and their
-  values are covered by rule 6 above.
-- **The builder API.** `with*()` methods only ever gain new siblings; an existing one
-  keeps its name, its parameter type and its "returns a new instance" contract.
+  sibling constant is the literal key Gacela reads. Renaming one silently changes
+  the meaning of an existing config file, so they are covered by rule 6.
+- **The builder API.** `with*()` methods only gain siblings; an existing one keeps
+  its name, parameter type and "returns a new instance" contract.
 
-The `.phel/` state directory layout is documented in
-[project-layout.md](project-layout.md) and is likewise frozen: a tool may rely on
-`.phel/cache/` and `.phel/repl-history` existing where they are. `PHEL_DIR` relocates
-the whole tree.
+The `.phel/` layout ([project-layout.md](project-layout.md)) is likewise frozen: a
+tool may rely on `.phel/cache/` and `.phel/repl-history` being where they are.
+`PHEL_DIR` relocates the tree.
 
 ## Explicitly not covered
 
-None of the following is under semver, and none of it will be before `1.0`:
+Not under semver, and not before `1.0`:
 
-- The exact PHP source text the emitter produces. It is an implementation detail with
-  a test suite pinning it, not an output format. Only its *behaviour* is promised.
-- Compiler diagnostic wording, and the shape of error output.
-- The `.phel/cache/` file format. It is keyed by source hash plus Phel version, so a
+- The exact PHP source the emitter produces. Only its *behaviour* is promised;
+  the test suite pins the text so changes are reviewed, not forbidden.
+- Compiler diagnostic wording and error-output shape.
+- The `.phel/cache/` file format. Keyed by source hash plus Phel version, so a
   version bump invalidates it by design.
 - Anything under `tests/`, `tools/`, `build/` or `resources/`.
-- The nREPL and LSP wire protocols beyond the upstream specifications they implement.
+- The nREPL and LSP wire protocols beyond the upstream specifications.
 
 ## Quality gates behind the promises
-
-A promise is only as good as what fails when it is broken. Every gate below runs in
-CI.
 
 | Gate | Where | Fails when |
 |---|---|---|
 | Public PHP API snapshot | `PublicApiSurfaceTest` | a public signature changes |
 | `@internal` annotations | `InternalAnnotationTest` | an internal class is unmarked, or a public one is marked |
-| Standard-library snapshot | `CoreApiSurfaceTest` | a definition or an arity disappears |
+| Standard-library snapshot | `CoreApiSurfaceTest` | a definition or arity disappears |
 | Special-form list | `LanguageSurfaceSpecTest` | the spec and the analyzer disagree |
 | Static analysis | `quality.yml` | PHPStan level 9 or Psalm level 1 reports anything |
 | Coverage floor | `coverage.yml` (nightly) | line coverage drops below the floor |
-| Benchmark regression | `tests.yml` | a benchmark is more than 25% slower than the base revision (`phpbench.json` uses a tighter 17% locally, where the machine is quiet) |
+| Benchmark regression | `tests.yml` | a benchmark is >25% slower than the base revision (`phpbench.json` uses 17% locally, where the machine is quiet) |
 | Mutation score | `mutation.yml` (weekly) | MSI over `Lang/` and the analyzer drops below the floor |
 | Clojure divergences | `run-clojure-test-suite.yml` (nightly) | behaviour changes without the suite being updated |
 
-The coverage floor and the MSI floors are ratchets. They are raised when a real run
-clears them comfortably and never lowered to make a red build green. As of this
-writing line coverage is **86.9%** (floor 85) and the mutation score is **83%**
-(floor 80) over `Lang/` and the analyzer; both jobs print the current figure to
-their run summary.
+The coverage and MSI floors are ratchets: raised when a real run clears them
+comfortably, never lowered to make a red build green. Currently line coverage
+**86.9%** (floor 85) and mutation score **83%** (floor 80) over `Lang/` and the
+analyzer; both jobs print the figure to their run summary.
 
-Neither runs on every pull request. Coverage takes around 22 minutes and mutation
-testing longer, so on a pull request they were the only checks a merge waited on,
-and both answer questions ("this code is not exercised", "this test asserts
-nothing") that are worth knowing on a schedule rather than within the hour. They
-still run against `main`, still gate on their floors, and both can be triggered on
-demand with `workflow_dispatch`, including a one-off floor override.
+Neither runs per pull request. Coverage takes ~22 minutes and mutation longer, so
+on a PR they were the only checks a merge waited on, and both answer questions
+("this code is not exercised", "this test asserts nothing") worth knowing on a
+schedule rather than within the hour. They still run against `main`, still gate on
+their floors, and both take `workflow_dispatch` including a one-off floor
+override.
 
 ## See also
 
-- [Upgrading 0.49 to 1.0](migration/upgrade-0.49-to-1.0.md)
-- [The language surface spec](spec/language-surface.md): the frozen half of promise 1
-- [Clojure divergences](spec/clojure-divergences.md): where Phel deliberately differs
-- [The currently deprecated surface](migration/deprecated-surface.md)
-- [Architecture](internals/architecture.md): why the module boundary sits where it does
-- [Architecture decisions](adr/README.md): the arguments behind this policy.
-  [ADR 0005](adr/0005-public-php-api-by-rule-and-snapshot.md) for the public API as
-  a rule plus a snapshot, [ADR 0006](adr/0006-one-opt-in-deprecation-channel.md)
-  for deprecation warnings being off by default
+[Upgrading 0.49 to 1.0](migration/upgrade-0.49-to-1.0.md) ·
+[Language surface spec](spec/language-surface.md) ·
+[Clojure divergences](spec/clojure-divergences.md) ·
+[Deprecated surface](migration/deprecated-surface.md) ·
+[Architecture](internals/architecture.md) ·
+[Architecture decisions](adr/README.md)

--- a/tools/validate-agents.sh
+++ b/tools/validate-agents.sh
@@ -14,6 +14,12 @@ if [[ ! -d "$examples_dir" ]]; then
   exit 1
 fi
 
+# Each example's `.phel/` (compiled cache + opcache) is throwaway state worth
+# ~18M per project. Keep it outside the repo so the working tree stays small and
+# `build/phar.sh` has nothing extra to sync.
+phel_state_dir=$(mktemp -d "${TMPDIR:-/tmp}/phel-agents-XXXXXX")
+trap 'rm -rf "$phel_state_dir"' EXIT
+
 failures=0
 for example in "$examples_dir"/*/; do
   name=$(basename "$example")
@@ -38,7 +44,7 @@ JSON
     rm -f composer.local.json composer.local.lock
   fi
 
-  if ./vendor/bin/phel test; then
+  if PHEL_DIR="$phel_state_dir/$name" ./vendor/bin/phel test; then
     echo "    OK: $name"
   else
     echo "    FAIL: $name"


### PR DESCRIPTION
## 🤔 Background

Two passes in one branch: the `docs/` tree had grown discursive since the spec and stability pages landed, and reading every page end to end surfaced three stale references plus, separately, a PHAR build that copies half a gigabyte of local cache on every run.

## 💡 Goal

Same content, less of it. Fix what reading found.

## 🔖 Changes

**Docs compression**

Rewrote the pages that had grown longest: `stability.md`, `spec/language-surface.md`, `spec/clojure-divergences.md`, both migration guides, `internals/testing-performance.md`, `internals/benchmarks.md`, `playground.md`, `cli-reference.md` and the docs index. Tables, class names, test paths and issue numbers are all kept; the cuts are restated context, hedging and duplicated cross-references. 24334 -> 22362 words across `docs/`, with the non-ADR pages down about 11%.

`upgrade-0.49-to-1.0.md` restated the whole reader-syntax removal table that `removed-deprecated-core-fns.md` already owns. It now links it.

`LanguageSurfaceSpecTest` parses two tables out of the spec, so both keep their exact row format; that test and the other doc-coupled architecture tests pass.

**Three stale references, found by reading**

- `deprecated-surface.md` and ADR 0006 named `Phel\Shared\Console\DeprecatedOptionWarner` as the channel for CLI-option deprecations. That class was deleted in #2862 along with the last two deprecated aliases. `cli-flag-conventions.md` had it right all along ("no shared helper today, because no rename is currently in flight"), so the two pages contradicted each other.
- `removed-deprecated-core-fns.md` gave its replacements in the deprecated backslash spelling (`phel\string\contains?`, which is also missing the `/`), as did the upgrade guide's `phel\test/print-summary` row. A migration page telling you to migrate onto deprecated syntax.
- `cli-reference.md` linked `README.md#enable-shell-completion-optional`. That line is bold text, not a heading, so the anchor never resolved.

**PHAR build: stop copying local caches**

`phar.sh` excluded `/.phel-cache`, the pre-0.37 name for the state directory. The current `.phel/` was never excluded, so every build rsynced the whole local compiled + opcache tree into `build/.phar-cache`: 476M and 19171 entries on my checkout. The examples include rule also matched before the generic `vendor` exclude, so each example's `vendor/` and `.phel/` came along too (another 7184 entries).

`build-phar.php` filtered all of it back out at assembly, so the artifact was always correct and only the build paid for it:

| | before | after |
|---|---|---|
| wall | 12.3s | 7.3s |
| system time | 6.5s | 2.2s |
| PHAR size | 2.175 MB | 2.175 MB |
| example files in PHAR | 30 | 30 |

`validate-agents.sh` was where most of that junk came from: it ran each example's suite in place, leaving ~18M of `.phel/` per project. It now points each at a temp `PHEL_DIR`, so `resources/agents` drops from 69M to 14M and repeat runs start clean.

Verified: `composer test-agents`, `composer test-tools` (100 tests), `PharExecutionTest` (10 tests) and the rebuilt PHAR's `--version` all pass.

## Related finding, not in this PR

`phel cache:clear` clears the compiled cache and temp dir but not `<PHEL_DIR>/opcache`, which `bin/phel` fills via its OPcache re-exec and which PHP's file cache never evicts. On this checkout that is 428M of the 476M total, so the documented way to reclaim space leaves 90% behind. Happy to fix separately, since it changes a documented command's behaviour.
