### PR TITLE
fix(compiler): assign static properties (#2907)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
 - Qualified members in value position: `\C/m` is a static method as a value (`(map \Phel\Lang\Keyword/create ["a" "b"])`), `\C/.m` an instance method as a function of its receiver. `\C/CONST` wins when a class has both, so `\C/new` is never a constructor (#2883)
 - `(.cases enum-class)` reaches a static method through a class name held in a value, object or `"\\App\\Status"` alike (#2881)
 - `php-invoke` calls a method named at runtime: `(php-invoke obj "format" "Y")`, ClojureScript's `js-invoke`. A class-name target calls the static method (#2887)
-- `set!` covers both Clojure shapes: `(set! (.-total o) 10)` assigns a property, `(set! *x* 2)` the current `binding` frame, throwing when there is none. `alter-var-root` still changes a root (#2884, #2888)
+- `set!` covers all three Clojure shapes: `(set! (.-total o) 10)` assigns a property, `(set! \Foo/slot v)` a static property, `(set! *x* 2)` the current `binding` frame, throwing when there is none. `alter-var-root` still changes a root (#2884, #2888, #2907)
+- `\C/$prop` reads a static property in value position. The bare name stays the class constant, since PHP files the two separately and a class may carry both (#2907)
 - The standard library is written in the Clojure-style interop spelling, and `docs/` leads with it (#2875, #2882)
 - `phel nrepl` writes the bound port to `.nrepl-port` for editor discovery and removes it on exit; Ctrl+C and SIGTERM shut the accept loop down gracefully (#2894)
 - A `def`/`defn` carrying `:deprecated` metadata warns at every call site under `--warn-deprecations` (or `PHEL_WARN_DEPRECATIONS=1`)
@@ -26,6 +27,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Assigning a static property compiles. `(php/oset (php/:: \Foo slot) v)` emitted `\Foo::slot = v`, a class-constant fetch PHP rejects with `syntax error, unexpected token "="`, and a class name as the place of `.-` emitted `\Foo::class->slot = v` (#2907)
 - Bare all-caps PHP classes such as `PDO` are no longer read as global constants, so `PDO/ATTR_ERRMODE`, `(.-ATTR_ERRMODE PDO)` and `(new PDO ...)` need no leading backslash. A class beats a same-named constant; `php/NAME` stays the explicit escape hatch
 - `phel init`, the three bundled example apps, the `.agents/` task recipes and the `--template=` scaffolds all emit the dot separator (`my-app.main`). A generated project used to start on syntax the compiler warns about (#2827)
 - nREPL sessions each keep their own namespace, as reference nREPL does. Client A evaluating `(ns foo)` no longer moves where client B's next form compiles. Definitions stay shared; only the current namespace is per session (#2906)

--- a/docs/spec/clojure-divergences.md
+++ b/docs/spec/clojure-divergences.md
@@ -153,6 +153,18 @@ The suite does not pin this one, because no working program can observe it: a
 string receiver was an error before and after, and only the message differs. It is
 listed because the *capability* is a difference a Clojure reader will notice.
 
+### A static property is read with a `$` sigil
+
+Clojure reads a static field and a constant with one spelling, `Classname/field`,
+because the JVM has no separate constant namespace. PHP has two, and a class may
+carry `const slot` and `public static $slot` at once, so Phel keeps the bare name
+on the constant it has always meant and spells the property `\C/$prop`
+([#2907](https://github.com/phel-lang/phel-lang/issues/2907)).
+
+Assignment needs no sigil: a class constant cannot be assigned, so
+`(set! \C/slot v)` and `(php/oset (php/:: \C slot) v)` can only mean the property
+and emit `\C::$slot = v`.
+
 ### `aset` and `set!` are macros, not functions
 
 Clojure's `aset` is a function, so `(map (partial aset arr) …)` works. Phel's is a
@@ -186,6 +198,7 @@ mutation its own name. Phel matches that, plus one name it inherited:
 | Operation | Clojure | Phel |
 |---|---|---|
 | assign an object field | `(set! (.-f o) v)` | `(set! (.-f o) v)` |
+| assign a static field | `(set! Foo/staticField v)` | `(set! \Foo/slot v)` |
 | assign the current thread-local binding | `(set! *x* v)` | `(set! *x* v)`, or `(var-set #'*x* v)` |
 | change the root | `(alter-var-root #'*x* f)` | `(alter-var-root #'*x* f)` |
 | *(no Clojure counterpart)* | | `(set-var *x* v)`, a special form writing the root directly, **deprecated** |

--- a/docs/spec/language-surface.md
+++ b/docs/spec/language-surface.md
@@ -119,10 +119,17 @@ major. One rule puts them here:
 | `php/::` | `(\Foo/method arg)` and `\Foo/CONST` |
 | `set-var` | `(alter-var-root #'v f)`, or `(set! v x)` for the current binding frame |
 
-One position is still open: an **assignable static property**. Neither spelling
-works today (`(php/oset (php/:: \Foo slot) v)` emits invalid PHP and
-`(set! \Foo/slot v)` routes to the var branch), so `php/::` is not the answer for
-it either ([#2907](https://github.com/phel-lang/phel-lang/issues/2907)).
+The one position that had no spelling, an **assignable static property**, is
+`(set! \Foo/slot v)` ([#2907](https://github.com/phel-lang/phel-lang/issues/2907)),
+which is what Clojure writes for a static field. `set!` tells the two symbol
+shapes apart the way the analyzer does everywhere else: a namespace starting with
+`\` or an upper-case letter is a class reference and assigns the static property,
+anything else is a dynamic var. The primitive underneath stays
+`(php/oset (php/:: \Foo slot) v)`, now emitting `\Foo::$slot = v` — in assignment
+position a bare name can only be the property, since a class constant is not
+assignable. Reading it back needs the explicit sigil, `\Foo/$slot`, because in
+read position the bare name is the constant: PHP keeps the two in separate
+namespaces and a class may hold both under one name.
 
 The remaining `php/*` forms stay, because each reaches a PHP capability Phel has
 no other word for: `php/aget`, `php/aset`, `php/apush`, `php/aunset` and
@@ -158,6 +165,7 @@ at expansion time is reached by building the head symbol,
 | `(\C/m args…)` | `(php/:: \C (m args…))` | call |
 | `(\C. args…)` | `(php/new \C args…)` | call |
 | `\C/CONST` | `(php/:: \C CONST)` | value |
+| `\C/$prop` | `(php/:: \C $prop)` | value |
 | `\C/m` | `(php/callable \C m)` | value |
 | `\C/.m` | `(fn [o & args] (apply (php/callable o m) args))` | value |
 
@@ -174,7 +182,10 @@ and definitions still resolve first.
 In value position a qualified member is a class constant unless the class has no
 constant of that name and does have a public static method, decided by reflection
 at analysis time. A class with both keeps the constant, so `\C/new` is never a
-constructor; see [clojure-divergences.md](clojure-divergences.md).
+constructor; see [clojure-divergences.md](clojure-divergences.md). A static
+property is the one member the bare name cannot reach: PHP files constants and
+static properties separately, so `\C/$prop` carries the sigil and needs no
+reflection.
 
 ## 3. The standard library
 

--- a/docs/spec/language-surface.md
+++ b/docs/spec/language-surface.md
@@ -125,7 +125,7 @@ which is what Clojure writes for a static field. `set!` tells the two symbol
 shapes apart the way the analyzer does everywhere else: a namespace starting with
 `\` or an upper-case letter is a class reference and assigns the static property,
 anything else is a dynamic var. The primitive underneath stays
-`(php/oset (php/:: \Foo slot) v)`, now emitting `\Foo::$slot = v` — in assignment
+`(php/oset (php/:: \Foo slot) v)`, now emitting `\Foo::$slot = v`: in assignment
 position a bare name can only be the property, since a class constant is not
 assignable. Reading it back needs the explicit sigil, `\Foo/$slot`, because in
 read position the bare name is the constant: PHP keeps the two in separate

--- a/resources/agents/tasks/use-php-libs.md
+++ b/resources/agents/tasks/use-php-libs.md
@@ -11,6 +11,7 @@
 | Static | `(Class/method args)` |
 | Constant | `Class/CONST` |
 | Property | `(.-prop obj)` |
+| Static property | read `Class/$prop`, write `(set! Class/prop v)` |
 | Fn (global) | `(php/strlen s)` |
 | Fn (namespaced) | `(php/Amp\trapSignal xs)` |
 | PHP array indexed | `#php [1 2 3]` |

--- a/src/phel/core/interop.phel
+++ b/src/phel/core/interop.phel
@@ -7,12 +7,12 @@
 ;; --------------------------------------------
 
 (defn- static-property-place?
-  "True when `place` is a symbol naming a static property. Both halves are the
-  test the analyzer applies to `\\Foo/member`: the namespace reads as a PHP
-  class reference (a leading `\\` or an upper-case first character) and the
-  name starts like a PHP member, optionally carrying the `$` sigil. A dynamic
-  var fails the second half, since `Foo/*x*` is no member PHP can name, and
-  stays a var."
+  "True when `place` is a symbol naming a static property. Both halves restate
+  the analyzer's `QualifiedMemberSyntax`, which the standard library cannot
+  import: the namespace reads as a PHP class reference (a leading `\\` or an
+  upper-case first character) and the name starts like a PHP member, optionally
+  carrying the `$` sigil. A dynamic var fails the second half, since `Foo/*x*`
+  is no member PHP can name, and stays a var."
   [place]
   (and (symbol? place)
        (= 1 (php/preg_match "/^[\\\\A-Z]/" (or (namespace place) "")))

--- a/src/phel/core/interop.phel
+++ b/src/phel/core/interop.phel
@@ -6,20 +6,24 @@
 ;; PHP interop helpers whose target is a value
 ;; --------------------------------------------
 
-(defn- class-reference-ns?
-  "True when `ns-str` reads as a PHP class reference rather than a Phel
-  namespace: a leading `\\` or an upper-case first character. Same test the
-  analyzer applies to the namespace part of `\\Foo/member`."
-  [ns-str]
-  (and (string? ns-str)
-       (= 1 (php/preg_match "/^[\\\\A-Z]/" ns-str))))
+(defn- static-property-place?
+  "True when `place` is a symbol naming a static property. Both halves are the
+  test the analyzer applies to `\\Foo/member`: the namespace reads as a PHP
+  class reference (a leading `\\` or an upper-case first character) and the
+  name starts like a PHP member, optionally carrying the `$` sigil. A dynamic
+  var fails the second half — `Foo/*x*` is not a member PHP can name — and
+  stays a var."
+  [place]
+  (and (symbol? place)
+       (= 1 (php/preg_match "/^[\\\\A-Z]/" (or (namespace place) "")))
+       (= 1 (php/preg_match "/^[$]?[A-Za-z_]/" (name place)))))
 
 (defmacro set!
   "Sets `place` to `value` and returns `value`, covering all three shapes
   Clojure's `set!` covers.
 
   A property access (`(.-prop obj)`) assigns the property, as does any other
-  place `php/oset` accepts. A **qualified symbol whose namespace names a PHP
+  place `php/oset` accepts. A **qualified symbol naming a member of a PHP
   class** (`\\Foo/slot`) assigns that static property. Any other **symbol**
   names a dynamic var and assigns its current thread-local binding, throwing
   when no `binding` frame is active, so it never writes the root by accident;
@@ -29,20 +33,19 @@
   {:example "(let [o (new \\ArrayObject)] (set! (.-y o) 2024)) ; => 2024\n(def ^:dynamic *x* 0)\n(binding [*x* 1] (set! *x* 2) *x*) ; => 2"
    :see-also ["var-set" "alter-var-root" "aset" "php/oset"]}
   [place value]
-  (let [place-ns (when (symbol? place) (namespace place))]
-    (cond
-      (class-reference-ns? place-ns)
-      `(let [value# ~value]
-         (php/oset (php/:: ~(symbol place-ns) ~(symbol (name place))) value#)
-         value#)
+  (cond
+    (static-property-place? place)
+    `(let [value# ~value]
+       (php/oset (php/:: ~(symbol (namespace place)) ~(symbol (name place))) value#)
+       value#)
 
-      (symbol? place)
-      `(var-set (var ~place) ~value)
+    (symbol? place)
+    `(var-set (var ~place) ~value)
 
-      :else
-      `(let [value# ~value]
-         (php/oset ~place value#)
-         value#))))
+    :else
+    `(let [value# ~value]
+       (php/oset ~place value#)
+       value#)))
 
 (defn- invoke-target-name
   "Returns the name to report for `target` in an undefined-method error:

--- a/src/phel/core/interop.phel
+++ b/src/phel/core/interop.phel
@@ -11,7 +11,7 @@
   test the analyzer applies to `\\Foo/member`: the namespace reads as a PHP
   class reference (a leading `\\` or an upper-case first character) and the
   name starts like a PHP member, optionally carrying the `$` sigil. A dynamic
-  var fails the second half — `Foo/*x*` is not a member PHP can name — and
+  var fails the second half, since `Foo/*x*` is no member PHP can name, and
   stays a var."
   [place]
   (and (symbol? place)

--- a/src/phel/core/interop.phel
+++ b/src/phel/core/interop.phel
@@ -6,25 +6,43 @@
 ;; PHP interop helpers whose target is a value
 ;; --------------------------------------------
 
+(defn- class-reference-ns?
+  "True when `ns-str` reads as a PHP class reference rather than a Phel
+  namespace: a leading `\\` or an upper-case first character. Same test the
+  analyzer applies to the namespace part of `\\Foo/member`."
+  [ns-str]
+  (and (string? ns-str)
+       (= 1 (php/preg_match "/^[\\\\A-Z]/" ns-str))))
+
 (defmacro set!
-  "Sets `place` to `value` and returns `value`, covering both shapes Clojure's
-  `set!` covers.
+  "Sets `place` to `value` and returns `value`, covering all three shapes
+  Clojure's `set!` covers.
 
   A property access (`(.-prop obj)`) assigns the property, as does any other
-  place `php/oset` accepts. A **symbol** naming a dynamic var
-  assigns its current thread-local binding, and throws when no `binding` frame
-  is active, so it never writes the root by accident; `alter-var-root` is the
-  way to change a root.
+  place `php/oset` accepts. A **qualified symbol whose namespace names a PHP
+  class** (`\\Foo/slot`) assigns that static property. Any other **symbol**
+  names a dynamic var and assigns its current thread-local binding, throwing
+  when no `binding` frame is active, so it never writes the root by accident;
+  `alter-var-root` is the way to change a root.
 
   A macro rather than a function because the place is a location, not a value."
   {:example "(let [o (new \\ArrayObject)] (set! (.-y o) 2024)) ; => 2024\n(def ^:dynamic *x* 0)\n(binding [*x* 1] (set! *x* 2) *x*) ; => 2"
    :see-also ["var-set" "alter-var-root" "aset" "php/oset"]}
   [place value]
-  (if (symbol? place)
-    `(var-set (var ~place) ~value)
-    `(let [value# ~value]
-       (php/oset ~place value#)
-       value#)))
+  (let [place-ns (when (symbol? place) (namespace place))]
+    (cond
+      (class-reference-ns? place-ns)
+      `(let [value# ~value]
+         (php/oset (php/:: ~(symbol place-ns) ~(symbol (name place))) value#)
+         value#)
+
+      (symbol? place)
+      `(var-set (var ~place) ~value)
+
+      :else
+      `(let [value# ~value]
+         (php/oset ~place value#)
+         value#))))
 
 (defn- invoke-target-name
   "Returns the name to report for `target` in an undefined-method error:

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -42,6 +42,8 @@ Clojure-style interop spellings are sugar, expanded to `php/*` forms before anal
 
 `QualifiedMemberExpander` reflects the resolved class to tell a static method from a constant. A class carrying both under one name resolves to the **constant** (pre-existing behaviour, and the reason `\C/new` is not a constructor); an unresolvable or unloadable class falls back to the constant reading so the error stays what it was.
 
+`Domain/Analyzer/QualifiedMemberSyntax` is the single statement of *how a class member is spelled* (namespace reads as a class reference, name starts like a PHP member). Call position, value position and `phel.core/set!` all decide with it, so `(\Foo/m 1)`, `\Foo/CONST` and `(set! \Foo/slot v)` cannot disagree; `set!` re-spells it in Phel because the stdlib cannot import `@internal` compiler classes. Purely lexical: `PhpClassLike` answers existence.
+
 Bare host symbols have one separate collision rule, in `SymbolResolver::resolveBareHostSymbol()`: an existing PHP class/interface/trait/enum wins over a same-named global constant, including all-caps classes such as `PDO`; `php/NAME` is the explicit constant escape hatch. `Domain/Analyzer/PhpClassLike` is the single class-like existence predicate (also used by `UseAliasRegistrar`). Keep it autoloading, otherwise the same source changes meaning according to which earlier form happened to load the class.
 
 ### Simplification pass

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -36,7 +36,9 @@ Lexer (source → `TokenStream`) → Parser (→ `FileNode` parse tree) → Read
 Clojure-style interop spellings are sugar, expanded to `php/*` forms before analysis, never registered as special forms (`LanguageSurfaceSpecTest` fails on a spec table row with no dispatch entry):
 
 - Call position — `AnalyzePersistentList`: `(.m obj …)`, `(.-field obj)`, `(\C/m …)`, `(\C. …)`.
-- Value position — `Domain/Analyzer/TypeAnalyzer/QualifiedMemberExpander`, reached from `AnalyzeSymbol` when global resolution finds nothing: `\C/CONST` → `php/::`, `\C/m` → `php/callable`, `\C/.m` → an `fn` of the receiver.
+- Value position — `Domain/Analyzer/TypeAnalyzer/QualifiedMemberExpander`, reached from `AnalyzeSymbol` when global resolution finds nothing: `\C/CONST` → `php/::`, `\C/$prop` → `php/::` (static property, no reflection: the sigil decides), `\C/m` → `php/callable`, `\C/.m` → an `fn` of the receiver.
+
+`NodeEmitter/PhpObjectSetEmitter` shares `PhpObjectCallDispatchResolver` with the read path, so a class-name target is static however it was written, and it prefixes a bare static member name with `$`: a class constant is not assignable, so an assignment can only mean the property (#2907).
 
 `QualifiedMemberExpander` reflects the resolved class to tell a static method from a constant. A class carrying both under one name resolves to the **constant** (pre-existing behaviour, and the reason `\C/new` is not a constructor); an unresolvable or unloadable class falls back to the constant reading so the error stays what it was.
 

--- a/src/php/Compiler/Domain/Analyzer/QualifiedMemberSyntax.php
+++ b/src/php/Compiler/Domain/Analyzer/QualifiedMemberSyntax.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer;
+
+use function in_array;
+use function strlen;
+
+/**
+ * How a symbol has to be spelled to name a PHP class member, `\Foo/member`.
+ *
+ * Purely lexical, and the single statement of the rule: call position
+ * (`AnalyzePersistentList`), value position (`QualifiedMemberExpander`) and
+ * `phel.core/set!` all decide the same way, so `(\Foo/m 1)`, `\Foo/CONST` and
+ * `(set! \Foo/slot v)` cannot disagree about what counts as a class. Nothing
+ * here loads a class; `PhpClassLike` answers existence.
+ *
+ * @internal
+ */
+final class QualifiedMemberSyntax
+{
+    /**
+     * A namespace part naming a PHP class rather than a Phel namespace. Phel
+     * namespaces are lower case by convention, so an upper-case first
+     * character is the signal, as is the leading `\` of an absolute name.
+     * `php` is the host-function prefix, never a class.
+     */
+    public static function isClassReference(?string $namespace): bool
+    {
+        if (in_array($namespace, [null, '', 'php'], true)) {
+            return false;
+        }
+
+        return $namespace[0] === '\\'
+            || ($namespace[0] >= 'A' && $namespace[0] <= 'Z');
+    }
+
+    /**
+     * A name part PHP could parse as a member. Only the first character is
+     * checked, which is what keeps a Phel name PHP cannot spell (`*x*`, `-`)
+     * out of the member readings.
+     */
+    public static function isMemberName(string $name): bool
+    {
+        return $name !== '' && self::isIdentifierStartChar($name[0]);
+    }
+
+    /**
+     * A name part naming a static property, `$prop`. PHP files constants and
+     * static properties separately and only the sigil tells them apart, so the
+     * bare name stays the constant it has always been.
+     */
+    public static function isStaticPropertyName(string $name): bool
+    {
+        return strlen($name) > 1
+            && $name[0] === '$'
+            && self::isIdentifierStartChar($name[1]);
+    }
+
+    public static function isIdentifierStartChar(string $char): bool
+    {
+        return ($char >= 'a' && $char <= 'z')
+            || ($char >= 'A' && $char <= 'Z')
+            || $char === '_';
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -11,6 +11,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Compiler\Domain\Analyzer\QualifiedMemberSyntax;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ApplySymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\BindingValidator;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor;
@@ -64,7 +65,6 @@ use Phel\Shared\MungeInterface;
 
 use function array_keys;
 use function count;
-use function in_array;
 use function str_ends_with;
 use function strlen;
 use function substr;
@@ -286,18 +286,8 @@ final class AnalyzePersistentList
 
     private function isStaticCallShorthand(Symbol $symbol): bool
     {
-        $ns = $symbol->getNamespace();
-        if (in_array($ns, [null, '', 'php'], true)) {
-            return false;
-        }
-
-        $method = $symbol->getName();
-        if ($method === '' || !$this->isIdentifierStartChar($method[0])) {
-            return false;
-        }
-
-        return $ns[0] === '\\'
-            || ($ns[0] >= 'A' && $ns[0] <= 'Z');
+        return QualifiedMemberSyntax::isClassReference($symbol->getNamespace())
+            && QualifiedMemberSyntax::isMemberName($symbol->getName());
     }
 
     private function isMethodCallShorthandName(string $name): bool
@@ -307,7 +297,7 @@ final class AnalyzePersistentList
             return false;
         }
 
-        return $this->isIdentifierStartChar($name[1]);
+        return QualifiedMemberSyntax::isIdentifierStartChar($name[1]);
     }
 
     private function isPropertyAccessShorthandName(string $name): bool
@@ -317,14 +307,7 @@ final class AnalyzePersistentList
             return false;
         }
 
-        return $this->isIdentifierStartChar($name[2]);
-    }
-
-    private function isIdentifierStartChar(string $c): bool
-    {
-        return ($c >= 'a' && $c <= 'z')
-            || ($c >= 'A' && $c <= 'Z')
-            || $c === '_';
+        return QualifiedMemberSyntax::isIdentifierStartChar($name[2]);
     }
 
     private function createSymbolAnalyzerByName(string $symbolName): SpecialFormAnalyzerInterface

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/QualifiedMemberExpander.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/QualifiedMemberExpander.php
@@ -60,6 +60,10 @@ final readonly class QualifiedMemberExpander
             return $this->instanceMethodValue($symbol, substr($name, 1));
         }
 
+        if ($this->isStaticPropertyName($name)) {
+            return $this->classMemberForm(Symbol::NAME_PHP_OBJECT_STATIC_CALL, $symbol);
+        }
+
         if ($name === '' || !$this->isIdentifierStartChar($name[0])) {
             return null;
         }
@@ -89,6 +93,19 @@ final readonly class QualifiedMemberExpander
     {
         return strlen($name) > 1
             && $name[0] === '.'
+            && $this->isIdentifierStartChar($name[1]);
+    }
+
+    /**
+     * `$slot` names a static property. PHP keeps constants and static
+     * properties in separate namespaces and only the sigil tells them apart,
+     * so the bare name stays the constant it has always been and no reflection
+     * is needed here.
+     */
+    private function isStaticPropertyName(string $name): bool
+    {
+        return strlen($name) > 1
+            && $name[0] === '$'
             && $this->isIdentifierStartChar($name[1]);
     }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/QualifiedMemberExpander.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/QualifiedMemberExpander.php
@@ -8,13 +8,13 @@ use Phel;
 use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\QualifiedMemberSyntax;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
 use ReflectionClass;
 
 use function class_exists;
 use function enum_exists;
-use function in_array;
 use function interface_exists;
 use function strlen;
 use function substr;
@@ -24,6 +24,7 @@ use function substr;
  * that are safe in PHP:
  *
  *   `\C/CONST`  -> `(php/:: \C CONST)`            class constant, unchanged
+ *   `\C/$prop`  -> `(php/:: \C $prop)`            static property
  *   `\C/m`      -> `(php/callable \C m)`          static method as a value
  *   `\C/.m`     -> `(fn [o & args] ...)`          instance method as a value
  *
@@ -50,7 +51,7 @@ final readonly class QualifiedMemberExpander
     public function expand(Symbol $symbol, NodeEnvironmentInterface $env): ?PersistentListInterface
     {
         $ns = $symbol->getNamespace();
-        if (!$this->isClassReference($ns)) {
+        if (!QualifiedMemberSyntax::isClassReference($ns)) {
             return null;
         }
 
@@ -60,11 +61,11 @@ final readonly class QualifiedMemberExpander
             return $this->instanceMethodValue($symbol, substr($name, 1));
         }
 
-        if ($this->isStaticPropertyName($name)) {
+        if (QualifiedMemberSyntax::isStaticPropertyName($name)) {
             return $this->classMemberForm(Symbol::NAME_PHP_OBJECT_STATIC_CALL, $symbol);
         }
 
-        if ($name === '' || !$this->isIdentifierStartChar($name[0])) {
+        if (!QualifiedMemberSyntax::isMemberName($name)) {
             return null;
         }
 
@@ -75,16 +76,6 @@ final readonly class QualifiedMemberExpander
         return $this->classMemberForm(Symbol::NAME_PHP_OBJECT_STATIC_CALL, $symbol);
     }
 
-    private function isClassReference(?string $ns): bool
-    {
-        if (in_array($ns, [null, '', 'php'], true)) {
-            return false;
-        }
-
-        return $ns[0] === '\\'
-            || ($ns[0] >= 'A' && $ns[0] <= 'Z');
-    }
-
     /**
      * `.m` names an instance method; `.` is not a legal PHP identifier
      * character, so the form cannot collide with a real member name.
@@ -93,20 +84,7 @@ final readonly class QualifiedMemberExpander
     {
         return strlen($name) > 1
             && $name[0] === '.'
-            && $this->isIdentifierStartChar($name[1]);
-    }
-
-    /**
-     * `$slot` names a static property. PHP keeps constants and static
-     * properties in separate namespaces and only the sigil tells them apart,
-     * so the bare name stays the constant it has always been and no reflection
-     * is needed here.
-     */
-    private function isStaticPropertyName(string $name): bool
-    {
-        return strlen($name) > 1
-            && $name[0] === '$'
-            && $this->isIdentifierStartChar($name[1]);
+            && QualifiedMemberSyntax::isIdentifierStartChar($name[1]);
     }
 
     /**
@@ -194,12 +172,5 @@ final readonly class QualifiedMemberExpander
                 ->copyLocationFrom($symbol),
             $body,
         ])->copyLocationFrom($symbol);
-    }
-
-    private function isIdentifierStartChar(string $c): bool
-    {
-        return ($c >= 'a' && $c <= 'z')
-            || ($c >= 'A' && $c <= 'Z')
-            || $c === '_';
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectSetEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectSetEmitter.php
@@ -14,7 +14,6 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpObjectCallDispatch;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpObjectCallDispatchResolver;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
-use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 
 use function assert;
@@ -37,100 +36,102 @@ final readonly class PhpObjectSetEmitter implements NodeEmitterInterface
     {
         assert($node instanceof PhpObjectSetNode);
 
-        // Same operator decision the read path makes, so `(.-slot \Foo)` and
-        // `(php/:: \Foo slot)` name the same place: a class-name target is
-        // static however it was written. A write is never the runtime-dispatch
-        // case, which only applies to method calls.
-        $isStatic = $this->dispatchResolver->resolve($node->getLeftExpr()) === PhpObjectCallDispatch::StaticClass;
-        $fnCode = $isStatic ? '::' : '->';
-        $targetExpr = $node->getLeftExpr()->getTargetExpr();
-        $callExpr = $node->getLeftExpr()->getCallExpr();
-        assert($callExpr instanceof PropertyOrConstantAccessNode);
-        $propertyName = $this->propertyName($callExpr->getName()->getName(), $isStatic);
-        $propertyLoc = $callExpr->getName()->getStartLocation();
-
         // `php/oset` is contractually required to evaluate to the *target
         // object* (not the assigned value, as a bare PHP `$o->p = v` would
-        // yield). In statement context the value is discarded, so we emit the
-        // assignment directly with no closure and no temp: the target is still
-        // evaluated exactly once inline.
+        // yield). In statement context that value is discarded, so the
+        // assignment goes out with no closure and no temp: the target is still
+        // evaluated exactly once, inline.
         if ($node->getEnv()->isContext(NodeEnvironment::CONTEXT_STATEMENT)) {
-            $this->emitTarget($targetExpr);
-            $this->outputEmitter->emitStr($fnCode, $node->getStartSourceLocation());
-            $this->outputEmitter->emitStr($propertyName, $propertyLoc);
-            $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
-            $this->outputEmitter->emitNode($node->getRightExpr());
+            $this->emitAssignment($node, null);
             $this->outputEmitter->emitStr(';', $node->getStartSourceLocation());
 
             return;
         }
 
-        // Expression or return context: the value is consumed, so we host a
-        // temp and yield `$target` to preserve the "returns the target object"
-        // semantics. The shared kernel wraps it in an IIFE only in expression
-        // context; in return context it elides the closure and emits plain
-        // statements ending in `return $target;`.
+        // Expression or return context: the value is consumed, so a computed
+        // target is hoisted into a temp that the form can both assign through
+        // and yield, preserving the "returns the target" semantics. A class
+        // name is not a computed expression, so it needs no temp and yields
+        // itself, which in Phel is the class-name string.
         //
-        // A class name is not a value expression, so it cannot be hoisted into
-        // the temp: the assignment goes out inline and the result is the
-        // class-name string, which is what a class name evaluates to in Phel.
-        if ($targetExpr instanceof PhpClassNameNode) {
-            new ContextualWrapEmitter($this->outputEmitter)->emit(
-                $node,
-                function () use ($node, $targetExpr, $fnCode, $propertyName, $propertyLoc): void {
-                    $this->emitTarget($targetExpr);
-                    $this->emitAssignment($node, $fnCode, $propertyName, $propertyLoc);
-                },
-                function () use ($targetExpr): void {
-                    $this->outputEmitter->emitNode($targetExpr);
-                },
-            );
-
-            return;
-        }
-
-        $targetSym = Symbol::gen('target_');
+        // The shared kernel wraps this in an IIFE only in expression context;
+        // in return context it elides the closure and emits plain statements.
+        $targetSym = $this->needsTemp($node) ? Symbol::gen('target_') : null;
 
         new ContextualWrapEmitter($this->outputEmitter)->emit(
             $node,
-            function () use ($node, $targetExpr, $fnCode, $propertyName, $propertyLoc, $targetSym): void {
-                $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
-                $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
-                $this->outputEmitter->emitNode($targetExpr);
-                $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
+            function () use ($node, $targetSym): void {
+                if ($targetSym instanceof Symbol) {
+                    $this->emitTempAssignment($node, $targetSym);
+                }
 
-                $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
-                $this->emitAssignment($node, $fnCode, $propertyName, $propertyLoc);
+                $this->emitAssignment($node, $targetSym);
+                $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
             },
             function () use ($node, $targetSym): void {
-                $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
+                $this->emitResult($node, $targetSym);
             },
         );
     }
 
     /**
-     * The member and the value, `<fnCode><property> = <right>;`, with the
-     * target already emitted by the caller.
+     * `<target><::|-><property> = <value>`, without its terminator. The target
+     * is the temp when there is one, and the place written in the source when
+     * there is not.
      */
-    private function emitAssignment(
-        PhpObjectSetNode $node,
-        string $fnCode,
-        string $propertyName,
-        ?SourceLocation $propertyLoc,
-    ): void {
-        $this->outputEmitter->emitStr($fnCode, $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr($propertyName, $propertyLoc);
+    private function emitAssignment(PhpObjectSetNode $node, ?Symbol $targetSym): void
+    {
+        $isStatic = $this->isStatic($node);
+        $callExpr = $node->getLeftExpr()->getCallExpr();
+        assert($callExpr instanceof PropertyOrConstantAccessNode);
+
+        if ($targetSym instanceof Symbol) {
+            $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
+        } else {
+            $this->emitTarget($node);
+        }
+
+        $this->outputEmitter->emitStr($isStatic ? '::' : '->', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr(
+            $this->propertyName($callExpr->getName()->getName(), $isStatic),
+            $callExpr->getName()->getStartLocation(),
+        );
         $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
         $this->outputEmitter->emitNode($node->getRightExpr());
+    }
+
+    private function emitTempAssignment(PhpObjectSetNode $node, Symbol $targetSym): void
+    {
+        $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
+        $this->outputEmitter->emitNode($node->getLeftExpr()->getTargetExpr());
         $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
     }
 
     /**
-     * A class name is written bare in a member access (`\Foo::$slot`), not as
-     * the `\Foo::class` string its value emission produces.
+     * The value the form evaluates to: the temp, or the class name as the
+     * `\Foo::class` string a class name evaluates to everywhere else.
      */
-    private function emitTarget(AbstractNode $targetExpr): void
+    private function emitResult(PhpObjectSetNode $node, ?Symbol $targetSym): void
     {
+        if ($targetSym instanceof Symbol) {
+            $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
+
+            return;
+        }
+
+        $this->outputEmitter->emitNode($node->getLeftExpr()->getTargetExpr());
+    }
+
+    /**
+     * A class name is written bare on the left of a member access
+     * (`\Foo::$slot`), not as the `\Foo::class` string its value emission
+     * produces.
+     */
+    private function emitTarget(PhpObjectSetNode $node): void
+    {
+        $targetExpr = $node->getLeftExpr()->getTargetExpr();
+
         if ($targetExpr instanceof PhpClassNameNode) {
             $this->outputEmitter->emitStr(
                 $targetExpr->getAbsolutePhpName(),
@@ -143,13 +144,29 @@ final readonly class PhpObjectSetEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitNode($targetExpr);
     }
 
+    private function needsTemp(PhpObjectSetNode $node): bool
+    {
+        return !$node->getLeftExpr()->getTargetExpr() instanceof PhpClassNameNode;
+    }
+
+    /**
+     * The same operator decision the read path makes, so `(.-slot \Foo)` and
+     * `(php/:: \Foo slot)` name one place: a class-name target is static
+     * however it was written. A write is never the runtime-dispatch case,
+     * which only applies to method calls.
+     */
+    private function isStatic(PhpObjectSetNode $node): bool
+    {
+        return $this->dispatchResolver->resolve($node->getLeftExpr()) === PhpObjectCallDispatch::StaticClass;
+    }
+
     /**
      * A static member reached through `::` is a class constant unless the name
      * carries the `$` sigil, and a constant is not assignable. The assignment
-     * context settles the ambiguity `PropertyOrConstantAccessNode` keeps open:
-     * only the property reading can be written to, so a bare name gets the
-     * sigil. A name that already carries it is left alone, since doubling it
-     * would emit a variable variable.
+     * settles the ambiguity `PropertyOrConstantAccessNode` keeps open: only the
+     * property reading can be written to, so a bare name gets the sigil. A name
+     * that already carries it is left alone, since doubling it would emit a
+     * variable variable.
      */
     private function propertyName(string $name, bool $isStatic): string
     {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectSetEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectSetEmitter.php
@@ -5,31 +5,48 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectSetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PropertyOrConstantAccessNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\ContextualWrapEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpObjectCallDispatch;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpObjectCallDispatchResolver;
+use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
+use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 
 use function assert;
+use function str_starts_with;
 
 /**
  * @internal
  */
-final class PhpObjectSetEmitter implements NodeEmitterInterface
+final readonly class PhpObjectSetEmitter implements NodeEmitterInterface
 {
-    use WithOutputEmitterTrait;
+    private PhpObjectCallDispatchResolver $dispatchResolver;
+
+    public function __construct(
+        private OutputEmitterInterface $outputEmitter,
+    ) {
+        $this->dispatchResolver = new PhpObjectCallDispatchResolver();
+    }
 
     public function emit(AbstractNode $node): void
     {
         assert($node instanceof PhpObjectSetNode);
 
-        $fnCode = $node->getLeftExpr()->isStatic() ? '::' : '->';
+        // Same operator decision the read path makes, so `(.-slot \Foo)` and
+        // `(php/:: \Foo slot)` name the same place: a class-name target is
+        // static however it was written. A write is never the runtime-dispatch
+        // case, which only applies to method calls.
+        $isStatic = $this->dispatchResolver->resolve($node->getLeftExpr()) === PhpObjectCallDispatch::StaticClass;
+        $fnCode = $isStatic ? '::' : '->';
         $targetExpr = $node->getLeftExpr()->getTargetExpr();
         $callExpr = $node->getLeftExpr()->getCallExpr();
         assert($callExpr instanceof PropertyOrConstantAccessNode);
-        $propertyName = $callExpr->getName()->getName();
+        $propertyName = $this->propertyName($callExpr->getName()->getName(), $isStatic);
         $propertyLoc = $callExpr->getName()->getStartLocation();
 
         // `php/oset` is contractually required to evaluate to the *target
@@ -38,7 +55,7 @@ final class PhpObjectSetEmitter implements NodeEmitterInterface
         // assignment directly with no closure and no temp: the target is still
         // evaluated exactly once inline.
         if ($node->getEnv()->isContext(NodeEnvironment::CONTEXT_STATEMENT)) {
-            $this->outputEmitter->emitNode($targetExpr);
+            $this->emitTarget($targetExpr);
             $this->outputEmitter->emitStr($fnCode, $node->getStartSourceLocation());
             $this->outputEmitter->emitStr($propertyName, $propertyLoc);
             $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
@@ -53,6 +70,25 @@ final class PhpObjectSetEmitter implements NodeEmitterInterface
         // semantics. The shared kernel wraps it in an IIFE only in expression
         // context; in return context it elides the closure and emits plain
         // statements ending in `return $target;`.
+        //
+        // A class name is not a value expression, so it cannot be hoisted into
+        // the temp: the assignment goes out inline and the result is the
+        // class-name string, which is what a class name evaluates to in Phel.
+        if ($targetExpr instanceof PhpClassNameNode) {
+            new ContextualWrapEmitter($this->outputEmitter)->emit(
+                $node,
+                function () use ($node, $targetExpr, $fnCode, $propertyName, $propertyLoc): void {
+                    $this->emitTarget($targetExpr);
+                    $this->emitAssignment($node, $fnCode, $propertyName, $propertyLoc);
+                },
+                function () use ($targetExpr): void {
+                    $this->outputEmitter->emitNode($targetExpr);
+                },
+            );
+
+            return;
+        }
+
         $targetSym = Symbol::gen('target_');
 
         new ContextualWrapEmitter($this->outputEmitter)->emit(
@@ -64,15 +100,63 @@ final class PhpObjectSetEmitter implements NodeEmitterInterface
                 $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
 
                 $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
-                $this->outputEmitter->emitStr($fnCode, $node->getStartSourceLocation());
-                $this->outputEmitter->emitStr($propertyName, $propertyLoc);
-                $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
-                $this->outputEmitter->emitNode($node->getRightExpr());
-                $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
+                $this->emitAssignment($node, $fnCode, $propertyName, $propertyLoc);
             },
             function () use ($node, $targetSym): void {
                 $this->outputEmitter->emitPhpVariable($targetSym, $node->getStartSourceLocation());
             },
         );
+    }
+
+    /**
+     * The member and the value, `<fnCode><property> = <right>;`, with the
+     * target already emitted by the caller.
+     */
+    private function emitAssignment(
+        PhpObjectSetNode $node,
+        string $fnCode,
+        string $propertyName,
+        ?SourceLocation $propertyLoc,
+    ): void {
+        $this->outputEmitter->emitStr($fnCode, $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr($propertyName, $propertyLoc);
+        $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
+        $this->outputEmitter->emitNode($node->getRightExpr());
+        $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
+    }
+
+    /**
+     * A class name is written bare in a member access (`\Foo::$slot`), not as
+     * the `\Foo::class` string its value emission produces.
+     */
+    private function emitTarget(AbstractNode $targetExpr): void
+    {
+        if ($targetExpr instanceof PhpClassNameNode) {
+            $this->outputEmitter->emitStr(
+                $targetExpr->getAbsolutePhpName(),
+                $targetExpr->getName()->getStartLocation(),
+            );
+
+            return;
+        }
+
+        $this->outputEmitter->emitNode($targetExpr);
+    }
+
+    /**
+     * A static member reached through `::` is a class constant unless the name
+     * carries the `$` sigil, and a constant is not assignable. The assignment
+     * context settles the ambiguity `PropertyOrConstantAccessNode` keeps open:
+     * only the property reading can be written to, so a bare name gets the
+     * sigil. A name that already carries it is left alone, since doubling it
+     * would emit a variable variable.
+     */
+    private function propertyName(string $name, bool $isStatic): string
+    {
+        if (!$isStatic || str_starts_with($name, '$')) {
+            return $name;
+        }
+
+        return '$' . $name;
     }
 }

--- a/tests/phel/core/set-bang.phel
+++ b/tests/phel/core/set-bang.phel
@@ -70,6 +70,12 @@
       "a class name as the place of `.-` assigns the static property")
   (reset-static-target))
 
+(deftest a-var-in-a-class-looking-namespace-stays-a-var
+  (is (= 'phel.core/var-set (first (macroexpand '(set! Foo/*x* 1))))
+      "an earmuffed name is no member PHP can spell, so an upper-case namespace does not capture it")
+  (is (= 'php/oset (first (nth (macroexpand '(set! Foo/slot 1)) 2)))
+      "a member-shaped name in the same namespace is the static-property branch"))
+
 (deftest sets-a-static-property-through-oset
   (reset-static-target)
   (php/oset (php/:: StaticPropertyTarget slot) "via-oset")

--- a/tests/phel/core/set-bang.phel
+++ b/tests/phel/core/set-bang.phel
@@ -1,6 +1,7 @@
 (ns phel-test.core.set-bang
   (:require phel.test :refer [deftest is])
-  (:use \stdClass))
+  (:use \stdClass)
+  (:use PhelTest\Support\Fixtures\PhpInterop\StaticPropertyTarget))
 
 (def ^:dynamic *counter* 0)
 
@@ -43,6 +44,41 @@
 (deftest returns-the-value-for-a-var-too
   (is (= 7 (binding [*counter* 1] (set! *counter* 7)))
       "the var branch returns the assigned value as well"))
+
+(defn- reset-static-target []
+  (.reset StaticPropertyTarget))
+
+(deftest sets-a-static-property
+  (reset-static-target)
+  (is (= "written" (set! StaticPropertyTarget/slot "written"))
+      "the static branch returns the assigned value, like the other two")
+  (is (= "written" StaticPropertyTarget/$slot)
+      "the class-level property holds the assigned value")
+  (reset-static-target))
+
+(deftest keeps-a-same-named-constant-out-of-the-way
+  (reset-static-target)
+  (set! StaticPropertyTarget/slot "property")
+  (is (= "i-am-a-constant" StaticPropertyTarget/slot)
+      "the bare name is still the constant; only the sigil reaches the property")
+  (reset-static-target))
+
+(deftest sets-a-static-property-through-a-class-place
+  (reset-static-target)
+  (set! (.-slot StaticPropertyTarget) "dot-member")
+  (is (= "dot-member" StaticPropertyTarget/$slot)
+      "a class name as the place of `.-` assigns the static property")
+  (reset-static-target))
+
+(deftest sets-a-static-property-through-oset
+  (reset-static-target)
+  (php/oset (php/:: StaticPropertyTarget slot) "via-oset")
+  (is (= "via-oset" StaticPropertyTarget/$slot)
+      "a bare name in assignment position is the property, never the constant")
+  (php/oset (php/:: StaticPropertyTarget $slot) "via-sigil")
+  (is (= "via-sigil" StaticPropertyTarget/$slot)
+      "an explicit `$` sigil is not doubled into a variable variable")
+  (reset-static-target))
 
 (deftest refuses-to-write-a-root
   (let [err (try (set! *counter* 3)

--- a/tests/php/Integration/Compiler/QualifiedMemberSpellingParityTest.php
+++ b/tests/php/Integration/Compiler/QualifiedMemberSpellingParityTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Compiler;
+
+use Iterator;
+use Phel\Compiler\Domain\Analyzer\QualifiedMemberSyntax;
+use Phel\Shared\CompileOptions;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+use function sprintf;
+
+/**
+ * `QualifiedMemberSyntax` states in PHP which symbols name a PHP class member,
+ * and `phel.core/set!` restates it in Phel, because the standard library cannot
+ * import an `@internal` compiler class. Nothing but this test keeps the two
+ * copies from drifting: a symbol the analyzer reads as a class member has to
+ * reach `set!`'s property branch, and anything else has to stay a var.
+ */
+final class QualifiedMemberSpellingParityTest extends AbstractCompilerRuntimeTestCase
+{
+    /**
+     * @return Iterator<int<0, max>, array{string, string, bool}>
+     */
+    public static function providerSpellings(): Iterator
+    {
+        yield 'absolute class name' => ['\\Foo', 'slot', true];
+        yield 'bare class name' => ['Foo', 'slot', true];
+        yield 'sigil names the static property' => ['Foo', '$slot', true];
+        yield 'underscore opens a PHP identifier' => ['Foo', '_slot', true];
+        yield 'earmuffed var is no PHP member' => ['Foo', '*x*', false];
+        yield 'kebab name is no PHP member' => ['Foo', '-x', false];
+        yield 'lower-case namespace is a Phel namespace' => ['my-ns', 'slot', false];
+        yield 'php is the host-function prefix' => ['php', 'slot', false];
+    }
+
+    #[DataProvider('providerSpellings')]
+    public function test_both_copies_of_the_rule_agree(string $ns, string $name, bool $isMember): void
+    {
+        self::assertSame(
+            $isMember,
+            QualifiedMemberSyntax::isClassReference($ns)
+                && (QualifiedMemberSyntax::isMemberName($name) || QualifiedMemberSyntax::isStaticPropertyName($name)),
+            'the analyzer disagrees with the expected reading',
+        );
+
+        // `let` heads the property branch (it binds the value once), `var-set`
+        // the var branch. Asserting on the expansion keeps the check away from
+        // whether the class or the var happens to exist.
+        $head = $this->compilerFacade->eval(
+            sprintf("(str (first (macroexpand '(set! %s/%s 1))))", $ns, $name),
+            new CompileOptions(),
+        );
+
+        self::assertSame(
+            $isMember ? 'let' : 'phel.core/var-set',
+            $head,
+            'set! took the other branch',
+        );
+    }
+}

--- a/tests/php/Integration/Compiler/QualifiedMemberValueRuntimeTest.php
+++ b/tests/php/Integration/Compiler/QualifiedMemberValueRuntimeTest.php
@@ -9,6 +9,7 @@ use PDO;
 use Phel\Shared\CompileOptions;
 use PhelTest\Support\DefinesClassConstantCollisionTrait;
 use PhelTest\Support\Fixtures\PhpInterop\QualifiedMemberFixture;
+use PhelTest\Support\Fixtures\PhpInterop\StaticPropertyTarget;
 
 use function class_exists;
 use function sprintf;
@@ -18,6 +19,8 @@ final class QualifiedMemberValueRuntimeTest extends AbstractCompilerRuntimeTestC
     use DefinesClassConstantCollisionTrait;
 
     private const string FIXTURE = '\\' . QualifiedMemberFixture::class;
+
+    private const string STATIC_PROPERTY = '\\' . StaticPropertyTarget::class;
 
     private const string HOST_COLLISION = 'PHEL_TEST_RUNTIME_CLASS_CONSTANT_COLLISION';
 
@@ -98,6 +101,37 @@ final class QualifiedMemberValueRuntimeTest extends AbstractCompilerRuntimeTestC
         );
 
         self::assertSame('fixture', $result);
+    }
+
+    public function test_a_static_property_is_read_through_the_sigil(): void
+    {
+        StaticPropertyTarget::$slot = 'i-am-a-property';
+
+        try {
+            $property = $this->compilerFacade->eval(self::STATIC_PROPERTY . '/$slot', new CompileOptions());
+            $constant = $this->compilerFacade->eval(self::STATIC_PROPERTY . '/slot', new CompileOptions());
+        } finally {
+            StaticPropertyTarget::reset();
+        }
+
+        self::assertSame('i-am-a-property', $property);
+        self::assertSame(StaticPropertyTarget::slot, $constant, 'the bare name stays the constant');
+    }
+
+    public function test_a_static_property_is_assigned_through_set(): void
+    {
+        try {
+            $result = $this->compilerFacade->eval(
+                sprintf('(set! %s/slot "written")', self::STATIC_PROPERTY),
+                new CompileOptions(),
+            );
+
+            self::assertSame('written', $result, 'set! returns the assigned value');
+            self::assertSame('written', StaticPropertyTarget::$slot);
+            self::assertSame('i-am-a-constant', StaticPropertyTarget::slot, 'the constant is untouched');
+        } finally {
+            StaticPropertyTarget::reset();
+        }
     }
 
     public function test_an_all_caps_class_works_in_both_static_constant_spellings(): void

--- a/tests/php/Integration/Fixtures/PhpObjectSet/set-static-property-explicit-sigil.test
+++ b/tests/php/Integration/Fixtures/PhpObjectSet/set-static-property-explicit-sigil.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [] (php/oset (php/:: \DateTime $slot) "x") nil)
+--PHP--
+(function() {
+  \DateTime::$slot = "x";
+  return null;
+});

--- a/tests/php/Integration/Fixtures/PhpObjectSet/set-static-property-expression-context.test
+++ b/tests/php/Integration/Fixtures/PhpObjectSet/set-static-property-expression-context.test
@@ -1,0 +1,9 @@
+--PHEL--
+(fn [] (php/print_r (php/oset (php/:: \DateTime slot) "x")))
+--PHP--
+(function() {
+  return print_r((function() {
+    \DateTime::$slot = "x";
+    return \DateTime::class;
+  })());
+});

--- a/tests/php/Integration/Fixtures/PhpObjectSet/set-static-property-return-context.test
+++ b/tests/php/Integration/Fixtures/PhpObjectSet/set-static-property-return-context.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [] (php/oset (php/:: \DateTime slot) "x"))
+--PHP--
+(function() {
+  \DateTime::$slot = "x";
+  return \DateTime::class;
+});

--- a/tests/php/Integration/Fixtures/PhpObjectSet/set-static-property-through-class-place.test
+++ b/tests/php/Integration/Fixtures/PhpObjectSet/set-static-property-through-class-place.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [] (php/oset (php/-> \DateTime slot) "x") nil)
+--PHP--
+(function() {
+  \DateTime::$slot = "x";
+  return null;
+});

--- a/tests/php/Integration/Fixtures/PhpObjectSet/set-static-property.test
+++ b/tests/php/Integration/Fixtures/PhpObjectSet/set-static-property.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [] (php/oset (php/:: \DateTime slot) "x") nil)
+--PHP--
+(function() {
+  \DateTime::$slot = "x";
+  return null;
+});

--- a/tests/php/Support/Fixtures/PhpInterop/StaticPropertyTarget.php
+++ b/tests/php/Support/Fixtures/PhpInterop/StaticPropertyTarget.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Support\Fixtures\PhpInterop;
+
+/**
+ * Carries a static property and a class constant under the same name, which
+ * PHP allows because it files the two separately. Only the `$` sigil tells
+ * them apart, which is what the static-property interop tests pin.
+ */
+final class StaticPropertyTarget
+{
+    public const string slot = 'i-am-a-constant';
+
+    public static mixed $slot = null;
+
+    public static function reset(): void
+    {
+        self::$slot = null;
+    }
+}


### PR DESCRIPTION
## 🤔 Background

There was no working way to assign a static property. The spelling the docs advertise, `(php/oset (php/:: \Foo slot) v)`, emitted `\Foo::slot = v`: PHP reads a bare `::name` as a class-constant fetch, so the compile died with `syntax error, unexpected token "="`. The Clojure-style spelling `(set! \Foo/slot v)` never reached the property branch at all, because `set!` sent every symbol down `var-set` and answered a property assignment with `Cannot resolve '\Foo/slot' to a var`.

A third shape was broken silently: a class name as the place of `.-`, `(set! (.-slot \Foo) v)`, emitted `\Foo::class->slot = v` and died at runtime with `Cannot use temporary expression in write context`. The read path had solved this long ago (it shares `PhpObjectCallDispatchResolver`, which calls a class-name target static however it was written); the set emitter never got the same treatment.

Reading a static property back was possible only through `(php/:: \Foo $slot)`, a form deprecated as source with no replacement.

Closes #2907

## 💡 Goal

One spelling per direction, no spelling that emits broken PHP, and neither of them a deprecated form.

```phel
(set! \Foo/slot "x")   ; write, what Clojure writes for a static field
\Foo/$slot             ; read, sigil because PHP files constants separately
```

## 🔖 Changes

- `PhpObjectSetEmitter` resolves the operator through `PhpObjectCallDispatchResolver` instead of `PhpObjectCallNode::isStatic()`, so a class-name target is static however it was written, and emits a class-name target bare rather than as its `::class` string. Statement context now emits `\Foo::$slot = v` and the value contexts skip the temp, since a class name is not a value expression to hoist.
- A bare static member name in assignment position gets the `$` sigil: a class constant is not assignable, so there is no ambiguity left to preserve. A name that already carries the sigil is left alone, or `::$$slot` would emit a variable variable.
- `set!` gets a third branch. A qualified symbol whose namespace names a PHP class (leading `\` or upper-case first character, the test `AnalyzePersistentList::isStaticCallShorthand()` already uses) assigns the static property; anything else stays a dynamic var.
- `QualifiedMemberExpander` expands `\C/$prop` in value position, so reading a static property no longer needs the deprecated `php/::`. The bare name stays the constant it has always been, and no reflection is involved: PHP keeps constants and static properties in separate namespaces and the sigil alone decides.
- Docs: the open position in `docs/spec/language-surface.md` is resolved and the shorthand table gains `\C/$prop`; `docs/spec/clojure-divergences.md` records the sigil as a divergence from `Classname/field` and adds static-field assignment to the var-mutation table.

- `Domain/Analyzer/QualifiedMemberSyntax` states once how a symbol has to be spelled to name a PHP class member. Call position and value position each carried their own copy of the rule plus a private `isIdentifierStartChar`; both now delegate, and the class also owns the `$`-sigil reading. `set!` keeps a Phel restatement, because the standard library cannot import an `@internal` compiler class.
- `PhpObjectSetEmitter` collapsed to a single emission path. Statement, return and expression context disagreed about one thing, whether the place is a temp or is written inline, so that is the only branch left; the operator, the sigil and the terminator stopped being threaded through closures. Emitted PHP is unchanged, which is what the fixtures assert.

### Tests

- `tests/php/Integration/Fixtures/PhpObjectSet/set-static-property{,-return-context,-expression-context}.test` pin the emitted PHP for all three contexts (the emitter branches differ).
- `QualifiedMemberValueRuntimeTest` covers read and write against a fixture carrying `const slot` and `public static $slot` under one name, so a test fails if either spelling reaches the other member.
- `tests/phel/core/set-bang.phel` covers the three source spellings end to end, including that `$slot` is not doubled, and that a dynamic var in a class-looking namespace (`Foo/*x*`) stays a var: an earmuffed name is no member PHP can spell.
- `QualifiedMemberSpellingParityTest` pins the PHP rule and the Phel restatement to one table, so the two copies cannot drift.
