### PR TITLE
fix(compiler): reject a `$`-prefixed member outside a static-property place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- A `$`-prefixed member outside a static-property place fails to compile instead of emitting a PHP variable-property access. `(php/-> o $foo)` used to compile to `$o->$foo`, warn twice about an undefined variable and read `$o->{''}` (#2915)
 - Assigning a static property compiles. `(php/oset (php/:: \Foo slot) v)` emitted `\Foo::slot = v`, a class-constant fetch PHP rejects with `syntax error, unexpected token "="`, and a class name as the place of `.-` emitted `\Foo::class->slot = v` (#2907)
 - Bare all-caps PHP classes such as `PDO` are no longer read as global constants, so `PDO/ATTR_ERRMODE`, `(.-ATTR_ERRMODE PDO)` and `(new PDO ...)` need no leading backslash. A class beats a same-named constant; `php/NAME` stays the explicit escape hatch
 - `phel init`, the three bundled example apps, the `.agents/` task recipes and the `--template=` scaffolds all emit the dot separator (`my-app.main`). A generated project used to start on syntax the compiler warns about (#2827)

--- a/docs/spec/clojure-divergences.md
+++ b/docs/spec/clojure-divergences.md
@@ -165,6 +165,11 @@ Assignment needs no sigil: a class constant cannot be assigned, so
 `(set! \C/slot v)` and `(php/oset (php/:: \C slot) v)` can only mean the property
 and emit `\C::$slot = v`.
 
+The sigil is rejected anywhere it could not mean a static property, `(php/-> o $x)`
+and `(php/:: \C ($x))` among them. PHP would read the `$x` as one of its own
+variables, which no Phel binding defines
+([#2915](https://github.com/phel-lang/phel-lang/issues/2915)).
+
 ### `aset` and `set!` are macros, not functions
 
 Clojure's `aset` is a function, so `(map (partial aset arr) …)` works. Phel's is a

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
@@ -6,6 +6,7 @@ namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
 use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
 use Phel\Compiler\Domain\Analyzer\Ast\MethodCallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PropertyOrConstantAccessNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
@@ -64,6 +65,10 @@ final readonly class PhpObjectCallSymbol implements SpecialFormAnalyzerInterface
                 $callExpr = $this->callExprForPropertyCall($env, $current);
             }
 
+            $isStaticPlace = !$methodCall
+                && ($this->isStatic && $i === 2 || $targetExpr instanceof PhpClassNameNode);
+            $this->assertSigilNamesAStaticProperty($current, $isStaticPlace, $list);
+
             $isLast = $i === $counter - 1;
             $nodeEnv = $isLast ? $env : $env->withExpressionContext();
 
@@ -107,5 +112,41 @@ final readonly class PhpObjectCallSymbol implements SpecialFormAnalyzerInterface
     private function callExprForPropertyCall(NodeEnvironmentInterface $env, Symbol $segment): PropertyOrConstantAccessNode
     {
         return new PropertyOrConstantAccessNode($env, $segment, $segment->getStartLocation());
+    }
+
+    /**
+     * The `$` sigil names a static property, and PHP spells every other member
+     * without it. Emitted verbatim anywhere else it reads as a PHP *variable*
+     * of that name, which no Phel binding ever defines: `(php/-> o $foo)` used
+     * to compile to `$o->$foo` and read `$o->{''}` after two warnings (#2915).
+     *
+     * @param PersistentListInterface<mixed>|Symbol $segment
+     * @param PersistentListInterface<mixed>        $list
+     */
+    private function assertSigilNamesAStaticProperty(
+        Symbol|PersistentListInterface $segment,
+        bool $isStaticPlace,
+        PersistentListInterface $list,
+    ): void {
+        $member = $segment instanceof PersistentListInterface ? $segment->get(0) : $segment;
+        if (!$member instanceof Symbol) {
+            return;
+        }
+
+        $name = $member->getName();
+        if (!str_starts_with($name, '$') || $isStaticPlace) {
+            return;
+        }
+
+        throw AnalyzerException::withLocation(
+            sprintf(
+                "'%s' names a static property, which only a class can hold: write \\Foo/%s or (php/:: \\Foo %s). "
+                . 'An instance member and a method name carry no sigil.',
+                $name,
+                $name,
+                $name,
+            ),
+            $list,
+        );
     }
 }

--- a/tests/php/Integration/Compiler/QualifiedMemberValueRuntimeTest.php
+++ b/tests/php/Integration/Compiler/QualifiedMemberValueRuntimeTest.php
@@ -7,6 +7,7 @@ namespace PhelTest\Integration\Compiler;
 use Override;
 use PDO;
 use Phel\Shared\CompileOptions;
+use Phel\Shared\Exceptions\CompilerException;
 use PhelTest\Support\DefinesClassConstantCollisionTrait;
 use PhelTest\Support\Fixtures\PhpInterop\QualifiedMemberFixture;
 use PhelTest\Support\Fixtures\PhpInterop\StaticPropertyTarget;
@@ -132,6 +133,17 @@ final class QualifiedMemberValueRuntimeTest extends AbstractCompilerRuntimeTestC
         } finally {
             StaticPropertyTarget::reset();
         }
+    }
+
+    public function test_a_sigil_on_an_instance_member_fails_to_compile(): void
+    {
+        $this->expectException(CompilerException::class);
+        $this->expectExceptionMessage("'\$foo' names a static property, which only a class can hold");
+
+        $this->compilerFacade->eval(
+            '(let [o (php/new \\stdClass)] (php/-> o $foo))',
+            new CompileOptions(),
+        );
     }
 
     public function test_an_all_caps_class_works_in_both_static_constant_spellings(): void

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/PhpObjectCallSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/PhpObjectCallSymbolTest.php
@@ -117,6 +117,65 @@ final class PhpObjectCallSymbolTest extends TestCase
         self::assertInstanceOf(PropertyOrConstantAccessNode::class, $objCallNode->getCallExpr());
     }
 
+    public function test_sigil_on_an_instance_member_is_rejected(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage("'\$foo' names a static property, which only a class can hold");
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
+            1,
+            Symbol::create('$foo'),
+        ]);
+
+        new PhpObjectCallSymbol($this->analyzer, isStatic: false)
+            ->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_sigil_on_a_method_name_is_rejected(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage("'\$foo' names a static property, which only a class can hold");
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL),
+            Symbol::create('\\'),
+            Phel::list([Symbol::create('$foo')]),
+        ]);
+
+        new PhpObjectCallSymbol($this->analyzer, isStatic: true)
+            ->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_sigil_on_a_static_property_is_allowed(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL),
+            Symbol::create('\\'),
+            Symbol::create('$foo'),
+        ]);
+
+        $objCallNode = new PhpObjectCallSymbol($this->analyzer, isStatic: true)
+            ->analyze($list, NodeEnvironment::empty());
+
+        self::assertInstanceOf(PropertyOrConstantAccessNode::class, $objCallNode->getCallExpr());
+    }
+
+    public function test_sigil_on_a_class_name_target_is_allowed(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
+            Symbol::create('\\'),
+            Symbol::create('$foo'),
+        ]);
+
+        $objCallNode = new PhpObjectCallSymbol($this->analyzer, isStatic: false)
+            ->analyze($list, NodeEnvironment::empty());
+
+        self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());
+        self::assertInstanceOf(PropertyOrConstantAccessNode::class, $objCallNode->getCallExpr());
+    }
+
     public function test_nested_calls(): void
     {
         $list = Phel::list([


### PR DESCRIPTION
## 🤔 Background

`$` in a member position means one thing after #2907: a static property. Everywhere else it was emitted verbatim, so PHP read it as one of its own variables, and no Phel binding ever defines those.

```bash
./bin/phel eval '(let [o (php/new \stdClass)] (php/print_r (php/-> o $foo)))'
# Warning: Undefined variable $foo
# Warning: Undefined property: stdClass::$
```

The emitted PHP was `$o->$foo`: two warnings, a read of `$o->{''}`, and `nil` back. Nothing named the real mistake, and the same held for `(php/oset (php/-> o $name) v)` and for a method name spelled `($foo)`.

Closes #2915

## 💡 Goal

The form that cannot mean anything stops compiling, and the error names the spelling that works.

```
'$foo' names a static property, which only a class can hold: write \Foo/$foo or
(php/:: \Foo $foo). An instance member and a method name carry no sigil.
```

## 🔖 Changes

- `PhpObjectCallSymbol` rejects a `$`-prefixed member unless the place can hold a static property: a non-method access whose hop is `php/::`, or whose target is a class name (`(php/-> \Foo $slot)`, which `PhpObjectCallDispatchResolver` already emits as `::`). A chained hop, an instance receiver and a receiver deferred to the runtime `is_string()` test all fail, because in every one of those readings the `$foo` is a PHP variable rather than a member name.
- The check is analysis-time, so the report carries the source location rather than surfacing as two PHP warnings at run time.
- `docs/spec/clojure-divergences.md` records where the sigil is accepted and why it is refused elsewhere.

### Tests

- `PhpObjectCallSymbolTest`: rejection on an instance member and on a method name, acceptance on `php/::` and on a class-name target.
- `QualifiedMemberValueRuntimeTest`: the compile fails end to end with that message.
