### PR TITLE
docs(adr): record the static-property spelling as ADR 0013

### DIFF
--- a/.agnostic-ai/rules/architecture-decisions.md
+++ b/.agnostic-ai/rules/architecture-decisions.md
@@ -14,6 +14,8 @@ Each of these looks like an oversight and was argued once:
 - `php/new` / `php/->` / `php/::` are deprecated as source yet remain the
   compilation target the shorthand expands into (ADR 0007)
 - `\` still parses as a namespace separator alongside `.` (ADR 0008)
+- a static property reads as `\Foo/$prop` and assigns as `(set! \Foo/prop v)`,
+  sigil on one side only (ADR 0013)
 - static analysis stops at `src/`, never `tests/` (ADR 0010)
 - deprecation warnings are off unless `--warn-deprecations` (ADR 0006)
 

--- a/docs/adr/0013-static-property-spelling.md
+++ b/docs/adr/0013-static-property-spelling.md
@@ -1,0 +1,87 @@
+# ADR 0013: A static property is `$prop` to read and a plain name to assign
+
+- **Status**: Accepted
+- **Date**: 2026-08-01
+
+## Context
+
+PHP files class constants and static properties in separate namespaces, so one
+class can carry `const slot` and `public static $slot` at once, and only the `$`
+sigil tells `Foo::slot` from `Foo::$slot` apart. Every other host member Phel
+reaches is unambiguous.
+
+Until [#2907](https://github.com/phel-lang/phel-lang/issues/2907) a static
+property had no working spelling at all. `(php/oset (php/:: \Foo slot) v)`, the
+shape `NativeSymbolCatalog` advertised, emitted `\Foo::slot = v`, which PHP
+rejects at parse time as an assignment to a class constant, and
+`(set! \Foo/slot v)` reported "Cannot resolve to a var" because `set!` sent every
+symbol down the var branch.
+
+[ADR 0007](0007-clojure-style-interop-is-the-source-spelling.md) closes with
+"Still open: an assignable static property. Neither spelling works". That line is
+a snapshot of the day it was written; accepted records are immutable
+(`README.md`), so it stays, and this record is where the question is closed. ADR
+0007's decision, that the Clojure-style spelling is the source spelling, is
+unchanged and still in force.
+
+## Decision
+
+- **Read** carries the sigil: `\Foo/$prop`, expanded by `QualifiedMemberExpander`
+  to `(php/:: \Foo $prop)`. A bare `\Foo/prop` keeps meaning the class constant it
+  has always meant.
+- **Assign** carries no sigil: `(set! \Foo/prop v)`, and the primitive
+  `(php/oset (php/:: \Foo prop) v)` under it, both emit `\Foo::$prop = v`. A class
+  constant is not assignable, so an assignment can only mean the property and
+  there is no ambiguity for a sigil to resolve. A name that already carries one is
+  passed through rather than doubled.
+- **`set!`** reads a symbol place as a static property when the namespace names a
+  class and the name could be a PHP member. Both halves are `QualifiedMemberSyntax`,
+  the analyzer's rule for call and value position; anything else is a dynamic var,
+  which is what keeps `(set! Foo/*x* v)` a var.
+- **The sigil is refused** wherever a static property cannot live: an instance
+  member, a chained hop, a method name
+  ([#2915](https://github.com/phel-lang/phel-lang/issues/2915)). PHP would read
+  the `$x` as one of its own variables, which no Phel binding defines.
+
+## Consequences
+
+- Read and write are spelled differently for one member, which reads like an
+  oversight and is not: the sigil answers a question only the read position asks.
+- A class carrying `const slot` and `static $slot` stays fully reachable, and
+  neither spelling can silently reach the other member.
+- No reflection is involved, so the meaning of a form does not depend on whether
+  the class happened to be loaded, unlike the constant-versus-static-method rule
+  in ADR 0007.
+- Tooling has to learn the sigil: completion and hover still do not offer static
+  properties ([#2916](https://github.com/phel-lang/phel-lang/issues/2916)).
+- Instance property access is untouched: `(.-prop o)` and `(set! (.-prop o) v)`
+  never take a sigil.
+
+## Enforcement
+
+- `tests/php/Integration/Fixtures/PhpObjectSet/set-static-property*.test` pin the
+  emitted PHP for statement, return and expression context, the explicit-sigil
+  spelling and a class name as the place.
+- `QualifiedMemberValueRuntimeTest` covers read, write and the refused sigil.
+- `QualifiedMemberSpellingParityTest` pins `QualifiedMemberSyntax` and the Phel
+  restatement inside `set!` to one table.
+- `tests/phel/core/set-bang.phel` covers the source spellings end to end.
+
+## Alternatives considered
+
+- **Require the sigil on both sides.** Symmetrical, but assignment has no
+  ambiguity for it to resolve, and `(set! \Foo/$prop v)` next to
+  `(set! (.-prop o) v)` invents a difference the host does not have. It still
+  works, since a name that already carries the sigil is accepted.
+- **Reflect on the class to tell a constant from a static property.** Would let
+  the bare name mean either. Rejected: the class may not be loaded at analysis
+  time, and a class carrying both would have its meaning decided by load order.
+- **Leave the position unspelled.** The status quo #2907 documents: a signature
+  advertised in the catalogue that has never compiled.
+
+## See also
+
+[Language surface](../spec/language-surface.md) ·
+[Clojure divergences](../spec/clojure-divergences.md) ·
+[ADR 0007](0007-clojure-style-interop-is-the-source-spelling.md) ·
+#2907, #2914, #2915

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ Records are immutable: a changed decision gets a new ADR superseding the old one
 | [0010](0010-static-analysis-covers-src-only.md) | Static analysis covers `src/` only | Accepted |
 | [0011](0011-persistent-collections-in-php.md) | Persistent collections implemented in PHP | Accepted |
 | [0012](0012-non-hygienic-macros-with-auto-gensym.md) | Non-hygienic macros with auto-gensym | Accepted |
+| [0013](0013-static-property-spelling.md) | A static property is `$prop` to read and a plain name to assign | Accepted |
 
 Statuses: **Proposed**, **Accepted**, **Superseded by NNNN**, **Deprecated** (in
 force, being unwound).

--- a/docs/spec/language-surface.md
+++ b/docs/spec/language-surface.md
@@ -129,7 +129,8 @@ anything else is a dynamic var. The primitive underneath stays
 position a bare name can only be the property, since a class constant is not
 assignable. Reading it back needs the explicit sigil, `\Foo/$slot`, because in
 read position the bare name is the constant: PHP keeps the two in separate
-namespaces and a class may hold both under one name.
+namespaces and a class may hold both under one name. Rationale:
+[ADR 0013](../adr/0013-static-property-spelling.md).
 
 The remaining `php/*` forms stay, because each reaches a PHP capability Phel has
 no other word for: `php/aget`, `php/aset`, `php/apush`, `php/aunset` and


### PR DESCRIPTION
## 🤔 Background

ADR 0007 closes with "Still open: an assignable static property. Neither spelling works, so `php/::` is not the answer either". #2907 closed that question and `docs/spec/language-surface.md` carries the answer, so the record now states the opposite of what ships.

Accepted records are immutable, and the only edit `docs/adr/README.md` allows on one is a `Superseded by` marker, so the line could not be corrected in the pull request that resolved it.

Closes #2917

## 💡 Goal

The current answer is discoverable from `docs/adr/`, and the reader who wonders why a static property reads with a sigil and assigns without one finds the argument rather than re-litigating it.

## 🔖 Changes

- **ADR 0013**, "A static property is `$prop` to read and a plain name to assign". Records the decision: the sigil answers a question only the read position asks, since a class constant is not assignable and an assignment therefore has nothing to disambiguate; `set!` tells a class reference from a dynamic var with both halves of `QualifiedMemberSyntax`; the sigil is refused wherever a static property cannot live (#2915). Names the tests that fail when any of it breaks.
- ADR 0007 is **not** marked superseded, and this is deliberate. Its decision, that the Clojure-style spelling is the source spelling, is unchanged and still in force; a `Superseded by` marker would tell readers otherwise. 0013 records instead that 0007's closing line is a snapshot of the day it was written and that this record closes the question. The alternative, marking 0007 superseded, was the option the issue proposed, and it trades a stale sentence for a misleading status.
- Index row, plus the `Rationale:` link from the language-surface spec.
- `.agnostic-ai/rules/architecture-decisions.md` gains the sigil asymmetry in its list of things that look like an oversight and were argued once, which is exactly what this one looks like. Synced to the adapter directories.
