### PR TITLE
docs: bring the docs back in line with the code

### DIFF
--- a/.agnostic-ai/rules/load-order.md
+++ b/.agnostic-ai/rules/load-order.md
@@ -3,6 +3,10 @@ name: load-order
 globs: resources/agents/skills/codex/**
 ---
 
+Reading order for an agent working in a project that has the docs installed. This
+repository is where they are written, so here they live under `resources/agents/`
+and the paths below are what a user project sees after `phel agent-install`.
+
 1. `.agents/RULES.md` — hard rules, modern features, CLI cheatsheet
 2. `.agents/tasks/common-gotchas.md` — read BEFORE writing code
 3. `.agents/index.md` — task map; pick `.agents/tasks/<intent>.md`

--- a/.agnostic-ai/rules/phel.md
+++ b/.agnostic-ai/rules/phel.md
@@ -32,7 +32,9 @@ Every public function should have metadata:
 
 ## Macros
 
-Editing a `defmacro` body or `` ` `` quasiquote? Load [macro-hygiene.md](macro-hygiene.md) first — local `let` names can silently shadow globals.
+Editing a `defmacro` body or `` ` `` quasiquote? Load the macro-hygiene rule
+(`.agnostic-ai/rules/macro-hygiene.md`, mirrored into each adapter directory)
+first: local `let` names can silently shadow globals.
 
 ## Formatting
 

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -7,11 +7,19 @@ Guide to creating a new release for Phel.
 Run the release script from the repository root:
 
 ```bash
-./tools/release.sh          # Auto-increments minor version (0.28.0 → 0.29.0)
-./tools/release.sh 0.29.0   # Or specify explicit version
+./tools/release.sh          # Auto-increments the minor version (0.49.0 -> 0.50.0)
+./tools/release.sh 0.50.0   # Or specify an explicit version
 ```
 
-That's it. The script handles everything: version bumps, changelog updates, PHAR build, git tag, and GitHub release creation.
+That's it. The script handles everything: version bumps, changelog updates, PHAR
+build, QA smoke test, git tag, and GitHub release creation. Publishing the release
+fires `announce-release.yml`.
+
+**Always release with the script.** Doing it by hand misses steps: it is what
+updates `resources/agents/VERSION`, moves the `## Unreleased` section itself (so
+leave that section populated and never pre-convert it), and smoke-tests the PHAR
+before anything is pushed. Run `--dry-run` first; the real run pushes to `main`
+and publishes publicly.
 
 ## Prerequisites
 
@@ -26,43 +34,55 @@ Before releasing, ensure you have:
 
 ```bash
 # Standard release
-./tools/release.sh 0.29.0
+./tools/release.sh 0.50.0
 
-# Preview changes without modifying anything
-./tools/release.sh --dry-run 0.29.0
+# Preview everything, restore the files, no side effects
+./tools/release.sh --dry-run 0.50.0
 
-# Skip prompts for CI automation
-./tools/release.sh --force 0.29.0
+# Skip the confirmation prompt (CI automation)
+./tools/release.sh --force 0.50.0
 
-# Skip PHAR build (useful for quick patch releases)
-./tools/release.sh --skip-phar 0.29.0
+# Skip the PHAR build (also skips the QA smoke test that runs against it)
+./tools/release.sh --skip-phar 0.50.0
+
+# Build the PHAR but skip the QA suite
+./tools/release.sh --skip-qa 0.50.0
+
+# Name the release; omit to let the release notes suggest one
+./tools/release.sh --name "Life, PHP & Everything" 0.50.0
 ```
 
 ### What the Script Does
 
 1. Validates version format (X.Y.Z) and ensures new > current
-2. Runs pre-flight checks (gh CLI, git state, required files, network)
-3. Updates [VersionFinder.php](../src/php/Console/Application/VersionFinder.php)
-4. Updates [CHANGELOG.md](../CHANGELOG.md) (moves Unreleased to versioned section)
-5. Updates [.agents/VERSION](../.agents/VERSION) (targeted phel-lang release for agent docs/tests)
+2. Runs pre-flight checks (gh CLI, on `main`, in sync with `origin/main`, clean
+   tree, `## Unreleased` still populated, tag absent, network)
+3. Updates `LATEST_VERSION` in [VersionFinder.php](../src/php/Shared/VersionFinder.php)
+4. Updates [CHANGELOG.md](../CHANGELOG.md) (moves Unreleased to a versioned
+   section and opens a fresh empty one)
+5. Updates [resources/agents/VERSION](../resources/agents/VERSION) (targeted
+   phel-lang release for agent docs/tests)
 6. Commits changes with `chore(release): vX.Y.Z`
-7. Builds PHAR with `OFFICIAL_RELEASE=true`
-8. Creates git tag
-9. Pushes commit and tag to remote
-10. Creates GitHub release with PHAR attachment and changelog notes
+7. Builds the PHAR with `OFFICIAL_RELEASE=true` and QA-smoke-tests it
+8. Creates the git tag
+9. Pushes commit and tag to `main`
+10. Creates the GitHub release with notes, contributors and the PHAR attached,
+    which fires `announce-release.yml`
 
 ---
 
 ## Manual Release
 
-If you need to release manually (e.g., the script fails, you're debugging, or you prefer more control), follow these steps:
+Only when the script itself is broken. It is the supported path, and every step
+below is a step the script already performs.
 
 ### Step 1: Update Version Files
 
-Update the version string in [VersionFinder.php](../src/php/Console/Application/VersionFinder.php):
+Update the constant in [VersionFinder.php](../src/php/Shared/VersionFinder.php).
+Note the `v` prefix:
 
 ```php
-private const VERSION = '0.29.0';
+public const string LATEST_VERSION = 'v0.50.0';
 ```
 
 ### Step 2: Update Changelog
@@ -70,24 +90,25 @@ private const VERSION = '0.29.0';
 In [CHANGELOG.md](../CHANGELOG.md), rename the "Unreleased" section to the new version with today's date:
 
 ```markdown
-## [0.29.0] - 2025-01-19
+## [0.50.0] - 2026-08-01
 ```
 
 Add a new empty "Unreleased" section at the top.
 
-### Step 3: Update .agents/VERSION
+### Step 3: Update resources/agents/VERSION
 
 ```bash
-echo "0.29.0" > .agents/VERSION
+echo "0.50.0" > resources/agents/VERSION
 ```
 
-Tracked by `composer test-agents` as the targeted phel-lang release.
+Tracked by `composer test-agents`, which runs the bundled example projects
+against that release.
 
 ### Step 4: Commit and Push
 
 ```bash
-git add src/php/Console/Application/VersionFinder.php CHANGELOG.md .agents/VERSION
-git commit -m "chore(release): v0.29.0"
+git add src/php/Shared/VersionFinder.php CHANGELOG.md resources/agents/VERSION
+git commit -m "chore(release): v0.50.0"
 git push origin main
 ```
 
@@ -104,8 +125,8 @@ This creates `build/out/phel.phar`.
 ### Step 6: Create GitHub Release
 
 1. Go to [Releases > New Release](https://github.com/phel-lang/phel-lang/releases/new)
-2. Click "Choose a tag" and create a new tag `v0.29.0` from `main`
-3. Set the release title (e.g., "v0.29.0")
+2. Click "Choose a tag" and create a new tag `v0.50.0` from `main`
+3. Set the release title (e.g., "v0.50.0")
 4. Copy the changelog section for this version into the description
 5. Attach the `build/out/phel.phar` file
 6. Click "Publish release"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file.
 - `phel eval -h` shows a heredoc example for multi-line evaluation
 - The normative [language-surface spec](docs/spec/language-surface.md) and [Clojure divergences](docs/spec/clojure-divergences.md). A test compares the special-form table against the analyzer's dispatch registry, so the spec cannot drift from the compiler
 - The [stability policy](docs/stability.md), plus migration guides for [0.49 to 1.0](docs/migration/upgrade-0.49-to-1.0.md), [live deprecations](docs/migration/deprecated-surface.md) and [removed core fns](docs/migration/removed-deprecated-core-fns.md)
-- [Architecture decision records](docs/adr/README.md): 12 records covering the decisions that read as oversights and get re-proposed, each naming the test that fails when it is broken
+- [Architecture decision records](docs/adr/README.md): 13 records covering the decisions that read as oversights and get re-proposed, each naming the test that fails when it is broken
 - Compatibility gates that fail the build on drift: snapshots of the public PHP surface (`composer api-surface:update`) and of every public `phel.*` definition and arity (`composer core-api:update`), plus a `:doc` gate on public definitions
 - Every class outside the public PHP surface carries `@internal`, so the split reaches IDEs and static analysis. A test pins both directions
 - CI: macOS is a supported platform (Windows stays declared best-effort), coverage is published and gated at 85%, benchmarks are asserted against the base revision, and mutation testing runs weekly over `src/php/Lang/` and the analyzer (MSI floor 80)

--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ phel:3:> (greet "Phel")
 ./vendor/bin/phel init         # add `--minimal` for a single-file layout
 ```
 
-Creates `phel-config.php`, `src/phel/main.phel`, `tests/phel/main_test.phel`. Then:
+Creates `phel-config.php`, `src/main.phel`, `tests/main_test.phel`. With
+`--minimal` the two sources sit at the project root instead. Then:
 
 ```sh
-./vendor/bin/phel run src/phel/main.phel   # run
+./vendor/bin/phel run src/main.phel        # run
 ./vendor/bin/phel test                     # tests
 ./vendor/bin/phel build                    # compile to PHP
 ./vendor/bin/phel config                   # inspect the merged config

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -37,6 +37,11 @@ enables tab-completion (setup in the [README](../README.md)).
 | `test` `t` | Run the test suite (all tests, or the files/namespaces you pass) |
 | `watch` | Watch Phel files and reload changed namespaces on change |
 
+Gacela registers a few more through `Console/Infrastructure/Command/FrameworkCommands`:
+`debug:container`, `debug:dependencies`, `debug:modules`, `list:modules`,
+`profile:report` and `validate:config`. They inspect the module wiring rather than
+your Phel code, and `phel list` shows them alongside the commands above.
+
 ## Editor setup
 
 `phel lsp` (Language Server, stdio) and `phel nrepl` (default `127.0.0.1:7888`) plug

--- a/docs/internals/special-forms.md
+++ b/docs/internals/special-forms.md
@@ -75,9 +75,9 @@ why it runs on the list before `AnalyzePersistentList` desugars.
 |------|-------|-------|
 | `php/new` (`new`) | `NAME_PHP_NEW` / `NAME_NEW` | `new Foo(...)` |
 | `php/->` | `NAME_PHP_OBJECT_CALL` | `$obj->method(...)` / `$obj->prop` |
-| `php/::` | `NAME_PHP_OBJECT_STATIC_CALL` | `Foo::method(...)` / `Foo::CONST` |
+| `php/::` | `NAME_PHP_OBJECT_STATIC_CALL` | `Foo::method(...)` / `Foo::CONST` / `Foo::$prop` (sigil written by the author) |
 | `php/ref` | `NAME_PHP_REF` | by-ref interop arg; captures local via `use(&$x)` so an output parameter writes back |
-| `php/oset` | `NAME_PHP_OBJECT_SET` | `$obj->prop = $v` |
+| `php/oset` | `NAME_PHP_OBJECT_SET` | `$obj->prop = $v`, or `Foo::$prop = $v` when the target is a class; the emitter adds the sigil, since a constant is not assignable ([ADR 0013](../adr/0013-static-property-spelling.md)) |
 | `php/aget` | `NAME_PHP_ARRAY_GET` | `$arr[$k]` |
 | `php/aset` | `NAME_PHP_ARRAY_SET` | `$arr[$k] = $v` |
 | `php/apush` | `NAME_PHP_ARRAY_PUSH` | `$arr[] = $v` |

--- a/docs/migration/deprecated-surface.md
+++ b/docs/migration/deprecated-surface.md
@@ -69,7 +69,8 @@ one. Everything on the right has worked for a long time; what changed is that
 the last positions needing a `php/*` fallback were closed
 ([#2881](https://github.com/phel-lang/phel-lang/issues/2881),
 [#2883](https://github.com/phel-lang/phel-lang/issues/2883),
-[#2887](https://github.com/phel-lang/phel-lang/issues/2887)).
+[#2887](https://github.com/phel-lang/phel-lang/issues/2887),
+[#2907](https://github.com/phel-lang/phel-lang/issues/2907)).
 
 ```phel
 (php/new \DateTime "2024-03-10")      (new \DateTime "2024-03-10")
@@ -81,7 +82,14 @@ the last positions needing a `php/*` fallback were closed
 (php/:: \DateTime (createFromFormat   (\DateTime/createFromFormat
         "Y-m-d" "2024-03-10"))          "Y-m-d" "2024-03-10")
 (php/:: \Foo BAR)                     \Foo/BAR
+(php/:: \Foo $slot)                   \Foo/$slot
+(php/oset (php/:: \Foo slot) v)       (set! \Foo/slot v)
 ```
+
+A static property is the one member whose two spellings differ: the sigil reads
+it (`\Foo/$slot`), and assignment takes the plain name, because a class constant
+is not assignable and there is nothing to disambiguate
+([ADR 0013](../adr/0013-static-property-spelling.md)).
 
 Chaining needs nothing special: `(-> d (.modify "+1 day") (.format "Y-m-d"))`
 threads with plain `->`, methods and properties alike.

--- a/resources/agents/RULES.md
+++ b/resources/agents/RULES.md
@@ -7,13 +7,13 @@ Single source for every skill adapter.
 1. Verify fn names with `(doc <fn>)` or grep `src/phel/core/`. No invention.
 2. Collections immutable. `(conj v x)` returns new; rebind with `def`/`let`, or use `atom`.
 3. Top-level side effects break `phel build`. Guard with `(when-not *build-mode* ...)`.
-4. PHP interop: `(new Class args)`, `(.method obj args)`, `(.-prop obj)`, `(Class/method args)`, `Class/CONST`. Host functions keep the prefix: `(php/strlen s)`. `php/new`, `php/->` and `php/::` are deprecated.
+4. PHP interop: `(new Class args)`, `(.method obj args)`, `(.-prop obj)`, `(Class/method args)`, `Class/CONST`. A static property reads as `Class/$prop` and assigns as `(set! Class/prop v)`; the sigil belongs to the read only. Host functions keep the prefix: `(php/strlen s)`. `php/new`, `php/->` and `php/::` are deprecated.
 5. Threading: `->` first-arg, `->>` last-arg, `some->` / `some->>` nil-safe, `cond->` conditional.
 6. Only `false` and `nil` are falsy. `0`, `""`, `[]` truthy.
 7. Namespaces need ≥ 2 segments. Prefer `.` separator (`app.main`); `\` still parses but is deprecated. File path matches ns under src dir.
 8. Comments: `;` inline, `;;` standalone, `#_` skips the next form.
 9. PHP assoc array: `#php {"k" "v"}` or `(to-php-array m)`. Not `{:k "v"}`.
-10. Catch PHP: `(catch php\SomeException e ...)`.
+10. Catch PHP: `(catch \SomeException e ...)`.
 11. Annotate hot-path `defn` with `:tag` on params + return for PHP type emission, JIT-friendly call shape, and compile-time mismatch diagnostics. See `tasks/typed-defn.md`.
 
 ## New features (v0.30 – main)

--- a/resources/agents/quick-syntax.md
+++ b/resources/agents/quick-syntax.md
@@ -55,5 +55,9 @@ One-screen cheatsheet. For exhaustive rules see [`RULES.md`](RULES.md); for typi
 ;; PHP interop
 (new \DateTime "now")
 (.method obj args)
+(.-prop obj)
 (Class/staticMethod)
+Class/CONST
+Class/$staticProp             ; sigil reads a static property
+(set! Class/staticProp 1)     ; assignment takes no sigil
 ```

--- a/resources/agents/tasks/debug-errors.md
+++ b/resources/agents/tasks/debug-errors.md
@@ -27,6 +27,7 @@ File path must match ns:
 | flat | `my-app\main` | `src/main.phel` |
 | flat | `my-app\users\repo` | `src/users/repo.phel` |
 | nested | `my-app\main` | `src/phel/main.phel` |
+| root | `my-app\main` | `main.phel` (what `phel init --minimal` writes) |
 
 Namespaces need ≥ 2 segments.
 

--- a/resources/agents/tasks/repl-workflow.md
+++ b/resources/agents/tasks/repl-workflow.md
@@ -52,7 +52,7 @@ Shell: `./vendor/bin/phel test [path] [--filter=substring] [--testdox] [--fail-f
 
 ## Errors
 
-Errors print trace and keep REPL alive. `(try expr (catch php\Foo e (.getMessage e)))`.
+Errors print trace and keep REPL alive. `(try expr (catch \Foo e (.getMessage e)))`.
 
 ## Gotchas
 

--- a/resources/agents/tasks/use-php-libs.md
+++ b/resources/agents/tasks/use-php-libs.md
@@ -16,7 +16,7 @@
 | Fn (namespaced) | `(php/Amp\trapSignal xs)` |
 | PHP array indexed | `#php [1 2 3]` |
 | PHP array assoc | `#php {"k" "v"}` |
-| Catch | `(catch php\SomeException e ...)` |
+| Catch | `(catch \SomeException e ...)` |
 
 Full table: <https://phel-lang.org/documentation/php-interop/>.
 

--- a/src/php/Api/CLAUDE.md
+++ b/src/php/Api/CLAUDE.md
@@ -29,7 +29,7 @@ Every transfer the contract names lives in `Phel\Shared\Api`: `ProjectIndex`, `D
 
 - Run (namespace resolution, directory listing) — `FACADE_RUN`.
 - Compiler (lex, parse, read, analyze phases) — `FACADE_COMPILER`.
-- `ApiConfig::allNamespaces()` lists the 25 documented Phel namespaces; `ApiConfig::githubRef()` returns `VersionFinder::LATEST_VERSION`.
+- `ApiConfig::allNamespaces()` lists the 26 documented Phel namespaces; `ApiConfig::githubRef()` returns `VersionFinder::LATEST_VERSION`.
 
 `Api <-> Run` is the codebase's only mutual Gacela provider pair, and the cycle is a wiring detail rather than a structural one: both sides consume each other through `Phel\Shared\Facade\*Interface`, and the concrete facades appear only in `ApiProvider` / `RunProvider`, because Gacela's locator has to name a class. `ModuleDependencyCycleTest` pins exactly those two files.
 


### PR DESCRIPTION
## 🤔 Background

An audit of every markdown file in the repository, 224 of them, checked against what the code actually does rather than read for tone. Mechanical checks first (paths, links, command names, composer scripts, facade methods, structure trees, counts), then the claims that only running the thing can settle.

Most of it held up: no phantom `phel` command, no composer script that does not exist, no undocumented facade method across all 19 modules, and every path in a module structure tree resolves. What follows is what did not hold up.

## 💡 Goal

A contributor or an agent can follow any of these documents and end up where it says they will.

## 🔖 Changes

### Wrong instructions, verified by running them

- **`README.md`**: `phel init` was documented as creating `src/phel/main.phel` and `tests/phel/main_test.phel`. It creates `src/main.phel` and `tests/main_test.phel`; the default layout is flat. The run command in the next block pointed at the path that is never written. `--minimal` (root layout) is now named too.
- **`resources/agents/RULES.md`, `tasks/use-php-libs.md`, `tasks/repl-workflow.md`**: `(catch php\SomeException e ...)` does not compile. `Can not resolve type php\InvalidArgumentException`. The spelling is `(catch \SomeException e ...)`, which is what the whole standard library uses. This is guidance installed into user projects, so it was teaching agents to write code that fails.
- **`.github/RELEASE.md`**: pointed three times at `src/php/Console/Application/VersionFinder.php`, which lives at `src/php/Shared/VersionFinder.php`; named the constant `private const VERSION` when it is `public const string LATEST_VERSION` and carries a `v` prefix; and told a manual releaser to write `.agents/VERSION`, a path this repository does not have (`resources/agents/VERSION`). Also missing `--skip-qa` and `--name`, missing the PHAR QA smoke test and the announce workflow from the step list, and stuck on 0.28/0.29 examples. The manual section now says it is the fallback, since `tools/release.sh` is the supported path.

### Stale after the interop work

- **`docs/internals/special-forms.md`**: `php/::` emits `Foo::$prop` as well as methods and constants, and `php/oset` emits `Foo::$prop = $v` for a class target.
- **`docs/migration/deprecated-surface.md`**: the `php/::` conversion table had no row for a static property, which is the one member whose read and write spellings differ. #2907 added to the list of closed positions.
- **`resources/agents/RULES.md`, `quick-syntax.md`**: static property added to the interop rules and the cheatsheet, with a PHP-legal member name (a kebab-case one would not compile).

### Counts and coverage

- **`src/php/Api/CLAUDE.md`**: `ApiConfig::allNamespaces()` lists 26 namespaces, not 25.
- **`CHANGELOG.md`**: 13 ADRs, not 12.
- **`docs/cli-reference.md`**: six commands Gacela registers through `FrameworkCommands` (`debug:container`, `debug:dependencies`, `debug:modules`, `list:modules`, `profile:report`, `validate:config`) appear in `phel list` and appeared nowhere in the reference.
- **`resources/agents/tasks/debug-errors.md`**: the layout table listed flat and nested but not root, which is what `phel init --minimal` writes.

### Adapter rules

- **`.agnostic-ai/rules/phel.md`**: `[macro-hygiene.md](macro-hygiene.md)` resolves inside an adapter directory and breaks in the generated root `AGENTS.md`. No relative link works from both, so it names the rule and its spec path instead.
- **`.agnostic-ai/rules/load-order.md`**: the list points at `.agents/`, which exists in a user project after `phel agent-install` and not here, where the same files live under `resources/agents/`. One line of framing, since the reading order itself is right.

### Verified, not changed

`phel init`, `phel init --minimal` and `phel agent-install --all` were run in throwaway projects and their output compared against what the docs promise; the `.phel/` layout table, the spec pages' "each claim is checked" table, and the four module cycles all check out against the code and the tests they name.
