### PR TITLE
fix(compiler): root a class tag written with the dot separator

### DIFF
--- a/src/php/Shared/TagResolver.php
+++ b/src/php/Shared/TagResolver.php
@@ -38,6 +38,52 @@ final class TagResolver
             $tag = $tag->getName();
         }
 
-        return is_string($tag) && $tag !== '' ? $tag : null;
+        if (!is_string($tag) || $tag === '') {
+            return null;
+        }
+
+        return self::rootClassReferences($tag);
+    }
+
+    /**
+     * A class tag may be written with either separator, `.` being the namespace
+     * separator everywhere else in the language. PHP knows only `\`, and the
+     * tag reaches the generated signature verbatim, so a dotted name used to
+     * emit `function f(): Phel.Lang.Symbol` and fail to parse (#2924).
+     *
+     * No scalar type contains a dot, which is what makes the presence of one
+     * the whole test. The result is rooted, because a generated file declares
+     * its own `namespace` and an unrooted `Phel\Lang\Symbol` would resolve
+     * against it.
+     */
+    private static function rootClassReferences(string $tag): string
+    {
+        if (!str_contains($tag, '.')) {
+            return $tag;
+        }
+
+        // A union or intersection arrives as one string (`My.Type|null`), so
+        // each member is rooted on its own.
+        return preg_replace_callback(
+            '/[^|&]+/',
+            static fn(array $matches): string => self::rootClassReference($matches[0]),
+            $tag,
+        ) ?? $tag;
+    }
+
+    private static function rootClassReference(string $part): string
+    {
+        $trimmed = trim($part);
+        if (!str_contains($trimmed, '.') || str_contains($trimmed, '\\')) {
+            return $part;
+        }
+
+        $nullable = str_starts_with($trimmed, '?');
+        $name = $nullable ? substr($trimmed, 1) : $trimmed;
+
+        // Plain replacement rather than `Munge`: a PHP class name cannot carry
+        // a character the identifier mapping would rewrite, and the tag names
+        // a host class rather than a Phel namespace.
+        return ($nullable ? '?' : '') . '\\' . str_replace('.', '\\', $name);
     }
 }

--- a/tests/phel/core/tag-types.phel
+++ b/tests/phel/core/tag-types.phel
@@ -32,3 +32,18 @@
 (deftest nullable-return-tag-accepts-nil-and-value
   (is (= 1 (nullable-ret true)) "nullable return yields the int")
   (is (nil? (nullable-ret false)) "nullable return yields nil"))
+
+;; A class tag may use the dot separator, the way every other position spells a
+;; class name. PHP knows only `\`, so the tag is rooted before it is emitted.
+(defn dotted-tag ^Phel.Lang.Symbol [^Phel.Lang.Symbol s] s)
+
+(deftest dot-separated-class-tag-round-trips
+  (let [s (symbol "abc")]
+    (is (= s (dotted-tag s)) "a dotted class tag accepts and returns the class"))
+  (is (php/instanceof (dotted-tag (symbol "x")) \Phel\Lang\Symbol)
+      "the emitted signature names the real class"))
+
+(deftest dot-separated-class-tag-rejects-a-wrong-type
+  (let [err (try (dotted-tag 42) (catch \TypeError e e))]
+    (is (php/instanceof err \TypeError)
+        "the PHP type declaration is enforced, so it was emitted as a type")))

--- a/tests/php/Integration/Fixtures/Fn/fn-tag-dot-separator.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-tag-dot-separator.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^Phel.Lang.Symbol s] s)
+--PHP--
+(function(\Phel\Lang\Symbol $s): \Phel\Lang\Symbol {
+  return $s;
+});

--- a/tests/php/Unit/Shared/TagResolverTest.php
+++ b/tests/php/Unit/Shared/TagResolverTest.php
@@ -63,6 +63,41 @@ final class TagResolverTest extends TestCase
         self::assertNull(TagResolver::normalizeScalar(null));
     }
 
+    public function test_dotted_class_tag_is_rooted_for_php(): void
+    {
+        // The leading backslash is the point: a generated file declares its own
+        // namespace, so an unrooted type would resolve against it.
+        $rooted = '\\' . Symbol::class;
+
+        self::assertSame($rooted, TagResolver::normalizeScalar(Symbol::create('Phel.Lang.Symbol')));
+        self::assertSame($rooted, TagResolver::normalizeScalar('Phel.Lang.Symbol'));
+    }
+
+    public function test_dotted_class_tag_keeps_its_nullable_marker(): void
+    {
+        self::assertSame('?\\My\\Ns\\Thing', TagResolver::normalizeScalar('?My.Ns.Thing'));
+    }
+
+    public function test_each_member_of_a_composite_tag_is_rooted(): void
+    {
+        self::assertSame('\\My\\Ns\\Thing|null', TagResolver::normalizeScalar('My.Ns.Thing|null'));
+        self::assertSame('\\A\\B&\\C\\D', TagResolver::normalizeScalar('A.B&C.D'));
+    }
+
+    public function test_a_tag_without_a_dot_is_untouched(): void
+    {
+        self::assertSame('int|null', TagResolver::normalizeScalar('int|null'));
+        self::assertSame('DateTime', TagResolver::normalizeScalar('DateTime'));
+        self::assertSame('self', TagResolver::normalizeScalar('self'));
+    }
+
+    public function test_a_backslash_tag_is_untouched(): void
+    {
+        $rooted = '\\' . Symbol::class;
+
+        self::assertSame($rooted, TagResolver::normalizeScalar($rooted));
+    }
+
     private function tagMeta(mixed $value): PersistentMapInterface
     {
         return $this->meta(Keyword::create('tag'), $value);


### PR DESCRIPTION
## 🤔 Background

Every position that names a PHP class takes the dot separator: `(new DateTimeImmutable)`, `(new Phel.Lang.Keyword "x")`, `Phel.Lang.Symbol` in value position, `(catch InvalidArgumentException e ...)`, `(ns ... (:use phpDocumentor.Reflection.DocBlock))`, `Some.Ns.Class/$prop`. A `:tag` did not.

```bash
./bin/phel eval '(defn f ^Phel.Lang.Symbol [^Phel.Lang.Symbol s] s)'
# ParseError: syntax error, unexpected token ".", expecting variable
```

The tag reaches the signature verbatim, so the generated file read `function __invoke(Phel.Lang.Symbol $s): Phel.Lang.Symbol`. Not a diagnostic, a PHP parse error in emitted code.

Closes #2924

## 💡 Goal

The dot separator works in the last position that refused it, so moving a file off `\` cannot turn working code into a parse error.

## 🔖 Changes

- `TagResolver` roots a class reference written with dots: `^Phel.Lang.Symbol` emits `\Phel\Lang\Symbol`. No scalar type contains a dot, which is what makes the presence of one the whole test, so `int`, `?int`, `self` and `int|null` are untouched and so is the backslash spelling.
- The result is **rooted**. A generated file declares its own `namespace app\main;`, so an unrooted `Phel\Lang\Symbol` would resolve against it and name a class that does not exist.
- A union or intersection arrives as one string, so each member is rooted on its own: `My.Ns.Thing|null` becomes `\My\Ns\Thing|null`, and a leading `?` is preserved.
- Plain replacement rather than `Munge`: a PHP class name cannot carry a character the identifier mapping would rewrite, and the tag names a host class rather than a Phel namespace.

Because `TagResolver` is what the analyzer's inference and compatibility checks read too, both spellings now normalise to one form there as well, so a `^Phel.Lang.Symbol` parameter and a `^\Phel\Lang\Symbol` argument no longer look like different types.

### Tests

- `TagResolverTest`: rooting for both the symbol and the string form, the nullable marker, each member of a composite tag, and no change for a dotted-free or already-rooted tag.
- `Fn/fn-tag-dot-separator.test` pins the emitted signature.
- `tests/phel/core/tag-types.phel`: the tag round-trips a real `Symbol` and a wrong argument raises `TypeError`, which is what proves the type reached the signature rather than being dropped.

### Note on the test literals

Rector rewrites `'\Phel\Lang\Symbol'` to `Symbol::class`, which is the same name **without** the leading backslash and therefore not what these assertions are about. They spell it `'\\' . Symbol::class` so the rule and the intent can coexist.
