### PR TITLE
ref(stdlib): spell PHP classes with the dot separator

### DIFF
--- a/src/phel/cli.phel
+++ b/src/phel/cli.phel
@@ -372,7 +372,7 @@
 ;; ---- Application --------------------------------------------------------
 
 (defn- build-dispatcher [spec]
-  (let [d      (new \Symfony\Component\EventDispatcher\EventDispatcher)
+  (let [d      (new Symfony.Component.EventDispatcher.EventDispatcher)
         before (get spec :before)
         after  (get spec :after)
         on-err (get spec :on-error)]

--- a/src/phel/core/async.phel
+++ b/src/phel/core/async.phel
@@ -3,7 +3,7 @@
 ;; AMPHP-backed and fiber-backed async primitives, kept in core so that
 ;; `.cljc` portable code mirrors `clojure.core`'s default availability
 ;; (see #1537 for the analogous `future` move). The classes referenced
-;; below (`\Phel\Fiber\FiberFacade`, `\Phel\Lang\Future`, `Amp\\…`)
+;; below (`Phel.Fiber.FiberFacade`, `Phel.Lang.Future`, `Amp\\…`)
 ;; are autoloaded only when these functions are actually called, so
 ;; namespaces that don't use them pay no runtime cost.
 ;;
@@ -14,7 +14,7 @@
 (defn- fiber-facade
   "Lazily resolves the shared FiberFacade instance."
   []
-  (new \Phel\Fiber\FiberFacade))
+  (new Phel.Fiber.FiberFacade))
 
 (defn ->closure
   "Converts a Phel function to a PHP Closure. Many PHP libraries (AMPHP, ReactPHP) type-hint `\\Closure` and reject Phel's `AbstractFn` even though it is callable. This bridges the gap."
@@ -39,7 +39,7 @@
 (defn- unwrap-future
   "Returns the raw Amp\\Future for either a `Future` wrapper or a bare `Amp\\Future`."
   [future]
-  (if (php/instanceof future \Phel\Lang\Future)
+  (if (php/instanceof future Phel.Lang.Future)
     (.unwrap future)
     future))
 
@@ -108,15 +108,15 @@ Dispatches on type: for a `\\Phel\\Fiber\\Domain\\Future` (fiber-backed) it call
    :see-also ["realized?" "future-cancel" "future" "future-fiber"]}
   [f]
   (cond
-    (php/instanceof f \Phel\Fiber\Domain\Future) (.isDone f)
-    true                                         (realized? f)))
+    (php/instanceof f Phel.Fiber.Domain.Future) (.isDone f)
+    true                                        (realized? f)))
 
 ;; -----------------------------------------------------------------
 ;; Fiber-based promises and futures
 ;;
 ;; Unlike `future`/`async` above, these do not require AMPHP and work
 ;; at the top level. They use a cooperative single-threaded scheduler
-;; exposed by `\Phel\Fiber\FiberFacade`.
+;; exposed by `Phel.Fiber.FiberFacade`.
 ;; -----------------------------------------------------------------
 
 (defn promise
@@ -167,5 +167,5 @@ Once delivered the value is frozen; subsequent `deliver` calls are no-ops. `dere
   {:example "(future? (future-call (fn [] 1))) ; => true"
    :see-also ["future" "future-call" "future-fiber"]}
   [x]
-  (or (php/instanceof x \Phel\Fiber\Domain\Future)
-      (php/instanceof x \Phel\Lang\Future)))
+  (or (php/instanceof x Phel.Fiber.Domain.Future)
+      (php/instanceof x Phel.Lang.Future)))

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -74,11 +74,11 @@ With three arguments, and when `variable` is a future or promise, blocks for at 
   (case (count args)
     0 (.deref variable)
     2 (cond
-        (php/instanceof variable \Phel\Lang\Future)
+        (php/instanceof variable Phel.Lang.Future)
         (.derefWithTimeout variable (first args) (get args 1))
-        (php/instanceof variable \Phel\Fiber\Domain\Future)
+        (php/instanceof variable Phel.Fiber.Domain.Future)
         (.derefWithTimeout variable (first args) (get args 1))
-        (php/instanceof variable \Phel\Fiber\Domain\Promise)
+        (php/instanceof variable Phel.Fiber.Domain.Promise)
         (.derefWithTimeout variable (first args) (get args 1))
         true
         (throw (new \InvalidArgumentException

--- a/src/phel/core/collections.phel
+++ b/src/phel/core/collections.phel
@@ -4,7 +4,7 @@
 
 ;; Persistent collection constructors. Hash and sorted variants for both
 ;; maps and sets: `hash-set`, `sorted-map`, `sorted-map-by`, `sorted-set`,
-;; `sorted-set-by`. Thin wrappers around `Phel\Lang\Collections` factories —
+;; `sorted-set-by`. Thin wrappers around `Phel.Lang.Collections` factories —
 ;; `hash-map` / `array-map` / `list` / `vector` live in core.phel itself
 ;; because they are needed by the bootstrap primitives.
 

--- a/src/phel/core/exceptions.phel
+++ b/src/phel/core/exceptions.phel
@@ -4,7 +4,7 @@
 
 ;; Structured exceptions: the `ex-info` constructor and the `ex-data` /
 ;; `ex-message` / `ex-cause` accessors for carrying a data map alongside
-;; a thrown error. Thin wrapper over `Phel\Lang\ExceptionInfo`.
+;; a thrown error. Thin wrapper over `Phel.Lang.ExceptionInfo`.
 
 ;; --- Rich exceptions ---
 
@@ -13,9 +13,9 @@
   {:example "(throw (ex-info \"Invalid input\" {:field :email}))"
    :see-also ["ex-data" "ex-message" "ex-cause"]}
   ([msg data]
-   (new \Phel\Lang\ExceptionInfo msg data))
+   (new Phel.Lang.ExceptionInfo msg data))
   ([msg data cause]
-   (new \Phel\Lang\ExceptionInfo msg data cause)))
+   (new Phel.Lang.ExceptionInfo msg data cause)))
 
 (defn ex-data
   "Returns the data map from an ex-info exception, or nil if not an ExceptionInfo."

--- a/src/phel/core/futures.phel
+++ b/src/phel/core/futures.phel
@@ -16,8 +16,8 @@ Must be called from inside a fiber context (e.g. the AMPHP event loop or an encl
    :see-also ["realized?" "deref"]}
   [& body]
   `(let [frame# (\Phel/snapshotDynamicBindings)]
-     (new \Phel\Lang\Future
+     (new Phel.Lang.Future
           (php/amp\async
            (fn []
              (\Phel/withDynamicBindings frame# (fn [] ~@body))))
-          (new \Amp\DeferredCancellation))))
+          (new Amp.DeferredCancellation))))

--- a/src/phel/core/lazy.phel
+++ b/src/phel/core/lazy.phel
@@ -14,7 +14,7 @@
   {:example "(def d (delay (println \"computing\") 42))"
    :see-also ["force" "delay?" "realized?"]}
   [& body]
-  `(new \Phel\Lang\Delay (fn [] ~@body)))
+  `(new Phel.Lang.Delay (fn [] ~@body)))
 
 (defn force
   "If x is a Delay, forces it and returns its cached value. Otherwise returns x."

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -10,7 +10,7 @@
 ;; Numeric operations: arithmetic (`+`, `-`, `*`, `/`, `%`, `**`), bit ops
 ;; (`bit-and`, `bit-or`, `bit-xor`, `bit-shift-*`, `bit-set`, `bit-test`, …),
 ;; successor/predecessor (`inc`, `dec`), and constants (`NAN`). Arithmetic
-;; fns route through `Phel\Lang\NumericOperations` so they dispatch on
+;; fns route through `Phel.Lang.NumericOperations` so they dispatch on
 ;; `Ratio` and `BigInt` values; bit ops still rely on PHP integers.
 
 ;; ---

--- a/src/phel/core/meta.phel
+++ b/src/phel/core/meta.phel
@@ -42,7 +42,7 @@
             `(\Phel/getDefinitionMetaData ~ns ~(.getName quoted-sym))
             `(\Phel/getDefinitionMetaData (php/str_replace "-" "_" *ns*) ~(.getName quoted-sym))))
         `(let [obj-meta ~obj]
-           (if (php/instanceof obj-meta \Phel\Lang\MetaInterface)
+           (if (php/instanceof obj-meta Phel.Lang.MetaInterface)
              (.getMeta obj-meta)
              nil))))))
 

--- a/src/phel/core/seq-basics.phel
+++ b/src/phel/core/seq-basics.phel
@@ -24,9 +24,9 @@
   ;; Symmetric dispatch: prefer the side that carries equality semantics.
   ;; `AbstractType` already implements `EqualsInterface` via `TypeInterface`,
   ;; so a single instanceof check per side is enough.
-  (if (php/instanceof a \Phel\Lang\EqualsInterface)
+  (if (php/instanceof a Phel.Lang.EqualsInterface)
     (.equals a b)
-    (if (php/instanceof b \Phel\Lang\EqualsInterface)
+    (if (php/instanceof b Phel.Lang.EqualsInterface)
       (.equals b a)
       (php/=== a b))))
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1032,7 +1032,7 @@ With one argument returns an infinite lazy sequence of calls to f."
        (Seq/repeatedly a))
     1 (let [n a
             f (get rest 0)]
-        (new \Phel\Lang\Collections\LazySeq\LazySeq
+        (new Phel.Lang.Collections.LazySeq.LazySeq
              (new Hasher)
              (new Equalizer)
              (fn [] (for [_ :range [n]] (f)))))
@@ -1042,9 +1042,9 @@ With one argument returns an infinite lazy sequence of calls to f."
   "Creates a lazy sequence that evaluates the body only when accessed."
   {:example "(lazy-seq (cons 1 (lazy-seq nil))) ; => @[1]"}
   [& body]
-  `(new \Phel\Lang\Collections\LazySeq\LazySeq
-        (new \Phel\Lang\Hasher)
-        (new \Phel\Lang\Equalizer)
+  `(new Phel.Lang.Collections.LazySeq.LazySeq
+        (new Phel.Lang.Hasher)
+        (new Phel.Lang.Equalizer)
         (fn [] ~@body)))
 
 (defmacro lazy-cat
@@ -1136,7 +1136,7 @@ With one argument returns an infinite lazy sequence of calls to f."
           '()
           (let [input  (if (map? coll) (pairs coll) coll)
                 result (lazy-seq-from-generator
-                        (\Phel\Lang\Seq/mapcat f input))]
+                        (Phel.Lang.Seq/mapcat f input))]
             (if (php/=== nil result)
               '()
               (copy-meta coll result)))))
@@ -1166,7 +1166,7 @@ With one argument returns an infinite lazy sequence of calls to f."
           '()
           (let [seqd   (or (seq coll) coll)
                 result (lazy-seq-from-generator
-                        (\Phel\Lang\Seq/interpose sep seqd))]
+                        (Phel.Lang.Seq/interpose sep seqd))]
             (if (php/=== nil result)
               '()
               (copy-meta coll result)))))
@@ -1181,7 +1181,7 @@ Applies `f` to each element in `xs`. `f` is a two-argument function where the fi
   (if (php/=== nil coll)
     '()
     (let [result (lazy-seq-from-generator
-                  (\Phel\Lang\Seq/mapIndexed f coll))]
+                  (Phel.Lang.Seq/mapIndexed f coll))]
       (if (php/=== nil result)
         '()
         (copy-meta coll result)))))
@@ -1230,9 +1230,9 @@ Applies `f` to each element in `xs`. `f` is a two-argument function where the fi
     (php/instanceof coll LazySeqInterface) (.isRealized coll)
     (php/instanceof coll PersistentListInterface) true
     (php/instanceof coll Delay) (.isRealized coll)
-    (php/instanceof coll \Phel\Lang\Future) (.isRealized coll)
-    (php/instanceof coll \Phel\Fiber\Domain\Future) (.isRealized coll)
-    (php/instanceof coll \Phel\Fiber\Domain\Promise) (.isRealized coll)
+    (php/instanceof coll Phel.Lang.Future) (.isRealized coll)
+    (php/instanceof coll Phel.Fiber.Domain.Future) (.isRealized coll)
+    (php/instanceof coll Phel.Fiber.Domain.Promise) (.isRealized coll)
     true))
 
 (defn group-by

--- a/src/phel/core/strings.phel
+++ b/src/phel/core/strings.phel
@@ -23,16 +23,16 @@
   [x]
   (if (php/=== nil x)
     nil
-    (if (php/instanceof x \Phel\Lang\NamedInterface)
+    (if (php/instanceof x Phel.Lang.NamedInterface)
       (.getName x)
       x)))
 
 (defn- valid-symbol-name? [x]
   (if (php/is_string x)
     true
-    (if (php/instanceof x \Phel\Lang\Keyword)
+    (if (php/instanceof x Phel.Lang.Keyword)
       true
-      (php/instanceof x \Phel\Lang\Symbol))))
+      (php/instanceof x Phel.Lang.Symbol))))
 
 (defn- assert-symbol-name [arg-name x]
   (if (valid-symbol-name? x)

--- a/src/phel/core/uuid.phel
+++ b/src/phel/core/uuid.phel
@@ -4,7 +4,7 @@
 (use Phel.Lang.UUID)
 
 ;; UUID predicates, generator, and parser: `uuid?`, `random-uuid`,
-;; `parse-uuid`. Backed by the `Phel\Lang\UUID` value type — the literal
+;; `parse-uuid`. Backed by the `Phel.Lang.UUID` value type — the literal
 ;; `#uuid "..."` and `random-uuid` produce a typed value, so `uuid?`
 ;; rejects raw canonical strings.
 

--- a/src/phel/http-client.phel
+++ b/src/phel/http-client.phel
@@ -92,13 +92,13 @@
                          [headers body])
         url            (append-query-params url query-params)]
     (transport-result->response
-     (\Phel\HttpClient\StreamTransport/send (php/strtoupper (key->string method))
-                                            url
-                                            (build-headers-array headers)
-                                            body
-                                            (build-options-array {:timeout timeout
-                                                                  :follow-redirects follow-redirects
-                                                                  :verify-ssl verify-ssl})))))
+     (Phel.HttpClient.StreamTransport/send (php/strtoupper (key->string method))
+                                           url
+                                           (build-headers-array headers)
+                                           body
+                                           (build-options-array {:timeout timeout
+                                                                 :follow-redirects follow-redirects
+                                                                 :verify-ssl verify-ssl})))))
 
 (defn get
   "Makes a GET request. See `request` for available options."

--- a/tests/phel/async.phel
+++ b/tests/phel/async.phel
@@ -110,7 +110,7 @@
 
 (deftest test-future-returns-phel-future
   (let [f (await (async (future 42)))]
-    (is (= true (php/instanceof f \Phel\Lang\Future))
+    (is (= true (php/instanceof f Phel.Lang.Future))
         "future returns a Future wrapper")))
 
 (deftest test-future-deref

--- a/tests/phel/auto-refer.phel
+++ b/tests/phel/auto-refer.phel
@@ -1,7 +1,7 @@
 (ns phel-test.auto-refer
   (:require phel.test :refer [deftest is]))
 
-;; Verifies the curated `Phel\Lang\*` aliases are pre-registered in every
+;; Verifies the curated `Phel.Lang\*` aliases are pre-registered in every
 ;; namespace without any explicit `(:use ...)` line. See issue #1996.
 
 (deftest test-lazy-seq-alias-resolves-without-explicit-use
@@ -17,7 +17,7 @@
 
 (deftest test-persistent-map-alias
   (is (php/instanceof {:a 1} PersistentMap))
-  (is (php/instanceof (\Phel\Lang\Collections\Map\MapEntry/create :k :v) MapEntry)))
+  (is (php/instanceof (Phel.Lang.Collections.Map.MapEntry/create :k :v) MapEntry)))
 
 (deftest test-persistent-hash-set-alias
   (is (php/instanceof (hash-set 1 2 3) PersistentHashSet)))

--- a/tests/phel/core/async-in-core.phel
+++ b/tests/phel/core/async-in-core.phel
@@ -28,7 +28,7 @@
   (is (= [2 3 4] (pmap inc [1 2 3])) "pmap is in core"))
 
 ;; Regression: `await-all` must return results in *input* order even when
-;; later Futures resolve first. `Amp\Future\await` fills its result array
+;; later Futures resolve first. `Amp.Future.await` fills its result array
 ;; in completion order, so a naive value-iteration returned them shuffled.
 (deftest test-await-all-preserves-input-order
   (is (= [:a0 :a1 :a2 :a3]
@@ -77,7 +77,7 @@
 
 (deftest test-defn-async-basic
   (is (= 5 (await (async-meta-add 2 3))) "^:async defn returns awaitable")
-  (is (= true (php/instanceof (async-meta-add 1 1) \Amp\Future))
+  (is (= true (php/instanceof (async-meta-add 1 1) Amp.Future))
       "^:async defn returns Amp\\Future"))
 
 (defn ^:async async-meta-doc
@@ -108,7 +108,7 @@
 
 (deftest test-defn-async-false-opts-out
   (is (= 7 (async-meta-false 7)) "^{:async false} returns the value, not a future")
-  (is (= false (php/instanceof (async-meta-false 7) \Amp\Future))
+  (is (= false (php/instanceof (async-meta-false 7) Amp.Future))
       "^{:async false} bypasses async wrapper"))
 
 (def async-memoize-counter (atom 0))

--- a/tests/phel/core/future-in-core.phel
+++ b/tests/phel/core/future-in-core.phel
@@ -8,7 +8,7 @@
 (deftest test-future-macro-is-available-without-require
   (let [expanded (macroexpand '(future 42))
         source   (print-str expanded)]
-    (is (php/str_contains source "Phel\\Lang\\Future")
+    (is (php/str_contains source "Phel.Lang.Future")
         "future expansion constructs a Future")
     (is (php/str_contains source "amp\\async")
         "future expansion delegates to amp\\async")
@@ -17,5 +17,5 @@
 
 (deftest test-future-returns-phel-future-without-require
   (let [f (future 1)]
-    (is (= true (php/instanceof f \Phel\Lang\Future))
+    (is (= true (php/instanceof f Phel.Lang.Future))
         "future produces a Future instance at the top level")))

--- a/tests/phel/core/hydration.phel
+++ b/tests/phel/core/hydration.phel
@@ -5,7 +5,7 @@
 
 (deftest hydrate-sets-public-properties
   (let [t (hydrate target {:id 7 :name "kb"})]
-    (is (instance? \PhelTest\Fixtures\Interop\HydrationTarget t)
+    (is (instance? PhelTest.Fixtures.Interop.HydrationTarget t)
         "hydrate returns an instance of the target class")
     (is (= 7 (.-id t)) "id property is set")
     (is (= "kb" (.-name t)) "name property is set")))

--- a/tests/phel/core/infinite-seqs.phel
+++ b/tests/phel/core/infinite-seqs.phel
@@ -894,7 +894,7 @@
 
 (deftest test-lazy-seq-returns-lazy-seq
   (let [result (lazy-seq [1 2 3])]
-    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeq))
+    (is (true? (php/instanceof result Phel.Lang.Collections.LazySeq.LazySeq))
         "lazy-seq should return a LazySeq instance")))
 
 (deftest test-lazy-seq-defers-evaluation
@@ -1031,11 +1031,11 @@
 ;; private `LazySeq::realize()` return type; it now reports a Phel-level error,
 ;; the way Clojure rejects `(lazy-seq 5)`.
 (deftest test-lazy-seq-with-non-seq-body-reports-a-clear-error
-  (is (thrown-with-msg? \Phel\Lang\Collections\Exceptions\NotASeqException
+  (is (thrown-with-msg? Phel.Lang.Collections.Exceptions.NotASeqException
                         "Don't know how to create a seq from: int"
                         (first (lazy-seq 5)))
       "(lazy-seq <scalar>) reports a domain error instead of a PHP TypeError")
-  (is (thrown-with-msg? \Phel\Lang\Collections\Exceptions\NotASeqException
+  (is (thrown-with-msg? Phel.Lang.Collections.Exceptions.NotASeqException
                         "Don't know how to create a seq from: int"
                         (doall (lazy-seq 5)))
       "realizing (lazy-seq <scalar>) reports the same error from every entry point"))

--- a/tests/phel/core/math-operation.phel
+++ b/tests/phel/core/math-operation.phel
@@ -79,11 +79,11 @@
   (is (thrown? \DivisionByZeroError (mod 1 0)) "mod by zero throws"))
 
 (deftest test-quot-rem-mod-bigint
-  (let [big (\Phel\Lang\BigInt/fromString "1000000000000000000")]
+  (let [big (Phel.Lang.BigInt/fromString "1000000000000000000")]
     (is (= 333333333333333333 (quot big 3)) "quot on BigInt collapses to int when fits")
     (is (= 1 (rem big 3)) "rem on BigInt collapses to int when fits")
     (is (= 1 (mod big 3)) "mod on BigInt collapses to int when fits"))
-  (let [huge (\Phel\Lang\BigInt/fromString "100000000000000000000")]
+  (let [huge (Phel.Lang.BigInt/fromString "100000000000000000000")]
     (is (bigint? (quot huge 3)) "quot stays BigInt when result overflows int")))
 
 (deftest test-gcd
@@ -536,14 +536,14 @@
   (is (int? -1N) "(int? -1N)"))
 
 (deftest test-equality-bigint-int-symmetric
-  (let [b (\Phel\Lang\BigInt/fromString "5")]
+  (let [b (Phel.Lang.BigInt/fromString "5")]
     (is (= b 5) "(= bigint int) is true when values match")
     (is (= 5 b) "(= int bigint) is true when values match")
     (is (false? (= b 6)) "(= bigint int) is false on mismatch")
     (is (false? (= 6 b)) "(= int bigint) is false on mismatch")))
 
 (deftest test-equality-bigint-large-symmetric
-  (let [big     (\Phel\Lang\BigInt/fromString "1000000000000000000000000")
+  (let [big     (Phel.Lang.BigInt/fromString "1000000000000000000000000")
         product (* 100000000 100000000 100000000)]
     (is (= big product) "(= bigint product) is true when values match")
     (is (= product big) "(= product bigint) is true when values match")))
@@ -682,7 +682,7 @@
   (is (bigint? (bigint 42)) "(bigint 42) is BigInt")
   (is (bigint? (bigint "1000000000000000000000000")) "(bigint string) parses")
   (is (= "1000000000000000000000000" (str (bigint "1000000000000000000000000"))) "(bigint big-string)")
-  (let [b (\Phel\Lang\BigInt/fromInt 5)]
+  (let [b (Phel.Lang.BigInt/fromInt 5)]
     (is (= b (bigint b)) "(bigint BigInt) is identity"))
   (is (thrown? \InvalidArgumentException (bigint nil)) "(bigint nil) rejects nil"))
 
@@ -758,7 +758,7 @@
 (deftest test-rationalize-passes-through-exact
   (is (= 1/3 (rationalize 1/3)) "(rationalize 1/3) is identity")
   (is (= 7 (rationalize 7)) "(rationalize 7) is identity for ints")
-  (let [b (\Phel\Lang\BigInt/fromString "100000000000000000000")]
+  (let [b (Phel.Lang.BigInt/fromString "100000000000000000000")]
     (is (= b (rationalize b)) "(rationalize BigInt) is identity")))
 
 (deftest test-rationalize-rejects-non-finite

--- a/tests/phel/core/meta.phel
+++ b/tests/phel/core/meta.phel
@@ -73,10 +73,10 @@
 ;; The compiler lowers a chain of `assoc`/`conj` calls on a type-tagged target
 ;; to one transient chain. That fast path must answer `meta` exactly like the
 ;; untagged runtime path, which threads the metadata through every `put`.
-(defn- assoc-chain [^\Phel\Lang\Collections\Map\PersistentMapInterface m]
+(defn- assoc-chain [^Phel.Lang.Collections.Map.PersistentMapInterface m]
   (assoc (assoc m :b 2) :c 3))
 
-(defn- conj-chain [^\Phel\Lang\Collections\Vector\PersistentVectorInterface v]
+(defn- conj-chain [^Phel.Lang.Collections.Vector.PersistentVectorInterface v]
   (conj (conj v 2) 3))
 
 (deftest typed-assoc-conj-chain-preserves-meta

--- a/tests/phel/core/php-callable.phel
+++ b/tests/phel/core/php-callable.phel
@@ -4,8 +4,8 @@
 ;; Free function: emits `strtoupper(...)`.
 (def upper (php/callable \strtoupper))
 
-;; Static method: emits `\Phel\Lang\Keyword::create(...)`.
-(def make-kw (php/callable \Phel\Lang\Keyword create))
+;; Static method: emits `Phel.Lang.Keyword::create(...)`.
+(def make-kw (php/callable Phel.Lang.Keyword create))
 
 ;; Instance method: emits `($dt->format(...))`.
 (def formatter (php/callable (new \DateTime "2020-03-04") format))

--- a/tests/phel/core/set-bang.phel
+++ b/tests/phel/core/set-bang.phel
@@ -1,7 +1,7 @@
 (ns phel-test.core.set-bang
   (:require phel.test :refer [deftest is])
   (:use \stdClass)
-  (:use PhelTest\Support\Fixtures\PhpInterop\StaticPropertyTarget))
+  (:use PhelTest.Support.Fixtures.PhpInterop.StaticPropertyTarget))
 
 (def ^:dynamic *counter* 0)
 

--- a/tests/phel/core/tag-types.phel
+++ b/tests/phel/core/tag-types.phel
@@ -40,7 +40,7 @@
 (deftest dot-separated-class-tag-round-trips
   (let [s (symbol "abc")]
     (is (= s (dotted-tag s)) "a dotted class tag accepts and returns the class"))
-  (is (php/instanceof (dotted-tag (symbol "x")) \Phel\Lang\Symbol)
+  (is (php/instanceof (dotted-tag (symbol "x")) Phel.Lang.Symbol)
       "the emitted signature names the real class"))
 
 (deftest dot-separated-class-tag-rejects-a-wrong-type

--- a/tests/phel/core/transducers.phel
+++ b/tests/phel/core/transducers.phel
@@ -333,7 +333,7 @@
         "an eduction re-runs its pipeline, so first is not consuming")))
 
 (deftest test-first-of-a-php-generator
-  (is (= 6 (first (\Phel\Lang\Seq/map inc [5 6])))
+  (is (= 6 (first (Phel.Lang.Seq/map inc [5 6])))
       "first pulls one element from a bare PHP generator"))
 
 (deftest test-eduction-count-is-a-deliberate-error

--- a/tests/phel/core/type-operation.phel
+++ b/tests/phel/core/type-operation.phel
@@ -1,7 +1,7 @@
 (ns phel-test.core.type-operation
   (:use DateTime)
   (:use RuntimeException)
-  (:use Phel\Lang\Symbol)
+  (:use Phel.Lang.Symbol)
   (:require phel.test :refer [deftest is are]))
 
 (deftest test-type
@@ -374,7 +374,7 @@
        {:a 1}))
 
 (deftest test-bigint?
-  (is (true? (bigint? (\Phel\Lang\BigInt/fromString "100000000000000000000000")))
+  (is (true? (bigint? (Phel.Lang.BigInt/fromString "100000000000000000000000")))
       "bigint? on a BigInt value")
   (are [x] (false? (bigint? x))
        1

--- a/tests/phel/edn/read.phel
+++ b/tests/phel/edn/read.phel
@@ -64,7 +64,7 @@
 
 (deftest test-read-builtin-tags
   (let [uuid (edn/read-string "#uuid \"550e8400-e29b-41d4-a716-446655440000\"")]
-    (is (php/instanceof uuid \Phel\Lang\UUID) "#uuid returns UUID")
+    (is (php/instanceof uuid Phel.Lang.UUID) "#uuid returns UUID")
     (is (= "550e8400-e29b-41d4-a716-446655440000" (.__toString uuid)))))
 
 (deftest test-read-custom-tag
@@ -85,5 +85,5 @@
 (deftest test-read-readers-restored-after-call
   (edn/read-string "1" {:readers {'myapp/x (fn [v] v)}})
   (is (false?
-       (.has (\Phel\Lang\TagRegistry/getInstance) "myapp/x"))
+       (.has (Phel.Lang.TagRegistry/getInstance) "myapp/x"))
       "custom reader unregistered after call"))

--- a/tests/phel/edn/write.phel
+++ b/tests/phel/edn/write.phel
@@ -49,9 +49,9 @@
          (edn/read-string (edn/write-string #{1 2 3})))))
 
 (deftest test-write-uuid-round-trip
-  (let [u             (\Phel\Lang\UUID/fromString "550e8400-e29b-41d4-a716-446655440000")
+  (let [u             (Phel.Lang.UUID/fromString "550e8400-e29b-41d4-a716-446655440000")
         round-tripped (edn/read-string (edn/write-string u))]
-    (is (php/instanceof round-tripped \Phel\Lang\UUID))
+    (is (php/instanceof round-tripped Phel.Lang.UUID))
     (is (= (str u) (str round-tripped)) "UUID round-trips through EDN")))
 
 (deftest test-write-inst-round-trip

--- a/tests/phel/http-client.phel
+++ b/tests/phel/http-client.phel
@@ -6,9 +6,9 @@
 ;; --- Response parser integration (via PHP static call) ---
 
 (deftest test-response-parser-basic
-  (let [parsed (\Phel\HttpClient\ResponseParser/parse (php/array "HTTP/1.1 200 OK"
-                                                                 "Content-Type: application/json"
-                                                                 "X-Request-Id: abc-123"))]
+  (let [parsed (Phel.HttpClient.ResponseParser/parse (php/array "HTTP/1.1 200 OK"
+                                                                "Content-Type: application/json"
+                                                                "X-Request-Id: abc-123"))]
     (is (= 200 (php/aget parsed "status")) "parses status code")
     (is (= "1.1" (php/aget parsed "version")) "parses HTTP version")
     (is (= "OK" (php/aget parsed "reason")) "parses reason phrase")
@@ -17,27 +17,27 @@
       (is (= "abc-123" (php/aget headers "x-request-id")) "parses custom header"))))
 
 (deftest test-response-parser-empty-headers
-  (let [parsed (\Phel\HttpClient\ResponseParser/parse (php/array))]
+  (let [parsed (Phel.HttpClient.ResponseParser/parse (php/array))]
     (is (= 200 (php/aget parsed "status")) "defaults to 200 when no status line")
     (is (= "1.1" (php/aget parsed "version")) "defaults to HTTP/1.1")))
 
 (deftest test-response-parser-404
-  (let [parsed (\Phel\HttpClient\ResponseParser/parse (php/array "HTTP/1.1 404 Not Found"))]
+  (let [parsed (Phel.HttpClient.ResponseParser/parse (php/array "HTTP/1.1 404 Not Found"))]
     (is (= 404 (php/aget parsed "status")) "parses 404 status")
     (is (= "Not Found" (php/aget parsed "reason")) "parses reason phrase")))
 
 (deftest test-response-parser-redirect-chain
-  (let [parsed (\Phel\HttpClient\ResponseParser/parse (php/array "HTTP/1.1 301 Moved"
-                                                                 "Location: /new"
-                                                                 "HTTP/1.1 200 OK"
-                                                                 "Content-Type: text/html"))]
+  (let [parsed (Phel.HttpClient.ResponseParser/parse (php/array "HTTP/1.1 301 Moved"
+                                                                "Location: /new"
+                                                                "HTTP/1.1 200 OK"
+                                                                "Content-Type: text/html"))]
     (is (= 200 (php/aget parsed "status")) "uses final status after redirect")
     (is (= "text/html" (php/aget (php/aget parsed "headers") "content-type"))
         "parses headers from final response")))
 
 (deftest test-response-parser-colon-in-value
-  (let [parsed (\Phel\HttpClient\ResponseParser/parse (php/array "HTTP/1.1 200 OK"
-                                                                 "Location: https://example.com:8080/path"))]
+  (let [parsed (Phel.HttpClient.ResponseParser/parse (php/array "HTTP/1.1 200 OK"
+                                                                "Location: https://example.com:8080/path"))]
     (is (= "https://example.com:8080/path"
            (php/aget (php/aget parsed "headers") "location"))
         "preserves colons in header values")))

--- a/tests/phel/reflect.phel
+++ b/tests/phel/reflect.phel
@@ -81,7 +81,7 @@
     (is (= route-attr (get attr :name)) "an instance reflects its class' attributes")))
 
 (def- status-class "PhelTest\\Fixtures\\Enum\\Status")
-(def- status-active \PhelTest\Fixtures\Enum\Status/Active)
+(def- status-active PhelTest.Fixtures.Enum.Status/Active)
 
 (deftest enum->keyword-uses-the-case-name
   (is (= :Active (r/enum->keyword status-active))

--- a/tests/phel/repl.phel
+++ b/tests/phel/repl.phel
@@ -346,7 +346,7 @@
   (let [original *ns*]
     (eval-str "(ns test-ns-propagation)")
     (is (= "test-ns-propagation" *ns*) "*ns* propagates after eval-str returns")
-    (is (= *ns* (.getNs (\Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton/getInstance)))
+    (is (= *ns* (.getNs (Phel.Compiler.Infrastructure.GlobalEnvironmentSingleton/getInstance)))
         "GlobalEnvironment.ns matches *ns*")
     (eval-str (str "(ns " original ")"))))
 

--- a/tests/phel/router.phel
+++ b/tests/phel/router.phel
@@ -2,8 +2,8 @@
   (:require phel.http :as h)
   (:require phel.test :refer [deftest is])
   (:require phel.router :as r :refer [routes match-by-path match-by-name generate])
-  (:use Symfony\Component\Routing\Exception\RouteNotFoundException)
-  (:use Symfony\Component\Routing\Exception\MissingMandatoryParametersException))
+  (:use Symfony.Component.Routing.Exception.RouteNotFoundException)
+  (:use Symfony.Component.Routing.Exception.MissingMandatoryParametersException))
 
 ;; The `r/compiled-router` macro requires literal routes at compile-time, so the
 ;; shared assertions are wrapped in macros that take the router constructor as a

--- a/tests/phel/transit/read.phel
+++ b/tests/phel/transit/read.phel
@@ -20,7 +20,7 @@
 
 (deftest test-read-uuid
   (let [u (transit/read-string "\"~u550e8400-e29b-41d4-a716-446655440000\"")]
-    (is (php/instanceof u \Phel\Lang\UUID))
+    (is (php/instanceof u Phel.Lang.UUID))
     (is (= "550e8400-e29b-41d4-a716-446655440000" (str u)))))
 
 (deftest test-read-instant

--- a/tests/phel/transit/write.phel
+++ b/tests/phel/transit/write.phel
@@ -18,7 +18,7 @@
   (is (= "\"~$bar\"" (transit/write-string 'bar))))
 
 (deftest test-write-uuid
-  (let [u (\Phel\Lang\UUID/fromString "550e8400-e29b-41d4-a716-446655440000")]
+  (let [u (Phel.Lang.UUID/fromString "550e8400-e29b-41d4-a716-446655440000")]
     (is (= "\"~u550e8400-e29b-41d4-a716-446655440000\"" (transit/write-string u)))))
 
 (deftest test-write-vector


### PR DESCRIPTION
## 🤔 Background

[#2859 (comment)](https://github.com/phel-lang/phel-lang/issues/2859#issuecomment-5152721973): Phel's own sources still spell PHP classes with `\`, while the dot separator is the one the language points users at. Rewriting them is the same move #2882 made for the `php/*` forms, and it does the same job for #2827: the cheapest proof that the dot form reaches every position the standard library actually uses.

Prerequisite landed first: a `:tag` was the only position that rejected dots and emitted a PHP parse error (#2924, fixed in #2925).

## 💡 Goal

`Phel\Lang\Seq` becomes `Phel.Lang.Seq` everywhere the compiler reads it. Nothing about resolution changes: a multi-segment name with an upper-case first segment is a class reference under either spelling.

## 🔖 Changes

79 references across 32 stdlib and test files, plus one assertion and three reformats.

**What was rewritten:** a symbol with **at least two segments**, in `(new ...)`, `(:use ...)`, `(catch ...)`, value position, qualified members and `:tag`.

**What was not, and why the pass is safe:**

- **Single-segment names.** `\stdClass`, `\RuntimeException` and friends carry no separator, so there is nothing to convert. Dropping their leading `\` is a different change with different semantics, and it belongs to #2876: a bare name is resolved through the host-symbol fallback, where a same-named definition wins. `(def DateTime "shadow")` followed by `(new DateTime)` fails with `Class "shadow" not found`.
- **String literals.** The pass skips them, so regex escapes (`\d`, `\s`), string escapes (`\n`) and class-name strings such as `"\\Phel\\Lang\\Keyword"` are untouched. This is also why the 39 escaped FQNs inside docstrings are unchanged; several of them name a PHP-side interface a user implements in PHP (`\\Symfony\\Component\\Console\\Input\\InputInterface`) rather than a class they would write in Phel, so they want judgement rather than a sweep. Follow-up.
- **Char literals.** `\a`, `\newline` and `\uNNNN` are single-segment by construction, so the two-segment rule cannot reach them.

One test needed a real change: `future-in-core.phel` asserts on the text of a macroexpansion, and the expansion now reads `Phel.Lang.Future`. Three files were reformatted because shorter names change alignment.

## ✅ Verification

- Full gate green: unit 4476, integration 1173, core 6597, static analysis clean.
- `phel lint src/phel tests/phel` reports **132 issues before and 132 after**, so the sweep introduced nothing.
- `phel format` applied, so the tree is stable under the formatter.

Docs and `resources/agents/` are deliberately not in this PR: a markdown file mixes Phel samples with PHP samples and with emitted output, where the backslash spelling is correct, so it needs a fence-aware pass rather than this one.
