### PR TITLE
docs: teach the dot separator in the `:tag` documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- A `:tag` naming a class takes the dot separator: `^Phel.Lang.Symbol` emits `\Phel\Lang\Symbol` instead of reaching the generated signature verbatim and failing to parse. Unions, intersections and the nullable marker are handled; scalars and the backslash form are unchanged (#2924)
 - A `$`-prefixed member outside a static-property place fails to compile instead of emitting a PHP variable-property access. `(php/-> o $foo)` used to compile to `$o->$foo`, warn twice about an undefined variable and read `$o->{''}` (#2915)
 - Assigning a static property compiles. `(php/oset (php/:: \Foo slot) v)` emitted `\Foo::slot = v`, a class-constant fetch PHP rejects with `syntax error, unexpected token "="`, and a class name as the place of `.-` emitted `\Foo::class->slot = v` (#2907)
 - Bare all-caps PHP classes such as `PDO` are no longer read as global constants, so `PDO/ATTR_ERRMODE`, `(.-ATTR_ERRMODE PDO)` and `(new PDO ...)` need no leading backslash. A class beats a same-named constant; `php/NAME` stays the explicit escape hatch

--- a/resources/agents/RULES.md
+++ b/resources/agents/RULES.md
@@ -33,7 +33,7 @@ Use these when appropriate; stable and tested.
 | `defrecord` w/ protocols | `(defrecord Foo [x] MyProto (my-fn [this] ...))` | v0.32 |
 | `doseq` | `(doseq [x :in coll] (println x))`; side-effecting iteration | v0.31 |
 | `for` comprehension | `(for [x :in xs :when (odd? x)] (* x x))`; builds sequence | v0.31 |
-| `:tag` types | `(defn ^int square [^int x] (* x x))`, `^"?int"`, `^"\\Foo\\Bar"`, `^{:tag "..."}`. Emits PHP type decls; static checker rejects literal mismatches | main |
+| `:tag` types | `(defn ^int square [^int x] (* x x))`, `^"?int"`, `^Foo.Bar`, `^{:tag "..."}`. Emits PHP type decls; static checker rejects literal mismatches | main |
 | Return inference | Tagged params + tail primitive op (`(php/+ ...)` -> `int`, `(php/. ...)` -> `string`, comparisons -> `bool`) infers return; `if` / `let` / `loop` propagate. Explicit `:tag` always wins | main |
 | `^:async` defn | `(defn ^:async fetch [url] (await (http-get url)))`; body wrapped in `async`, returns `Amp\Future` | main |
 | `^:memoize` / `^{:memoize-lru N}` | `(defn ^{:memoize-lru 32} fib [^int n] ...)`; opt-in caching by arg vector, LRU bound optional | main |

--- a/resources/agents/skills/gemini/GEMINI.md
+++ b/resources/agents/skills/gemini/GEMINI.md
@@ -13,7 +13,7 @@ Phel is a Lisp dialect that compiles to PHP.
 ## Before suggesting code
 
 - Verify fn names in `src/phel/core/` or `./vendor/bin/phel doc <fn>`. Never invent.
-- Hot or public `defn`: add `:tag` (`^int`, `^"?int"`, `^"\\Foo\\Bar"`, `^{:tag "..."}`). See `.agents/tasks/typed-defn.md`.
+- Hot or public `defn`: add `:tag` (`^int`, `^"?int"`, `^Foo.Bar`, `^{:tag "..."}`). See `.agents/tasks/typed-defn.md`.
 - Opt-in defn metadata: `^:async`, `^:memoize`, `^{:memoize-lru N}`.
 - `phel profile <path>` locates hot fns before tagging.
 - Namespace separator: prefer `.` (`app.main`); `\` still parses but is deprecated.

--- a/resources/agents/tasks/async.md
+++ b/resources/agents/tasks/async.md
@@ -51,4 +51,4 @@ Cache hits skip the fiber entirely.
 ## See also
 
 - <https://phel-lang.org/documentation/language/async/>
-- `tasks/typed-defn.md` for combining `^:async` with `:tag` (`^"\\Amp\\Future"` return tag)
+- `tasks/typed-defn.md` for combining `^:async` with `:tag` (`^Amp.Future` return tag)

--- a/resources/agents/tasks/typed-defn.md
+++ b/resources/agents/tasks/typed-defn.md
@@ -23,7 +23,8 @@
 | `^int`, `^string`, `^bool`, `^float`, `^array`, `^void`, `^mixed` | builtin scalars |
 | `^"?int"` | `?int` (nullable) |
 | `^"int\|string"` | union |
-| `^"\\Foo\\Bar"` | leading `\\` for FQ class name |
+| `^Foo.Bar` | class name, dot separator (preferred) |
+| `^"\\Foo\\Bar"` | same class, backslash form |
 | `^{:tag "..."}` | map form (any string accepted by PHP) |
 
 ## Defn-name tag propagation
@@ -81,7 +82,7 @@ Type tags compose with `^:async`, `^:memoize`, `^{:memoize-lru N}`:
   [^int n]
   (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))
 
-(defn ^:async ^"\\Amp\\Future" fetch [^string url]
+(defn ^:async ^Amp.Future fetch [^string url]
   (await (http-get url)))
 ```
 
@@ -110,7 +111,7 @@ Per-fn call counts and self/total/avg/max timings, plus compile-phase cost (lex,
 - `:tag` on `def` of a non-fn is ignored (no PHP slot to type).
 - A bound symbol passed to a typed param is checked at runtime (PHP-level), not compile time; only literal mismatches are static.
 - `(php/+ 1 1.0)` infers `float`, not `int`. Promotion follows PHP rules.
-- Class FQNs need leading `\\`: `^"\\App\\User"`, otherwise the reader treats it as a relative ns symbol.
+- A class tag takes either separator: `^App.User` or `^"\\App\\User"`. The dot form is rooted for you; a backslash form needs the leading `\\`, or the reader treats it as a relative ns symbol.
 
 ## See also
 


### PR DESCRIPTION
## 🤔 Background

#2925 made a `:tag` accept the dot separator, so `^Phel.Lang.Symbol` now emits `\Phel\Lang\Symbol`. Two things were left behind: the agent docs still taught the backslash form as the only one, with a claim that is now wrong, and the fix shipped without a CHANGELOG entry.

## 💡 Goal

The `:tag` docs describe what the compiler does after #2925 and #2926.

## 🔖 Changes

- `tasks/typed-defn.md`: the shorthand table gains `^Foo.Bar` as the preferred class spelling, keeping the backslash form next to it. The note "Class FQNs need leading `\\`, otherwise the reader treats it as a relative ns symbol" was correct only about the backslash form and is now stated that way: the dot form is rooted for you. The `^:async` example switches to `^Amp.Future`, verified to compile to `function __invoke(string $url): \Amp\Future`.
- `RULES.md`, `GEMINI.md`, `tasks/async.md`: the `:tag` one-liners name the dot form.
- CHANGELOG: the #2924 fix, which went in without an entry.

Two occurrences were deliberately left as they are:

- `docs/spec/clojure-divergences.md`, `(.cases "\\App\\Status")`. That is a class name **as a string**, which is a PHP value rather than a Phel symbol, so the backslash spelling is the correct one.
- `docs/adr/0008-dot-namespace-separator.md`. An accepted ADR is immutable, and its examples are the record of what the separator decision was about.

## ✅ Verification

`composer test-agents` (the bundled example projects) and the agent-docs unit suite both pass. The `^Amp.Future` example was compiled rather than eyeballed.
