### PR TITLE
fix(command): honour NO_COLOR in the exception printer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - `(.cases enum-class)` reaches a static method through a class name held in a value, object or `"\\App\\Status"` alike (#2881)
 - `php-invoke` calls a method named at runtime: `(php-invoke obj "format" "Y")`, ClojureScript's `js-invoke`. A class-name target calls the static method (#2887)
 - `set!` covers all three Clojure shapes: `(set! (.-total o) 10)` assigns a property, `(set! \Foo/slot v)` a static property, `(set! *x* 2)` the current `binding` frame, throwing when there is none. `alter-var-root` still changes a root (#2884, #2888, #2907)
+- `Phel\Shared\NoColor` on the public PHP surface: `isRequested()` and `style()` answer whether the environment asked for plain output, so an embedder rendering Phel output makes the same decision the CLI does (#2923)
 - Editor completion and hover cover the Clojure-style interop spellings, not only the deprecated `php/*` ones: `\C/member` offers static methods, constants and static properties, and `(.method recv` / `(.-field recv` offer instance members of a receiver the resolver can type. Static properties are offered and hovered with their `$` sigil (#2916)
 - `\C/$prop` reads a static property in value position. The bare name stays the class constant, since PHP files the two separately and a class may carry both (#2907)
 - The standard library is written in the Clojure-style interop spelling, and `docs/` leads with it (#2875, #2882)
@@ -28,6 +29,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `NO_COLOR` is honoured by the exception printer and the REPL error formatter. `getStackTraceString()` returns a string, so the caller may be writing to a log or an error tracker, and it used to bake ANSI escapes in regardless. Symfony Console already obeyed the variable, so the two halves of a command disagreed (#2923)
 - A `:tag` naming a class takes the dot separator: `^Phel.Lang.Symbol` emits `\Phel\Lang\Symbol` instead of reaching the generated signature verbatim and failing to parse. Unions, intersections and the nullable marker are handled; scalars and the backslash form are unchanged (#2924)
 - A `$`-prefixed member outside a static-property place fails to compile instead of emitting a PHP variable-property access. `(php/-> o $foo)` used to compile to `$o->$foo`, warn twice about an undefined variable and read `$o->{''}` (#2915)
 - Assigning a static property compiles. `(php/oset (php/:: \Foo slot) v)` emitted `\Foo::slot = v`, a class-constant fetch PHP rejects with `syntax error, unexpected token "="`, and a class name as the place of `.-` emitted `\Foo::class->slot = v` (#2907)

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -17,7 +17,6 @@ use Phel\Command\Domain\Finder\VendorDirectoriesFinderInterface;
 use Phel\Command\Infrastructure\ComposerVendorDirectoriesFinder;
 use Phel\Command\Infrastructure\ErrorLog;
 use Phel\Command\Infrastructure\SourceMapExtractor;
-use Phel\Shared\ColorStyle;
 use Phel\Shared\Exceptions\ExceptionPrinterInterface;
 use Phel\Shared\Exceptions\Hint\ArgumentCountHint;
 use Phel\Shared\Exceptions\Hint\ExceptionHintInterface;
@@ -25,6 +24,7 @@ use Phel\Shared\Exceptions\Hint\ExceptionHintResolver;
 use Phel\Shared\Exceptions\Hint\NotCallableHint;
 use Phel\Shared\Exceptions\Hint\UndefinedSymbolHint;
 use Phel\Shared\Munge;
+use Phel\Shared\NoColor;
 use Phel\Shared\Printer\Printer;
 
 /**
@@ -66,7 +66,7 @@ final class CommandFactory extends AbstractFactory
     {
         return new TextExceptionPrinter(
             new ExceptionArgsPrinter(Printer::readable()),
-            ColorStyle::withStyles(),
+            NoColor::style(),
             new Munge(),
             $this->createFilePositionExtractor(),
             new ErrorLog($this->getConfig()->getErrorLogFile()),

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -38,12 +38,12 @@ use Phel\Run\Domain\Runner\NamespaceCollector;
 use Phel\Run\Domain\Runner\NamespaceRunnerInterface;
 use Phel\Run\Domain\StdinReaderInterface;
 use Phel\Run\Infrastructure\PhpStdinReader;
-use Phel\Shared\ColorStyle;
 use Phel\Shared\ColorStyleInterface;
 use Phel\Shared\Facade\ApiFacadeInterface;
 use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
 use Phel\Shared\Facade\CompilerFacadeInterface;
+use Phel\Shared\NoColor;
 use Phel\Shared\Performance\OpcacheWorkerFlags;
 use Phel\Shared\Printer\Printer;
 use Phel\Shared\Printer\PrinterInterface;
@@ -132,7 +132,7 @@ class RunFactory extends AbstractFactory
 
     public function createColorStyle(): ColorStyleInterface
     {
-        return ColorStyle::withStyles();
+        return NoColor::style();
     }
 
     public function createPrinter(): PrinterInterface

--- a/src/php/Shared/NoColor.php
+++ b/src/php/Shared/NoColor.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared;
+
+use function array_key_exists;
+use function getenv;
+use function is_string;
+
+/**
+ * Whether the environment asks for plain output.
+ *
+ * `NO_COLOR` is honoured the way <https://no-color.org> specifies: present and
+ * non-empty, whatever the value. Symfony Console already obeys it for its own
+ * output, so without this the two halves of a `phel` command disagree, and the
+ * string-returning half of `ExceptionPrinterInterface` hands escape codes to a
+ * caller that may be writing to a log or an error tracker (#2923).
+ *
+ * Public, like the rest of `Phel\Shared`: an embedder rendering Phel output of
+ * its own should be able to make the same decision the same way.
+ */
+final class NoColor
+{
+    /**
+     * @param array<string, mixed>|null $env defaults to the real environment
+     */
+    public static function isRequested(?array $env = null): bool
+    {
+        $value = $env === null
+            ? getenv('NO_COLOR')
+            : (array_key_exists('NO_COLOR', $env) ? $env['NO_COLOR'] : false);
+
+        return is_string($value) && $value !== '';
+    }
+
+    /**
+     * @param array<string, mixed>|null $env defaults to the real environment
+     */
+    public static function style(?array $env = null): ColorStyleInterface
+    {
+        return self::isRequested($env)
+            ? ColorStyle::noStyles()
+            : ColorStyle::withStyles();
+    }
+}

--- a/tests/php/Unit/Architecture/public-api.snapshot.txt
+++ b/tests/php/Unit/Architecture/public-api.snapshot.txt
@@ -1926,6 +1926,10 @@ final readonly class Phel\Shared\NamespaceInformation
   public function getNamespace(): string
   public function isPrimaryDefinition(): bool
 
+final class Phel\Shared\NoColor
+  public static function isRequested(?array $env = null): bool
+  public static function style(?array $env = null): Phel\Shared\ColorStyleInterface
+
 abstract class Phel\Shared\Parser\Node\AbstractAtomNode implements Phel\Shared\Parser\Node\NodeInterface
   public function __construct(string $code, Phel\Lang\SourceLocation $startLocation, Phel\Lang\SourceLocation $endLocation, mixed $value)
   public function getCode(): string

--- a/tests/php/Unit/Shared/NoColorTest.php
+++ b/tests/php/Unit/Shared/NoColorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared;
+
+use Phel\Shared\NoColor;
+use PHPUnit\Framework\TestCase;
+
+final class NoColorTest extends TestCase
+{
+    public function test_absent_variable_keeps_colour(): void
+    {
+        self::assertFalse(NoColor::isRequested([]));
+    }
+
+    public function test_empty_value_keeps_colour(): void
+    {
+        // <https://no-color.org>: the variable counts only when non-empty.
+        self::assertFalse(NoColor::isRequested(['NO_COLOR' => '']));
+    }
+
+    public function test_any_non_empty_value_requests_plain_output(): void
+    {
+        self::assertTrue(NoColor::isRequested(['NO_COLOR' => '1']));
+        self::assertTrue(NoColor::isRequested(['NO_COLOR' => '0']), 'the value is not read, only its presence');
+        self::assertTrue(NoColor::isRequested(['NO_COLOR' => 'false']));
+    }
+
+    public function test_style_is_plain_when_requested(): void
+    {
+        self::assertSame('x', NoColor::style(['NO_COLOR' => '1'])->red('x'));
+    }
+
+    public function test_style_carries_colour_by_default(): void
+    {
+        self::assertNotSame('x', NoColor::style([])->red('x'));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`ExceptionPrinterInterface` has three string-returning methods so the caller decides where the text goes. For an embedder that destination is usually a log file, a JSON payload or an error tracker, and the string arrived with ANSI escapes baked in regardless:

```bash
NO_COLOR=1 ./bin/phel eval '(throw (php/new \RuntimeException "boom"))' | cat -v
^[[33;34mRuntimeException: boom
^[[0min string:1 ...
```

`CommandFactory` and `RunFactory` both hardcoded `ColorStyle::withStyles()`, and `ColorStyle::noStyles()` had no production caller at all. Symfony Console already honours `NO_COLOR` for its own output, so a `phel` command under `NO_COLOR=1` disagreed with itself: the Symfony half went plain and the Phel half stayed coloured.

Closes #2923

## 💡 Goal

```bash
NO_COLOR=1 ./bin/phel eval '(throw (php/new \RuntimeException "boom"))' | cat -v
RuntimeException: boom
in string:1 ...
```

## 🔖 Changes

- `Phel\Shared\NoColor` answers the question once: `isRequested()` follows <https://no-color.org> exactly, the variable counting when present and non-empty whatever its value, and `style()` returns the matching `ColorStyle`.
- `CommandFactory::createExceptionPrinter()` and `RunFactory::createColorStyle()` both go through it, so the exception printer and the REPL error formatter cannot drift on the answer.
- Colour is unchanged when the variable is absent or empty.

### On the public surface

`Phel\Shared` is public by rule 6 of `docs/stability.md`, so `InternalAnnotationTest` and `PublicApiSurfaceTest` both fired on the new class, correctly. Rather than hide it, it is public on purpose: an embedder rendering Phel output of its own should be able to make the same decision the same way. The addition is additive, the snapshot is regenerated with `composer api-surface:update`, and the CHANGELOG carries both the fix and the addition.

The alternative was inlining the check in the two factories, which adds no public surface and duplicates the environment rule in two places. Two is how these things start.

### Tests

`NoColorTest` covers absent, empty and non-empty values, including `NO_COLOR=0`, which requests plain output because the spec reads presence rather than value.
