### PR TITLE
docs: give the backslash separator one removal answer

### DIFF
--- a/docs/migration/backslash-to-dot.md
+++ b/docs/migration/backslash-to-dot.md
@@ -2,7 +2,9 @@
 
 Phel historically used the PHP-style backslash (`\`) as the namespace separator everywhere: `ns` forms, `:require`/`:use` clauses, fully-qualified call sites, and class FQNs. The dot (`.`) is the target form going forward. The backslash form is **deprecated** and will be removed in a future release.
 
-Tracking issue: [phel-lang/phel-lang#1567](https://github.com/phel-lang/phel-lang/issues/1567).
+Tracking issue: [phel-lang/phel-lang#2827](https://github.com/phel-lang/phel-lang/issues/2827),
+which owns the removal decision. [#1567](https://github.com/phel-lang/phel-lang/issues/1567)
+delivered the deprecation and this migration path, and is closed.
 
 ## Opt-in to deprecation warnings
 
@@ -44,7 +46,7 @@ Symbols flowing through the analyzer's `SymbolResolver` or the `ns`-form analyze
 
 ## What is NOT yet detected
 
-Tracked as follow-up sub-tasks in #1567:
+Tracked as follow-up sub-tasks in #2827:
 
 - `:refer` targets inside a require (rarely contain `\` in practice)
 - `load` forms (take strings, not symbols)
@@ -58,4 +60,20 @@ Warnings are suppressed automatically for files under phel's bundled stdlib. Use
 
 ## Removal target
 
-TBD, tracked in #1567. At minimum one full minor-release cycle after the warning flag flips on by default.
+**Not 1.0.** The [0.49 to 1.0 upgrade guide](upgrade-0.49-to-1.0.md) lists the
+separator under what is *not* changing, so `\` keeps working for projects moving
+to the first stable release.
+
+That has a consequence worth stating plainly: the
+[deprecation policy](../stability.md#deprecation-policy-for-1x) removes a
+deprecated form **only in a major**, so a separator still shipping at `1.0.0`
+ships for the whole of `1.x`. The decision is not "now or later", it is "at 1.0
+or not until 2.0", and [#2827](https://github.com/phel-lang/phel-lang/issues/2827)
+owns it.
+
+An earlier version of this page set the bar at "one full minor-release cycle
+after the warning flag flips on by default". That bar cannot be met as written:
+the flag is opt-in by design and stays that way
+([ADR 0006](../adr/0006-one-opt-in-deprecation-channel.md)), because phel's own
+suite would flood stderr otherwise. Whoever decides the removal is deciding it
+for users who were never warned unless they asked to be.

--- a/docs/migration/deprecated-surface.md
+++ b/docs/migration/deprecated-surface.md
@@ -57,7 +57,7 @@ release such a message promises inevitably ships and the text goes stale.
 
 Full detail, including what is and is not detected today, is in
 [backslash-to-dot.md](backslash-to-dot.md). Tracked in
-[#1567](https://github.com/phel-lang/phel-lang/issues/1567).
+[#2827](https://github.com/phel-lang/phel-lang/issues/2827).
 
 ## Redundant interop forms: `php/new`, `php/->`, `php/::`
 

--- a/docs/migration/upgrade-0.49-to-1.0.md
+++ b/docs/migration/upgrade-0.49-to-1.0.md
@@ -95,7 +95,7 @@ facade is missing a method.
 ## What is *not* changing
 
 - **The `\` namespace separator still works.** Deprecated in favour of `.`, not
-  removed in 1.0 ([#1567](https://github.com/phel-lang/phel-lang/issues/1567)).
+  removed in 1.0 ([#2827](https://github.com/phel-lang/phel-lang/issues/2827)).
   Details in [backslash-to-dot.md](backslash-to-dot.md).
 - **Every other public `phel.*` function.** Pinned in
   `tests/php/Integration/Api/core-api.snapshot.txt`; a test fails if a definition

--- a/docs/spec/language-surface.md
+++ b/docs/spec/language-surface.md
@@ -42,7 +42,7 @@ auto-gensym. See
 [removed-deprecated-core-fns.md](../migration/removed-deprecated-core-fns.md).
 
 Still shipped and still deprecated: `\` as a namespace separator
-([#1567](https://github.com/phel-lang/phel-lang/issues/1567)). The only
+([#2827](https://github.com/phel-lang/phel-lang/issues/2827)). The only
 reader-level item whose fate is unsettled.
 
 ## 2. Special forms
@@ -213,7 +213,7 @@ behaviour listed there is a decision, not a bug.
 ## 4. Namespaces and project layout
 
 - A namespace name maps to a path. `.` is the separator; `\` still parses and is
-  deprecated (#1567).
+  deprecated (#2827).
 - `phel.core` is always loaded and must never be `:require`d explicitly.
 - The `.phel/` state directory and the `phel-config.php` keys are frozen; see
   [the configuration surface](../stability.md#configuration-surface) and


### PR DESCRIPTION
## 🤔 Background

#2827 says the removal decision for the `\` namespace separator is open. `docs/migration/upgrade-0.49-to-1.0.md` already tells users the opposite, under a heading that reads "What is *not* changing":

> **The `\` namespace separator still works.** Deprecated in favour of `.`, not removed in 1.0.

Both cannot be true for a reader. Alongside that, five documents still route the reader to #1567, which is closed and delivered the deprecation rather than the removal, and `backslash-to-dot.md` set a removal bar that cannot be met as written.

Related: #2827, #2876.

## 💡 Goal

A reader who wants to know what happens to `\` gets one answer, and whoever makes the call in #2827 sees what the call actually costs.

## 🔖 Changes

- **`backslash-to-dot.md`, "Removal target"** was "TBD, tracked in #1567. At minimum one full minor-release cycle after the warning flag flips on by default." Two problems: the flag is opt-in **by design and stays that way** ([ADR 0006](../adr/0006-one-opt-in-deprecation-channel.md)), because Phel's own suite would flood stderr otherwise, so that cycle can never start; and the answer is no longer TBD, because the upgrade guide publishes it.

  The section now states what ships, and the consequence that follows from the [deprecation policy](../stability.md#deprecation-policy-for-1x): a deprecated form is removed **only in a major**, so a separator still shipping at `1.0.0` ships for the whole of `1.x`. The decision is not "now or later", it is "at 1.0 or not until 2.0".

  It also records the part that is easy to miss when weighing it: opt-in notice means whoever decides the removal decides it for users who were never warned unless they asked to be.

- **Tracking pointers repointed to #2827** in `backslash-to-dot.md` (twice), `upgrade-0.49-to-1.0.md`, `deprecated-surface.md` and `language-surface.md`. #1567 is named once, where it belongs: as the closed issue that delivered the deprecation and this migration path.

`docs/adr/0008` keeps its `tracked in #1567`, because an accepted record is immutable and that is what it was tracked in.

## ✅ Verification

Nothing in this PR changes behaviour. The compiler suites pass, the link checker reports no new broken references, and the claims were checked against the code rather than the issue text: `BackslashSeparatorDeprecator` is still injected, `\` still parses (`(in-ns test\ns\here)` yields `test.ns.here`), and it still warns twice under `--warn-deprecations`. The three acceptance sites #2827 lists are exactly where it says they are (`NsSymbol.php:419`, `:425`, `InNsSymbol.php:75`).
