### PR TITLE
feat(compiler): announce the separator deprecation without the flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,15 @@ All notable changes to this project will be documented in this file.
 - `phel eval -h` shows a heredoc example for multi-line evaluation
 - The normative [language-surface spec](docs/spec/language-surface.md) and [Clojure divergences](docs/spec/clojure-divergences.md). A test compares the special-form table against the analyzer's dispatch registry, so the spec cannot drift from the compiler
 - The [stability policy](docs/stability.md), plus migration guides for [0.49 to 1.0](docs/migration/upgrade-0.49-to-1.0.md), [live deprecations](docs/migration/deprecated-surface.md) and [removed core fns](docs/migration/removed-deprecated-core-fns.md)
-- [Architecture decision records](docs/adr/README.md): 13 records covering the decisions that read as oversights and get re-proposed, each naming the test that fails when it is broken
+- [Architecture decision records](docs/adr/README.md): 14 records covering the decisions that read as oversights and get re-proposed, each naming the test that fails when it is broken
 - Compatibility gates that fail the build on drift: snapshots of the public PHP surface (`composer api-surface:update`) and of every public `phel.*` definition and arity (`composer core-api:update`), plus a `:doc` gate on public definitions
 - Every class outside the public PHP surface carries `@internal`, so the split reaches IDEs and static analysis. A test pins both directions
 - CI: macOS is a supported platform (Windows stays declared best-effort), coverage is published and gated at 85%, benchmarks are asserted against the base revision, and mutation testing runs weekly over `src/php/Lang/` and the analyzer (MSI floor 80)
+
+### Changed
+
+- The `\` namespace separator now warns without `--warn-deprecations`. It is the last deprecated language surface and the one scheduled for removal at the next major, so an opt-in notice was no notice at all: the policy promises a minor of warning before a removal and nobody was being warned. Every other deprecation stays opt-in ([ADR 0014](docs/adr/0014-announce-the-separator-deprecation.md), #2827)
+- Deprecations are never reported for code under a `vendor/` directory. A dependency's spelling is its author's to fix, and reporting it is how a warning channel earns being globally silenced. This is the first-party scoping ADR 0006 named as the precondition for announcing anything by default (#2827)
 
 ### Fixed
 

--- a/docs/adr/0014-announce-the-separator-deprecation.md
+++ b/docs/adr/0014-announce-the-separator-deprecation.md
@@ -1,0 +1,90 @@
+# ADR 0014: The `\` separator deprecation announces by default
+
+- **Status**: Accepted
+- **Date**: 2026-08-02
+
+## Context
+
+[ADR 0006](0006-one-opt-in-deprecation-channel.md) put every compiler
+deprecation behind one opt-in switch, and listed "on by default" under
+alternatives considered with a precondition attached:
+
+> **On by default.** Revisit only with a way to scope notices to first-party
+> source.
+
+The `\` namespace separator is the last deprecated language surface
+([#2827](https://github.com/phel-lang/phel-lang/issues/2827)) and the only one
+with a real migration cost. Two facts make its opt-in notice a problem rather
+than a preference.
+
+The [deprecation policy](../stability.md#deprecation-policy-for-1x) removes a
+deprecated form **only in a major**, and promises "a notice for at least one full
+minor" first. A separator still shipping at `1.0.0` therefore ships for the whole
+of `1.x`, and the notice that is supposed to precede its removal has never been
+shown to anyone who did not ask for it. A promise of warning, kept only for users
+who already knew to look, is not kept.
+
+The reason the switch was opt-in has also expired for this detector. Announcing
+by default was noisy because Phel's own sources used the separator everywhere;
+after #2926 they do not. Measured on `main`: the whole core suite, 6597
+assertions, emitted **two** notices, both the same symbol, from
+`resources/repl/startup.phel`, which this change fixes.
+
+## Decision
+
+`BackslashSeparatorDeprecator` reports whether or not `--warn-deprecations` is
+set. Every other detector stays opt-in, and ADR 0006's decision is otherwise
+untouched: one channel, one owner of dedup, suppression, attribution and message
+shape.
+
+Two things make it affordable, and both are conditions of the decision rather
+than side effects:
+
+1. **First-party scoping**, the precondition ADR 0006 named.
+   `DeprecationWarnings::isReportableSource()` now also excludes any path under a
+   `vendor/` directory. A deprecation inside a dependency is its author's to fix,
+   and reporting it is how a channel earns the global silencing that loses it
+   permanently.
+2. **The existing per-`(file, subject)` dedup**, so a file naming one
+   `\`-separated symbol a hundred times reports once.
+
+`DeprecationWarnings::announceOnceAtOrigin()` is the entry point, and it is
+deliberately narrow: it is for a deprecation already scheduled for removal at the
+next major. It is not a general escape from the opt-in rule.
+
+## Consequences
+
+- A project on the backslash form sees the notice from `1.0.0` without opting in,
+  which is what makes a `2.0` removal defensible instead of abrupt.
+- Phel's own integration fixtures pin the deprecated syntax on purpose, so the
+  integration suite reports many notices where it used to report none. They are
+  first-party and correct: those fixtures really do use the deprecated form.
+- A project living under a directory literally named `vendor` is suppressed as
+  though it were a dependency. That is the safe direction to be wrong in: a
+  missing notice, never a misdirected one.
+- Announcing does not shorten the schedule. `\` still works throughout `1.x`;
+  #2827 owns the removal.
+
+## Enforcement
+
+- `BackslashSeparatorDeprecatorTest`: announces with the flag off, and stays
+  silent for a `vendor/` path.
+- `WarnDeprecationsFlagTest`: the separator is the documented exception; the
+  test that pinned silence now pins the announcement.
+- `DeprecationWarningsTest` covers `isReportableSource()`.
+
+## Alternatives considered
+
+- **Leave it opt-in and remove at 2.0 anyway.** Removes a form most users were
+  never warned about, at the one release where the project asks to be trusted on
+  stability.
+- **Remove `\` at 1.0.** Same objection, sooner, and it contradicts what
+  [the upgrade guide](../migration/upgrade-0.49-to-1.0.md) already promises.
+- **Flip the whole channel on.** The scoping now exists, but the other
+  deprecations are not scheduled for removal, so the noise buys nothing yet.
+
+## See also
+
+[ADR 0006](0006-one-opt-in-deprecation-channel.md) ·
+[ADR 0008](0008-dot-namespace-separator.md) ·
+[backslash-to-dot.md](../migration/backslash-to-dot.md) · #2827, #2926

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,6 +21,7 @@ Records are immutable: a changed decision gets a new ADR superseding the old one
 | [0011](0011-persistent-collections-in-php.md) | Persistent collections implemented in PHP | Accepted |
 | [0012](0012-non-hygienic-macros-with-auto-gensym.md) | Non-hygienic macros with auto-gensym | Accepted |
 | [0013](0013-static-property-spelling.md) | A static property is `$prop` to read and a plain name to assign | Accepted |
+| [0014](0014-announce-the-separator-deprecation.md) | The `\` separator deprecation announces by default | Accepted |
 
 Statuses: **Proposed**, **Accepted**, **Superseded by NNNN**, **Deprecated** (in
 force, being unwound).

--- a/docs/migration/backslash-to-dot.md
+++ b/docs/migration/backslash-to-dot.md
@@ -6,9 +6,23 @@ Tracking issue: [phel-lang/phel-lang#2827](https://github.com/phel-lang/phel-lan
 which owns the removal decision. [#1567](https://github.com/phel-lang/phel-lang/issues/1567)
 delivered the deprecation and this migration path, and is closed.
 
-## Opt-in to deprecation warnings
+## This one warns without being asked
 
-Three equivalent ways; pick whichever fits your pipeline.
+The separator is the single deprecation that announces by default
+([ADR 0014](../adr/0014-announce-the-separator-deprecation.md)): it is scheduled
+for removal at the next major, and a notice shown only to people who already knew
+to ask for it does not give anyone time to act. Every other deprecation stays
+opt-in.
+
+Two rules keep it quiet enough to live with. A file naming one `\`-separated
+symbol a hundred times reports **once** per `(file, symbol)`, and code under a
+`vendor/` directory is never reported: a dependency's spelling is its author's to
+fix.
+
+## Opt-in to the rest of the deprecations
+
+Three equivalent ways; pick whichever fits your pipeline. These turn on every
+*other* detector, and the separator reports either way.
 
 **CLI flag**, for one-off runs and CI:
 
@@ -40,11 +54,15 @@ Symbols flowing through the analyzer's `SymbolResolver` or the `ns`-form analyze
 
 - **Namespace declarations** (Phase 1b): `(ns phel\foo)` becomes `(ns phel.foo)`
 - **`:require` targets** (Phase 1b, flat and `[ns :as alias]` vector forms): `(:require phel\walk)` becomes `(:require phel.walk)`
-- **Fully-qualified call sites** (Phase 1a): `(phel\core/map inc xs)` becomes `(phel.core/map inc xs)`
 - **Leading-backslash class FQNs** (Phase 1a): `\Phel\Lang\ExceptionInfo` becomes `Phel.Lang.ExceptionInfo`. Dot alias landed in [#1553](https://github.com/phel-lang/phel-lang/issues/1553).
 - **`:use` targets**: `(:use Phel\Lang\Foo)` becomes `(:use Phel.Lang.Foo)`. The analyzer already accepted the dot form; the warning makes the migration target explicit.
 
 ## What is NOT yet detected
+
+A **fully-qualified call site** (`(phel\string/join "," xs)`) is the notable one:
+it is not reported, with or without the flag
+([#2931](https://github.com/phel-lang/phel-lang/issues/2931)). An earlier version
+of this page listed it as detected, which it has never been.
 
 Tracked as follow-up sub-tasks in #2827:
 
@@ -56,7 +74,10 @@ Migrate these positions by hand now; the dot forms already work at the language 
 
 ## Suppression
 
-Warnings are suppressed automatically for files under phel's bundled stdlib. User projects using the nested `src/phel` layout still emit warnings normally.
+Warnings are suppressed automatically for files under phel's bundled stdlib, and
+for anything under a `vendor/` directory: a dependency's spelling is its author's
+to fix, not yours. User projects using the nested `src/phel` layout still emit
+warnings normally, since the stdlib rule anchors on phel's own package path.
 
 ## Removal target
 
@@ -72,8 +93,12 @@ or not until 2.0", and [#2827](https://github.com/phel-lang/phel-lang/issues/282
 owns it.
 
 An earlier version of this page set the bar at "one full minor-release cycle
-after the warning flag flips on by default". That bar cannot be met as written:
-the flag is opt-in by design and stays that way
-([ADR 0006](../adr/0006-one-opt-in-deprecation-channel.md)), because phel's own
-suite would flood stderr otherwise. Whoever decides the removal is deciding it
-for users who were never warned unless they asked to be.
+after the warning flag flips on by default", which could not be met while the
+flag gated this notice: the switch is opt-in by design
+([ADR 0006](../adr/0006-one-opt-in-deprecation-channel.md)), so the cycle could
+never start and a removal would have landed on users who were never warned.
+
+That is now settled the other way. The separator announces without the flag from
+`1.0.0` ([ADR 0014](../adr/0014-announce-the-separator-deprecation.md)), so the
+notice period is running for everyone, and the removal at the next major follows
+a warning people actually saw.

--- a/docs/migration/deprecated-surface.md
+++ b/docs/migration/deprecated-surface.md
@@ -17,11 +17,14 @@ Everything the **compiler** knows about, syntax and definitions alike, goes
 through one switch: `Phel\Compiler\Domain\Deprecation\DeprecationWarnings`. It
 is off by default and reports when you ask for it.
 
-CLI-option deprecations are the one thing outside it: a renamed flag prints a
-one-line notice on stderr unconditionally, because it is a single unmissable
-event rather than something scattered through your source. No rename is in
-flight today, so there is no shared helper for it; see
+Two things are outside it. A renamed CLI flag prints a one-line notice on stderr
+unconditionally, because it is a single unmissable event rather than something
+scattered through your source; no rename is in flight today, so there is no
+shared helper for it, see
 [cli-flag-conventions.md](../internals/cli-flag-conventions.md#renaming-an-option).
+And the `\` namespace separator announces without the flag, because it is the one
+deprecation scheduled for removal at the next major
+([ADR 0014](../adr/0014-announce-the-separator-deprecation.md)).
 
 Turn compiler deprecation warnings on with any of:
 
@@ -34,8 +37,8 @@ PHEL_WARN_DEPRECATIONS=1 vendor/bin/phel test
 return PhelConfig::forProject()->withWarnDeprecations(true);
 ```
 
-Uses inside phel's own bundled stdlib are suppressed, so the output lists only
-code you own. Notices about a *definition* or a `\`-separated symbol are
+Uses inside phel's own bundled stdlib are suppressed, and so is anything under a
+`vendor/` directory, so the output lists only code you own. Notices about a *definition* or a `\`-separated symbol are
 deduplicated per `(file, subject)` pair, since one name can recur hundreds of
 times in a file. Syntax notices are not deduplicated: each occurrence is a
 separate edit you have to make.

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -111,10 +111,15 @@ are where to look.
    least one full minor, and is removed only in a major.
 2. **One channel.** Everything the compiler knows about reports through
    `Phel\Compiler\Domain\Deprecation\DeprecationWarnings`, off by default,
-   enabled with `--warn-deprecations` or `PHEL_WARN_DEPRECATIONS=1`. CLI option
-   renames are the documented exception and always print on stderr, because a
-   renamed flag is one unmissable event.
-   ([ADR 0006](adr/0006-one-opt-in-deprecation-channel.md).)
+   enabled with `--warn-deprecations` or `PHEL_WARN_DEPRECATIONS=1`. Two
+   documented exceptions announce without the flag: a CLI option rename, because
+   a renamed flag is one unmissable event, and the `\` namespace separator,
+   because it is scheduled for removal at the next major and a notice nobody is
+   shown does not keep rule 1's promise
+   ([ADR 0006](adr/0006-one-opt-in-deprecation-channel.md),
+   [ADR 0014](adr/0014-announce-the-separator-deprecation.md)).
+   A deprecation inside a `vendor/` path is never reported: it belongs to the
+   dependency's author.
 3. **No version promises in the message.** The release such a message names
    inevitably ships and the text goes stale. The tracking issue carries the
    schedule.

--- a/resources/repl/startup.phel
+++ b/resources/repl/startup.phel
@@ -1,8 +1,8 @@
 ;; This is the startup script that is launch in the REPL.
 (ns user
-  (:require phel\repl :refer [doc require use print-colorful println-colorful
+  (:require phel.repl :refer [doc require use print-colorful println-colorful
                               dir apropos search-doc symbol-info load-file source
                               test-ns eval-capturing eval-str macroexpand-1 macroexpand ns-list])
-  (:require phel\pprint :refer [pprint pprint-str])
-  (:require phel\walk :refer [walk postwalk prewalk postwalk-replace
+  (:require phel.pprint :refer [pprint pprint-str])
+  (:require phel.walk :refer [walk postwalk prewalk postwalk-replace
                               prewalk-replace keywordize-keys stringify-keys]))

--- a/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
@@ -24,7 +24,7 @@ use function str_starts_with;
  * Scope of detection is intentionally narrow: only symbols that pass
  * through `SymbolResolver::resolve()` — call sites and qualified refs.
  * `ns`, `:require`, `:use`, and related forms are tracked as follow-ups
- * in https://github.com/phel-lang/phel-lang/issues/1567.
+ * in https://github.com/phel-lang/phel-lang/issues/2827.
  *
  * @internal
  */
@@ -53,15 +53,15 @@ final class BackslashSeparatorDeprecator
 
     public function maybeWarnString(string $namespace, SourceLocation $location): void
     {
-        if (!DeprecationWarnings::isEnabled()) {
-            return;
-        }
-
+        // No `isEnabled()` short-circuit: this one deprecation announces
+        // whether or not the flag is on, because it is the one already
+        // scheduled for removal at the next major. `announceOnceAtOrigin()`
+        // still applies the dedup and the first-party scoping.
         if (!$this->containsBackslashSeparator($namespace)) {
             return;
         }
 
-        DeprecationWarnings::warnOnceAtOrigin(
+        DeprecationWarnings::announceOnceAtOrigin(
             $location,
             $namespace,
             fn(string $file, int $line): string => $this->buildMessage($namespace, $file, $line),

--- a/src/php/Compiler/Domain/Deprecation/DeprecationWarnings.php
+++ b/src/php/Compiler/Domain/Deprecation/DeprecationWarnings.php
@@ -82,9 +82,34 @@ final class DeprecationWarnings
      */
     public static function isEnabledForSource(string $sourceFile): bool
     {
-        return self::isEnabled()
-            && $sourceFile !== ''
-            && !self::isBundledStdlibSource($sourceFile);
+        return self::isEnabled() && self::isReportableSource($sourceFile);
+    }
+
+    /**
+     * Whether a deprecation in `$sourceFile` names code the user can edit,
+     * independently of whether the flag is on.
+     *
+     * Two sources are excluded. Phel's own `src/phel`, for the reason below,
+     * and anything under a `vendor/` directory: a deprecation inside a
+     * dependency is the dependency author's to fix, and reporting it is how a
+     * channel earns the global silencing that loses it permanently. ADR 0006
+     * named this scoping as the precondition for ever announcing a deprecation
+     * by default, and `announceOnceAtOrigin()` is what spends it.
+     *
+     * A project living under a directory literally named `vendor` is
+     * suppressed too. That is the safe direction to be wrong in: a missing
+     * notice, never a misdirected one.
+     */
+    public static function isReportableSource(string $sourceFile): bool
+    {
+        return $sourceFile !== ''
+            && !self::isBundledStdlibSource($sourceFile)
+            && !self::isThirdPartySource($sourceFile);
+    }
+
+    public static function isThirdPartySource(string $file): bool
+    {
+        return str_contains(self::normalizePath($file) . '/', '/vendor/');
     }
 
     /**
@@ -179,13 +204,29 @@ final class DeprecationWarnings
         string $subject,
         callable $buildMessage,
     ): void {
-        $reportAt = $location->getExpansionOrigin() ?? $location;
+        self::reportOnceAtOrigin($location, $subject, $buildMessage, announced: false);
+    }
 
-        self::warnOnceForSource(
-            $reportAt->getFile(),
-            $subject,
-            $buildMessage($reportAt->getFile(), $reportAt->getLine()) . self::expansionSuffix($location),
-        );
+    /**
+     * Like {@see warnOnceAtOrigin()}, but reports whether or not the flag is
+     * on. Reserved for a deprecation already scheduled for removal at the next
+     * major, where an opt-in notice is no notice at all: the policy promises
+     * "one full minor of warning", and a warning nobody is shown does not keep
+     * that promise.
+     *
+     * Every other rule still applies, and they are what makes this safe: the
+     * per-`(file, subject)` dedup, the expansion attribution, and the
+     * first-party scoping in {@see isReportableSource()}, so a dependency's
+     * code stays quiet.
+     *
+     * @param callable(string, int): string $buildMessage receives the file and line to report against
+     */
+    public static function announceOnceAtOrigin(
+        SourceLocation $location,
+        string $subject,
+        callable $buildMessage,
+    ): void {
+        self::reportOnceAtOrigin($location, $subject, $buildMessage, announced: true);
     }
 
     /**
@@ -245,6 +286,35 @@ final class DeprecationWarnings
             $reportAt instanceof SourceLocation ? $reportAt->getFile() : '',
             self::syntaxMessage($construct, $purpose, $replacement, $reportAt) . self::expansionSuffix($location),
         );
+    }
+
+    /**
+     * @param callable(string, int): string $buildMessage
+     */
+    private static function reportOnceAtOrigin(
+        SourceLocation $location,
+        string $subject,
+        callable $buildMessage,
+        bool $announced,
+    ): void {
+        $reportAt = $location->getExpansionOrigin() ?? $location;
+        $sourceFile = $reportAt->getFile();
+
+        if (!$announced && !self::isEnabled()) {
+            return;
+        }
+
+        if (!self::isReportableSource($sourceFile)) {
+            return;
+        }
+
+        $key = $sourceFile . '|' . $subject;
+        if (isset(self::$seen[$key])) {
+            return;
+        }
+
+        self::$seen[$key] = true;
+        self::raise($buildMessage($sourceFile, $reportAt->getLine()) . self::expansionSuffix($location));
     }
 
     private static function raise(string $message): void

--- a/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
@@ -49,13 +49,27 @@ final class BackslashSeparatorDeprecatorTest extends TestCase
         self::assertStringContainsString("'Phel.Lang.Foo'", $captured[0]);
     }
 
-    public function test_stays_silent_when_warnings_are_disabled(): void
+    public function test_announces_even_when_warnings_are_disabled(): void
     {
+        // The one deprecation that does not wait for `--warn-deprecations`:
+        // it is scheduled for removal at the next major, and a notice nobody
+        // is shown does not keep the policy's promise of a minor of warning.
         DeprecationWarnings::disable();
 
         $this->deprecator()->maybeWarn($this->locatedRawNameSymbol('phel\\core/map', '/app/user.phel'));
 
-        self::assertSame([], $this->capturedDeprecations());
+        self::assertCount(1, $this->capturedDeprecations());
+    }
+
+    public function test_stays_silent_for_a_dependency(): void
+    {
+        DeprecationWarnings::disable();
+
+        $this->deprecator()->maybeWarn(
+            $this->locatedRawNameSymbol('phel\\core/map', '/app/vendor/acme/lib/src/x.phel'),
+        );
+
+        self::assertSame([], $this->capturedDeprecations(), 'a dependency is not the user to fix it');
     }
 
     public function test_no_warning_for_dot_separated_symbol(): void

--- a/tests/php/Unit/Compiler/Deprecation/DeprecationWarningsTest.php
+++ b/tests/php/Unit/Compiler/Deprecation/DeprecationWarningsTest.php
@@ -66,6 +66,26 @@ final class DeprecationWarningsTest extends TestCase
         }));
     }
 
+    public function test_source_gate_suppresses_a_dependency(): void
+    {
+        DeprecationWarnings::enable();
+
+        $vendorFile = '/app/vendor/acme/lib/src/thing.phel';
+
+        self::assertTrue(DeprecationWarnings::isThirdPartySource($vendorFile));
+        self::assertFalse(DeprecationWarnings::isReportableSource($vendorFile));
+        self::assertSame([], $this->capture(static function () use ($vendorFile): void {
+            DeprecationWarnings::warnForSource($vendorFile, 'a dependency deprecation');
+        }));
+    }
+
+    public function test_a_vendor_named_segment_is_only_matched_whole(): void
+    {
+        self::assertFalse(DeprecationWarnings::isThirdPartySource('/app/vendored/src/thing.phel'));
+        self::assertFalse(DeprecationWarnings::isThirdPartySource('/app/my-vendor/src/thing.phel'));
+        self::assertTrue(DeprecationWarnings::isThirdPartySource('/app/vendor'));
+    }
+
     public function test_source_gate_allows_user_sources_including_nested_src_phel(): void
     {
         DeprecationWarnings::enable();

--- a/tests/php/Unit/Console/Application/WarnDeprecationsFlagTest.php
+++ b/tests/php/Unit/Console/Application/WarnDeprecationsFlagTest.php
@@ -80,8 +80,10 @@ final class WarnDeprecationsFlagTest extends TestCase
         self::assertSame(['phel', 'run', 'src/main.phel'], $result);
     }
 
-    public function test_detectors_stay_silent_when_the_flag_is_absent(): void
+    public function test_the_separator_announces_when_the_flag_is_absent(): void
     {
+        // The documented exception to the opt-in channel: the separator is the
+        // one deprecation already scheduled for removal at the next major.
         DeprecationWarnings::disable();
         $this->captureDeprecationsWithoutEnabling();
 
@@ -93,7 +95,7 @@ final class WarnDeprecationsFlagTest extends TestCase
             $this->locatedRawNameSymbol('phel\\core/map', '/app/user.phel'),
         );
 
-        self::assertSame([], $this->capturedDeprecations());
+        self::assertCount(1, $this->capturedDeprecations());
     }
 
     /**


### PR DESCRIPTION
## 🤔 Background

The `\` namespace separator is the last deprecated language surface. Two facts about it collide with a 1.0:

- The [deprecation policy](../blob/main/docs/stability.md#deprecation-policy-for-1x) removes a deprecated form **only in a major**, and promises "a notice for at least one full minor" first. A separator still shipping at `1.0.0` therefore ships for all of `1.x`.
- That notice has never been shown to anyone who did not ask for it. `--warn-deprecations` is off by default, so the promise was being kept only for users who already knew to look.

[ADR 0006](../blob/main/docs/adr/0006-one-opt-in-deprecation-channel.md) anticipated this and set a price for revisiting it:

> **On by default.** Revisit only with a way to scope notices to first-party source.

That scoping did not exist: suppression covered Phel's own `src/phel` and nothing else, so a user's dependency would warn about spelling its author owns.

Related: #2827, #2926.

## 💡 Goal

The notice period runs for everyone from `1.0.0`, so removing `\` at the next major follows a warning people actually saw. `\` keeps working throughout `1.x`; this changes who hears about it, not the schedule.

## 🔖 Changes

- **First-party scoping**, the precondition ADR 0006 named. `DeprecationWarnings::isReportableSource()` now also excludes any path under a `vendor/` directory, for every detector, flag or no flag. A project living under a directory literally named `vendor` is suppressed too: a missing notice is the safe direction to be wrong in.
- **`announceOnceAtOrigin()`**, deliberately narrow: for a deprecation already scheduled for removal at the next major. Every other rule still applies and is what makes it affordable, in particular the per-`(file, subject)` dedup, so a file naming one `\` symbol a hundred times reports once.
- `BackslashSeparatorDeprecator` uses it, and drops its `isEnabled()` short-circuit. Every other detector stays opt-in.
- `resources/repl/startup.phel` required `phel\repl`, `phel\pprint` and `phel\walk`, so every REPL session was about to greet the user with three deprecation notices.
- **[ADR 0014](../blob/main/docs/adr/0014-announce-the-separator-deprecation.md)** records it, including why this is not a general escape from ADR 0006 and why the noise argument expired: after #2926 the stdlib no longer uses the separator.
- `stability.md`, `deprecated-surface.md` and `backslash-to-dot.md` updated, the last one substantially, because two of its sections asserted the opposite of what now ships.

## ✅ Verification

Measured rather than assumed. Before this branch, the whole core suite emitted **two** notices, both the same symbol from `startup.phel`; that was the evidence the noise argument had expired, and it is now zero.

End to end on a throwaway project with a Phel dependency:

```
symbol '\Phel\Lang\Keyword' at .../vendorprobe/src/main.phel:4 is deprecated ...
```

One notice, from the user's file, with no flag set. The dependency at `vendor/acme/lib/src/dep.phel` uses the identical spelling and stays silent.

Phel's own integration fixtures pin the deprecated syntax on purpose, so that suite now reports 161 deprecations where it reported 2. Nothing fails on them, and they are correct: those fixtures really do use the deprecated form.

## ⚠️ Found while verifying, not fixed here

A **fully-qualified call site** (`(phel\string/join "," xs)`) emits no notice, with or without the flag, and `backslash-to-dot.md` claimed it was detected. Filed as **#2931**; the false claim is corrected in this PR rather than left to mislead. It matters for the same reason this PR does: announcing is only as good as the detector's reach, and a project whose `\` usage is mostly call sites still hears nothing.
