### PR TITLE
fix(compiler): detect a backslash separator on a qualified call site

### DIFF
--- a/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
@@ -48,7 +48,7 @@ final class BackslashSeparatorDeprecator
             return;
         }
 
-        $this->maybeWarnString($symbol->getFullName(), $location);
+        $this->maybeWarnString($this->rawFullName($symbol), $location);
     }
 
     public function maybeWarnString(string $namespace, SourceLocation $location): void
@@ -66,6 +66,27 @@ final class BackslashSeparatorDeprecator
             $namespace,
             fn(string $file, int $line): string => $this->buildMessage($namespace, $file, $line),
         );
+    }
+
+    /**
+     * The symbol as written, rather than as displayed.
+     *
+     * `Symbol::getFullName()` renders through `displayNamespace()`, which
+     * rewrites a `\` separator to `.` and only leaves a leading `\` alone. Ask
+     * it and a qualified call site (`phel\string/join`) has already been
+     * canonicalised, so the separator this class exists to find is gone before
+     * it looks: only class FQNs ever warned (#2931). The raw namespace is what
+     * the user typed.
+     */
+    private function rawFullName(Symbol $symbol): string
+    {
+        $namespace = $symbol->getNamespace();
+
+        if ($namespace === null || $namespace === '') {
+            return $symbol->getName();
+        }
+
+        return $namespace . '/' . $symbol->getName();
     }
 
     /**

--- a/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
@@ -49,6 +49,19 @@ final class BackslashSeparatorDeprecatorTest extends TestCase
         self::assertStringContainsString("'Phel.Lang.Foo'", $captured[0]);
     }
 
+    public function test_emits_for_a_qualified_call_site(): void
+    {
+        // The shape the reader really produces: namespace and name held
+        // separately. `getFullName()` renders that through the canonical dot
+        // translation, so asking it hid every call site (#2931).
+        $this->deprecator()->maybeWarn($this->locatedSymbol('phel\\string', 'join', '/app/user.phel'));
+
+        $captured = $this->capturedDeprecations();
+        self::assertCount(1, $captured);
+        self::assertStringContainsString("'phel\\string/join'", $captured[0]);
+        self::assertStringContainsString("'phel.string/join'", $captured[0]);
+    }
+
     public function test_announces_even_when_warnings_are_disabled(): void
     {
         // The one deprecation that does not wait for `--warn-deprecations`:
@@ -227,9 +240,13 @@ final class BackslashSeparatorDeprecatorTest extends TestCase
     }
 
     /**
-     * Builds a Symbol whose raw name preserves backslash separators verbatim
-     * so the deprecator sees the legacy form via `getFullName()` without the
-     * canonical dot translation kicking in.
+     * Builds a Symbol whose raw name preserves backslash separators verbatim,
+     * by holding the whole thing in the *name* with no namespace.
+     *
+     * This is the shape `in-ns` and the `ns` form hand over, since they detect
+     * on the text before it is split. A qualified call site arrives split
+     * instead, which is what {@see test_emits_for_a_qualified_call_site()}
+     * covers; relying on this helper alone is how #2931 stayed hidden.
      */
     private function locatedRawNameSymbol(string $rawName, string $file): Symbol
     {


### PR DESCRIPTION
## 🤔 Background

A fully-qualified call site written with `\` emitted no deprecation notice, with or without `--warn-deprecations`, while `backslash-to-dot.md` listed that exact shape as detected.

```bash
./bin/phel eval --warn-deprecations '(do (require phel.string) (phel\string/join "," ["a" "b"]))'
# nothing
```

Closes #2931

## 💡 Goal

The detector sees what the user wrote.

```
symbol 'phel\string/join' at string:1 is deprecated; use dot ('.') instead
  ... e.g. 'phel.string/join'.
```

## 🔖 Changes

`BackslashSeparatorDeprecator::maybeWarn()` asked `Symbol::getFullName()`, which renders through `displayNamespace()`, and `displayNamespace()` rewrites a `\` separator to `.`. The separator this class exists to find was gone before it looked. Only a class FQN ever warned, because a namespace beginning with `\` is the one case `displayNamespace()` passes through untouched, which is exactly the pattern the old behaviour showed.

It now reads the raw namespace.

### Why the tests did not catch it

`locatedRawNameSymbol()` builds its symbol by putting the whole raw name in the **name** field with no namespace, so the display translation never ran. That is a real shape, the one `ns` and `in-ns` hand over, since they detect on the text before it is split. A qualified call site arrives split instead, and nothing exercised that. `test_emits_for_a_qualified_call_site()` uses `Symbol::createForNamespace('phel\string', 'join')`, the shape the reader actually produces, and the helper's docblock now says which shape it stands for.

### Verified

| Written | Before | After |
|---|---|---|
| `(phel\string/join "," xs)` | silent | reported |
| `(phel\core/count [1])` | silent | reported |
| `\Phel\Lang\Symbol` | reported | reported |
| `(phel.core/count [1])` | silent | silent |

## ⚠️ Note on suite timing

The integration suite got slower on this branch locally, and I could not finish isolating it: `paratest` also hung on a **clean tree** in the same environment, so the local signal is unreliable. The plausible mechanism is real, though, and worth watching on CI rather than dismissing: this fix multiplies how many notices a `\`-heavy fixture set emits, and each notice costs a `trigger_error` with `display_errors` juggling around it. If the CI integration job is materially slower than on #2932, the dedup granularity is the thing to revisit.
