### PR TITLE
feat(compiler): warn when a `def` shadows a PHP class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- A `def` whose name is a loadable PHP class warns. The definition wins from there on, so `(def DateTime "shadow")` used to make `(new DateTime)` fail with `Class "shadow" not found` and nothing said why. Clojure refuses the `def`; Phel warns for now and names `\DateTime` as the spelling that still reaches the class, with the refusal scheduled for the major that drops the leading `\` (#2876)
+
 - The `\` namespace separator now warns without `--warn-deprecations`. It is the last deprecated language surface and the one scheduled for removal at the next major, so an opt-in notice was no notice at all: the policy promises a minor of warning before a removal and nobody was being warned. Every other deprecation stays opt-in ([ADR 0014](docs/adr/0014-announce-the-separator-deprecation.md), #2827)
 - Deprecations are never reported for code under a `vendor/` directory. A dependency's spelling is its author's to fix, and reporting it is how a warning channel earns being globally silenced. This is the first-party scoping ADR 0006 named as the precondition for announcing anything by default (#2827)
 

--- a/docs/spec/clojure-divergences.md
+++ b/docs/spec/clojure-divergences.md
@@ -127,6 +127,31 @@ than syntax ([#2881](https://github.com/phel-lang/phel-lang/issues/2881)). A
 receiver the compiler can prove is an object still emits `->`, so only an
 unprovable one carries the runtime test.
 
+### A `def` may shadow a PHP class, and warns
+
+Clojure refuses it outright:
+
+```clojure
+user=> (def RuntimeException "shadow")
+Syntax error compiling def at (REPL:1:1).
+Expecting var, but RuntimeException is mapped to class java.lang.RuntimeException
+```
+
+Phel accepts the `def` and warns, because the definition really does win from
+there on: the bare-host-symbol fallback resolves a Phel definition before a
+class, so `(new DateTime)` after `(def DateTime "shadow")` fails with
+`Class "shadow" not found`. The warning names `\DateTime` as the spelling that
+still reaches the class.
+
+Warning rather than refusing is a timing decision, not a preference. Refusing is
+a breaking change, and the [deprecation policy](../stability.md#deprecation-policy-for-1x)
+buys one with a minor of notice first. The refusal belongs to the major that also
+drops the leading `\`, because that is when a bare class name has to be
+unambiguous ([#2876](https://github.com/phel-lang/phel-lang/issues/2876),
+[#2827](https://github.com/phel-lang/phel-lang/issues/2827)). Until then the
+leading `\` is the escape, and Clojure needs no equivalent because Java packages
+are lower case while PHP's are not.
+
 ### `Class/new` is not a constructor
 
 Clojure 1.12 reads `File/new` in value position as the constructor. Phel does not:

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -139,6 +139,7 @@ Two channels, differing only in the gate. Both raise through `Domain/Diagnostic/
 | Detector | Catches |
 |---|---|
 | `Domain/Analyzer/Environment/ReferShadowWarner` | a `def` whose name is already `:refer`red into the same namespace (#2897). Called from `DefSymbol` before `addDefinition`, so it warns once at `def` time like Clojure, not at every call site. Anchors on the *name* symbol: the enclosing list carries a `defn` expansion origin in `src/phel/core/defs.phel`, which the stdlib suppression would silence |
+| `Domain/Analyzer/Environment/ClassShadowWarner` | a `def` whose name is a loadable PHP class (#2876). Same hook point and the same reason to warn at `def` time. Filters on a PHP-identifier regex before probing, because `PhpClassLike::exists()` autoloads and `def` runs thousands of times loading the stdlib. Warns rather than refusing, which is what Clojure does; refusing is breaking and belongs to the major that drops the leading `\` |
 
 Not to be confused with `Phel\Lsp\Application\Diagnostics` (LSP publishing) or `Phel\Shared\Api\Diagnostic` (the Lint value object). Same word, unrelated concepts.
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/ClassShadowWarner.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/ClassShadowWarner.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Environment;
+
+use Phel\Compiler\Domain\Analyzer\PhpClassLike;
+use Phel\Compiler\Domain\Diagnostic\CompilerWarnings;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+
+use function preg_match;
+use function sprintf;
+
+/**
+ * Detects a `def` whose name is already a loadable PHP class.
+ *
+ * The definition wins from there on: `SymbolResolver`'s bare-host-symbol
+ * fallback resolves a Phel definition before it considers a class, so
+ * `(def DateTime "shadow")` makes `(new DateTime)` fail with
+ * `Class "shadow" not found` and nothing says why.
+ *
+ * Clojure refuses the `def` outright ("Expecting var, but RuntimeException is
+ * mapped to class java.lang.RuntimeException"), which is what makes a bare
+ * class name safe to write there. Phel warns rather than throws, because
+ * refusing is a breaking change and the
+ * [deprecation policy](../../../../../docs/stability.md) buys that with a
+ * minor of notice first. The refusal belongs to the same major that drops the
+ * leading `\` (#2876, #2827).
+ *
+ * Detection only: the stdlib suppression and the per-`(file, subject)` dedup
+ * belong to {@see CompilerWarnings}, which is why this class is stateless.
+ *
+ * @internal
+ */
+final class ClassShadowWarner
+{
+    /**
+     * A name PHP could resolve to a class. Nearly every Phel name fails it
+     * (`my-fn`, `empty?`, `set!`), which matters: {@see PhpClassLike::exists()}
+     * autoloads, and `def` runs thousands of times loading the stdlib alone.
+     */
+    private const string PHP_IDENTIFIER = '/^[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*$/';
+
+    private static ?self $instance = null;
+
+    /**
+     * Shared instance. Stateless, so it exists only to spare the analyzer a
+     * per-def allocation; there is nothing to reset between runs.
+     */
+    public static function getInstance(): self
+    {
+        return self::$instance ??= new self();
+    }
+
+    public function maybeWarn(string $ns, Symbol $name): void
+    {
+        $shadowed = $name->getName();
+
+        if (preg_match(self::PHP_IDENTIFIER, $shadowed) !== 1) {
+            return;
+        }
+
+        $location = $name->getStartLocation();
+        if (!$location instanceof SourceLocation) {
+            return;
+        }
+
+        if (!PhpClassLike::exists($shadowed)) {
+            return;
+        }
+
+        CompilerWarnings::warnOnceForSource(
+            $location->getFile(),
+            $ns . '/' . $shadowed,
+            sprintf(
+                '%s is mapped to the PHP class %s, and defining it here makes the '
+                . 'class unreachable by that name in namespace %s (at %s:%d). '
+                . 'Reach the class as \\%s, or rename the definition.',
+                $shadowed,
+                $shadowed,
+                $ns,
+                $location->getFile(),
+                $location->getLine(),
+                $shadowed,
+            ),
+        );
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -11,6 +11,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\DefNode;
 use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MultiFnNode;
+use Phel\Compiler\Domain\Analyzer\Environment\ClassShadowWarner;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Environment\ReferShadowWarner;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
@@ -79,6 +80,8 @@ final readonly class DefSymbol implements SpecialFormAnalyzerInterface
             $nameSymbol,
             $this->analyzer->getRefers($namespace),
         );
+
+        ClassShadowWarner::getInstance()->maybeWarn($namespace, $nameSymbol);
 
         $this->analyzer->addDefinition($namespace, $nameSymbol, $this->defonce);
 

--- a/tests/php/Unit/Compiler/Analyzer/Environment/ClassShadowWarnerTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/ClassShadowWarnerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\Environment;
+
+use Phel\Compiler\Domain\Analyzer\Environment\ClassShadowWarner;
+use Phel\Compiler\Domain\Diagnostic\CompilerWarnings;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+use PhelTest\Support\CapturesCompilerWarningsTrait;
+use PHPUnit\Framework\TestCase;
+
+final class ClassShadowWarnerTest extends TestCase
+{
+    use CapturesCompilerWarningsTrait;
+
+    protected function setUp(): void
+    {
+        CompilerWarnings::reset();
+        $this->startCapturingCompilerWarnings();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->stopCapturingCompilerWarnings();
+        CompilerWarnings::reset();
+    }
+
+    public function test_warns_when_a_def_shadows_a_php_class(): void
+    {
+        ClassShadowWarner::getInstance()->maybeWarn('user', $this->named('DateTime'));
+
+        $captured = $this->capturedCompilerWarnings();
+        self::assertCount(1, $captured);
+        self::assertStringContainsString('DateTime is mapped to the PHP class DateTime', $captured[0]);
+        self::assertStringContainsString('\\DateTime', $captured[0], 'names the spelling that still reaches the class');
+    }
+
+    public function test_is_silent_for_an_ordinary_phel_name(): void
+    {
+        ClassShadowWarner::getInstance()->maybeWarn('user', $this->named('my-thing'));
+
+        self::assertSame([], $this->capturedCompilerWarnings());
+    }
+
+    public function test_is_silent_for_a_name_php_cannot_spell(): void
+    {
+        // The cheap filter that keeps `def` off the autoloader: these can never
+        // be a class, so the existence probe never runs.
+        foreach (['empty?', 'set!', 'a->b', '*ns*'] as $name) {
+            ClassShadowWarner::getInstance()->maybeWarn('user', $this->named($name));
+        }
+
+        self::assertSame([], $this->capturedCompilerWarnings());
+    }
+
+    public function test_is_silent_for_a_pascal_case_name_that_is_no_class(): void
+    {
+        ClassShadowWarner::getInstance()->maybeWarn('user', $this->named('NotARealClassAnywhere'));
+
+        self::assertSame([], $this->capturedCompilerWarnings());
+    }
+
+    public function test_dedupes_per_file_and_name(): void
+    {
+        ClassShadowWarner::getInstance()->maybeWarn('user', $this->named('DateTime'));
+        ClassShadowWarner::getInstance()->maybeWarn('user', $this->named('DateTime'));
+
+        self::assertCount(1, $this->capturedCompilerWarnings());
+    }
+
+    public function test_is_silent_without_a_location(): void
+    {
+        ClassShadowWarner::getInstance()->maybeWarn('user', Symbol::create('DateTime'));
+
+        self::assertSame([], $this->capturedCompilerWarnings());
+    }
+
+    private function named(string $name): Symbol
+    {
+        $symbol = Symbol::create($name);
+        $symbol->setStartLocation(new SourceLocation('/app/user.phel', 1, 1));
+
+        return $symbol;
+    }
+}


### PR DESCRIPTION
## 🤔 Background

[#2876 (comment)](https://github.com/phel-lang/phel-lang/issues/2876#issuecomment-5156046021): #2926 kept the leading `\` on single-segment class names, and gave this as the reason a bare name is not simply equivalent:

> `(def DateTime "shadow")` followed by `(new DateTime)` fails with `Class "shadow" not found`.

@jasalt pointed out that Clojure does not have this problem because it refuses the `def`:

```clojure
user=> (def RuntimeException "shadow")
Syntax error compiling def at (REPL:1:1).
Expecting var, but RuntimeException is mapped to class java.lang.RuntimeException
```

That is the right observation, and it removes the objection rather than working around it. If a definition cannot shadow a class, a bare class name is unambiguous and #2876 can drop the leading `\`.

## 💡 Goal

Start the clock on that guarantee now, so the refusal is available to the major that needs it.

```
Warning: DateTime is mapped to the PHP class DateTime, and defining it here makes
the class unreachable by that name in namespace user (at src/main.phel:3).
Reach the class as \DateTime, or rename the definition.
```

## 🔖 Changes

- `ClassShadowWarner`, a sibling of `ReferShadowWarner`, called from `DefSymbol` at the same point: before `addDefinition`, anchored on the *name* symbol so a `defn` reports against the user's file rather than `src/phel/core/defs.phel`.
- It warns through `CompilerWarnings`, the always-on channel, which is the right one: this is a diagnostic about something that **has already changed what the program does**, not a deprecation.

### Why warn rather than refuse

Refusing is what Clojure does and where this should end up. It is also a breaking change, and the [deprecation policy](../blob/main/docs/stability.md#deprecation-policy-for-1x) buys one with a minor of notice first. Shipping the refusal in `1.0.0` would break any project with a `def` named after a class it never intended to reach, with no warning cycle at all.

So: warn in `1.x`, refuse in the major that drops the leading `\`, which is exactly when a bare class name has to be unambiguous (#2876, #2827). The warning names `\DateTime` as the spelling that still works today.

### The autoloader cost, which is why the filter exists

`PhpClassLike::exists()` autoloads, and `def` runs thousands of times just loading the standard library. The warner therefore filters on a PHP-identifier regex first, so `my-fn`, `empty?`, `set!` and `*ns*` never reach the probe. Only a name PHP could actually spell as a class costs a lookup.

Measured: loading the whole core suite emits **zero** of these warnings and shows no change in the suite's own timing.

### Tests

`ClassShadowWarnerTest` covers the shadow, an ordinary Phel name, the names PHP cannot spell, a PascalCase name that is not a class, the per-`(file, name)` dedup, and a symbol with no location.

`(defstruct Point [x y])` still works: it defines the class rather than shadowing one.
