### PR TITLE
docs(adr): record how a PHP class is named after the separator goes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,14 @@ All notable changes to this project will be documented in this file.
 - `phel eval -h` shows a heredoc example for multi-line evaluation
 - The normative [language-surface spec](docs/spec/language-surface.md) and [Clojure divergences](docs/spec/clojure-divergences.md). A test compares the special-form table against the analyzer's dispatch registry, so the spec cannot drift from the compiler
 - The [stability policy](docs/stability.md), plus migration guides for [0.49 to 1.0](docs/migration/upgrade-0.49-to-1.0.md), [live deprecations](docs/migration/deprecated-surface.md) and [removed core fns](docs/migration/removed-deprecated-core-fns.md)
-- [Architecture decision records](docs/adr/README.md): 14 records covering the decisions that read as oversights and get re-proposed, each naming the test that fails when it is broken
+- [Architecture decision records](docs/adr/README.md): 15 records covering the decisions that read as oversights and get re-proposed, each naming the test that fails when it is broken
 - Compatibility gates that fail the build on drift: snapshots of the public PHP surface (`composer api-surface:update`) and of every public `phel.*` definition and arity (`composer core-api:update`), plus a `:doc` gate on public definitions
 - Every class outside the public PHP surface carries `@internal`, so the split reaches IDEs and static analysis. A test pins both directions
 - CI: macOS is a supported platform (Windows stays declared best-effort), coverage is published and gated at 85%, benchmarks are asserted against the base revision, and mutation testing runs weekly over `src/php/Lang/` and the analyzer (MSI floor 80)
 
 ### Changed
+
+- The spelling a PHP class will have after `\` goes is recorded: dotted or bare, with no leading marker, and the marker retires with the separator rather than becoming permanent ([ADR 0015](docs/adr/0015-a-php-class-is-named-with-dots.md), #2876). Nothing changes in `1.x`, where both spellings work
 
 - A `def` whose name is a loadable PHP class warns. The definition wins from there on, so `(def DateTime "shadow")` used to make `(new DateTime)` fail with `Class "shadow" not found` and nothing said why. Clojure refuses the `def`; Phel warns for now and names `\DateTime` as the spelling that still reaches the class, with the refusal scheduled for the major that drops the leading `\` (#2876)
 

--- a/docs/adr/0015-a-php-class-is-named-with-dots.md
+++ b/docs/adr/0015-a-php-class-is-named-with-dots.md
@@ -1,0 +1,120 @@
+# ADR 0015: A PHP class is named with dots and no leading marker
+
+- **Status**: Proposed. Nothing in `1.x` depends on accepting it, and it should
+  carry @jasalt's review before it does: the Clojure-alignment argument is his
+  ([#2876](https://github.com/phel-lang/phel-lang/issues/2876#issuecomment-5156046021),
+  [#2859](https://github.com/phel-lang/phel-lang/issues/2859#issuecomment-5152721973)),
+  and this record only follows it to its conclusion.
+- **Date**: 2026-08-02
+- **Supersedes**: none. Settles the question [ADR 0008](0008-dot-namespace-separator.md) left open.
+
+## Context
+
+Phel spells a PHP class three ways today: `\Phel\Lang\Symbol`, `Phel.Lang.Symbol`,
+and, for a root class, `\DateTime` or `DateTime`. The leading `\` is not the
+separator, it is a marker meaning "this is a host class", and
+[#2876](https://github.com/phel-lang/phel-lang/issues/2876) exists because the two
+questions kept being conflated: dropping the separator does not by itself decide
+the marker's fate.
+
+Clojure needs no marker. `java.util.Date` is unambiguous because JVM packages are
+lower case and class names are not, and because a `def` **cannot** shadow a class:
+
+```clojure
+user=> (def RuntimeException "shadow")
+Syntax error compiling def at (REPL:1:1).
+Expecting var, but RuntimeException is mapped to class java.lang.RuntimeException
+```
+
+PHP is close enough for the same shape to work. A vendor namespace is
+conventionally PascalCase (`Symfony\Component\…`, `League\Uri\…`), so an
+upper-case first segment identifies a host class as reliably as lower case
+identifies a package on the JVM. Of the 99 PSR-4 namespaces installed in this
+repository, one begins lower case.
+
+The push to write Phel's own sources in the dot spelling, and the observation
+that Clojure's refusal is what makes a bare class name safe, both came from
+@jasalt. This record is those two arguments carried to their conclusion rather
+than a separate proposal.
+
+Two things were missing, and both landed first:
+
+- Phel's own sources modelled the old spelling, so no migration could be argued
+  from them ([#2926](https://github.com/phel-lang/phel-lang/pull/2926)).
+- A `def` silently shadowed a class, which is what made a bare name genuinely
+  less safe than a marked one ([#2934](https://github.com/phel-lang/phel-lang/pull/2934),
+  suggested by @jasalt). It now warns.
+
+## Decision
+
+**The destination is the Clojure shape.** A PHP class is written with the dot
+separator and no marker:
+
+```phel
+(new DateTime "now")
+(new Phel.Lang.Keyword "x")
+Phel.Lang.Symbol
+Symfony.Component.Console.Command.Command/SUCCESS
+```
+
+1. `.` is the separator, for Phel namespaces and PHP class names alike.
+2. A class reference is identified lexically, by an upper-case first segment.
+   No reflection, so meaning never depends on what happened to be loaded.
+3. A namespace whose first segment is lower case (`phpDocumentor\Reflection\…`)
+   is reached by importing it, `(:use phpDocumentor.Reflection.DocBlock)`, which
+   is Phel's `:import`. This is the one place PHP's conventions are looser than
+   the JVM's, and an import is the answer Clojure already gives.
+4. **The leading `\` retires with the separator**, at the next major. It is not
+   promoted to a permanent marker, and `\Phel.Lang.Symbol` is deliberately never
+   made to work: a marker that survives is a second way to say one thing.
+5. The `def`-shadows-a-class **warning becomes a refusal** in that same major.
+   That is what makes a bare name safe, and it is the guarantee Clojure gives.
+
+**Not at 1.0.** `\` keeps working for all of `1.x`, as
+[the upgrade guide](../migration/upgrade-0.49-to-1.0.md) already promises. Its
+notice period only starts at `1.0.0`, when the deprecation begins announcing
+without a flag ([ADR 0014](0014-announce-the-separator-deprecation.md)).
+[#2827](https://github.com/phel-lang/phel-lang/issues/2827) carries out the
+removal.
+
+## Consequences
+
+- One spelling to teach, and it is the one a Clojure reader already knows.
+- `1.x` accepts both, warns about one, and breaks nothing.
+- Removal at the major is now a mechanical change for users: the same sweep that
+  moved this repository's own sources is a `\` to `.` rewrite over multi-segment
+  names, and the deprecation names every site.
+- A project that defines a name colliding with a PHP class gets a warning in
+  `1.x` and an error at the major, which is a real behaviour change and the
+  reason it is not being done sooner.
+- `Munge::encodePhpNs()` keeps emitting `\` for PHP namespace declarations and
+  class FQNs in generated code. Only the *source* spelling is settled here.
+- Class names as **data** are unaffected: `"\\App\\Status"` is a PHP string, and
+  `(.cases "\\App\\Status")` keeps its backslashes.
+
+## Enforcement
+
+- `QualifiedMemberSpellingParityTest` pins the lexical class-reference rule
+  across the analyzer and `phel.core/set!`.
+- `ClassShadowWarnerTest` pins the warning that becomes the refusal.
+- `BackslashSeparatorDeprecatorTest` pins that every position still announces.
+- The stdlib and the Phel test suite are written in the destination spelling, so
+  a regression to `\` shows up as a diff rather than as an opinion.
+
+## Alternatives considered
+
+- **Keep `\` as a permanent host marker.** Two ways to name one thing, forever,
+  and the reason it looked necessary (shadowing) is being removed instead.
+- **Remove `\` at 1.0.** Breaks the published promise of the upgrade guide and
+  lands on users whose notice period began the same week.
+- **Make `\Phel.Lang.Symbol` compose.** Preserves the marker this record retires,
+  and adds a fourth spelling on the way to having one.
+- **Resolve a lower-case-initial namespace without an import.** Needs a rule
+  beyond "upper case is a class", and every candidate makes a name's meaning
+  depend on what is loaded.
+
+## See also
+
+[ADR 0008](0008-dot-namespace-separator.md) ·
+[ADR 0014](0014-announce-the-separator-deprecation.md) ·
+[backslash-to-dot.md](../migration/backslash-to-dot.md) · #2876, #2827, #2926, #2934

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ Records are immutable: a changed decision gets a new ADR superseding the old one
 | [0012](0012-non-hygienic-macros-with-auto-gensym.md) | Non-hygienic macros with auto-gensym | Accepted |
 | [0013](0013-static-property-spelling.md) | A static property is `$prop` to read and a plain name to assign | Accepted |
 | [0014](0014-announce-the-separator-deprecation.md) | The `\` separator deprecation announces by default | Accepted |
+| [0015](0015-a-php-class-is-named-with-dots.md) | A PHP class is named with dots and no leading marker | Proposed |
 
 Statuses: **Proposed**, **Accepted**, **Superseded by NNNN**, **Deprecated** (in
 force, being unwound).

--- a/docs/migration/backslash-to-dot.md
+++ b/docs/migration/backslash-to-dot.md
@@ -102,3 +102,20 @@ That is now settled the other way. The separator announces without the flag from
 `1.0.0` ([ADR 0014](../adr/0014-announce-the-separator-deprecation.md)), so the
 notice period is running for everyone, and the removal at the next major follows
 a warning people actually saw.
+
+## What replaces it
+
+The destination is one spelling, with no marker:
+[ADR 0015](../adr/0015-a-php-class-is-named-with-dots.md).
+
+```phel
+(new DateTime "now")                  ; a root class, bare
+(new Phel.Lang.Keyword "x")           ; a namespaced class, dotted
+Phel.Lang.Symbol                      ; in value position
+```
+
+The leading `\` retires **with** the separator rather than being promoted to a
+permanent host-class marker, so `\Phel.Lang.Symbol` is deliberately not a form.
+A namespace whose first segment is lower case (`phpDocumentor\Reflection\…`) is
+reached by importing it, `(:use phpDocumentor.Reflection.DocBlock)`, the way
+Clojure reaches a class through `:import`.

--- a/docs/spec/clojure-divergences.md
+++ b/docs/spec/clojure-divergences.md
@@ -150,7 +150,9 @@ drops the leading `\`, because that is when a bare class name has to be
 unambiguous ([#2876](https://github.com/phel-lang/phel-lang/issues/2876),
 [#2827](https://github.com/phel-lang/phel-lang/issues/2827)). Until then the
 leading `\` is the escape, and Clojure needs no equivalent because Java packages
-are lower case while PHP's are not.
+are lower case while PHP's are not. The refusal is what lets the marker retire
+rather than become permanent
+([ADR 0015](../adr/0015-a-php-class-is-named-with-dots.md)).
 
 ### `Class/new` is not a constructor
 

--- a/docs/spec/language-surface.md
+++ b/docs/spec/language-surface.md
@@ -213,7 +213,11 @@ behaviour listed there is a decision, not a bug.
 ## 4. Namespaces and project layout
 
 - A namespace name maps to a path. `.` is the separator; `\` still parses and is
-  deprecated (#2827).
+  deprecated (#2827). It announces without `--warn-deprecations`
+  ([ADR 0014](../adr/0014-announce-the-separator-deprecation.md)) and keeps
+  working for every `1.x`. What replaces it, including the fate of the leading
+  `\` on a class name, is
+  [ADR 0015](../adr/0015-a-php-class-is-named-with-dots.md).
 - `phel.core` is always loaded and must never be `:require`d explicitly.
 - The `.phel/` state directory and the `phel-config.php` keys are frozen; see
   [the configuration surface](../stability.md#configuration-surface) and


### PR DESCRIPTION
## 🤔 Background

#2876 asks which spelling replaces `\` for a PHP class. It stayed open because two questions kept being conflated: `\` is the namespace **separator**, and a leading `\` is a **marker** meaning "this is a host class". Dropping the separator does not decide the marker.

Two arguments from @jasalt settle it, and this record only follows them to their conclusion:

- [#2859 (comment)](https://github.com/phel-lang/phel-lang/issues/2859#issuecomment-5152721973): write Phel's own sources in the dot spelling. Done in #2926, which is what makes any argument from them honest.
- [#2876 (comment)](https://github.com/phel-lang/phel-lang/issues/2876#issuecomment-5156046021): Clojure refuses a `def` that shadows a class, which is what makes a bare class name safe there. Shipped as a warning in #2934.

Closes #2876

## 💡 Goal

One spelling, and it is the one a Clojure reader already knows.

```phel
(new DateTime "now")                  ; a root class, bare
(new Phel.Lang.Keyword "x")           ; a namespaced class, dotted
Phel.Lang.Symbol                      ; in value position
```

## 🔖 Changes

Documentation only. Nothing in `1.x` changes, and no code moves.

**[ADR 0015](../blob/main/docs/adr/0015-a-php-class-is-named-with-dots.md)**, status **Proposed**:

1. `.` is the separator, for Phel namespaces and PHP class names alike.
2. A class reference is identified lexically, by an upper-case first segment. No reflection, so a name's meaning never depends on what happened to be loaded.
3. A lower-case-initial namespace (`phpDocumentor\Reflection\…`) is reached by importing it, `(:use phpDocumentor.Reflection.DocBlock)`, which is Phel's `:import`. One of the 99 PSR-4 namespaces installed here needs it.
4. **The leading `\` retires with the separator** at the next major, rather than being promoted to a permanent marker. `\Phel.Lang.Symbol` is deliberately never made to work: I checked, it currently fails with `Undefined constant "Phel"`, and making it work would add a fourth spelling on the way to having one.
5. The `def`-shadows-a-class warning becomes a **refusal** in that same major. That is the guarantee Clojure gives, and it is what makes a bare name safe.

`\` keeps working for all of `1.x`, as the upgrade guide already promises, and its notice period starts at `1.0.0` per ADR 0014. #2827 carries out the removal.

Also updated: the migration guide gains a "What replaces it" section, and the language-surface and divergences pages point at the record.

## 🙋 Why Proposed rather than Accepted

The Clojure-alignment argument is @jasalt's, so the record should carry his review before it is frozen. Nothing in `1.x` depends on accepting it: both spellings work today either way, and the only thing this changes now is that the destination is written down instead of being re-argued.

Worth his eye in particular: point 3, whether an import is the right answer for a lower-case-initial vendor namespace, or whether that case deserves resolution of its own.
