### PR TITLE
fix(compiler): resolve the `defexception` parent like every other class position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `phel doc` no longer warns about `phel-internal\doc`, a namespace only Phel writes. It generated the deprecated separator, which became visible once the notice stopped being opt-in (#2936)
 - `defexception` takes the same class spellings every other position takes. Its parent was wrapped raw instead of resolved, so `\Exception` worked while a bare `RuntimeException` bound to the *current* PHP namespace and a dotted `My.Ns.Error` reached the generated file with its dots and failed to parse. `(:use ...)` aliases now work there too (#2936)
 
 - `NO_COLOR` is honoured by the exception printer and the REPL error formatter. `getStackTraceString()` returns a string, so the caller may be writing to a log or an error tracker, and it used to bake ANSI escapes in regardless. Symfony Console already obeyed the variable, so the two halves of a command disagreed (#2923)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `defexception` takes the same class spellings every other position takes. Its parent was wrapped raw instead of resolved, so `\Exception` worked while a bare `RuntimeException` bound to the *current* PHP namespace and a dotted `My.Ns.Error` reached the generated file with its dots and failed to parse. `(:use ...)` aliases now work there too (#2936)
+
 - `NO_COLOR` is honoured by the exception printer and the REPL error formatter. `getStackTraceString()` returns a string, so the caller may be writing to a log or an error tracker, and it used to bake ANSI escapes in regardless. Symfony Console already obeyed the variable, so the two halves of a command disagreed (#2923)
 - A `:tag` naming a class takes the dot separator: `^Phel.Lang.Symbol` emits `\Phel\Lang\Symbol` instead of reaching the generated signature verbatim and failing to parse. Unions, intersections and the nullable marker are handled; scalars and the backslash form are unchanged (#2924)
 - A `$`-prefixed member outside a static-property place fails to compile instead of emitting a PHP variable-property access. `(php/-> o $foo)` used to compile to `$o->$foo`, warn twice about an undefined variable and read `$o->{''}` (#2915)

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -136,8 +136,9 @@
 
 (defmacro defexception
   "Define a new exception. Optionally pass a parent class to extend (defaults to
-  `\\Exception`), so frameworks can catch it by type, e.g.
-  `(defexception ProductNotFound \\RuntimeException)`."
+  `Exception`), so frameworks can catch it by type, e.g.
+  `(defexception ProductNotFound RuntimeException)`. The parent takes any class
+  spelling: bare, dotted (`My.Ns.Error`), or an alias brought in with `:use`."
   [name & [parent]]
   (let [name-str       (.getName name)
         munge          (new Munge)

--- a/src/php/Api/Infrastructure/PhelFunctionRuntimeLoader.php
+++ b/src/php/Api/Infrastructure/PhelFunctionRuntimeLoader.php
@@ -182,9 +182,12 @@ final readonly class PhelFunctionRuntimeLoader
             $requireNamespaces .= sprintf('(:require %s)', $ns);
         }
 
+        // The dot separator, like any Phel source: `\` is deprecated and now
+        // announces without the flag, so generating it here made `phel doc`
+        // warn the user about a namespace only Phel writes (ADR 0014).
         return <<<EOF
 ;; Simply require all namespaces that should be documented
-(ns phel-internal\doc
+(ns phel-internal.doc
   {$requireNamespaces}
 )
 EOF;

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefExceptionSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefExceptionSymbol.php
@@ -13,6 +13,7 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
 
 use function count;
+use function sprintf;
 
 /**
  * (defexception Name).
@@ -47,11 +48,7 @@ final class DefExceptionSymbol implements SpecialFormAnalyzerInterface
             }
         }
 
-        $parent = new PhpClassNameNode(
-            $env,
-            $parentSymbol,
-            $list->getStartLocation(),
-        );
+        $parent = $this->analyzeParent($parentSymbol, $env, $list);
 
         return new DefExceptionNode(
             $env,
@@ -60,5 +57,44 @@ final class DefExceptionSymbol implements SpecialFormAnalyzerInterface
             $parent,
             $list->getStartLocation(),
         );
+    }
+
+    /**
+     * Resolves the parent the way every other class position resolves one.
+     *
+     * Wrapping the raw symbol in a `PhpClassNameNode` skipped resolution
+     * entirely, so `\Exception` worked while the two spellings the language
+     * points users at did not: a bare `RuntimeException` emitted an unrooted
+     * name and bound to the *current* PHP namespace, and a dotted
+     * `Phel.Lang.ExceptionInfo` reached the generated file with its dots and
+     * failed to parse (#2936). Going through the analyzer also picks up
+     * `(:use ...)` aliases for free.
+     *
+     * The caller's environment is passed through unchanged: the node is never
+     * emitted as an expression, since `DefExceptionEmitter` reads its
+     * `getAbsolutePhpName()` directly, so widening the context would only
+     * change what the AST looks like.
+     *
+     * @param PersistentListInterface<mixed> $list
+     */
+    private function analyzeParent(
+        Symbol $parentSymbol,
+        NodeEnvironmentInterface $env,
+        PersistentListInterface $list,
+    ): PhpClassNameNode {
+        $parent = $this->analyzer->analyze($parentSymbol, $env);
+
+        if (!$parent instanceof PhpClassNameNode) {
+            throw AnalyzerException::withLocation(
+                sprintf(
+                    "Second argument of 'defexception must name a PHP class, but '%s' resolves to %s",
+                    $parentSymbol->getFullName(),
+                    $parent::class,
+                ),
+                $list,
+            );
+        }
+
+        return $parent;
     }
 }

--- a/tests/phel/core/defexception-parent.phel
+++ b/tests/phel/core/defexception-parent.phel
@@ -15,3 +15,16 @@
 
 (deftest default-parent-is-exception
   (is (instance? Exception (Plain "y")) "without a parent it still extends \\Exception"))
+
+;; The parent takes the same spellings every other class position takes:
+;; bare for a root class, dots for a namespaced one (#2936).
+(defexception BareParent RuntimeException)
+(defexception DottedParent PhelTest.Support.Fixtures.PhpInterop.ExtendableException)
+
+(deftest bare-root-class-parent
+  (is (instance? \RuntimeException (BareParent "x"))
+      "a bare root class names the global class, not one in the current namespace"))
+
+(deftest dotted-namespaced-parent
+  (is (instance? PhelTest.Support.Fixtures.PhpInterop.ExtendableException (DottedParent "x"))
+      "a dotted class path resolves like it does everywhere else"))

--- a/tests/php/Support/Fixtures/PhpInterop/ExtendableException.php
+++ b/tests/php/Support/Fixtures/PhpInterop/ExtendableException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Support\Fixtures\PhpInterop;
+
+use RuntimeException;
+
+/**
+ * A namespaced exception that is deliberately not `final`, so a Phel
+ * `defexception` can extend it. Phel classes are `final` by convention, which
+ * leaves nothing in `src/` to point a dotted-parent test at.
+ */
+class ExtendableException extends RuntimeException {}


### PR DESCRIPTION
## 🤔 Background

`defexception` accepted only `\Exception`-style spellings for its parent. The two the language points users at both failed:

```bash
./bin/phel eval '(do (defexception E RuntimeException) 1)'
# Error: Class "user\RuntimeException" not found

./bin/phel eval '(do (defexception E My.Ns.Error) 1)'
# ParseError: syntax error, unexpected token ".", expecting "{"
```

Closes #2936

## 💡 Goal

The parent takes what every other class position takes: bare, dotted, backslash, or a `(:use ...)` alias.

## 🔖 Changes

`DefExceptionSymbol` built a `PhpClassNameNode` straight from the raw symbol, skipping resolution entirely. That is why `\Exception` worked and hid the gap: a leading `\` needs no resolving. A bare name got no rooting, so it bound to the *current* PHP namespace, and a dotted name got no separator conversion, so its dots reached the generated `extends` clause.

It now goes through `$this->analyzer->analyze(...)`, which is what every other position uses, so all four spellings work and aliases come for free. A parent resolving to something other than a class reports that instead of emitting a broken `extends`.

The caller's environment is passed through unchanged rather than widened: the node is never emitted as an expression, since `DefExceptionEmitter` reads `getAbsolutePhpName()` directly, so widening would only change what the AST looks like. `DefExceptionSymbolTest` pins that shape and caught the difference.

### Refactor pass

- The `defexception` docstring taught `(defexception ProductNotFound \RuntimeException)`, modelling the spelling being retired. It now teaches the destination and names all three forms.
- **`phel doc` was warning about Phel's own code.** It builds a `phel-internal\doc` namespace at runtime and wrote it with a backslash, so every invocation printed a deprecation for source only Phel writes. Invisible while the notice was opt-in, unmissable now that it is not (#2932). The generator emits `phel-internal.doc`, and `phel doc`, `list`, `ns` and `doctor` are all clean.

## ✅ Verification

Full gate green: unit 4491, integration 1175, core 6599.

Four spellings, each checked end to end:

| Written | Result |
|---|---|
| `(defexception A RuntimeException)` | `instance? \RuntimeException` is true |
| `(defexception B My.Ns.ExtendableException)` | compiles and extends it |
| `(defexception C AliasedName)` after `(:use ...)` | resolves through the alias |
| `(defexception D \RuntimeException)` | unchanged |

The dotted test needed a non-`final` namespaced exception to extend, and Phel classes are `final` by convention, so `ExtendableException` joins the shared fixtures.
