### PR TITLE
docs: record what a deployment loads, and stop teaching the retiring spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- [The stability policy](docs/stability.md#what-a-deployment-loads) records what a built application actually loads: `Phel\Lang` plus seven `Phel\Compiler` classes reached through the singleton whose name is compiled into build artifacts, and nothing from `Run`, `Console`, `Api`, `Lsp`, `Nrepl`, `Build`, `Formatter` or `Lint`. Measured rather than asserted
+- `(in-ns ...)`, `(ns ...)` and `(use ...)` teach the dot separator in `phel doc`, instead of the spelling being retired
 - `phel doc` no longer warns about `phel-internal\doc`, a namespace only Phel writes. It generated the deprecated separator, which became visible once the notice stopped being opt-in (#2936)
 - `defexception` takes the same class spellings every other position takes. Its parent was wrapped raw instead of resolved, so `\Exception` worked while a bare `RuntimeException` bound to the *current* PHP namespace and a dotted `My.Ns.Error` reached the generated file with its dots and failed to parse. `(:use ...)` aliases now work there too (#2936)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ modules, deployment) live on **[phel-lang.org](https://phel-lang.org/documentati
 ## What lives here
 
 - [Specification](spec/README.md): the normative language surface and the deliberate Clojure divergences
-- [Stability policy](stability.md): what a version number promises, which PHP symbols semver covers, and the 1.x deprecation and PHP support policies
+- [Stability policy](stability.md): what a version number promises, which PHP symbols semver covers, what a deployment actually loads, and the 1.x deprecation and PHP support policies
 - [Architecture decisions](adr/README.md): why the repository is shaped the way it
   is, one record per decision, including the ones that look like oversights
 - [CLI Reference & DX Guide](cli-reference.md): every command, the dev loop, and compile vs eval vs run vs build

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -105,6 +105,38 @@ base's members, so a dependency upgrade changing an inherited signature is a rea
 break the snapshot cannot see. Phel ancestors are folded in. Dependency upgrades
 are where to look.
 
+## What a deployment loads
+
+`phel build` emits PHP, and the emitted PHP is what production runs. Measured on
+a stock `phel init` project, `require`-ing the built entry point declares classes
+from four places and no others:
+
+| Namespace | Classes | Why |
+|---|---|---|
+| `Phel\Lang\` | ~690 | the runtime: persistent collections, `AbstractFn`, `Registry` |
+| `Phel\Compiler\` | 7 | `GlobalEnvironmentSingleton` and the environment it resolves through. The emitter bakes that FQN into every compiled file, so it is an ABI shim rather than the compiler running |
+| `Phel\Shared\` | 3 | `Munge` and the printer reached from generated code |
+| `Phel\Phel` | 1 | `addDefinition()` / `getDefinition()`, which every compiled file calls |
+
+Nothing from `Run`, `Console`, `Api`, `Lsp`, `Nrepl`, `Build`, `Formatter` or
+`Lint` is loaded by a built application. Those are build-time and tooling
+surfaces: they ship in the package, and a request never touches them.
+
+Two consequences worth stating, because both come up in review:
+
+- **A deployed app does load compiler classes**, seven of them. "Production needs
+  only `Lang`" is the intuitive answer and it is wrong. The reason is the
+  singleton whose fully-qualified name is compiled into build artifacts, which is
+  also why it cannot be renamed.
+- **The package is not split.** One Composer package carries the compiler, the
+  language server and the nREPL server into a production install. Splitting it is
+  not a `1.x` change, so this section is the honest answer in the meantime: what
+  is *reachable* is broader than what is *loaded*, and the table says which is
+  which.
+
+The numbers come from counting declared classes before and after requiring the
+entry point, so they follow the code rather than an intention.
+
 ## Deprecation policy for 1.x
 
 1. **Announce before removing.** A deprecated symbol ships with a notice for at

--- a/src/php/Api/Infrastructure/NativeSymbolCatalog.php
+++ b/src/php/Api/Infrastructure/NativeSymbolCatalog.php
@@ -208,7 +208,7 @@ Switches to an existing namespace without creating it. Two uses: at the REPL, to
             'docUrl' => '/documentation/namespaces/',
             'signatures' => ['(in-ns namespace)'],
             'desc' => 'Switches to an existing namespace without creating it (REPL, and `load`-ed files).',
-            'example' => '(in-ns my-app\\core)',
+            'example' => '(in-ns my-app.core)',
         ],
         Symbol::NAME_LET => [
             'doc' => '```phel
@@ -268,7 +268,7 @@ Defines the namespace for the current file and adds imports to the environment. 
             'docUrl' => '/documentation/namespaces/#namespace-ns',
             'signatures' => ['(ns name imports*)'],
             'desc' => 'Defines the namespace for the current file and adds imports to the environment. Imports can either be uses or requires. The keyword :use is used to import PHP classes, the keyword :require is used to import Phel modules and the keyword :require-file is used to load php files.',
-            'example' => '(ns my-app\\core (:require phel\\string :as str))',
+            'example' => '(ns my-app.core (:require phel.string :as str))',
         ],
         Symbol::NAME_PHP_ARRAY_GET => [
             'doc' => '```phel
@@ -501,7 +501,7 @@ Registers PHP class aliases in the current namespace without the full `(ns ... (
             'docUrl' => '/documentation/namespaces/',
             'signatures' => ['(use ClassName & options)'],
             'desc' => 'Registers PHP class aliases in the current namespace (compile-time only).',
-            'example' => '(use \\DateTimeImmutable :as Date)',
+            'example' => '(use DateTimeImmutable :as Date)',
         ],
         Symbol::NAME_VAR => [
             'doc' => '```phel


### PR DESCRIPTION
## 🤔 Background

Two loose ends before 1.0, both found by looking rather than by a report.

The stability policy says which PHP symbols semver covers. It does not say which of them a production request actually touches, and that is the question a security review asks first: one Composer package carries the compiler, the language server and the nREPL server into a production install.

Separately, `NativeSymbolCatalog` taught the retiring spelling. `phel doc` handed users `(in-ns my-app\core)` and `(ns my-app\core (:require phel\string :as str))`, which is the form the compiler now warns about by default.

## 💡 Goal

The stability document answers the deployment question with numbers, and `phel doc` teaches the spelling the language is moving to.

## 🔖 Changes

### `docs/stability.md`, "What a deployment loads"

Measured on a stock `phel init` project by counting declared classes either side of requiring the built entry point:

| Namespace | Classes | Why |
|---|---|---|
| `Phel\Lang\` | ~690 | the runtime |
| `Phel\Compiler\` | 7 | `GlobalEnvironmentSingleton` and the environment it resolves through |
| `Phel\Shared\` | 3 | `Munge` and the printer reached from generated code |
| `Phel\Phel` | 1 | `addDefinition()` / `getDefinition()` |

Nothing from `Run`, `Console`, `Api`, `Lsp`, `Nrepl`, `Build`, `Formatter` or `Lint`.

The section states the two things reviewers actually ask about, including the one that is counter-intuitive: **a deployed app does load compiler classes**, seven of them, because the emitter bakes that singleton's FQN into every compiled file. "Production needs only `Lang`" is the intuitive answer and it is wrong. It also says plainly that the package is not split and that this table is the honest answer in the meantime.

### `NativeSymbolCatalog`

Three `:example` entries moved to the destination spelling: `(in-ns my-app.core)`, `(ns my-app.core (:require phel.string :as str))`, `(use DateTimeImmutable :as Date)`.

## ✅ Verification

Full gate green: unit 4491, integration 1175, core 6599.

The numbers in the table come from a script, not from reading the code, and a freshly generated project was checked end to end: no backslash in any generated `.phel`, and `phel run` on it emits zero deprecations.

The Lint tests that parse `(ns my-app\core)` are untouched on purpose: they exist to prove the deprecated form still parses.
