### PR TITLE
docs: accept dotted PHP class spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Warn for `\` namespace separators without `--warn-deprecations`; other deprecations stay opt-in (#2827)
-- Record the future PHP class spelling after `\`: dotted or bare, with no leading marker (#2876)
+- Accept the future PHP class spelling after `\`: dotted or bare, with no leading marker (#2876)
 - Warn when a `def` shadows a loadable PHP class; `\DateTime` still reaches the class (#2876)
 - Suppress deprecation reports for code under `vendor/` (#2827)
 - BC: require `symfony/console` `^7.3|^8.0`

--- a/docs/adr/0015-a-php-class-is-named-with-dots.md
+++ b/docs/adr/0015-a-php-class-is-named-with-dots.md
@@ -1,10 +1,8 @@
 # ADR 0015: A PHP class is named with dots and no leading marker
 
-- **Status**: Proposed. Nothing in `1.x` depends on accepting it, and it should
-  carry @jasalt's review before it does: the Clojure-alignment argument is his
-  ([#2876](https://github.com/phel-lang/phel-lang/issues/2876#issuecomment-5156046021),
-  [#2859](https://github.com/phel-lang/phel-lang/issues/2859#issuecomment-5152721973)),
-  and this record only follows it to its conclusion.
+- **Status**: Accepted. Reviewed by @jasalt, including the lower-case vendor
+  namespace trade-off
+  ([#2876](https://github.com/phel-lang/phel-lang/issues/2876#issuecomment-5159303444)).
 - **Date**: 2026-08-02
 - **Supersedes**: none. Settles the question [ADR 0008](0008-dot-namespace-separator.md) left open.
 
@@ -30,7 +28,9 @@ PHP is close enough for the same shape to work. A vendor namespace is
 conventionally PascalCase (`Symfony\Component\…`, `League\Uri\…`), so an
 upper-case first segment identifies a host class as reliably as lower case
 identifies a package on the JVM. Of the 99 PSR-4 namespaces installed in this
-repository, one begins lower case.
+repository, one begins lower case. PHP class names are case-insensitive once a
+class is loaded, but that does not make recasing a portable source spelling:
+an autoloader may need the declared prefix casing to load the class first.
 
 The push to write Phel's own sources in the dot spelling, and the observation
 that Clojure's refusal is what makes a bare class name safe, both came from
@@ -62,8 +62,11 @@ Symfony.Component.Console.Command.Command/SUCCESS
    No reflection, so meaning never depends on what happened to be loaded.
 3. A namespace whose first segment is lower case (`phpDocumentor\Reflection\…`)
    is reached by importing it, `(:use phpDocumentor.Reflection.DocBlock)`, which
-   is Phel's `:import`. This is the one place PHP's conventions are looser than
-   the JVM's, and an import is the answer Clojure already gives.
+   is Phel's `:import`. An upper-case spelling may resolve after PHP has already
+   loaded the class, because PHP class names are case-insensitive, but it can
+   fail when Composer must autoload the lower-case PSR-4 prefix. It is therefore
+   not part of the language contract. This is the one place PHP's conventions
+   are looser than the JVM's, and an import is the answer Clojure already gives.
 4. **The leading `\` retires with the separator**, at the next major. It is not
    promoted to a permanent marker, and `\Phel.Lang.Symbol` is deliberately never
    made to work: a marker that survives is a second way to say one thing.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,7 +26,7 @@ stale exactly that way. See [Editing](#editing).
 | [0012](0012-non-hygienic-macros-with-auto-gensym.md) | Non-hygienic macros with auto-gensym | Accepted |
 | [0013](0013-static-property-spelling.md) | A static property is `$prop` to read and a plain name to assign | Accepted |
 | [0014](0014-announce-the-separator-deprecation.md) | The `\` separator deprecation announces by default | Accepted |
-| [0015](0015-a-php-class-is-named-with-dots.md) | A PHP class is named with dots and no leading marker | Proposed |
+| [0015](0015-a-php-class-is-named-with-dots.md) | A PHP class is named with dots and no leading marker | Accepted |
 
 Statuses: **Proposed**, **Accepted**, **Amended by NNNN** (in force, narrowed by a
 later record), **Superseded by NNNN**, **Deprecated** (in force, being unwound).

--- a/docs/spec/language-surface.md
+++ b/docs/spec/language-surface.md
@@ -175,6 +175,14 @@ constant, `(.-ATTR_ERRMODE PDO)` is the dot-member equivalent. Namespaced classe
 have the dotted form, for example
 `Symfony.Component.Console.Command.Command/SUCCESS`.
 
+A class name is recognized lexically by an upper-case first segment. Import a
+lower-case-initial vendor namespace before using its short name, for example
+`(:use phpDocumentor.Reflection.DocBlock)`. Recasing the prefix is not portable:
+PHP class names are case-insensitive after loading, but Composer may need the
+declared prefix casing to autoload the class first. The destination at the next
+major is this dotted spelling without a leading `\`; see
+[ADR 0015](../adr/0015-a-php-class-is-named-with-dots.md).
+
 At host-symbol fallback an existing PHP class, interface, trait or enum takes
 precedence over the global-constant reading of the same bare name. `php/NAME`
 bypasses the fallback and stays the explicit constant escape hatch. Phel locals
@@ -215,9 +223,10 @@ behaviour listed there is a decision, not a bug.
 - A namespace name maps to a path. `.` is the separator; `\` still parses and is
   deprecated (#2827). It announces without `--warn-deprecations`
   ([ADR 0014](../adr/0014-announce-the-separator-deprecation.md)) and keeps
-  working for every `1.x`. What replaces it, including the fate of the leading
-  `\` on a class name, is
-  [ADR 0015](../adr/0015-a-php-class-is-named-with-dots.md).
+  working for every `1.x`. At the next major, a PHP class uses the dotted
+  upper-case-first spelling above, the leading `\` marker retires, and a `def`
+  that shadows a loadable class becomes an error
+  ([ADR 0015](../adr/0015-a-php-class-is-named-with-dots.md)).
 - `phel.core` is always loaded and must never be `:require`d explicitly.
 - The `.phel/` state directory and the `phel-config.php` keys are frozen; see
   [the configuration surface](../stability.md#configuration-surface) and


### PR DESCRIPTION
## 🤔 Background
ADR 0015 remained proposed pending review of lower-case PHP vendor namespaces.

## 💡 Goal
Accept one marker-free dotted class spelling for the next major without overstating PHP case-insensitivity.

## 🔖 Changes
- Mark ADR 0015 accepted and synchronize the ADR index.
- Specify that lower-case vendor namespaces use `(:use ...)` because autoload prefix casing still matters.
- Update the normative language surface and existing Unreleased note.
- Full suite passed; final refactor review found no additional changes.

Closes #2876