### PR TITLE
perf: inline PHP array constructors

### DIFF
--- a/.agnostic-ai/rules/phel.md
+++ b/.agnostic-ai/rules/phel.md
@@ -29,6 +29,7 @@ Every public function should have metadata:
 - Follow Clojure-aligned semantics where possible
 - Prefer `conj` over `put` for collection operations
 - Use `defstruct` for data types, not PHP classes
+- Prefer `php-indexed-array` / `php-associative-array` over direct `php/array` construction. Raw construction is reserved for core bootstrap code that loads before `core/arrays`, the constructor implementations themselves, and measured higher-order paths where applying the wrapper would add runtime cost.
 
 ## Macros
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ All notable changes to this project will be documented in this file.
 
 Runtime core:
 
+- Inline PHP array constructors and use `php-indexed-array` across core and standard libraries (#2941)
 - Speed up `re-find`, `re-matches` and `parse-long` by avoiding full match-map conversion (#2941 #2943)
 - Give `aget` a fixed single-index arity and require an index, matching Clojure (#2941)
 - Use `aget` and `aset` across core/std libraries where bootstrap allows it (#2941 #2942)

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -398,7 +398,7 @@ Useful for building multi-turn conversations."
   (let [trimmed (php/trim response)]
     (if (php/str_starts_with trimmed "{")
       trimmed
-      (let [matches (php/array)
+      (let [matches (php-indexed-array)
             found   (php/preg_match "/```(?:json)?\\s*\\n?(\\{[\\s\\S]*?\\})\\s*\\n?```/" trimmed matches)]
         (if (one? found)
           (aget matches 1)

--- a/src/phel/cli.phel
+++ b/src/phel/cli.phel
@@ -288,7 +288,7 @@
 (defn- sugg-array [spec]
   (if (fn? (get spec :complete))
     (Closure/fromCallable (fn [input] (apply php/array ((get spec :complete) input))))
-    (php/array)))
+    (php-indexed-array)))
 
 (defn- add-args [cmd args]
   (foreach [a args]

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -78,6 +78,7 @@
   {:private true
    :doc "Returns all entries after the first persistent map entry as `MapEntry` instances, or nil."}
   (fn [m]
+    ;; Bootstrap: `php-indexed-array` is defined later in `core/arrays`.
     (let [entries (php/array)]
       (foreach [k v m]
         (php/apush entries (MapEntry/create k v)))

--- a/src/phel/core/arrays.phel
+++ b/src/phel/core/arrays.phel
@@ -14,10 +14,12 @@
 ;;      typed builders just coerce element type.
 ;; Persistent collection constructors (`hash-set`, `sorted-map`, …) live
 ;; in core.phel because they are required earlier in the bootstrap.
+;; Raw `php/array` calls in this file implement the public constructors.
 
 (defn php-indexed-array
   "Creates a PHP indexed array from the given values."
-  {:example "(php-indexed-array 1 2 3) ; => <PHP-Array [1, 2, 3]>"}
+  {:inline (fn [& xs] `(php/array ~@xs))
+   :example "(php-indexed-array 1 2 3) ; => <PHP-Array [1, 2, 3]>"}
   [& xs]
   (apply php/array xs))
 
@@ -26,7 +28,22 @@
 
   Arguments:
     Key-value pairs (must be even number of arguments)"
-  {:example "(php-associative-array \"name\" \"Alice\" \"age\" 30) ; => <PHP-Array [\"name\":\"Alice\", \"age\":30]>"}
+  {:inline
+   (fn [& xs]
+     (let [result-sym (gensym)
+           cnt        (.count xs)]
+       (loop [i                0
+              assignment-forms []]
+         (if (php/< i cnt)
+           (recur
+            (php/+ i 2)
+            (conj assignment-forms
+                  `(php/aset ~result-sym ~(.get xs i) ~(.get xs (php/+ i 1)))))
+           `(let [~result-sym (php/array)]
+              ~@assignment-forms
+              ~result-sym)))))
+   :inline-arity (fn [n] (php/=== 0 (php/% n 2)))
+   :example "(php-associative-array \"name\" \"Alice\" \"age\" 30) ; => <PHP-Array [\"name\":\"Alice\", \"age\":30]>"}
   [& xs]
   (let [cnt (php/count xs)
         res (php/array)]
@@ -188,7 +205,7 @@
 
 (defn aget
   "Returns the value at `index` in a PHP array. With multiple indices, accesses nested arrays: `(aget arr i j)` is `(aget (aget arr i) j)`. Matches Clojure's `aget` for `.cljc` interop."
-  {:example "(aget (php/array 10 20 30) 1) ; => 20"
+  {:example "(aget (php-indexed-array 10 20 30) 1) ; => 20"
    :see-also ["aset" "aclone" "object-array"]}
   ;; The single-index arity is spelled out so the common read does not pay for
   ;; collecting rest arguments; it is the shape every hot path uses.
@@ -207,7 +224,7 @@
    Matches Clojure's `aset` for `.cljc` interop.
    This is a macro because PHP arrays are value types; a function
    wrapper would mutate a copy rather than the original."
-  {:example "(let [a (php/array 1 2 3)] (aset a 0 42) (aget a 0)) ; => 42"
+  {:example "(let [a (php-indexed-array 1 2 3)] (aset a 0 42) (aget a 0)) ; => 42"
    :see-also ["aget" "aclone" "object-array"]}
   [arr idx & more]
   (let [n       (.count more)

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -64,6 +64,7 @@
                                 (php/. "(" name ")")))
                        ;; Multi-arity: generate signature for each arity
                             (let [arities fdecl
+                                  ;; Bootstrap: `php-indexed-array` is defined after `defn`.
                                   sigs    (php/array)]
                               (foreach [arity arities]
                                 (if (php/instanceof arity PersistentListInterface)

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -309,7 +309,7 @@ Without arguments, uses a default cache size of 128 entries."
    :see-also ["flatten"]}
   [branch? children root]
   (let [ret (transient [])]
-    (loop [stack (php/array root)]
+    (loop [stack (php-indexed-array root)]
       (if (> (count stack) 0)
         (let [node (pop stack)]
           (.append ret node)

--- a/src/phel/core/interop.phel
+++ b/src/phel/core/interop.phel
@@ -65,7 +65,7 @@
   {:example "(php-invoke (new \\DateTimeImmutable \"2024-03-10\") \"format\" \"Y\") ; => \"2024\"\n(let [m \"format\"] (php-invoke (new \\DateTimeImmutable \"2024-03-10\") m \"Y\")) ; => \"2024\""
    :see-also ["php/callable" "apply"]}
   [target method & args]
-  (let [callable (php/array target method)]
+  (let [callable (php-indexed-array target method)]
     (if (php/is_callable callable)
       (php/call_user_func_array callable (to-php-array args))
       (throw (new InvalidArgumentException

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -38,7 +38,7 @@
   {:example "(re-seq #\"\\d+\" \"a1b2c3\") ; => [\"1\" \"2\" \"3\"]"
    :see-also ["re-find" "re-matches"]}
   [re s]
-  (let [matches (php/array)
+  (let [matches (php-indexed-array)
         _       (php/preg_match_all re s matches) ; fills `matches` by reference
         matches (php->phel matches)]
     (if (= (count matches) 1)
@@ -50,7 +50,7 @@
   {:example "(re-find #\"\\d+\" \"abc123def\") ; => \"123\""
    :see-also ["re-seq" "re-matches"]}
   [re s]
-  (let [matches (php/array)]
+  (let [matches (php-indexed-array)]
     (when (php/=== 1 (php/preg_match re s matches))
       ;; A group-less pattern is the common case, and converting the whole
       ;; match array to read element zero out of it costs more than the match.
@@ -282,8 +282,8 @@ See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-co
   [filename]
   (let [result (lazy-seq-from-generator
                 (php/call_user_func_array
-                 (php/array "\\Phel\\Lang\\Seq" "fileLines")
-                 (php/array filename)))]
+                 (php-indexed-array "\\Phel\\Lang\\Seq" "fileLines")
+                 (php-indexed-array filename)))]
     (if (php/=== nil result)
       '()
       result)))
@@ -294,8 +294,8 @@ See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-co
   [path]
   (let [result (lazy-seq-from-generator
                 (php/call_user_func_array
-                 (php/array "\\Phel\\Lang\\Seq" "fileSeq")
-                 (php/array path)))]
+                 (php-indexed-array "\\Phel\\Lang\\Seq" "fileSeq")
+                 (php-indexed-array path)))]
     (if (php/=== nil result)
       '()
       result)))
@@ -308,8 +308,8 @@ See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-co
   ([filename chunk-size]
    (let [result (lazy-seq-from-generator
                  (php/call_user_func_array
-                  (php/array "\\Phel\\Lang\\Seq" "readFileChunks")
-                  (php/array filename chunk-size)))]
+                  (php-indexed-array "\\Phel\\Lang\\Seq" "readFileChunks")
+                  (php-indexed-array filename chunk-size)))]
      (if (php/=== nil result)
        '()
        result))))
@@ -325,8 +325,8 @@ See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-co
          escape    (get options :escape "\\")
          result    (lazy-seq-from-generator
                     (php/call_user_func_array
-                     (php/array "\\Phel\\Lang\\Seq" "csvLines")
-                     (php/array filename separator enclosure escape)))]
+                     (php-indexed-array "\\Phel\\Lang\\Seq" "csvLines")
+                     (php-indexed-array filename separator enclosure escape)))]
      (if (php/=== nil result)
        '()
        result))))

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -391,7 +391,7 @@
 
 (defn php-array?
   "Returns true if `x` is a PHP Array, false otherwise."
-  {:example "(php-array? (php/array 1 2)) ; => true\n(php-array? [1 2]) ; => false"
+  {:example "(php-array? (php-indexed-array 1 2)) ; => true\n(php-array? [1 2]) ; => false"
    :see-also ["php-object?" "php-resource?" "vector?"]}
   [x]
   (php/is_array x))
@@ -464,7 +464,7 @@ A non-countable iterable (an `eduction` pipeline, a PHP generator) is answered b
                      (php/instanceof coll PersistentHashSetInterface) (hash-set)
                      (list? coll)                                     '()
                      (php/instanceof coll LazySeqInterface)           '()
-                     (php-array? coll)                                (php/array)
+                     (php-array? coll)                                (php-indexed-array)
                      :else                                            nil)]
     (if (and empty-coll (php/instanceof coll MetaInterface))
       (copy-meta coll empty-coll)

--- a/src/phel/core/seq-basics.phel
+++ b/src/phel/core/seq-basics.phel
@@ -31,19 +31,19 @@
       (php/=== a b))))
 
 (defn- cons-string [x coll]
-  (let [result (php/array x)]
+  (let [result (php-indexed-array x)]
     (foreach [char (php/mb_str_split coll)]
       (php/apush result char))
     (Phel/vector result)))
 
 (defn- cons-map [x coll]
-  (let [result (php/array x)]
+  (let [result (php-indexed-array x)]
     (foreach [k v coll]
       (php/apush result [k v]))
     (Phel/vector result)))
 
 (defn- cons-iterable [x coll]
-  (let [result (php/array x)]
+  (let [result (php-indexed-array x)]
     (foreach [v coll]
       (php/apush result v))
     (Phel/vector result)))

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -85,8 +85,8 @@
                   (new Hasher)
                   (new Equalizer)
                   (php/call_user_func_array
-                   (php/array "\\Phel\\Lang\\Seq" "mapMulti")
-                   (php/array_merge (php/array f) (apply php/array colls))))]
+                   (php-indexed-array "\\Phel\\Lang\\Seq" "mapMulti")
+                   (php/array_merge (php-indexed-array f) (apply php/array colls))))]
       (copy-meta (first colls) result))))
 
 (defn comp
@@ -480,7 +480,7 @@ Creates intermediate maps if they don't exist."
 
 (defn- take-last-buffered
   [n coll]
-  (let [buffer (php/array)]
+  (let [buffer (php-indexed-array)]
     (dofor [x :in coll]
       (php/apush buffer x)
       (when (php/> (php/count buffer) n)
@@ -872,25 +872,25 @@ Works with vectors, lists, sets, and strings."
   [x]
   (cond
     (php-array? x)
-    (let [arr (php/array)]
+    (let [arr (php-indexed-array)]
       (foreach [k v x]
         (aset arr k (phel->php v)))
       arr)
 
     (indexed? x)
-    (let [arr (php/array)]
+    (let [arr (php-indexed-array)]
       (foreach [v x]
         (php/apush arr (phel->php v)))
       arr)
 
     (associative? x)
-    (let [arr (php/array)]
+    (let [arr (php-indexed-array)]
       (foreach [k v x]
         (aset arr (phel->php-key k) (phel->php v)))
       arr)
 
     (set? x)
-    (let [arr (php/array)]
+    (let [arr (php-indexed-array)]
       (foreach [v x]
         (php/apush arr (phel->php v)))
       arr)
@@ -1081,7 +1081,7 @@ With one argument returns an infinite lazy sequence of calls to f."
 
 (defn iterator-seq
   "Returns a lazy sequence over a PHP `Traversable` (Iterator, Generator, IteratorAggregate, ...), pulling one element at a time. Unlike the eager coercion that materialises a `Traversable` via `iterator_to_array`, this streams a large or infinite source (DB cursor, stream reader, paginated API), so `take`/`map`/`filter` only pull what they consume."
-  {:example "(take 3 (iterator-seq (new \\ArrayIterator (php/array 1 2 3 4 5)))) ; => @[1 2 3]"
+  {:example "(take 3 (iterator-seq (new \\ArrayIterator (php-indexed-array 1 2 3 4 5)))) ; => @[1 2 3]"
    :see-also ["lazy-seq" "map" "take"]}
   [traversable]
   (LazySeq/fromTraversable (new Hasher) (new Equalizer) traversable))
@@ -1107,7 +1107,7 @@ With one argument returns an infinite lazy sequence of calls to f."
      (new Hasher)
      (new Equalizer)
      (php/call_user_func_array
-      (php/array "\\Phel\\Lang\\Seq" "concat")
+      (php-indexed-array "\\Phel\\Lang\\Seq" "concat")
       (apply php/array colls)))))
 
 (defn cat
@@ -1194,10 +1194,10 @@ Applies `f` to each element in `xs`. `f` is a two-argument function where the fi
     (php/=== nil colls) '()
     (some nil? colls)   '()
     :else
-    (let [seqs   (apply php/array (map (fn [c] (or (seq c) (php/array))) colls))
+    (let [seqs   (apply php/array (map (fn [c] (or (seq c) (php-indexed-array))) colls))
           result (lazy-seq-from-generator
                   (php/call_user_func_array
-                   (php/array "\\Phel\\Lang\\Seq" "interleave")
+                   (php-indexed-array "\\Phel\\Lang\\Seq" "interleave")
                    seqs))]
       (if (php/=== nil result)
         '()
@@ -1406,8 +1406,8 @@ If map has duplicated values, some keys will be ignored."
     (and (indexed? coll) (= 0 (count coll))) []
     true                                     (lazy-seq-from-generator
                                               (php/call_user_func_array
-                                               (php/array "\\Phel\\Lang\\Seq" "compact")
-                                               (php/array_merge (php/array coll) (apply php/array values))))))
+                                               (php-indexed-array "\\Phel\\Lang\\Seq" "compact")
+                                               (php/array_merge (php-indexed-array coll) (apply php/array values))))))
 
 (defn partition
   "Partitions `coll` into chunks of `n` elements.
@@ -1418,8 +1418,8 @@ If map has duplicated values, some keys will be ignored."
   ([n coll]
    (let [result (lazy-seq-from-generator
                  (php/call_user_func_array
-                  (php/array "\\Phel\\Lang\\Seq" "partition")
-                  (php/array n coll)))]
+                  (php-indexed-array "\\Phel\\Lang\\Seq" "partition")
+                  (php-indexed-array n coll)))]
      (if (php/=== nil result)
        '()
        (copy-meta coll result))))
@@ -1446,8 +1446,8 @@ If map has duplicated values, some keys will be ignored."
   ([n coll]
    (let [result (lazy-seq-from-generator
                  (php/call_user_func_array
-                  (php/array "\\Phel\\Lang\\Seq" "partitionAll")
-                  (php/array n coll)))]
+                  (php-indexed-array "\\Phel\\Lang\\Seq" "partitionAll")
+                  (php-indexed-array n coll)))]
      (if (php/=== nil result)
        '()
        (copy-meta coll result))))

--- a/src/phel/core/strings.phel
+++ b/src/phel/core/strings.phel
@@ -111,6 +111,7 @@ Throws `InvalidArgumentException` for any other input (including functions, numb
       ""
       (if (php/=== cnt 1)
         (val-to-str (aget args 0))
+        ;; Bootstrap: `php-indexed-array` is defined after `str`.
         (let [parts (php/array)]
           (loop [i 0]
             (if (php/< i cnt)

--- a/src/phel/http-client.phel
+++ b/src/phel/http-client.phel
@@ -14,7 +14,7 @@
 (defn- build-headers-array
   "Converts a Phel header map to a PHP associative array."
   [headers]
-  (let [arr (php/array)]
+  (let [arr (php-indexed-array)]
     (foreach [k v headers]
       (aset arr (key->string k) (str v)))
     arr))
@@ -26,7 +26,7 @@
 (defn- build-options-array
   "Converts Phel options to a PHP associative array for the transport."
   [{:timeout timeout, :follow-redirects follow-redirects, :verify-ssl verify-ssl}]
-  (let [arr (php/array)]
+  (let [arr (php-indexed-array)]
     (when timeout (aset arr "timeout" timeout))
     (when-not (nil? follow-redirects) (aset arr "follow_redirects" follow-redirects))
     (when-not (nil? verify-ssl) (aset arr "verify_ssl" verify-ssl))
@@ -37,7 +37,7 @@
   [url params]
   (if (or (nil? params) (empty? params))
     url
-    (let [php-params (php/array)]
+    (let [php-params (php-indexed-array)]
       (foreach [k v params]
         (aset php-params (key->string k) (str v)))
       (let [query-string (php/http_build_query php-params)

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -42,7 +42,7 @@
         http-host    (get server "HTTP_HOST")
         server-name  (get server "SERVER_NAME")
         server-port  (php/intval (get server "SERVER_PORT"))
-        matches      (php/array)
+        matches      (php-indexed-array)
         match-result (when-not (nil? http-host) (php/preg_match uri-host-port-regex http-host matches))]
     (cond
       (and (not (nil? http-host)) (one? match-result))
@@ -84,7 +84,7 @@
   {:example "(uri-from-string \"https://example.com/path?foo=bar\") ; => (phel.http.uri \"https\" nil \"example.com\" nil \"/path\" \"foo=bar\" nil)"
    :see-also ["uri-from-globals" "request-from-map"]}
   [url]
-  (let [matches      (php/array)
+  (let [matches      (php-indexed-array)
         [prefix url] (if (one? (php/preg_match "%^(.*://\\[[0-9:a-f]+\\])(.*?)$%" url matches))
                        [(aget matches 1) (aget matches 2)]
                        ["" url])
@@ -217,7 +217,7 @@
 
 (defn- form-content-type? [content-type]
   (php/in_array content-type
-                (php/array "application/x-www-form-urlencoded" "multipart/form-data")))
+                (php-indexed-array "application/x-www-form-urlencoded" "multipart/form-data")))
 
 (defn- decode-json-body
   "Decodes a JSON request body. Returns nil for an empty or malformed body so handlers can distinguish 'no usable body' from a real value."

--- a/src/phel/json.phel
+++ b/src/phel/json.phel
@@ -19,7 +19,7 @@
     (encode-value k)))
 
 (defn- encode-value-iterable [x]
-  (let [arr (php/array)]
+  (let [arr (php-indexed-array)]
     (foreach [k v x]
       (when-not (valid-key? k)
         (throw (new JsonException "Key can only be an integer, float, symbol, keyword or a string.")))

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -54,7 +54,7 @@
 
 (defn- eval-namespace [namespace]
   (let [canonical    (canonical-ns namespace)
-        dependencies (.getDependenciesForNamespace build-facade (get-src-dirs) (php/array canonical))
+        dependencies (.getDependenciesForNamespace build-facade (get-src-dirs) (php-indexed-array canonical))
         found        (php/> (php/count dependencies) 0)]
     (when-not found
       (throw (new RuntimeException
@@ -64,7 +64,7 @@
         (eval-file (.getFile dep))))))
 
 (defn- clean-doc [str]
-  (php/trim (php/str_replace (php/array "```phel\n" "```") "" str)))
+  (php/trim (php/str_replace (php-indexed-array "```phel\n" "```") "" str)))
 
 (defn- find-doc [namespace name]
   (let [meta (Phel/getDefinitionMetaData namespace name)]
@@ -558,7 +558,7 @@ Returns nil. Prints one name per line, sorted alphabetically."
   (let [project  (filter reloadable? (loaded-namespaces))
         ns-array (apply php/array (map canonical-ns project))]
     (if (php/empty ns-array)
-      (php/array)
+      (php-indexed-array)
       (filter (fn [info] (reloadable? (.getNamespace info)))
               (.getDependenciesForNamespace build-facade (get-src-dirs) ns-array)))))
 

--- a/src/phel/router.phel
+++ b/src/phel/router.phel
@@ -143,7 +143,7 @@
 (defn- build-route-collection [normalized-routes]
   (for [route :in normalized-routes
         :let [[path data] route
-              symfony-route (new Route path (php/array) (php/array) (php-associative-array "data" data "template" path))]
+              symfony-route (new Route path (php-indexed-array) (php-indexed-array) (php-associative-array "data" data "template" path))]
         :reduce [coll (new RouteCollection)]]
     (.add coll (route-name-of route) symfony-route)
     coll))
@@ -151,7 +151,7 @@
 (defn- params->php-array
   "Converts a Phel map of parameters into a PHP associative array keyed by name."
   [parameters]
-  (let [arr (php/array)]
+  (let [arr (php-indexed-array)]
     (dofor [[k v] :pairs parameters]
       (aset arr (name k) v))
     arr))

--- a/src/phel/transit.phel
+++ b/src/phel/transit.phel
@@ -233,11 +233,11 @@
 
 (defn- encode-map [m]
   (if (string-keys? m)
-    (let [obj (php/array)]
+    (let [obj (php-indexed-array)]
       (foreach [k v m]
         (aset obj k (encode v)))
       obj)
-    (let [pairs (php/array)]
+    (let [pairs (php-indexed-array)]
       (foreach [k v m]
         (php/apush pairs (encode k))
         (php/apush pairs (encode v)))
@@ -246,7 +246,7 @@
 (defn- encode-sequential
   "Encodes each element of `coll` into a PHP array. When `tag` is non-nil the array is wrapped as a Transit tagged array (e.g. \"~#set\"); a nil `tag` yields a bare array."
   [coll tag]
-  (let [arr (php/array)]
+  (let [arr (php-indexed-array)]
     (foreach [x coll]
       (php/apush arr (encode x)))
     (if tag (php-indexed-array tag arr) arr)))

--- a/src/phel/watch.phel
+++ b/src/phel/watch.phel
@@ -34,7 +34,7 @@
   {:example "(watch! [\"src/\" \"tests/\"])"}
   [paths & [opts]]
   (let [facade  (new WatchFacade)
-        phpOpts (php/array)]
+        phpOpts (php-indexed-array)]
     (when (and opts (get opts :backend))
       (aset phpOpts "backend" (get opts :backend)))
     (when (and opts (get opts :poll))

--- a/tests/phel/core/basic-constructors.phel
+++ b/tests/phel/core/basic-constructors.phel
@@ -350,41 +350,41 @@
       "int-array raises on negative size"))
 
 (deftest test-aget
-  (let [a (php/array 10 20 30)]
+  (let [a (php-indexed-array 10 20 30)]
     (is (= 10 (aget a 0)) "aget first element")
     (is (= 20 (aget a 1)) "aget second element")
     (is (= 30 (aget a 2)) "aget third element")))
 
 (deftest test-aget-nested
-  (let [outer (php/array (php/array 1 2) (php/array 3 4))]
+  (let [outer (php-indexed-array (php-indexed-array 1 2) (php-indexed-array 3 4))]
     (is (= 2 (aget outer 0 1)) "aget nested with two indices")
     (is (= 3 (aget outer 1 0)) "aget nested second array")))
 
 (deftest test-aset-returns-value
-  (let [a (php/array 1 2 3)]
+  (let [a (php-indexed-array 1 2 3)]
     (is (= 42 (aset a 0 42)) "aset returns the value")))
 
 (deftest test-aset-mutates-array
-  (let [a (php/array 1 2 3)]
+  (let [a (php-indexed-array 1 2 3)]
     (aset a 0 42)
     (is (= 42 (aget a 0)) "aset mutated the array")))
 
 (deftest test-aset-nested
-  (let [inner (php/array 10 20)
-        outer (php/array inner)]
+  (let [inner (php-indexed-array 10 20)
+        outer (php-indexed-array inner)]
     (aset outer 0 1 99)
     (is (= 99 (aget (aget outer 0) 1)) "aset nested modified inner array")))
 
 (deftest test-aset-evaluates-value-once
   (let [calls (atom 0)
-        a     (php/array 1 2 3)]
+        a     (php-indexed-array 1 2 3)]
     (aset a 0 (do (swap! calls inc) 42))
     (is (= 1 @calls) "aset evaluates its value expression once")
     (is (= 42 (aget a 0)) "aset stored the evaluated value")))
 
 (deftest test-aset-nested-evaluates-value-once
   (let [calls (atom 0)
-        outer (php/array (php/array 10 20))]
+        outer (php-indexed-array (php-indexed-array 10 20))]
     (aset outer 0 1 (do (swap! calls inc) 99))
     (is (= 1 @calls) "nested aset evaluates its value expression once")
     (is (= 99 (aget outer 0 1)) "nested aset stored the evaluated value")))

--- a/tests/phel/core/basic-sequence-operation.phel
+++ b/tests/phel/core/basic-sequence-operation.phel
@@ -2,7 +2,7 @@
   (:require phel.test :refer [deftest is]))
 
 (deftest test-cons
-  (is (= (php/array 1 2) (cons 1 (php/array 2))) "cons php array")
+  (is (= (php-indexed-array 1 2) (cons 1 (php-indexed-array 2))) "cons php array")
   (is (= '(1 2) (cons 1 '(2))) "cons list")
   (is (= '(1 2 3) (cons 1 '(2 3))) "cons list multiple elements")
   (is (= [1 2] (cons 1 [2])) "cons vector")
@@ -18,7 +18,7 @@
   (is (= [1] (cons 1 nil)) "cons nil"))
 
 (deftest test-cons-32-more-elements
-  (is (= (php/array 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39)
+  (is (= (php-indexed-array 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39)
          (cons 0 (php/range 1 39)))
       "cons php array with 32 or more elements")
   (is (= '(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39)
@@ -34,8 +34,8 @@
 (deftest test-first
   (is (= 1 (first [1])) "first of vector")
   (is (nil? (first [])) "frist of empty vector")
-  (is (= 1 (first (php/array 1))) "first of php array")
-  (is (nil? (first (php/array))) "frist of empty php array")
+  (is (= 1 (first (php-indexed-array 1))) "first of php array")
+  (is (nil? (first (php-indexed-array))) "frist of empty php array")
   (is (nil? (first #{})) "first of empty set")
   (is (contains? #{[1] [2]} (first #{[1] [2]})) "first of set")
   (is (nil? (first nil)) "frist of nil"))
@@ -72,8 +72,8 @@
 (deftest test-second
   (is (= 2 (second [1 2])) "second of vector")
   (is (nil? (second [])) "second of empty vector")
-  (is (= 2 (second (php/array 1 2))) "second of pgp array")
-  (is (nil? (second (php/array))) "second of empty php array")
+  (is (= 2 (second (php-indexed-array 1 2))) "second of pgp array")
+  (is (nil? (second (php-indexed-array))) "second of empty php array")
   (is (nil? (second #{})) "second of empty set")
   (let [values #{[1] [2]}]
     (is (= values (set [(first values) (second values)])) "second of set"))
@@ -117,9 +117,9 @@
 (deftest test-count
   (is (= 0 (count [])) "count of empty vector")
   (is (= 0 (count nil)) "count of nil")
-  (is (= 0 (count (php/array))) "count of empty php array")
+  (is (= 0 (count (php-indexed-array))) "count of empty php array")
   (is (= 0 (count {})) "count of empty hash map")
   (is (= 1 (count ["a"])) "count of one element vector")
-  (is (= 1 (count (php/array "a"))) "count of one element php array")
+  (is (= 1 (count (php-indexed-array "a"))) "count of one element php array")
   (is (= 1 (count {:a 1})) "count of one element hash map")
   (is (= 3 (count "str")) "strings are now supported"))

--- a/tests/phel/core/by-ref-param.phel
+++ b/tests/phel/core/by-ref-param.phel
@@ -5,7 +5,7 @@
   (php/array_push parts msg))
 
 (deftest test-by-ref-param-propagates-mutation
-  (let [parts (php/array)]
+  (let [parts (php-indexed-array)]
     (paint-overlay! parts "hello")
     (paint-overlay! parts "world")
     (is (= 2 (php/count parts)) "mutations via &$arg propagate to caller")
@@ -16,7 +16,7 @@
   (aset counter "n" 0))
 
 (deftest test-by-ref-param-on-assoc-array
-  (let [counter (php/array)]
+  (let [counter (php-indexed-array)]
     (aset counter "n" 5)
     (reset-counter! counter)
     (is (= 0 (aget counter "n")) "aset under ^:by-ref mutates caller")))

--- a/tests/phel/core/destructuring.phel
+++ b/tests/phel/core/destructuring.phel
@@ -3,7 +3,7 @@
 
 (deftest destructure-vector
   (is (= 3 (let [[a b] [1 2]] (+ a b))) "from vector")
-  (is (= 3 (let [[a b] (php/array 1 2)] (+ a b))) "from php array")
+  (is (= 3 (let [[a b] (php-indexed-array 1 2)] (+ a b))) "from php array")
   (is (= 10 (let [[a [c d] b] [1 (list 4 3) 2]] (+ a b c d))) "nested")
   (is (= 4 (let [[a _ b] [1 2 3]] (+ a b))) "ignore value"))
 

--- a/tests/phel/core/interop-by-ref.phel
+++ b/tests/phel/core/interop-by-ref.phel
@@ -21,7 +21,7 @@
     (is (= "123" (aget m 1)) "preg_match writes its matches into the local")))
 
 (deftest php-ref-on-a-plain-function-mutating-in-place
-  (let [arr (php/array 3 1 2)]
+  (let [arr (php-indexed-array 3 1 2)]
     (php/sort (php/ref arr))
     (is (and (= 1 (aget arr 0)) (= 2 (aget arr 1)) (= 3 (aget arr 2)))
         "sort reorders the local array in place")))

--- a/tests/phel/core/interop-named-args.phel
+++ b/tests/phel/core/interop-named-args.phel
@@ -4,7 +4,7 @@
 (def- by-ref-target "PhelTest\\Fixtures\\Interop\\ByRefTarget")
 
 (deftest php-new-with-named-args
-  (let [ao (new ArrayObject :& :array (php/array 1 2 3))]
+  (let [ao (new ArrayObject :& :array (php-indexed-array 1 2 3))]
     (is (= 3 (.count ao)) "named args bind to the constructor parameters")))
 
 (deftest php-new-with-positional-then-named-args
@@ -16,7 +16,7 @@
     (is (= "2024-01-15" (.format dt "Y-m-d")) "static interop calls accept named args")))
 
 (deftest php-method-call-with-named-args
-  (let [ao (new ArrayObject (php/array 1 2))]
+  (let [ao (new ArrayObject (php-indexed-array 1 2))]
     (.setFlags ao :& :flags ArrayObject/ARRAY_AS_PROPS)
     (is (= 2 (.count ao)) "method interop calls accept named args")))
 

--- a/tests/phel/core/sequence-functions.phel
+++ b/tests/phel/core/sequence-functions.phel
@@ -114,7 +114,7 @@
   (is (= [] (drop 4 ["a" "b" "c"])) "drop four elements")
   (is (= ["a" "b" "c"] (doall (drop -1 ["a" "b" "c"]))) "drop with negative number")
   (is (= ["c"] (doall (drop 2 ["a" "b" "c"]))) "drop on vector")
-  (is (= ["c"] (doall (drop 2 (php/array "a" "b" "c")))) "drop on php array (returns lazy seq)"))
+  (is (= ["c"] (doall (drop 2 (php-indexed-array "a" "b" "c")))) "drop on php array (returns lazy seq)"))
 
 (deftest test-drop-last
   (is (= ["a" "b"] (doall (drop-last 1 ["a" "b" "c"]))) "drop-last element")
@@ -124,16 +124,16 @@
   (is (= ["a" "b" "c"] (doall (drop-last 0 ["a" "b" "c"]))) "drop-last zero elements")
   (is (= ["a" "b" "c"] (doall (drop-last -1 ["a" "b" "c"]))) "drop-last with negative number")
   (is (= [] (doall (drop-last 1 []))) "drop-last on empty vector")
-  (is (= ["a" "b"] (doall (drop-last 1 (php/array "a" "b" "c")))) "drop-last on php array")
-  (is (= [] (doall (drop-last 1 (php/array)))) "drop-last on empty php array"))
+  (is (= ["a" "b"] (doall (drop-last 1 (php-indexed-array "a" "b" "c")))) "drop-last on php array")
+  (is (= [] (doall (drop-last 1 (php-indexed-array)))) "drop-last on empty php array"))
 
 (deftest test-drop-last-single-arity
   (is (= ["a" "b"] (doall (drop-last ["a" "b" "c"]))) "drop-last single-arity defaults to 1 on vector")
   (is (= [] (doall (drop-last ["a"]))) "drop-last single-arity on single-element vector")
   (is (= [] (doall (drop-last []))) "drop-last single-arity on empty vector")
   (is (= [1 2 3] (doall (drop-last [1 2 3 4]))) "drop-last single-arity on longer vector")
-  (is (= ["a" "b"] (doall (drop-last (php/array "a" "b" "c")))) "drop-last single-arity on php array")
-  (is (= [] (doall (drop-last (php/array "a")))) "drop-last single-arity on single-element php array"))
+  (is (= ["a" "b"] (doall (drop-last (php-indexed-array "a" "b" "c")))) "drop-last single-arity on php array")
+  (is (= [] (doall (drop-last (php-indexed-array "a")))) "drop-last single-arity on single-element php array"))
 
 (deftest test-drop-last-nil
   (is (= [] (doall (drop-last 5 nil))) "drop-last with n on nil returns empty sequence")
@@ -149,8 +149,8 @@
 (deftest test-last
   (is (= "c" (last ["a" "b" "c"])) "last element")
   (is (nil? (last [])) "last on empty vector")
-  (is (= "c" (last (php/array "a" "b" "c"))) "last on php array")
-  (is (nil? (last (php/array))) "last on empty php array")
+  (is (= "c" (last (php-indexed-array "a" "b" "c"))) "last on php array")
+  (is (nil? (last (php-indexed-array))) "last on empty php array")
   (is (= 3 (last [1 2 3])) "last on numeric vector")
   (is (nil? (last nil)) "last on nil")
   (is (= "c" (last "abc")) "last on string")
@@ -165,7 +165,7 @@
   (is (nil? (butlast '(0))) "butlast single-element list returns nil")
   (is (nil? (butlast (range 1))) "butlast single-element range returns nil")
   (is (nil? (butlast nil)) "butlast on nil returns nil")
-  (is (= ["a" "b"] (doall (butlast (php/array "a" "b" "c")))) "butlast on php array"))
+  (is (= ["a" "b"] (doall (butlast (php-indexed-array "a" "b" "c")))) "butlast on php array"))
 
 (deftest test-drop-while
   (is (= [1 2 3 4 -1 -2 -3] (doall (drop-while neg? [-1 -2 -3 1 2 3 4 -1 -2 -3]))) "drop-while: first three element")
@@ -173,7 +173,7 @@
   (is (= [] (drop-while neg? [])) "drop-while: empty array")
   (is (= [1 2 3 4] (doall (drop-while neg? [1 2 3 4]))) "drop-while: nothing")
   (is (= [1 2 3 4 -1 -2 -3] (doall (drop-while neg? [-1 -2 -3 1 2 3 4 -1 -2 -3]))) "drop-while: vector")
-  (is (= [1 2 3 4 -1 -2 -3] (doall (drop-while neg? (php/array -1 -2 -3 1 2 3 4 -1 -2 -3)))) "drop-while: php array (returns lazy seq)"))
+  (is (= [1 2 3 4 -1 -2 -3] (doall (drop-while neg? (php-indexed-array -1 -2 -3 1 2 3 4 -1 -2 -3)))) "drop-while: php array (returns lazy seq)"))
 
 (deftest test-drop-while-empty-element
   (is (= [] (drop-while #(throw (new Exception)) [])) "`pred` is not executed when searching for empty vectors."))
@@ -186,8 +186,8 @@
   (is (= [] (take -1 ["a" "b" "c"])) "take with negative number")
   (is (= ["a" "b"] (doall (take 2 ["a" "b" "c"]))) "take on vector")
   (is (= [] (take -1 ["a" "b" "c"])) "take on vector")
-  (is (= ["a" "b"] (doall (take 2 (php/array "a" "b" "c")))) "take on php array returns lazy seq")
-  (is (= [] (take -1 (php/array "a" "b" "c"))) "take on php array with negative"))
+  (is (= ["a" "b"] (doall (take 2 (php-indexed-array "a" "b" "c")))) "take on php array returns lazy seq")
+  (is (= [] (take -1 (php-indexed-array "a" "b" "c"))) "take on php array with negative"))
 
 (deftest test-take-generator
   (is (= [0 1 2] (take 3 (naturals))) "take on generator"))
@@ -212,9 +212,9 @@
   (is (= ["b" "c"] (take-last 2 ["a" "b" "c"])) "take-last on vector")
   (is (= [] (take-last 1 [])) "take-last on empty vector")
   (is (= [] (take-last -1 ["a" "b" "c"])) "take-last with negative number on vector")
-  (is (= (php/array "b" "c") (take-last 2 (php/array "a" "b" "c"))) "take-last on php array")
-  (is (= (php/array) (take-last 1 (php/array))) "take-last on empty php array")
-  (is (= [] (take-last -1 (php/array "a" "b" "c"))) "take-last with negative number on php array")
+  (is (= (php-indexed-array "b" "c") (take-last 2 (php-indexed-array "a" "b" "c"))) "take-last on php array")
+  (is (= (php-indexed-array) (take-last 1 (php-indexed-array))) "take-last on empty php array")
+  (is (= [] (take-last -1 (php-indexed-array "a" "b" "c"))) "take-last with negative number on php array")
   (is (= [8 9] (take-last 2 (range 0 10))) "take-last on finite range")
   (is (thrown? InvalidArgumentException (doall (take-last nil (range 0 10))))
       "take-last with nil n compiles and throws at runtime"))
@@ -225,7 +225,7 @@
   (is (= [] (take-while neg? [1 2 3 4])) "take-while: nothing")
   (is (= [] (take-while neg? [])) "take-while: empty array")
   (is (= [-1 -2 -3] (take-while neg? [-1 -2 -3 1 2 3 4 -4 -5 -6])) "take-while on vector")
-  (is (= [-1 -2 -3] (take-while neg? (php/array -1 -2 -3 1 2 3 4 -4 -5 -6))) "take-while on php array"))
+  (is (= [-1 -2 -3] (take-while neg? (php-indexed-array -1 -2 -3 1 2 3 4 -4 -5 -6))) "take-while on php array"))
 
 ;; =============================================================================
 ;; Filtering & Searching
@@ -234,7 +234,7 @@
 (deftest test-filter
   (is (= [-1 -2 -3] (filter neg? [-1 2 3 -2 -3 4 5])) "filter: neg?")
   (is (= [-1 -2 -3] (filter neg? [-1 2 3 -2 -3 4 5])) "filter on vector")
-  (is (= [-1 -2 -3] (filter neg? (php/array -1 2 3 -2 -3 4 5))) "filter on php array"))
+  (is (= [-1 -2 -3] (filter neg? (php-indexed-array -1 2 3 -2 -3 4 5))) "filter on php array"))
 
 (deftest test-filter-empty-element
   (is (= [] (filter #(throw (new Exception)) [])) "`pred` is not executed when searching for empty vectors."))
@@ -293,7 +293,7 @@
 
 (deftest test-distinct
   (is (= [1 2 3] (distinct [1 1 2 3 2 2 3 1])) "distinct: array")
-  (is (= [1 2 3] (distinct (php/array 1 1 2 3 2 2 3 1))) "distinct: php array"))
+  (is (= [1 2 3] (distinct (php-indexed-array 1 1 2 3 2 2 3 1))) "distinct: php array"))
 
 (deftest test-distinct?
   (is (true? (distinct? 1)) "distinct? of a single argument")
@@ -425,8 +425,8 @@
   (is (= [0 3 1 2 2 1] (kvs [3 2 1])) "kvs of vector"))
 
 (deftest test-to-php-array
-  (is (= (php/array 3 2 1) (to-php-array [3 2 1])) "to-php-array")
-  (is (= (php/array "a" "b" "c") (to-php-array "abc")) "to-php-array string characters"))
+  (is (= (php-indexed-array 3 2 1) (to-php-array [3 2 1])) "to-php-array")
+  (is (= (php-indexed-array "a" "b" "c") (to-php-array "abc")) "to-php-array string characters"))
 
 (deftest test-sort
   (is (= [] (sort nil)) "sort nil")
@@ -645,10 +645,10 @@
       (is (= {"a" [1 {"b" 2}]} (php->phel arr)) "phel->php -> php->phel roundtrip"))))
 
 (deftest test-php-phel-roundtrip
-  (let [m     (php/array)
-        inner (php/array)]
+  (let [m     (php-indexed-array)
+        inner (php-indexed-array)]
     (aset inner "b" 2)
-    (aset m "a" (php/array 1 inner))
+    (aset m "a" (php-indexed-array 1 inner))
     (is (= m (phel->php (php->phel m))) "php->phel -> phel->php roundtrip")))
 
 ;; Issue #2298: phel->php must accept non-named map keys (int/string), not only keywords

--- a/tests/phel/core/sequence-operation.phel
+++ b/tests/phel/core/sequence-operation.phel
@@ -17,8 +17,8 @@
 (deftest test-peek
   (is (= 3 (peek [1 2 3])) "peek on a vector returns the last element")
   (is (nil? (peek [])) "peek on empty vector")
-  (is (= 3 (peek (php/array 1 2 3))) "peek on php array returns the last element")
-  (is (nil? (peek (php/array))) "peek on empty php array")
+  (is (= 3 (peek (php-indexed-array 1 2 3))) "peek on php array returns the last element")
+  (is (nil? (peek (php-indexed-array))) "peek on empty php array")
   (is (nil? (peek nil)) "peek on nil")
   (is (= :a (peek '(:a :b :c))) "peek on a list returns the first element")
   (is (nil? (peek '())) "peek on an empty list")
@@ -27,47 +27,47 @@
   (is (= 2 (peek (map #(* % 2) [1 2 3]))) "peek on lazy seq from map returns the head")
   (is (nil? (peek (filter false? [1 2 3]))) "peek on empty lazy seq"))
 
-(def- testing-set-global-array (php/array 1 2 3))
+(def- testing-set-global-array (php-indexed-array 1 2 3))
 
 (deftest test-native-global-array-set
   (aset testing-set-global-array 0 4)
-  (is (= (php/array 4 2 3) testing-set-global-array) "native global set on PHP array"))
+  (is (= (php-indexed-array 4 2 3) testing-set-global-array) "native global set on PHP array"))
 
-(def- testing-unset-global-array (php/array 1 2 3))
+(def- testing-unset-global-array (php-indexed-array 1 2 3))
 
 (deftest test-native-global-array-unset
   (php/aunset testing-unset-global-array 2)
-  (is (= (php/array 1 2) testing-unset-global-array) "native global unset on PHP array"))
+  (is (= (php-indexed-array 1 2) testing-unset-global-array) "native global unset on PHP array"))
 
-(def- testing-push-global-array (php/array 1 2 3))
+(def- testing-push-global-array (php-indexed-array 1 2 3))
 
 (deftest test-native-global-array-push
   (php/apush testing-push-global-array 4)
-  (is (= (php/array 1 2 3 4) testing-push-global-array) "native global push on PHP array"))
+  (is (= (php-indexed-array 1 2 3 4) testing-push-global-array) "native global push on PHP array"))
 
 (deftest test-native-array-aget-in
-  (let [arr (php/array (php/array 1 2 3))]
+  (let [arr (php-indexed-array (php-indexed-array 1 2 3))]
     (is (= 2 (php/aget-in arr [0 1])) "nested php array get")))
 
 (deftest test-native-array-aset-in
-  (let [arr (php/array (php/array 1 2 3))]
+  (let [arr (php-indexed-array (php-indexed-array 1 2 3))]
     (php/aset-in arr [0 1] 4)
-    (is (= (php/array (php/array 1 4 3)) arr) "nested php array set")))
+    (is (= (php-indexed-array (php-indexed-array 1 4 3)) arr) "nested php array set")))
 
 (deftest test-native-array-aunset-in
-  (let [arr (php/array (php/array 1 2 3))]
+  (let [arr (php-indexed-array (php-indexed-array 1 2 3))]
     (php/aunset-in arr [0 2])
-    (is (= (php/array (php/array 1 2)) arr) "nested php array unset")))
+    (is (= (php-indexed-array (php-indexed-array 1 2)) arr) "nested php array unset")))
 
 (deftest test-native-array-apush-in
-  (let [arr (php/array (php/array 1 2))]
+  (let [arr (php-indexed-array (php-indexed-array 1 2))]
     (php/apush-in arr [0] 3)
-    (is (= (php/array (php/array 1 2 3)) arr) "nested php array push")))
+    (is (= (php-indexed-array (php-indexed-array 1 2 3)) arr) "nested php array push")))
 
 (deftest test-native-apush
-  (let [x (php/array)]
+  (let [x (php-indexed-array)]
     (php/apush x 1)
-    (is (= (php/array 1) x) "native push on PHP array")))
+    (is (= (php-indexed-array 1) x) "native push on PHP array")))
 
 (deftest test-conj
   (is (= [] (conj)) "conj without arguments returns an empty vector")
@@ -88,8 +88,8 @@
   (is (= (list 1) (conj nil 1)) "conj on nil with a value returns a single-item list"))
 
 (deftest test-conj-php-arrays
-  (is (= (php/array 1 2 3) (conj (php/array 1 2) 3)) "conj on PHP array appends element")
-  (is (= (php/array 1 2 3 4) (conj (php/array 1 2) 3 4)) "conj on PHP array with multiple values"))
+  (is (= (php-indexed-array 1 2 3) (conj (php-indexed-array 1 2) 3)) "conj on PHP array appends element")
+  (is (= (php-indexed-array 1 2 3 4) (conj (php-indexed-array 1 2) 3 4)) "conj on PHP array with multiple values"))
 
 (deftest test-conj-transients
   (is (= [1 2 3] (persistent (conj (transient [1 2]) 3))) "conj on transient vector appends")
@@ -218,9 +218,9 @@
   (is (thrown? InvalidArgumentException (pop! nil)) "pop! on nil throws"))
 
 (deftest test-pop
-  (let [x (php/array 1 2)
+  (let [x (php-indexed-array 1 2)
         y (pop x)]
-    (is (= (php/array 1) x) "pop on PHP array: last element is removed")
+    (is (= (php-indexed-array 1) x) "pop on PHP array: last element is removed")
     (is (= 2 y) "pop on PHP array: last element is returned"))
 
   (is (nil? (pop nil)) "pop on nil returns nil")
@@ -275,7 +275,7 @@
     (is (= [1 2 3 4 5] v) "original vector is unchanged")))
 
 (deftest test-get
-  (is (= "b" (get (php/array "a" "b" "c") 1)) "get on php array")
+  (is (= "b" (get (php-indexed-array "a" "b" "c") 1)) "get on php array")
   (is (= "b" (get ["a" "b" "c"] 1)) "get on vector")
   (is (= "a" (get {:a "a" :b "b"} :a)) "get on map")
   (is (= 1 (get #{1 2 3} 1)) "get on set")

--- a/tests/phel/core/type-operation.phel
+++ b/tests/phel/core/type-operation.phel
@@ -18,7 +18,7 @@
   (is (= :boolean (type true)) "type of boolean")
   (is (= :boolean (type false)) "type of boolean")
   (is (= :function (type concat)) "type of function")
-  (is (= :php/array (type (php/array))) "type of php array")
+  (is (= :php/array (type (php-indexed-array))) "type of php array")
   (is (= :php/resource (type (php/tmpfile))) "type of php resource")
   (is (= :php/object (type (new DateTime))) "type of php object"))
 
@@ -431,7 +431,7 @@
       "clojure.lang.Symbol auto-aliases to Phel\\Lang\\Symbol"))
 
 (deftest test-php-array?
-  (is (true? (php-array? (php/array))) "php-array? on php array")
+  (is (true? (php-array? (php-indexed-array))) "php-array? on php array")
   (is (false? (php-array? [])) "php-array? on vector"))
 
 (deftest test-php-resource?
@@ -442,11 +442,11 @@
 
 (deftest test-empty?
   (is (true? (empty? [])) "empty? on empty vector")
-  (is (true? (empty? (php/array))) "empty? on empty php array")
+  (is (true? (empty? (php-indexed-array))) "empty? on empty php array")
   (is (true? (empty? {})) "empty? on empty map")
   (is (true? (empty? "")) "empty? on one empty string")
   (is (false? (empty? [1])) "empty? on one element vector")
-  (is (false? (empty? (php/array 1))) "empty? on one element php array")
+  (is (false? (empty? (php-indexed-array 1))) "empty? on one element php array")
   (is (false? (empty? {:a 1})) "empty? on one element map")
   (is (false? (empty? 1)) "empty? on positive number")
   (is (true? (empty? 0)) "empty? on zero")
@@ -460,7 +460,7 @@
   (is (false? (indexed? {})) "indexed? on map")
   (is (false? (indexed? (php-associative-array "a" 1 "b" 2))) "indexed? on associative array")
   (is (true? (indexed? [])) "indexed? on vector")
-  (is (true? (indexed? (php/array))) "indexed? on php array"))
+  (is (true? (indexed? (php-indexed-array))) "indexed? on php array"))
 
 (deftest test-associative?
   (is (true? (associative? {})) "associative? on empty map")
@@ -468,8 +468,8 @@
   (is (true? (associative? (php-associative-array "a" 1 "b" 2))) "associative? on associative php array")
   (is (true? (associative? [])) "associative? on empty vector")
   (is (true? (associative? [1 2 3])) "associative? on non-empty vector")
-  (is (true? (associative? (php/array))) "associative? on empty php array")
-  (is (true? (associative? (php/array "a" "b"))) "associative? on indexed php array")
+  (is (true? (associative? (php-indexed-array))) "associative? on empty php array")
+  (is (true? (associative? (php-indexed-array "a" "b"))) "associative? on indexed php array")
   (is (false? (associative? '())) "associative? on list is false")
   (is (false? (associative? '(1 2 3))) "associative? on non-empty list is false")
   (is (false? (associative? #{1 2})) "associative? on set is false")
@@ -512,8 +512,8 @@
   (is (false? (counted? true)) "counted? on boolean")
   (is (false? (counted? :a)) "counted? on keyword")
   (is (false? (counted? 'a)) "counted? on symbol")
-  (is (false? (counted? (php/array))) "counted? on empty php array")
-  (is (false? (counted? (php/array 1 2 3))) "counted? on non-empty php array"))
+  (is (false? (counted? (php-indexed-array))) "counted? on empty php array")
+  (is (false? (counted? (php-indexed-array 1 2 3))) "counted? on non-empty php array"))
 
 (deftest test-sequential?
   (is (true? (sequential? [])) "sequential? on empty vector")
@@ -553,8 +553,8 @@
   (is (false? (coll? true)) "coll? on boolean")
   (is (false? (coll? :a)) "coll? on keyword")
   (is (false? (coll? 'a)) "coll? on symbol")
-  (is (false? (coll? (php/array))) "coll? on empty php array")
-  (is (false? (coll? (php/array 1 2 3))) "coll? on non-empty php array"))
+  (is (false? (coll? (php-indexed-array))) "coll? on empty php array")
+  (is (false? (coll? (php-indexed-array 1 2 3))) "coll? on non-empty php array"))
 
 (deftest test-seqable?
   (is (true? (seqable? [])) "seqable? on empty vector")
@@ -569,7 +569,7 @@
   (is (true? (seqable? "hello")) "seqable? on string")
   (is (true? (seqable? "")) "seqable? on empty string")
   (is (true? (seqable? nil)) "seqable? on nil")
-  (is (true? (seqable? (php/array 1 2))) "seqable? on php array")
+  (is (true? (seqable? (php-indexed-array 1 2))) "seqable? on php array")
   (is (false? (seqable? 42)) "seqable? on integer")
   (is (false? (seqable? 1.5)) "seqable? on float")
   (is (false? (seqable? true)) "seqable? on boolean")

--- a/tests/phel/http-client.phel
+++ b/tests/phel/http-client.phel
@@ -6,9 +6,9 @@
 ;; --- Response parser integration (via PHP static call) ---
 
 (deftest test-response-parser-basic
-  (let [parsed (Phel.HttpClient.ResponseParser/parse (php/array "HTTP/1.1 200 OK"
-                                                                "Content-Type: application/json"
-                                                                "X-Request-Id: abc-123"))]
+  (let [parsed (Phel.HttpClient.ResponseParser/parse (php-indexed-array "HTTP/1.1 200 OK"
+                                                                        "Content-Type: application/json"
+                                                                        "X-Request-Id: abc-123"))]
     (is (= 200 (aget parsed "status")) "parses status code")
     (is (= "1.1" (aget parsed "version")) "parses HTTP version")
     (is (= "OK" (aget parsed "reason")) "parses reason phrase")
@@ -17,27 +17,27 @@
       (is (= "abc-123" (aget headers "x-request-id")) "parses custom header"))))
 
 (deftest test-response-parser-empty-headers
-  (let [parsed (Phel.HttpClient.ResponseParser/parse (php/array))]
+  (let [parsed (Phel.HttpClient.ResponseParser/parse (php-indexed-array))]
     (is (= 200 (aget parsed "status")) "defaults to 200 when no status line")
     (is (= "1.1" (aget parsed "version")) "defaults to HTTP/1.1")))
 
 (deftest test-response-parser-404
-  (let [parsed (Phel.HttpClient.ResponseParser/parse (php/array "HTTP/1.1 404 Not Found"))]
+  (let [parsed (Phel.HttpClient.ResponseParser/parse (php-indexed-array "HTTP/1.1 404 Not Found"))]
     (is (= 404 (aget parsed "status")) "parses 404 status")
     (is (= "Not Found" (aget parsed "reason")) "parses reason phrase")))
 
 (deftest test-response-parser-redirect-chain
-  (let [parsed (Phel.HttpClient.ResponseParser/parse (php/array "HTTP/1.1 301 Moved"
-                                                                "Location: /new"
-                                                                "HTTP/1.1 200 OK"
-                                                                "Content-Type: text/html"))]
+  (let [parsed (Phel.HttpClient.ResponseParser/parse (php-indexed-array "HTTP/1.1 301 Moved"
+                                                                        "Location: /new"
+                                                                        "HTTP/1.1 200 OK"
+                                                                        "Content-Type: text/html"))]
     (is (= 200 (aget parsed "status")) "uses final status after redirect")
     (is (= "text/html" (aget (aget parsed "headers") "content-type"))
         "parses headers from final response")))
 
 (deftest test-response-parser-colon-in-value
-  (let [parsed (Phel.HttpClient.ResponseParser/parse (php/array "HTTP/1.1 200 OK"
-                                                                "Location: https://example.com:8080/path"))]
+  (let [parsed (Phel.HttpClient.ResponseParser/parse (php-indexed-array "HTTP/1.1 200 OK"
+                                                                        "Location: https://example.com:8080/path"))]
     (is (= "https://example.com:8080/path"
            (aget (aget parsed "headers") "location"))
         "preserves colons in header values")))

--- a/tests/phel/http.phel
+++ b/tests/phel/http.phel
@@ -48,7 +48,7 @@
     (php/array_merge uri-server-default (php-associative-array "SERVER_PORT" "8081" "HTTP_HOST" "::1:8081"))]
    ["empty server variable"
     (h/uri nil nil nil 0 nil nil nil)
-    (php/array)]])
+    (php-indexed-array)]])
 
 (deftest test-url
   (foreach [[name uri server] uri-examples]
@@ -133,27 +133,27 @@
    ["nested files"
     (php-associative-array
      "files" (php-associative-array
-              "name" (php/array "my-file.txt" "Image.png")
-              "type" (php/array "text/plain" "image/png")
-              "tmp_name" (php/array "/tmp/my-file.txt" "/tmp/my-image.png")
-              "error" (php/array "0" "1")
-              "size" (php/array "123" "4321"))
+              "name" (php-indexed-array "my-file.txt" "Image.png")
+              "type" (php-indexed-array "text/plain" "image/png")
+              "tmp_name" (php-indexed-array "/tmp/my-file.txt" "/tmp/my-image.png")
+              "error" (php-indexed-array "0" "1")
+              "size" (php-indexed-array "123" "4321"))
      "nested" (php-associative-array
                "name" (php-associative-array
                        "a" "a.txt"
-                       "b" (php/array "b.txt" ""))
+                       "b" (php-indexed-array "b.txt" ""))
                "type" (php-associative-array
                        "a" "text/plain"
-                       "b" (php/array "text/plain" ""))
+                       "b" (php-indexed-array "text/plain" ""))
                "tmp_name" (php-associative-array
                            "a" "/tmp/a.txt"
-                           "b" (php/array "/tmp/b1.txt" "/tmp/b2.txt"))
+                           "b" (php-indexed-array "/tmp/b1.txt" "/tmp/b2.txt"))
                "error" (php-associative-array
                         "a" "0"
-                        "b" (php/array "0" "4"))
+                        "b" (php-indexed-array "0" "4"))
                "size" (php-associative-array
                        "a" "421"
-                       "b" (php/array "32" "0"))))
+                       "b" (php-indexed-array "32" "0"))))
     {"files" {0 (h/uploaded-file "/tmp/my-file.txt" 123 0 "my-file.txt" "text/plain")
               1 (h/uploaded-file "/tmp/my-image.png" 4321 1 "Image.png" "image/png")}
      "nested" {"a" (h/uploaded-file "/tmp/a.txt" 421 0 "a.txt" "text/plain")
@@ -418,7 +418,7 @@
    "REQUEST_URI"    "/api"))
 
 (defn- req-with-body [server raw-body]
-  (h/request-from-globals-args server (php/array) (php/array) (php/array) (php/array) raw-body))
+  (h/request-from-globals-args server (php-indexed-array) (php-indexed-array) (php-indexed-array) (php-indexed-array) raw-body))
 
 (deftest test-json-body-decoded
   (is (= {:name "Alice" :age 30}
@@ -447,12 +447,12 @@
   (let [server (php/array_merge json-req-server
                                 (php-associative-array "CONTENT_TYPE" "application/x-www-form-urlencoded"))
         req    (h/request-from-globals-args
-                server (php/array) (php-associative-array "name" "Bob") (php/array) (php/array) "name=Bob")]
+                server (php-indexed-array) (php-associative-array "name" "Bob") (php-indexed-array) (php-indexed-array) "name=Bob")]
     ;; form data keeps string keys (php-array-to-map), unlike JSON's keyword keys
     (is (= {"name" "Bob"} (:parsed-body req))
         "form-encoded body still comes from $_POST")))
 
 (deftest test-no-body-arg-back-compat
   (is (nil? (:parsed-body (h/request-from-globals-args
-                           json-req-server (php/array) (php/array) (php/array) (php/array))))
+                           json-req-server (php-indexed-array) (php-indexed-array) (php-indexed-array) (php-indexed-array))))
       "omitting raw-body keeps the 5-arg arity working"))

--- a/tests/php/Integration/Compiler/PhpArrayConstructorInlineTest.php
+++ b/tests/php/Integration/Compiler/PhpArrayConstructorInlineTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Compiler;
+
+use Phel\Compiler\Domain\Evaluator\Exceptions\EvaluatedCodeException;
+
+final class PhpArrayConstructorInlineTest extends AbstractCompilerRuntimeTestCase
+{
+    public function test_direct_indexed_constructor_skips_global_dispatch(): void
+    {
+        $php = $this->compilerFacade->compile('(def xs (php-indexed-array 1 2 3))')->getPhpCode();
+
+        self::assertStringNotContainsString('"php-indexed-array"', $php);
+        self::assertSame([1, 2, 3], $this->compilerFacade->eval('(php-indexed-array 1 2 3)'));
+    }
+
+    public function test_direct_associative_constructor_skips_global_dispatch(): void
+    {
+        $php = $this->compilerFacade->compile(
+            '(def attrs (php-associative-array "name" "Phel" "stable" true))',
+        )->getPhpCode();
+
+        self::assertStringNotContainsString('"php-associative-array"', $php);
+        self::assertSame(
+            ['name' => 'Phel', 'stable' => true],
+            $this->compilerFacade->eval('(php-associative-array "name" "Phel" "stable" true)'),
+        );
+    }
+
+    public function test_apply_keeps_both_constructors_callable(): void
+    {
+        $indexedPhp = $this->compilerFacade->compile('(apply php-indexed-array [1 2 3])')->getPhpCode();
+        $associativePhp = $this->compilerFacade
+            ->compile('(apply php-associative-array ["a" 1 "b" 2])')
+            ->getPhpCode();
+
+        self::assertStringContainsString('"php-indexed-array"', $indexedPhp);
+        self::assertStringContainsString('"php-associative-array"', $associativePhp);
+        self::assertSame([1, 2, 3], $this->compilerFacade->eval('(apply php-indexed-array [1 2 3])'));
+        self::assertSame(
+            ['a' => 1, 'b' => 2],
+            $this->compilerFacade->eval('(apply php-associative-array ["a" 1 "b" 2])'),
+        );
+    }
+
+    public function test_odd_associative_arity_keeps_runtime_validation(): void
+    {
+        $php = $this->compilerFacade
+            ->compile('(defn invalid-attrs [] (php-associative-array "a" 1 "b"))')
+            ->getPhpCode();
+
+        self::assertStringContainsString('"php-associative-array"', $php);
+
+        $this->expectException(EvaluatedCodeException::class);
+        $this->expectExceptionMessage(
+            "An even number of parameters must be provided for 'php-associative-array'",
+        );
+
+        $this->compilerFacade->eval('(php-associative-array "a" 1 "b")');
+    }
+
+    public function test_inline_arguments_run_once_in_left_to_right_order(): void
+    {
+        $this->compilerFacade->eval('(def constructor-log (atom []))');
+
+        $indexed = $this->compilerFacade->eval(
+            '(php-indexed-array (do (swap! constructor-log conj :first) 1)'
+            . ' (do (swap! constructor-log conj :second) 2))',
+        );
+        $associative = $this->compilerFacade->eval(
+            '(php-associative-array'
+            . ' (do (swap! constructor-log conj :third) "key")'
+            . ' (do (swap! constructor-log conj :fourth) "value"))',
+        );
+
+        self::assertSame([1, 2], $indexed);
+        self::assertSame(['key' => 'value'], $associative);
+        self::assertTrue(
+            $this->compilerFacade->eval('(= [:first :second :third :fourth] @constructor-log)'),
+        );
+    }
+}

--- a/tests/php/Integration/Fixtures/Def/hash-php-map-literal.test
+++ b/tests/php/Integration/Fixtures/Def/hash-php-map-literal.test
@@ -4,6 +4,11 @@
 \Phel::addDefinition(
   "user",
   "arr",
-  (\Phel::getDefinition("phel.core", "php-associative-array"))->__invoke("a", 1, "b", 2),
+  (function() {
+    $__phel_1_2 = array();
+    ($__phel_1_2)[("a")] = 1;
+    ($__phel_1_2)[("b")] = 2;
+    return $__phel_1_2;
+  })(),
   \Phel::locationMeta(\Phel::location("Def/hash-php-map-literal.test", 1, 0), \Phel::location("Def/hash-php-map-literal.test", 1, 28))
 );

--- a/tests/php/Integration/Fixtures/Def/hash-php-vector-literal.test
+++ b/tests/php/Integration/Fixtures/Def/hash-php-vector-literal.test
@@ -4,6 +4,6 @@
 \Phel::addDefinition(
   "user",
   "arr",
-  (\Phel::getDefinition("phel.core", "php-indexed-array"))->__invoke(1, 2, 3),
+  array(1, 2, 3),
   \Phel::locationMeta(\Phel::location("Def/hash-php-vector-literal.test", 1, 0), \Phel::location("Def/hash-php-vector-literal.test", 1, 22))
 );

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -263,6 +263,7 @@ PHEL);
                 default => '',
             },
         );
+        $input->method('getOption')->willReturn(false);
 
         return $input;
     }


### PR DESCRIPTION
## 🤔 Background

Direct `php-indexed-array` and `php-associative-array` calls paid variadic wrapper dispatch, keeping core on raw `php/array`.

## 💡 Goal

Make high-level PHP array constructors cheap enough to use throughout core and standard libraries.

## 🔖 Changes

- Inline direct constructors while preserving `apply`, evaluation order, and odd-arity validation.
- Migrate safe direct call sites and document bootstrap-only raw construction.
- Add compiler regressions, generated-code fixtures, benchmarks, and a run-command test stub fix.

Refs #2941