### PR TITLE
docs: fix invalid :closed? predicate in schema validation docs

### DIFF
--- a/resources/agents/tasks/validate-with-schema.md
+++ b/resources/agents/tasks/validate-with-schema.md
@@ -9,7 +9,7 @@
   (:require phel.schema :as s))
 
 (def User
-  [:map {:closed? true}
+  [:map {:closed true}
    [:id    :int]
    [:email [:re #"^[^@]+@[^@]+$"]]
    [:age   [:maybe :int]]])
@@ -44,7 +44,7 @@
 
 ## Gotchas
 
-- `:map` is open by default; add `{:closed? true}` to reject extras
+- `:map` is open by default; add `{:closed true}` to reject extras
 - `[:re #"..."]` expects a regex literal, not a string
 - `generate` may diverge on tight `[:and ...]` or `[:re ...]`; provide a `:gen` hint
 


### PR DESCRIPTION
The closed-map option is **`:closed`** (as in `metosin/malli`), not `:closed?`. The validator reads `(get (schema-options schema) :closed)` (`schema/validator.phel:258`, `explainer.phel:107`). So `[:map {:closed? true} ...]` from the doc would silently be treated as **open**. Use `{:closed true}`.

REPL example:
```clojure
$ ./bin/phel
Welcome to the Phel Repl (v0.49.0-beta#1fe571c)

(ns schema-demo
  (:require phel.schema :as s))

;; Incorrectly documented keyword
(s/validate [:map {:closed? true} [:id :int]] {:id 1 :extra 2})
;; => true

;; Correct
(s/validate [:map {:closed true} [:id :int]] {:id 1 :extra 2})
;; => false
```
