### PR TITLE
fix: stop internal namespace separator warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Stop internal test and nREPL eval forms from emitting namespace separator deprecations (#2950)
 - Teach preferred dotted namespace and markerless PHP class spellings across active docs and agent guidance (#2949)
 - Amend stale ADRs and document accepted ADR corrections (#2827 #2876)
 - Validate `slurp` paths correctly while preserving stream-wrapper support (#2941 #2943)

--- a/src/php/Nrepl/Application/Op/ReloadOp.php
+++ b/src/php/Nrepl/Application/Op/ReloadOp.php
@@ -12,7 +12,7 @@ use Phel\Shared\Facade\RunFacadeInterface;
 /**
  * Reloads project namespaces whose source files changed since the last load
  * (or all of them when the `all` param is truthy), delegating to the
- * `phel\repl/reload!` / `phel\repl/reload-all!` helpers. Editors bind this to
+ * `phel.repl/reload!` / `phel.repl/reload-all!` helpers. Editors bind this to
  * a "reload changed namespaces" shortcut.
  *
  * @internal
@@ -35,7 +35,7 @@ final readonly class ReloadOp implements OpHandlerInterface
         $reloadFn = ($all === '1' || $all === 'true') ? 'reload-all!' : 'reload!';
 
         $result = $this->runFacade->structuredEval(
-            '(phel\repl/' . $reloadFn . ')',
+            '(phel.repl/' . $reloadFn . ')',
             new CompileOptions(),
         );
 

--- a/src/php/Nrepl/Application/Op/RunTestsOp.php
+++ b/src/php/Nrepl/Application/Op/RunTestsOp.php
@@ -14,8 +14,8 @@ use Phel\Shared\Facade\RunFacadeInterface;
 use function preg_match;
 
 /**
- * Runs tests from inside the nREPL session, delegating to `phel\repl/run-tests`
- * (a whole namespace) or `phel\repl/run-test` (a single test when the `var`
+ * Runs tests from inside the nREPL session, delegating to `phel.repl/run-tests`
+ * (a whole namespace) or `phel.repl/run-test` (a single test when the `var`
  * param is set). Editors bind this to "run namespace tests" / "run test under
  * cursor" shortcuts.
  *
@@ -63,8 +63,8 @@ final readonly class RunTestsOp implements OpHandlerInterface
         }
 
         $code = $var === ''
-            ? "(phel\\repl/run-tests '" . $ns . ')'
-            : "(phel\\repl/run-test '" . $identifier . ')';
+            ? "(phel.repl/run-tests '" . $ns . ')'
+            : "(phel.repl/run-test '" . $identifier . ')';
 
         $result = $this->runFacade->structuredEval($code, new CompileOptions());
 

--- a/src/php/Nrepl/CLAUDE.md
+++ b/src/php/Nrepl/CLAUDE.md
@@ -18,8 +18,8 @@ The facade is production surface only. `NreplFactory::createOpDispatcher()` stay
 | `clone` `close` `describe` `eval` `load-file` `interrupt` | local handlers | core nREPL |
 | `completions` | Api `replCompleteWithTypes` | |
 | `lookup` / `info` / `eldoc` | Api `findSymbolMetadata` | three `LookupOp` instances differing only by name |
-| `reload` | Run `structuredEval` → `phel\repl/reload!`; `all` param (`1`/`true`) → `reload-all!` | |
-| `run-tests` | Run `structuredEval` → `phel\repl/run-tests` (required `ns` param); add `var` param → `phel\repl/run-test` (single test) | |
+| `reload` | Run `structuredEval` → `phel.repl/reload!`; `all` param (`1`/`true`) → `reload-all!` | |
+| `run-tests` | Run `structuredEval` → `phel.repl/run-tests` (required `ns` param); add `var` param → `phel.repl/run-test` (single test) | |
 
 ## Dependencies (NreplProvider)
 

--- a/src/php/Run/Domain/Test/TestNamespacePruner.php
+++ b/src/php/Run/Domain/Test/TestNamespacePruner.php
@@ -87,7 +87,7 @@ final readonly class TestNamespacePruner
     }
 
     /**
-     * Mirrors `phel\test\selector/glob->regex`: `*` matches one segment,
+     * Mirrors `phel.test.selector/glob->regex`: `*` matches one segment,
      * `**` matches any run, `.` is literal.
      */
     private function globToRegex(string $pattern): string

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -494,7 +494,7 @@ HELP)
     private function generatePhelTestCodeFromOptions(array $options, array $namespacesInformation): string
     {
         return sprintf(
-            '(do (phel\test/run-tests %s %s) [(phel\test/successful?) (get (get (phel\test/get-stats) :counts) :total)])',
+            '(do (phel.test/run-tests %s %s) [(phel.test/successful?) (get (get (phel.test/get-stats) :counts) :total)])',
             TestCommandOptions::fromArray($options)->asPhelHashMap(),
             $this->namespacesAsString($namespacesInformation),
         );

--- a/src/php/Run/Infrastructure/Command/TestWorkerCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestWorkerCommand.php
@@ -77,7 +77,7 @@ final class TestWorkerCommand extends Command
 
         try {
             // Bootstrap: load phel.core and every bundled phel.* module
-            // so `(phel\test/run-tests ...)` resolves without per-call requires.
+            // so `(phel.test/run-tests ...)` resolves without per-call requires.
             $this->getFacade()->loadPhelNamespaces();
 
             while (true) {
@@ -151,10 +151,10 @@ final class TestWorkerCommand extends Command
     private function runTestsForNamespace(WorkRequest $request): mixed
     {
         $phelCode = sprintf(
-            "(do (phel\\test/run-tests %s '%s) "
-            . '(phel\\json/encode {"ok" (phel\\test/successful?) '
-            . '"failed-tests" (phel\\test/get-failed-tests) '
-            . '"counts" (get (phel\\test/get-stats) :counts)}))',
+            "(do (phel.test/run-tests %s '%s) "
+            . '(phel.json/encode {"ok" (phel.test/successful?) '
+            . '"failed-tests" (phel.test/get-failed-tests) '
+            . '"counts" (get (phel.test/get-stats) :counts)}))',
             $request->options,
             $request->ns,
         );

--- a/src/php/Shared/Exceptions/ExceptionPrinterInterface.php
+++ b/src/php/Shared/Exceptions/ExceptionPrinterInterface.php
@@ -12,7 +12,7 @@ interface ExceptionPrinterInterface
     public function getExceptionString(AbstractLocatedException $e, CodeSnippet $codeSnippet): string;
 
     /**
-     * Called from Phel through PHP interop by `phel\test` (`(php/-> printer
+     * Called from Phel through PHP interop by `phel.test` (`(php/-> printer
      * (printStackTrace exception))`), so it has no PHP-side call site to grep
      * for. Do not remove as unused.
      */

--- a/tests/phel/repl.phel
+++ b/tests/phel/repl.phel
@@ -222,13 +222,13 @@
 (deftest test-eval-capturing-dir-accepts-bare-namespace-symbol
   (let [original-ns *ns*]
     (try
-      (eval-str "(ns user (:require phel\\repl :refer [dir]))")
-      (let [result (eval-capturing "(dir phel\\string)")
+      (eval-str "(ns user (:require phel.repl :refer [dir]))")
+      (let [result (eval-capturing "(dir phel.string)")
             out    (get result :out)]
         (is (= nil (get result :value)) "dir returns nil")
         (is (= true (get result :success)) "dir succeeds from a REPL string")
-        (is (s/contains? out "split") "dir lists phel\\string definitions")
-        (is (s/contains? out "trim") "dir lists phel\\string definitions"))
+        (is (s/contains? out "split") "dir lists phel.string definitions")
+        (is (s/contains? out "trim") "dir lists phel.string definitions"))
       (finally
         (eval-str (str "(ns " original-ns ")"))))))
 
@@ -282,15 +282,15 @@
 
 (deftest test-eval-str-runtime-require-resolves
   (let [result (eval-str "(ns test-rt-require-demo
-                            (:require phel\\repl :refer [require]))
-                          (require phel\\string)
+                            (:require phel.repl :refer [require]))
+                          (require phel.string)
                           (string/upper-case \"hello\")")]
     (is (= "HELLO" result) "runtime require resolves symbols without explicit src-dirs init")))
 
 (deftest test-eval-str-require-nonexistent-throws
   (let [result (eval-capturing "(ns test-rt-require-missing
-                                  (:require phel\\repl :refer [require]))
-                                (require nonexistent\\foo)")]
+                                  (:require phel.repl :refer [require]))
+                                (require nonexistent.foo)")]
     (is (= false (get result :success)) "requiring non-existent namespace fails")
     (is (s/contains? (get result :error) "nonexistent.foo")
         "error message includes the missing namespace name")))
@@ -301,36 +301,36 @@
 
 (deftest test-require-vector-form-with-alias
   (let [result (eval-str "(ns test-require-vec-alias
-                            (:require phel\\repl :refer [require]))
-                          (require '[phel\\string :as str])
+                            (:require phel.repl :refer [require]))
+                          (require '[phel.string :as str])
                           (str/upper-case \"hello\")")]
     (is (= "HELLO" result) "vector form require with :as alias resolves functions")))
 
 (deftest test-require-vector-form-bare
   (let [result (eval-str "(ns test-require-vec-bare
-                            (:require phel\\repl :refer [require]))
-                          (require '[phel\\string])
+                            (:require phel.repl :refer [require]))
+                          (require '[phel.string])
                           (string/upper-case \"hello\")")]
     (is (= "HELLO" result) "vector form require without :as auto-generates alias from ns tail")))
 
 (deftest test-require-vector-form-with-refer
   (let [result (eval-str "(ns test-require-vec-refer
-                            (:require phel\\repl :refer [require]))
-                          (require '[phel\\string :as ps :refer [upper-case]])
+                            (:require phel.repl :refer [require]))
+                          (require '[phel.string :as ps :refer [upper-case]])
                           (upper-case \"world\")")]
     (is (= "WORLD" result) "vector form require with :refer brings symbols into scope")))
 
 (deftest test-require-vector-form-clojure-ns-mapping
   (let [result (eval-str "(ns test-require-vec-clojure
-                            (:require phel\\repl :refer [require]))
+                            (:require phel.repl :refer [require]))
                           (require '[clojure.string :as cs])
                           (cs/upper-case \"mapped\")")]
     (is (= "MAPPED" result) "vector form require maps clojure.string to phel.string")))
 
 (deftest test-require-flat-form-still-works
   (let [result (eval-str "(ns test-require-flat-compat
-                            (:require phel\\repl :refer [require]))
-                          (require 'phel\\string :as flat-str)
+                            (:require phel.repl :refer [require]))
+                          (require 'phel.string :as flat-str)
                           (flat-str/upper-case \"flat\")")]
     (is (= "FLAT" result) "flat require form continues to work after vector-form addition")))
 

--- a/tests/php/Benchmark/Command/fixtures/test-command.phel
+++ b/tests/php/Benchmark/Command/fixtures/test-command.phel
@@ -1,5 +1,5 @@
-(ns tests-phpbench\Command\fixtures\test-command
-  (:require phel\test :refer [deftest is]))
+(ns tests-phpbench.Command.fixtures.test-command
+  (:require phel.test :refer [deftest is]))
 
 (deftest my-working-test
   (is (true? true)))

--- a/tests/php/Integration/Formatter/Command/Format/Fixtures/bad-format.phel
+++ b/tests/php/Integration/Formatter/Command/Format/Fixtures/bad-format.phel
@@ -1,4 +1,4 @@
-(ns phel-test\formatter\bad-format)
+(ns phel-test.formatter.bad-format)
 
 (+ 1
 2)

--- a/tests/php/Integration/Formatter/Command/Format/Fixtures/good-format.phel
+++ b/tests/php/Integration/Formatter/Command/Format/Fixtures/good-format.phel
@@ -1,4 +1,4 @@
-(ns phel-test\formatter\good-format)
+(ns phel-test.formatter.good-format)
 
 (+ 1
    2)

--- a/tests/php/Integration/Formatter/Command/Format/FormatCommandTest.php
+++ b/tests/php/Integration/Formatter/Command/Format/FormatCommandTest.php
@@ -87,7 +87,7 @@ TXT;
     {
         Phel::bootstrap(__DIR__);
 
-        $path = $this->writeTemporaryPhelFile("(ns phel-test\\formatter\\broken)\n\n(defn broken [\n");
+        $path = $this->writeTemporaryPhelFile("(ns phel-test.formatter.broken)\n\n(defn broken [\n");
 
         try {
             $tester = $this->createCommandTester();
@@ -104,7 +104,7 @@ TXT;
     {
         Phel::bootstrap(__DIR__);
 
-        $path = $this->writeTemporaryPhelFile("(ns phel-test\\formatter\\broken)\n\n(defn broken [\n");
+        $path = $this->writeTemporaryPhelFile("(ns phel-test.formatter.broken)\n\n(defn broken [\n");
 
         try {
             $tester = $this->createCommandTester();

--- a/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
@@ -122,7 +122,7 @@ final class ReplPromptNamespaceTest extends AbstractTestCommand
     {
         $io = $this->createReplTestIo();
         $io->setInputs(
-            new InputLine('user:1> ', '(require phel\test :refer [deftest is run-tests])'),
+            new InputLine('user:1> ', '(require phel.test :refer [deftest is run-tests])'),
             new InputLine('user:2> ', '(deftest test-issue (is (= 0 "")))'),
             new InputLine('user:3> ', '(run-tests {} *ns*)'),
             new InputLine('user:4> ', 'exit'),

--- a/tests/php/Integration/Run/Command/Test/TestCommandCoverage/TestCommandCoverageTest.php
+++ b/tests/php/Integration/Run/Command/Test/TestCommandCoverage/TestCommandCoverageTest.php
@@ -58,7 +58,7 @@ final class TestCommandCoverageTest extends TestCase
         );
         file_put_contents(
             $this->projectDir . '/tests/calc_test.phel',
-            "(ns app.calc-test\n  (:require phel\\test :refer [deftest is])\n  (:require app.calc))\n"
+            "(ns app.calc-test\n  (:require phel.test :refer [deftest is])\n  (:require app.calc))\n"
             . "(deftest add-works\n  (is (= 3 (app.calc/add 1 2))))\n",
         );
     }

--- a/tests/php/Integration/Run/Command/Test/TestCommandProjectSuccess/OutsideFixtures/no-tests.phel
+++ b/tests/php/Integration/Run/Command/Test/TestCommandProjectSuccess/OutsideFixtures/no-tests.phel
@@ -1,3 +1,3 @@
-(ns test-cmd-out-of-tree\no-tests)
+(ns test-cmd-out-of-tree.no-tests)
 
 (defn helper [x] (+ x 1))

--- a/tests/php/Integration/Run/Command/Test/TestCommandProjectSuccess/OutsideFixtures/test3.phel
+++ b/tests/php/Integration/Run/Command/Test/TestCommandProjectSuccess/OutsideFixtures/test3.phel
@@ -1,5 +1,5 @@
-(ns test-cmd-out-of-tree\test3
-  (:require phel\test :refer [deftest is]))
+(ns test-cmd-out-of-tree.test3
+  (:require phel.test :refer [deftest is]))
 
 (deftest my-out-of-tree-test
   (is (true? true)))

--- a/tests/php/Integration/Run/Command/Test/TestCommandProjectSuccess/TestCommandProjectSuccessTest.php
+++ b/tests/php/Integration/Run/Command/Test/TestCommandProjectSuccess/TestCommandProjectSuccessTest.php
@@ -33,6 +33,7 @@ final class TestCommandProjectSuccessTest extends TestCase
         self::assertMatchesRegularExpression('/Failed: 0/', $output);
         self::assertMatchesRegularExpression('/Error: 0/', $output);
         self::assertMatchesRegularExpression('/Total: 2/', $output);
+        self::assertStringNotContainsString("Backslash ('\\') namespace separator", $output);
     }
 
     public function test_one_file_in_project(): void

--- a/tests/php/Unit/Nrepl/Domain/Op/ReloadOpTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/ReloadOpTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Op;
+
+use Phel\Nrepl\Application\Op\EvalResultResponder;
+use Phel\Nrepl\Application\Op\ReloadOp;
+use Phel\Nrepl\Application\Session\SessionNamespaceBinder;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+use Phel\Shared\CompileOptions;
+use Phel\Shared\Eval\EvalResult;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+use Phel\Shared\Facade\RunFacadeInterface;
+use Phel\Shared\Printer\PrinterInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ReloadOpTest extends TestCase
+{
+    public function test_it_evaluates_reload_with_a_dotted_namespace(): void
+    {
+        $run = $this->createMock(RunFacadeInterface::class);
+        $run->expects(self::once())
+            ->method('structuredEval')
+            ->with('(phel.repl/reload!)', self::isInstanceOf(CompileOptions::class))
+            ->willReturn(EvalResult::success(null));
+
+        $this->reloadOp($run)->handle(new OpRequest('reload', 'r1', null, ['op' => 'reload']));
+    }
+
+    public function test_it_evaluates_reload_all_with_a_dotted_namespace(): void
+    {
+        $run = $this->createMock(RunFacadeInterface::class);
+        $run->expects(self::once())
+            ->method('structuredEval')
+            ->with('(phel.repl/reload-all!)', self::isInstanceOf(CompileOptions::class))
+            ->willReturn(EvalResult::success(null));
+
+        $this->reloadOp($run)->handle(new OpRequest('reload', 'r1', null, [
+            'op' => 'reload',
+            'all' => 'true',
+        ]));
+    }
+
+    private function reloadOp(RunFacadeInterface $run): ReloadOp
+    {
+        $binder = new SessionNamespaceBinder(
+            $this->createStub(CompilerFacadeInterface::class),
+            new SessionRegistry(),
+        );
+
+        return new ReloadOp(
+            $run,
+            new EvalResultResponder($this->createStub(PrinterInterface::class), $binder),
+        );
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Op/RunTestsOpTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/RunTestsOpTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Op;
+
+use Phel\Nrepl\Application\Op\EvalResultResponder;
+use Phel\Nrepl\Application\Op\RunTestsOp;
+use Phel\Nrepl\Application\Session\SessionNamespaceBinder;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+use Phel\Shared\CompileOptions;
+use Phel\Shared\Eval\EvalResult;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+use Phel\Shared\Facade\RunFacadeInterface;
+use Phel\Shared\Printer\PrinterInterface;
+use PHPUnit\Framework\TestCase;
+
+final class RunTestsOpTest extends TestCase
+{
+    public function test_it_evaluates_a_namespace_with_a_dotted_internal_namespace(): void
+    {
+        $run = $this->createMock(RunFacadeInterface::class);
+        $run->expects(self::once())
+            ->method('structuredEval')
+            ->with("(phel.repl/run-tests 'app.test)", self::isInstanceOf(CompileOptions::class))
+            ->willReturn(EvalResult::success(null));
+
+        $this->runTestsOp($run)->handle(new OpRequest('run-tests', 'r1', null, [
+            'op' => 'run-tests',
+            'ns' => 'app.test',
+        ]));
+    }
+
+    public function test_it_evaluates_one_test_with_a_dotted_internal_namespace(): void
+    {
+        $run = $this->createMock(RunFacadeInterface::class);
+        $run->expects(self::once())
+            ->method('structuredEval')
+            ->with("(phel.repl/run-test 'app.test/works)", self::isInstanceOf(CompileOptions::class))
+            ->willReturn(EvalResult::success(null));
+
+        $this->runTestsOp($run)->handle(new OpRequest('run-tests', 'r1', null, [
+            'op' => 'run-tests',
+            'ns' => 'app.test',
+            'var' => 'works',
+        ]));
+    }
+
+    private function runTestsOp(RunFacadeInterface $run): RunTestsOp
+    {
+        $binder = new SessionNamespaceBinder(
+            $this->createStub(CompilerFacadeInterface::class),
+            new SessionRegistry(),
+        );
+
+        return new RunTestsOp(
+            $run,
+            new EvalResultResponder($this->createStub(PrinterInterface::class), $binder),
+        );
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Internal CLI/nREPL eval forms and bundled fixtures still used backslash namespaces, emitting always-on warnings during normal tests.

## 💡 Goal

Keep Phel internals on preferred dotted syntax so user commands remain warning-free.

## 🔖 Changes

- Generate dotted forms for serial/parallel test runners and nREPL reload/test ops.
- Refresh related fixtures, module docs, and regression tests.
- Full refactor review found no additional changes.

Closes #2950