### PR TITLE
feat(reader): support keyword keys in #php maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Allow keyword keys in `#php` map literals (#2952)
 - Add Clojure-style PHP interop for value members, dynamic calls, enum cases and `set!` (#2881 #2883 #2887 #2888 #2907)
 - Add editor completion and hover for Clojure-style PHP interop, including static properties (#2916)
 - Add `Phel::installExceptionHandler($projectRootDir)` for source-mapped uncaught throwable reports (#2922)

--- a/resources/agents/RULES.md
+++ b/resources/agents/RULES.md
@@ -12,7 +12,7 @@ Single source for every skill adapter.
 6. Only `false` and `nil` are falsy. `0`, `""`, `[]` truthy.
 7. Namespaces need ≥ 2 segments. Prefer `.` separator (`app.main`); `\` still parses but is deprecated. File path matches ns under src dir.
 8. Comments: `;` inline, `;;` standalone, `#_` skips the next form.
-9. PHP assoc array: `#php {"k" "v"}` or `(to-php-array m)`. Not `{:k "v"}`.
+9. PHP assoc array: `#php {:k "v"}` stringifies keyword keys; use `(to-php-array m)` for an existing Phel map.
 10. Catch PHP: `(catch SomeException e ...)`.
 11. Annotate hot-path `defn` with `:tag` on params + return for PHP type emission, JIT-friendly call shape, and compile-time mismatch diagnostics. See `tasks/typed-defn.md`.
 

--- a/resources/agents/tasks/debug-errors.md
+++ b/resources/agents/tasks/debug-errors.md
@@ -60,7 +60,7 @@ Use `some->`:
 ### PHP assoc array vs Phel map
 
 ```phel
-(php/array_merge #php {"a" 1} #php {"b" 2})    ; OK
+(php/array_merge #php {:a 1} #php {:b 2})        ; OK
 (php/array_merge (to-php-array {:a 1}) ...)    ; OK
 (php-array-to-map arr)                         ; reverse
 ```

--- a/resources/agents/tasks/use-php-libs.md
+++ b/resources/agents/tasks/use-php-libs.md
@@ -15,7 +15,7 @@
 | Fn (global) | `(php/strlen s)` |
 | Fn (namespaced) | `(php/Amp\trapSignal xs)` |
 | PHP array indexed | `#php [1 2 3]` |
-| PHP array assoc | `#php {"k" "v"}` |
+| PHP array assoc | `#php {:k "v"}` |
 | Catch | `(catch SomeException e ...)` |
 
 Full table: <https://phel-lang.org/documentation/php-interop/>.
@@ -33,7 +33,7 @@ composer require guzzlehttp/guzzle
 
 (def client
   (new Client
-    #php {"base_uri" "https://api.example.com/" "timeout" 5.0}))
+    #php {:base_uri "https://api.example.com/" :timeout 5.0}))
 
 (defn fetch-user [id]
   (let [resp (.request client "GET" (str "/users/" id))]

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -30,6 +30,7 @@ The source map is split across the boundary on purpose: the writer (`Domain/Emit
 Lexer (source → `TokenStream`) → Parser (→ `FileNode` parse tree) → Reader (→ `ReaderResult` Phel data) → Analyzer (→ `AbstractNode` AST with `NodeEnvironment`) → Simplifier (→ optimized AST) → Emitter (→ `EmitterResult` PHP code).
 
 - Lexer `Token` and parse-tree nodes live in `Phel\Shared\Parser\Node`; `ExpressionParserFactory` produces them (sub-parsers in `Domain/Parser/ExpressionParser/`).
+- The `#php` reader tag expands vectors to indexed PHP arrays and maps to associative PHP arrays; literal keyword map keys become strings at read time.
 
 ### Interop shorthand expansion
 

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/TaggedLiteralReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/TaggedLiteralReader.php
@@ -8,6 +8,7 @@ use Phel;
 use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
 use Phel\Compiler\Domain\Reader\ReaderInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use Phel\Lang\TagHandlerException;
 use Phel\Lang\TagHandlers\BuiltinTagHandlers;
@@ -105,7 +106,7 @@ final readonly class TaggedLiteralReader
         }
 
         if ($tokenType === Token::T_OPEN_BRACE) {
-            return $this->buildCall($node, 'php-associative-array', $form);
+            return $this->buildCall($node, 'php-associative-array', $form, stringifyKeywordKeys: true);
         }
 
         throw ReaderException::forNode(
@@ -120,16 +121,26 @@ final readonly class TaggedLiteralReader
      *
      * @return PersistentListInterface<mixed>
      */
-    private function buildCall(TaggedLiteralNode $node, string $fnName, ListNode $form): PersistentListInterface
-    {
+    private function buildCall(
+        TaggedLiteralNode $node,
+        string $fnName,
+        ListNode $form,
+        bool $stringifyKeywordKeys = false,
+    ): PersistentListInterface {
         $elements = [Symbol::create($fnName)->setStartLocation($node->getStartLocation())];
+        $isKey = $stringifyKeywordKeys;
 
         foreach ($form->getChildren() as $child) {
             if ($child instanceof TriviaNodeInterface) {
                 continue;
             }
 
-            $elements[] = $this->reader->readExpression($child, $node);
+            $value = $this->reader->readExpression($child, $node);
+            $elements[] = $isKey && $value instanceof Keyword ? $value->getFullName() : $value;
+
+            if ($stringifyKeywordKeys) {
+                $isKey = !$isKey;
+            }
         }
 
         return Phel::list($elements)

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -1282,10 +1282,14 @@ final class ReaderTest extends TestCase
 
     public function test_php_tagged_literal_on_map_expands_to_associative_array_call(): void
     {
-        $form = $this->read('#php {"a" 1 "b" 2}');
+        $form = $this->read('#php {:a :first :app/b :second}');
 
         self::assertInstanceOf(PersistentListInterface::class, $form);
         self::assertSame('php-associative-array', $form->get(0)->getName());
+        self::assertSame('a', $form->get(1));
+        self::assertSame(Keyword::create('first'), $form->get(2));
+        self::assertSame('app/b', $form->get(3));
+        self::assertSame(Keyword::create('second'), $form->get(4));
     }
 
     public function test_php_tagged_literal_rejects_non_collection_form(): void

--- a/tests/php/Integration/Fixtures/Def/hash-php-map-literal.test
+++ b/tests/php/Integration/Fixtures/Def/hash-php-map-literal.test
@@ -1,5 +1,5 @@
 --PHEL--
-(def arr #php {"a" 1 "b" 2})
+(def arr #php {:a 1 :b 2})
 --PHP--
 \Phel::addDefinition(
   "user",
@@ -10,5 +10,5 @@
     ($__phel_1_2)[("b")] = 2;
     return $__phel_1_2;
   })(),
-  \Phel::locationMeta(\Phel::location("Def/hash-php-map-literal.test", 1, 0), \Phel::location("Def/hash-php-map-literal.test", 1, 28))
+  \Phel::locationMeta(\Phel::location("Def/hash-php-map-literal.test", 1, 0), \Phel::location("Def/hash-php-map-literal.test", 1, 26))
 );


### PR DESCRIPTION
## 🤔 Background
`#php` maps passed keyword keys to PHP unchanged, causing a runtime TypeError.

## 💡 Goal
Make `#php {:key value}` compile to a valid associative PHP array.

## 🔖 Changes
- Stringify literal keyword keys during reader expansion, including namespaced keywords.
- Preserve keyword values and existing string/expression keys.
- Refresh compiler fixtures, module notes, downstream guidance, and changelog.
- Full refactor review found no additional changes.

Closes #2952