### PR TITLE
fix(watch): finish the dotted-namespace sweep and guard it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Stop internal test and nREPL eval forms from emitting namespace separator deprecations (#2950)
+- Stop internal test, nREPL and watch eval forms from emitting namespace separator deprecations (#2950)
 - Teach preferred dotted namespace and markerless PHP class spellings across active docs and agent guidance (#2949)
 - Amend stale ADRs and document accepted ADR corrections (#2827 #2876)
 - Validate `slurp` paths correctly while preserving stream-wrapper support (#2941 #2943)

--- a/src/php/Run/Domain/Init/ProjectTemplateScaffolder.php
+++ b/src/php/Run/Domain/Init/ProjectTemplateScaffolder.php
@@ -35,7 +35,7 @@ final class ProjectTemplateScaffolder
 {
     /** Template name => one-line description, shown by `--list-templates`. */
     private const array TEMPLATES = [
-        'http-json-api' => 'Minimal HTTP JSON API (phel\http routing, handlers, public/index.php)',
+        'http-json-api' => 'Minimal HTTP JSON API (phel.http routing, handlers, public/index.php)',
         'todo-app' => 'HTTP todo app with an in-memory store and route handlers',
         'cli-wordcount' => 'CLI word-count tool reading stdin or file arguments',
     ];

--- a/src/php/Run/Infrastructure/Command/NsCommand.php
+++ b/src/php/Run/Infrastructure/Command/NsCommand.php
@@ -42,7 +42,7 @@ Lists loaded namespaces, or shows the definitions of one you name.
 
 <info>Examples:</info>
   <comment>phel ns</comment>                 List all loaded namespaces
-  <comment>phel ns phel\core --simple</comment>   Names only, for one namespace
+  <comment>phel ns phel.core --simple</comment>   Names only, for one namespace
 HELP)
             ->addArgument('inspect', InputArgument::OPTIONAL, 'Namespace to inspect')
             ->addOption('simple', 's', InputOption::VALUE_NONE, 'Display only namespace names');

--- a/src/php/Watch/Application/ReloadOrchestrator.php
+++ b/src/php/Watch/Application/ReloadOrchestrator.php
@@ -127,7 +127,7 @@ final readonly class ReloadOrchestrator implements ReloadOrchestratorInterface
     private function runReloadHooks(array $reloadedNamespaces): void
     {
         foreach ($reloadedNamespaces as $namespace) {
-            $code = sprintf('(phel\watch/run-on-reload-hooks "%s")', $namespace);
+            $code = sprintf('(phel.watch/run-on-reload-hooks "%s")', $namespace);
             try {
                 $this->runFacade->structuredEval($code, new CompileOptions());
             } catch (Throwable) {

--- a/src/php/Watch/CLAUDE.md
+++ b/src/php/Watch/CLAUDE.md
@@ -41,6 +41,6 @@ All four getters return the Shared contract, never a concrete facade, and `Satel
 
 - Backends are strategies. Only `PollingWatcher` runs in CI; `InotifyWatcher`/`FswatchWatcher` are runtime-probed but not unit-tested (need external binaries).
 - Debounce coalesces rapid changes so an editor double-save triggers a single reload.
-- `ReloadOrchestrator.handleChanges` order: resolve namespaces → reload in dep order → run `(phel\watch/run-on-reload-hooks <ns>)` per ns → re-index → publish event. Reload, hooks, and reindex are best-effort (catch `Throwable`) so one broken file never kills the loop. Deleted files are skipped.
+- `ReloadOrchestrator.handleChanges` order: resolve namespaces → reload in dep order → run `(phel.watch/run-on-reload-hooks <ns>)` per ns → re-index → publish event. Reload, hooks, and reindex are best-effort (catch `Throwable`) so one broken file never kills the loop. Deleted files are skipped.
 - `NullReloadEventPublisher` is the default; inject an nREPL-aware publisher for nREPL contexts.
 - `NamespaceResolver` uses a regex on the first `ns`/`in-ns` form (runs on every change — speed over full parse); not the compiler reader.

--- a/tests/php/Unit/Architecture/GeneratedPhelSourceTest.php
+++ b/tests/php/Unit/Architecture/GeneratedPhelSourceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Architecture;
+
+use PHPUnit\Framework\TestCase;
+
+use function implode;
+use function is_array;
+use function preg_match_all;
+use function sprintf;
+use function token_get_all;
+
+/**
+ * Phel source that phel itself generates and evaluates must spell namespaces
+ * with `.`, never `\`.
+ *
+ * `DeprecationWarnings` suppresses the separator notice for the bundled stdlib
+ * by *source path*, but a form built in PHP and handed to `eval()` has no such
+ * path, so it is reported as if the user had written it. The user cannot act on
+ * it: the offending text lives in phel's own PHP. `phel test`, the nREPL
+ * `reload` / `run-tests` ops and the watch reload hooks all did this, so a run
+ * with `--warn-deprecations` buried real notices under phel's own.
+ *
+ * Scoped to `src/php` on purpose. `\` is still supported (ADR 0008) and test
+ * fixtures exercise it deliberately, `test-dir-accepts-dot-form` among them, so
+ * a repository-wide rule would fail on the coverage that keeps the separator
+ * honest.
+ */
+final class GeneratedPhelSourceTest extends TestCase
+{
+    use ScansPhpSourcesTrait;
+
+    /**
+     * A bundled `phel*` namespace whose segments are joined with `\`.
+     *
+     * Anchored to the reserved `phel` prefix, in lowercase, because that is what
+     * tells generated Phel apart from a PHP FQN: `phel\test/run-tests` is Phel
+     * source, `Phel\Lang\Keyword` is a class name that legitimately appears in
+     * emitted PHP. Matching one or two backslashes covers both quoting styles,
+     * since a single-quoted PHP literal carries `phel\test` and a double-quoted
+     * one carries `phel\\test`.
+     *
+     * The trailing `/` is deliberately *not* required. A var reference spells it
+     * (`phel\test/run-tests`), but a `(:require phel\repl ...)` inside an
+     * evaluated `ns` form does not, and that form warns just the same.
+     *
+     * The segment needs two characters or more, so an escape sequence in a
+     * double-quoted literal is not read as a namespace: the regex in
+     * `DocstringSignatureParser` matches a fenced ```` ```phel\n ```` block, and
+     * every real bundled segment (`core`, `test`, `repl`, ...) is longer.
+     */
+    private const string BACKSLASH_NAMESPACE = '#\bphel(?:-[a-z0-9]+)?\\\\{1,2}[a-z][a-z0-9-]+#';
+
+    public function test_generated_phel_source_uses_dotted_namespaces(): void
+    {
+        $offenders = [];
+
+        foreach ($this->phpFilesIn('src/php') as $relativePath => $contents) {
+            foreach ($this->stringLiteralsOf($contents) as [$line, $literal]) {
+                if (preg_match_all(self::BACKSLASH_NAMESPACE, $literal, $matches) === 0) {
+                    continue;
+                }
+
+                $offenders[] = sprintf('src/php/%s:%d uses %s', $relativePath, $line, implode(', ', $matches[0]));
+            }
+        }
+
+        self::assertSame([], $offenders, 'Generated Phel source must use `.` as the namespace separator.');
+    }
+
+    /**
+     * Only string literals, so the separator stays legal in prose: a docblock
+     * naming `phel\repl/reload!` documents what the op used to emit and is not
+     * itself evaluated.
+     *
+     * @return list<array{int, string}> [line, raw literal including quotes]
+     */
+    private function stringLiteralsOf(string $contents): array
+    {
+        $literals = [];
+
+        foreach (token_get_all($contents) as $token) {
+            if (!is_array($token)) {
+                continue;
+            }
+
+            if ($token[0] !== T_CONSTANT_ENCAPSED_STRING && $token[0] !== T_ENCAPSED_AND_WHITESPACE) {
+                continue;
+            }
+
+            $literals[] = [$token[2], $token[1]];
+        }
+
+        return $literals;
+    }
+}


### PR DESCRIPTION
## 🤔 Background

#2954 closed #2950 for the test and nREPL eval forms. Two generated forms were left behind, and nothing stops the next one.

## 💡 Goal

Finish the sweep, and make the rule enforceable instead of a thing to remember.

## 🔖 Changes

- `ReloadOrchestrator` still built `(phel\watch/run-on-reload-hooks ...)`, so a watch reload warned against code the user cannot edit.
- `phel ns` help and the http-json-api template description still taught the old spelling.
- `GeneratedPhelSourceTest` scans PHP string literals under `src/php` for a `phel*` namespace joined with `\`. Reverting the watch line is what proves it bites, and that is the site the first pass missed, so the guard matters more here than the four one-line edits.
- It matches a bare `phel\repl` as well as `phel\test/run-tests`: a `(:require ...)` inside an evaluated `ns` form carries no trailing `/` and warns the same. Scoped to `src/php`, since `\` is still supported (ADR 0008) and fixtures like `test-dir-accepts-dot-form` compare both spellings on purpose.

`composer test` green. Extends the existing CHANGELOG entry rather than adding a second one.

Related to #2950
