### PR TITLE
fix(string): treat plain matches as literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix literal matching in `phel.string/replace` and `replace-first` (#2957)
 - Stop internal test, nREPL and watch eval forms from emitting namespace separator deprecations (#2950)
 - Teach preferred dotted namespace and markerless PHP class spellings across active docs and agent guidance (#2949)
 - Amend stale ADRs and document accepted ADR corrections (#2827 #2876)

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -60,19 +60,18 @@ This is a convenience function for converting strings to character sequences. Pr
   (php/str_repeat s n))
 
 (defn- as-pattern
-  "Ensures match is a regex pattern. If it looks like a delimited regex
-  (first and last chars match), returns as-is; otherwise wraps as literal."
+  "Returns slash-delimited patterns as-is and wraps other strings as literals."
   [match]
   (if (and
        (> (php/mb_strlen match) 1)
-       (=
-        (php/substr match 0 1)
-        (php/substr match -1 1)))
+       (= "/" (php/substr match 0 1))
+       (= "/" (php/substr match -1 1)))
     match
     (format "/%s/" (php/preg_quote match "/"))))
 
 (defn replace
-  "Replaces all instances of match with replacement in s."
+  "Replaces all instances of match with replacement in s. Plain string matches
+  are literal; use a regex literal for regular-expression matching."
   {:example "(replace \"hello world\" \"world\" \"there\") ; => \"hello there\""}
   [s match replacement]
   (assert-string s)
@@ -84,7 +83,8 @@ This is a convenience function for converting strings to character sequences. Pr
       (php/preg_replace match replacement s))))
 
 (defn replace-first
-  "Replaces the first instance of match with replacement in s."
+  "Replaces the first instance of match with replacement in s. Plain string
+  matches are literal; use a regex literal for regular-expression matching."
   {:example "(replace-first \"hello world world\" \"world\" \"there\") ; => \"hello there world\""}
   [s match replacement]
   (assert-string s)

--- a/tests/phel/string.phel
+++ b/tests/phel/string.phel
@@ -25,9 +25,12 @@
 
 (deftest test-replace
   (is (= "barbarbar" (s/replace "foobarfoo" "foo" "bar")))
+  (is (= "1X2" (s/replace "1aba2" "aba" "X")))
+  (is (= "aXb" (s/replace "a--b" "--" "X")))
   (is (= "foobarfoo" (s/replace "foobarfoo" "baz" "bar")))
   (is (= "f$$d" (s/replace "food" "o" "$")))
   (is (= "f\\\\d" (s/replace "food" "o" "\\")))
+  (is (= "barbarbar" (s/replace "foobarfoo" #"foo" "bar")))
   (is (= "barbarbar" (s/replace "foobarfoo" "/foo/" "bar")))
   (is (= "foobarfoo" (s/replace "foobarfoo" "/baz/" "bar")))
   (is (= "f$$d" (s/replace "food" "/o/" "$")))
@@ -39,6 +42,8 @@
 
 (deftest test-replace-first
   (is (= "faobar" (s/replace-first "foobar" "o" "a")))
+  (is (= "1X2aba" (s/replace-first "1aba2aba" "aba" "X")))
+  (is (= "aXb--c" (s/replace-first "a--b--c" "--" "X")))
   (is (= "foobar" (s/replace-first "foobar" "z" "a")))
   (is (= "z.ology" (s/replace-first "zoology" "o" ".")))
   (is (= "barbarfoo" (s/replace-first "foobarfoo" "foo" "bar")))


### PR DESCRIPTION
## 🤔 Background
`replace` and `replace-first` misread matching endpoint characters as regex delimiters, causing warnings or corrupt output.

## 💡 Goal
Treat plain strings literally while preserving Phel regex literals.

## 🔖 Changes
- Recognize the slash-delimited representation emitted by Phel regex literals.
- Add regressions for alphanumeric and punctuation endpoint collisions.
- Clarify public docstrings and update the changelog.
- Full refactor review found no additional changes.

Closes #2957