### PR TITLE
perf(core): order int and conj dispatch by how often each case is hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Runtime core:
 - Speed up `re-find`, `re-matches` and `parse-long` by avoiding full match-map conversion (#2941 #2943)
 - Give `aget` a fixed single-index arity and require an index, matching Clojure (#2941)
 - Use `aget` and `aset` across core/std libraries where bootstrap allows it (#2941 #2942)
+- Order `int` and `conj` dispatch by how often each case is hit (#2965)
 
 ### Removed
 

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -423,14 +423,20 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(int 1.9) ; => 1\n(int \"42\") ; => 42\n(int 1/10) ; => 0"
    :see-also ["float" "double" "int?" "number?"]}
   [x]
+  ;; Ordered by how often each case is reached, not by how interesting it is.
+  ;; An int or a numeric string used to fall through three `instanceof` checks
+  ;; and `is_object` before reaching `intval`; the boxed numerics are the rare
+  ;; case, so they now sit behind the single `is_object` they all require.
   (cond
-    (or (php/instanceof x Ratio)
-        (php/instanceof x BigInt)
-        (php/instanceof x BigDecimal)) (.toInt x)
-    (php/is_float x)                   (.toInt (BigInt/fromFloat x))
-    (php/is_object x)                  (throw (new InvalidArgumentException
-                                                   (str "int expects a number, numeric string, or nil, got " (type x))))
-    :else                             (php/intval x)))
+    (php/is_int x)    x
+    (php/is_float x)  (.toInt (BigInt/fromFloat x))
+    (php/is_object x) (cond
+                        (php/instanceof x Ratio)      (.toInt x)
+                        (php/instanceof x BigInt)     (.toInt x)
+                        (php/instanceof x BigDecimal) (.toInt x)
+                        :else                         (throw (new InvalidArgumentException
+                                          (str "int expects a number, numeric string, or nil, got " (type x)))))
+    :else             (php/intval x)))
 
 (defn float
   "Coerces `x` to a float. In PHP there is no distinction between float and

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -201,18 +201,24 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
 (defn- conj-impl
   [coll value]
   (cond
-    (php/=== coll nil)                            (list value)
-    (php/instanceof coll PersistentListInterface) (cons value coll)
-    (php/instanceof coll LazySeqInterface)        (cons value coll)
-    (php/is_array coll)                           (do (php/apush coll value) coll)
-    (vector-target? coll)                         (.append coll value)
-    (set-target? coll)                            (.add coll value)
-    (map-target? coll)                            (conj-map-entry coll value)
+    ;; Persistent vector first: it is the most common conj target, and reaching
+    ;; it through `vector-target?` cost two `instanceof`, an `is_array` and a
+    ;; function call. Hoisting the concrete check is safe because MapEntry does
+    ;; not implement PersistentVectorInterface, so the MapEntry branch below
+    ;; still sees every entry. Transients keep their original slot.
+    (php/instanceof coll PersistentVectorInterface) (.append coll value)
+    (php/=== coll nil)                              (list value)
+    (php/instanceof coll PersistentListInterface)   (cons value coll)
+    (php/instanceof coll LazySeqInterface)          (cons value coll)
+    (php/is_array coll)                             (do (php/apush coll value) coll)
+    (vector-target? coll)                           (.append coll value)
+    (set-target? coll)                              (.add coll value)
+    (map-target? coll)                              (conj-map-entry coll value)
     ;; MapEntry degrades to a 3-vector when grown; the result is no longer
     ;; an entry. Matches Clojure's MapEntry under conj.
     (php/instanceof coll MapEntry)
     (.append [(.key coll) (.value coll)] value)
-    (php/instanceof coll PushInterface)           (.push coll value)
+    (php/instanceof coll PushInterface)             (.push coll value)
     :else
     (throw (new InvalidArgumentException
                 (str "Cannot conj on type " (type coll))))))


### PR DESCRIPTION
## 🤔 Background

Both functions reach their most common case last. `int` sends an int or a numeric string through three `instanceof` checks and `is_object` before `intval`; `conj` reaches a persistent vector through two `instanceof`, an `is_array` and a call to `vector-target?`.

## 💡 Goal

Order each `cond` by how often the branch is actually taken.

## 🔖 Changes

- `int`: the three boxed numerics all require `is_object`, so they now sit behind that one check.
- `conj`: the concrete `PersistentVectorInterface` check is hoisted. Safe because `MapEntry` does not implement it, so the `MapEntry` branch below still sees every entry; transients keep their original slot.

Net of an empty-closure floor, 300k iterations:

| | before | after |
|---|---|---|
| `(int 42)` | 72.4 ms | 36.2 ms (-50%) |
| `(int "42")` | 74.9 ms | 42.2 ms (-44%) |
| `(int 1.9)` | 326.7 ms | 295.2 ms (-10%) |
| `(conj v 9)` | 238.1 ms | 213.2 ms (-10%) |

Results unchanged everywhere, including where `int` diverges from `php/intval`: `1e30` still raises `OverflowException`, `NaN` still raises `InvalidArgumentException`.

**This is the small one.** `(int ...)` has 2 call sites in the whole stdlib, so its 50% is a win for user code rather than for phel. No benchmark pins any of it yet, which is #2959. #2960 (`get`, 5.7x) and #2961 (`empty?`, 12x) are where the money is.

Closes #2965
