### PR TITLE
perf(core): reach collections earlier in empty?, and count them raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Runtime core:
 - Use `aget` and `aset` across core/std libraries where bootstrap allows it (#2941 #2942)
 - Order `int` and `conj` dispatch by how often each case is hit (#2965)
 - Reach maps and vectors first in `get`, and give it fixed `[ds k]` / `[ds k opt]` arities (#2960)
+- Reach collections earlier in `empty?`, and count them without core dispatch (#2961)
 
 ### Removed
 

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -434,13 +434,26 @@ A non-countable iterable (an `eduction` pipeline, a PHP generator) is answered b
   {:example "(empty? []) ; => true\n(empty? [1]) ; => false"
    :see-also ["not-empty" "empty" "count"]}
   [x]
+  ;; Collections are the common argument and were reached fifth, behind two
+  ;; scalar checks. They move up, but only as far as the lazy branches: a
+  ;; `LazySeq` *is* `Countable`, so putting the countable branch above it would
+  ;; count an infinite sequence rather than pull one element, which is the
+  ;; guarantee in the docstring above.
+  ;;
+  ;; The scalar branches keep their order relative to each other. `is_numeric`
+  ;; claims `"0"` before `is_string` sees it, and `(php/empty "0")` is `true`
+  ;; where `(= 0 "0")` is `false`, so swapping them changes `(empty? "0")`.
   (cond
-    (php/is_numeric x)                  (= 0 x)
-    (php/is_string x)                   (true? (php/empty x))
     (php/instanceof x LazySeqInterface) (nil? (first x))
     (php/instanceof x Cons)             false
-    (php/instanceof x Countable)        (= 0 (count x))
+    ;; `instanceof Countable` has already proven `php/count` valid here, so
+    ;; there is nothing for core `count` and core `=` to dispatch on.
+    (php/instanceof x Countable)        (php/=== 0 (php/count x))
+    (php/is_numeric x)                  (= 0 x)
+    (php/is_string x)                   (true? (php/empty x))
     (php/instanceof x Traversable)      (Seq/isEmpty x)
+    ;; Core `count` stays: this branch is reached by values `php/count` would
+    ;; reject outright, `nil` among them.
     :else                               (= 0 (count x))))
 
 (defn not-empty

--- a/tests/phel/core/empty-dispatch.phel
+++ b/tests/phel/core/empty-dispatch.phel
@@ -1,0 +1,50 @@
+(ns phel-test.core.empty-dispatch
+  (:require phel.test :refer [deftest is]))
+
+;; Pins the branches `empty?` dispatches through. Two of them are ordering
+;; constraints rather than behaviour, and neither is obvious from reading the
+;; function:
+;;
+;; - `LazySeq` implements `Countable`, so the lazy branches must stay above the
+;;   countable one. Reversing them makes `(empty? (iterate inc 0))` count an
+;;   infinite sequence and the suite hangs rather than fails.
+;; - `(php/empty "0")` is `true` in PHP, so `"0"` must keep reaching the numeric
+;;   branch before the string one. Swapping them flips `(empty? "0")`.
+
+(deftest test-empty-on-collections
+  (is (true? (empty? [])) "empty vector")
+  (is (false? (empty? [1])) "non-empty vector")
+  (is (true? (empty? {})) "empty map")
+  (is (false? (empty? {:a 1})) "non-empty map")
+  (is (true? (empty? '())) "empty list")
+  (is (false? (empty? '(1))) "non-empty list")
+  (is (true? (empty? (php-indexed-array))) "empty php array")
+  (is (false? (empty? (php-indexed-array 1))) "non-empty php array"))
+
+(deftest test-empty-on-strings
+  (is (true? (empty? "")) "empty string")
+  (is (false? (empty? "abc")) "non-empty string")
+  (is (false? (empty? "0"))
+      "\"0\" reaches the numeric branch, and `(= 0 \"0\")` is false: phel `=` does not coerce")
+  (is (false? (empty? "00")) "\"00\" is numeric and not zero"))
+
+(deftest test-empty-on-numbers
+  (is (true? (empty? 0)) "zero is empty")
+  (is (false? (empty? 1)) "non-zero is not empty")
+  (is (false? (empty? 0.0))
+      "0.0 is not `=` to the int 0, so a zero float is not empty"))
+
+(deftest test-empty-on-nil
+  (is (true? (empty? nil)) "nil is empty"))
+
+(deftest test-empty-on-lazy-seqs
+  (is (false? (empty? (map inc [1 2 3]))) "non-empty lazy seq")
+  (is (true? (empty? (filter (fn [x] false) [1 2 3]))) "lazy seq with nothing left")
+  ;; The one that would hang rather than fail if the ordering regressed: this
+  ;; sequence has no end to count.
+  (is (false? (empty? (iterate inc 0))) "an infinite lazy seq is answered without counting"))
+
+(deftest test-empty-on-eduction
+  ;; Traversable but not Countable: answered by pulling one element.
+  (is (false? (empty? (eduction (map inc) [1 2 3]))) "non-empty eduction")
+  (is (true? (empty? (eduction (filter (fn [x] false)) [1 2 3]))) "empty eduction"))

--- a/tests/phel/core/empty-dispatch.phel
+++ b/tests/phel/core/empty-dispatch.phel
@@ -39,7 +39,7 @@
 
 (deftest test-empty-on-lazy-seqs
   (is (false? (empty? (map inc [1 2 3]))) "non-empty lazy seq")
-  (is (true? (empty? (filter (fn [x] false) [1 2 3]))) "lazy seq with nothing left")
+  (is (true? (empty? (filter (constantly false) [1 2 3]))) "lazy seq with nothing left")
   ;; The one that would hang rather than fail if the ordering regressed: this
   ;; sequence has no end to count.
   (is (false? (empty? (iterate inc 0))) "an infinite lazy seq is answered without counting"))
@@ -47,4 +47,4 @@
 (deftest test-empty-on-eduction
   ;; Traversable but not Countable: answered by pulling one element.
   (is (false? (empty? (eduction (map inc) [1 2 3]))) "non-empty eduction")
-  (is (true? (empty? (eduction (filter (fn [x] false)) [1 2 3]))) "empty eduction"))
+  (is (true? (empty? (eduction (filter (constantly false)) [1 2 3]))) "empty eduction"))


### PR DESCRIPTION
## 🤔 Background

`empty?` had the worst wrapper-to-work ratio in `phel.core`, **35.6x** on `CoreDispatchBench`. Collections are the common argument and were reached fifth, behind `is_numeric` and `is_string`, and the branch then called core `=` and core `count` even though `instanceof Countable` had already proven `php/count` valid.

## 💡 Goal

Reach collections earlier, and stop dispatching on a type the branch already knows.

## 🔖 Changes

```
empty? vector   38.604µs -> 3.000µs    12.9x faster
ratio vs raw       35.6x -> 2.8x
```

The largest win of the perf set, from the smallest diff.

## ⚠️ Two orderings are load-bearing

Both are stated in the source now and pinned by tests, because neither is visible from reading the function:

- **`LazySeq` implements `Countable`.** Moving the countable branch to *first*, which is what #2961 originally proposed, would count an infinite sequence instead of pulling one element, contradicting this function's own docstring. It moves to third, below the lazy branches, not first.
- **`is_numeric` claims `"0"` before `is_string` sees it**, and `(php/empty "0")` is `true` where `(= 0 "0")` is `false`. The scalar branches keep their relative order.

The `:else` branch keeps core `count`: it is reached by values `php/count` rejects outright, `nil` among them.

`tests/phel/core/empty-dispatch.phel` covers collections, strings, numbers, nil, lazy seqs and a non-countable eduction. Two assertions were written from a wrong prediction and corrected against the implementation: `(empty? "0")` and `(empty? 0.0)` are both **false**, because phel `=` does not coerce. The infinite lazy seq case would hang rather than fail if the ordering regressed, which is why it is there.

Closes #2961
