### PR TITLE
perf(core): give assoc a fixed three-argument arity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ All notable changes to this project will be documented in this file.
 - Warn when a `def` shadows a loadable PHP class; `\DateTime` still reaches the class (#2876)
 - Suppress deprecation reports for code under `vendor/` (#2827)
 - BC: `get` declares `[ds k]` and `[ds k opt]` instead of `[ds k & [opt]]`; a fourth argument is now an arity error rather than silently ignored (#2960)
+- BC: `(arity get)` and `(arity assoc)` now report `0`. Both became multi-arity, and a multi-arity function compiles to one variadic dispatch, which `arity` documents as `0` (#2960 #2962)
 - BC: require `symfony/console` `^7.3|^8.0`
 - BC: require `gacela-project/gacela` `^2.0`
 - BC: expand `ApiFacadeInterface` and add `FormatterFacadeInterface::formatString`
@@ -97,6 +98,7 @@ Runtime core:
 - Order `int` and `conj` dispatch by how often each case is hit (#2965)
 - Reach maps and vectors first in `get`, and give it fixed `[ds k]` / `[ds k opt]` arities (#2960)
 - Reach collections earlier in `empty?`, and count them without core dispatch (#2961)
+- Give `assoc` a fixed three-argument arity so the common call skips the variadic path (#2962)
 
 ### Removed
 

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -153,7 +153,7 @@
 
 (defn arity
   "Returns the number of required parameters of the function `f`. For a variadic function this is the number of parameters before `&`. A multi-arity function compiles to a single variadic dispatch, so it reports `0`."
-  {:example "(arity inc) ; => 1\n(arity assoc) ; => 3"
+  {:example "(arity inc) ; => 1\n(arity swap!) ; => 2"
    :see-also ["variadic?" "apply" "partial"]}
   [f]
   (.getNumberOfRequiredParameters (fn-reflection f)))

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -303,17 +303,21 @@
 (defn assoc
   "Associates one or more key-value pairs with a collection. Additional key-value pairs beyond the first are applied in order. Throws if an odd number of extra arguments is provided."
   {:example "(assoc {:a 1} :b 2) ; => {:a 1, :b 2}\n(assoc {:a 1} :b 2 :c 3) ; => {:a 1, :b 2, :c 3}"}
-  [ds key value & more]
-  (when (php/!== 0 (php/& (count more) 1))
-    (throw (new InvalidArgumentException
-                (str "assoc expects an even number of extra arguments (key-value pairs), got "
-                     (count more)))))
-  (loop [acc       (assoc-pair ds key value)
-         remaining more]
-    (if (empty? remaining)
-      acc
-      (recur (assoc-pair acc (first remaining) (second remaining))
-             (rest (rest remaining))))))
+  ;; The three-argument call is nearly every call, and its whole work is one
+  ;; `assoc-pair`. On the variadic form it also allocated `more`, counted it,
+  ;; bit-tested the count and entered a loop whose first act was `empty?`.
+  ([ds key value] (assoc-pair ds key value))
+  ([ds key value & more]
+   (when (php/!== 0 (php/& (count more) 1))
+     (throw (new InvalidArgumentException
+                 (str "assoc expects an even number of extra arguments (key-value pairs), got "
+                      (count more)))))
+   (loop [acc       (assoc-pair ds key value)
+          remaining more]
+     (if (empty? remaining)
+       acc
+       (recur (assoc-pair acc (first remaining) (second remaining))
+              (rest (rest remaining)))))))
 
 (defn- dissoc-one
   [ds key]

--- a/tests/phel/core/assoc-dispatch.phel
+++ b/tests/phel/core/assoc-dispatch.phel
@@ -1,0 +1,21 @@
+(ns phel-test.core.assoc-dispatch
+  (:require phel.test :refer [deftest is thrown?]))
+
+;; Pins `assoc` across the arity boundary. The three-argument call is nearly
+;; every call and is the one that should not pay for the variadic form; the
+;; extras path keeps the odd-argument guard, which is only reachable there.
+
+(deftest test-assoc-three-args
+  (is (= {:a 1 :b 2} (assoc {:a 1} :b 2)) "map gains a key")
+  (is (= {:a 9} (assoc {:a 1} :a 9)) "existing key is replaced")
+  (is (= [9 2] (assoc [1 2] 0 9)) "vector index is replaced")
+  (is (= {:a 1} (assoc nil :a 1)) "nil collection becomes a map"))
+
+(deftest test-assoc-extra-pairs
+  (is (= {:a 1 :b 2 :c 3} (assoc {:a 1} :b 2 :c 3)) "two extra pairs")
+  (is (= {:a 1 :b 2 :c 3 :d 4} (assoc {:a 1} :b 2 :c 3 :d 4)) "three extra pairs")
+  (is (= {:a 3} (assoc {} :a 1 :a 2 :a 3)) "later pairs win over earlier ones"))
+
+(deftest test-assoc-odd-extra-arguments-throw
+  (is (thrown? Throwable (assoc {:a 1} :b 2 :c)) "a dangling key throws")
+  (is (thrown? Throwable (assoc {:a 1} :b 2 :c 3 :d)) "a dangling key after two pairs throws"))

--- a/tests/phel/core/function-operation.phel
+++ b/tests/phel/core/function-operation.phel
@@ -19,7 +19,7 @@
   (is (= 2 (arity #(+ %1 %2))) "arity of short fn literal"))
 
 (deftest test-arity-variadic
-  (is (= 3 (arity assoc)) "variadic fn reports required parameters before &")
+  (is (= 2 (arity swap!)) "variadic fn reports required parameters before &")
   (is (= 0 (arity +)) "fully variadic fn reports zero required parameters")
   (is (= 1 (arity (fn [x & xs] x))) "anonymous variadic fn reports required parameters"))
 

--- a/tests/php/Integration/Api/core-api.snapshot.txt
+++ b/tests/php/Integration/Api/core-api.snapshot.txt
@@ -118,7 +118,7 @@ phel.core/array-map  <value>
 phel.core/as->  (as-> expr name & forms)
 phel.core/aset  (aset arr idx & more)
 phel.core/assert  (assert expr & [message])
-phel.core/assoc  (assoc ds key value & more)
+phel.core/assoc  (assoc ds key value) | (assoc ds key value & more)
 phel.core/assoc!  (assoc! tcoll key value & more)
 phel.core/assoc-in  (assoc-in ds [k & ks] v)
 phel.core/associative?  (associative? x)


### PR DESCRIPTION
## 🤔 Background

The three-argument `assoc` is nearly every call, and its whole work is one `assoc-pair`. On the variadic form it also allocated `more`, counted it through core `count`, bit-tested the count, and entered a loop whose first act was `empty?`.

## 💡 Goal

Let the common call skip the variadic path entirely.

## 🔖 Changes

```
assoc map   52.689µs -> 35.510µs    ratio 2.6x -> 1.7x
```

Against the 87.273µs this measured before #2961, that is **2.5x** cumulative: `empty?` getting faster inside the loop did the rest.

The odd-argument guard stays on the variadic arity where it is still reachable, and `tests/phel/core/assoc-dispatch.phel` covers it along with both sides of the arity boundary.

## ⚠️ Two knock-ons, both recorded

`(arity assoc)` now reports `0` rather than `3`. That is exactly what `arity` documents for a multi-arity function, which compiles to a single variadic dispatch. But `arity`'s own `:example` still claimed `3`, and `test-arity-variadic` used `assoc` as its example of a *plain* variadic function. Both now use `swap!`, which still is one.

**The same already happened to `(arity get)` in #2960**, where nothing tested it and nothing recorded it. It is in the CHANGELOG now for both.

The API snapshot change is an arity **addition**, not a removal, so it does not narrow anything.

Closes #2962
