### PR TITLE
perf(core): inline the seq? check in seq and count countable raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ Runtime core:
 - Reach maps and vectors first in `get`, and give it fixed `[ds k]` / `[ds k opt]` arities (#2960)
 - Reach collections earlier in `empty?`, and count them without core dispatch (#2961)
 - Give `assoc` a fixed three-argument arity so the common call skips the variadic path (#2962)
+- Inline the `seq?` check in `seq` and count countable collections without core dispatch (#2963)
 
 ### Removed
 

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -498,19 +498,29 @@ This function is useful for explicitly converting strings to sequences of charac
   {:example "(seq \"hello\") ; => [\"h\" \"e\" \"l\" \"l\" \"o\"]\n(seq [1 2 3]) ; => (1 2 3)"
    :see-also ["count"]}
   [coll]
+  ;; Most of what this function costs is the conversion at the bottom, not the
+  ;; dispatch: on a vector, `to-php-array` plus `seqList` is the bulk of it and
+  ;; no ordering changes that. What the dispatch can stop paying for is the
+  ;; `seq?` call and core `count`, which is what the two changes below remove.
   (cond
-    (php/is_string coll)
-    (seq-vector (php/mb_str_split coll))
-
     (php/=== coll nil)
     nil
 
-    ;; For lazy sequences and lists, don't force them - just check if first element exists
-    (seq? coll)
+    (php/is_string coll)
+    (seq-vector (php/mb_str_split coll))
+
+    ;; `seq?` inlined. Same three checks it makes, without the call, and it sits
+    ;; on the path of every collection that is not one of these three.
+    ;; Lazy sequences and lists are not forced: only the first element is read.
+    (or (php/instanceof coll LazySeqInterface)
+        (php/instanceof coll Cons)
+        (php/instanceof coll PersistentListInterface))
     (if (php/=== nil (.first coll)) nil coll)
 
-    ;; For other countable collections, check count (won't force lazy seqs)
-    (and (php/instanceof coll Countable) (= 0 (count coll)))
+    ;; For other countable collections, check count (won't force lazy seqs).
+    ;; `instanceof Countable` has already proven `php/count` valid, so core
+    ;; `count` and core `=` have nothing left to dispatch on.
+    (and (php/instanceof coll Countable) (php/=== 0 (php/count coll)))
     nil
 
     (php/is_array coll)

--- a/tests/phel/core/seq-dispatch.phel
+++ b/tests/phel/core/seq-dispatch.phel
@@ -1,0 +1,32 @@
+(ns phel-test.core.seq-dispatch
+  (:require phel.test :refer [deftest is]))
+
+;; Pins what `seq` returns per input category. The empty cases are the ones a
+;; reordering is most likely to break: `seq` answers nil for an empty
+;; collection, which is what makes it usable as a truth test.
+
+(deftest test-seq-on-nil-and-empty
+  (is (nil? (seq nil)) "nil")
+  (is (nil? (seq [])) "empty vector")
+  (is (nil? (seq {})) "empty map")
+  (is (nil? (seq '())) "empty list")
+  (is (nil? (seq "")) "empty string")
+  (is (nil? (seq (php-indexed-array))) "empty php array"))
+
+(deftest test-seq-on-string
+  (is (= ["h" "i"] (seq "hi")) "string becomes a vector of characters"))
+
+(deftest test-seq-on-collections
+  (is (= [1 2 3] (vec (seq [1 2 3]))) "vector keeps its order")
+  (is (= [1 2 3] (vec (seq '(1 2 3)))) "list keeps its order")
+  (is (= [1 2 3] (vec (seq (php-indexed-array 1 2 3)))) "php array keeps its order"))
+
+(deftest test-seq-on-lazy-seqs
+  (is (nil? (seq (filter (constantly false) [1 2 3]))) "a lazy seq with nothing left is nil")
+  (is (= [2 3 4] (vec (seq (map inc [1 2 3])))) "a non-empty lazy seq is returned as-is")
+  ;; Must not be counted: this one has no end.
+  (is (some? (seq (iterate inc 0))) "an infinite lazy seq is answered without counting"))
+
+(deftest test-seq-on-set
+  (is (= 2 (count (seq (set [:a :b])))) "a set becomes a two-element seq")
+  (is (nil? (seq (set []))) "an empty set is nil"))

--- a/tests/php/Benchmark/Phel/CoreDispatchBench.php
+++ b/tests/php/Benchmark/Phel/CoreDispatchBench.php
@@ -197,12 +197,23 @@ final class CoreDispatchBench
     }
 
     /**
+     * A floor, not a target, and the only pair here that is not like for like.
+     *
+     * `seq` on a vector falls through to `(seq-list (to-php-array coll))`, so
+     * it materialises a *list*. No single native call does that, and the gap
+     * between this subject and `bench_seq_vector` is mostly `Phel::seqList`
+     * building the result, which is the value `seq` exists to return rather
+     * than overhead to remove.
+     *
+     * `getIterator()` was worse: it builds nothing at all, and reported a
+     * ratio near 15x that implied a win no reordering could deliver.
+     *
      * @Revs(1000)
      */
     public function bench_seq_vector_raw(): void
     {
         for ($i = 0; $i < self::INNER; ++$i) {
-            $this->vector->getIterator();
+            $this->vector->toArray();
         }
     }
 


### PR DESCRIPTION
## 🤔 Background

`seq` reached concrete collections through a `seq?` call, and its countable branch called core `=` and core `count` after `instanceof Countable` had already proven `php/count` valid.

## 💡 Goal

Stop paying for dispatch that the branch above has already decided.

## 🔖 Changes

```
seq vector   109.391µs -> 68.638µs   -37%
```

`seq?` is inlined to the same three `instanceof` checks it makes, the countable branch uses `php/===` and `php/count`, and `(php/=== coll nil)` moves ahead of `is_string` as the cheaper of the two.

## ⚠️ The issue's 15.3x was a bad comparison, not a missed win

I filed #2963 pairing `seq` against `getIterator()`. That builds nothing, while `seq` on a vector falls through to `(seq-list (to-php-array coll))` and materialises a **list**. Splitting the cost showed conversion dominating, with roughly a sixth removable, which is what this delivers.

So the benchmark pair is corrected here too. `bench_seq_vector_raw` calls `toArray()` and the file now says it is a **floor, not a target**: no single native call materialises a list, and the remaining gap is `Phel::seqList` building the value `seq` exists to return. Left as it was, the committed harness would have kept advertising a win no reordering can reach.

`tests/phel/core/seq-dispatch.phel` covers nil, every empty collection, strings, vectors, lists, PHP arrays, sets and lazy sequences, including an infinite one that must not be counted.

Closes #2963
