### PR TITLE
perf(core): give the arithmetic operators fixed arities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Runtime core:
 - Give `get-in` fixed arities and test the path with `nil?` rather than `empty?` per step (#2964)
 - Give `str` fixed arities up to three arguments, skipping the array and `implode` (#2974)
 - Declare real arities on `reduce` and `into` instead of a `case` over a rest argument (#2975)
+- Give `+`, `-`, `*` and `/` fixed arities, cutting untagged two-operand arithmetic 7.7x (#2978)
 
 ### Removed
 

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -27,6 +27,20 @@
   [& xs]
   (assert-non-nil-coll xs))
 
+;; Inlined nil guards for the fixed arities of the arithmetic operators. A
+;; `defn-` here would put a call back on the path the arities exist to shorten,
+;; which is the point of #2978. Arguments must be symbols: each is referenced
+;; once in the expansion, and the operators only ever pass their own parameters.
+(defmacro- assert-non-nil-1
+  [a]
+  `(when (php/=== nil ~a)
+     (throw (new InvalidArgumentException "Arithmetic functions do not accept nil values"))))
+
+(defmacro- assert-non-nil-2
+  [a b]
+  `(when (or (php/=== nil ~a) (php/=== nil ~b))
+     (throw (new InvalidArgumentException "Arithmetic functions do not accept nil values"))))
+
 ;; -----------------
 ;; Bitwise operation
 ;; -----------------
@@ -149,37 +163,49 @@
   "Returns the sum of all elements in `xs`. All elements `xs` must be numbers. If `xs` is empty, return 0."
   {:example "(+ 1 2 3) ; => 6"
    :see-also ["-" "*" "/" "sum"]}
-  [& xs]
-  (assert-non-nil-coll xs)
-  (case (count xs)
-    0 0
-    1 (first xs)
-    2 (NumericOperations/add (first xs) (second xs))
-    (reduce #(NumericOperations/add %1 %2) xs)))
+  ;; Fixed arities. The variadic form allocated a rest argument, called
+  ;; `assert-non-nil-coll`, core `count`, a `case`, then `first` and `second` to
+  ;; recover values the caller had already passed positionally: about six calls
+  ;; to perform one operation. See #2973 and #2978.
+  ([] 0)
+  ([x] (assert-non-nil-1 x) x)
+  ([x y] (assert-non-nil-2 x y) (NumericOperations/add x y))
+  ([x y & more]
+   (assert-non-nil-2 x y)
+   (assert-non-nil-coll more)
+   (reduce #(NumericOperations/add %1 %2) (NumericOperations/add x y) more)))
 
 (defn -
   "Returns the difference of all elements in `xs`. If `xs` is empty, return 0. If `xs` has one element, return the negative value of that element."
   {:example "(- 10 3 2) ; => 5\n(- 4) ; => -4"
    :see-also ["+" "*" "/"]}
-  [& xs]
-  (assert-non-nil-coll xs)
-  (case (count xs)
-    0 0
-    1 (NumericOperations/negate (first xs))
-    2 (NumericOperations/subtract (first xs) (second xs))
-    (reduce #(NumericOperations/subtract %1 %2) xs)))
+  ;; Fixed arities. The variadic form allocated a rest argument, called
+  ;; `assert-non-nil-coll`, core `count`, a `case`, then `first` and `second` to
+  ;; recover values the caller had already passed positionally: about six calls
+  ;; to perform one operation. See #2973 and #2978.
+  ([] 0)
+  ([x] (assert-non-nil-1 x) (NumericOperations/negate x))
+  ([x y] (assert-non-nil-2 x y) (NumericOperations/subtract x y))
+  ([x y & more]
+   (assert-non-nil-2 x y)
+   (assert-non-nil-coll more)
+   (reduce #(NumericOperations/subtract %1 %2) (NumericOperations/subtract x y) more)))
 
 (defn *
   "Returns the product of all elements in `xs`. All elements in `xs` must be numbers. If `xs` is empty, return 1."
   {:example "(* 2 3 4) ; => 24"
    :see-also ["+" "-" "/"]}
-  [& xs]
-  (assert-non-nil-coll xs)
-  (case (count xs)
-    0 1
-    1 (first xs)
-    2 (NumericOperations/multiply (first xs) (second xs))
-    (reduce #(NumericOperations/multiply %1 %2) xs)))
+  ;; Fixed arities. The variadic form allocated a rest argument, called
+  ;; `assert-non-nil-coll`, core `count`, a `case`, then `first` and `second` to
+  ;; recover values the caller had already passed positionally: about six calls
+  ;; to perform one operation. See #2973 and #2978.
+  ([] 1)
+  ([x] (assert-non-nil-1 x) x)
+  ([x y] (assert-non-nil-2 x y) (NumericOperations/multiply x y))
+  ([x y & more]
+   (assert-non-nil-2 x y)
+   (assert-non-nil-coll more)
+   (reduce #(NumericOperations/multiply %1 %2) (NumericOperations/multiply x y) more)))
 
 (defn /
   "Returns the nominator divided by all the denominators. If `xs` is empty,
@@ -190,13 +216,17 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   division."
   {:example "(/ 1 2) ; => 1/2\n(/ 10 2) ; => 5"
    :see-also ["+" "-" "*" "quot" "mod"]}
-  [& xs]
-  (assert-non-nil-coll xs)
-  (case (count xs)
-    0 1
-    1 (NumericOperations/divide 1 (first xs))
-    2 (NumericOperations/divide (first xs) (second xs))
-    (reduce #(NumericOperations/divide %1 %2) xs)))
+  ;; Fixed arities. The variadic form allocated a rest argument, called
+  ;; `assert-non-nil-coll`, core `count`, a `case`, then `first` and `second` to
+  ;; recover values the caller had already passed positionally: about six calls
+  ;; to perform one operation. See #2973 and #2978.
+  ([] 1)
+  ([x] (assert-non-nil-1 x) (NumericOperations/divide 1 x))
+  ([x y] (assert-non-nil-2 x y) (NumericOperations/divide x y))
+  ([x y & more]
+   (assert-non-nil-2 x y)
+   (assert-non-nil-coll more)
+   (reduce #(NumericOperations/divide %1 %2) (NumericOperations/divide x y) more)))
 
 (defn quot
   "Returns the truncated integer quotient of `dividend` / `divisor`. Truncates toward zero. Throws `\\DivisionByZeroError` when `divisor` is zero."
@@ -435,7 +465,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
                         (php/instanceof x BigInt)     (.toInt x)
                         (php/instanceof x BigDecimal) (.toInt x)
                         :else                         (throw (new InvalidArgumentException
-                                          (str "int expects a number, numeric string, or nil, got " (type x)))))
+                                                                  (str "int expects a number, numeric string, or nil, got " (type x)))))
     :else             (php/intval x)))
 
 (defn float

--- a/tests/phel/core/arith-dispatch.phel
+++ b/tests/phel/core/arith-dispatch.phel
@@ -1,0 +1,45 @@
+(ns phel-test.core.arith-dispatch
+  (:require phel.test :refer [deftest is thrown?]))
+
+;; Pins every arity of the arithmetic operators plus the nil rejection, which
+;; applies on all of them and is easy to lose when arities are split out.
+
+(deftest test-plus
+  (is (= 0 (+)) "no arguments is the additive identity")
+  (is (= 5 (+ 5)) "one argument is itself")
+  (is (= 3 (+ 1 2)) "two arguments")
+  (is (= 6 (+ 1 2 3)) "three arguments")
+  (is (= 10 (+ 1 2 3 4)) "four arguments"))
+
+(deftest test-minus
+  (is (= 0 (-)) "no arguments is zero")
+  (is (= -4 (- 4)) "one argument negates")
+  (is (= 7 (- 10 3)) "two arguments")
+  (is (= 5 (- 10 3 2)) "three arguments"))
+
+(deftest test-times
+  (is (= 1 (*)) "no arguments is the multiplicative identity")
+  (is (= 5 (* 5)) "one argument is itself")
+  (is (= 6 (* 2 3)) "two arguments")
+  (is (= 24 (* 2 3 4)) "three arguments"))
+
+(deftest test-divide
+  (is (= 1 (/)) "no arguments is one")
+  (is (= 1/2 (/ 2)) "one argument is the reciprocal")
+  (is (= 5 (/ 10 2)) "two arguments")
+  (is (= 1/2 (/ 1 2)) "integer division with a remainder is a Ratio")
+  (is (= 2 (/ 12 3 2)) "three arguments"))
+
+(deftest test-nil-is-rejected-on-every-arity
+  (is (thrown? Throwable (+ nil)) "+ one argument")
+  (is (thrown? Throwable (+ 1 nil)) "+ two arguments")
+  (is (thrown? Throwable (+ nil 1)) "+ first of two")
+  (is (thrown? Throwable (+ 1 2 nil)) "+ in the tail")
+  (is (thrown? Throwable (- 1 nil)) "- two arguments")
+  (is (thrown? Throwable (* 1 nil)) "* two arguments")
+  (is (thrown? Throwable (/ 1 nil)) "/ two arguments"))
+
+(deftest test-mixed-numeric-tower
+  (is (= 3.5 (+ 1 2.5)) "int plus float")
+  (is (= 1/2 (+ 1/4 1/4)) "ratio plus ratio")
+  (is (= 2.0 (* 1.0 2)) "float times int"))

--- a/tests/php/Integration/Api/core-api.snapshot.txt
+++ b/tests/php/Integration/Api/core-api.snapshot.txt
@@ -73,7 +73,7 @@ phel.cli/warning  (warning ctx text)
 phel.cli/write  (write ctx text)
 phel.cli/writeln  (writeln ctx text)
 phel.core/%  (% dividend divisor)
-phel.core/*  (* & xs)
+phel.core/*  (*) | (* x) | (* x y) | (* x y & more)
 phel.core/*'  (*' & xs)
 phel.core/**  (** a x)
 phel.core/*argv*  <value>
@@ -82,14 +82,14 @@ phel.core/*build-mode*  <value>
 phel.core/*file*  *file*
 phel.core/*ns*  *ns*
 phel.core/*program*  <value>
-phel.core/+  (+ & xs)
+phel.core/+  (+) | (+ x) | (+ x y) | (+ x y & more)
 phel.core/+'  (+' & xs)
-phel.core/-  (- & xs)
+phel.core/-  (-) | (- x) | (- x y) | (- x y & more)
 phel.core/-'  (-' & xs)
 phel.core/->  (-> x & forms)
 phel.core/->>  (->> x & forms)
 phel.core/->closure  (->closure f)
-phel.core//  (/ & xs)
+phel.core//  (/) | (/ x) | (/ x y) | (/ x y & more)
 phel.core/<  (< a & more)
 phel.core/<=  (<= a & more)
 phel.core/<=>  (<=> a b)


### PR DESCRIPTION
## 🤔 Background

Adding two numbers cost about **six calls**. `[& xs]` allocated a rest argument, then the body called `assert-non-nil-coll`, core `count`, ran a `case`, and used `first` and `second` to recover the two values the caller had already passed positionally, before reaching `NumericOperations`.

## 💡 Goal

Make `(+ a b)` cost roughly what an addition costs.

## 🔖 Changes

Untagged operands, 200k iterations net of floor:

| | before | after |
|---|---|---|
| `(+ x y)` | 602.3ms | **78.4ms** (7.7x) |
| `(* x y)` | 592.2ms | **75.0ms** (7.9x) |
| `(- x y)` | | **74.4ms** |
| `php/+` raw | | 32.8ms |

**Ratio against raw PHP addition: 18.2x → 2.4x.**

The nil guard is preserved on every arity, inlined through two private macros rather than a `defn-`, which would have put a call back on the path the arities exist to shorten. Identities unchanged: `(+)` is 0, `(*)` is 1, `(- x)` negates, `(/ x)` reciprocates.

## Where this does and does not apply

Arithmetic on operands the analyser can type never reaches this code, since `NumericOperationCallEmitter` lowers it. This is the **untagged** path: values from parameters, globals and collection reads, which is most arithmetic in ordinary code and the reason phel arithmetic read as slow next to PHP's.

`tests/phel/core/arith-dispatch.phel` covers every arity of all four operators, nil rejection on each, and mixed numeric-tower operands (int/float, ratio, float/int).

Rationale for the series: #2973

Closes #2978
