### PR TITLE
perf(compiler): specialize count on a map tag, not only a vector tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Runtime core:
 - Inline the `seq?` check in `seq` and count countable collections without core dispatch (#2963)
 - Give `get-in` fixed arities and test the path with `nil?` rather than `empty?` per step (#2964)
 - Give `str` fixed arities up to three arguments, skipping the array and `implode` (#2974)
+- Specialize `count` on a map-tagged local to a direct `->count()`, as `empty?` already did (#2985)
 - Declare real arities on `reduce` and `into` instead of a `case` over a rest argument (#2975)
 - Give `+`, `-`, `*` and `/` fixed arities, cutting untagged two-operand arithmetic 7.7x (#2978)
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecialization.php
@@ -6,6 +6,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\SeqInterface;
 
@@ -55,15 +56,19 @@ final readonly class TypedCollectionMethodSpecialization
         }
 
         $args = $node->getArguments();
-        if (TagNormalizer::ofLocalVar($args[0] ?? null) !== PersistentVectorInterface::class) {
-            return null;
-        }
+        $tag = TagNormalizer::ofLocalVar($args[0] ?? null);
 
-        if ($name === 'count' && count($args) === 1) {
+        // `count` takes a map tag as well. Both interfaces extend `Countable`,
+        // and {@see TypedValueSpecialization::emptyCheckFragment} already emits
+        // `->count()` for either, so this widens a table rather than trusting a
+        // new type. `nth` stays vector-only: a map has no positional `get`.
+        if ($name === 'count' && count($args) === 1
+            && ($tag === PersistentVectorInterface::class || $tag === PersistentMapInterface::class)
+        ) {
             return ['method' => 'count', 'args' => []];
         }
 
-        if ($name === 'nth' && count($args) === 2) {
+        if ($name === 'nth' && count($args) === 2 && $tag === PersistentVectorInterface::class) {
             return ['method' => 'get', 'args' => [1]];
         }
 

--- a/tests/php/Integration/Fixtures/Call/count-on-persistent-map-local.test
+++ b/tests/php/Integration/Fixtures/Call/count-on-persistent-map-local.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^"\\Phel\\Lang\\Collections\\Map\\PersistentMapInterface" m] (count m))
+--PHP--
+(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m): int {
+  return ($m->count());
+});

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/TypedCollectionMethodSpecializationTest.php
@@ -12,6 +12,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\TypedCollectionMethodSpecialization;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SeqInterface;
@@ -28,6 +29,34 @@ final class TypedCollectionMethodSpecializationTest extends TestCase
         $spec = TypedCollectionMethodSpecialization::typedVectorMethodCall($node);
 
         self::assertSame(['method' => 'count', 'args' => []], $spec);
+    }
+
+    /**
+     * Both interfaces extend `Countable`, and `empty?` already emits
+     * `->count()` for either, so the map tag is not a new trust edge.
+     */
+    public function test_count_on_typed_map_specialises_to_method_call(): void
+    {
+        $node = $this->coreCall('count', [$this->localWithTag('m', PersistentMapInterface::class)]);
+
+        $spec = TypedCollectionMethodSpecialization::typedVectorMethodCall($node);
+
+        self::assertSame(['method' => 'count', 'args' => []], $spec);
+    }
+
+    /**
+     * A map has no positional accessor, so widening `count` must not widen
+     * `nth` with it. `PersistentMap::get` exists but takes a key, not an index,
+     * and lowering to it here would silently return a value for a wrong lookup.
+     */
+    public function test_nth_on_typed_map_falls_back(): void
+    {
+        $node = $this->coreCall('nth', [
+            $this->localWithTag('m', PersistentMapInterface::class),
+            new LiteralNode($this->env(), 0),
+        ]);
+
+        self::assertNull(TypedCollectionMethodSpecialization::typedVectorMethodCall($node));
     }
 
     public function test_nth_on_typed_vector_specialises_to_get(): void


### PR DESCRIPTION
## 🤔 Background

`TypedCollectionMethodSpecialization::typedVectorMethodCall` gated on `PersistentVectorInterface` alone, so `(count m)` on a map-tagged local fell through to a registry dispatch even though the emitter already knew the type.

## 🔖 Changes

```
count untagged   50.2ms
count ^Map       13.5ms    3.7x
```

300k iterations net of a floor measured in the same process. 157 `count` dispatch sites in the built stdlib take a plain local as argument 0.

## Why this is a table widening, not a new trust edge

Both interfaces extend `Countable`, and `TypedValueSpecialization::emptyCheckFragment` **already** emits `(%s->count() === 0)` for `PersistentMapInterface` and `PersistentVectorInterface` alike. The proof that `->count()` is valid on a map tag was already in the codebase; `count` simply had not been widened with it.

`nth` deliberately stays vector-only inside the same function, with a test pinning that half: `PersistentMap::get` exists but takes a **key** rather than an index, so lowering `nth` on a map would compile fine and silently answer a different question.

Found by a research pass over the specialization tables rather than by guessing at hot spots.

Closes #2985
