### PR TITLE
perf(compiler): type let bindings whose init is control flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Runtime core:
 - Give `get-in` fixed arities and test the path with `nil?` rather than `empty?` per step (#2964)
 - Give `str` fixed arities up to three arguments, skipping the array and `implode` (#2974)
 - Specialize `count` on a map-tagged local to a direct `->count()`, as `empty?` already did (#2985)
+- Infer a primitive tag for `let` bindings whose init is `if`, `do` or a nested `let` (#2987)
 - Declare real arities on `reduce` and `into` instead of a `case` over a rest argument (#2975)
 - Give `+`, `-`, `*` and `/` fixed arities, cutting untagged two-operand arithmetic 7.7x (#2978)
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrer.php
@@ -256,6 +256,35 @@ final class BindingTypeInferrer
             return $this->callType($node, $locals);
         }
 
+        // Control-flow inits. `(let [n (if c 1 2)] ...)` left `n` untagged, so
+        // every later use of it paid a registry dispatch even though both arms
+        // are statically the same primitive. {@see collectRecurArgTypes} above
+        // already walks these three node kinds with the same accessors; this
+        // reads their value instead of their `recur` arguments.
+        if ($node instanceof DoNode) {
+            return $this->typeOf($node->getRet(), $locals);
+        }
+
+        if ($node instanceof IfNode) {
+            // Both arms must agree. A disagreement, or an arm this cannot type,
+            // yields null, which is exactly the untagged status quo. There is no
+            // `@bottom` here as there is in {@see ReturnTypeInferrer}: a `throw`
+            // arm types as null and suppresses the tag rather than deferring to
+            // its sibling. Conservative, and never wrong.
+            $then = $this->typeOf($node->getThenExpr(), $locals);
+            if ($then === null) {
+                return null;
+            }
+
+            return $then === $this->typeOf($node->getElseExpr(), $locals) ? $then : null;
+        }
+
+        // A loop is excluded for the same reason it is in `collectRecurArgTypes`:
+        // its body type depends on the recur fixpoint, not on a single walk.
+        if ($node instanceof LetNode && !$node->isLoop()) {
+            return $this->typeOf($node->getBodyExpr(), $locals);
+        }
+
         return null;
     }
 

--- a/tests/php/Integration/Fixtures/Call/let-do-init-infers-int.test
+++ b/tests/php/Integration/Fixtures/Call/let-do-init-infers-int.test
@@ -1,0 +1,12 @@
+--PHEL--
+(fn [] (let [n (do (php/count [1]) 7)] (+ n 1)))
+--PHP--
+(function() {
+  static $__phel_const_0;
+  /** @var int $n_1 */
+  $n_1 = (function() use(&$__phel_const_0) {
+    count(($__phel_const_0 ??= \Phel::vector([1])));
+    return 7;
+  })();
+  return ($n_1 + 1);
+});

--- a/tests/php/Integration/Fixtures/Call/let-if-init-disagreeing-arms-bails.test
+++ b/tests/php/Integration/Fixtures/Call/let-if-init-disagreeing-arms-bails.test
@@ -1,0 +1,8 @@
+--PHEL--
+(fn [c] (let [n (if c 1 "s")] (str n)))
+--PHP--
+(function($c): string {
+  static $__phel_call_0;
+  $n_1 = (($__truthy = $c) !== null && $__truthy !== false ? 1 : "s");
+  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "str"))->__invoke($n_1);
+});

--- a/tests/php/Integration/Fixtures/Call/let-if-init-infers-int.test
+++ b/tests/php/Integration/Fixtures/Call/let-if-init-infers-int.test
@@ -1,0 +1,8 @@
+--PHEL--
+(fn [c] (let [n (if c 1 2)] (+ n 1)))
+--PHP--
+(function($c) {
+  /** @var int $n_1 */
+  $n_1 = (($__truthy = $c) !== null && $__truthy !== false ? 1 : 2);
+  return ($n_1 + 1);
+});


### PR DESCRIPTION
## 🤔 Background

`BindingTypeInferrer::typeOf` handled `Literal`, `LocalVar` and `Call`, then returned null. `ReturnTypeInferrer::inferNode` handles eight node kinds including `Do`, `If` and `Let`. So a binding whose init is control flow stayed untagged:

```phel
(let [n (if c 1 2)] (+ n 1))   ; both arms are int; n was untyped
```

In `src/phel`: 106 `let` inits headed by `if`, 70 by `or`, 11 by `when`, 7 by `cond`, out of 1860 bindings.

## 🔖 Changes

Teaches `typeOf` the same three node kinds `collectRecurArgTypes` **already walks in this very class**, with the same accessors. Loops stay excluded for the reason that function excludes them: their type depends on the recur fixpoint, not a single walk.

Stays inside `PRIMITIVE_TAGS`, adds no lowering and no new trust edge. A disagreement or an untypable arm yields null, which is the untagged status quo. There is no `@bottom` equivalent here, so a `throw` arm suppresses the tag rather than deferring to its sibling: conservative, never wrong.

## ⚠️ On the evidence, stated plainly

The **emitted code** is the evidence, and three new fixtures pin it, including the disagreeing-arms case that must keep dispatching:

```php
- (\Phel::getDefinition("phel.core", "+"))->__invoke($n_1, 1)
+ ($n_1 + 1)
```

**I could not produce an honest end-to-end microbenchmark for this one.** The expression is loop-invariant in any small harness and the simplifier hoists or folds it, so wall-clock came out flat in both directions. My first three attempts reported the work at *below* the floor, which is a broken benchmark, not a null result. The per-op saving for the ops this unlocks was measured separately at roughly 225ns for `+`. Anyone re-measuring should check `phel compile` output first.

No existing fixture changed, so nothing previously depended on these bindings staying untyped.

Rationale for the series: #2973

Closes #2987
