### PR TITLE
perf(core): inline the nil guard in inc and dec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Runtime core:
 - Give `str` fixed arities up to three arguments, skipping the array and `implode` (#2974)
 - Specialize `count` on a map-tagged local to a direct `->count()`, as `empty?` already did (#2985)
 - Infer a primitive tag for `let` bindings whose init is `if`, `do` or a nested `let` (#2987)
+- Inline the nil guard in `inc` and `dec`, which still called the variadic one (#2989)
 - Declare real arities on `reduce` and `into` instead of a `case` over a rest argument (#2975)
 - Give `+`, `-`, `*` and `/` fixed arities, cutting untagged two-operand arithmetic 7.7x (#2978)
 

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -275,7 +275,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(inc 1) ; => 2"
    :see-also ["dec" "+"]}
   [x]
-  (assert-non-nil x)
+  (assert-non-nil-1 x)
   (NumericOperations/add x 1))
 
 (defn dec
@@ -283,7 +283,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(dec 5) ; => 4"
    :see-also ["inc" "-"]}
   [x]
-  (assert-non-nil x)
+  (assert-non-nil-1 x)
   (NumericOperations/subtract x 1))
 
 (defn- promote-int->bigint

--- a/tests/phel/core/arith-dispatch.phel
+++ b/tests/phel/core/arith-dispatch.phel
@@ -43,3 +43,15 @@
   (is (= 3.5 (+ 1 2.5)) "int plus float")
   (is (= 1/2 (+ 1/4 1/4)) "ratio plus ratio")
   (is (= 2.0 (* 1.0 2)) "float times int"))
+
+(deftest test-inc-dec-reject-nil
+  ;; The guard is inlined rather than a call to the variadic `assert-non-nil`,
+  ;; which `core/math` defines and which allocated a rest array for one value.
+  (is (thrown? Throwable (inc nil)) "inc rejects nil")
+  (is (thrown? Throwable (dec nil)) "dec rejects nil"))
+
+(deftest test-inc-dec-values
+  (is (= 2 (inc 1)) "inc int")
+  (is (= 4 (dec 5)) "dec int")
+  (is (= 2.5 (inc 1.5)) "inc float")
+  (is (= 3/4 (inc -1/4)) "inc ratio"))


### PR DESCRIPTION
## 🤔 Background

`inc` and `dec` are already fixed-arity `[x]`, but their body called the **variadic** `assert-non-nil` (`math.phel:26`, `[& xs]`), so a single value was boxed into a rest array on every call.

#2982 inlined that guard through two private macros for `+ - * /` and left these behind. The result is that `inc` cost **5.9x** the operator it is sugar for.

## 🔖 Changes

```
(inc x)   278.9ms -> 31.5ms    8.9x
(dec x)   281.8ms -> 29.7ms
(+ x 1)              44.4ms
```

Both now come out **faster than `(+ x 1)`**, which is the expected shape: a single-arity function has no arity dispatch to pay.

nil is still rejected, tested rather than assumed.

## Deliberately out of scope

The bit operators (`bit-not`, `bit-shift-left`, `bit-shift-right`, `unsigned-bit-shift-right`, `bit-and`, `bit-or`, `bit-xor`) call the same variadic guard, and their bodies would be a straight swap. But they also name it inside `:inline` metadata, and that quasiquote expands at the **caller's** site, where it would reference a private *macro* rather than a private function. Whether a `defmacro-` resolves from an inline expansion in another namespace needs checking before anyone changes it, so it is filed separately rather than bundled in on an assumption.

Found by a measurement sweep against vanilla PHP. Rationale for the series: #2973

Closes #2989
