### PR TITLE
test(emitter): pin the interop copy barrier at the emitted-code level

### DIFF
--- a/tests/php/Integration/Fixtures/PhpObjectCall/dot-call-with-local-arg-keeps-copy-barrier.test
+++ b/tests/php/Integration/Fixtures/PhpObjectCall/dot-call-with-local-arg-keeps-copy-barrier.test
@@ -1,0 +1,9 @@
+--PHEL--
+(fn [o k] (.offsetGet o k))
+--PHP--
+(function($o, $k) {
+  return (function() use($o,$k) {
+    $target_1 = $o;
+    return is_string($target_1) ? $target_1::offsetGet($k) : $target_1->offsetGet($k);
+  })();
+});


### PR DESCRIPTION
## 🤔 Background

A research pass in this perf series measured the IIFE that an interop call **with arguments** emits (131.7ns against 33.2ns for the no-argument form) and proposed removing it as an emitter artifact.

**It is not an artifact.** The by-value `use($local)` capture is a copy barrier: it stops a PHP **by-reference** parameter writing back into a Phel binding. Only `(php/ref local)` is meant to opt into that.

Verified by disabling the `hasByValueLocalArg` branch and calling a method whose parameter is `&$x`:

```
with the barrier:     local stays 1        correct
without the barrier:  local becomes 101    leaked
```

## 🔖 Changes

One fixture: `(fn [o k] (.offsetGet o k))`, pinning that the wrap is emitted.

## Scope, honestly

**This is not filling a coverage hole.** The behaviour is already covered by `without-php-ref-the-write-is-not-observed` in `tests/phel/core/interop-by-ref.phel`, which I found only after re-deriving the guarantee myself.

What the fixture adds is the emitted *shape*. None of the four existing `PhpObjectCall` fixtures passes a bare local as a method argument, so an emitter change that dropped the wrap would surface as a value mismatch in a phel test rather than as a readable diff of the generated code, next to a filename saying what the wrap is for.

Modest, and I would rather say that than oversell it.

The measured ~100ns is real and still open: the barrier is only needed when an argument is a bare local **and** the callee's parameter is genuinely by-reference. Narrowing it would need the same tag-gated route the collection specializations use. Refutation recorded on #2973.
