### PR TITLE
fix(phar): stop shipping release scripts and the infection config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ All notable changes to this project will be documented in this file.
 ### Performance
 
 - Keep the PHAR within its release size budget by excluding dependency-only Gacela tooling
+- Exclude the release-announcement scripts and `infection.json5` from the PHAR (#2994)
 
 Runtime core:
 

--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -61,6 +61,9 @@ final class PharBuilder
      */
     private array $excludeDirsAtRoot = [
         'data', 'node_modules', 'var',
+        // Release automation, run by .github/workflows/announce-release*.yml
+        // against the repository. Nothing in the shipped runtime references it.
+        'scripts',
     ];
 
     /**
@@ -102,6 +105,7 @@ final class PharBuilder
         'psalm-gacela.xml' => true,
         'rector.php' => true,
         'phpunit.xml.dist' => true,
+        'infection.json5' => true,
         'logo_readme.svg' => true,
         'logo.svg' => true,
         'README.md' => true,


### PR DESCRIPTION
## 🤔 Background

Two dev-only artifacts were shipping inside the PHAR:

| | uncompressed |
|---|---|
| `scripts/announce-release/` + `announce-release.mjs` | 18,397 bytes |
| `infection.json5` | 2,320 bytes |

`scripts/` is release automation that `announce-release.yml` runs **against the repository**. `infection.json5` is mutation-testing config. Nothing in `src/`, `bin/` or `Phel.php` references either, and neither appeared in any exclusion list in `build/build-phar.php`.

## 💡 Why this matters right now

The size gate is at **2359296** and recent `main` builds are at **2359162**: **134 bytes of headroom**. It has not moved since #2676 while the stdlib grew, and its comment is stale by ~350KB (it claims "headroom over the ~2.0 MiB compressed phar"; the phar is at the 2.25 MiB line).

That currently blocks #2992, and would block the next change of any kind regardless of content.

## 🔖 Changes

```
local build: 2360235 -> 2351678      8,557 bytes
```

Turning 134 bytes of headroom into roughly 8,700.

**Reducing what ships is the better answer than raising the gate.** The gate is doing exactly its job here: it caught dev artifacts in a release binary. I did not touch the budget.

Verified:

- `php build/out/phel.phar --version` runs
- `resources/agents` intact at 30 files, so `phel agent-install` is unaffected
- `PharExecutionTest` passes against the rebuilt phar
- neither path remains in the archive

`scripts` goes in `excludeDirsAtRoot` rather than `excludeDirs`, matching how `data` is handled, since a vendor package may legitimately ship its own.

Local and CI phar sizes differ, so the exact CI saving will differ from 8,557; the direction and magnitude will not.

Closes #2994
