### PR TITLE
perf(core): collect for results into a PHP array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ Runtime core:
 - Infer a primitive tag for `let` bindings whose init is `if`, `do` or a nested `let` (#2987)
 - Inline the nil guard in `inc` and `dec`, which still called the variadic one (#2989)
 - Give `max` and `min` fixed arities, dropping a lazy sequence built to NaN-check two arguments (#2991)
+- Collect `for` results into a PHP array instead of an atom and a persistent `conj` per element (#2997)
 - Declare real arities on `reduce` and `into` instead of a `case` over a rest argument (#2975)
 - Give `+`, `-`, `*` and `/` fixed arities, cutting untagged two-operand arithmetic 7.7x (#2978)
 

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -327,20 +327,30 @@ Returns the new value after the swap."
      is bound to `initial-value`."
   {:example "(for [x :in [1 2 3]] (* x 2)) ; => [2 4 6]"}
   [head & body]
-  (let [res-sym   (gensym "res__")
-        acc-sym   (gensym "acc__")
-        options   (for-builder-options head 0 {})
-        swap-body (if (:reduce options)
-                    (let [[sym _] (:reduce options)]
-                      `(swap! ~res-sym (fn [~sym] (do ~@body))))
-                    `(swap! ~res-sym (fn [~acc-sym] (conj ~acc-sym (do ~@body)))))
-        init      (if (:reduce options)
-                    (second (:reduce options))
-                    [])
-        loop-body (for-builder swap-body head 0)]
-    `(let [~res-sym (atom ~init)]
-       ~loop-body
-       (deref ~res-sym))))
+  (let [res-sym (gensym "res__")
+        options (for-builder-options head 0 {})]
+    (if (:reduce options)
+      ;; `:reduce` threads a user-named accumulator whose value is whatever the
+      ;; body returns, so it keeps the atom: there is nothing to append to.
+      (let [[sym _]   (:reduce options)
+            loop-body (for-builder `(swap! ~res-sym (fn [~sym] (do ~@body))) head 0)]
+        `(let [~res-sym (atom ~(second (:reduce options)))]
+           ~loop-body
+           (deref ~res-sym)))
+
+      ;; The collecting form appends, so it does not need an atom at all.
+      ;; It used to pay, per element, a `swap!`, a closure, and a `conj` onto a
+      ;; persistent vector, which is copy-on-write and so O(N log N) over the
+      ;; loop. A PHP array appends in place and converts once at the end.
+      ;;
+      ;; This is sound because `for-builder` emits `foreach` in statement
+      ;; position, which the emitter compiles inline rather than as a closure,
+      ;; so `php/apush` reaches the binding above it. `:when`, `:while` and
+      ;; `:let` only wrap the body further inside that same scope.
+      (let [loop-body (for-builder `(php/apush ~res-sym (do ~@body)) head 0)]
+        `(let [~res-sym (php/array)]
+           ~loop-body
+           (Phel/vector ~res-sym))))))
 
 (defmacro dofor
   "Repeatedly executes body for side effects with bindings and modifiers as provided by for. Returns nil."

--- a/tests/phel/core/for-dispatch.phel
+++ b/tests/phel/core/for-dispatch.phel
@@ -1,0 +1,64 @@
+(ns phel-test.core.for-dispatch
+  (:require phel.test :refer [deftest is]))
+
+;; Pins the whole `for` surface before its accumulator changes: every verb,
+;; every modifier, nesting, the `:reduce` path, and the result type.
+
+(deftest test-verbs
+  (is (= [1 2 3] (for [x :in [1 2 3]] x)) ":in over a vector")
+  (is (= [2 4 6] (for [x :in [1 2 3]] (* x 2))) ":in with a body expression")
+  (is (= [0 1 2] (for [x :range [0 3]] x)) ":range")
+  (is (= [:a :b] (for [k :keys {:a 1 :b 2}] k)) ":keys over a map")
+  (is (= [[:a 1] [:b 2]] (for [p :pairs {:a 1 :b 2}] p)) ":pairs over a map")
+  (is (= [0 1 2] (for [k :keys [10 20 30]] k)) ":keys over a vector gives indexes")
+  (is (= ["a" "b"] (for [c :in "ab"] c)) ":in over a string"))
+
+(deftest test-modifiers
+  (is (= [1 3 5] (for [x :in [1 2 3 4 5] :when (odd? x)] x)) ":when filters")
+  (is (= [1 2] (for [x :in [1 2 3 4] :while (< x 3)] x)) ":while stops")
+  (is (= [10 20] (for [x :in [1 2] :let [y (* x 10)]] y)) ":let binds")
+  (is (= [2 8] (for [x :in [1 2 3] :when (odd? x) :let [y (* x 2)]] (+ y (dec x))))
+      ":when and :let together"))
+
+(deftest test-nesting
+  (is (= [[1 3] [1 4] [2 3] [2 4]] (for [x :in [1 2] y :in [3 4]] [x y]))
+      "two bindings nest")
+  (is (= [[1 3] [2 3]] (for [x :in [1 2] y :in [3 4] :when (= y 3)] [x y]))
+      "a modifier applies to the inner binding"))
+
+(deftest test-empty-and-nil
+  (is (= [] (for [x :in []] x)) "empty collection gives an empty vector")
+  (is (= [] (for [x :in {}] x)) "empty map")
+  (is (= [] (for [x :in [1 2 3] :when false] x)) "everything filtered out"))
+
+(deftest test-reduce-option
+  (is (= 6 (for [x :in [1 2 3] :reduce [acc 0]] (+ acc x))) ":reduce sums")
+  (is (= [3 2 1] (for [x :in [1 2 3] :reduce [acc []]] (cons x acc))) ":reduce builds")
+  (is (= 0 (for [x :in [] :reduce [acc 0]] (+ acc x))) ":reduce over empty returns the init")
+  (is (= 4 (for [x :in [1 2 3 4] :when (even? x) :reduce [acc 0]] (+ acc (- x acc))))
+      ":reduce with a modifier"))
+
+(deftest test-result-type
+  (is (vector? (for [x :in [1 2]] x)) "the collecting form returns a vector")
+  (is (vector? (for [x :in []] x)) "an empty result is still a vector"))
+
+(deftest test-callers-that-build-on-for
+  (is (= [:a :b] (keys {:a 1 :b 2})) "keys")
+  (is (= [1 2] (vals {:a 1 :b 2})) "vals")
+  (is (nil? (keys {})) "keys on an empty map is nil")
+  (is (= [1 2 3] (vec (php-indexed-array 1 2 3))) "vec")
+  (is (= {1 2, 3 1} (frequencies [1 1 3])) "frequencies"))
+
+(deftest test-nested-for-forms-keep-separate-accumulators
+  ;; Each `for` gensyms its own accumulator, so an inner one must not append
+  ;; into the outer one whichever way they are nested.
+  (is (= [[11 21] [12 22]] (for [x :in [1 2]] (for [y :in [10 20]] (php/+ x y))))
+      "a collecting for inside a collecting for")
+  (is (= [[6] [7]] (for [x :in [1 2] :reduce [a []]] (conj a (for [y :in [5]] (php/+ x y)))))
+      "a collecting for inside a :reduce for")
+  (is (= [11 11] (for [x :in [1 2]] (for [y :in [5 6] :reduce [a 0]] (php/+ a y))))
+      "a :reduce for inside a collecting for"))
+
+(deftest test-metadata-survives-the-accumulator
+  (is (= {:tag :m} (meta (keys (with-meta {:a 1} {:tag :m}))))
+      "keys copies the source metadata onto the result"))


### PR DESCRIPTION
## 🤔 Background

The collecting form of `for` paid, **per element**: an atom `swap!`, a closure allocation, and a `conj` onto a *persistent* vector, which is copy-on-write and so O(N log N) across the loop.

It appends and never reads. It does not need an atom at all.

## 🔖 Changes

20-element collection, 20k repetitions, net of floor:

| | before | after | |
|---|---|---|---|
| `for` | 722.3ms | **83.7ms** | **8.6x** |
| bare `dofor` (iteration floor) | 45.0ms | 43.9ms | |
| `keys` | 142.9ms | **30.9ms** | 4.6x |
| `vals` | | **32.3ms** | |

**Accumulation went from 674ms over the iteration floor to about 40ms.**

`:reduce` keeps the atom and is untouched: it threads a user-named accumulator whose value is whatever the body returns, so there is nothing to append to.

## Why this is sound

It rests on `for-builder` emitting `foreach` in **statement** position, which the emitter compiles inline rather than as a closure, so `php/apush` reaches the binding above it. `:when`, `:while` and `:let` only wrap the body further inside that same scope.

I verified that before writing the change rather than after, including through nested loops and a `when`.

## Tests

`tests/phel/core/for-dispatch.phel` pins the surface **first**: all four verbs, all three modifiers, nesting, `:reduce`, empty collections, result type, and the callers that build on it.

Two cases carry the risk and are covered explicitly:

- **nested `for` forms must keep separate accumulators**, in all three combinations (collecting-in-collecting, collecting-in-`:reduce`, `:reduce`-in-collecting)
- **`keys` must still copy source metadata** onto the result

One assertion was written from a wrong expectation of mine and corrected against the implementation: `(+ 6 2)` is 8, not 6.

Full gate green: 6840 core, 4541 unit, 1185 integration.

Closes #2997
