### PR TITLE
perf(core): thread the for :reduce accumulator through a PHP cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Runtime core:
 - Inline the nil guard in `inc` and `dec`, which still called the variadic one (#2989)
 - Give `max` and `min` fixed arities, dropping a lazy sequence built to NaN-check two arguments (#2991)
 - Collect `for` results into a PHP array instead of an atom and a persistent `conj` per element (#2997)
+- Thread the `for` `:reduce` accumulator through a one-slot PHP array instead of an atom (#2999)
 - Declare real arities on `reduce` and `into` instead of a `case` over a rest argument (#2975)
 - Give `+`, `-`, `*` and `/` fixed arities, cutting untagged two-operand arithmetic 7.7x (#2978)
 

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -331,12 +331,17 @@ Returns the new value after the swap."
         options (for-builder-options head 0 {})]
     (if (:reduce options)
       ;; `:reduce` threads a user-named accumulator whose value is whatever the
-      ;; body returns, so it keeps the atom: there is nothing to append to.
+      ;; body returns, so it cannot append the way the collecting form does. It
+      ;; still does not need an atom: a one-slot PHP array is a mutable cell in
+      ;; the same scope, which drops the `swap!` and its closure per element.
+      ;; Same inline-`foreach` reasoning as the collecting branch below.
       (let [[sym _]   (:reduce options)
-            loop-body (for-builder `(swap! ~res-sym (fn [~sym] (do ~@body))) head 0)]
-        `(let [~res-sym (atom ~(second (:reduce options)))]
+            loop-body (for-builder
+                       `(php/aset ~res-sym 0 (let [~sym (php/aget ~res-sym 0)] (do ~@body)))
+                       head 0)]
+        `(let [~res-sym (php/array ~(second (:reduce options)))]
            ~loop-body
-           (deref ~res-sym)))
+           (php/aget ~res-sym 0)))
 
       ;; The collecting form appends, so it does not need an atom at all.
       ;; It used to pay, per element, a `swap!`, a closure, and a `conj` onto a


### PR DESCRIPTION
## 🤔 Background

#2998 removed the atom from the **collecting** form of `for` and deliberately left `:reduce` on it, since `:reduce` threads a user-named accumulator whose value is whatever the body returns, so it cannot append.

Re-measuring afterwards showed why that mattered: `vec`, `frequencies`, `group-by`, `distinct`, `merge` and `zipmap` are **all** `for ... :reduce`, so they barely moved. 24 `:reduce` sites across core.

`:reduce` does not need an atom either. A one-slot PHP array is a mutable cell in the same scope, which drops the `swap!` and its closure per element.

## 🔖 Changes

Isolated loop, 10 elements, 20k repetitions:

```
atom + swap! + closure   268.8ms
one-slot php cell         47.3ms    5.7x
```

End to end, same process, stash A/B:

| | atom | cell | |
|---|---|---|---|
| `vec` | 339.6ms | **118.7ms** | **2.9x** |
| `distinct` | 683.8ms | **435.3ms** | 1.6x |
| `frequencies` | 882.7ms | **589.2ms** | 1.5x |

I measured this as a clean A/B in one process rather than comparing across runs, because run-to-run variance on these was large enough to invent a result either way.

## Why this is sound

The same argument as #2998, resting on the same fact: `for-builder` emits `foreach` in **statement** position, which the emitter compiles inline rather than as a closure, so `php/aset` reaches the cell above it.

`tests/phel/core/for-dispatch.phel` already covers `:reduce` on its own, with a modifier, over an empty collection, and nested **both ways** inside a collecting `for`, which is the case that would break if the two accumulator strategies interfered.

Full gate green: 6840 core.

Closes #2999
