### PR TITLE
perf(core): build interleave's seq array in one pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ Runtime core:
 - Collect `for` results into a PHP array instead of an atom and a persistent `conj` per element (#2997)
 - Thread the `for` `:reduce` accumulator through a one-slot PHP array instead of an atom (#2999)
 - Give `hash-set` fixed arities for the small counts, skipping the variadic parameter and `apply` (#2981)
+- Build `interleave`'s seq array in one pass instead of `some`, `map` and `apply` (#2980)
 - Declare real arities on `reduce` and `into` instead of a `case` over a rest argument (#2975)
 - Give `+`, `-`, `*` and `/` fixed arities, cutting untagged two-operand arithmetic 7.7x (#2978)
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1202,18 +1202,27 @@ Applies `f` to each element in `xs`. `f` is a two-argument function where the fi
   "Returns a lazy sequence of the first item in each `colls`, then the second item in each, until any one of the collections is exhausted. Any remaining items in the other collections are ignored. Returns an empty sequence when no collections are supplied or when any collection is empty or `nil`. Maps are iterated as `[key value]` pairs."
   {:example "(interleave [1 2 3] [:a :b :c]) ; => @[1 :a 2 :b 3 :c]\n(interleave [1 2 3] [:a :b]) ; => @[1 :a 2 :b]"}
   [& colls]
-  (cond
-    (php/=== nil colls) '()
-    (some nil? colls)   '()
-    :else
-    (let [seqs   (apply php/array (map (fn [c] (or (seq c) (php-indexed-array))) colls))
-          result (lazy-seq-from-generator
-                  (php/call_user_func_array
-                   (php-indexed-array "\\Phel\\Lang\\Seq" "interleave")
-                   seqs))]
-      (if (php/=== nil result)
-        '()
-        (copy-meta (first colls) result)))))
+  ;; One pass builds the seq array and answers "was any collection nil?".
+  ;; It used to take three: `some` built a lazy sequence to check for nil,
+  ;; `map` built another to convert, and `apply` then rebuilt that as a PHP
+  ;; array. Together those were about half the cost of the call (#2980).
+  (let [seqs    (php/array)
+        has-nil (php/array false)]
+    (dofor [c :in (or colls [])]
+      (if (php/=== nil c)
+        (php/aset has-nil 0 true)
+        (php/apush seqs (or (seq c) (php-indexed-array)))))
+    (cond
+      (php/=== nil colls)  '()
+      (php/aget has-nil 0) '()
+      :else
+      (let [result (lazy-seq-from-generator
+                    (php/call_user_func_array
+                     (php-indexed-array "\\Phel\\Lang\\Seq" "interleave")
+                     seqs))]
+        (if (php/=== nil result)
+          '()
+          (copy-meta (first colls) result))))))
 
 (defn doall
   "Forces realization of a lazy sequence and returns it as a vector."

--- a/tests/phel/core/interleave-dispatch.phel
+++ b/tests/phel/core/interleave-dispatch.phel
@@ -1,0 +1,30 @@
+(ns phel-test.core.interleave-dispatch
+  (:require phel.test :refer [deftest is]))
+
+;; Pins interleave before its arity changes. The truncation rule and the
+;; empty/nil short-circuits are what a fixed 2-arity most easily loses.
+
+(deftest test-two-collections
+  (is (= [1 :a 2 :b 3 :c] (vec (interleave [1 2 3] [:a :b :c]))) "equal lengths")
+  (is (= [1 :a 2 :b] (vec (interleave [1 2 3] [:a :b]))) "stops at the shorter, second")
+  (is (= [1 :a 2 :b] (vec (interleave [1 2] [:a :b :c]))) "stops at the shorter, first"))
+
+(deftest test-more-than-two
+  (is (= [1 :a "x" 2 :b "y"] (vec (interleave [1 2] [:a :b] ["x" "y"]))) "three collections")
+  (is (= [1 :a "x"] (vec (interleave [1 2] [:a :b] ["x"]))) "three, truncated by the last"))
+
+(deftest test-empty-and-nil
+  (is (= [] (vec (interleave))) "no collections")
+  (is (= [] (vec (interleave [] [1 2]))) "an empty collection yields nothing")
+  (is (= [] (vec (interleave [1 2] []))) "an empty second collection")
+  (is (= [] (vec (interleave nil [1 2]))) "a nil collection")
+  (is (= [] (vec (interleave [1 2] nil))) "a nil second collection"))
+
+(deftest test-one-collection
+  (is (= [1 2 3] (vec (interleave [1 2 3]))) "a single collection is itself"))
+
+(deftest test-other-shapes
+  (is (= [1 :a 2 :b] (vec (interleave '(1 2) [:a :b]))) "a list works")
+  (is (= ["a" 1 "b" 2] (vec (interleave "ab" [1 2]))) "a string iterates by character")
+  (is (= [[:a 1] :x] (vec (interleave {:a 1} [:x])))
+      "a map iterates as pairs, so one entry is one element"))


### PR DESCRIPTION
## 🤔 Background

`interleave` took **three passes** over its collections before interleaving anything:

- `(some nil? colls)` built a lazy sequence to check for nil
- `(map (fn [c] ...) colls)` built another to convert each to a seq
- `(apply php/array ...)` rebuilt that as a PHP array

One `dofor` does all three.

## 🔖 Changes

Clean A/B in one process, 10 elements, 20k repetitions:

```
728.4ms -> 528.1ms   1.4x
```

## Less than the profile suggested, and worth saying

The profile put `some` at 109.5ms and `map` plus `apply` at 271.0ms, about **half** the call. The realised gain is smaller than that, because the passes partly overlapped in what they cost.

The remainder is `call_user_func_array` and the lazy-seq machinery, which this does not touch. That is where anyone continuing on #2980 should look, and it is why I am not claiming this closes the gap to vanilla PHP.

## Tests

`tests/phel/core/interleave-dispatch.phel` pins the surface first: truncation from either side, nil and empty short-circuits, one collection, three collections, and lists, strings and maps as inputs.

One assertion was written from a wrong expectation of mine and corrected against the implementation: a map seqs to one pair per entry, so `(interleave {:a 1} [:x])` has **two** elements, not four.

Full gate green: 6867 core.

Closes #2980
