### PR TITLE
perf(core): sort an all-int collection natively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Runtime core:
 - Thread the `for` `:reduce` accumulator through a one-slot PHP array instead of an atom (#2999)
 - Give `hash-set` fixed arities for the small counts, skipping the variadic parameter and `apply` (#2981)
 - Build `interleave`'s seq array in one pass instead of `some`, `map` and `apply` (#2980)
+- Sort an all-int collection natively instead of calling back into Phel per comparison (#3003)
 - Declare real arities on `reduce` and `into` instead of a `case` over a rest argument (#2975)
 - Give `+`, `-`, `*` and `/` fixed arities, cutting untagged two-operand arithmetic 7.7x (#2978)
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -971,10 +971,42 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps."
           (cmp b a)     1
           :else         0)))))
 
+(defn- all-native-ints?
+  "True when every element is a PHP int. Deliberately narrow: floats bring NaN
+  and mixed-type comparison, and anything else is not orderable by
+  `SORT_NUMERIC` the way `compare` orders it."
+  [php-array]
+  ;; `foreach` rather than `dofor`: this runs during bootstrap, before the
+  ;; macro layer `dofor` expands into is resolvable. `php/break` leaves at the
+  ;; first non-int, so a float or string sort does not walk its whole
+  ;; collection to discover it cannot use the fast path.
+  (let [found (php/array true)]
+    (foreach [x php-array]
+      (when-not (php/is_int x)
+        (php/aset found 0 false)
+        php/break))
+    (php/aget found 0)))
+
 (defn- sorted-vector
   [coll comp]
   (let [php-array (to-php-array coll)]
     (php/usort php-array comp)
+    (copy-meta coll (Phel/vector php-array))))
+
+(defn- sorted-vector-natural
+  "`sort` with no comparator, where `usort` would call back into Phel twice per
+  comparison: once for the `sort-comparator` wrapper and once for `compare`,
+  O(n log n) times. When every element is a native int, `SORT_NUMERIC` produces
+  exactly the order `compare` produces, and PHP does the whole sort natively.
+  One O(n) scan buys that, which is cheaper than the calls it replaces."
+  [coll]
+  ;; The array is converted once and reused by both branches. Delegating the
+  ;; fallback to `sorted-vector` would convert a second time, which made every
+  ;; non-int sort slower than before the fast path existed.
+  (let [php-array (to-php-array coll)]
+    (if (all-native-ints? php-array)
+      (php/sort (php/ref php-array) php/SORT_NUMERIC)
+      (php/usort php-array (sort-comparator nil)))
     (copy-meta coll (Phel/vector php-array))))
 
 (defn- sort-with
@@ -991,7 +1023,7 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps."
   {:example "(sort [3 1 4 1 5 9 2 6]) ; => [1 1 2 3 4 5 6 9]\n(sort (fn [a b] (compare b a)) [1 2 3]) ; => [3 2 1]"
    :see-also ["sort-by" "compare"]}
   ([coll]
-   (sort-with coll compare))
+   (sorted-vector-natural coll))
   ([a b]
    (if (fn? a)
      (sort-with b a)

--- a/tests/phel/core/sort-dispatch.phel
+++ b/tests/phel/core/sort-dispatch.phel
@@ -1,0 +1,34 @@
+(ns phel-test.core.sort-dispatch
+  (:require phel.test :refer [deftest is]))
+
+;; Pins sort across the fast path and the general one. The fast path is gated
+;; on every element being a native int, so the cases that must NOT take it are
+;; as important as the ones that must.
+
+(deftest test-all-int-collections
+  (is (= [1 2 3] (sort [3 1 2])) "ints")
+  (is (= [0 1 2 3 4 5 6 7 8 9] (sort [5 3 9 1 7 2 8 4 6 0])) "ten ints")
+  (is (= [1 1 2] (sort [2 1 1])) "duplicates")
+  (is (= [-3 -1 2] (sort [2 -1 -3])) "negatives")
+  (is (= [] (sort [])) "empty")
+  (is (= [1] (sort [1])) "single"))
+
+(deftest test-collections-that-must-not-take-the-int-path
+  (is (= [1.5 2.5] (sort [2.5 1.5])) "floats")
+  (is (= [1 2.5] (sort [2.5 1])) "mixed int and float")
+  (is (= ["a" "b" "c"] (sort ["b" "c" "a"])) "strings")
+  (is (= [1/4 1/2] (sort [1/2 1/4])) "ratios")
+  (is (= [1 2 3] (sort '(3 1 2))) "a list still sorts"))
+
+(deftest test-custom-comparator
+  (is (= [3 2 1] (sort (fn [a b] (compare b a)) [1 2 3])) "reverse comparator")
+  (is (= [3 2 1] (sort (fn [a b] (> a b)) [1 3 2])) "predicate-style comparator")
+  (is (= [1 2 3] (sort compare [3 1 2])) "compare passed explicitly"))
+
+(deftest test-result-shape
+  (is (vector? (sort [3 1 2])) "returns a vector")
+  (is (= [1 2 3] (sort (php-indexed-array 3 1 2))) "sorts a php array"))
+
+(deftest test-sort-by-unaffected
+  (is (= ["b" "aa" "ccc"] (sort-by count ["aa" "ccc" "b"])) "sort-by still works")
+  (is (= [3 2 1] (sort-by (fn [x] (- x)) [1 2 3])) "sort-by with a key fn"))


### PR DESCRIPTION
## 🤔 Background

`(sort coll)` with no comparator went through `usort` with a Phel closure, so PHP called **back into Phel twice per comparison**: once for the `sort-comparator` wrapper and once for `compare`, O(n log n) times.

## 🔖 Changes

When every element is a native int, `SORT_NUMERIC` produces exactly the order `compare` produces and PHP does the whole sort itself. One O(n) scan buys that, which is cheaper than the calls it replaces.

Clean A/B in one process, 10 elements, 20k repetitions:

| | before | after | |
|---|---|---|---|
| ints | 1069.1ms | **75.4ms** | **14.2x** |
| floats | 366.7ms | 368.2ms | parity |
| strings | 352.1ms | 358.0ms | parity |

## The gate is deliberately narrow

Floats bring NaN and mixed-type comparison, strings bring PHP's numeric-string rules, and `Ratio` or `BigInt` are not orderable by `SORT_NUMERIC` the way `compare` orders them. **Integer ordering has none of those questions.** Everything else takes exactly the path it took before, which is why the other two rows are at parity rather than regressed.

## Two bugs of mine on the way

Both caught by measuring rather than reading, and both worth recording:

- **The fallback converted the collection twice**, once in the new function and again inside `sorted-vector`. That made every non-int sort *slower* than before the fast path existed. Now converted once, both branches share it.
- **The scan first used `dofor`**, which expands into a macro layer not resolvable this early in bootstrap. The entire stdlib failed to load with `Cannot resolve symbol 'phel.core/apply'`. `foreach` with `php/break` is the primitive that works here, and it exits at the first non-int.

`tests/phel/core/sort-dispatch.phel` pins both paths. The collections that must **not** take the fast path (floats, mixed int/float, strings, ratios) matter as much as the ones that must.

Full gate green: 6885 core.

Closes #3003
