### PR TITLE
perf(core): give the five core constructors fixed arities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Runtime core:
 - Give the closures returned by `partial`, `fnil` and `comp` real arities: 30x, 50x and 8x faster to call (#3021)
 - Guard the twelve nil-rejecting arithmetic functions with the fixed-arity macros instead of the variadic helper: `round` and `floor` 25x, `quot`, `rem` and `mod` 14 to 17x, `even?` and `odd?` 6 to 7x (#3018)
 - Compile a literal `(list ...)`, `(vector ...)`, `(queue ...)`, `(hash-map ...)` or `(array-map ...)` straight to its `Phel` factory: 2.2 to 3.6 times faster (#3014)
+- Give `list`, `vector`, `queue`, `hash-map` and `array-map` fixed arities, so the calls the literal lowering cannot reach get faster too: 2.1 to 3.4 times through an alias or `apply`, 1.5 times passed as a value to `map` (#3010)
 - Inline PHP array constructors and use `php-indexed-array` across core and standard libraries (#2941)
 - Speed up `re-find`, `re-matches` and `parse-long` by avoiding full match-map conversion (#2941 #2943)
 - Give `aget` a fixed single-index arity and require an index, matching Clojure (#2941)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -28,36 +28,73 @@
 ;; Basic methods for quasiquote and destructure
 ;; --------------------------------------------
 
+;; Each constructor declares real arities for the small argument counts it is
+;; actually called with, and keeps a variadic tail for the rest. A `&`
+;; parameter costs several times a fixed one per call before the body runs
+;; (#2973), and these five sit on the quasiquote and destructuring expansion
+;; paths, so they pay it more often than anything else in the language.
+;; The tail still accepts every argument count, so nothing that used to be a
+;; runtime error becomes a compile-time one, and an odd argument count still
+;; reaches `Phel/map` and still throws there (#3010).
+
 (def list
   {:doc "Creates a new list. If no argument is provided, an empty list is created. Shortcut: '()"
    :example "(list 1 2 3) ; => '(1 2 3)"}
-  (fn [& xs]
-    (Phel/list (apply php/array xs))))
+  (fn
+    ([] (Phel/list (php/array)))
+    ([a] (Phel/list (php/array a)))
+    ([a b] (Phel/list (php/array a b)))
+    ([a b c] (Phel/list (php/array a b c)))
+    ([a b c & more] (Phel/list (apply php/array a b c more)))))
 
 (def vector
   {:doc "Creates a new vector. If no argument is provided, an empty vector is created. Shortcut: []"
    :example "(vector 1 2 3) ; => [1 2 3]"}
-  (fn [& xs]
-    (Phel/vector (apply php/array xs))))
+  (fn
+    ([] (Phel/vector (php/array)))
+    ([a] (Phel/vector (php/array a)))
+    ([a b] (Phel/vector (php/array a b)))
+    ([a b c] (Phel/vector (php/array a b c)))
+    ([a b c & more] (Phel/vector (apply php/array a b c more)))))
 
 (def queue
   {:doc "Creates a persistent FIFO queue. With no arguments returns an empty queue; with arguments returns a queue with the values pushed in order so that the first argument is at the front."
    :example "(queue 1 2 3) ; => <-(1 2 3)-<"}
-  (fn [& xs]
-    (Phel/queue (apply php/array xs))))
+  (fn
+    ([] (Phel/queue (php/array)))
+    ([a] (Phel/queue (php/array a)))
+    ([a b] (Phel/queue (php/array a b)))
+    ([a b c] (Phel/queue (php/array a b c)))
+    ([a b c & more] (Phel/queue (apply php/array a b c more)))))
 
+;; The map constructors take key/value pairs, so the arities that matter are
+;; the even ones: 2 and 4 cover the overwhelming majority of literal maps. The
+;; odd arities in between are declared anyway, and deliberately: without them
+;; an odd argument count would match no arity at all and fail on dispatch,
+;; where today it reaches `Phel/map` and throws there. Keeping them routes
+;; every count to the same constructor and leaves that error exactly as it was.
 (def hash-map
   {:doc "Creates a new hash map. If no argument is provided, an empty hash map is created. The number of parameters must be even. Shortcut: {}"
    :example "(hash-map :a 1 :b 2) ; => {:a 1, :b 2}"}
-  (fn [& xs]
-    (Phel/map (apply php/array xs))))
+  (fn
+    ([] (Phel/map (php/array)))
+    ([k] (Phel/map (php/array k)))
+    ([k v] (Phel/map (php/array k v)))
+    ([k v k2] (Phel/map (php/array k v k2)))
+    ([k v k2 v2] (Phel/map (php/array k v k2 v2)))
+    ([k v k2 v2 & more] (Phel/map (apply php/array k v k2 v2 more)))))
 
 (def array-map
   {:doc "Constructs a map from the given key/value pairs. If any keys are equal, later values replace earlier ones, as if by repeated `assoc`. Phel has no distinct array-map type, so the result is the same persistent map as `hash-map` — `array-map` exists for `.cljc` interop with Clojure sources."
    :example "(array-map :a 1 :b 2) ; => {:a 1, :b 2}"
    :see-also ["hash-map"]}
-  (fn [& xs]
-    (Phel/map (apply php/array xs))))
+  (fn
+    ([] (Phel/map (php/array)))
+    ([k] (Phel/map (php/array k)))
+    ([k v] (Phel/map (php/array k v)))
+    ([k v k2] (Phel/map (php/array k v k2)))
+    ([k v k2 v2] (Phel/map (php/array k v k2 v2)))
+    ([k v k2 v2 & more] (Phel/map (apply php/array k v k2 v2 more)))))
 
 (def next-vector-or-nil
   {:private true

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -33,9 +33,8 @@
 ;; parameter costs several times a fixed one per call before the body runs
 ;; (#2973), and these five sit on the quasiquote and destructuring expansion
 ;; paths, so they pay it more often than anything else in the language.
-;; The tail still accepts every argument count, so nothing that used to be a
-;; runtime error becomes a compile-time one, and an odd argument count still
-;; reaches `Phel/map` and still throws there (#3010).
+;; The tail still accepts every argument count, so no call that used to fail at
+;; runtime now fails at compile time (#3010).
 
 (def list
   {:doc "Creates a new list. If no argument is provided, an empty list is created. Shortcut: '()"

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -29,10 +29,15 @@
 ;; --------------------------------------------
 
 ;; Each constructor declares real arities for the small argument counts it is
-;; actually called with, and keeps a variadic tail for the rest. A `&`
-;; parameter costs several times a fixed one per call before the body runs
-;; (#2973), and these five sit on the quasiquote and destructuring expansion
-;; paths, so they pay it more often than anything else in the language.
+;; actually called with, and keeps a variadic tail for the rest. A `&` parameter
+;; costs several times a fixed one per call before the body runs (#2973).
+;;
+;; A literal call does not reach these functions at all: the emitter lowers it
+;; straight to the `Phel` factory (#3014). What is left is every other way of
+;; calling them, which the lowering declines by design because the callee is not
+;; in call-head position: through a local alias, through `apply`, and passed as
+;; a value to `map` and friends. Those are the calls the arities are for.
+;;
 ;; The tail still accepts every argument count, so no call that used to fail at
 ;; runtime now fails at compile time (#3010).
 

--- a/tests/phel/core/constructor-runtime-arities.phel
+++ b/tests/phel/core/constructor-runtime-arities.phel
@@ -1,0 +1,110 @@
+(ns phel-test.core.constructor-runtime-arities
+  (:require phel.test :refer [deftest is]))
+
+;; `constructor-dispatch.phel` pins the emitter lowering (#3014): a literal
+;; `(list 1 2 3)` compiles straight to the `Phel` factory and never reaches the
+;; function defined in `core.phel` at all. So it cannot see the arities added in
+;; #3010, and this file exists to cover the other half.
+;;
+;; Every call below goes through a `let`-bound alias. An alias is a
+;; `LocalVarNode`, which the lowering declines, so the call reaches the runtime
+;; function and dispatches on its declared arities. That is the only way to
+;; exercise them from Phel.
+
+(deftest test-list-reaches-every-declared-arity
+  (let [f list]
+    (is (= '() (f)) "arity 0")
+    (is (= '(1) (f 1)) "arity 1")
+    (is (= '(1 2) (f 1 2)) "arity 2")
+    (is (= '(1 2 3) (f 1 2 3)) "arity 3, the last fixed one")
+    (is (= '(1 2 3 4) (f 1 2 3 4)) "one past the fixed arities, into the tail")
+    (is (= '(1 2 3 4 5 6) (f 1 2 3 4 5 6)) "well into the tail")))
+
+(deftest test-vector-reaches-every-declared-arity
+  (let [f vector]
+    (is (= [] (f)) "arity 0")
+    (is (= [1] (f 1)) "arity 1")
+    (is (= [1 2] (f 1 2)) "arity 2")
+    (is (= [1 2 3] (f 1 2 3)) "arity 3, the last fixed one")
+    (is (= [1 2 3 4] (f 1 2 3 4)) "one past the fixed arities, into the tail")
+    (is (= [1 2 3 4 5 6] (f 1 2 3 4 5 6)) "well into the tail")))
+
+(deftest test-queue-reaches-every-declared-arity
+  (let [f queue]
+    (is (= 0 (count (f))) "arity 0")
+    (is (= 1 (count (f 1))) "arity 1")
+    (is (= 2 (count (f 1 2))) "arity 2")
+    (is (= 3 (count (f 1 2 3))) "arity 3, the last fixed one")
+    (is (= 4 (count (f 1 2 3 4))) "one past the fixed arities, into the tail")
+    (is (= 1 (first (f 1 2 3))) "the front is the first argument, fixed arity")
+    (is (= 1 (first (f 1 2 3 4 5))) "and through the tail too")))
+
+(deftest test-hash-map-reaches-every-declared-arity
+  (let [f hash-map]
+    (is (= {} (f)) "arity 0")
+    (is (= {:a 1} (f :a 1)) "arity 2, one pair")
+    (is (= {:a 1, :b 2} (f :a 1 :b 2)) "arity 4, the last fixed even one")
+    (is (= {:a 1, :b 2, :c 3} (f :a 1 :b 2 :c 3)) "one pair past the fixed arities")
+    (is (= {:a 1, :b 2, :c 3, :d 4} (f :a 1 :b 2 :c 3 :d 4)) "well into the tail")))
+
+(deftest test-array-map-reaches-every-declared-arity
+  (let [f array-map]
+    (is (= {} (f)) "arity 0")
+    (is (= {:a 1} (f :a 1)) "arity 2, one pair")
+    (is (= {:a 1, :b 2} (f :a 1 :b 2)) "arity 4, the last fixed even one")
+    (is (= {:a 1, :b 2, :c 3} (f :a 1 :b 2 :c 3)) "one pair past the fixed arities")))
+
+;; The map constructors declare their odd arities as well as their even ones,
+;; which looks redundant and is not. An odd count has no pair to build from and
+;; has always failed inside `Phel/map`, with a message naming the real problem.
+;; Drop the odd arities and an odd count matches no arity at all, so it fails
+;; earlier and less usefully, on dispatch. These assertions are what keeps them.
+(deftest test-an-odd-argument-count-still-fails-inside-the-constructor
+  (let [f hash-map g array-map]
+    (is (thrown-with-msg? \RuntimeException
+                          "An even number of elements must be provided to build a map, got 1"
+                          (f :a))
+        "one argument")
+    (is (thrown-with-msg? \RuntimeException
+                          "An even number of elements must be provided to build a map, got 3"
+                          (f :a 1 :b))
+        "three arguments")
+    (is (thrown-with-msg? \RuntimeException
+                          "An even number of elements must be provided to build a map, got 5"
+                          (f :a 1 :b 2 :c))
+        "five arguments, past the fixed arities and into the tail")
+    (is (thrown-with-msg? \RuntimeException
+                          "An even number of elements must be provided to build a map, got 1"
+                          (g :a))
+        "array-map fails the same way")))
+
+;; The two paths have to agree. A literal call is lowered to the factory and an
+;; aliased one runs the arities, so a divergence between them is exactly the
+;; regression the split could introduce.
+(deftest test-the-runtime-function-agrees-with-the-lowered-call
+  (let [l list v vector q queue h hash-map]
+    (is (= (list) (l)) "list, no arguments")
+    (is (= (list 1 2 3) (l 1 2 3)) "list, a fixed arity")
+    (is (= (list 1 2 3 4 5) (l 1 2 3 4 5)) "list, the tail")
+    (is (= (vector 1 2 3) (v 1 2 3)) "vector, a fixed arity")
+    (is (= (count (queue 1 2)) (count (q 1 2))) "queue, a fixed arity")
+    (is (= (hash-map :a 1 :b 2) (h :a 1 :b 2)) "hash-map, a fixed arity")
+    (is (= (hash-map :a 1 :b 2 :c 3 :d 4) (h :a 1 :b 2 :c 3 :d 4)) "hash-map, the tail")))
+
+;; `apply` never puts the constructor in call-head position either, so it also
+;; reaches the runtime function and dispatches on the same arities.
+(deftest test-apply-dispatches-on-the-same-arities
+  (is (= '() (apply list [])) "arity 0")
+  (is (= '(1 2 3) (apply list [1 2 3])) "a fixed arity")
+  (is (= '(1 2 3 4 5) (apply list [1 2 3 4 5])) "the tail")
+  (is (= [1 2 3] (apply vector [1 2 3])) "vector, a fixed arity")
+  (is (= {:a 1, :b 2} (apply hash-map [:a 1 :b 2])) "hash-map, a fixed arity")
+  (is (thrown? \RuntimeException (apply hash-map [:a])) "an odd count still fails in the constructor"))
+
+;; Passing a constructor as a value is the other common way to reach the runtime
+;; function, and the one that benefits most from the arities in practice.
+(deftest test-constructors-work-as-values
+  (is (= ['(1) '(2) '(3)] (map list [1 2 3])) "list as a value")
+  (is (= [[1] [2] [3]] (map vector [1 2 3])) "vector as a value")
+  (is (= '((1 4) (2 5) (3 6)) (map list [1 2 3] [4 5 6])) "list as a value, arity 2")
+  (is (= [[1 4] [2 5]] (map vector [1 2] [4 5])) "vector as a value, arity 2"))


### PR DESCRIPTION
## 🤔 Background

`list`, `vector`, `queue`, `hash-map` and `array-map` are the five most
fundamental constructors in the language, and all five were bare variadics:

```phel
(def list
  {:doc "..."}
  (fn [& xs]
    (Phel/list (apply php/array xs))))
```

Per #2973 a `&` parameter costs several times a fixed one per call before the
body runs.

**This PR was opened before #3016, and #3016 changed what it is for.** That
change lowers a literal `(list 1 2 3)` straight to `\Phel::list([1, 2, 3])` at
the call site, so a literal call no longer reaches these functions at all. The
original benchmark table here measured literal calls and is now obsolete: those
numbers belong to #3016.

What the lowering deliberately declines is every call where the constructor is
not in call-head position, because there the argument count is not known at
compile time:

- a local alias, `(let [f list] (f 1 2 3))`
- `apply`
- passing the constructor as a value, `(map list xs)`

Those calls still pay the variadic in full, and they are what this PR is for.

## 💡 Goal

Remove the variadic tax from the calls the literal lowering cannot reach,
without changing what any call does.

## 🔖 Changes

- Declare real arities for the small argument counts on all five, keeping a
  variadic tail.
- The map constructors additionally declare their **odd** arities. Those exist
  only so that an odd argument count keeps reaching `Phel/map` and failing
  there with the message it always had. With only the even arities declared, an
  odd count matches no arity and fails earlier, on dispatch, with a less useful
  exception.
- New `tests/phel/core/constructor-runtime-arities.phel`. The existing
  `constructor-dispatch.phel` pins the #3016 lowering, so every call in it is
  lowered and none of them dispatches on an arity: it cannot see this change at
  all. The new file routes every call through a `let`-bound alias, which is a
  `LocalVarNode` that the lowering declines, and covers each declared arity, one
  past the tail, `apply`, and use as a value.
- Corrected the comment above the constructors. It credited the quasiquote
  expansion path, but quasiquote expands to literal calls, which #3016 now
  lowers, so that is no longer where the cost is.

### Measured

On top of #3016, so these are the calls that remain. Empty-closure floor taken
in the same process and subtracted, 200k revs per row, arguments passed through
an alias so nothing can be folded away:

| call | before | after | speedup |
|---|---|---|---|
| `(f 1)` where `f` is `list` | 1.673 us | 0.489 us | 3.42x |
| `(f 1 2 3)` where `f` is `list` | 2.445 us | 0.887 us | 2.76x |
| `(f 1 2 3)` where `f` is `vector` | 2.314 us | 0.805 us | 2.87x |
| `(f 1 2)` where `f` is `queue` | 2.685 us | 1.254 us | 2.14x |
| `(f :a 1)` where `f` is `hash-map` | 2.463 us | 0.976 us | 2.52x |
| `(f :a 1 :b 2)` where `f` is `hash-map` | 3.297 us | 1.431 us | 2.30x |
| `(apply list [1 2 3])` | 3.363 us | 1.789 us | 1.88x |
| `(f 1 2 3 4 5)` where `f` is `list`, the tail | 3.157 us | 2.680 us | 1.18x |
| `(map list xs)` over 10, realized | 37.859 us | 24.261 us | 1.56x |
| `(list 1 2 3)`, literal | 0.987 us | 0.973 us | unchanged, #3016 owns it |

The literal row is the control: it is already lowered, so it should not move,
and it does not.

### No BC cost

Unlike the arity split on `max` (#2992), nothing moves from a runtime error to
a compile-time one, because the variadic tail still accepts every argument
count. The odd-count errors were diffed against `main` and are byte-identical:

```
RuntimeException: An even number of elements must be provided to build a map, got 1
```

Deleting the odd arities turns four assertions in the new test red with
`InvalidArgumentException: No matching function arity`, so that guard bites.

`composer core-api:update` reports the API snapshot unchanged, and
`composer test-all` passes with 7,156 core tests.

### Depends on #3029

Growing `core.phel` by 1,945 bytes tripped four compiler bench subjects that
read `src/phel/core.phel` as their input, at +31%, +31%, +27% and +35% against
a 25% tolerance. Nothing got slower per byte; the input got bigger on one side
of the comparison only. #3029 freezes that corpus under `tests/php/Benchmark`,
which is the side the job already pins to the pull request for both runs. This
branch is built on it, and with it in place those subjects move by -0.8%,
+2.9%, -2.7% and +1.5%.

### Known limitation, tracked separately

`phel doc list` still renders `(list & xs)` rather than the five arities, while
`phel doc hash-set` renders all of that one's. That string is identical before
and after this PR, and it still describes the accepted call shapes correctly,
so nothing regresses; it is simply less complete than reality now. The cause is
pre-existing and already filed as #3012: a multi-arity `defn` reports every
arity, a `def` over an `fn` reports one. These five cannot be `defn`, because
they are defined before `defn` exists.

Closes #3010
