### PR TITLE
docs: use canonical `:add` instead of `'add` in validate-with-schema.md

### DIFF
--- a/resources/agents/tasks/validate-with-schema.md
+++ b/resources/agents/tasks/validate-with-schema.md
@@ -27,7 +27,7 @@
 
 ```phel
 (defn add [a b] (+ a b))
-(s/instrument! 'add add [:=> [:int :int] :int])
+(s/instrument! :add add [:=> [:int :int] :int])
 ;; (add "x" 2) ; throws with explain data
 ```
 


### PR DESCRIPTION
Small docs cleanup:

`instrument!` accepts any key for the name, but a keyword `:add` is canonical. The quoted symbol `'add` previously used here works at runtime but is non-idiomatic as every example in instrument.phel, schema.phel, and the test suite consistently uses keywords.
