### PR TITLE
perf(core): guard the arithmetic nil checks with the fixed-arity macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ All notable changes to this project will be documented in this file.
 
 Runtime core:
 
+- Guard the twelve nil-rejecting arithmetic functions with the fixed-arity macros instead of the variadic helper: `round` and `floor` 25x, `quot`, `rem` and `mod` 14 to 17x, `even?` and `odd?` 6 to 7x (#3018)
 - Compile a literal `(list ...)`, `(vector ...)`, `(queue ...)`, `(hash-map ...)` or `(array-map ...)` straight to its `Phel` factory: 2.2 to 3.6 times faster (#3014)
 - Inline PHP array constructors and use `php-indexed-array` across core and standard libraries (#2941)
 - Speed up `re-find`, `re-matches` and `parse-long` by avoiding full match-map conversion (#2941 #2943)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -27,10 +27,20 @@
   [& xs]
   (assert-non-nil-coll xs))
 
-;; Inlined nil guards for the fixed arities of the arithmetic operators. A
-;; `defn-` here would put a call back on the path the arities exist to shorten,
-;; which is the point of #2978. Arguments must be symbols: each is referenced
-;; once in the expansion, and the operators only ever pass their own parameters.
+;; Inlined nil guards, used by every fixed-arity function in this file that
+;; rejects nil: the arithmetic operators (#2978) and the twelve bodies that
+;; moved off the variadic `assert-non-nil` in #3018. A `defn-` here would put a
+;; call back on the path these guards exist to shorten, and for most of those
+;; twelve the guard was the whole cost of the call.
+;;
+;; Arguments must be symbols. Each is referenced once in the expansion, so a
+;; caller passing an expression would evaluate it a second time in the guard;
+;; every call site passes its own bare parameters.
+;;
+;; The `:inline` forms below still call the variadic `assert-non-nil` instead.
+;; They expand into the *caller's* namespace, where a `defmacro-` private to
+;; `phel.core` is not in scope, and three of them splice `~@args` and so have no
+;; fixed arity to target.
 (defmacro- assert-non-nil-1
   [a]
   `(when (php/=== nil ~a)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -81,7 +81,7 @@
    :example "(bit-not 0) ; => -1"
    :see-also ["bit-and" "bit-or" "bit-xor"]}
   [x]
-  (assert-non-nil x)
+  (assert-non-nil-1 x)
   (php/~ x))
 
 (defn bit-shift-left
@@ -90,7 +90,7 @@
    :example "(bit-shift-left 1 4) ; => 16"
    :see-also ["bit-shift-right"]}
   [x n]
-  (assert-non-nil x n)
+  (assert-non-nil-2 x n)
   (php/<< x n))
 
 (defn bit-shift-right
@@ -99,7 +99,7 @@
    :example "(bit-shift-right 16 2) ; => 4"
    :see-also ["bit-shift-left"]}
   [x n]
-  (assert-non-nil x n)
+  (assert-non-nil-2 x n)
   (php/>> x n))
 
 (defn unsigned-bit-shift-right
@@ -107,7 +107,7 @@
   {:example "(unsigned-bit-shift-right -1 10) ; => 18014398509481983"
    :see-also ["bit-shift-right" "bit-shift-left"]}
   [x n]
-  (assert-non-nil x n)
+  (assert-non-nil-2 x n)
   ;; A right shift by 0 would make the mask `PHP_INT_MAX >> -1`, which PHP
   ;; rejects as a negative shift; the value is already unchanged in that case.
   (if (php/=== 0 n)
@@ -233,7 +233,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(quot 7 3) ; => 2\n(quot -7 3) ; => -2"
    :see-also ["rem" "mod" "/"]}
   [dividend divisor]
-  (assert-non-nil dividend divisor)
+  (assert-non-nil-2 dividend divisor)
   (NumericOperations/quot dividend divisor))
 
 (defn rem
@@ -241,7 +241,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(rem 7 3) ; => 1\n(rem -7 3) ; => -1"
    :see-also ["quot" "mod" "%"]}
   [dividend divisor]
-  (assert-non-nil dividend divisor)
+  (assert-non-nil-2 dividend divisor)
   (NumericOperations/rem dividend divisor))
 
 (defn mod
@@ -251,7 +251,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(mod 7 3) ; => 1\n(mod -7 3) ; => 2"
    :see-also ["quot" "rem" "%"]}
   [dividend divisor]
-  (assert-non-nil dividend divisor)
+  (assert-non-nil-2 dividend divisor)
   (NumericOperations/mod dividend divisor))
 
 (defn %
@@ -267,7 +267,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(** 2 8) ; => 256"
    :see-also ["*" "sqrt"]}
   [a x]
-  (assert-non-nil a x)
+  (assert-non-nil-2 a x)
   (NumericOperations/power a x))
 
 (defn inc
@@ -884,7 +884,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(floor 1.7) ; => 1.0\n(floor -1.2) ; => -2.0\n(floor 7/3) ; => 2"
    :see-also ["ceil" "round" "quot"]}
   [x]
-  (assert-non-nil x)
+  (assert-non-nil-1 x)
   (cond
     (php/is_int x)            x
     (php/instanceof x BigInt) x
@@ -899,7 +899,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(ceil 1.2) ; => 2.0\n(ceil -1.7) ; => -1.0\n(ceil 7/3) ; => 3"
    :see-also ["floor" "round" "quot"]}
   [x]
-  (assert-non-nil x)
+  (assert-non-nil-1 x)
   (cond
     (php/is_int x)            x
     (php/instanceof x BigInt) x
@@ -914,7 +914,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(round 1.5) ; => 2.0\n(round -1.5) ; => -2.0\n(round 5) ; => 5"
    :see-also ["floor" "ceil"]}
   [x]
-  (assert-non-nil x)
+  (assert-non-nil-1 x)
   (cond
     (php/is_int x)            x
     (php/instanceof x BigInt) x
@@ -926,5 +926,5 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(sqrt 9) ; => 3.0\n(sqrt 2) ; => 1.4142135623731"
    :see-also ["**" "abs"]}
   [x]
-  (assert-non-nil x)
+  (assert-non-nil-1 x)
   (php/sqrt (number->float x)))

--- a/tests/phel/core/math-nil-guard.phel
+++ b/tests/phel/core/math-nil-guard.phel
@@ -1,0 +1,67 @@
+(ns phel-test.core.math-nil-guard
+  (:require phel.test :refer [deftest is]))
+
+;; The twelve arithmetic functions that reject nil arguments do so through a
+;; guard in their body. Nothing pinned that guard before, which mattered when
+;; the variadic `assert-non-nil` was swapped for the fixed-arity
+;; `assert-non-nil-1` / `assert-non-nil-2` macros: the rejection is the whole
+;; observable behaviour of the thing being replaced.
+;;
+;; Both arguments are covered for the two-argument functions, since a guard
+;; that only checks the first would still pass a first-argument test.
+
+(deftest test-single-argument-functions-reject-nil
+  (is (thrown? \InvalidArgumentException (bit-not nil)) "bit-not")
+  (is (thrown? \InvalidArgumentException (floor nil)) "floor")
+  (is (thrown? \InvalidArgumentException (ceil nil)) "ceil")
+  (is (thrown? \InvalidArgumentException (round nil)) "round")
+  (is (thrown? \InvalidArgumentException (sqrt nil)) "sqrt"))
+
+(deftest test-two-argument-functions-reject-nil-in-first-position
+  (is (thrown? \InvalidArgumentException (bit-shift-left nil 1)) "bit-shift-left")
+  (is (thrown? \InvalidArgumentException (bit-shift-right nil 1)) "bit-shift-right")
+  (is (thrown? \InvalidArgumentException (unsigned-bit-shift-right nil 1)) "unsigned-bit-shift-right")
+  (is (thrown? \InvalidArgumentException (quot nil 2)) "quot")
+  (is (thrown? \InvalidArgumentException (rem nil 2)) "rem")
+  (is (thrown? \InvalidArgumentException (mod nil 2)) "mod")
+  (is (thrown? \InvalidArgumentException (** nil 2)) "**"))
+
+(deftest test-two-argument-functions-reject-nil-in-second-position
+  (is (thrown? \InvalidArgumentException (bit-shift-left 1 nil)) "bit-shift-left")
+  (is (thrown? \InvalidArgumentException (bit-shift-right 1 nil)) "bit-shift-right")
+  (is (thrown? \InvalidArgumentException (unsigned-bit-shift-right 1 nil)) "unsigned-bit-shift-right")
+  (is (thrown? \InvalidArgumentException (quot 4 nil)) "quot")
+  (is (thrown? \InvalidArgumentException (rem 4 nil)) "rem")
+  (is (thrown? \InvalidArgumentException (mod 4 nil)) "mod")
+  (is (thrown? \InvalidArgumentException (** 4 nil)) "**"))
+
+(deftest test-the-message-is-unchanged
+  (is (thrown-with-msg? \InvalidArgumentException "Arithmetic functions do not accept nil values"
+                        (rem nil 2))
+      "one argument guard")
+  (is (thrown-with-msg? \InvalidArgumentException "Arithmetic functions do not accept nil values"
+                        (sqrt nil))
+      "two argument guard"))
+
+;; `even?` and `odd?` reach the guard through `%`, so they are the indirect
+;; callers and worth pinning separately from the functions that hold it.
+(deftest test-parity-predicates-reject-nil
+  (is (thrown? \InvalidArgumentException (even? nil)) "even?")
+  (is (thrown? \InvalidArgumentException (odd? nil)) "odd?"))
+
+(deftest test-valid-arguments-still-compute
+  (is (= 2 (quot 5 2)) "quot")
+  (is (= 1 (rem 5 2)) "rem")
+  (is (= 1 (mod 5 2)) "mod")
+  (is (= 1 (mod -5 2)) "mod keeps its sign convention")
+  (is (= 16 (** 2 4)) "**")
+  (is (= 3.0 (floor 3.7)) "floor returns a float")
+  (is (= 4.0 (ceil 3.2)) "ceil returns a float")
+  (is (= 4.0 (round 3.5)) "round returns a float")
+  (is (= 3.0 (sqrt 9)) "sqrt")
+  (is (= -1 (bit-not 0)) "bit-not")
+  (is (= 8 (bit-shift-left 1 3)) "bit-shift-left")
+  (is (= 1 (bit-shift-right 8 3)) "bit-shift-right")
+  (is (= 1 (unsigned-bit-shift-right 8 3)) "unsigned-bit-shift-right")
+  (is (even? 4) "even?")
+  (is (odd? 3) "odd?"))


### PR DESCRIPTION
## 🤔 Background

Twelve public arithmetic functions rejected nil through `assert-non-nil`
(`src/phel/core/math.phel:26`), which is a **variadic** private helper:

```phel
(defn- assert-non-nil
  [& xs]
  (assert-non-nil-coll xs))
```

Each call allocated a rest vector and walked it with a `foreach`, to check one or two values the
caller had already passed positionally. For most of these functions that guard was the entire
cost of the call.

The replacement was already sitting in the same file: `assert-non-nil-1` and `assert-non-nil-2`
(`math.phel:34`) are fixed-arity macros written for `+ - * /` in #2978, whose documented
precondition is bare symbol arguments. All twelve sites pass bare parameters.

## 💡 Goal

Take the guard off the hot path of the functions it guards, without changing what any of them
accepts or rejects.

## 🔖 Changes

- Twelve one-line swaps in `math.phel`: `bit-not`, `bit-shift-left`, `bit-shift-right`,
  `unsigned-bit-shift-right`, `quot`, `rem`, `mod`, `**`, `floor`, `ceil`, `round`, `sqrt`.
  No signature changes, no new code, no public API change.
- New `tests/phel/core/math-nil-guard.phel` (see below).

### Measured

One process, empty-closure floor subtracted, inputs rotated through an 8-element table so
nothing folds:

| function | before | after | speedup |
|---|---|---|---|
| `round` | 1.325 us | 0.051 us | 26.1x |
| `floor` | 1.341 us | 0.055 us | 24.6x |
| `rem` | 1.544 us | 0.088 us | 17.5x |
| `quot` | 1.538 us | 0.096 us | 16.1x |
| `mod` | 1.555 us | 0.109 us | 14.3x |
| `sqrt` | 1.467 us | 0.178 us | 8.3x |
| `even?` | 1.725 us | 0.245 us | 7.1x |
| `odd?` | 1.808 us | 0.297 us | 6.1x |

`even?` and `odd?` reach the guard indirectly, through `%` to `rem`, so every
`(filter even? …)` was paying it once per element.

### The `:inline` sites are deliberately untouched

Lines 50, 60, 70, 80, 89, 98 keep calling the variadic helper. Three splice `~@args` and so have
no fixed arity to target, and all six expand into the **caller's** namespace, where a
`defmacro-` private to `phel.core` is not in scope.

`bit-and` is measured unchanged, 9.263 us before against 9.443 us after, which is the check that
they really were left alone rather than an assumption that they were.

Worth a separate look later: an `:inline` that expands to a runtime `assert-non-nil` call is
paying for a guard the surrounding native operator does not otherwise need.

### Test gap this exposed

Nothing in the suite pinned nil rejection for **any** of these twelve, which is uncomfortable
given the guard is the entire observable behaviour being replaced. The new file covers rejection
for every function, both argument positions for the two-argument ones, the message text, the two
indirect callers, and valid arguments still computing.

Confirmed it bites: deleting one guard makes it fail.

Closes #3018
