### PR TITLE
fix(lang): `lazy-seq` over a chunked sequence yields only its first element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix `lazy-seq` over a chunked sequence (`take`, `keep`, `range`, ...) yielding only its first element while `count` reported the true length (#3020)
 - Stop the scan-index and namespace caches growing without bound on every `phel doc`, LSP hover and REPL completion (#3007)
 - Fix literal matching in `phel.string/replace` and `replace-first` (#2957)
 - Stop internal test, nREPL and watch eval forms from emitting namespace separator deprecations (#2950)

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -379,19 +379,17 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
             }
 
             if (!$next instanceof self) {
-                // A tail that is lazy but is not a `LazySeq` (today that means
-                // `ChunkedSeq`, which everything built on
-                // `lazy-seq-from-generator` returns) cannot drive this loop,
-                // because the loop walks `LazySeq` links. Handing off to the
-                // tail's own iterator keeps it lazy; assigning null here
-                // instead ended the loop and silently dropped every remaining
-                // element, while `count` still reported the true length
-                // (#3020). `toArray()` above already merges this case, and the
-                // two traversals must not disagree.
+                // A lazy tail that is not a `LazySeq` (today: `ChunkedSeq`,
+                // which everything built on `lazy-seq-from-generator` returns)
+                // cannot drive this loop, which walks `LazySeq` links. Hand off
+                // to its own iterator, itself a generator, so this stays lazy.
+                // Ending the walk here instead silently dropped the rest while
+                // `count` still reported the full length (#3020); `toArray()`
+                // merges the same tail, and the two must not disagree.
                 //
-                // Yielding each value rather than `yield from` keeps the keys
-                // contiguous with the ones yielded above, which a caller doing
-                // `iterator_to_array()` with preserved keys depends on.
+                // Yield each value rather than `yield from`: that keeps the
+                // keys contiguous with the ones yielded above, which a caller
+                // using `iterator_to_array()` with preserved keys relies on.
                 foreach ($next as $value) {
                     yield $value;
                 }

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -358,7 +358,9 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
     {
         $seq = $this;
 
-        while ($seq instanceof self) {
+        // `$seq` only ever advances to another `self`; every other tail shape
+        // returns below, so the walk has no condition of its own.
+        while (true) {
             // See `toArray()`: realize is the only nil-safe empty check.
             $realized = $seq->realizeSeq();
             if (!$realized instanceof SeqInterface) {
@@ -376,7 +378,28 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
                 return;
             }
 
-            $seq = $next instanceof self ? $next : null;
+            if (!$next instanceof self) {
+                // A tail that is lazy but is not a `LazySeq` (today that means
+                // `ChunkedSeq`, which everything built on
+                // `lazy-seq-from-generator` returns) cannot drive this loop,
+                // because the loop walks `LazySeq` links. Handing off to the
+                // tail's own iterator keeps it lazy; assigning null here
+                // instead ended the loop and silently dropped every remaining
+                // element, while `count` still reported the true length
+                // (#3020). `toArray()` above already merges this case, and the
+                // two traversals must not disagree.
+                //
+                // Yielding each value rather than `yield from` keeps the keys
+                // contiguous with the ones yielded above, which a caller doing
+                // `iterator_to_array()` with preserved keys depends on.
+                foreach ($next as $value) {
+                    yield $value;
+                }
+
+                return;
+            }
+
+            $seq = $next;
         }
     }
 

--- a/tests/phel/core/lazy-seq-chunked-tail.phel
+++ b/tests/phel/core/lazy-seq-chunked-tail.phel
@@ -1,0 +1,45 @@
+(ns phel-test.core.lazy-seq-chunked-tail
+  (:require phel.test :refer [deftest is]))
+
+;; A `lazy-seq` whose body returns a chunked sequence used to yield only its
+;; first element, while `count` still reported the true length, so the
+;; collection disagreed with itself (#3020). Everything built on
+;; `lazy-seq-from-generator` is chunked: `take`, `drop`, `keep`, `keep-indexed`,
+;; `take-while`, `take-nth`, `interpose`, `dedupe`, `map-indexed`,
+;; `partition-by`, `range`.
+;;
+;; The combination is what matters, not either half: a bare `(take 4 …)` was
+;; always correct, and a `lazy-seq` over a non-chunked tail (`map`, `filter`)
+;; was always correct. Only the two together lost elements.
+
+(deftest test-lazy-seq-over-a-chunked-tail-keeps-every-element
+  (is (= [1 2 3 4] (vec (lazy-seq (take 4 [1 2 3 4 5 6])))) "take")
+  (is (= [1 2 3] (vec (lazy-seq (keep identity [1 2 3])))) "keep")
+  (is (= [3 4 5] (vec (lazy-seq (drop 2 [1 2 3 4 5])))) "drop")
+  (is (= [0 1 2] (vec (lazy-seq (range 0 3)))) "range")
+  (is (= [1 2] (vec (lazy-seq (take-while #(< % 3) [1 2 3 4])))) "take-while"))
+
+;; The three traversals have to agree. Before the fix `count` said 4 while `vec`
+;; said 1, which is the shape of the bug: no error, just a shorter sequence.
+(deftest test-count-vec-and-foreach-agree
+  (let [s (lazy-seq (take 4 [1 2 3 4 5 6]))]
+    (is (= 4 (count s)) "count")
+    (is (= 4 (count (vec s))) "vec")
+    (is (= 4 (let [n (php/array 0)]
+               (foreach [_ s] (php/aset n 0 (php/+ 1 (php/aget n 0))))
+               (php/aget n 0)))
+        "foreach")))
+
+;; A non-chunked tail was never affected; pinned so a fix for the chunked case
+;; cannot regress the case that already worked.
+(deftest test-lazy-seq-over-a-non-chunked-tail-still-works
+  (is (= [2 3 4] (vec (lazy-seq (map inc [1 2 3])))) "map")
+  (is (= [2 4] (vec (lazy-seq (filter even? [1 2 3 4])))) "filter"))
+
+(deftest test-nesting-does-not-truncate
+  (is (= [1 2 3 4] (vec (lazy-seq (lazy-seq (take 4 [1 2 3 4 5 6]))))) "two wrappers")
+  (is (= [2 3 4 5] (vec (map inc (lazy-seq (take 4 [1 2 3 4 5 6]))))) "consumed through map"))
+
+(deftest test-an-empty-chunked-tail-is-still-empty
+  (is (= [] (vec (lazy-seq (take 0 [1 2 3])))) "take 0")
+  (is (= [] (vec (lazy-seq (keep (fn [_] nil) [1 2 3])))) "keep that matches nothing"))

--- a/tests/php/Unit/Lang/Collections/LazySeq/LazySeqTest.php
+++ b/tests/php/Unit/Lang/Collections/LazySeq/LazySeqTest.php
@@ -9,6 +9,7 @@ use Generator;
 use Iterator;
 use IteratorAggregate;
 use Phel\Lang\Collections\Exceptions\NotASeqException;
+use Phel\Lang\Collections\LazySeq\ChunkedSeq;
 use Phel\Lang\Collections\LazySeq\Cons;
 use Phel\Lang\Collections\LazySeq\LazySeq;
 use Phel\Lang\Collections\LazySeq\LazySeqInterface;
@@ -17,6 +18,7 @@ use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
 use PHPUnit\Framework\TestCase;
 
+use function iterator_to_array;
 use function sprintf;
 
 final class LazySeqTest extends TestCase
@@ -29,6 +31,51 @@ final class LazySeqTest extends TestCase
     {
         $this->hasher = new ModuloHasher();
         $this->equalizer = new SimpleEqualizer();
+    }
+
+    /**
+     * A `LazySeq` whose realized value is a `ChunkedSeq` used to yield only its
+     * first element from `getIterator()`, because the walk assigned null to
+     * anything that was not a `LazySeq` and stopped. `toArray()` merged the
+     * same tail correctly, so the two traversals of one value disagreed
+     * (#3020).
+     */
+    public function test_iterates_a_chunked_tail_to_the_end(): void
+    {
+        $lazySeq = new LazySeq(
+            $this->hasher,
+            $this->equalizer,
+            fn(): ?ChunkedSeq => ChunkedSeq::fromGenerator(
+                $this->hasher,
+                $this->equalizer,
+                (static function (): Generator {
+                    yield from [1, 2, 3, 4];
+                })(),
+            ),
+        );
+
+        self::assertSame([1, 2, 3, 4], iterator_to_array($lazySeq, false));
+    }
+
+    /**
+     * The two traversals must agree, which is the property that actually broke:
+     * there was no error, just a shorter sequence from one of them.
+     */
+    public function test_iterator_and_to_array_agree_on_a_chunked_tail(): void
+    {
+        $make = fn(): LazySeq => new LazySeq(
+            $this->hasher,
+            $this->equalizer,
+            fn(): ?ChunkedSeq => ChunkedSeq::fromGenerator(
+                $this->hasher,
+                $this->equalizer,
+                (static function (): Generator {
+                    yield from [1, 2, 3, 4];
+                })(),
+            ),
+        );
+
+        self::assertSame($make()->toArray(), iterator_to_array($make(), false));
     }
 
     public function test_creates_lazy_seq_from_function(): void


### PR DESCRIPTION
## 🤔 Background

A `lazy-seq` whose realized value is a chunked sequence yielded only its first element, while
`count` still reported the true length. One value, two answers, no error:

```phel
(vec   (lazy-seq (take 4 [1 2 3 4 5 6])))   ; => [1]
(count (lazy-seq (take 4 [1 2 3 4 5 6])))   ; => 4
(vec   (take 4 [1 2 3 4 5 6]))              ; => [1 2 3 4]   correct unwrapped
```

`LazySeq::getIterator()` walks `LazySeq` links and ended the walk by assigning null to any tail
that was not one:

```php
if (!$next instanceof LazySeqInterface) {
    return;
}

$seq = $next instanceof self ? $next : null;   // ChunkedSeq -> null -> loop ends
```

`cdr()` returns `LazySeqInterface`, and `ChunkedSeq` is one, so a chunked tail passed the guard
and was then discarded by the assignment. Everything built on `lazy-seq-from-generator` is
chunked: `take`, `drop`, `keep`, `keep-indexed`, `take-while`, `take-nth`, `interpose`, `dedupe`,
`map-indexed`, `partition-by`, `range`.

`toArray()` already merged this case, so the two traversals of the same value disagreed and which
answer you got depended on the operation.

## 💡 Goal

Make every traversal of a `lazy-seq` return the same elements.

## 🔖 Changes

- `getIterator()` hands off to the tail's own iterator instead of dropping it. `ChunkedSeq`'s
  iterator is itself a generator, so the handoff stays lazy.
- Values are yielded individually rather than with `yield from`, which keeps the keys contiguous
  with the ones yielded above for callers using `iterator_to_array()` with preserved keys.
- With the null assignment gone the loop condition is always true, which psalm flagged, so the
  walk is now an explicit `while (true)` with returns.
- Tests at both levels: `tests/phel/core/lazy-seq-chunked-tail.phel` (five chunked producers,
  `count`/`vec`/`foreach` agreeing, nesting, empty tails, and the non-chunked case that always
  worked) and two `LazySeqTest` cases, one of which asserts `toArray()` and `getIterator()` agree.

Verified across sizes: at 1,000 and 100,000 elements main returns `[0]` and this returns
`[0 1 2 3 4]`.

## Reviewed and deliberately not changed

`toArray()` and `getIterator()` are now structurally identical walks, so `toArray()` could be
`iterator_to_array($this, false)` and the two would be **incapable** of disagreeing rather than
merely agreeing today. Measured: going through the generator costs 5 to 7 percent (2.696 to
2.888 us at 10 elements, 51.5 to 53.9 us at 200), and `toArray()` is a hot path. The test
asserting the two agree is the cheaper guarantee, so that is what this relies on.

## Two pre-existing problems found next door, not fixed here

Both reproduce identically on `main`, so neither is caused by this change:

1. **`LazySeq::getIterator()` drains the sequence to test emptiness.** The
   `count($realized) === 0` check calls `ChunkedSeq::count()`, whose own comment reads
   *"Warning: This realizes the entire sequence!"*. So iterating any `lazy-seq` over a chunked
   tail realizes all of it up front, and over an unbounded source it never terminates. This is
   what makes `(vec (take 5 (lazy-seq (range))))` hang on main today, and it is why this PR has
   no laziness assertion at the `LazySeq` level: the drain happens before the handoff is reached.
   `Seq::isEmpty()` already exists and pulls at most one element.
2. **A 2,000,000 element source segfaults** (exit 139) on main and on this branch alike.

Filing 1 separately; it is the more valuable of the two and blocks any future work on chunk
laziness.

Closes #3020
