### PR TITLE
perf(lang): answer emptiness without realizing the sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Stop the emptiness check on a lazy sequence realizing the whole sequence: an unbounded source now terminates, a 2,000,000 element one no longer crashes, and taking 5 of a 200,000 element `lazy-seq` drops from 21ms to 0.004ms (#3023)
 - Fix `lazy-seq` over a chunked sequence (`take`, `keep`, `range`, ...) yielding only its first element while `count` reported the true length (#3020)
 - Stop the scan-index and namespace caches growing without bound on every `phel doc`, LSP hover and REPL completion (#3007)
 - Fix literal matching in `phel.string/replace` and `replace-first` (#2957)

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -12,6 +12,7 @@ use Phel\Lang\Collections\Exceptions\NotASeqException;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
+use Phel\Lang\Seq;
 use Phel\Lang\SeqInterface;
 
 use Traversable;
@@ -324,7 +325,7 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
                 break;
             }
 
-            if ($realized instanceof Countable && count($realized) === 0) {
+            if ($this->isEmptySeq($realized)) {
                 break;
             }
 
@@ -367,7 +368,7 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
                 return;
             }
 
-            if ($realized instanceof Countable && count($realized) === 0) {
+            if ($this->isEmptySeq($realized)) {
                 return;
             }
 
@@ -439,6 +440,36 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
         }
 
         return LazySeqEquality::walkPairwise($this->getIterator(), $otherIter, $this->equalizer);
+    }
+
+    /**
+     * Whether a realized seq holds no elements, without realizing it.
+     *
+     * `count()` cannot answer this for a lazy seq: both `LazySeq::count()` and
+     * `ChunkedSeq::count()` compute it by realizing the whole sequence, and
+     * each says so in its own comment. Asking it here materialized every
+     * element of a chunked tail before the first one was yielded, and over an
+     * unbounded source never returned at all (#3023).
+     *
+     * `first() === null` cannot answer it either, because nil is a legitimate
+     * element: `(lazy-seq [nil])` holds one, not zero.
+     *
+     * So: a Countable that is not lazy knows its size in O(1) and is asked
+     * directly, and a lazy one is probed with {@see Seq::isEmpty()}, which
+     * pulls at most one element and therefore distinguishes "empty" from
+     * "first element is nil" without draining anything.
+     */
+    private function isEmptySeq(mixed $seq): bool
+    {
+        if ($seq instanceof Countable && !$seq instanceof LazySeqInterface) {
+            return count($seq) === 0;
+        }
+
+        if ($seq instanceof Traversable) {
+            return Seq::isEmpty($seq);
+        }
+
+        return false;
     }
 
     /**

--- a/tests/phel/core/lazy-seq-empty-check.phel
+++ b/tests/phel/core/lazy-seq-empty-check.phel
@@ -1,0 +1,41 @@
+(ns phel-test.core.lazy-seq-empty-check
+  (:require phel.test :refer [deftest is]))
+
+;; Asking a lazy sequence whether it is empty used to realize all of it,
+;; because the check went through `count`, and `count` on both `LazySeq` and
+;; `ChunkedSeq` is documented as realizing the whole sequence. So an unbounded
+;; source never returned, and a large bounded one was materialized in full to
+;; produce a handful of elements (#3023).
+
+;; The case that never terminated before. Kept deliberately: an unbounded
+;; source is the only input that distinguishes "lazy" from "fast".
+(deftest test-an-unbounded-source-terminates
+  (is (= [0 1 2 3 4] (vec (take 5 (lazy-seq (range))))) "take from an infinite range")
+  (is (= 0 (first (lazy-seq (range)))) "first of an infinite range")
+  (is (= [0 2 4] (vec (take 3 (filter even? (lazy-seq (range)))))) "filtered infinite range"))
+
+;; Emptiness has to stay distinguishable from "the first element is nil", which
+;; is why the check cannot simply be `(nil? (first s))`.
+(deftest test-nil-is-an-element-not-an-empty-signal
+  (is (= [nil] (vec (lazy-seq [nil]))) "a single nil is one element")
+  (is (= 1 (count (lazy-seq [nil]))) "and counts as one")
+  (is (= [nil nil] (vec (lazy-seq [nil nil]))) "two nils are two elements"))
+
+;; Not asserted here, deliberately: `(empty? (lazy-seq [nil]))` returns true
+;; while `count` returns 1 and `vec` returns `[nil]`. That disagreement is
+;; pre-existing and unrelated to the emptiness check inside `LazySeq`, which
+;; this file covers. Tracked separately.
+
+(deftest test-genuinely-empty-sources-are-still-empty
+  (is (= [] (vec (lazy-seq []))) "empty vector")
+  (is (= 0 (count (lazy-seq []))) "counts zero")
+  (is (empty? (lazy-seq [])) "empty?")
+  (is (= [] (vec (lazy-seq nil))) "nil body")
+  (is (= [] (vec (lazy-seq (lazy-seq [])))) "an empty lazy-seq inside a lazy-seq")
+  (is (= [] (vec (lazy-seq (take 0 [1 2 3])))) "an empty chunked tail"))
+
+;; A large bounded source should cost what the consumer asks for, not what the
+;; source holds. Correctness only here; the timing is in the PR.
+(deftest test-a-large-source-is-not-realized-to-take-a-few
+  (is (= [0 1 2 3 4] (vec (take 5 (lazy-seq (range 0 200000))))) "take 5 of 200k")
+  (is (= 0 (first (lazy-seq (range 0 200000)))) "first of 200k"))


### PR DESCRIPTION
## 🤔 Background

Both traversals in `LazySeq` tested emptiness the same way:

```php
if ($realized instanceof Countable && count($realized) === 0) {
```

`ChunkedSeq::count()` and `LazySeq::count()` compute that by realizing the entire sequence, and
each says so in its own comment:

```php
public function count(): int
{
    // Warning: This realizes the entire sequence!
    return count($this->toArray());
}
```

So asking a lazy sequence whether it was empty materialized all of it, before the first element
was yielded. Everything built on `lazy-seq-from-generator` is chunked: `take`, `drop`, `keep`,
`keep-indexed`, `take-while`, `take-nth`, `interpose`, `dedupe`, `map-indexed`, `partition-by`,
`range`.

## 💡 Goal

Make a lazy sequence cost what the consumer asks for, not what the source holds.

## 🔖 Changes

`isEmptySeq()` replaces the inline check in both `toArray()` and `getIterator()`, so the two
cannot drift apart on this either (they already had one such disagreement, #3020):

- a `Countable` that is **not** lazy knows its size in O(1) and is still asked directly, so the
  common non-lazy path is unchanged;
- a lazy one is probed with `Seq::isEmpty()`, which pulls at most one element.

Pulling one element rather than reading `first()` is what keeps nil usable as a value:
`(lazy-seq [nil])` holds one element, not zero.

### Measured

| | main | this branch |
|---|---|---|
| `(vec (take 5 (lazy-seq (range))))` | never terminates | `[0 1 2 3 4]` |
| `(vec (take 5 (lazy-seq (range 0 2000000))))` | segfault, exit 139 | `[0 1 2 3 4]` |
| take 5 from a 200,000 element `lazy-seq`, in process | 21.055 ms/op | **0.004 ms/op** |

The 2,000,000 element crash was reported in #3022 as a separate pre-existing problem. It was the
same root cause and it is fixed here.

### Edge cases, all verified unchanged against main

| | before | after |
|---|---|---|
| `(lazy-seq [])` | `[]`, count 0 | same |
| `(lazy-seq nil)` | `[]`, count 0 | same |
| `(lazy-seq (lazy-seq []))` | `[]`, count 0 | same |
| `(lazy-seq [nil])` | `[nil]`, count 1 | same |

The third row is why the obvious cheap fix was rejected. Skipping the count for lazy types
outright would treat an empty `LazySeq` nested inside a `lazy-seq` as non-empty and yield a
spurious nil. The fourth row is why the check cannot be `first() === null`.

## Reviewed, no further changes

The shared `isEmptySeq()` is itself the de-duplication the review would otherwise have asked
for, and nothing else in the touched code needed changing, so there is no separate `ref` commit
on this branch.

## Found next door, not fixed here

`(empty? (lazy-seq [nil]))` returns `true` while `count` returns 1 and `vec` returns `[nil]`.
That reproduces identically on main, so it is pre-existing and unrelated to the check inside
`LazySeq`. It is the same family as #3020 (traversals of one value disagreeing) and is filed
separately. The new test file deliberately does **not** assert the current behaviour, since
doing so would pin a bug.

Closes #3023
