### PR TITLE
perf(core): give the closures returned by `partial`, `fnil` and `comp` real arities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ All notable changes to this project will be documented in this file.
 
 Runtime core:
 
+- Give the closures returned by `partial`, `fnil` and `comp` real arities: 30x, 50x and 8x faster to call (#3021)
 - Guard the twelve nil-rejecting arithmetic functions with the fixed-arity macros instead of the variadic helper: `round` and `floor` 25x, `quot`, `rem` and `mod` 14 to 17x, `even?` and `odd?` 6 to 7x (#3018)
 - Compile a literal `(list ...)`, `(vector ...)`, `(queue ...)`, `(hash-map ...)` or `(array-map ...)` straight to its `Phel` factory: 2.2 to 3.6 times faster (#3014)
 - Inline PHP array constructors and use `php-indexed-array` across core and standard libraries (#2941)

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -202,25 +202,83 @@
   "Takes a function `f` and fewer than the normal number of arguments to `f`, and returns a function that takes a variable number of additional arguments. When called, `f` will be invoked with the bound `args` prepended to the additional arguments."
   {:example "((partial + 10) 1 2) ; => 13"
    :see-also ["comp" "apply"]}
+  ;; The returned closure is what runs per call, so it is the thing that must
+  ;; not be variadic. The bound argument count is known here, once, so dispatch
+  ;; on it now and hand back a closure with real arities; the previous single
+  ;; `#(apply f (concat args %&))` rebuilt a rest vector, built a lazy seq with
+  ;; `concat`, and went through `apply` on every call, which cost 44x the call
+  ;; it was wrapping (#3021). Clojure specialises the same three counts.
   [f & args]
-  #(apply f (concat args %&)))
+  (case (count args)
+    1 (let [a (first args)]
+        (fn
+          ([] (f a))
+          ([x] (f a x))
+          ([x y] (f a x y))
+          ([x y & more] (apply f a x y more))))
+    2 (let [a (first args)
+            b (second args)]
+        (fn
+          ([] (f a b))
+          ([x] (f a b x))
+          ([x y] (f a b x y))
+          ([x y & more] (apply f a b x y more))))
+    3 (let [a (first args)
+            b (second args)
+            c (get args 2)]
+        (fn
+          ([] (f a b c))
+          ([x] (f a b c x))
+          ([x y] (f a b c x y))
+          ([x y & more] (apply f a b c x y more))))
+    (fn [& more] (apply f (concat args more)))))
 
 (defn fnil
   "Returns a function that replaces nil arguments with the provided defaults before calling f. The number of defaults determines how many leading arguments are nil-checked."
   {:example "(let [safe-inc (fnil inc 0)] (safe-inc nil)) ; => 1"
    :see-also ["partial" "comp"]}
+  ;; As with `partial`, the returned closure is what runs per call. The general
+  ;; form below rebuilt a rest vector, walked it with a transient `for`, and
+  ;; `apply`ed, which cost 56x the call it wrapped (#3021). The number of
+  ;; defaults is known here, so the common counts get closures that patch the
+  ;; arguments inline, the way Clojure spells it.
   [f & defaults]
-  (let [n (count defaults)]
-    (fn [& args]
-      (let [patched (persistent
-                     (for [i :range [0 (count args)]
-                           :reduce [acc (transient [])]]
-                       (let [arg (get args i)]
-                         (conj acc
-                               (if (and (php/< i n) (nil? arg))
-                                 (get defaults i)
-                                 arg)))))]
-        (apply f patched)))))
+  (case (count defaults)
+    1 (let [x (first defaults)]
+        (fn
+          ([a] (f (if (nil? a) x a)))
+          ([a b] (f (if (nil? a) x a) b))
+          ([a b c] (f (if (nil? a) x a) b c))
+          ([a b c & more] (apply f (if (nil? a) x a) b c more))))
+    2 (let [x (first defaults)
+            y (second defaults)]
+        (fn
+          ([a] (f (if (nil? a) x a)))
+          ([a b] (f (if (nil? a) x a) (if (nil? b) y b)))
+          ([a b c] (f (if (nil? a) x a) (if (nil? b) y b) c))
+          ([a b c & more] (apply f (if (nil? a) x a) (if (nil? b) y b) c more))))
+    3 (let [x (first defaults)
+            y (second defaults)
+            z (get defaults 2)]
+        (fn
+          ([a] (f (if (nil? a) x a)))
+          ([a b] (f (if (nil? a) x a) (if (nil? b) y b)))
+          ([a b c] (f (if (nil? a) x a) (if (nil? b) y b) (if (nil? c) z c)))
+          ([a b c & more] (apply f (if (nil? a) x a) (if (nil? b) y b) (if (nil? c) z c) more))))
+    ;; 0 defaults, or more than three: keep the general walk. It patches the
+    ;; first `n` arguments that are present, which is the contract the fixed
+    ;; arities above reproduce.
+    (let [n (count defaults)]
+      (fn [& args]
+        (let [patched (persistent
+                       (for [i :range [0 (count args)]
+                             :reduce [acc (transient [])]]
+                         (let [arg (get args i)]
+                           (conj acc
+                                 (if (and (php/< i n) (nil? arg))
+                                   (get defaults i)
+                                   arg)))))]
+          (apply f patched))))))
 
 (defn trampoline
   "Calls `f` with any supplied `args`. While the return value is a function, calls it with no arguments and repeats; returns the first non-function value. Use it for stack-safe mutual recursion: have the functions return a zero-argument function wrapping the next call instead of calling it directly. Only Phel functions bounce — keywords and collections, although callable, are returned as-is. To return a function as the final value, wrap it in a collection and unwrap it after `trampoline` returns."

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -97,7 +97,18 @@
   (case (count fs)
     0 identity
     1 (first fs)
-    2 #((first fs) (apply (second fs) %&))
+    ;; Both functions are pulled out of `fs` here rather than inside the
+    ;; closure: the previous `#((first fs) (apply (second fs) %&))` re-ran both
+    ;; lookups on every call, on top of building a rest vector and going
+    ;; through `apply`. Real arities on the closure remove the rest of it
+    ;; (#3021).
+    2 (let [outer (first fs)
+            inner (second fs)]
+        (fn
+          ([] (outer (inner)))
+          ([a] (outer (inner a)))
+          ([a b] (outer (inner a b)))
+          ([a b & more] (outer (apply inner a b more)))))
     (reduce comp fs)))
 
 (defn- map-entry-source?

--- a/tests/phel/core/closure-arity-dispatch.phel
+++ b/tests/phel/core/closure-arity-dispatch.phel
@@ -1,0 +1,82 @@
+(ns phel-test.core.closure-arity-dispatch
+  (:require phel.test :refer [deftest is]))
+
+;; `partial`, `fnil` and `comp` each return a closure, and that closure is what
+;; runs per call, so it is the part that had to stop being variadic (#3021).
+;; Each now dispatches once, at construction, on how many arguments were bound,
+;; and hands back a closure with real arities plus a variadic tail.
+;;
+;; The interesting cases are therefore the boundaries of that dispatch: the
+;; bound counts that get a specialised closure, the count just past them that
+;; falls to the general form, and the call arities either side of each
+;; closure's own tail.
+
+(deftest test-partial-by-bound-argument-count
+  (is (= 3 ((partial +) 1 2)) "no bound arguments falls to the general form")
+  (is (= 15 ((partial + 10) 5)) "one bound")
+  (is (= 35 ((partial + 10 20) 5)) "two bound")
+  (is (= 15 ((partial + 1 2 3) 4 5)) "three bound, the last specialised count")
+  (is (= 21 ((partial + 1 2 3 4 5) 6)) "five bound falls to the general form"))
+
+(deftest test-partial-by-call-argument-count
+  (let [add10 (partial + 10)]
+    (is (= 10 (add10)) "called with none")
+    (is (= 11 (add10 1)) "called with one")
+    (is (= 13 (add10 1 2)) "called with two")
+    (is (= 16 (add10 1 2 3)) "called with three, into the closure's tail")
+    (is (= 25 (add10 1 2 3 4 5)) "well into the tail")))
+
+(deftest test-partial-preserves-argument-order
+  (is (= "abc" ((partial str "a") "b" "c")) "bound arguments come first")
+  (is (= [1 2 3] ((partial vector 1) 2 3)) "and stay in order")
+  (is (= [1 2 3 4] ((partial vector 1 2) 3 4)) "two bound")
+  (is (= 5 ((partial - 10) 5)) "order matters for a non-commutative fn")
+  (is (= 3 ((partial - 10 2) 5)) "two bound, non-commutative"))
+
+(deftest test-fnil-patches-only-nil-and-only-the-leading-arguments
+  (is (= 1 ((fnil inc 0) nil)) "one default, nil patched")
+  (is (= 6 ((fnil inc 0) 5)) "one default, value kept")
+  (is (= 3 ((fnil + 1 2) nil nil)) "two defaults, both patched")
+  (is (= 10 ((fnil + 1 2) nil 9)) "two defaults, second kept")
+  (is (= 9 ((fnil + 1 2) 7 nil)) "two defaults, first kept")
+  (is (= 15 ((fnil + 1 2) 7 8)) "two defaults, neither patched")
+  (is (= 6 ((fnil + 1 2 3) nil nil nil)) "three defaults")
+  (is (= 10 ((fnil + 1 2 3 4) nil nil nil nil)) "four defaults falls to the general form")
+  (is (= 12 ((fnil + 1) nil 5 6)) "arguments past the defaults are untouched")
+  (is (= [1 9 3] ((fnil vector 1 2 3) nil 9 nil)) "patched and kept interleaved"))
+
+;; Only nil is replaced. `false` is a value, and treating it as missing would
+;; be the easy mistake for a nil check to make.
+(deftest test-fnil-does-not-patch-false
+  (is (= :d ((fnil identity :d) nil)) "nil is replaced")
+  (is (= false ((fnil identity :d) false)) "false is not")
+  (is (= 0 ((fnil identity :d) 0)) "nor is zero")
+  (is (= "" ((fnil identity :d) "")) "nor is an empty string"))
+
+(deftest test-comp-by-function-count
+  (is (= 7 ((comp) 7)) "no functions is identity")
+  (is (= 8 ((comp inc) 7)) "one function")
+  (is (= 7 ((comp inc inc) 5)) "two functions, the specialised count")
+  (is (= 4 ((comp inc inc inc) 1)) "three functions folds through the pair"))
+
+(deftest test-comp-applies-right-to-left
+  (is (= 7 ((comp inc (fn [x] (* x 2))) 3)) "the docstring example")
+  (is (= 8 ((comp (fn [x] (* x 2)) inc) 3)) "the other order gives a different answer")
+  (is (= 4 ((comp inc +) 1 2)) "the inner function takes the arguments"))
+
+(deftest test-comp-by-call-argument-count
+  (let [f (comp inc +)]
+    (is (= 1 (f)) "called with none")
+    (is (= 2 (f 1)) "called with one")
+    (is (= 4 (f 1 2)) "called with two")
+    (is (= 7 (f 1 2 3)) "called with three, into the closure's tail")
+    (is (= 16 (f 1 2 3 4 5)) "well into the tail")))
+
+;; These are the shapes a caller reaches through `apply` or by passing the
+;; closure on, neither of which sees a fixed arity.
+(deftest test-the-returned-closures-work-through-apply
+  (is (= 16 (apply (partial + 10) [1 2 3])) "partial")
+  (is (= 1 (apply (fnil inc 0) [nil])) "fnil")
+  (is (= 4 (apply (comp inc +) [1 2])) "comp")
+  (is (= [11 12] (map (partial + 10) [1 2])) "partial as a value")
+  (is (= [1 6] (map (fnil inc 0) [nil 5])) "fnil as a value"))


### PR DESCRIPTION
## 🤔 Background

`partial`, `fnil` and `comp` each return a closure, and **that closure** is what runs per call.
The constructors run once. So the variadic cost was in the wrong place entirely:

```phel
partial  #(apply f (concat args %&))
fnil     (fn [& args] ... transient for over args ... (apply f patched))
comp     #((first fs) (apply (second fs) %&))
```

Per call, `partial` rebuilt a rest vector, built a lazy seq with `concat`, then went through
`apply`. `fnil` rebuilt a rest vector and walked it with a transient `for`. `comp` did both
`(first fs)` and `(second fs)` lookups **again on every call**, on top of the rest vector and
`apply`.

This family is invisible to #2973's scoping, which counts head-position uses of the
*constructor*: `partial` appears once in source and runs once per element.

## 💡 Goal

Move the arity work to construction, where it happens once, instead of the call, where it
happens per element.

## 🔖 Changes

The bound argument count is known at construction, so each now dispatches on it once and returns
a closure with real arities plus a variadic tail. Clojure specialises the same counts.

- `partial`: specialised for 1, 2 and 3 bound arguments; 0 or 4+ keep the general form.
- `fnil`: specialised for 1, 2 and 3 defaults; 0 or 4+ keep the general walk, which is the
  contract the specialised arities reproduce (patch the first n arguments that are present).
- `comp`: both functions pulled out of `fs` into the enclosing `let` rather than looked up per
  call, plus real arities. The 3+ case is `(reduce comp fs)`, so it folds pairwise through the
  fast path automatically.

### Measured

Empty-closure floor subtracted, same process:

| | before | after | speedup |
|---|---|---|---|
| `((fnil inc 0) x)` | 9.474 us | 0.190 us | **49.9x** |
| `((partial + 10) x)` | 7.491 us | 0.254 us | **29.5x** |
| `((comp inc inc) x)` | 2.258 us | 0.293 us | **7.7x** |

For scale `(+ 10 x)` called directly is 0.172 us. So `partial` went from **44x the call it wraps
to 1.5x**, and `fnil` from 55x to 1.1x.

### Behaviour

25 cases covering every bound count, every call arity either side of each closure's tail,
argument order, `apply` and higher-order use, and `fnil` patching only nil, produce
**byte-identical** output before and after.

The new `tests/phel/core/closure-arity-dispatch.phel` passes **unmodified against the old
implementations**, which is what makes it a regression guard rather than a description of the new
code. Deleting one argument from one specialised arity makes it fail.

Worth calling out one case it pins: `fnil` replaces nil and nothing else, so
`((fnil identity :d) false)` is `false`, not `:d`. Treating `false` as missing is the easy
mistake for a nil check to make.

## Reviewed, no further changes

The three near-identical blocks in `partial` and `fnil` are the optimisation, not duplication to
factor out: extracting them behind a helper would put back the call the arities exist to remove.
So there is no separate `ref` commit on this branch.

## Note on the local test run

The full parallel integration suite failed one test locally, but it fails a **different** test on
`main` in the same conditions (`DataReadersAutoloadTest` here, `DocCommandTest` on main), and both
pass in isolation on both. That is a known contention artifact of running two suites concurrently
on one machine, not a regression. CI is the clean arbiter.

Related to #3021
