### PR TITLE
perf(compiler): lower or/and test chains over php interop nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Lower `(or …)` / `(and …)` test chains containing `php/instanceof`, `php/aget` or a quoted literal to native `||` / `&&` instead of an IIFE; `(get <set> k)` is ~24% faster (#3027)
 - Warn for `\` namespace separators without `--warn-deprecations`; other deprecations stay opt-in (#2827)
 - Accept the future PHP class spelling after `\`: dotted or bare, with no leading marker (#2876)
 - Warn when a `def` shadows a loadable PHP class; `\DateTime` still reaches the class (#2876)

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -121,8 +121,10 @@
      (nil? ds)                                                                                                                   opt
      (and (nil? k) (indexed? ds))                                                                                                opt
 
+     ;; `set?` is `(php/instanceof x PersistentHashSetInterface)` and the
+     ;; emitter inlines it to exactly that, so spelling it alongside the same
+     ;; `php/instanceof` tested the identical thing twice per lookup.
      (or (set? ds)
-         (php/instanceof ds PersistentHashSetInterface)
          (php/instanceof ds TransientHashSetInterface))
      (if (.contains ds k)
        k

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/SimpleExpressionNode.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/SimpleExpressionNode.php
@@ -10,7 +10,10 @@ use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayGetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
 
 use function array_all;
 
@@ -45,12 +48,21 @@ final readonly class SimpleExpressionNode
             || $node instanceof LiteralNode
             || $node instanceof GlobalVarNode
             || $node instanceof PhpVarNode
+            || $node instanceof PhpClassNameNode
+            || $node instanceof QuoteNode
         ) {
             return true;
         }
 
         if ($node instanceof CallNode) {
             return array_all([$node->getFn(), ...$node->getArguments()], static fn(AbstractNode $child): bool => self::is($child, $unwrapTransparentDo));
+        }
+
+        if ($node instanceof PhpArrayGetNode) {
+            return array_all(
+                [$node->getArrayExpr(), ...$node->getAccessExprs()],
+                static fn(AbstractNode $child): bool => self::is($child, $unwrapTransparentDo),
+            );
         }
 
         return false;

--- a/tests/php/Integration/Fixtures/If/if-test-lowering-php-nodes.test
+++ b/tests/php/Integration/Fixtures/If/if-test-lowering-php-nodes.test
@@ -1,0 +1,11 @@
+--PHEL--
+(fn [ds k] (if (or (php/instanceof ds Phel.Lang.Keyword) (php/instanceof ds Phel.Lang.Symbol)) 1 2))
+(fn [arr] (if (or (php/aget arr 0) (php/aget arr 1)) 1 2))
+--PHP--
+(function($ds, $k): int {
+  return ((($ds instanceof \Phel\Lang\Keyword)) || (($ds instanceof \Phel\Lang\Symbol)) ? 1 : 2);
+
+});(function($arr) {
+  return ((($__truthy = (($arr)[(0)] ?? null)) !== null && $__truthy !== false) || (($__truthy = (($arr)[(1)] ?? null)) !== null && $__truthy !== false) ? 1 : 2);
+
+});


### PR DESCRIPTION
## 🤔 Background

`get` allocated a `Closure` on every call that reached its set-lookup branch:

```php
if (($__truthy = (function() use($ds,$k,$opt,&$__phel_call_0,…,&$__phel_call_10) {
      $__phel_335_336 = ($ds instanceof PersistentHashSetInterface);
      …
    })()) !== null && $__truthy !== false) {
```

Fourteen captured bindings, allocated and invoked per call, to decide three
`instanceof` checks.

`AndOrShortCircuitLowerer` exists to flatten an `(or …)` in test position into a
native `||`, and does it correctly for `(or (set? ds) (vector? ds))`. It bailed
here because `SimpleExpressionNode::is()`, the shared "renders as one PHP
expression" predicate, does not list `PhpClassNameNode`: one
`(php/instanceof x Class)` operand makes the whole chain "not simple" and forces
the IIFE fallback.

## 💡 Goal

Let the lowering see the interop nodes that are already single expressions, so
the hot paths that use them stop paying for a closure.

## 🔖 Changes

- `SimpleExpressionNode` accepts `PhpClassNameNode`, `QuoteNode` and
  `PhpArrayGetNode`. The first two are leaves (`\Foo::class`,
  `\Phel\Lang\Symbol::create("x")`); `PhpArrayGetNode` recurses into its array
  and access expressions, since `(($arr)[($k)] ?? null)` is only simple when
  those are.
- `get` no longer tests the same thing twice. Its `cond` read

  ```phel
  (or (set? ds)
      (php/instanceof ds PersistentHashSetInterface)
      (php/instanceof ds TransientHashSetInterface))
  ```

  and `set?` *is* `(php/instanceof x PersistentHashSetInterface)`, which
  `TypePredicateSpecialization` inlines, so every set lookup ran the identical
  `instanceof` twice. It was invisible while it sat inside the IIFE; the lowered
  `||` shows it on one line.
- New fixture `If/if-test-lowering-php-nodes.test` pins both lowerings at the
  emitted-code level.

### Measurement

`(get <set> k)`, best of seven over 200k calls, `phel.core` loaded, OPcache off:

| | ns/call |
|---|---|
| before | 1035.8 |
| after | **785.6** |

Across the compiled `phel.core`: 205 IIFEs down to 197, and 11.4 KB less
generated PHP (1,977,900 → 1,966,470 bytes).

### Deliberately not in scope

Most of the remaining 197 IIFEs are `$target_N = $local;` wrappers from
`PhpObjectCallEmitter`. That is the interop copy barrier from #2993: the
by-value `use($local)` capture *is* the barrier, so the closure is load-bearing
and PHP offers no cheaper way to copy an argument in expression position
(`($x)` and `...[$x]` both raise on a by-reference parameter rather than
copying).

Closes #3027
