### PR TITLE
test(bench): read the front-half benchmarks from a frozen corpus

### DIFF
--- a/tests/php/Benchmark/Compiler/Fixtures/CoreCorpus.php
+++ b/tests/php/Benchmark/Compiler/Fixtures/CoreCorpus.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler\Fixtures;
+
+use RuntimeException;
+
+use function sprintf;
+
+/**
+ * The realistic-source corpus the front-half compiler benchmarks read.
+ *
+ * It is a frozen snapshot of `src/phel/core.phel`, and it is frozen because
+ * the bench job compares a baseline run against a head run: an input taken
+ * from `src/` differs between the two whenever the pull request touches the
+ * standard library, so the assertion measures how much the file grew instead
+ * of how fast the compiler is. Living under `tests/php/Benchmark` puts it on
+ * the side the job pins to the pull request's revision for both runs.
+ *
+ * The `.phel.txt` extension is load-bearing. The corpus declares `ns
+ * phel.core`, so with a bare `.phel` extension the namespace scanner finds a
+ * second file claiming that namespace and `(load "core/meta")` starts
+ * resolving against this directory. It is benchmark input text, never a
+ * namespace to load, and the extension is what says so.
+ */
+final class CoreCorpus
+{
+    private const string PATH = __DIR__ . '/core-corpus.phel.txt';
+
+    public static function source(): string
+    {
+        $source = file_get_contents(self::PATH);
+        if ($source === false) {
+            throw new RuntimeException(sprintf('Unable to read the benchmark corpus at %s', self::PATH));
+        }
+
+        return $source;
+    }
+}

--- a/tests/php/Benchmark/Compiler/Fixtures/core-corpus.phel.txt
+++ b/tests/php/Benchmark/Compiler/Fixtures/core-corpus.phel.txt
@@ -1,0 +1,273 @@
+;; Frozen corpus for the compiler benchmarks. Do not edit by hand.
+;;
+;; This is a snapshot of `src/phel/core.phel`, kept here so that the lexer,
+;; parser and reader benchmarks measure the compiler rather than the size of
+;; the standard library. The CI bench job checks out `tests/php/Benchmark`
+;; from the pull request for both the baseline and the head run, so a corpus
+;; that lives here is byte-identical on both sides of the comparison; one read
+;; out of `src/` is not, and any commit that adds a function to the core
+;; library moves the number.
+;;
+;; Refreshing it is a deliberate act: it will shift every subject that reads
+;; it by however much the token mix changed, once, in that pull request.
+;;
+;; The `.txt` extension keeps the namespace scanner out: this file declares
+;; `ns phel.core`, and a second loadable file claiming that namespace breaks
+;; `(load ...)` resolution across the whole project.
+
+(ns phel.core
+  (:use InvalidArgumentException)
+  (:use Phel)
+  (:use Phel.Lang.CdrInterface)
+  (:use Phel.Lang.Collections.HashSet.PersistentHashSetInterface)
+  (:use Phel.Lang.Collections.LazySeq.Cons)
+  (:use Phel.Lang.Collections.LazySeq.LazySeqInterface)
+  (:use Phel.Lang.Collections.Map.MapEntry)
+  (:use Phel.Lang.Collections.Map.PersistentMapInterface)
+  (:use Phel.Lang.ConcatInterface)
+  (:use Phel.Lang.FirstInterface)
+  (:use Phel.Lang.Seq)
+  (:use Traversable))
+
+(def *ns*
+  {:doc "Returns the namespace in the current scope."}
+  "phel.core")
+
+(def *file*
+  {:doc "Returns the path of the current source file."}
+  "")
+
+(def *assert*
+  {:doc "Controls whether `assert` expands to a runtime check. When logical false at macroexpansion time, `assert` expands to nil and performs no runtime check, matching Clojure's compile-time `*assert*` semantics. Defaults to `true`. To disable globally, set the core binding before compilation via PHP: `\\Phel::addDefinition(\"phel\\\\core\", \"*assert*\", false)`."}
+  true)
+
+;; --------------------------------------------
+;; Basic methods for quasiquote and destructure
+;; --------------------------------------------
+
+(def list
+  {:doc "Creates a new list. If no argument is provided, an empty list is created. Shortcut: '()"
+   :example "(list 1 2 3) ; => '(1 2 3)"}
+  (fn [& xs]
+    (Phel/list (apply php/array xs))))
+
+(def vector
+  {:doc "Creates a new vector. If no argument is provided, an empty vector is created. Shortcut: []"
+   :example "(vector 1 2 3) ; => [1 2 3]"}
+  (fn [& xs]
+    (Phel/vector (apply php/array xs))))
+
+(def queue
+  {:doc "Creates a persistent FIFO queue. With no arguments returns an empty queue; with arguments returns a queue with the values pushed in order so that the first argument is at the front."
+   :example "(queue 1 2 3) ; => <-(1 2 3)-<"}
+  (fn [& xs]
+    (Phel/queue (apply php/array xs))))
+
+(def hash-map
+  {:doc "Creates a new hash map. If no argument is provided, an empty hash map is created. The number of parameters must be even. Shortcut: {}"
+   :example "(hash-map :a 1 :b 2) ; => {:a 1, :b 2}"}
+  (fn [& xs]
+    (Phel/map (apply php/array xs))))
+
+(def array-map
+  {:doc "Constructs a map from the given key/value pairs. If any keys are equal, later values replace earlier ones, as if by repeated `assoc`. Phel has no distinct array-map type, so the result is the same persistent map as `hash-map` — `array-map` exists for `.cljc` interop with Clojure sources."
+   :example "(array-map :a 1 :b 2) ; => {:a 1, :b 2}"
+   :see-also ["hash-map"]}
+  (fn [& xs]
+    (Phel/map (apply php/array xs))))
+
+(def next-vector-or-nil
+  {:private true
+   :doc "Returns all values after the first array value as a persistent vector, or nil."}
+  (fn [values]
+    (let [sliced (php/array_slice values 1)]
+      (if (php/empty sliced)
+        nil
+        (Phel/vector sliced)))))
+
+(def next-of-set
+  {:private true
+   :doc "Returns all values after the first persistent set value, or nil."}
+  (fn [s]
+    (next-vector-or-nil (.toPhpArray s))))
+
+(def next-of-map
+  {:private true
+   :doc "Returns all entries after the first persistent map entry as `MapEntry` instances, or nil."}
+  (fn [m]
+    ;; Bootstrap: `php-indexed-array` is defined later in `core/arrays`.
+    (let [entries (php/array)]
+      (foreach [k v m]
+        (php/apush entries (MapEntry/create k v)))
+      (next-vector-or-nil entries))))
+
+(def next
+  {:doc "Returns the sequence after the first element, or nil if empty."
+   :example "(next [1 2 3]) ; => [2 3]"}
+  (fn [xs]
+    (if (php/=== xs nil)
+      nil
+      (if (php/instanceof xs LazySeqInterface)
+        (.nextSeq xs)
+        (if (php/instanceof xs Cons)
+          (.nextSeq xs)
+          (if (php/instanceof xs CdrInterface)
+            (.cdr xs)
+            (if (php/is_string xs)
+              (let [chars (php/mb_str_split xs)]
+                (if (php/<= (php/count chars) 1)
+                  nil
+                  (Phel/vector (php/array_slice chars 1))))
+              (if (php/is_array xs)
+                (let [sliced (php/array_slice xs 1)]
+                  (if (php/empty sliced)
+                    nil
+                    sliced))
+                (if (php/instanceof xs PersistentHashSetInterface)
+                  (next-of-set xs)
+                  (if (php/instanceof xs PersistentMapInterface)
+                    (next-of-map xs)
+                    (throw (new InvalidArgumentException
+                                (php/. "cannot call 'next on " (php/gettype xs))))))))))))))
+
+(def first-map-entry
+  {:private true
+   :doc "Returns the first entry of a persistent map as a typed `MapEntry`, or nil if empty."}
+  (fn [m]
+    (let [it (.getIterator m)]
+      (.rewind it)
+      (if (.valid it)
+        (MapEntry/create (.key it) (.current it))
+        nil))))
+
+(def first-of-string
+  {:private true
+   :doc "Returns the first multibyte character of a string, or nil if empty."}
+  (fn [s]
+    (if (php/=== "" s) nil (php/mb_substr s 0 1))))
+
+(def first-of-set
+  {:private true
+   :doc "Returns the first value of a persistent set, or nil if empty."}
+  (fn [s]
+    (let [values (.toPhpArray s)]
+      (if (php/empty values) nil (php/aget values 0)))))
+
+(def first
+  {:doc "Returns the first element of a sequence, or nil if empty.
+
+Maps are treated as a sequence of entries: `(first {:a 1})` returns a typed `MapEntry` equal by value to `[:a 1]`. Strings are treated as sequences of multibyte characters.
+
+A lazily consumed source with no indexed access of its own (an `eduction` pipeline, a PHP generator, an iterator) is answered by pulling a single element, the same way `empty?` answers it. `count` is the one that refuses such a source, because counting means draining it."
+   :example "(first [1 2 3]) ; => 1"}
+  (fn [xs]
+    (if (php/instanceof xs FirstInterface)         (.first xs)
+        (if (php/instanceof xs PersistentMapInterface) (first-map-entry xs)
+            (if (php/is_string xs)                      (first-of-string xs)
+                (if (php/instanceof xs PersistentHashSetInterface) (first-of-set xs)
+                    (if (php/instanceof xs Traversable) (Seq/first xs)
+                        (php/aget xs 0))))))))
+
+(def concat1
+  {:private true
+   :doc "Concatenates two sequential data structures."}
+  (fn [xs ys]
+    (if (php/=== nil ys)
+      xs
+      (if (php/instanceof xs ConcatInterface)
+        (.concat xs ys)
+        (do
+          (foreach [y ys]
+            (php/apush xs y))
+          xs)))))
+
+(def concat
+  "Concatenates multiple sequential data structures."
+  (fn [arr & others]
+    (if (php/=== nil arr)
+      '()
+      (loop [res   arr
+             other others]
+        (if (php/=== nil other)
+          res
+          (let [[y & ys] other]
+            (recur (concat1 res y) ys)))))))
+
+;; quasiquote can be used down here
+
+(def declare
+  {:macro true
+   :doc "Declare a global symbol before it is defined."}
+  (fn [name]
+    `(def ~name nil)))
+
+;; Forward-declare symbols used by sub-files loaded before their definitions
+;; so they can still pass compile-time symbol resolution.
+(declare nil?)
+(declare seq)
+(declare map)
+(declare aget)
+
+(def *program*
+  "The script path or namespace being executed."
+  (let [prog (php/aget php/$GLOBALS "__phel_program")]
+    (if (php/=== prog nil) "" prog)))
+
+(def *argv*
+  "Vector of user arguments passed to the script (excludes program name). Use *program* to get the script path or namespace."
+  (let [argv-raw (php/aget php/$GLOBALS "__phel_argv")]
+    (if (php/=== argv-raw nil)
+      []
+      (Phel/vector argv-raw))))
+
+;; Metadata + macro machinery, then the primitive value constructors that
+;; depend on `defn` / `defmacro`
+(load "core/meta")
+(load "core/defs")
+(load "core/strings")
+
+;; Persistent + PHP array constructors
+(load "core/collections")
+(load "core/arrays")
+
+;; Tier-1 sequence primitives (cons, count, rest, …)
+(load "core/seq-basics")
+
+;; Control flow and boolean / comparison operators
+(load "core/control")
+(load "core/booleans")
+
+;; Type system, seq/peek access, mutable references
+(load "core/predicates")
+(load "core/sequences")
+(load "core/atoms")
+
+;; Reducers + transducers, transient mutation, then the full sequence-function library
+(load "core/transducers")
+(load "core/transients")
+(load "core/seq-fns")
+
+;; Functional core
+(load "core/fns-sets")
+(load "core/math")
+
+;; I/O and polymorphism
+(load "core/io")
+(load "core/protocols")
+
+;; Ad-hoc observability (requires disj + filter from seq-fns)
+(load "core/tap")
+
+;; Topic libraries
+(load "core/lazy")
+(load "core/exceptions")
+(load "core/macroexpand")
+(load "core/parsing")
+(load "core/interop")
+(load "core/uuid")
+(load "core/loops")
+(load "core/futures")
+(load "core/async")
+
+;; Namespace introspection and manipulation
+(load "core/ns")

--- a/tests/php/Benchmark/Compiler/LexerBench.php
+++ b/tests/php/Benchmark/Compiler/LexerBench.php
@@ -7,12 +7,11 @@ namespace PhelTest\Benchmark\Compiler;
 use Phel;
 use Phel\Compiler\CompilerFacade;
 use Phel\Compiler\Domain\Lexer\LexerInterface;
+use PhelTest\Benchmark\Compiler\Fixtures\CoreCorpus;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
 use PhpBench\Benchmark\Metadata\Annotations\Iterations;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
 use RuntimeException;
-
-use function sprintf;
 
 /**
  * Lexer throughput micro-benchmark.
@@ -29,10 +28,13 @@ use function sprintf;
  * comments carry multibyte code points, so a regression in the
  * multibyte path shows up as a divergence between the two.
  *
- * A third subject lexes the real `phel.core` aggregate source so the
- * realistic token mix (symbols, keywords, parens, strings, comments)
- * is covered too. All fixtures are built once in `setUp` and are
- * deterministic — no wall-clock or cache dependency.
+ * A third subject lexes {@see CoreCorpus}, a frozen snapshot of the
+ * `phel.core` source, so the realistic token mix (symbols, keywords,
+ * parens, strings, comments) is covered too. It is a snapshot rather
+ * than a read of `src/` so that a commit which grows the standard
+ * library does not read as a lexer regression. All fixtures are built
+ * once in `setUp` and are deterministic — no wall-clock or cache
+ * dependency.
  *
  * @BeforeMethods("setUp")
  */
@@ -55,7 +57,7 @@ final class LexerBench
         $this->compilerFacade = new CompilerFacade();
         $this->asciiSource = $this->buildSource(asciiOnly: true);
         $this->utf8Source = $this->buildSource(asciiOnly: false);
-        $this->coreSource = $this->readCoreSource();
+        $this->coreSource = CoreCorpus::source();
     }
 
     /**
@@ -130,14 +132,4 @@ final class LexerBench
         return implode("\n\n", $forms) . "\n";
     }
 
-    private function readCoreSource(): string
-    {
-        $path = __DIR__ . '/../../../../src/phel/core.phel';
-        $source = file_get_contents($path);
-        if ($source === false) {
-            throw new RuntimeException(sprintf('Unable to read core source at %s', $path));
-        }
-
-        return $source;
-    }
 }

--- a/tests/php/Benchmark/Compiler/ParserBench.php
+++ b/tests/php/Benchmark/Compiler/ParserBench.php
@@ -7,12 +7,11 @@ namespace PhelTest\Benchmark\Compiler;
 use Phel;
 use Phel\Compiler\CompilerFacade;
 use Phel\Compiler\Domain\Lexer\LexerInterface;
+use PhelTest\Benchmark\Compiler\Fixtures\CoreCorpus;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
 use PhpBench\Benchmark\Metadata\Annotations\Iterations;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
 use RuntimeException;
-
-use function sprintf;
 
 /**
  * Parser throughput micro-benchmark.
@@ -24,8 +23,10 @@ use function sprintf;
  * `FileNode`. The lex cost is shared overhead common to both subjects,
  * so deltas still attribute cleanly to the parser.
  *
- * `bench_parse_core` parses the real `phel.core` aggregate; the
- * synthetic `bench_parse_fixture` parses a fixed-shape source with a
+ * `bench_parse_core` parses {@see CoreCorpus}, a frozen snapshot of the
+ * `phel.core` source held under `tests/` so that growing the standard
+ * library cannot read as a parser regression; the synthetic
+ * `bench_parse_fixture` parses a fixed-shape source with a
  * dense mix of vectors, maps and nested calls to stress collection and
  * list node construction. Both fixtures are deterministic and built
  * once in `setUp`.
@@ -47,7 +48,7 @@ final class ParserBench
         Phel::bootstrap(__DIR__ . '/../../../../');
 
         $this->compilerFacade = new CompilerFacade();
-        $this->coreSource = $this->readCoreSource();
+        $this->coreSource = CoreCorpus::source();
         $this->fixtureSource = $this->buildFixtureSource();
     }
 
@@ -97,14 +98,4 @@ final class ParserBench
         return implode("\n\n", $forms) . "\n";
     }
 
-    private function readCoreSource(): string
-    {
-        $path = __DIR__ . '/../../../../src/phel/core.phel';
-        $source = file_get_contents($path);
-        if ($source === false) {
-            throw new RuntimeException(sprintf('Unable to read core source at %s', $path));
-        }
-
-        return $source;
-    }
 }

--- a/tests/php/Benchmark/Compiler/ReaderResultCacheBench.php
+++ b/tests/php/Benchmark/Compiler/ReaderResultCacheBench.php
@@ -12,14 +12,16 @@ use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Lang\Symbol;
 use Phel\Shared\Parser\Node\NodeInterface;
 use Phel\Shared\Parser\Node\TriviaNodeInterface;
+use PhelTest\Benchmark\Compiler\Fixtures\CoreCorpus;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
 use PhpBench\Benchmark\Metadata\Annotations\Iterations;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
 use PhpBench\Benchmark\Metadata\Annotations\Warmup;
 
 /**
- * Isolates the front half of the compiler (lex -> parse -> read) over the whole
- * `phel.core` source, contrasting a cold run that re-lexes/parses/reads every
+ * Isolates the front half of the compiler (lex -> parse -> read) over
+ * {@see CoreCorpus}, a frozen snapshot of the `phel.core` source, contrasting
+ * a cold run that re-lexes/parses/reads every
  * form against a warm run served from the {@see FileSystemReaderResultCache}
  * (gzip-inflate + unserialize). This is the slice the intermediate-artifact
  * cache replaces on a warm rebuild; analysis + emission are unchanged by it and
@@ -42,7 +44,7 @@ final class ReaderResultCacheBench
         GlobalEnvironmentSingleton::initializeNew();
 
         $this->facade = new CompilerFacade();
-        $this->source = (string) file_get_contents($projectRoot . 'src/phel/core.phel');
+        $this->source = CoreCorpus::source();
         $this->cacheDir = sys_get_temp_dir() . '/phel-rr-cache-bench-' . uniqid();
 
         // Prime the persisted cache once so the warm subject reads it back.


### PR DESCRIPTION
## 🤔 Background

The bench job measures the base revision, stores it as `baseline`, then measures
the pull request against it. Four subjects take their input from
`src/phel/core.phel`:

- `LexerBench::bench_lex_core`
- `ParserBench::bench_parse_core`
- `ReaderResultCacheBench::bench_cold_front_half`
- `ReaderResultCacheBench::bench_warm_front_half`

The baseline run happens on the base checkout and the head run on the pull
request's, so that input is not the same file on both sides. Any commit that
adds to the standard library makes the head run lex a bigger file, and the
assertion reports the difference as a compiler regression.

It is not hypothetical. #3011 adds 1,945 bytes to `core.phel`, 22% of an 8.7 KB
file, and those exact four subjects came back at +31%, +31%, +27% and +35%
against a 25% tolerance, on a change that does not touch the compiler at all.
Nothing got slower per byte; there were simply more bytes.

## 💡 Goal

Make the front-half compiler benchmarks measure the compiler, so that growing
the standard library cannot read as a compiler regression.

## 🔖 Changes

- New `Fixtures/CoreCorpus`, a frozen snapshot of the `phel.core` source, and
  the four subjects read it instead of `src/phel/core.phel`.

  The workflow already checks out `tests/php/Benchmark` from the pull request
  for *both* runs, with the stated reason that both should "measure the same
  set of cases against the same rules". A benchmark's input corpus is part of
  the case, not part of the code under measurement, so moving it there is the
  existing rule applied to the one thing that had escaped it. No workflow
  change is needed, and the snapshot is byte-identical on both sides by
  construction.

- The corpus keeps the realistic token mix that made `core.phel` worth
  benchmarking. Same file, same workload shape, so the numbers stay comparable
  with the history already recorded for these subjects.

### The extension is load-bearing

The corpus is `core-corpus.phel.txt`, not `.phel`. It declares `ns phel.core`,
and as a loadable `.phel` file the namespace scanner finds a second file
claiming that namespace, after which `(load "core/meta")` resolves against the
fixtures directory. That failure is not local to the benchmarks:
`ParallelTestRunnerTest` goes from 10 passing to 7 failing with
`Cannot locate core/meta for (load ...)`. Both the class docblock and the
corpus header say so, because the next person to tidy up an odd-looking
extension needs to find out from a comment rather than from a red suite.

### Verified

With the corpus frozen, applying #3011's `core.phel` on top moves the four
subjects by -0.8%, +2.9%, -2.7% and +1.5%, all inside run-to-run noise, against
the +31%/+31%/+27%/+35% they showed before.

`composer test-all` passes, including the 7,107 core tests.

### Not in scope

`EmitterCaptureBench`, `TypeInferenceBench` and `WideLetAnalysisBench` also
touch `src/phel/core.phel`, but they `evalFile` it in `setUp` and measure
something else afterwards, so the corpus size does not enter the measured
region. They are left alone.
