### PR TITLE
perf(core): compare two native ints without the numeric-tower dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ All notable changes to this project will be documented in this file.
 
 Runtime core:
 
+- Compare two native ints in `<`, `<=`, `>` and `>=` without the numeric-tower dispatch: 2.5 to 2.7 times faster, down to raw PHP comparison speed (#2984)
 - Give the closures returned by `partial`, `fnil` and `comp` real arities: 30x, 50x and 8x faster to call (#3021)
 - Guard the twelve nil-rejecting arithmetic functions with the fixed-arity macros instead of the variadic helper: `round` and `floor` 25x, `quot`, `rem` and `mod` 14 to 17x, `even?` and `odd?` 6 to 7x (#3018)
 - Compile a literal `(list ...)`, `(vector ...)`, `(queue ...)`, `(hash-map ...)` or `(array-map ...)` straight to its `Phel` factory: 2.2 to 3.6 times faster (#3014)

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -197,29 +197,52 @@
   (when (or (php/=== nil a) (php/=== nil b))
     (throw (new InvalidArgumentException "Comparison functions do not accept nil values"))))
 
+;; Two native ints is the overwhelmingly common case, and answering it through
+;; the general chain costs three calls and six `instanceof` before comparing
+;; anything: `assert-non-nil-pair`, then `numeric-object?` on each operand.
+;;
+;; The `is_int` pair is what makes the shortcut safe rather than a hole in the
+;; nil guard. `(php/is_int nil)` is false, so a nil operand cannot take this
+;; branch and still reaches `assert-non-nil-pair` below. Everything else the
+;; general path exists for is equally excluded by construction: a `Ratio`,
+;; `BigInt` or `BigDecimal` is an object, and a float is not an int, so both
+;; keep routing to `NumericOperations/compare` and to PHP's own comparison
+;; respectively. Two ints never needed either.
 (defn- lt2 [a b]
-  (assert-non-nil-pair a b)
-  (if (or (numeric-object? a) (numeric-object? b))
-    (php/< (NumericOperations/compare a b) 0)
-    (php/< a b)))
+  (if (and (php/is_int a) (php/is_int b))
+    (php/< a b)
+    (do
+      (assert-non-nil-pair a b)
+      (if (or (numeric-object? a) (numeric-object? b))
+        (php/< (NumericOperations/compare a b) 0)
+        (php/< a b)))))
 
 (defn- lte2 [a b]
-  (assert-non-nil-pair a b)
-  (if (or (numeric-object? a) (numeric-object? b))
-    (php/<= (NumericOperations/compare a b) 0)
-    (php/<= a b)))
+  (if (and (php/is_int a) (php/is_int b))
+    (php/<= a b)
+    (do
+      (assert-non-nil-pair a b)
+      (if (or (numeric-object? a) (numeric-object? b))
+        (php/<= (NumericOperations/compare a b) 0)
+        (php/<= a b)))))
 
 (defn- gt2 [a b]
-  (assert-non-nil-pair a b)
-  (if (or (numeric-object? a) (numeric-object? b))
-    (php/> (NumericOperations/compare a b) 0)
-    (php/> a b)))
+  (if (and (php/is_int a) (php/is_int b))
+    (php/> a b)
+    (do
+      (assert-non-nil-pair a b)
+      (if (or (numeric-object? a) (numeric-object? b))
+        (php/> (NumericOperations/compare a b) 0)
+        (php/> a b)))))
 
 (defn- gte2 [a b]
-  (assert-non-nil-pair a b)
-  (if (or (numeric-object? a) (numeric-object? b))
-    (php/>= (NumericOperations/compare a b) 0)
-    (php/>= a b)))
+  (if (and (php/is_int a) (php/is_int b))
+    (php/>= a b)
+    (do
+      (assert-non-nil-pair a b)
+      (if (or (numeric-object? a) (numeric-object? b))
+        (php/>= (NumericOperations/compare a b) 0)
+        (php/>= a b)))))
 
 (defn <
   "Checks if each argument is strictly less than the following argument."

--- a/tests/phel/core/ordered-comparison-int-fast-path.phel
+++ b/tests/phel/core/ordered-comparison-int-fast-path.phel
@@ -1,0 +1,89 @@
+(ns phel-test.core.ordered-comparison-int-fast-path
+  (:require phel.test :refer [deftest is]))
+
+;; `<`, `<=`, `>` and `>=` take a native-int shortcut ahead of the general
+;; chain (#2984). Everything here goes through these helpers rather than
+;; comparing literals directly, because the emitter folds a comparison of two
+;; literals at compile time: `(< 1 2)` never reaches the runtime function, so a
+;; test written that way cannot see the shortcut or the path around it.
+(defn- lt [a b] (< a b))
+(defn- lte [a b] (<= a b))
+(defn- gt [a b] (> a b))
+(defn- gte [a b] (>= a b))
+
+(deftest test-two-native-ints-take-the-fast-path
+  (is (true? (lt 1 2)) "less than")
+  (is (false? (lt 2 1)) "not less than")
+  (is (false? (lt 1 1)) "strict, equal is not less")
+  (is (true? (lte 1 1)) "less or equal, equal")
+  (is (true? (lte 1 2)) "less or equal, less")
+  (is (false? (lte 2 1)) "less or equal, greater")
+  (is (true? (gt 2 1)) "greater than")
+  (is (false? (gt 1 2)) "not greater than")
+  (is (false? (gt 1 1)) "strict, equal is not greater")
+  (is (true? (gte 1 1)) "greater or equal, equal")
+  (is (true? (gte 2 1)) "greater or equal, greater")
+  (is (false? (gte 1 2)) "greater or equal, less"))
+
+(deftest test-negative-and-zero-ints
+  (is (true? (lt -2 -1)) "two negatives")
+  (is (true? (lt -1 0)) "negative against zero")
+  (is (false? (gt -1 0)) "negative is not greater than zero")
+  (is (true? (gte 0 0)) "zero against zero"))
+
+;; The shortcut is guarded by `is_int` on both operands, and `(php/is_int nil)`
+;; is false, so a nil operand cannot take it and still reaches the nil guard.
+;; This is the assertion that makes the shortcut safe rather than a hole.
+(deftest test-nil-is-still-rejected-on-both-sides
+  (let [msg "Comparison functions do not accept nil values"]
+    (is (thrown-with-msg? \InvalidArgumentException msg (lt nil 1)) "< nil on the left")
+    (is (thrown-with-msg? \InvalidArgumentException msg (lt 1 nil)) "< nil on the right")
+    (is (thrown-with-msg? \InvalidArgumentException msg (lt nil nil)) "< nil on both sides")
+    (is (thrown-with-msg? \InvalidArgumentException msg (lte nil 1)) "<= nil")
+    (is (thrown-with-msg? \InvalidArgumentException msg (gt nil 1)) "> nil")
+    (is (thrown-with-msg? \InvalidArgumentException msg (gte 1 nil)) ">= nil")))
+
+;; A Ratio, BigInt or BigDecimal is an object, so `is_int` is false and the
+;; operand keeps routing through `NumericOperations/compare`. Comparing them by
+;; PHP's own operators would be wrong, which is what the general path is for.
+(deftest test-the-numeric-tower-keeps-its-own-comparison
+  (is (true? (lt (/ 1 3) 1)) "ratio against int")
+  (is (false? (lt 1 (/ 1 3))) "int against ratio")
+  (is (true? (lt (/ 1 3) (/ 1 2))) "ratio against ratio")
+  (is (true? (gt 1 (/ 1 2))) "int greater than ratio")
+  (is (true? (lt (bigint "5") (bigint "6"))) "bigint against bigint")
+  (is (true? (lt (bigint "5") 6)) "bigint against int")
+  (is (true? (gt 6 (bigint "5"))) "int against bigint")
+  (is (true? (lte (bigint "5") (bigint "5"))) "equal bigints")
+  (is (true? (lt (bigdec "1.5") (bigdec "2.5"))) "bigdec against bigdec")
+  (is (true? (lt (bigdec "1.5") 2)) "bigdec against int"))
+
+;; A float is not an int, so a mixed pair keeps PHP's comparison rather than
+;; taking the int branch on one side only.
+(deftest test-mixed-int-and-float
+  (is (true? (lt 1 1.5)) "int against float")
+  (is (true? (gt 1.5 1)) "float against int")
+  (is (true? (lt 1.5 2.5)) "two floats")
+  (is (true? (gte 1 1.0)) "int against an equal float")
+  (is (true? (lte 1.0 1)) "float against an equal int"))
+
+(deftest test-strings-are-unaffected
+  (is (true? (lt "ab" "cd")) "string ordering")
+  (is (false? (gt "ab" "cd")) "string ordering, reversed")
+  (is (true? (gte "b" "a")) "single characters"))
+
+;; Booleans are not ints either, so they fall through to PHP's comparison,
+;; which is the behaviour these operators had before the shortcut.
+(deftest test-booleans-fall-through
+  (is (true? (lt false true)) "false is less than true")
+  (is (false? (gt false true)) "false is not greater than true"))
+
+;; The chained arities compare each argument with the next through the same
+;; helpers, so a shortcut that answered one pair wrongly would surface here.
+(deftest test-chained-comparisons-still-hold
+  (let [a 1 b 2 c 3]
+    (is (true? (< a b c)) "ascending chain of ints")
+    (is (false? (< a c b)) "chain broken in the middle")
+    (is (true? (> c b a)) "descending chain")
+    (is (true? (<= a a b)) "non-strict chain")
+    (is (false? (< a b b)) "strict chain rejects an equal pair")))

--- a/tests/php/Benchmark/Phel/CoreComparisonBench.php
+++ b/tests/php/Benchmark/Phel/CoreComparisonBench.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Phel;
+
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+
+/**
+ * The ordered comparison operators of `phel.core`: `<`, `<=`, `>` and `>=`.
+ *
+ * Two optimisations meet in these four. #2983 gave the operators fixed arities
+ * and a `bool` return; #2984 put a native-int shortcut in the `lt2` family of
+ * helpers underneath them, where the remaining time was. The helpers are
+ * private, so the operator is the only way to reach them.
+ *
+ * Each operator is measured on three operand shapes, because they take
+ * different paths and only the first one is shortcut:
+ *
+ * - **int/int** takes the shortcut and should sit near its `_raw` pair;
+ * - **int/float** is excluded from it by `is_int` and falls through to PHP's
+ *   own comparison, so it measures the cost the shortcut adds to operands that
+ *   cannot use it;
+ * - **ratio/int** routes through `NumericOperations/compare`, which the
+ *   shortcut must never divert.
+ *
+ * Without the last two, a change that made ints fast by breaking the numeric
+ * tower would look like a clean win here.
+ *
+ * {@see CoreBenchCase} for the conventions every subject here follows.
+ *
+ * @BeforeMethods("setUp")
+ */
+final class CoreComparisonBench extends CoreBenchCase
+{
+    /** @var callable */
+    private $lt;
+
+    /** @var callable */
+    private $lte;
+
+    /** @var callable */
+    private $gt;
+
+    /** @var callable */
+    private $gte;
+
+    /** Typed `mixed` so the raw pairs are real work rather than a foldable literal. */
+    private mixed $a = 7;
+
+    private mixed $b = 11;
+
+    private mixed $float = 11.5;
+
+    private mixed $ratio = null;
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_lt_int_int(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->lt)($this->a, $this->b);
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_lt_int_int_raw(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            $unused = $this->a < $this->b;
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_lte_int_int(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->lte)($this->a, $this->b);
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_gt_int_int(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->gt)($this->a, $this->b);
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_gte_int_int(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->gte)($this->a, $this->b);
+        }
+    }
+
+    /**
+     * Three arguments reach the chained arity, which compares each pair through
+     * the same helpers. A shortcut that only paid off on the two-argument form
+     * would show up as this subject failing to move with the one above.
+     *
+     * @Revs(1000)
+     */
+    public function bench_lt_three_ints(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->lt)($this->a, $this->b, 19);
+        }
+    }
+
+    /**
+     * Excluded from the int shortcut by the float, so this is the operand shape
+     * that pays for the shortcut without using it.
+     *
+     * @Revs(1000)
+     */
+    public function bench_lt_int_float(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->lt)($this->a, $this->float);
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_lt_int_float_raw(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            $unused = $this->a < $this->float;
+        }
+    }
+
+    /**
+     * The numeric tower path. It must stay flat: the shortcut is guarded so a
+     * `Ratio` never reaches it.
+     *
+     * @Revs(1000)
+     */
+    public function bench_lt_ratio_int(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->lt)($this->ratio, $this->b);
+        }
+    }
+
+    protected function setUpFixtures(): void
+    {
+        $this->lt = $this->coreFn('<');
+        $this->lte = $this->coreFn('<=');
+        $this->gt = $this->coreFn('>');
+        $this->gte = $this->coreFn('>=');
+        $this->ratio = $this->coreFn('/')(1, 3);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`lt2`, `lte2`, `gt2` and `gte2` all share one shape:

```phel
(defn- lt2 [a b]
  (assert-non-nil-pair a b)
  (if (or (numeric-object? a) (numeric-object? b))
    (php/< (NumericOperations/compare a b) 0)
    (php/< a b)))
```

Comparing two native ints therefore costs three function calls and six
`instanceof` before anything is compared: `assert-non-nil-pair`, then
`numeric-object?` on each operand, each of which runs three `instanceof` of its
own.

#2983 gave the *operators* fixed arities, which is why `<` still lagged `=`
there: the arity split does not touch `lt2`, and that is where the remaining
time was. The two changes compose.

## 💡 Goal

Answer the common case, two native ints, without the dispatch that exists for
the cases it is not.

## 🔖 Changes

- A native-int shortcut ahead of the existing chain in all four helpers.

  The `is_int` **pair** is what makes it safe rather than a hole in the nil
  guard. `(php/is_int nil)` is false, so a nil operand cannot take the branch
  and still reaches `assert-non-nil-pair` below. Everything the general path
  exists for is excluded by construction too: `Ratio`, `BigInt` and
  `BigDecimal` are objects, and a float is not an int, so they keep routing to
  `NumericOperations/compare` and to PHP's own comparison respectively.

- New `tests/phel/core/ordered-comparison-int-fast-path.phel`, 47 assertions.

  Every case goes through a helper function rather than comparing literals,
  because the emitter folds `(< 1 2)` at compile time. The existing
  literal-based assertions in `cmp-dispatch.phel` therefore never reach these
  helpers, and a test written that way cannot see this change at all.

- New `CoreComparisonBench`, per the rule that a `perf(core)` change ships the
  subject that guards it.

### Measured

Empty-closure floor taken in the same process and subtracted, 200k revs,
operands passed as `fn` parameters so nothing can be folded away:

| call | before | after | speedup |
|---|---|---|---|
| `(< x y)` two ints | 0.329 us | 0.130 us | **2.53x** |
| `(<= x y)` | 0.331 us | 0.122 us | **2.71x** |
| `(> x y)` | 0.330 us | 0.121 us | **2.73x** |
| `(>= x y)` | 0.320 us | 0.125 us | **2.56x** |
| `(< x y 9)` three ints | 1.609 us | 1.202 us | 1.34x |
| `(< x y)` two floats | 0.317 us | 0.331 us | 0.96x |
| `(< x y)` ratio/int | 1.714 us | 1.701 us | unchanged |
| `(< x y)` strings | 0.347 us | 0.341 us | unchanged |
| `(php/< x y)` raw | 0.137 us | 0.140 us | reference |

Two ints now land on raw PHP comparison speed. The one cost is a float pair
paying a single extra `is_int`, 4%, which is the trade the numbers above buy.

### Behaviour

Unchanged, and the tests are built to prove it rather than assert it. Relaxing
the guard from `and` to `or`, the naive version of the same idea, turns three
assertions red: nil stops being rejected on either side, and `(< 1/3 1)` starts
answering from PHP's comparison instead of the numeric tower.

Bench coverage deliberately includes `int/float` and `ratio/int`, so a future
change that makes ints fast by breaking the numeric tower cannot read as a
clean win.

`composer test-all` passes with 7,203 core tests.

Closes #2984
