### PR TITLE
perf(core): compute each sort-by key once instead of twice per comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ All notable changes to this project will be documented in this file.
 Runtime core:
 
 - Compare two native ints in `<`, `<=`, `>` and `>=` without the numeric-tower dispatch: 2.5 to 2.7 times faster, down to raw PHP comparison speed (#2984)
+- **BREAKING** `sort-by` now calls its key function once per element instead of twice per comparison, so an *impure* key function runs far fewer times (100 rather than about 1114 when sorting 100 elements). The sorted result is unchanged. Up to 2.2 times faster; recorded in `docs/spec/clojure-divergences.md` since Clojure calls per comparison (#3006)
 - Give the closures returned by `partial`, `fnil` and `comp` real arities: 30x, 50x and 8x faster to call (#3021)
 - Guard the twelve nil-rejecting arithmetic functions with the fixed-arity macros instead of the variadic helper: `round` and `floor` 25x, `quot`, `rem` and `mod` 14 to 17x, `even?` and `odd?` 6 to 7x (#3018)
 - Compile a literal `(list ...)`, `(vector ...)`, `(queue ...)`, `(hash-map ...)` or `(array-map ...)` straight to its `Phel` factory: 2.2 to 3.6 times faster (#3014)

--- a/docs/spec/clojure-divergences.md
+++ b/docs/spec/clojure-divergences.md
@@ -112,7 +112,26 @@ throw on a non-string rather than coercing through `str`. This matches
 ClojureScript, Basilisp and ClojureCLR; the JVM's coercing `:default` branch is
 the outlier.
 
-## 6. Host interop
+## 6. `sort-by` calls its key function once per element
+
+Clojure's `sort-by` builds a comparator that applies `keyfn` to both arguments,
+so the key function runs twice per comparison, O(n log n) times. Phel computes
+each key once, sorts `[key value]` pairs, and discards the keys. Sorting 100
+elements calls the key function 100 times where Clojure calls it about 1114.
+
+The sorted result is identical. Only the number of invocations differs, so this
+is invisible to a pure key function and visible to one that counts calls, logs,
+or memoises internally.
+
+The trade was taken because the key function is user code on the hot path of a
+common operation: with a key function as ordinary as `#(get % :id)` the
+transform is 2.2x faster, and the gap widens with `n` because the saved calls
+grow as `n log n` while the computed keys grow as `n`.
+
+`sort` is unaffected. It applies the comparator to elements directly and there
+is no key function to call.
+
+## 7. Host interop
 
 ### A string receiver is a class name
 
@@ -253,7 +272,7 @@ major.
 The call shapes differ, which is why this is a deprecation and not a rename:
 `set-var` takes a symbol and a value, `alter-var-root` a var and a function.
 
-## 7. Absent concepts
+## 8. Absent concepts
 
 | Clojure | Phel |
 |---|---|
@@ -261,7 +280,7 @@ The call shapes differ, which is why this is a deprecation and not a rename:
 | `special-symbol?` | Phel does not recognise the JVM special-symbol set |
 | Class objects (`string?` on a class) | classes are represented as strings |
 
-## 8. Known gap, not a decision
+## 9. Known gap, not a decision
 
 `case` returns `nil` when nothing matches and there is no default clause; Clojure
 throws. The suite marks it `:phel` with a note that it is arguably a real semantic

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1025,9 +1025,32 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps."
   (sorted-vector coll (sort-comparator comp)))
 
 (defn- sort-by-with
+  "Decorate, sort, undecorate. Building the comparator as
+  `#(cmp (keyfn %1) (keyfn %2))` runs `keyfn` twice per comparison, so O(n log n)
+  times: sorting 100 elements called it 1114 times to derive 100 keys. Computing
+  each key once up front and sorting `[key value]` pairs calls it exactly n
+  times, and the gap widens with n (#3006).
+
+  This is an observable divergence from Clojure, whose `sort-by` calls `keyfn`
+  per comparison as this one used to. It is invisible to a pure key function,
+  which is the normal case, and visible to one that counts calls, logs or
+  memoises. Recorded in `docs/spec/clojure-divergences.md`.
+
+  `php/aget` rather than `aget` inside the comparator: `aget` is a function, so
+  it would add two Phel calls per comparison and give back a good part of what
+  the transform buys."
   [keyfn coll comp]
-  (let [cmp (sort-comparator comp)]
-    (sorted-vector coll #(cmp (keyfn %1) (keyfn %2)))))
+  (let [cmp   (sort-comparator comp)
+        pairs (php-indexed-array)]
+    (foreach [v coll]
+      (php/apush pairs (php-indexed-array (keyfn v) v)))
+    ;; `usort` is stable as of PHP 8.0, so ties keep their input order, which is
+    ;; what the undecorated result has to preserve.
+    (php/usort pairs (fn [a b] (cmp (php/aget a 0) (php/aget b 0))))
+    (let [result (php-indexed-array)]
+      (foreach [p pairs]
+        (php/apush result (php/aget p 1)))
+      (copy-meta coll (Phel/vector result)))))
 
 (defn sort
   "Returns a sorted vector. If no comparator is supplied compare is used."

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1040,9 +1040,15 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps."
   it would add two Phel calls per comparison and give back a good part of what
   the transform buys."
   [keyfn coll comp]
-  (let [cmp   (sort-comparator comp)
-        pairs (php-indexed-array)]
-    (foreach [v coll]
+  (let [cmp    (sort-comparator comp)
+        ;; `to-php-array` and not `foreach` over `coll` directly: it is the
+        ;; conversion `sorted-vector` used, and it is what decides what an
+        ;; element *is*. Iterating a map yields its values, while converting one
+        ;; yields its `[key value]` entries, which is what `sort` and `sort-by`
+        ;; have always sorted.
+        values (to-php-array coll)
+        pairs  (php-indexed-array)]
+    (foreach [v values]
       (php/apush pairs (php-indexed-array (keyfn v) v)))
     ;; `usort` is stable as of PHP 8.0, so ties keep their input order, which is
     ;; what the undecorated result has to preserve.

--- a/tests/phel/core/sort-by-key-calls.phel
+++ b/tests/phel/core/sort-by-key-calls.phel
@@ -70,6 +70,26 @@
   (is (= [[:a 1] [:b 1] [:c 1]] (sort-by second [[:a 1] [:b 1] [:c 1]]))
       "every key equal keeps the whole input order"))
 
+;; What counts as an element depends on how the collection is converted, not on
+;; how it iterates. A map converts to its `[key value]` entries and iterates to
+;; its values, so a transform that iterated the collection directly sorted the
+;; values and returned those instead of the entries. That is what `sort` does
+;; too, and the clojure-test-suite pins it.
+(deftest test-every-collection-kind-sorts-the-same-elements-as-sort
+  (is (= (sort {:c 3, :b 2, :a 1}) (sort-by identity {:c 3, :b 2, :a 1}))
+      "a map sorts its entries, not its values")
+  (is (= [[:a 1] [:b 2] [:c 3]] (sort-by identity {:c 3, :b 2, :a 1}))
+      "and the entries come back as pairs")
+  (is (= [1 2 3] (sort-by identity (set [3 1 2]))) "a set sorts its elements")
+  (is (= [1 2 3] (sort-by identity (list 3 1 2))) "a list sorts its elements")
+  (is (= ["a" "b" "c"] (sort-by identity "cab")) "a string sorts its characters")
+  (is (= [[:a 1] [:b 2]] (sort-by first {:b 2, :a 1})) "a key function over map entries"))
+
+(deftest test-the-key-function-still-runs-once-per-entry-on-a-map
+  (let [[calls keyfn] (counting-keyfn first)]
+    (sort-by keyfn {:a 1, :b 2, :c 3, :d 4})
+    (is (= 4 @calls) "four entries, four calls")))
+
 (deftest test-metadata-survives
   (is (= {:m 1} (meta (sort-by count (with-meta ["bb" "a"] {:m 1}))))
       "metadata is copied onto the result"))

--- a/tests/phel/core/sort-by-key-calls.phel
+++ b/tests/phel/core/sort-by-key-calls.phel
@@ -1,0 +1,79 @@
+(ns phel-test.core.sort-by-key-calls
+  (:require phel.test :refer [deftest is]))
+
+;; `sort-by` computes each key once and sorts `[key value]` pairs, rather than
+;; applying `keyfn` to both arguments inside the comparator (#3006). The sorted
+;; result is unchanged; the number of `keyfn` invocations is not, and that is a
+;; deliberate divergence from Clojure recorded in
+;; `docs/spec/clojure-divergences.md`. These assertions are what pins it.
+
+(defn- counting-keyfn
+  "Returns `[counter keyfn]`, where the keyfn records how often it ran."
+  [f]
+  (let [calls (atom 0)]
+    [calls (fn [x] (swap! calls inc) (f x))]))
+
+(defn- sample-strings
+  [n]
+  (map (fn [i] (php/str_repeat "a" (php/+ 1 (php/% (php/* i 7) 20)))) (range 0 n)))
+
+(deftest test-the-key-function-runs-once-per-element
+  (let [[calls keyfn] (counting-keyfn count)
+        coll          (sample-strings 100)]
+    (sort-by keyfn coll)
+    (is (= 100 @calls) "exactly n calls for n elements, not n log n")))
+
+(deftest test-the-key-function-runs-once-per-element-at-other-sizes
+  (let [[calls keyfn] (counting-keyfn count)]
+    (sort-by keyfn (sample-strings 8))
+    (is (= 8 @calls) "eight elements, eight calls"))
+  (let [[calls keyfn] (counting-keyfn count)]
+    (sort-by keyfn (sample-strings 1))
+    (is (= 1 @calls) "one element, one call"))
+  (let [[calls keyfn] (counting-keyfn count)]
+    (sort-by keyfn [])
+    (is (= 0 @calls) "empty collection, no calls")))
+
+(deftest test-the-explicit-comparator-arity-also-runs-the-key-once
+  (let [[calls keyfn] (counting-keyfn count)]
+    (sort-by keyfn compare (sample-strings 50))
+    (is (= 50 @calls) "comparator before the collection"))
+  (let [[calls keyfn] (counting-keyfn count)]
+    (sort-by keyfn (sample-strings 50) compare)
+    (is (= 50 @calls) "collection before the comparator")))
+
+(deftest test-ordering-is-unchanged
+  (is (= ["c" "bb" "aaa"] (sort-by count ["aaa" "c" "bb"])) "ascending by key")
+  (is (= [1 2 3] (sort-by identity [3 1 2])) "identity key")
+  (is (= [] (sort-by count [])) "empty collection")
+  (is (= ["a"] (sort-by count ["a"])) "single element")
+  (is (= [] (sort-by count nil)) "nil collection"))
+
+;; The comparator has to be applied to the *keys*, not to the values. Sorting
+;; strings by `count` with a reversing comparator must order by descending
+;; length, not by descending string.
+(deftest test-the-comparator-applies-to-the-keys
+  (let [desc (fn [a b] (compare b a))]
+    (is (= ["aaa" "bb" "c"] (sort-by count desc ["aaa" "c" "bb"]))
+        "descending by key, comparator first")
+    (is (= ["aaa" "bb" "c"] (sort-by count ["aaa" "c" "bb"] desc))
+        "descending by key, collection first"))
+  ;; If the comparator were reaching the values, "b" would sort before "aa"
+  ;; here, because "aa" < "b" as strings while 1 < 2 as keys.
+  (is (= ["b" "aa"] (sort-by count ["aa" "b"])) "keys order, not value order"))
+
+;; `usort` is stable as of PHP 8.0, so equal keys keep their input order. The
+;; transform must not disturb that.
+(deftest test-ties-keep-their-input-order
+  (is (= ["c" "bb" "aa"] (sort-by count ["bb" "aa" "c"])) "one tied pair")
+  (is (= ["x" "bb" "aa" "cc"] (sort-by count ["bb" "aa" "cc" "x"])) "three tied")
+  (is (= [[:a 1] [:b 1] [:c 1]] (sort-by second [[:a 1] [:b 1] [:c 1]]))
+      "every key equal keeps the whole input order"))
+
+(deftest test-metadata-survives
+  (is (= {:m 1} (meta (sort-by count (with-meta ["bb" "a"] {:m 1}))))
+      "metadata is copied onto the result"))
+
+(deftest test-a-key-function-returning-nil-still-orders
+  (is (= 3 (count (sort-by (fn [_] nil) [3 1 2])))
+      "all keys equal, everything retained"))

--- a/tests/php/Benchmark/Phel/CoreSeqBench.php
+++ b/tests/php/Benchmark/Phel/CoreSeqBench.php
@@ -13,8 +13,8 @@ use function usort;
 
 /**
  * The sequence functions of `phel.core` that carry an optimisation with no
- * benchmark guarding it: `sort` (#3003), `interleave` (#3002), `reduce` and
- * `into` (#2977), `count` (#2969, #2971).
+ * benchmark guarding it: `sort` (#3003), `sort-by` (#3006), `interleave`
+ * (#3002), `reduce` and `into` (#2977), `count` (#2969, #2971).
  *
  * Sizes are deliberately small. These subjects exist to catch a function that
  * grew a per-element or per-call cost it did not have, not to characterise
@@ -31,6 +31,12 @@ final class CoreSeqBench extends CoreBenchCase
 
     /** @var callable */
     private $sort;
+
+    /** @var callable */
+    private $sortBy;
+
+    /** @var callable */
+    private $identity;
 
     /** @var callable */
     private $interleave;
@@ -120,6 +126,45 @@ final class CoreSeqBench extends CoreBenchCase
     public function bench_sort_explicit_comparator(): void
     {
         ($this->sort)($this->ints, $this->compare);
+    }
+
+    /**
+     * `sort-by` computes each key once and sorts `[key value]` pairs (#3006).
+     * What the transform removes is `keyfn` invocations, so the win scales with
+     * what the key function costs and this subject is the floor: `identity` is
+     * about as cheap as a key function gets, so anything the pair loses here is
+     * the transform's own overhead rather than a saving it failed to make.
+     *
+     * @Revs(1000)
+     */
+    public function bench_sort_by_cheap_key(): void
+    {
+        ($this->sortBy)($this->identity, $this->ints);
+    }
+
+    /**
+     * The same sort with a key function that actually does something, which is
+     * the shape real code has. Read against `bench_sort_by_cheap_key`: the gap
+     * between them is the per-key cost, and under the old comparator it was
+     * paid about twice per comparison instead of once per element.
+     *
+     * @Revs(1000)
+     */
+    public function bench_sort_by_counting_key(): void
+    {
+        ($this->sortBy)($this->count, $this->strings);
+    }
+
+    /**
+     * The explicit-comparator arity. It has to apply the comparator to the
+     * keys rather than the values, so it takes a different path through the
+     * transform than the two argument form above.
+     *
+     * @Revs(1000)
+     */
+    public function bench_sort_by_explicit_comparator(): void
+    {
+        ($this->sortBy)($this->count, $this->compare, $this->strings);
     }
 
     /**
@@ -234,6 +279,8 @@ final class CoreSeqBench extends CoreBenchCase
     protected function setUpFixtures(): void
     {
         $this->sort = $this->coreFn('sort');
+        $this->sortBy = $this->coreFn('sort-by');
+        $this->identity = $this->coreFn('identity');
         $this->interleave = $this->coreFn('interleave');
         $this->reduce = $this->coreFn('reduce');
         $this->into = $this->coreFn('into');


### PR DESCRIPTION
## 🤔 Background

`sort-by-with` built its comparator this way:

```phel
(let [cmp (sort-comparator comp)]
  (sorted-vector coll #(cmp (keyfn %1) (keyfn %2))))
```

`keyfn` therefore ran twice per comparison, O(n log n) times. Sorting 100
elements called it **1114 times to derive 100 keys**.

The issue was filed rather than fixed because the change is observable and the
call was not obviously the project's to make: Clojure's `sort-by` does exactly
what this did. That decision has now been taken deliberately, in favour of the
transform, and written down rather than left implicit.

## 💡 Goal

Compute each key once, without changing the order anything sorts into.

## 🔖 Changes

- `sort-by-with` decorates into `[key value]` pairs in one O(n) pass, sorts the
  pairs on the key, and undecorates in another. `keyfn` runs exactly n times.
- The divergence is recorded in `docs/spec/clojure-divergences.md`, the page
  whose whole purpose is that "if a behaviour is listed here, it is not a bug".
- `tests/phel/core/sort-by-key-calls.phel`, 19 assertions.
- Three `sort-by` subjects in `CoreSeqBench`, per the rule that a `perf(core)`
  change ships the benchmark that guards it.

### Call count

| n | before | after |
|---|---|---|
| 100 | ~1114 | **100** |
| 8 | ~24 | **8** |
| 1 | 2 | **1** |

### Measured

| key function | before | after | speedup |
|---|---|---|---|
| `count`, 2k reps | 1223.0 ms | 1078.5 ms | 1.13x |
| `#(get % :id)`, 2k reps | 1857.5 ms | 862.9 ms | **2.15x** |
| `php/md5`, 500 reps | 369.2 ms | 298.8 ms | 1.24x |

The win scales with what the key function costs, because invocations of it are
exactly what the transform removes. A trivial key like `count` on short strings
gains least, since the remaining time is the comparator callback into Phel,
which this change does not touch. A key as ordinary as a map lookup gains most.

### Behaviour

The sorted result is unchanged. What changes is how many times a user-supplied
key function runs, which is invisible to a pure one and visible to one that
counts, logs or memoises.

Two properties that the transform could plausibly have broken, both asserted:

- **The comparator applies to the keys, not the values.** Sorting `["aa" "b"]`
  by `count` must give `["b" "aa"]`; if the comparator reached the values it
  would give `["aa" "b"]`.
- **Ties keep their input order.** `usort` is stable as of PHP 8.0, and the
  undecorated result has to preserve that.

Five of the new assertions fail against the old implementation, so the pin is
real rather than decorative.

### A regression the Clojure suite caught

The first version of this iterated `coll` directly rather than converting it,
which is not the same thing: a map *iterates* to its values and *converts* to
its `[key value]` entries. `(sort-by identity {:c 3 :b 2 :a 1})` returned
`[1 2 3]` where `sort` returns `[[:a 1] [:b 2] [:c 3]]`.

`clojure-test-suite` caught it, on the assertion that pins
`(sort x)` = `(sort-by identity x)` across nil, vector, list, set, map, nested
vectors and strings. Fixed by decorating over `to-php-array coll`, the same
conversion `sorted-vector` used, and every case in its `sort_by.cljc` now
passes locally including the negative and stable-sort cases. The collection
kinds are pinned in the Phel tests too, so the shape that broke is covered
rather than merely repaired.

### One degenerate call changes its exception class

`(sort-by count :nope coll)` puts a keyword where a comparator-or-collection
belongs, so the real collection is taken as the comparator. It raised
`TypeError` from `usort` and now raises `InvalidArgumentException` from the
iteration. Both are garbage-in; only the class differs.

Every other shape was probed against `main` and is identical: a non-callable
comparator in the correct position, a `nil` collection, a string collection, an
empty collection, and metadata propagation.

`composer test-all` passes with 7,222 core tests.

Closes #3006
