### PR TITLE
fix(core): empty? no longer reads a leading nil as an empty sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - `phel doc` and the API reference report every arity of a `def` over an `fn`. `defn` renders its arities into the docstring and a bare `def` does not, so 23 symbols published no signature at all, `defn` and `defmacro` among them, while `list`, `vector` and `hash-map` published a stale hardcoded one (#3012)
+- `empty?` no longer reports a lazy sequence whose first element is `nil` as empty. `(empty? (lazy-seq [nil]))` answered `true` while `count` answered 1 and `vec` answered `[nil]` (#3025)
 - Stop the emptiness check on a lazy sequence realizing the whole sequence: an unbounded source now terminates, a 2,000,000 element one no longer crashes, and taking 5 of a 200,000 element `lazy-seq` drops from 21ms to 0.004ms (#3023)
 - Fix `lazy-seq` over a chunked sequence (`take`, `keep`, `range`, ...) yielding only its first element while `count` reported the true length (#3020)
 - Stop the scan-index and namespace caches growing without bound on every `phel doc`, LSP hover and REPL completion (#3007)

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -444,7 +444,16 @@ A non-countable iterable (an `eduction` pipeline, a PHP generator) is answered b
   ;; claims `"0"` before `is_string` sees it, and `(php/empty "0")` is `true`
   ;; where `(= 0 "0")` is `false`, so swapping them changes `(empty? "0")`.
   (cond
-    (php/instanceof x LazySeqInterface) (nil? (first x))
+    ;; `(nil? (first x))` is not the question. `first` answers `nil` both for an
+    ;; empty sequence and for one whose first element *is* `nil`, and `nil` is a
+    ;; legitimate element: `(empty? (lazy-seq [nil]))` was `true` while `count`
+    ;; said 1 and `vec` said `[nil]` (#3025). `LazySeq::toArray()` already states
+    ;; the rule, that only realizing distinguishes the two.
+    ;;
+    ;; `Seq/isEmpty` pulls at most one element through the iterator, so it
+    ;; answers from whether an element exists rather than from what it is, and
+    ;; still never realizes an unbounded sequence (#3023).
+    (php/instanceof x LazySeqInterface) (Seq/isEmpty x)
     (php/instanceof x Cons)             false
     ;; `instanceof Countable` has already proven `php/count` valid here, so
     ;; there is nothing for core `count` and core `=` to dispatch on.

--- a/tests/phel/core/lazy-seq-empty-check.phel
+++ b/tests/phel/core/lazy-seq-empty-check.phel
@@ -21,10 +21,32 @@
   (is (= 1 (count (lazy-seq [nil]))) "and counts as one")
   (is (= [nil nil] (vec (lazy-seq [nil nil]))) "two nils are two elements"))
 
-;; Not asserted here, deliberately: `(empty? (lazy-seq [nil]))` returns true
-;; while `count` returns 1 and `vec` returns `[nil]`. That disagreement is
-;; pre-existing and unrelated to the emptiness check inside `LazySeq`, which
-;; this file covers. Tracked separately.
+;; `empty?` used to answer that same question with `(nil? (first s))`, so it
+;; disagreed with `count` and `vec` about a sequence whose first element is nil
+;; (#3025). It now asks whether an element exists rather than what it is.
+(deftest test-empty-agrees-with-count-and-vec-about-a-leading-nil
+  (is (false? (empty? (lazy-seq [nil]))) "a single nil is not empty")
+  (is (false? (empty? (lazy-seq [nil nil]))) "two nils are not empty")
+  (is (false? (empty? (lazy-seq [nil 1]))) "nil first, value second")
+  (is (false? (empty? (lazy-seq [1 nil]))) "value first, nil second")
+  (is (= [nil] (not-empty (lazy-seq [nil]))) "not-empty hands the sequence back"))
+
+;; The three answers have to agree for every one of these, which is the property
+;; that failed: `empty?` said true where `count` said 1.
+(deftest test-empty-count-and-vec-agree
+  (let [cases [(lazy-seq [nil]) (lazy-seq [nil nil]) (lazy-seq [1 nil])
+               (lazy-seq []) (lazy-seq nil) (lazy-seq [1 2 3])]]
+    (foreach [s cases]
+      (is (= (empty? s) (= 0 (count s)))
+          (str "empty? agrees with count for " (vec s)))
+      (is (= (empty? s) (= [] (vec s)))
+          (str "empty? agrees with vec for " (vec s))))))
+
+;; A leading nil must not cost the laziness guarantee: the disambiguation pulls
+;; one element, it does not realize the sequence.
+(deftest test-an-unbounded-sequence-of-nils-still-answers
+  (is (false? (empty? (map (fn [_] nil) (iterate inc 0)))) "infinite nils")
+  (is (false? (empty? (iterate inc 0))) "infinite ints"))
 
 (deftest test-genuinely-empty-sources-are-still-empty
   (is (= [] (vec (lazy-seq []))) "empty vector")


### PR DESCRIPTION
## 🤔 Background

Three answers to the same question:

```phel
(empty? (lazy-seq [nil]))   ; => true
(count  (lazy-seq [nil]))   ; => 1
(vec    (lazy-seq [nil]))   ; => [nil]
```

`empty?` asked `(nil? (first x))`, and `first` answers `nil` both for an empty
sequence and for one whose first element *is* `nil`. `nil` is a legitimate
element in Phel, and the rule is already written down in `LazySeq::toArray()`:

> `realize() === null` is the only reliable "empty" signal; `first() === null`
> is ambiguous because the user may have stored `nil` as a legitimate value.

`empty?` was the one place not honouring it, so `(when-not (empty? s) ...)`
silently skipped a sequence that had elements.

## 💡 Goal

Answer from whether an element exists, not from what that element is, without
giving up the laziness guarantee #3023 established.

## 🔖 Changes

- `empty?` asks `Seq/isEmpty` for a `LazySeq`. It pulls at most one element
  through the iterator, so it distinguishes "no element" from "a nil element"
  and still never realizes an unbounded sequence.

- **Guarded by the cheap probe.** `Seq/isEmpty` is reached only when `first`
  returns `nil`, which is the sole ambiguous case: a non-nil head already
  proves the sequence non-empty, and that is the ordinary call.

  This is not a micro-optimisation for its own sake. Asking the iterator
  unconditionally cost about 10% on the common path, which would have traded
  one bug for a regression in the work #3024 had just landed.

### Measured, 10k calls

| | before | after |
|---|---|---|
| non-empty lazy-seq (common path) | 16.59 ms | 16.89 ms |
| empty lazy-seq | 10.10 ms | 13.68 ms |
| 200k element source | 0.517 ms | 0.507 ms |
| vector | 3.29 ms | 3.35 ms |

The empty case pays for the disambiguation. Nothing else does.

### Behaviour

| expression | before | after |
|---|---|---|
| `(empty? (lazy-seq [nil]))` | true | **false** |
| `(empty? (lazy-seq [nil nil]))` | true | **false** |
| `(empty? (lazy-seq [1 nil]))` | false | false |
| `(empty? (lazy-seq []))` | true | true |
| `(empty? (lazy-seq nil))` | true | true |
| `(empty? [nil])` | false | false |

Laziness is intact: an unbounded sequence still terminates, including an
unbounded sequence of nils, which is the case that would hang if the fix had
reached for `count`.

### Tests

`lazy-seq-empty-check.phel` carried a comment parking exactly this
disagreement:

> Not asserted here, deliberately: `(empty? (lazy-seq [nil]))` returns true
> while `count` returns 1 and `vec` returns `[nil]`. [...] Tracked separately.

Replaced with the assertions, plus the property the bug violated: `empty?`,
`count` and `vec` must agree for every one of these sequences. Eight assertions
fail against the old implementation.

`composer test-all` passes with 7,248 core tests.

Closes #3025
