### PR TITLE
fix(compiler): do not pin call sites while loading a required namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `BuildFacade::enterDependencyLoad()`, `leaveDependencyLoad()` and `isLoadingDependencies()`, plus `BuildConstants::LOADING_DEPENDENCIES`. Additive: they mark the region in which an `ns` form loads its requires, so the emitter can decline to pin call sites there (#3015)
 - Add `phel.bench` and the `phel bench` command: `defbench` benchmarks written in Phel, with baseline storage (`--store`), comparison (`--ref`) and a tolerance gate (`--tolerance`) (#3005)
 - Allow keyword keys in `#php` map literals (#2952)
 - Add Clojure-style PHP interop for value members, dynamic calls, enum cases and `set!` (#2881 #2883 #2887 #2888 #2907)
@@ -24,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `with-redefs` is no longer ignored after `phel eval` has loaded a required namespace. Loading a dependency runs under build mode, which also let the emitter pin global call sites into `static` slots, and the pinned artifact was written to the ordinary cache for later `phel test` runs to reuse (#3015)
 - `phel doc` and the API reference report every arity of a `def` over an `fn`. `defn` renders its arities into the docstring and a bare `def` does not, so 23 symbols published no signature at all, `defn` and `defmacro` among them, while `list`, `vector` and `hash-map` published a stale hardcoded one (#3012)
 - Stop the emptiness check on a lazy sequence realizing the whole sequence: an unbounded source now terminates, a 2,000,000 element one no longer crashes, and taking 5 of a 200,000 element `lazy-seq` drops from 21ms to 0.004ms (#3023)
 - Fix `lazy-seq` over a chunked sequence (`take`, `keep`, `range`, ...) yielding only its first element while `count` reported the true length (#3020)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -117,7 +117,8 @@ parameters:
         # a mirror of the facade. `Shared/CLAUDE.md` says to keep its imports
         # minimal, and every method below is called only from inside its own
         # module (its own `Infrastructure/Command/`, or emitted PHP for the
-        # BuildMode trio), so no consumer type-hinting the interface is missing
+        # BuildMode trio and the `*loading-dependencies*` trio #3015 added
+        # alongside it), so no consumer type-hinting the interface is missing
         # anything. Declaring them would drag `BuildOptions`, `ApiDaemon`,
         # `CoverageDriver`, `CoverageReport`, `ParallelTestOrchestrator` and
         # `CpuCountDetector` into the leaf layer and widen the public surface
@@ -137,7 +138,11 @@ parameters:
         -
             identifier: gacela.facadeInterfaceDrift
             path: src/php/Build/BuildFacade.php
-            count: 8
+            # 8 + the three `*loading-dependencies*` statics (#3015). They are
+            # emitted into compiled PHP by NsEmitter exactly as the BuildMode
+            # trio is, so they have to be public static and cannot go on the
+            # cross-module contract.
+            count: 11
         -
             identifier: gacela.facadeInterfaceDrift
             path: src/php/Compiler/CompilerFacade.php

--- a/src/php/Build/BuildFacade.php
+++ b/src/php/Build/BuildFacade.php
@@ -53,6 +53,46 @@ final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
     }
 
     /**
+     * Marks the region in which an `ns` form evaluates the files its requires
+     * resolve to, and returns the previous value so the caller can restore it.
+     *
+     * Nested requires are why the previous value is returned rather than
+     * assumed false: the inner region must not clear the flag on the way out
+     * and let the outer one start scanning again.
+     *
+     * {@see BuildConstants::LOADING_DEPENDENCIES} for why this is not build
+     * mode.
+     */
+    public static function enterDependencyLoad(): bool
+    {
+        $previous = self::isLoadingDependencies();
+        Registry::getInstance()->addDefinition(
+            CompilerConstants::PHEL_CORE_NAMESPACE,
+            BuildConstants::LOADING_DEPENDENCIES,
+            true,
+        );
+
+        return $previous;
+    }
+
+    public static function leaveDependencyLoad(bool $previous): void
+    {
+        Registry::getInstance()->addDefinition(
+            CompilerConstants::PHEL_CORE_NAMESPACE,
+            BuildConstants::LOADING_DEPENDENCIES,
+            $previous,
+        );
+    }
+
+    public static function isLoadingDependencies(): bool
+    {
+        return Registry::getInstance()->getDefinition(
+            CompilerConstants::PHEL_CORE_NAMESPACE,
+            BuildConstants::LOADING_DEPENDENCIES,
+        ) === true;
+    }
+
+    /**
      * Extracts the namespace from a given file. It expects that the
      * first statement in the file is the 'ns statement.
      *

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -119,14 +119,32 @@ final readonly class MethodEmitter
     }
 
     /**
-     * Read `*build-mode*` straight from the registry to avoid a hard
-     * compile-time dependency from the emitter onto `BuildFacade`.
-     * Caching call-site resolutions is only safe when redefinitions are
-     * not expected, which is exactly the contract of build mode.
+     * Read the flags straight from the registry to avoid a hard compile-time
+     * dependency from the emitter onto `BuildFacade`.
+     *
+     * Caching call-site resolutions is only safe when redefinitions are not
+     * expected, which is the contract of build mode.
+     *
+     * `*loading-dependencies*` is the one place that contract does not hold
+     * while build mode is set. An `ns` form turns build mode on to load the
+     * files its requires resolve to, so the required file can skip its
+     * non-build side effects, but that is an ordinary runtime load: the
+     * program goes on to run, and `with-redefs` is entitled to be seen. Pinning
+     * there produced an artifact that ignored every later redefinition, and
+     * wrote it to the ordinary cache for the next process to reuse (#3015).
      */
     private function shouldCacheCallSites(): bool
     {
-        return Registry::getInstance()->getDefinition(
+        $registry = Registry::getInstance();
+
+        if ($registry->getDefinition(
+            CompilerConstants::PHEL_CORE_NAMESPACE,
+            BuildConstants::LOADING_DEPENDENCIES,
+        ) === true) {
+            return false;
+        }
+
+        return $registry->getDefinition(
             CompilerConstants::PHEL_CORE_NAMESPACE,
             BuildConstants::BUILD_MODE,
         ) === true;

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
@@ -105,9 +105,33 @@ final class NsEmitter implements NodeEmitterInterface
                 // each require re-evaluated its file and re-ran its top level.
                 $this->outputEmitter->emitLine('if (!\\Phel::isNamespaceLoaded($__phelNsInfo->getNamespace())) {');
                 $this->outputEmitter->increaseIndentLevel();
+                // Build mode stays: a required file reads `*build-mode*` at its
+                // top level to skip non-build side effects, and
+                // `RequireBuildModeTest` pins that.
+                //
+                // `*loading-dependencies*` is set alongside it to say *why*
+                // build mode is on here. Build mode alone also licenses the
+                // emitter to pin global call sites into `static $__phel_call_N`
+                // slots, which is sound only when redefinitions are not
+                // expected. A runtime dependency load does not meet that, and
+                // the pinned artifact was written to the ordinary cache for
+                // later processes to reuse, so every later `with-redefs` was
+                // ignored (#3015). `MethodEmitter` reads this flag to decline.
+                //
+                // `finally` so a throwing dependency cannot leave either flag
+                // set for the rest of the process.
+                $this->outputEmitter->emitLine('$__phelPrevLoading = \\Phel\\Build\\BuildFacade::enterDependencyLoad();');
                 $this->outputEmitter->emitLine('\\Phel\\Build\\BuildFacade::enableBuildMode();');
+                $this->outputEmitter->emitLine('try {');
+                $this->outputEmitter->increaseIndentLevel();
                 $this->outputEmitter->emitLine('$__phelBuildFacade->evalFile($__phelNsInfo->getFile());');
+                $this->outputEmitter->decreaseIndentLevel();
+                $this->outputEmitter->emitLine('} finally {');
+                $this->outputEmitter->increaseIndentLevel();
                 $this->outputEmitter->emitLine('\\Phel\\Build\\BuildFacade::disableBuildMode();');
+                $this->outputEmitter->emitLine('\\Phel\\Build\\BuildFacade::leaveDependencyLoad($__phelPrevLoading);');
+                $this->outputEmitter->decreaseIndentLevel();
+                $this->outputEmitter->emitLine('}');
                 $this->outputEmitter->emitLine('\\Phel\\Compiler\\Infrastructure\\GlobalEnvironmentSingleton::getInstance()->setNs("' . addslashes($node->getNamespace()) . '");');
                 $this->outputEmitter->decreaseIndentLevel();
                 $this->outputEmitter->emitLine('}');

--- a/src/php/Shared/BuildConstants.php
+++ b/src/php/Shared/BuildConstants.php
@@ -7,4 +7,18 @@ namespace Phel\Shared;
 interface BuildConstants
 {
     public const string BUILD_MODE = '*build-mode*';
+
+    /**
+     * Set while an `ns` form loads the files its `(:require ...)` clauses
+     * resolve to. It suppresses the source-directory scan in the required
+     * file's own `ns` form, which would otherwise recurse.
+     *
+     * Deliberately not `*build-mode*`, which it used to borrow. Build mode
+     * additionally licenses the emitter to pin global call sites into
+     * `static $__phel_call_N` slots, on the contract that redefinitions are
+     * not expected. Loading a dependency at runtime does not meet that
+     * contract: the resulting artifact ignored every later `with-redefs`, and
+     * was written to the ordinary cache for later processes to reuse (#3015).
+     */
+    public const string LOADING_DEPENDENCIES = '*loading-dependencies*';
 }

--- a/tests/php/Integration/Run/Command/Eval/EvalDependencyRedefTest.php
+++ b/tests/php/Integration/Run/Command/Eval/EvalDependencyRedefTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Run\Command\Eval;
+
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function escapeshellarg;
+use function exec;
+use function file_get_contents;
+use function file_put_contents;
+use function glob;
+use function implode;
+use function mkdir;
+use function sprintf;
+use function sys_get_temp_dir;
+
+/**
+ * `phel eval` loads the files a `(:require ...)` resolves to, and used to do it
+ * with build mode switched on, borrowing it as a recursion guard.
+ *
+ * Build mode also licenses the emitter to pin a global call site into a
+ * `static $__phel_call_N` slot, which is sound only when redefinitions are not
+ * expected. A runtime dependency load does not meet that: the pinned artifact
+ * ignored every later `with-redefs`, and it was written to the ordinary cache
+ * for the next process to pick up, so `phel test` failed afterwards until the
+ * cache was deleted by hand (#3015).
+ */
+final class EvalDependencyRedefTest extends TestCase
+{
+    private string $projectDir = '';
+
+    protected function setUp(): void
+    {
+        $repoRoot = dirname(__DIR__, 6);
+        $this->projectDir = sys_get_temp_dir() . '/phel-eval-redef-' . bin2hex(random_bytes(8));
+
+        mkdir($this->projectDir . '/src/app', 0755, true);
+        mkdir($this->projectDir . '/vendor', 0755, true);
+
+        file_put_contents(
+            $this->projectDir . '/vendor/autoload.php',
+            sprintf("<?php return require '%s/vendor/autoload.php';\n", $repoRoot),
+        );
+
+        file_put_contents($this->projectDir . '/phel-config.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Phel\Config\PhelConfig;
+
+            $cacheDir = __DIR__ . '/.phel-cache';
+
+            return new PhelConfig()
+                ->withSrcDirs(['src'])
+                ->withTestDirs(['tests'])
+                ->withVendorDir('vendor')
+                ->withPhelDir($cacheDir)
+                ->withTempDir($cacheDir . '/tmp');
+
+            PHP);
+
+        file_put_contents($this->projectDir . '/src/app/target.phel', <<<'PHEL'
+            (ns app.target)
+
+            (defn read-search []
+              "real-value")
+
+            PHEL);
+
+        // The indirection matters: `runner` is the namespace whose compiled
+        // artifact holds the call site, and it is reached only as a dependency.
+        file_put_contents($this->projectDir . '/src/app/runner.phel', <<<'PHEL'
+            (ns app.runner
+              (:require app.target :as target))
+
+            (defn search-filter []
+              {:search (target/read-search)})
+
+            PHEL);
+    }
+
+    protected function tearDown(): void
+    {
+        exec('rm -rf ' . escapeshellarg($this->projectDir));
+    }
+
+    public function test_a_second_with_redefs_is_visible_through_a_required_namespace(): void
+    {
+        [$exitCode, $output] = $this->runEval();
+
+        self::assertSame(0, $exitCode, $output);
+        self::assertStringContainsString('{:search first}', $output);
+        self::assertStringContainsString(
+            '{:search second}',
+            $output,
+            'the second redefinition was ignored, so the call site is pinned',
+        );
+    }
+
+    /**
+     * The artifact outlives the process that wrote it, so a run that looks
+     * correct can still leave a poisoned cache behind for the next one.
+     */
+    public function test_the_cached_artifact_does_not_pin_the_call_site(): void
+    {
+        $this->runEval();
+
+        $compiled = glob($this->projectDir . '/.phel-cache/cache/compiled/app.runner__*.php');
+        self::assertNotSame([], $compiled, 'expected a compiled artifact for app.runner');
+
+        $contents = (string) file_get_contents($compiled[0]);
+        self::assertStringNotContainsString(
+            '$__phel_call_',
+            $contents,
+            'the dependency was compiled as if for a build, pinning its call sites',
+        );
+        self::assertStringContainsString(
+            'getDefinition("app.target", "read-search")', $contents,
+            'the call site should still resolve through the registry',
+        );
+    }
+
+    public function test_a_later_process_reusing_the_cache_still_sees_the_redefinition(): void
+    {
+        $this->runEval();
+
+        [$exitCode, $output] = $this->runEval();
+
+        self::assertSame(0, $exitCode, $output);
+        self::assertStringContainsString(
+            '{:search second}',
+            $output,
+            'a warm cache reintroduced the pinned call site',
+        );
+    }
+
+    /**
+     * @return array{0: int, 1: string}
+     */
+    private function runEval(): array
+    {
+        $source = <<<'PHEL'
+            (ns app.repro
+              (:require app.runner :as runner)
+              (:require app.target :as target))
+
+            (with-redefs [target/read-search (fn [] "first")]
+              (println (runner/search-filter)))
+
+            (with-redefs [target/read-search (fn [] "second")]
+              (println (runner/search-filter)))
+            PHEL;
+
+        $cmd = 'cd ' . escapeshellarg($this->projectDir)
+            . ' && php -d memory_limit=256M ' . escapeshellarg(dirname(__DIR__, 6) . '/bin/phel')
+            . ' eval ' . escapeshellarg($source) . ' 2>&1';
+
+        exec($cmd, $output, $exitCode);
+
+        return [$exitCode, implode("\n", $output)];
+    }
+}

--- a/tests/php/Integration/Run/Command/Eval/EvalDependencyRedefTest.php
+++ b/tests/php/Integration/Run/Command/Eval/EvalDependencyRedefTest.php
@@ -119,7 +119,8 @@ final class EvalDependencyRedefTest extends TestCase
             'the dependency was compiled as if for a build, pinning its call sites',
         );
         self::assertStringContainsString(
-            'getDefinition("app.target", "read-search")', $contents,
+            'getDefinition("app.target", "read-search")',
+            $contents,
             'the call site should still resolve through the registry',
         );
     }

--- a/tests/php/Unit/Architecture/public-api.snapshot.txt
+++ b/tests/php/Unit/Architecture/public-api.snapshot.txt
@@ -77,7 +77,10 @@ final class Phel\Build\BuildFacade extends Gacela\Framework\AbstractFacade imple
   public function writeStackTrace(Symfony\Component\Console\Output\OutputInterface $output, Throwable $e): void
   public static function disableBuildMode(): void
   public static function enableBuildMode(): void
+  public static function enterDependencyLoad(): bool
   public static function isBuildMode(): bool
+  public static function isLoadingDependencies(): bool
+  public static function leaveDependencyLoad(bool $previous): void
 
 final class Phel\Command\CommandFacade extends Gacela\Framework\AbstractFacade implements Phel\Shared\Facade\CommandFacadeInterface
   public function getAllPhelDirectories(): array
@@ -1629,6 +1632,7 @@ final class Phel\Shared\Binding\IterationHead
 
 interface Phel\Shared\BuildConstants
   public const string BUILD_MODE = '*build-mode*'
+  public const string LOADING_DEPENDENCIES = '*loading-dependencies*'
 
 final class Phel\Shared\ColorStyle implements Phel\Shared\ColorStyleInterface
   public function blue(string $str): string

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitterTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitterTest.php
@@ -90,6 +90,42 @@ final class NsEmitterTest extends TestCase
     }
 
     /**
+     * Build mode is what lets the required file skip its non-build side
+     * effects, so it stays. It also licenses the emitter to pin global call
+     * sites, which is wrong for a runtime load, so the region is additionally
+     * marked as a dependency load for `MethodEmitter` to decline on (#3015).
+     */
+    public function test_loading_a_required_namespace_marks_the_region_as_a_dependency_load(): void
+    {
+        $node = new NsNode('my\\app', [Symbol::create('phel\\string')], []);
+
+        ob_start();
+        $this->nsEmitter->emit($node);
+        $output = (string) ob_get_clean();
+
+        self::assertStringContainsString(
+            'enterDependencyLoad()',
+            $output,
+            'The load must be marked, so call-site pinning can be declined for it',
+        );
+        self::assertStringContainsString(
+            'enableBuildMode()',
+            $output,
+            'Build mode still gates the non-build side effects of the required file',
+        );
+        self::assertStringContainsString(
+            'leaveDependencyLoad($__phelPrevLoading)',
+            $output,
+            'The previous value is restored, so a nested require cannot clear the flag for its parent',
+        );
+        self::assertStringContainsString(
+            '} finally {',
+            $output,
+            'A throwing dependency must not leak either flag into the rest of the process',
+        );
+    }
+
+    /**
      * A seed that resolves to no file returns an empty list, and the load loop
      * then does nothing, so a missing or typo'd `:require` used to be
      * indistinguishable from a successful one (#2891).


### PR DESCRIPTION
## 🤔 Background

```phel
(with-redefs [target/read-search (fn [] "first")]  (println (runner/search-filter)))
(with-redefs [target/read-search (fn [] "second")] (println (runner/search-filter)))
```

```text
{:search first}
{:search first}     <- expected {:search second}
```

An `ns` form turns build mode on to evaluate the files its `(:require ...)`
clauses resolve to, so the required file can skip the side effects it guards
with `*build-mode*`.

Build mode also licenses the emitter to hoist a global call site into a
`static $__phel_call_N` slot. `MethodEmitter` says exactly when that is sound:

> Caching call-site resolutions is only safe when redefinitions are not
> expected, which is exactly the contract of build mode.

A dependency load does not meet that contract. The program goes on to run, and
`with-redefs` is entitled to be seen. Worse, the artifact is written to the
**ordinary runtime cache**, so a later `phel test` in a fresh process failed the
same way until the cache was deleted by hand.

## 💡 Goal

Withdraw the emitter's licence exactly where it was never sound, without
touching what `*build-mode*` means to user code.

## 🔖 Changes

- `*loading-dependencies*` marks the region in which an `ns` form loads its
  requires. `MethodEmitter::shouldCacheCallSites()` declines while it is set.
- Build mode itself is unchanged. A required file still skips its non-build side
  effects, and `RequireBuildModeTest`, which pins that, still passes.
- The emitted region is now `try`/`finally` and restores the *previous* value
  rather than clearing the flag, so a throwing dependency cannot leak the state
  into the rest of the process and a nested require cannot clear it for the
  require that contains it.

### Why not simply stop setting build mode there

That was the first attempt, and it is what the issue suggests. It fails
`RequireBuildModeTest`: a required namespace is meant to load with
`*build-mode*` set, so its `(when-not *build-mode* ...)` side effect does not
run. That is a deliberate, tested behaviour, and changing it is a wider question
than this bug. Splitting the emitter licence off is the narrow fix.

### Verified

```text
{:search first}
{:search second}
```

The compiled artifact no longer pins:

```php
- ($__phel_call_0 ??= \Phel::getDefinition("app.target", "read-search"))->__invoke()
+ (\Phel::getDefinition("app.target", "read-search"))->__invoke()
```

And a second process reusing that cache gets the same correct answer.

### Tests

`EvalDependencyRedefTest` covers all three symptoms, because fixing only the
first still leaves a poisoned cache behind for the next process:

1. the second redefinition is visible;
2. the cached artifact does not pin the call site;
3. a second process reusing that cache still sees the redefinition.

All three fail before the fix. `NsEmitterTest` pins the emitted guard.

### Surface

The public API snapshot gains three statics and a constant, additively. They are
emitted into compiled PHP exactly as the `BuildMode` trio is, so they have to be
public static and cannot move to the cross-module contract; the phpstan
`facadeInterfaceDrift` pin goes 8 to 11 for the same reason.

`composer test-all` passes with 7,229 core tests.

Closes #3015
