### PR TITLE
perf(compiler): carry a collection tag through a let rebinding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ Runtime core:
 - Give `str` fixed arities up to three arguments, skipping the array and `implode` (#2974)
 - Specialize `count` on a map-tagged local to a direct `->count()`, as `empty?` already did (#2985)
 - Infer a primitive tag for `let` bindings whose init is `if`, `do` or a nested `let` (#2987)
+- Carry a collection tag through a `let` rebinding: `(let [w v] (nth w 0))` now emits `$w->get(0)` like `(nth v 0)` already did, and the temp a vector destructure binds the collection to reaches `first` as a direct method call (#3021)
 - Inline the nil guard in `inc` and `dec`, which still called the variadic one (#2989)
 - Give `max` and `min` fixed arities, dropping a lazy sequence built to NaN-check two arguments (#2991)
 - Collect `for` results into a PHP array instead of an atom and a persistent `conj` per element (#2997)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrer.php
@@ -35,8 +35,9 @@ use function strrpos;
 use function substr;
 
 /**
- * Infers a primitive `:tag` (`int` / `float` / `bool` / `string`) for
- * `let` / `loop` bindings from their already-analyzed init expression and
+ * Infers a `:tag` for `let` / `loop` bindings: a primitive
+ * (`int` / `float` / `bool` / `string`), or the source's own tag when the init
+ * is a pure alias. Read from their already-analyzed init expression and
  * grafts it onto the binding symbol — the very `:tag` a hand-written
  * `^int` annotation would carry. With the tag present,
  * {@see LocalVarNode::getInferredType()} reports the type and the emitter
@@ -56,8 +57,16 @@ use function substr;
  * tags are themselves author-declared or filled by {@see ReturnTypeInferrer},
  * so trusting them here cannot disagree with what the callee returns.
  *
- * Inference is intentionally conservative: any binding not provably one of
- * the primitive tags is left untouched. A missing tag only ever costs a
+ * A binding whose init is *another local* is the one case not limited to
+ * {@see self::PRIMITIVE_TAGS}: it is a pure alias, so whatever tag the source
+ * carries (a collection class among them) describes this binding exactly.
+ * Without that, `(let [w v] (nth w 0))` fell back to runtime dispatch where
+ * `(nth v 0)` emitted `$v->get(0)`, and the same drop hit the temp a vector
+ * destructure binds the collection to. Every other arm still narrows to a
+ * primitive, because it *derives* a type rather than carrying one over.
+ *
+ * Inference is intentionally conservative: any binding whose type is not
+ * provable is left untouched. A missing tag only ever costs a
  * (correct) runtime dispatch; it never produces a wrong lowering. An
  * inferred tag is byte-identical to the same tag written by hand, so it
  * inherits the emitter's existing specialization guards verbatim — including
@@ -236,9 +245,16 @@ final class BindingTypeInferrer
     }
 
     /**
-     * Primitive tag of an already-analyzed expression node, or `null` when it
-     * is not statically one of {@see self::PRIMITIVE_TAGS}. `$locals` maps a
-     * loop binding's shadow name to its seeded type for `recur` arg typing.
+     * Tag of an already-analyzed expression node, or `null` when it has none.
+     * `$locals` maps a loop binding's shadow name to its seeded type for
+     * `recur` arg typing.
+     *
+     * A `LocalVarNode` yields its tag verbatim (see the class docblock: an
+     * alias carries a class tag over too); every other arm derives a type and
+     * so answers only with a {@see self::PRIMITIVE_TAGS} member or `null`.
+     * The derivations stay narrow on their own: {@see ArithmeticResultType}
+     * rejects any operand that is not `int` or `float`, so a class tag
+     * reaching one of them bails rather than lowering to a native operator.
      *
      * @param array<string, string> $locals
      */
@@ -249,7 +265,7 @@ final class BindingTypeInferrer
         }
 
         if ($node instanceof LocalVarNode) {
-            return $locals[$node->getName()->getName()] ?? $this->primitiveInferredType($node);
+            return $locals[$node->getName()->getName()] ?? $node->getInferredType();
         }
 
         if ($node instanceof CallNode) {
@@ -388,12 +404,6 @@ final class BindingTypeInferrer
         return ArithmeticResultType::fromOperands(
             array_map(fn(AbstractNode $arg): ?string => $this->typeOf($arg, $locals), $node->getArguments()),
         );
-    }
-
-    private function primitiveInferredType(LocalVarNode $node): ?string
-    {
-        $type = $node->getInferredType();
-        return in_array($type, self::PRIMITIVE_TAGS, true) ? $type : null;
     }
 
     private function literalType(mixed $value): ?string

--- a/tests/php/Integration/Fixtures/Call/let-alias-keeps-map-tag.test
+++ b/tests/php/Integration/Fixtures/Call/let-alias-keeps-map-tag.test
@@ -1,0 +1,8 @@
+--PHEL--
+(fn [^"\Phel\Lang\Collections\Map\PersistentMapInterface" m] (let [n m] (count n)))
+--PHP--
+(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m): int {
+  /** @var \Phel\Lang\Collections\Map\PersistentMapInterface $n_1 */
+  $n_1 = $m;
+  return ($n_1->count());
+});

--- a/tests/php/Integration/Fixtures/Call/let-alias-keeps-vector-tag.test
+++ b/tests/php/Integration/Fixtures/Call/let-alias-keeps-vector-tag.test
@@ -1,0 +1,8 @@
+--PHEL--
+(fn [^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" v] (let [w v] [(nth w 0) (count w) (first w)]))
+--PHP--
+(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
+  /** @var \Phel\Lang\Collections\Vector\PersistentVectorInterface $w_1 */
+  $w_1 = $v;
+  return \Phel::vector([($w_1->get(0)), ($w_1->count()), ($w_1->first())]);
+});

--- a/tests/php/Integration/Fixtures/Call/let-destructure-vector-first-temp-typed.test
+++ b/tests/php/Integration/Fixtures/Call/let-destructure-vector-first-temp-typed.test
@@ -1,0 +1,15 @@
+--PHEL--
+(fn [^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" v] (let [[a b] v] [a b]))
+--PHP--
+(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
+  static $__phel_call_0, $__phel_call_1, $__phel_call_2;
+  /** @var \Phel\Lang\Collections\Vector\PersistentVectorInterface $__phel_1_6 */
+  $__phel_1_6 = $v;
+  $__phel_2_7 = ($__phel_1_6->first());
+  $__phel_3_8 = ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "next"))->__invoke($__phel_1_6);
+  $a_9 = $__phel_2_7;
+  $__phel_4_10 = ($__phel_call_1 ??= \Phel::getDefinition("phel.core", "first"))->__invoke($__phel_3_8);
+  $__phel_5_11 = ($__phel_call_2 ??= \Phel::getDefinition("phel.core", "next"))->__invoke($__phel_3_8);
+  $b_12 = $__phel_4_10;
+  return \Phel::vector([$a_9, $b_12]);
+});

--- a/tests/php/Integration/Fixtures/Let/loop-alias-rebound-by-recur-bails.test
+++ b/tests/php/Integration/Fixtures/Let/loop-alias-rebound-by-recur-bails.test
@@ -1,0 +1,17 @@
+--PHEL--
+(fn [^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" v] (loop [w v] (if (php/=== 0 (count w)) nil (recur (rest w)))))
+--PHP--
+(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
+  static $__phel_call_0, $__phel_call_1;
+  $w_1 = $v;
+  while (true) {
+    if (((0 === ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "count"))->__invoke($w_1)))) {
+      return null;
+    } else {
+      $w_1 = ($__phel_call_1 ??= \Phel::getDefinition("phel.core", "rest"))->__invoke($w_1);
+      continue;
+
+    }
+    break;
+  }
+});

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrerTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrerTest.php
@@ -222,7 +222,7 @@ final class BindingTypeInferrerTest extends TestCase
 
     /**
      * A reference to a local whose binding symbol carries `$tag`: the shape
-     * {@see Phel\Compiler\Domain\Analyzer\SpecialForm\AnalyzeSymbol} builds
+     * {@see Phel\Compiler\Domain\Analyzer\TypeAnalyzer\AnalyzeSymbol} builds
      * for a reference to a tagged `let` binding or `defn` param.
      */
     private function taggedLocal(string $name, string $tag): LocalVarNode

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrerTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrerTest.php
@@ -10,11 +10,13 @@ use Phel\Compiler\Domain\Analyzer\Ast\BindingNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\BindingTypeInferrer;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use Phel\Shared\CompilerConstants;
@@ -26,8 +28,9 @@ use function is_string;
  * Pins the graft contract directly — what integration fixtures can only
  * observe transitively through emitted PHP. A grafted tag must land on BOTH
  * the binding symbol (for the emitter's doctag) and its shadow (the instance
- * a reference resolves to), an explicit user tag must always win, and a
- * non-primitive init must leave the binding untouched.
+ * a reference resolves to), an explicit user tag must always win, an
+ * untypeable init must leave the binding untouched, and a pure alias must
+ * carry its source's tag over verbatim, class tags included.
  */
 final class BindingTypeInferrerTest extends TestCase
 {
@@ -174,9 +177,60 @@ final class BindingTypeInferrerTest extends TestCase
         self::assertSame('string', $this->tagOf($binding->getSymbol()));
     }
 
+    public function test_class_tag_survives_a_rebinding(): void
+    {
+        // `(let [w v] ...)` where `v` is a tagged vector. The binding is a pure
+        // alias, so `w` is provably the same runtime type. Without this the
+        // rebinding dropped the tag and every accessor over `w` fell back to
+        // the runtime dispatch `v` was already skipping.
+        $binding = $this->letBinding('w', $this->taggedLocal('v', PersistentVectorInterface::class));
+
+        new BindingTypeInferrer()->graftLetBindings([$binding]);
+
+        self::assertSame(PersistentVectorInterface::class, $this->tagOf($binding->getSymbol()));
+        self::assertSame(PersistentVectorInterface::class, $this->tagOf($binding->getShadow()));
+    }
+
+    public function test_class_tagged_alias_does_not_become_a_numeric_operand(): void
+    {
+        // Aliasing propagates the tag verbatim, but arithmetic over it must
+        // still bail: only `int`/`float` operands lower to a native operator.
+        $binding = $this->letBinding('n', $this->coreCall('+', [
+            $this->taggedLocal('v', PersistentVectorInterface::class),
+            new LiteralNode($this->env, 1),
+        ]));
+
+        new BindingTypeInferrer()->graftLetBindings([$binding]);
+
+        self::assertNull($this->tagOf($binding->getSymbol()));
+    }
+
+    public function test_untagged_local_alias_stays_untagged(): void
+    {
+        $binding = $this->letBinding('w', new LocalVarNode($this->env, Symbol::create('v')));
+
+        new BindingTypeInferrer()->graftLetBindings([$binding]);
+
+        self::assertNull($this->tagOf($binding->getSymbol()));
+        self::assertNull($this->tagOf($binding->getShadow()));
+    }
+
     private function letBinding(string $name, AbstractNode $init): BindingNode
     {
         return new BindingNode($this->env, Symbol::create($name), Symbol::gen($name . '_'), $init);
+    }
+
+    /**
+     * A reference to a local whose binding symbol carries `$tag`: the shape
+     * {@see Phel\Compiler\Domain\Analyzer\SpecialForm\AnalyzeSymbol} builds
+     * for a reference to a tagged `let` binding or `defn` param.
+     */
+    private function taggedLocal(string $name, string $tag): LocalVarNode
+    {
+        return new LocalVarNode(
+            $this->env,
+            Symbol::create($name)->withMeta(Phel::map(Keyword::create('tag'), Symbol::create($tag))),
+        );
     }
 
     /**


### PR DESCRIPTION
## 🤔 Background

Item C2 of the audit backlog in #3021, which the issue calls the highest-leverage entry. `BindingTypeInferrer` narrowed a binding to `int`/`float`/`bool`/`string`, so a binding whose init is just another local lost whatever tag that local carried. `(let [w v] (nth w 0))` fell back to runtime dispatch where `(nth v 0)` already emitted `$v->get(0)`.

## 💡 Goal

Let a pure alias carry its source's tag over verbatim, class tags included, so a rebinding stops being a place where type information dies.

## 🔖 Changes

- A `LocalVarNode` init yields its tag as is instead of being filtered to a primitive. Every other arm still narrows, because it derives a type rather than carrying one over, and the derivations reject a class tag on their own (`ArithmeticResultType` takes `int` and `float` only).
- The temp a vector destructure binds the collection to is such an alias, so it now reaches `first` as a direct method call. Deeper temps stay untagged, correctly: they are bound to `(next ...)`, whose return type is not the source collection's.
- A loop binding rebound by `recur` still bails, pinned by a fixture.
- Four integration fixtures and three unit tests; `composer test` green.

Related to #3021 (kept open: this closes one item of a multi-item backlog).
