### PR TITLE
perf(compiler): graft let binding tags before the body is analyzed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ Runtime core:
 - Specialize `count` on a map-tagged local to a direct `->count()`, as `empty?` already did (#2985)
 - Infer a primitive tag for `let` bindings whose init is `if`, `do` or a nested `let` (#2987)
 - Carry a collection tag through a `let` rebinding: `(let [w v] (nth w 0))` now emits `$w->get(0)` like `(nth v 0)` already did, and the temp a vector destructure binds the collection to reaches `first` as a direct method call (#3021)
+- Let an inferred tag reach a nested `let`, so `(let [n (php/count v)] (let [m n] (+ m 1)))` lowers to a native `+` like the flat `(let [n (php/count v) m n] ...)` already did. `if-let`, `when-let` and `binding` all expand to the nested shape (#3040)
 - Inline the nil guard in `inc` and `dec`, which still called the variadic one (#2989)
 - Give `max` and `min` fixed arities, dropping a lazy sequence built to NaN-check two arguments (#2991)
 - Collect `for` results into a PHP array instead of an atom and a persistent `conj` per element (#2997)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrer.php
@@ -123,6 +123,12 @@ final class BindingTypeInferrer
      * `$boundTo` is the enclosing def's `"ns\name"` (empty when anonymous),
      * used to skip a binding's own recursive self-call return tag.
      *
+     * MUST run before the `let`'s body is analyzed. A `let` nested in that body
+     * infers its own bindings as it is analyzed, so it can only read an outer
+     * tag that is already grafted (#3040). This is the opposite constraint to
+     * {@see self::graftLoopBindings}, whose bindings need the `recur` fixpoint
+     * and so cannot be typed until the body exists.
+     *
      * @param list<BindingNode> $bindings
      */
     public function graftLetBindings(array $bindings, string $boundTo = ''): void

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
@@ -84,6 +84,22 @@ final readonly class LetSymbol implements SpecialFormAnalyzerInterface
         $bindingVector = $list->get(1);
         $bindings = $this->analyzeBindings($bindingVector, $env->withDisallowRecurFrame());
 
+        // Infer a `:tag` from each binding's init so ops over the binding lower
+        // to native PHP (a `let` cannot `recur`, so the init type holds for the
+        // whole scope). Runs BEFORE the body is analyzed, because a `let` in
+        // that body infers its own bindings as it is analyzed: grafting
+        // afterwards left the inner scope reading an untagged outer binding,
+        // so `(let [n (php/count v)] (let [m n] (+ m 1)))` stayed on runtime
+        // dispatch while the flat `(let [n (php/count v) m n] ...)` did not
+        // (#3040). `if-let`, `when-let` and `binding` all expand to the nested
+        // shape.
+        //
+        // Running ahead of `LetSimplifier` costs nothing: it only drops or
+        // inlines whole bindings, never rewrites a surviving binding's init,
+        // so a tag it would have produced afterwards is the same tag, and a
+        // tag grafted onto a binding the simplifier then removes goes with it.
+        $this->bindingTypeInferrer->graftLetBindings($bindings, $env->getBoundTo());
+
         $locals = [];
         foreach ($bindings as $binding) {
             $locals[] = $binding->getSymbol();
@@ -119,18 +135,6 @@ final readonly class LetSymbol implements SpecialFormAnalyzerInterface
             $list->getStartLocation(),
         );
 
-        $simplified = $this->letSimplifier->simplify($node);
-
-        // Infer a primitive `:tag` from each binding's init so ops over the
-        // binding lower to native PHP operators (a `let` cannot `recur`, so
-        // the init type holds for the whole scope). Run after simplification:
-        // dropped / inlined bindings are gone, and a surviving binding's
-        // symbol is the same instance the body references, so the in-place
-        // graft is visible to its `LocalVarNode`s at emit time.
-        if ($simplified instanceof LetNode) {
-            $this->bindingTypeInferrer->graftLetBindings($simplified->getBindings(), $env->getBoundTo());
-        }
-
-        return $simplified;
+        return $this->letSimplifier->simplify($node);
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
@@ -86,13 +86,8 @@ final readonly class LetSymbol implements SpecialFormAnalyzerInterface
 
         // Infer a `:tag` from each binding's init so ops over the binding lower
         // to native PHP (a `let` cannot `recur`, so the init type holds for the
-        // whole scope). Runs BEFORE the body is analyzed, because a `let` in
-        // that body infers its own bindings as it is analyzed: grafting
-        // afterwards left the inner scope reading an untagged outer binding,
-        // so `(let [n (php/count v)] (let [m n] (+ m 1)))` stayed on runtime
-        // dispatch while the flat `(let [n (php/count v) m n] ...)` did not
-        // (#3040). `if-let`, `when-let` and `binding` all expand to the nested
-        // shape.
+        // whole scope). Must precede the body analysis below, for the reason
+        // {@see BindingTypeInferrer::graftLetBindings} states.
         //
         // Running ahead of `LetSimplifier` costs nothing: it only drops or
         // inlines whole bindings, never rewrites a surviving binding's init,

--- a/tests/php/Integration/Fixtures/Let/let-nested-in-if-arm-inherits-outer-tag.test
+++ b/tests/php/Integration/Fixtures/Let/let-nested-in-if-arm-inherits-outer-tag.test
@@ -1,0 +1,15 @@
+--PHEL--
+(fn [^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" v] (let [w v] (if (php/=== 1 1) (let [x w] (nth x 0)) nil)))
+--PHP--
+(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
+  /** @var \Phel\Lang\Collections\Vector\PersistentVectorInterface $w_1 */
+  $w_1 = $v;
+  if (((1 === 1))) {
+    /** @var \Phel\Lang\Collections\Vector\PersistentVectorInterface $x_2 */
+    $x_2 = $w_1;
+    return ($x_2->get(0));
+  } else {
+    return null;
+  }
+
+});

--- a/tests/php/Integration/Fixtures/Let/let-nested-inherits-outer-tag.test
+++ b/tests/php/Integration/Fixtures/Let/let-nested-inherits-outer-tag.test
@@ -1,0 +1,10 @@
+--PHEL--
+(fn [v] (let [n (php/count v)] (let [m n] (+ m 1))))
+--PHP--
+(function($v) {
+  /** @var int $n_1 */
+  $n_1 = count($v);
+  /** @var int $m_2 */
+  $m_2 = $n_1;
+  return ($m_2 + 1);
+});

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/LetSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/LetSymbolTest.php
@@ -15,6 +15,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\DeconstructorInterface;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\LetSymbol;
+use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use PHPUnit\Framework\TestCase;
 
@@ -95,6 +96,13 @@ final class LetSymbolTest extends TestCase
         // The body is empty (analyser inserts an implicit `nil`), so the
         // binding `a` is unused and its literal init is pure — the
         // simplifier drops the binding entirely.
+        //
+        // `a` and its shadow still carry the inferred `^int`: the tag is
+        // grafted before the body is analyzed, so a nested `let` can read it
+        // (#3040), which is ahead of the simplifier deciding to drop this
+        // binding. Dead metadata on a node that no longer exists, and no
+        // `LocalVarNode` can reach it — the binding was dropped precisely
+        // because nothing references it.
         Symbol::resetGen();
         $list = Phel::list([
             Symbol::create('let'),
@@ -109,10 +117,12 @@ final class LetSymbolTest extends TestCase
                 $env,
                 [],
                 new DoNode(
-                    $env->withLocals([Symbol::create('a')])->withShadowedLocal(Symbol::create('a'), Symbol::create('a_1')),
+                    $env->withLocals([$this->intTagged('a')])
+                        ->withShadowedLocal($this->intTagged('a'), $this->intTagged('a_1')),
                     [],
                     new LiteralNode(
-                        $env->withLocals([Symbol::create('a')])->withShadowedLocal(Symbol::create('a'), Symbol::create('a_1')),
+                        $env->withLocals([$this->intTagged('a')])
+                            ->withShadowedLocal($this->intTagged('a'), $this->intTagged('a_1')),
                         null,
                     ),
                 ),
@@ -171,5 +181,15 @@ final class LetSymbolTest extends TestCase
             ),
             $this->analyzer->analyze($list, $env),
         );
+    }
+
+    /**
+     * A symbol carrying the `^int` the `BindingTypeInferrer` grafts, so an
+     * expected node tree compares equal to one built from a typed binding.
+     */
+    private function intTagged(string $name): Symbol
+    {
+        return Symbol::create($name)
+            ->withMeta(Phel::map(Keyword::create('tag'), Symbol::create('int')));
     }
 }


### PR DESCRIPTION
## 🤔 Background

`BindingTypeInferrer` grafted a `let`'s tags *after* its body was analyzed. A `let` nested in that body infers its own bindings while it is analyzed, so it read the outer binding while it was still untagged. Found while landing #3039, filed as #3040.

Same code, only the nesting differs, and only the flat form lowered:

```phel
(let [n (php/count v)] (let [m n] (+ m 1)))   ; registry dispatch
(let [n (php/count v) m n]  (+ m 1))          ; ($m + 1)
```

`if-let`, `when-let` and `binding` all expand to the nested shape, so their inner scope never saw an outer tag either.

## 💡 Goal

Make nesting stop costing type information.

## 🔖 Changes

- The graft moves to the analyzed bindings, ahead of the body. `LetSymbol` had it after `LetSimplifier`, which is free to give up: the simplifier only drops or inlines whole bindings and never rewrites a surviving binding's init, so a tag it would have produced afterwards is the same tag.
- A binding the simplifier then removes now keeps a tag nothing can reach, because it was dropped precisely for being unreferenced. `LetSymbolTest` records that.
- The `loop` graft stays late: its bindings need the `recur` fixpoint. Both constraints are now stated on the inferrer.
- Two integration fixtures, `composer test` green, and no analysis-time cost: `TypeInferenceBench` 33.4ms to 32.3ms, `WideLetAnalysisBench` 5.06ms to 4.91ms against `origin/main` at 55e9316f4.

Closes #3040
