### PR TITLE
perf(compiler): read a class or array return type into a let binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ Runtime core:
 - Infer a primitive tag for `let` bindings whose init is `if`, `do` or a nested `let` (#2987)
 - Carry a collection tag through a `let` rebinding: `(let [w v] (nth w 0))` now emits `$w->get(0)` like `(nth v 0)` already did, and the temp a vector destructure binds the collection to reaches `first` as a direct method call (#3021)
 - Let an inferred tag reach a nested `let`, so `(let [n (php/count v)] (let [m n] (+ m 1)))` lowers to a native `+` like the flat `(let [n (php/count v) m n] ...)` already did. `if-let`, `when-let` and `binding` all expand to the nested shape (#3040)
+- Read a class or `array` return type into the binding it initialises, not only a scalar one, so `(let [a (mkvec)] (nth a 0))` over a fn returning a tagged vector emits `$a->get(0)`. Nullable, union and intersection returns stay on dispatch (#3021)
 - Inline the nil guard in `inc` and `dec`, which still called the variadic one (#2989)
 - Give `max` and `min` fixed arities, dropping a lazy sequence built to NaN-check two arguments (#2991)
 - Collect `for` results into a PHP array instead of an atom and a persistent `conj` per element (#2997)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrer.php
@@ -30,7 +30,6 @@ use function is_bool;
 use function is_float;
 use function is_int;
 use function is_string;
-use function str_contains;
 use function str_replace;
 use function strrpos;
 use function strtolower;
@@ -38,8 +37,8 @@ use function substr;
 
 /**
  * Infers a `:tag` for `let` / `loop` bindings: a primitive
- * (`int` / `float` / `bool` / `string`), or the source's own tag when the init
- * is a pure alias. Read from their already-analyzed init expression and
+ * (`int` / `float` / `bool` / `string`) where the init derives one, else the
+ * type the init already carries. Read from their already-analyzed init and
  * grafts it onto the binding symbol — the very `:tag` a hand-written
  * `^int` annotation would carry. With the tag present,
  * {@see LocalVarNode::getInferredType()} reports the type and the emitter
@@ -53,19 +52,23 @@ use function substr;
  * `php/` interop operators.
  *
  * The init type is read from literals, sibling/param locals, `php/` interop
- * ops, `phel.core` arithmetic — and from the primitive return `:tag` of any
- * global call (a `phel.core` helper or user `defn`), so a call to a typed fn
- * feeds the binding the same way a hand-written annotation would. Those return
- * tags are themselves author-declared or filled by {@see ReturnTypeInferrer},
- * so trusting them here cannot disagree with what the callee returns.
+ * ops, `phel.core` arithmetic — and from the return `:tag` of any global call
+ * (a `phel.core` helper or user `defn`), so a call to a typed fn feeds the
+ * binding the same way a hand-written annotation would. Those return tags are
+ * themselves author-declared or filled by {@see ReturnTypeInferrer}, and either
+ * way `FnSymbol` emits them as the PHP return type, so trusting them here
+ * cannot disagree with what the callee returns. A class or `array` return is
+ * carried over too; {@see self::isBindableReturnTag} states what is not.
  *
- * A binding whose init is *another local* is the one case not limited to
- * {@see self::PRIMITIVE_TAGS}: it is a pure alias, so whatever tag the source
- * carries (a collection class among them) describes this binding exactly.
- * Without that, `(let [w v] (nth w 0))` fell back to runtime dispatch where
- * `(nth v 0)` emitted `$v->get(0)`, and the same drop hit the temp a vector
- * destructure binds the collection to. Every other arm still narrows to a
- * primitive, because it *derives* a type rather than carrying one over.
+ * Two arms *carry* a type rather than deriving one, and only those two reach
+ * past the primitives. A binding whose init is another local is a pure alias,
+ * so whatever tag the source holds (a collection class among them) describes
+ * it exactly; without that, `(let [w v] (nth w 0))` fell back to runtime
+ * dispatch where `(nth v 0)` emitted `$v->get(0)`, and the same drop hit the
+ * temp a vector destructure binds the collection to. A binding whose init is a
+ * call takes the callee's return tag, on the terms
+ * {@see self::isBindableReturnTag} sets out. Every remaining arm computes a
+ * type from its operands and so can only answer with a primitive.
  *
  * Inference is intentionally conservative: any binding whose type is not
  * provable is left untouched. A missing tag only ever costs a
@@ -80,9 +83,6 @@ use function substr;
  */
 final class BindingTypeInferrer
 {
-    /** @var list<string> */
-    private const array PRIMITIVE_TAGS = ['int', 'float', 'bool', 'string'];
-
     /**
      * `php/<op>` binary ops whose result type is exactly PHP's: `int` when
      * every operand is int, `float` when any operand is float. Restricted to
@@ -102,12 +102,11 @@ final class BindingTypeInferrer
     private const array CORE_INC_DEC_OPS = ['inc', 'dec'];
 
     /**
-     * A tag containing any of these is a nullable, union or intersection type.
-     * None of them names one runtime type, so none can back a binding tag.
-     *
-     * @var list<string>
+     * A tag containing any of these characters is a nullable, union or
+     * intersection type. None of them names one runtime type, so none can
+     * back a binding tag.
      */
-    private const array COMPOSITE_TAG_MARKERS = ['?', '|', '&'];
+    private const string COMPOSITE_TAG_CHARS = '?|&';
 
     /**
      * PHP type names that are never a concrete instance type a specialisation
@@ -279,8 +278,9 @@ final class BindingTypeInferrer
      * `recur` arg typing.
      *
      * A `LocalVarNode` yields its tag verbatim (see the class docblock: an
-     * alias carries a class tag over too); every other arm derives a type and
-     * so answers only with a {@see self::PRIMITIVE_TAGS} member or `null`.
+     * alias carries a class tag over too), as does a call to a fn with a
+     * bindable return type; every other arm derives a type and so answers only
+     * with `int`, `float`, `bool`, `string` or `null`.
      * The derivations stay narrow on their own: {@see ArithmeticResultType}
      * rejects any operand that is not `int` or `float`, so a class tag
      * reaching one of them bails rather than lowering to a native operator.
@@ -445,18 +445,8 @@ final class BindingTypeInferrer
      */
     private function isBindableReturnTag(?string $tag): bool
     {
-        if ($tag === null) {
+        if ($tag === null || strpbrk($tag, self::COMPOSITE_TAG_CHARS) !== false) {
             return false;
-        }
-
-        if (in_array($tag, self::PRIMITIVE_TAGS, true)) {
-            return true;
-        }
-
-        foreach (self::COMPOSITE_TAG_MARKERS as $marker) {
-            if (str_contains($tag, $marker)) {
-                return false;
-            }
         }
 
         return !isset(self::NON_BINDABLE_TAGS[strtolower($tag)]);

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrer.php
@@ -30,8 +30,10 @@ use function is_bool;
 use function is_float;
 use function is_int;
 use function is_string;
+use function str_contains;
 use function str_replace;
 use function strrpos;
+use function strtolower;
 use function substr;
 
 /**
@@ -98,6 +100,27 @@ final class BindingTypeInferrer
      * @var list<string>
      */
     private const array CORE_INC_DEC_OPS = ['inc', 'dec'];
+
+    /**
+     * A tag containing any of these is a nullable, union or intersection type.
+     * None of them names one runtime type, so none can back a binding tag.
+     *
+     * @var list<string>
+     */
+    private const array COMPOSITE_TAG_MARKERS = ['?', '|', '&'];
+
+    /**
+     * PHP type names that are never a concrete instance type a specialisation
+     * can dispatch on, plus the three that resolve against the callee's class
+     * context rather than the binding's.
+     *
+     * @var array<string, true>
+     */
+    private const array NON_BINDABLE_TAGS = [
+        'void' => true, 'never' => true, 'null' => true, 'mixed' => true,
+        'object' => true, 'iterable' => true, 'callable' => true,
+        'self' => true, 'static' => true, 'parent' => true,
+    ];
 
     /** @var array<string, string> */
     private const array COMPARISON_OPS = [
@@ -379,11 +402,11 @@ final class BindingTypeInferrer
     }
 
     /**
-     * The callee's declared or inferred return `:tag`, kept only when it is one
-     * of {@see self::PRIMITIVE_TAGS} — a nullable/union/class return never feeds
-     * a native scalar op, and `int` inherits the same overflow policy as every
-     * other inferred int (see the class docblock). A recursive self-call is
-     * skipped so a redefinition never reads its own stale registry tag.
+     * The callee's declared or inferred return `:tag`, kept only when a binding
+     * can stand on it (see {@see self::isBindableReturnTag}). `int` inherits the
+     * same overflow policy as every other inferred int (see the class docblock).
+     * A recursive self-call is skipped so a redefinition never reads its own
+     * stale registry tag.
      */
     private function globalReturnTag(GlobalVarNode $fn): ?string
     {
@@ -396,7 +419,47 @@ final class BindingTypeInferrer
         }
 
         $tag = $this->tagFromMeta($fn->getMeta());
-        return in_array($tag, self::PRIMITIVE_TAGS, true) ? $tag : null;
+        return $this->isBindableReturnTag($tag) ? $tag : null;
+    }
+
+    /**
+     * Whether a callee's return `:tag` describes the binding it initialises.
+     *
+     * A `def`'s `:tag` over an `fn` **is** that fn's return type: `FnSymbol`
+     * emits it on every arity's closure, so PHP enforces it on the way out and
+     * the tag is a guarantee rather than a hope. That makes a class or `array`
+     * return as trustworthy as the `int` this used to be limited to, and the
+     * narrowing was an inconsistency rather than caution: `array` already
+     * propagates param to param, and {@see ReturnTypeInferrer::inferGlobalCall}
+     * already trusts the same tag wholesale for the *caller's* return type.
+     *
+     * Three groups stay out:
+     *
+     * - Anything composite (`?X`, `X|Y`, `X&Y`). A nullable collection is the
+     *   dangerous one: `TypedCollectionMethodSpecialization` would lower
+     *   `(nth a 0)` to `$a->get(0)` on a value that is allowed to be nil.
+     * - PHP's non-instance pseudo-types. They match no specialisation, so
+     *   keeping them buys nothing and only puts noise in the `@var` doctag.
+     * - `self` / `static` / `parent`, which resolve against the *callee's*
+     *   class context and would mean something else at the binding.
+     */
+    private function isBindableReturnTag(?string $tag): bool
+    {
+        if ($tag === null) {
+            return false;
+        }
+
+        if (in_array($tag, self::PRIMITIVE_TAGS, true)) {
+            return true;
+        }
+
+        foreach (self::COMPOSITE_TAG_MARKERS as $marker) {
+            if (str_contains($tag, $marker)) {
+                return false;
+            }
+        }
+
+        return !isset(self::NON_BINDABLE_TAGS[strtolower($tag)]);
     }
 
     /**

--- a/tests/php/Integration/Fixtures/Let/let-user-fn-vector-return-typed-nth.test
+++ b/tests/php/Integration/Fixtures/Let/let-user-fn-vector-return-typed-nth.test
@@ -1,0 +1,46 @@
+--PHEL--
+(defn ^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" mkvec [] (vector 1 2 3))
+(defn use-it [] (let [a (mkvec)] (nth a 0)))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "mkvec",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\mkvec";
+
+    public function __invoke(): \Phel\Lang\Collections\Vector\PersistentVectorInterface {
+      return \Phel::vector([1, 2, 3]);
+    }
+  },
+  \Phel::locationMeta(
+    \Phel::location("Let/let-user-fn-vector-return-typed-nth.test", 1, 0),
+    \Phel::location("Let/let-user-fn-vector-return-typed-nth.test", 1, 89),
+    \Phel\Lang\Keyword::create("tag"), "\\Phel\\Lang\\Collections\\Vector\\PersistentVectorInterface",
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(mkvec)\n```\n",
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
+);
+\Phel::addDefinition(
+  "user",
+  "use-it",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\use_it";
+
+    public function __invoke() {
+      static $__phel_call_0;
+      /** @var \Phel\Lang\Collections\Vector\PersistentVectorInterface $a_1 */
+      $a_1 = ($__phel_call_0 ??= \Phel::getDefinition("user", "mkvec"))->__invoke();
+      return ($a_1->get(0));
+    }
+  },
+  \Phel::locationMeta(
+    \Phel::location("Let/let-user-fn-vector-return-typed-nth.test", 2, 0),
+    \Phel::location("Let/let-user-fn-vector-return-typed-nth.test", 2, 44),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(use-it)\n```\n",
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
+);

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrerTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/SpecialForm/BindingTypeInferrerTest.php
@@ -144,15 +144,48 @@ final class BindingTypeInferrerTest extends TestCase
         self::assertSame('string', $this->tagOf($binding->getShadow()));
     }
 
-    public function test_non_primitive_return_tag_is_not_grafted(): void
+    public function test_composite_return_tag_is_not_grafted(): void
     {
-        // A `?int` / union / class return never feeds a native scalar op.
-        $binding = $this->letBinding('x', $this->taggedGlobalCall('app', 'find', '?int'));
+        // A nullable, union or intersection return names no single runtime
+        // type. The nullable collection is the dangerous one: the typed-vector
+        // specialisation would lower `(nth a 0)` to `$a->get(0)` on a value the
+        // signature allows to be nil.
+        foreach (['?int', '?\\Phel\\Lang\\Collections\\Vector\\PersistentVectorInterface', 'int|string', 'A&B'] as $tag) {
+            $binding = $this->letBinding('x', $this->taggedGlobalCall('app', 'find', $tag));
 
-        new BindingTypeInferrer()->graftLetBindings([$binding]);
+            new BindingTypeInferrer()->graftLetBindings([$binding]);
 
-        self::assertNull($this->tagOf($binding->getSymbol()));
-        self::assertNull($this->tagOf($binding->getShadow()));
+            self::assertNull($this->tagOf($binding->getSymbol()), $tag);
+            self::assertNull($this->tagOf($binding->getShadow()), $tag);
+        }
+    }
+
+    public function test_class_and_array_return_tags_type_the_binding(): void
+    {
+        // A `def`'s `:tag` over an `fn` is emitted as that fn's return type on
+        // every arity, so PHP enforces it: as trustworthy as the `int` this was
+        // once limited to.
+        $vector = $this->letBinding('v', $this->taggedGlobalCall('app', 'mkvec', PersistentVectorInterface::class));
+        $array = $this->letBinding('a', $this->taggedGlobalCall('app', 'mkarr', 'array'));
+
+        new BindingTypeInferrer()->graftLetBindings([$vector, $array]);
+
+        self::assertSame(PersistentVectorInterface::class, $this->tagOf($vector->getSymbol()));
+        self::assertSame(PersistentVectorInterface::class, $this->tagOf($vector->getShadow()));
+        self::assertSame('array', $this->tagOf($array->getSymbol()));
+    }
+
+    public function test_non_instance_return_tags_are_not_grafted(): void
+    {
+        // `void` / `never` / `mixed` and friends match no specialisation, and
+        // `self` / `static` / `parent` mean the callee's class, not this one.
+        foreach (['void', 'never', 'null', 'mixed', 'object', 'iterable', 'callable', 'self', 'static', 'parent'] as $tag) {
+            $binding = $this->letBinding('x', $this->taggedGlobalCall('app', 'find', $tag));
+
+            new BindingTypeInferrer()->graftLetBindings([$binding]);
+
+            self::assertNull($this->tagOf($binding->getSymbol()), $tag);
+        }
     }
 
     public function test_recursive_self_call_return_tag_is_skipped(): void


### PR DESCRIPTION
## 🤔 Background

Item C3 of #3021. `BindingTypeInferrer` kept a callee's return `:tag` only when it was `int`, `float`, `bool` or `string`, so a fn declaring a collection return fed its caller nothing:

```phel
(defn ^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" mkvec [] (vector 1 2 3))
(defn use-it [] (let [a (mkvec)] (nth a 0)))   ; generic dispatch
```

The same `(nth a 0)` on a tagged *parameter* already emitted `$a->get(0)`.

## 💡 Goal

Let a binding stand on a return type the way it stands on a parameter type.

## 🔖 Changes

- A class or `array` return now reaches the binding. This is a guarantee, not a hope: a `def`'s `:tag` over an `fn` **is** that fn's return type, and `FnSymbol` emits it on every arity's closure, so PHP enforces it on the way out. `ReturnTypeInferrer::inferGlobalCall` already trusted the same tag wholesale for the caller's return type, and `array` already propagated parameter to parameter, so the narrowing was an inconsistency.
- Three groups stay out, because a binding tag drives native lowering where a return type does not: composite types (`?X`, `X|Y`, `X&Y`), since a nullable collection would lower `(nth a 0)` to `$a->get(0)` on a value the signature allows to be nil; PHP's non-instance pseudo-types, which match no specialisation; and `self`/`static`/`parent`, which name the callee's class rather than the binding's.
- One integration fixture, three unit tests covering each rejected group, `composer test` green.

Worth stating plainly: this pays off for *annotated* fns only. C1's claim that C2 would unblock it "wholesale" does not hold, and #3042 records the measurement.

Related to #3021
