### PR TITLE
docs(console): list Balance among the registered command modules

### DIFF
--- a/src/php/Console/CLAUDE.md
+++ b/src/php/Console/CLAUDE.md
@@ -15,7 +15,7 @@ CLI entry point: bootstraps Symfony Console, lazily registers every module's com
 |--------------|--------|----------|
 | `FilesystemFacadeInterface::class` | Filesystem | `clearAll()` cleanup after each run |
 
-`FilesystemFacadeInterface::class` is the only injected facade dependency, but it is not the only edge. As the CLI entry point, `ConsoleFactory` also imports the command classes of twelve modules (Api, Build, Compiler, Filesystem, Formatter, Interop, Lint, Lsp, Nrepl, Profile, Run, Watch) to register them with Symfony Console.
+`FilesystemFacadeInterface::class` is the only injected facade dependency, but it is not the only edge. As the CLI entry point, `ConsoleFactory` also imports the command classes of thirteen modules (Api, Balance, Build, Compiler, Filesystem, Formatter, Interop, Lint, Lsp, Nrepl, Profile, Run, Watch) to register them with Symfony Console.
 
 That makes Console the graph's sink: it depends on nearly everything and **nothing depends on it**. Keep it that way. A module importing `Phel\Console` would turn the widest fan-in in the codebase into a cycle, which is why `ConsoleFacadeInterface` exists in `Shared/Facade` for the rare case a module needs to describe console behaviour.
 
@@ -33,7 +33,7 @@ That makes Console the graph's sink: it depends on nearly everything and **nothi
 ## CLI Commands (lazy)
 
 - Sibling Command classes (in other modules) are NOT injected via Facade; each per-module `*Commands.php` provider wraps them as Symfony `LazyCommand`s.
-- Command providers: Run, Interop, Formatter, Api, Build, Framework (debug), Nrepl, Lint, Profile, Lsp, Watch — order set by `ConsoleProvider::commandProviders()`; command order follows that list.
+- Command providers: Run, Interop, Formatter, Api, Build, Framework (debug), Nrepl, Lint, Balance, Profile, Lsp, Watch — order set by `ConsoleProvider::commandProviders()`; command order follows that list.
 - `LazyCommand` wrappers carry name/aliases/description/hidden up front, so `list`/`help`/alias resolution work without constructing every command — only the dispatched one is built per invocation.
 - `ConsoleProvider::LAZY_COMMANDS` aggregates all providers' commands; `ConsoleFactory::createCommandLoader()` feeds them to `LazyCommandLoader`.
 


### PR DESCRIPTION
## 🤔 Background

#3044 added the `Balance` module and registered `BalanceCommands` in `ConsoleProvider::commandProviders()`. `src/php/Console/CLAUDE.md` enumerates both lists by hand, so it drifted the moment that merged.

## 💡 Goal

Keep the Console module docs matching the code, per `.claude/rules/modules.md`.

## 🔖 Changes

- "twelve modules" to "thirteen modules", with `Balance` in the list.
- `Balance` added to the command-provider order, positioned after `Lint` to match `ConsoleProvider::commandProviders()`.

Docs only, no behaviour change, so no CHANGELOG entry.

Refs #3044