### PR TITLE
perf(compiler): lower `not` over a known bool to a native `!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ All notable changes to this project will be documented in this file.
 
 ### Performance
 
+- Lower `(not x)` to a native `!` when `x` is already a proven PHP bool, instead of dispatching `phel.core/not`: 3.7 times faster, and in an `if` test the `Truthy` adapter goes too. Only a hard bool guarantee qualifies, never "looks like a predicate", because `(not 0)` is `false` in Phel while `!0` is `true` in PHP (#3021)
 - Keep the PHAR within its release size budget by excluding dependency-only Gacela tooling
 - Exclude the release-announcement scripts and `infection.json5` from the PHAR (#2994)
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -45,6 +45,7 @@ final readonly class CallSpecialization
             || TypedValueSpecialization::isEmptyCheck($node)
             || TypedValueSpecialization::isContainsCheck($node)
             || NumericOperationSpecialization::isNotEqPeephole($node)
+            || NumericOperationSpecialization::isNotOverBoolOperand($node)
         ) {
             return true;
         }
@@ -84,6 +85,7 @@ final readonly class CallSpecialization
             || AssocConjSpecialization::isTypedAssocConjDissoc($node)
             || AssocConjSpecialization::isAssocConjChain($node)
             || NumericOperationSpecialization::isNotEqPeephole($node)
+            || NumericOperationSpecialization::isNotOverBoolOperand($node)
             || NumericOperationSpecialization::isTypedVariadicChain($node)
             || NumericOperationSpecialization::isTypedIncDec($node)
             || ReduceSpecialization::isTypedVectorReduce($node)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/NumericOperationCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/Specialized/NumericOperationCallEmitter.php
@@ -32,6 +32,12 @@ final readonly class NumericOperationCallEmitter implements SpecializedCallEmitt
             return true;
         }
 
+        // After the `=` peephole on purpose: a typed `=` operand is itself a
+        // bool, so both match `(not (= a b))` and `!==` beats `!(===)`.
+        if ($this->tryEmitNotOverBool($node)) {
+            return true;
+        }
+
         if ($this->tryEmitTypedVariadicChain($node)) {
             return true;
         }
@@ -68,6 +74,28 @@ final readonly class NumericOperationCallEmitter implements SpecializedCallEmitt
         $this->outputEmitter->emitStr('(', $loc);
         $this->outputEmitter->emitNode($args[0]);
         $this->outputEmitter->emitStr(' ' . $op . ' 1)', $loc);
+        return true;
+    }
+
+    /**
+     * `(not x)` where `x` is a guaranteed PHP bool: emits `(!($x))`,
+     * skipping the `phel.core/not` dispatch. Registered as
+     * bool-returning, so a surrounding `if` splices it into the test slot
+     * instead of wrapping it in the truthy adapter.
+     *
+     * Eligibility lives on {@see NumericOperationSpecialization::notOverBoolOperand()}.
+     */
+    private function tryEmitNotOverBool(CallNode $node): bool
+    {
+        $operand = NumericOperationSpecialization::notOverBoolOperand($node);
+        if (!$operand instanceof AbstractNode) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(!(', $loc);
+        $this->outputEmitter->emitNode($operand);
+        $this->outputEmitter->emitStr('))', $loc);
         return true;
     }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecialization.php
@@ -10,6 +10,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\PhpFunctionReturnTypes;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\BooleanExprDetector;
 use Phel\Lang\Keyword;
 
 use function array_all;
@@ -239,6 +240,44 @@ final readonly class NumericOperationSpecialization
     public static function isTypedComparison(CallNode $node): bool
     {
         return in_array(self::typedBinaryOpName($node), self::BOOL_BINARY_OPS, true);
+    }
+
+    /**
+     * `(not x)` where `x` is guaranteed to be a PHP `bool`: returns the
+     * operand so the emitter can splice it behind a native `!`, sparing
+     * the `phel.core/not` dispatch and, in a test slot, the truthy adapter.
+     *
+     * The guard is {@see BooleanExprDetector::isBool()} and nothing looser.
+     * "Looks like a predicate" would be wrong: `(not 0)` is `false` in Phel
+     * because only `nil` and `false` are falsy, while `!0` is `true` in PHP.
+     *
+     * Declines when {@see self::notEqPeepholeInner()} applies. A typed `=`
+     * operand is itself a bool, so both match `(not (= a b))`, and that
+     * peephole's `($a !== $b)` beats this one's `!(($a === $b))`. Keeping
+     * every `not` lowering in this one class is what lets the emitter order
+     * them; the families registered in `CallEmitter` stay disjoint.
+     */
+    public static function notOverBoolOperand(CallNode $node): ?AbstractNode
+    {
+        if (!PhelCoreCall::is($node, 'not')) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        if (self::notEqPeepholeInner($node) instanceof CallNode) {
+            return null;
+        }
+
+        return BooleanExprDetector::isBool($args[0]) ? $args[0] : null;
+    }
+
+    public static function isNotOverBoolOperand(CallNode $node): bool
+    {
+        return self::notOverBoolOperand($node) instanceof AbstractNode;
     }
 
     /**

--- a/tests/phel/core/boolean-operation.phel
+++ b/tests/phel/core/boolean-operation.phel
@@ -106,6 +106,22 @@
   (is (false? (not 10)) "(not 10)")
   (is (false? (not [])) "(not [])"))
 
+;; The emitter lowers `(not x)` to a native `!` only when `x` is a proven PHP
+;; bool. These pin the semantics on both sides of that line: PHP's `!` inverts
+;; truthiness for 0 and "", where Phel treats only nil and false as falsy.
+(deftest test-not-over-a-bool-operand
+  (is (false? (not (php/is_int 1))) "(not (php/is_int 1))")
+  (is (true? (not (php/is_int "a"))) "(not (php/is_int \"a\"))")
+  (is (false? (not (nil? nil))) "(not (nil? nil))")
+  (is (true? (not (nil? 0))) "(not (nil? 0))")
+  (is (true? (not (not (php/is_int 1)))) "a nested (not (not ...)) still folds"))
+
+(deftest test-not-over-a-non-bool-operand-keeps-phel-truthiness
+  (is (false? (not (php/strlen ""))) "(not (php/strlen \"\")) is false: 0 is truthy in Phel")
+  (is (false? (not 0)) "(not 0)")
+  (is (false? (not "")) "(not \"\")")
+  (is (true? (not nil)) "(not nil)"))
+
 (deftest test-not=
   (is (false? (not= false)) "(not= false)")
   (is (false? (not= false false)) "(notfalse? false)")

--- a/tests/php/Benchmark/Phel/CoreBooleanBench.php
+++ b/tests/php/Benchmark/Phel/CoreBooleanBench.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Phel;
+
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+
+use function is_int;
+
+/**
+ * The boolean operators of `phel.core` that carry an emitter optimisation with
+ * no benchmark guarding it: `not` over an operand already known to be a PHP
+ * bool (#3021 C5).
+ *
+ * The pair brackets what that specialisation removes: `bench_not_over_bool`
+ * invokes `phel.core/not`, `bench_not_over_bool_raw` is the native `!` the
+ * emitter now writes instead. Measured 3.7x here (0.751μs against 0.203μs).
+ *
+ * That ratio is a lower bound, not the whole saving. `coreFn()` resolves the
+ * callable once in `setUp`, so the subject pays the invoke but not the registry
+ * lookup a cold call site pays, and in a test slot the change also drops the
+ * `Truthy` adapter (see below).
+ *
+ * Not covered: the same call in an `if` test slot, where registering `not` as
+ * bool-returning also drops the `Truthy` adapter. That saving lives in
+ * `IfEmitter` and cannot be reached through a callable, so it is pinned by the
+ * `Call/not-over-bool-operand-in-test-slot.test` fixture instead.
+ *
+ * {@see CoreBenchCase} for the conventions every subject here follows.
+ *
+ * @BeforeMethods("setUp")
+ */
+final class CoreBooleanBench extends CoreBenchCase
+{
+    /** @var callable */
+    private $not;
+
+    /** Typed `mixed` so the raw pair is real work rather than a foldable literal. */
+    private mixed $a = 7;
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_not_over_bool(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->not)(is_int($this->a));
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_not_over_bool_raw(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            $unused = !is_int($this->a);
+        }
+    }
+
+    protected function setUpFixtures(): void
+    {
+        $this->not = $this->coreFn('not');
+    }
+}

--- a/tests/php/Integration/Fixtures/Call/not-over-bool-operand-in-test-slot.test
+++ b/tests/php/Integration/Fixtures/Call/not-over-bool-operand-in-test-slot.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [x] (if (not (php/is_int x)) 1 2))
+--PHP--
+(function($x) {
+  return (((!(is_int($x)))) ? 1 : 2);
+
+});

--- a/tests/php/Integration/Fixtures/Call/not-over-bool-operand.test
+++ b/tests/php/Integration/Fixtures/Call/not-over-bool-operand.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [x] (not (php/is_int x)))
+--PHP--
+(function($x) {
+  return (!(is_int($x)));
+});

--- a/tests/php/Integration/Fixtures/Call/not-over-non-bool-operand-stays-generic.test
+++ b/tests/php/Integration/Fixtures/Call/not-over-non-bool-operand-stays-generic.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [x] (not (php/strlen x)))
+--PHP--
+(function($x) {
+  static $__phel_call_0;
+  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "not"))->__invoke(strlen($x));
+});

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NumericOperationSpecializationTest.php
@@ -10,6 +10,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NumericOperationSpecialization;
 use Phel\Lang\Keyword;
@@ -55,6 +56,68 @@ final class NumericOperationSpecializationTest extends TestCase
         $outer = $this->coreCall('inc', [$inner]);
 
         self::assertNull(NumericOperationSpecialization::notEqPeepholeInner($outer));
+    }
+
+    public function test_not_over_bool_operand_returns_the_operand(): void
+    {
+        $operand = $this->boolPhpCall('is_int');
+        $outer = $this->coreCall('not', [$operand]);
+
+        self::assertSame($operand, NumericOperationSpecialization::notOverBoolOperand($outer));
+        self::assertTrue(NumericOperationSpecialization::isNotOverBoolOperand($outer));
+    }
+
+    /**
+     * `strlen` returns int, and `!0` is `true` in PHP while `(not 0)` is
+     * `false` in Phel. Anything looser than a hard bool guarantee inverts
+     * truthiness here.
+     */
+    public function test_not_over_a_non_bool_php_call_declines(): void
+    {
+        $outer = $this->coreCall('not', [$this->boolPhpCall('strlen')]);
+
+        self::assertNull(NumericOperationSpecialization::notOverBoolOperand($outer));
+    }
+
+    public function test_not_over_an_untyped_local_declines(): void
+    {
+        $outer = $this->coreCall('not', [new LocalVarNode($this->env(), Symbol::create('x'))]);
+
+        self::assertNull(NumericOperationSpecialization::notOverBoolOperand($outer));
+    }
+
+    /**
+     * A typed `=` operand is itself a bool, so both lowerings match. The
+     * `=` peephole emits `($a !== $b)`, which beats `!(($a === $b))`, so
+     * this one must stand down and let the emitter reach it.
+     */
+    public function test_not_over_bool_yields_to_the_typed_eq_peephole(): void
+    {
+        $inner = $this->coreCall('=', [
+            $this->localWithTag('a', 'int'),
+            $this->localWithTag('b', 'int'),
+        ]);
+        $outer = $this->coreCall('not', [$inner]);
+
+        self::assertNull(NumericOperationSpecialization::notOverBoolOperand($outer));
+        self::assertSame($inner, NumericOperationSpecialization::notEqPeepholeInner($outer));
+    }
+
+    public function test_not_with_two_arguments_declines(): void
+    {
+        $outer = $this->coreCall('not', [
+            $this->boolPhpCall('is_int'),
+            $this->boolPhpCall('is_int'),
+        ]);
+
+        self::assertNull(NumericOperationSpecialization::notOverBoolOperand($outer));
+    }
+
+    public function test_a_call_that_is_not_not_declines(): void
+    {
+        $outer = $this->coreCall('inc', [$this->boolPhpCall('is_int')]);
+
+        self::assertNull(NumericOperationSpecialization::notOverBoolOperand($outer));
     }
 
     public function test_variadic_mul_three_int_locals_chains_arith(): void
@@ -257,6 +320,20 @@ final class NumericOperationSpecializationTest extends TestCase
                 Phel::map(),
             ),
             $args,
+        );
+    }
+
+    /**
+     * A `(php/<fn> x)` call node. `is_int` is on
+     * `BooleanExprDetector::BOOL_PHP_FUNCTIONS`, `strlen` is not, which is
+     * what separates the eligible case from the ineligible one.
+     */
+    private function boolPhpCall(string $phpFunction): CallNode
+    {
+        return new CallNode(
+            $this->env(),
+            new PhpVarNode($this->env(), $phpFunction),
+            [new LocalVarNode($this->env(), Symbol::create('x'))],
         );
     }
 


### PR DESCRIPTION
## 🤔 Background

C5 from #3021, which the issue flags as the best value for effort in the emitter list. `(not x)` went through the `phel.core/not` registry dispatch even when `x` was already a proven PHP bool, and in an `if` test the result was then wrapped in the truthy adapter.

The eligibility test already existed as `BooleanExprDetector::isBool`. Nothing consumed it for `not`.

## 💡 Goal

Emit `!` where `!` is provably correct, and nowhere else.

## 🔖 Changes

Before and after, same snippet:

```php
// (fn [x] (not (php/is_int x)))
return (\Phel::getDefinition("phel.core", "not"))->__invoke(is_int($x));   // before
return (!(is_int($x)));                                                    // after

// (fn [x] (if (not (php/is_int x)) 1 2))   — the adapter goes too
return (($__truthy = (\Phel::getDefinition("phel.core", "not"))->__invoke(is_int($x))) !== null && $__truthy !== false ? 1 : 2);
return (((!(is_int($x)))) ? 1 : 2);
```

**Measured 3.7x** on the dispatch alone, 0.751μs against 0.203μs, via the new `CoreBooleanBench`. That is a lower bound, not the headline: the benchmark pre-resolves the callable in `setUp`, so it pays the invoke but not a cold call site's registry lookup, and the test-slot saving cannot be reached through a callable at all. The issue's own estimate was 12.9x; I could not reproduce that figure and am reporting what I measured.

### The guard

`BooleanExprDetector::isBool` and nothing looser. "Looks like a predicate" inverts truthiness: `(not 0)` is `false` in Phel because only `nil` and `false` are falsy, while `!0` is `true` in PHP. So this deliberately keeps dispatching:

```php
// (fn [x] (not (php/strlen x)))   — strlen returns int, not bool
return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "not"))->__invoke(strlen($x));
```

### Why both `not` lowerings share one class

A typed `=` operand is itself a bool, so this specialisation and the existing `=` peephole both match `(not (= a b))`, and `($a !== $b)` beats `!(($a === $b))`. Putting the new one in `NumericOperationSpecialization` next to `notEqPeepholeInner` lets the emitter order them explicitly and keeps `CallEmitter`'s documented invariant intact: the registered families stay disjoint, so the order *between* families still does not matter.

### Tests

- 3 integration fixtures: the plain lowering, the test-slot lowering, and `php/strlen` staying generic. The test-slot one is the only pin on the adapter saving, since no benchmark can reach it.
- 6 unit tests on the eligibility predicate, including the yield-to-`=`-peephole case and the two-argument and wrong-fn declines.
- 2 Phel-level tests in `boolean-operation.phel` pinning runtime semantics on both sides of the line: `(not (php/strlen ""))`, `(not 0)` and `(not "")` all stay `false`.
- `CoreBooleanBench`, new. `not` had no benchmark, so CI's regression gate could not see this until now.

`composer test` exits 0; core tests 7341 → 7350.

Refs #3021