### PR TITLE
perf(core): build to-php-array's result with toArray, not apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ Standard library:
 
 Runtime core:
 
+- Build a PHP array in `to-php-array` with `SeqInterface::toArray` instead of spreading the collection through `apply`, which rebuilt it from the iterator: 3.3x on a three-element vector and 8.7x on a hundred-element one, carrying `phel.string/join` 2.2x with it. Maps, sets and strings have no `toArray` and keep the old path, which is also the only one that flattens a map into pairs (#3057)
 - Give `map` and `filter` fixed arities instead of a rest argument plus a count check: 2.7 times faster to call, and 3 times for the transducer arity (#3021)
 - Compare two native ints in `<`, `<=`, `>` and `>=` without the numeric-tower dispatch: 2.5 to 2.7 times faster, down to raw PHP comparison speed (#2984)
 - **BREAKING** `sort-by` now calls its key function once per element instead of twice per comparison, so an *impure* key function runs far fewer times (100 rather than about 1114 when sorting 100 elements). The sorted result is unchanged. Up to 2.2 times faster; recorded in `docs/spec/clojure-divergences.md` since Clojure calls per comparison (#3006)

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -4,6 +4,7 @@
 (use Phel.Lang.Collections.LinkedList.PersistentListInterface)
 (use Phel.Lang.Collections.Map.PersistentMapInterface)
 (use Phel.Lang.Collections.Vector.PersistentVectorInterface)
+(use Phel.Lang.SeqInterface)
 (use Phel.Lang.Symbol)
 
 ;; The macro-definition layer that the rest of the language is built on.
@@ -25,7 +26,16 @@
   (fn [coll]
     (if (php/is_array coll)
       coll
-      (apply php/array coll))))
+      ;; `SeqInterface` declares `toArray`, and every sequential type reaches
+      ;; it: `PersistentVectorInterface` and `PersistentListInterface` both
+      ;; extend it, as do the lazy seqs and `Cons`. Going through `apply`
+      ;; instead spread the collection into a variadic call and rebuilt the
+      ;; array from the iterator. Maps, sets and strings have no `toArray` and
+      ;; keep the old path, which is also the only one that can flatten a map
+      ;; into pairs.
+      (if (php/instanceof coll SeqInterface)
+        (php/-> coll (toArray))
+        (apply php/array coll)))))
 
 (def defn-builder
   {:macro true, :private true}

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -34,7 +34,7 @@
       ;; keep the old path, which is also the only one that can flatten a map
       ;; into pairs.
       (if (php/instanceof coll SeqInterface)
-        (php/-> coll (toArray))
+        (.toArray coll)
         (apply php/array coll)))))
 
 (def defn-builder

--- a/tests/phel/core/sequence-functions.phel
+++ b/tests/phel/core/sequence-functions.phel
@@ -428,6 +428,21 @@
   (is (= (php-indexed-array 3 2 1) (to-php-array [3 2 1])) "to-php-array")
   (is (= (php-indexed-array "a" "b" "c") (to-php-array "abc")) "to-php-array string characters"))
 
+(deftest test-to-php-array-over-every-input-shape
+  ;; Sequential types now go through `SeqInterface::toArray`; everything else
+  ;; keeps the `apply` path. Both must answer what they always did.
+  (is (= (php-indexed-array 1 2 3) (to-php-array '(1 2 3))) "list")
+  (is (= (php-indexed-array) (to-php-array [])) "empty vector")
+  (is (= (php-indexed-array) (to-php-array '())) "empty list")
+  (is (= (php-indexed-array 1 2 3) (to-php-array (subvec [0 1 2 3] 1 4))) "subvector")
+  (is (= (php-indexed-array 1 2 3) (to-php-array (cons 1 '(2 3)))) "cons")
+  (is (= (php-indexed-array 2 3 4) (to-php-array (map inc [1 2 3]))) "lazy seq")
+  (is (= (php-indexed-array 0 1 2) (to-php-array (range 0 3))) "range")
+  (is (= (php-indexed-array 1 2) (to-php-array (php-indexed-array 1 2))) "a PHP array passes through")
+  ;; A map has no `toArray`, and only the `apply` path flattens it to pairs.
+  (is (= 2 (php/count (to-php-array {:a 1, :b 2}))) "map yields one entry per pair")
+  (is (= [:a 1] (php/aget (to-php-array {:a 1}) 0)) "map entries stay key/value vectors"))
+
 (deftest test-sort
   (is (= [] (sort nil)) "sort nil")
   (is (= [1 2 3] (sort [3 2 1])) "sort")

--- a/tests/php/Benchmark/Phel/CoreConstructionBench.php
+++ b/tests/php/Benchmark/Phel/CoreConstructionBench.php
@@ -38,6 +38,15 @@ final class CoreConstructionBench extends CoreBenchCase
     /** @var callable */
     private $str;
 
+    /** @var callable */
+    private $toPhpArray;
+
+    private mixed $smallVector = null;
+
+    private mixed $largeVector = null;
+
+    private mixed $map = null;
+
     /** Typed `mixed` so `str` cannot see a string and skip its conversion. */
     private mixed $a = 'a';
 
@@ -139,9 +148,58 @@ final class CoreConstructionBench extends CoreBenchCase
         }
     }
 
+    /**
+     * `to-php-array` over a sequential collection (#3021 A6). It used to be
+     * `(apply php/array coll)`, which spread the collection into a variadic
+     * call and rebuilt the array from the iterator; `SeqInterface::toArray`
+     * does it directly.
+     *
+     * Two sizes, because the old cost grew with the collection and the new one
+     * barely does: 1.08μs to 0.47μs at three elements, 10.61μs to 1.39μs at a
+     * hundred, against a ~0.18μs empty-closure floor.
+     *
+     * @Revs(1000)
+     */
+    public function bench_to_php_array_small(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->toPhpArray)($this->smallVector);
+        }
+    }
+
+    /**
+     * Called once per rev rather than folded into the `INNER` loop: the cost
+     * already grows with the input, so the timer is negligible against it.
+     *
+     * @Revs(1000)
+     */
+    public function bench_to_php_array_large(): void
+    {
+        ($this->toPhpArray)($this->largeVector);
+    }
+
+    /**
+     * A map has no `toArray`, so it still goes through `apply`. Paired with the
+     * two above it shows the branch is doing what it claims: this one should
+     * not move.
+     *
+     * @Revs(1000)
+     */
+    public function bench_to_php_array_map(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->toPhpArray)($this->map);
+        }
+    }
+
     protected function setUpFixtures(): void
     {
         $this->hashSet = $this->coreFn('hash-set');
         $this->str = $this->coreFn('str');
+
+        $this->toPhpArray = $this->coreFn('to-php-array');
+        $this->smallVector = Phel::vector(['a', 'b', 'c']);
+        $this->largeVector = Phel::vector(range(0, 99));
+        $this->map = Phel::map(Phel::keyword('a'), 1, Phel::keyword('b'), 2);
     }
 }


### PR DESCRIPTION
## 🤔 Background

Item A6 of #3021, and the residual #3053 left behind and named: `phel.string/join` still cost 1.32us because `to-php-array` was most of it.

`to-php-array` was `(apply php/array coll)`, which spreads the collection into a variadic call and rebuilds the array from the iterator, so the cost grew with the collection.

## 💡 Goal

Ask the collection for its array instead of reconstructing one.

## 🔖 Changes

- `SeqInterface` declares `toArray`, and every sequential type reaches it: `PersistentVectorInterface` and `PersistentListInterface` both extend it, as do the lazy seqs and `Cons`.
- Against a ~0.18us empty-closure floor, same process, `origin/main` at f6bcc4490: a three-element vector 1.08us to 0.47us (**3.3x**), a hundred-element vector 10.61us to 1.39us (**8.7x**), and `phel.string/join` 1.32us to 0.70us (**2.2x**).
- Maps, sets and strings have no `toArray` and keep the `apply` path, which is also the only one that flattens a map into key/value pairs. Lists, maps and plain PHP arrays measure unchanged, and a bench subject over a map pins that the untouched branch stays untouched.
- Equivalence checked against the previous implementation over vectors, empty vectors, a hundred-element vector, lists, empty lists, subvectors, `cons`, lazy seqs, ranges, maps, empty maps, sets, strings, nested and mixed vectors, and a plain PHP array: 18 shapes, no differences.

## One correction to the audit

It records that this item "caps how fast B4 can get". Measured, it does not: a whole-document `phel.html` render is flat across the change, 89.6us against 90.1us. `to-php-array` is only reached there for map-valued and vector-valued attributes, not per node.

Worth knowing for anyone writing a similar harness: Phel `=` over a PHP array of objects is identity-based, so `(= (old m) (old m))` is already false. My first sweep reported a false mismatch on the map case until I compared serialised.

Closes #3057
