### PR TITLE
docs(core): add `to-array` to `to-php-array` see also section

### DIFF
--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -22,7 +22,7 @@
 
 (def to-php-array
   {:doc "Creates a PHP Array from a sequential data structure."
-   :see-also ["php-array-to-map" "phel->php"]}
+   :see-also ["to-array" "php-array-to-map" "phel->php"]}
   (fn [coll]
     (if (php/is_array coll)
       coll


### PR DESCRIPTION
 Added `to-array` link to `to-php-array` ’s `:see-also` metadata in `src/phel/core/defs.phel`.