### PR TITLE
perf(core): give sort-by the native int fast path sort already had

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ Compiler:
 
 Runtime core:
 
+- Order `sort-by`'s decorated keys with native comparisons when they are all native ints and no comparator was supplied, the fast path `sort` got in #3004: 8.4x over 100 ints, 6.4x over 20, 5.2x for `(sort-by count strings)`. Non-int keys and a supplied comparator keep the general path (#3079)
 - Seed `union`'s result from its first argument instead of re-adding every element of it to a fresh set, and give it fixed arities: `(union big small)` over 200 and 5 elements 63x, `(union s)` 51x, two 20-element sets 3.0x. Non-set iterables are still added element by element, since `union` accepts any iterable and returns a set (#3077)
 - Stop `all?` and `some?` re-testing `empty?` on the collection once per element, by testing the first element directly and walking a seq only for the tail: `every?` over a list 2.1x, `not-any?` 1.5x, `all?` and `every?` over a vector 1.4x, with a short-circuiting call unchanged. `some` keeps its seq walk on purpose (#3074)
 - Reach a transient map in `get` by its own branch instead of falling through seven predicates to the generic `aget`, and give `assoc!` the fixed three-argument arity `conj!`, `dissoc!` and `disj!` already had: `assoc!` 1.74x, `frequencies` 1.18x, `select-keys` 1.16x. Paid by every `for :reduce` over a transient (#3071)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1035,6 +1035,17 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps."
   [coll comp]
   (sorted-vector coll (sort-comparator comp)))
 
+(defn- all-int-first-elements?
+  "True when every `[key value]` pair carries a native int key. Mirrors
+  `all-native-ints?`, over the decorated pairs rather than the elements."
+  [pairs]
+  (let [found (php/array true)]
+    (foreach [p pairs]
+      (when-not (php/is_int (php/aget p 0))
+        (php/aset found 0 false)
+        php/break))
+    (php/aget found 0)))
+
 (defn- sort-by-with
   "Decorate, sort, undecorate. Building the comparator as
   `#(cmp (keyfn %1) (keyfn %2))` runs `keyfn` twice per comparison, so O(n log n)
@@ -1063,7 +1074,21 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps."
       (php/apush pairs (php-indexed-array (keyfn v) v)))
     ;; `usort` is stable as of PHP 8.0, so ties keep their input order, which is
     ;; what the undecorated result has to preserve.
-    (php/usort pairs (fn [a b] (cmp (php/aget a 0) (php/aget b 0))))
+    ;; When the derived keys are all native ints and no comparator was
+    ;; supplied, order them with native comparisons rather than calling back
+    ;; into Phel. `usort` still runs a closure per comparison either way, but
+    ;; this one's body is `php/` interop and reaches no registry, where `cmp`
+    ;; is a Phel function wrapping `compare`. Same idea as
+    ;; `sorted-vector-natural`, and the same narrowness: ints only, because a
+    ;; float brings NaN and a mixed pair does not order the way `compare` does.
+    (if (and (identical? comp compare) (all-int-first-elements? pairs))
+      (php/usort pairs (fn [a b]
+                         (let [ka (php/aget a 0)
+                               kb (php/aget b 0)]
+                           (if (php/< ka kb)
+                             -1
+                             (if (php/> ka kb) 1 0)))))
+      (php/usort pairs (fn [a b] (cmp (php/aget a 0) (php/aget b 0)))))
     (let [result (php-indexed-array)]
       (foreach [p pairs]
         (php/apush result (php/aget p 1)))

--- a/tests/phel/core/sort-by-int-keys.phel
+++ b/tests/phel/core/sort-by-int-keys.phel
@@ -1,0 +1,54 @@
+(ns phel-test.core.sort-by-int-keys
+  (:require phel.test :refer [deftest is]))
+
+;; `sort-by` orders its decorated `[key value]` pairs with native comparisons
+;; when every key is a native int and no comparator was supplied. The fast path
+;; must produce exactly what the general path produces, ties included, and must
+;; not engage for anything else.
+
+(def- reference-comparator (fn [a b] (compare a b)))
+
+(defn- slow-sort-by
+  "`sort-by` forced onto the general path by handing it a comparator that is
+  not `compare` itself, so the two orders can be diffed."
+  [keyfn coll]
+  (sort-by keyfn reference-comparator coll))
+
+(deftest test-int-keys-match-the-general-path
+  (foreach [coll [[3 1 4 1 5 9 2 6]
+                  []
+                  [1]
+                  [2 2 2]
+                  [-5 3 -1 0]
+                  [1000000 -1000000 0]
+                  (vec (range 0 50))
+                  (vec (map (fn [i] (php/% (* i 17) 30)) (range 0 60)))]]
+    (is (= (slow-sort-by identity coll) (sort-by identity coll))
+        (str "identity keys over " (count coll) " elements"))))
+
+(deftest test-derived-int-keys
+  (let [words ["ccc" "a" "bb" "dddd" "e"]]
+    (is (= (slow-sort-by count words) (sort-by count words)) "count as the key"))
+  (let [maps [{:n 3} {:n 1} {:n 2}]]
+    (is (= [{:n 1} {:n 2} {:n 3}] (sort-by (fn [m] (get m :n)) maps)) "a key read out of a map")))
+
+(deftest test-ties-keep-their-input-order
+  ;; usort is stable as of PHP 8, and the fast path must not change that.
+  (let [pairs [[1 :a] [0 :b] [1 :c] [0 :d] [1 :e]]]
+    (is (= [[0 :b] [0 :d] [1 :a] [1 :c] [1 :e]]
+           (sort-by (fn [p] (get p 0)) pairs))
+        "equal keys stay in the order they arrived")))
+
+(deftest test-non-int-keys-do-not-take-the-fast-path
+  (is (= ["a" "bb" "ccc"] (sort-by identity ["ccc" "a" "bb"])) "string keys")
+  (is (= [1.5 2.5 3.5] (sort-by identity [3.5 1.5 2.5])) "float keys")
+  (is (= [[1] [2] [3]] (sort-by identity [[3] [1] [2]])) "vector keys")
+  ;; One non-int key is enough to disqualify the whole collection.
+  (is (= (slow-sort-by identity [1 2.0 3]) (sort-by identity [1 2.0 3]))
+      "a single float among ints"))
+
+(deftest test-a-supplied-comparator-still-wins
+  (is (= [9 5 4 3 2 1] (sort-by identity (fn [a b] (compare b a)) [3 1 4 9 2 5]))
+      "a reversing comparator is honoured over the fast path")
+  (is (= [1 2 3 4 5 9] (sort-by identity compare [3 1 4 9 2 5]))
+      "passing `compare` explicitly gives the same order as omitting it"))


### PR DESCRIPTION
## 🤔 Background

Fourth pass of the core outlier survey, after #3071, #3074 and #3077.

`(sort-by identity coll)` over 20 ints costs **67us**. `(sort coll)` over the same 20 ints costs **3.5us**. A 19x gap for a key function that does nothing.

#3004 gave `sort` a native fast path and `sort-by` never got one. `sorted-vector-natural` scans for all-native-ints and hands the whole sort to `php/sort`; `sort-by` always calls `php/usort` with a closure whose body calls `cmp` — a Phel function wrapping `compare` — once per comparison, O(n log n) times.

## 💡 Goal

Stop `sort-by` calling back into Phel per comparison when it does not need to.

## 🔖 Changes

`sort-by` cannot use `php/sort`, because it sorts decorated `[key value]` pairs and undecorates afterwards. It can still avoid the registry: `usort` runs a closure per comparison either way, and a closure whose body is `php/` interop reaches nothing.

Floor-subtracted, same process, `origin/main` at af1fd81a7:

| | before | after | |
|---|---|---|---|
| `(sort-by identity …)` over 100 ints | 453.2us | 54.2us | **8.4x** |
| `(sort-by identity …)` over 20 ints | 67.2us | 10.6us | **6.4x** |
| `(sort-by identity compare …)` over 20 | 67.8us | 10.8us | **6.3x** |
| `(sort-by count …)` over 20 strings | 55.5us | 10.9us | **5.2x** |
| `(sort-by #(get % :n) …)` over 20 maps | 81.6us | 24.3us | **3.4x** |
| `(sort-by identity …)` over 20 strings | 62.4us | 64.0us | unchanged |
| `(sort …)` over 20 ints | 3.50us | 3.50us | unchanged |

The gap widens with n, being a per-comparison cost.

## Constraints it respects

- **Ints only**, for the reason `all-native-ints?` already documents: a float brings NaN, and a mixed pair does not order the way `compare` orders it. One non-int key disqualifies the collection.
- The eligibility test is on the **derived keys**, not the elements — which is why `(sort-by count strings)` qualifies while `(sort-by identity strings)` does not.
- A supplied comparator wins over the fast path. Passing `compare` explicitly is the same request as omitting it, so `(sort-by f compare coll)` takes it too.
- `usort` is stable as of PHP 8 and the general path relies on that, so equal keys must keep their input order.

## Tests

Rather than asserting expected orders by hand, the tests **diff the fast path against the general one** over the same collections — forced apart by supplying a comparator that is not `compare` itself. Plus stability on repeated keys, a single float among ints disqualifying the whole collection, and a reversing comparator winning.

Closes #3079
