### PR TITLE
perf(core): stop tree-seq dispatching per node and reversing per branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ Compiler:
 
 Runtime core:
 
+- Walk `tree-seq`'s stack with native PHP operations and push children by index instead of building a reversed collection per branch node: 2.1x, carrying `flatten` with it (#3081)
 - Order `sort-by`'s decorated keys with native comparisons when they are all native ints and no comparator was supplied, the fast path `sort` got in #3004: 8.4x over 100 ints, 6.4x over 20, 5.2x for `(sort-by count strings)`. Non-int keys and a supplied comparator keep the general path (#3079)
 - Seed `union`'s result from its first argument instead of re-adding every element of it to a fresh set, and give it fixed arities: `(union big small)` over 200 and 5 elements 63x, `(union s)` 51x, two 20-element sets 3.0x. Non-set iterables are still added element by element, since `union` accepts any iterable and returns a set (#3077)
 - Stop `all?` and `some?` re-testing `empty?` on the collection once per element, by testing the first element directly and walking a seq only for the tail: `every?` over a list 2.1x, `not-any?` 1.5x, `all?` and `every?` over a vector 1.4x, with a short-circuiting call unchanged. `some` keeps its seq walk on purpose (#3074)

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -387,14 +387,26 @@ Without arguments, uses a default cache size of 128 entries."
   {:example "(tree-seq indexed? identity [1 [2 3]]) ; => [[1 [2 3]] 1 [2 3] 2 3]"
    :see-also ["flatten"]}
   [branch? children root]
+  ;; The stack is a PHP array, so its length and its pop are PHP operations.
+  ;; `count` and `pop` are core functions that dispatch over every collection
+  ;; kind to answer for one, and this loop runs them once per node.
   (let [ret (transient [])]
     (loop [stack (php-indexed-array root)]
-      (if (> (count stack) 0)
-        (let [node (pop stack)]
+      (if (php/> (php/count stack) 0)
+        (let [node (php/array_pop (php/ref stack))]
           (.append ret node)
           (when (branch? node)
-            (foreach [child (reverse (children node))]
-              (php/apush stack child)))
+            ;; Children go onto the stack in reverse so they come off in order.
+            ;; Collected into a PHP array and walked backwards rather than run
+            ;; through core `reverse`, which builds a persistent collection per
+            ;; branch node only to iterate it once.
+            (let [kids (php/array)]
+              (foreach [child (children node)]
+                (php/apush kids child))
+              (loop [i (php/- (php/count kids) 1)]
+                (when (php/>= i 0)
+                  (php/apush stack (php/aget kids i))
+                  (recur (php/- i 1))))))
           (recur stack))
         (copy-meta root (persistent ret))))))
 

--- a/tests/phel/core/tree-seq-walk.phel
+++ b/tests/phel/core/tree-seq-walk.phel
@@ -1,0 +1,44 @@
+(ns phel-test.core.tree-seq-walk
+  (:require phel.test :refer [deftest is]))
+
+;; `tree-seq` walks with a PHP-array stack now, and pushes children by index
+;; rather than through core `reverse`. The visit order is the contract, so it
+;; is what these pin: depth-first, parent before children, children left to
+;; right.
+
+(deftest test-documented-example
+  (is (= [[1 [2 3]] 1 [2 3] 2 3] (tree-seq indexed? identity [1 [2 3]]))
+      "the docstring example"))
+
+(deftest test-visit-order-is-depth-first-left-to-right
+  (is (= [[1 2] 1 2] (tree-seq indexed? identity [1 2])) "a flat vector")
+  (is (= [[[1 2] [3 4]] [1 2] 1 2 [3 4] 3 4]
+         (tree-seq indexed? identity [[1 2] [3 4]]))
+      "the first subtree is fully visited before the second")
+  (is (= [[1 [2 [3]]] 1 [2 [3]] 2 [3] 3]
+         (tree-seq indexed? identity [1 [2 [3]]]))
+      "nesting descends before moving on")
+  (is (= [[1 2 3 4 5] 1 2 3 4 5] (tree-seq indexed? identity [1 2 3 4 5]))
+      "five children keep their order"))
+
+(deftest test-edge-shapes
+  (is (= [[]] (tree-seq indexed? identity [])) "an empty branch is still visited")
+  (is (= [1] (tree-seq indexed? identity 1)) "a leaf root")
+  (is (= [[[]] []] (tree-seq indexed? identity [[]])) "a branch holding an empty branch")
+  (is (= ['(1 2) 1 2] (tree-seq indexed? identity '(1 2))) "over a list"))
+
+(deftest test-branch-and-children-are-honoured
+  ;; `branch?` decides what is descended into, `children` decides what comes
+  ;; back; neither is assumed to be `indexed?` / `identity`.
+  (let [tree {:v 1, :kids [{:v 2, :kids []} {:v 3, :kids [{:v 4, :kids []}]}]}
+        nodes (tree-seq (fn [n] (not (empty? (get n :kids))))
+                        (fn [n] (get n :kids))
+                        tree)]
+    (is (= [1 2 3 4] (map (fn [n] (get n :v)) nodes))
+        "a map tree walks parent then children in order")))
+
+(deftest test-flatten-rides-on-tree-seq
+  (is (= [1 2 3 4 5 6] (vec (flatten [[1 2] [3 [4 5]] 6]))) "the docstring example")
+  (is (= [] (vec (flatten []))) "an empty collection")
+  (is (= [1 2 3] (vec (flatten [1 [2] [[3]]]))) "uneven nesting")
+  (is (= [1 2 3 4] (vec (flatten [[[1]] [[2] [3]] 4]))) "deeper nesting"))


### PR DESCRIPTION
## 🤔 Background

Fifth pass of the core outlier survey, after #3071, #3074, #3077 and #3079.

`flatten` costs 17.7us on `[[1 2] [3 [4 5]] 6]`, and **15.9us of that is `tree-seq`**, which it is built on. `tree-seq` walks with an explicit stack held in a PHP array, then reaches for core functions to work on it.

## 💡 Goal

Stop paying collection-agnostic dispatch for a stack that is always a PHP array.

## 🔖 Changes

Two costs, both per node:

1. **`count` and `pop` are core functions** that dispatch over every collection kind to answer for the one kind this stack ever is. `php/count` and `php/array_pop` do it natively — and `pop` on a PHP array is already `array_pop` semantics, mutation included, so the meaning does not change.
2. **`(reverse (children node))` built a persistent collection for every branch node** only to iterate it once and throw it away. Children are pushed reversed so they come off the stack in order, which an index walk gives without materialising anything.

Floor-subtracted, same process, `origin/main` at d4746aad8:

| | before | after | |
|---|---|---|---|
| `tree-seq` over a 20-branch tree | 85.3us | 40.7us | **2.09x** |
| `flatten` over the same | 86.9us | 42.3us | **2.06x** |
| `tree-seq` over a deep chain | 30.5us | 14.7us | **2.08x** |
| `tree-seq` over the docstring example | 16.4us | 8.4us | **1.96x** |
| `flatten` over the docstring example | 17.5us | 10.0us | **1.76x** |

Splitting the two: the native stack operations are **1.3x** on their own, and dropping the per-node `reverse` takes it the rest of the way.

## Tests

Visit order is the whole contract, so it is pinned directly rather than trusted through `flatten`'s output: depth-first, parent before children, children left to right. Plus an empty branch (still visited), a leaf root, a list rather than a vector, and a `branch?`/`children` pair that is not `indexed?`/`identity` — because neither is assumed by the walk.

Closes #3081
