### PR TITLE
perf(core): add ints natively in sum instead of spreading them into +

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Compiler:
 
 Runtime core:
 
+- Add a PHP array of ints in `sum` with `array_sum` instead of spreading the collection into the variadic arm of `+`: 27.5x over 200 ints, 17.5x over 20, carrying `mean` 13.9x with it. An overflowing int sum is redone through `+` so it still promotes to BigInt rather than becoming a float (#3085)
 - Give the closure returned by `juxt` real arities, as `partial`, `fnil` and `comp` got in #3026: 4.3x to 5.8x per call for one to three functions, 2.5x through `map`. Give `interleave` a two-collection arity: 13x when a collection is nil, 1.4x on small inputs (#3083)
 - Walk `tree-seq`'s stack with native PHP operations and push children by index instead of building a reversed collection per branch node: 2.1x, carrying `flatten` with it (#3081)
 - Order `sort-by`'s decorated keys with native comparisons when they are all native ints and no comparator was supplied, the fast path `sort` got in #3004: 8.4x over 100 ints, 6.4x over 20, 5.2x for `(sort-by count strings)`. Non-int keys and a supplied comparator keep the general path (#3079)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -732,12 +732,41 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
     (throw (new InvalidArgumentException "Max values is bigger than min value")))
   (php/max (php/min v max) min))
 
+(defn- all-native-ints?
+  "True when every element of the PHP array is a native int. Mirrors the
+  namesake in `seq-fns`, which cannot be reached from here: both are private,
+  and this file loads first."
+  [php-array]
+  (let [found (php/array true)]
+    (foreach [x php-array]
+      (when-not (php/is_int x)
+        (php/aset found 0 false)
+        php/break))
+    (php/aget found 0)))
+
 (defn sum
   "Returns the sum of all elements is `xs`."
   {:example "(sum [1 2 3]) ; => 6"
    :see-also ["+" "mean" "median"]}
   [xs]
-  (apply + xs))
+  ;; `array_sum` adds a PHP array of ints in C, where `(apply + xs)` spreads the
+  ;; collection into the variadic arm of `+` and walks it one guarded addition
+  ;; at a time. Narrow to all-native-ints for the reason `sort`'s fast path is
+  ;; (`all-native-ints?` in `seq-fns`): anything else brings BigInt, Ratio, NaN
+  ;; or mixed-type addition, none of which `array_sum` reproduces.
+  ;;
+  ;; `array_sum` returns a float exactly when the int sum overflowed, and Phel's
+  ;; `+` promotes to BigInt there instead, so that case is redone the long way.
+  ;; The fallback spreads `arr` rather than `xs`: the conversion has already
+  ;; happened by then, and re-walking the original collection made a non-int
+  ;; sum measurably slower than before the fast path existed.
+  (let [arr (to-php-array xs)]
+    (if (all-native-ints? arr)
+      (let [total (php/array_sum arr)]
+        (if (php/is_int total)
+          total
+          (apply + arr)))
+      (apply + arr))))
 
 (defn mean
   "Returns the mean of `xs` as a float."

--- a/tests/phel/core/sum-fast-path.phel
+++ b/tests/phel/core/sum-fast-path.phel
@@ -1,0 +1,48 @@
+(ns phel-test.core.sum-fast-path
+  (:require phel.test :refer [deftest is]))
+
+;; `sum` adds a PHP array of ints with `array_sum` instead of spreading the
+;; collection into the variadic arm of `+`. The fast path is narrow on purpose,
+;; and the one case it cannot answer is an int sum that overflows, where Phel's
+;; `+` promotes to BigInt and `array_sum` gives a float.
+
+(deftest test-sum-over-int-collections
+  (is (= 6 (sum [1 2 3])) "a vector of ints")
+  (is (= 0 (sum [])) "an empty collection")
+  (is (= 42 (sum [42])) "a single element")
+  (is (= -3 (sum [-5 3 -1])) "negatives")
+  (is (= 0 (sum [0 0 0])) "zeros")
+  (is (= 6 (sum '(1 2 3))) "a list")
+  (is (= 45 (sum (range 0 10))) "a range")
+  (is (= 10 (sum (take 5 (range 0 100)))) "a lazy seq")
+  (is (= 6 (sum (php-indexed-array 1 2 3))) "a PHP array")
+  (is (= 19900 (sum (range 0 200))) "200 elements"))
+
+(deftest test-sum-keeps-int-results-int
+  (is (= "int" (php/get_debug_type (sum [1 2 3]))) "ints sum to an int")
+  (is (= "int" (php/get_debug_type (sum []))) "an empty sum is an int"))
+
+(deftest test-sum-over-non-int-collections
+  (is (= 4.0 (sum [1.5 2.5])) "floats")
+  (is (= 6.5 (sum [1 2.5 3])) "mixed ints and floats")
+  (is (= "float" (php/get_debug_type (sum [1.5 2.5]))) "floats sum to a float")
+  ;; One non-int is enough to leave the fast path.
+  (is (= 3.5 (sum [1 2.5])) "a single float among ints"))
+
+(deftest test-sum-overflow-promotes-like-plus
+  ;; array_sum returns a float exactly when the int sum overflows; `+` promotes
+  ;; to BigInt instead, and `sum` has to keep doing that.
+  (let [maxi (php/constant "PHP_INT_MAX")
+        mini (php/constant "PHP_INT_MIN")]
+    (is (= (+ maxi 0) (sum [maxi 0])) "at the boundary, no overflow")
+    (is (= "int" (php/get_debug_type (sum [maxi 0]))) "and still an int")
+    (is (= (+ maxi 1) (sum [maxi 1])) "past the boundary matches `+`")
+    (is (= (php/get_debug_type (+ maxi 1)) (php/get_debug_type (sum [maxi 1])))
+        "and promotes to the same type `+` promotes to")
+    (is (= (+ mini -1) (sum [mini -1])) "negative overflow matches `+`")))
+
+(deftest test-mean-rides-on-sum
+  (is (= 2.0 (mean [1 2 3])) "ints give a float mean")
+  (is (= 2.0 (mean [1.5 2.5])) "floats")
+  (is (= 4.0 (mean [4])) "a single element")
+  (is (= 99.5 (mean (range 0 200))) "200 elements"))


### PR DESCRIPTION
## 🤔 Background

Seventh pass of the core survey, widened to the files the earlier ones did not cover: `math`, `predicates`, `arrays`, `control`, destructuring.

**Almost everything there is already at or below an empty-closure floor** — `abs`, `min`, `nil?`, `int?`, `string?`, `cond`, `case`, `when-let`, `if-let`, `php-indexed-array` all measure 0.11us to 0.40us against a 0.14us floor. The compiler specialisations are doing their job, and that is worth recording as a result too.

Two functions are not: `sum` at 15.4us and `mean` at 15.6us over a 20-element vector, which is **0.77us per element to add ints**.

## 💡 Goal

`sum` is `(apply + xs)`: it spreads the collection into the variadic arm of `+` and walks it one guarded addition at a time. `array_sum` adds a PHP array of ints in C.

## 🔖 Changes

Floor-subtracted, same process, `origin/main` at c664ed67e:

| | before | after | |
|---|---|---|---|
| `sum` over 200 ints | 154.6us | 5.6us | **27.5x** |
| `sum` over 20 ints | 16.2us | 0.9us | **17.5x** |
| `mean` over 20 ints | 16.1us | 1.0us | **13.9x** |
| `sum` over 20 floats | 17.4us | 15.7us | **1.11x** |

## The case the fast path cannot answer

`array_sum` returns a **float exactly when the int sum overflows**, where Phel's `+` promotes to **BigInt**. So an overflowing sum is redone the long way, and whether the result is still an int is the test. Narrow to all-native-ints for the same reason `sort`'s fast path is: anything else brings BigInt, Ratio, NaN or mixed-type addition, none of which `array_sum` reproduces.

## One implementation detail that mattered

The fallback spreads the **already-converted array**, not the original collection. Converting and then re-walking the original made a non-int sum measurably *slower than before the fast path existed* (17.6us against 17.4us). Spreading the converted array makes it faster instead — which is why the float row above is a gain rather than the regression it first was.

## Tests

Diffed against `(apply + xs)` over ints, floats, mixed, empty, lists, ranges, lazy seqs and PHP arrays — comparing the **result type** as well as the value, so BigInt-versus-float is actually checked rather than assumed. `PHP_INT_MAX + 1` and `PHP_INT_MIN - 1` are the cases that matter.

Closes #3085
