### PR TITLE
perf(walk): build each branch through a transient instead of map and into

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ Runtime core:
 
 Standard library:
 
+- Build every `phel.walk` branch through a transient instead of `map` plus `into`, and the same inside `keywordize-keys` and `stringify-keys`: 1.67x to 1.71x. `map` returns a lazy sequence whose first chunk is realized on construction and `into` then walks it again, once per node of the tree (#3087)
 - Hoist `phel.html/escape-html`'s flag constant out of the call instead of recombining it per call: 4.4x, and 1.20x on a whole-document render (#3054)
 - Rewrite the hot half of `phel.string`: `assert-string` becomes `:inline`, seven functions take fixed arities in place of `& [x]`, `trim-newline` uses `rtrim`, `blank?` settles ASCII input with `strspn` before the unicode regex, `contains?` stops running its guards twice, and `split` builds its vector directly. 1.6x to 8.4x across fourteen functions (#3050 #3051 #3052)
 - Swap `phel.base64/encode-url` and `decode-url`'s alphabet with one `strtr` instead of a chain of `phel.string/replace` calls: 28x and 17x. All three also take fixed arities in place of `& [strict?]`, making `decode` 5.2x (#3021)

--- a/src/phel/walk.phel
+++ b/src/phel/walk.phel
@@ -6,19 +6,29 @@
    :see-also ["postwalk" "prewalk"]
    :example "(walk inc identity [1 2 3]) ; => [2 3 4]"}
   [inner outer form]
+  ;; Each branch builds its result through a transient rather than through
+  ;; `map` and `into`. `map` returns a lazy sequence whose first chunk is
+  ;; realized on construction, and `into` then walks that sequence a second
+  ;; time; the map branch also allocated a `[k v]` vector per pair only for
+  ;; `into` to take it apart again. Walkers recurse, so every one of those is
+  ;; paid once per node of the tree.
   (outer
    (cond
      (list? form)
-     (apply list (map inner form))
+     (apply list (persistent (for [x :in form :reduce [acc (transient [])]]
+                               (conj! acc (inner x)))))
 
      (vector? form)
-     (vec (map inner form))
+     (persistent (for [x :in form :reduce [acc (transient [])]]
+                   (conj! acc (inner x))))
 
      (or (map? form) (struct? form))
-     (into {} (for [[k v] :pairs form] [(inner k) (inner v)]))
+     (persistent (for [[k v] :pairs form :reduce [acc (transient {})]]
+                   (assoc! acc (inner k) (inner v))))
 
      (set? form)
-     (into (hash-set) (map inner form))
+     (persistent (for [x :in form :reduce [acc (transient (hash-set))]]
+                   (conj! acc (inner x))))
 
      form)))
 
@@ -65,9 +75,12 @@
   (postwalk
    (fn [form]
      (if (map? form)
-       (into {}
-             (for [[k v] :pairs form]
-               [(if (string? k) (keyword k) k) v]))
+       ;; Built through a transient for the same reason `walk` is: the pair
+       ;; vector and `into`'s second walk are both avoidable, and this runs
+       ;; once per map in the tree.
+       (persistent
+        (for [[k v] :pairs form :reduce [acc (transient {})]]
+          (assoc! acc (if (string? k) (keyword k) k) v)))
        form))
    m))
 
@@ -80,8 +93,11 @@
   (postwalk
    (fn [form]
      (if (map? form)
-       (into {}
-             (for [[k v] :pairs form]
-               [(if (keyword? k) (name k) k) v]))
+       ;; Built through a transient for the same reason `walk` is: the pair
+       ;; vector and `into`'s second walk are both avoidable, and this runs
+       ;; once per map in the tree.
+       (persistent
+        (for [[k v] :pairs form :reduce [acc (transient {})]]
+          (assoc! acc (if (keyword? k) (name k) k) v)))
        form))
    m))

--- a/tests/phel/walk-transients.phel
+++ b/tests/phel/walk-transients.phel
@@ -1,0 +1,54 @@
+(ns phel-test.walk-transients
+  (:require phel.walk :as w)
+  (:require phel.test :refer [deftest is]))
+
+;; `walk` and the two key-converting helpers build their results through
+;; transients rather than `map` plus `into`. The collection type each branch
+;; returns, and the order it returns things in, are the contract.
+
+(deftest test-walk-preserves-collection-types
+  (is (vector? (w/postwalk identity [1 2 3])) "a vector stays a vector")
+  (is (list? (w/postwalk identity '(1 2 3))) "a list stays a list")
+  (is (map? (w/postwalk identity {:a 1})) "a map stays a map")
+  (is (set? (w/postwalk identity (set [1 2 3]))) "a set stays a set")
+  (is (= "int" (php/get_debug_type (w/postwalk identity 1))) "a scalar is returned as-is")
+  (is (nil? (w/postwalk identity nil)) "nil is returned as-is"))
+
+(deftest test-walk-preserves-order-and-contents
+  (is (= [1 2 3] (w/postwalk identity [1 2 3])) "vector order")
+  (is (= '(1 2 3) (w/postwalk identity '(1 2 3))) "list order")
+  (is (= [2 3 4] (w/postwalk (fn [x] (if (int? x) (inc x) x)) [1 2 3])) "vector values")
+  (is (= '(2 3 4) (w/postwalk (fn [x] (if (int? x) (inc x) x)) '(1 2 3))) "list values")
+  (is (= {:a 1, :b 2} (w/postwalk identity {:a 1, :b 2})) "map contents")
+  (is (= (set [1 2 3]) (w/postwalk identity (set [1 2 3]))) "set contents")
+  (is (= [] (w/postwalk identity [])) "an empty vector")
+  (is (= {} (w/postwalk identity {})) "an empty map"))
+
+(deftest test-walk-recurses
+  (is (= [1 [2 [3]]] (w/postwalk identity [1 [2 [3]]])) "nested vectors")
+  (is (= {:a {:b {:c 1}}} (w/postwalk identity {:a {:b {:c 1}}})) "nested maps")
+  (is (= {:a [1 {:b 2}]} (w/postwalk identity {:a [1 {:b 2}]})) "mixed nesting")
+  (is (= [2 [3 [4]]] (w/postwalk (fn [x] (if (int? x) (inc x) x)) [1 [2 [3]]]))
+      "the function reaches every leaf"))
+
+(deftest test-postwalk-and-prewalk-order
+  (is (= [2 [3 4]] (w/postwalk (fn [x] (if (int? x) (inc x) x)) [1 [2 3]])) "postwalk")
+  (is (= [1 [2 3]] (w/prewalk identity [1 [2 3]])) "prewalk with identity")
+  (is (= [2 [3 4]] (w/prewalk (fn [x] (if (int? x) (inc x) x)) [1 [2 3]])) "prewalk transforms"))
+
+(deftest test-keywordize-and-stringify
+  (is (= {:a 1} (w/keywordize-keys {"a" 1})) "one string key")
+  (is (= {:a {:b 2}} (w/keywordize-keys {"a" {"b" 2}})) "nested string keys")
+  (is (= {:a 1, :b 2} (w/keywordize-keys {"a" 1, "b" 2})) "several keys")
+  (is (= {:a 1} (w/keywordize-keys {:a 1})) "a keyword key is left alone")
+  (is (= {1 :x} (w/keywordize-keys {1 :x})) "a non-string key is left alone")
+  (is (= {} (w/keywordize-keys {})) "an empty map")
+  (is (= {"a" 1} (w/stringify-keys {:a 1})) "one keyword key")
+  (is (= {"a" {"b" 2}} (w/stringify-keys {:a {:b 2}})) "nested keyword keys")
+  (is (= {"a" 1} (w/stringify-keys {"a" 1})) "a string key is left alone")
+  (is (= {:a 1} (w/keywordize-keys (w/stringify-keys {:a 1}))) "the two round-trip"))
+
+(deftest test-replace-helpers-still-work
+  (is (= [:b :c] (w/postwalk-replace {:a :b} [:a :c])) "postwalk-replace")
+  (is (= [:b :c] (w/prewalk-replace {:a :b} [:a :c])) "prewalk-replace")
+  (is (= {:b 1} (w/postwalk-replace {:a :b} {:a 1})) "replacing a map key"))


### PR DESCRIPTION
## 🤔 Background

Half of item B7 in #3021. That item says to **re-measure `phel.walk` first**, because it was measured before #3016 lowered exactly the per-pair vector it complains about. Re-measured — and it is still the slowest thing in the non-core standard library:

| | |
|---|---|
| `postwalk` over a 5-node structure | 52.6us |
| `prewalk` over the same | 54.6us |
| `keywordize-keys` over a 3-node map | 50.4us |
| `stringify-keys` over a 5-node structure | 94.7us |

That is **10-20us per node**, for `identity`.

## 💡 Goal

`walk` built every branch through `map` and `into`. `map` returns a lazy sequence whose first chunk is realized on construction (#3061), and `into` then walks that sequence a second time. The map branch additionally allocated a `[k v]` vector per pair only for `into` to take it apart again. Walkers recurse, so all of that is paid **once per node of the tree**.

## 🔖 Changes

Each branch builds through a transient instead. Floor-subtracted, same process, `origin/main` at c93e21864:

| | before | after | |
|---|---|---|---|
| `stringify-keys` | 94.7us | 55.5us | **1.71x** |
| `keywordize-keys` | 50.4us | 29.8us | **1.69x** |
| `postwalk` | 52.6us | 31.3us | **1.68x** |
| `prewalk` | 54.6us | 32.9us | **1.67x** |

`keywordize-keys` and `stringify-keys` needed the same treatment **in their own bodies**, not just through `walk` — each built its converted map with `(into {} (for ...))` too. Fixing only `walk` moved them 1.23x and 1.27x; fixing both moves them 1.69x and 1.71x.

The audit predicted 1.95x for `postwalk` and 1.71x for `keywordize-keys`, so this lands about where it said it would.

## Tests

The collection type each branch returns is the contract, along with ordering, so it is tested directly rather than inferred from the replace helpers: a vector stays a vector, a list stays a list, a set stays a set, and a scalar or nil comes back as-is. Plus nesting, empty collections, and that `keywordize-keys`/`stringify-keys` round-trip.

## Not included

`phel.json` is the other half of B7. `encode` measures 7.4us and `decode` 9.4us and neither moved with this change; they want their own look at real arities and hoisting the option validation out of the no-options path.

Closes #3087
