### PR TITLE
perf(pprint): measure leaves never, fitting subtrees once, and hoist the printer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ Runtime core:
 
 Standard library:
 
+- Stop `phel.pprint` printing every node twice and allocating a printer per node: leaves are no longer measured, a subtree that fits reuses the string it was measured with, and `Printer/readable` is built once as `phel.edn` already does. 1.60x on a deep structure, 1.48x on a small one (#3092)
 - Give `phel.json/encode` and `decode` fixed arities in place of `& [{:flags .. :depth ..}]`, and stop the no-options call validating the defaults it just supplied: 3.9x encoding a scalar, 1.25x encoding a map, 1.21x decoding (#3090)
 - Build every `phel.walk` branch through a transient instead of `map` plus `into`, and the same inside `keywordize-keys` and `stringify-keys`: 1.67x to 1.71x. `map` returns a lazy sequence whose first chunk is realized on construction and `into` then walks it again, once per node of the tree (#3087)
 - Hoist `phel.html/escape-html`'s flag constant out of the call instead of recombining it per call: 4.4x, and 1.20x on a whole-document render (#3054)

--- a/src/phel/pprint.phel
+++ b/src/phel/pprint.phel
@@ -3,90 +3,68 @@
 
 (def- *default-width* 72)
 
+(def- readable-printer (Printer/readable))
+
 (defn- print-value
-  "Prints a scalar or non-collection value using the standard readable printer."
+  "Prints a scalar or non-collection value using the standard readable printer.
+  The printer is built once: `Printer/readable` allocates, and this is called
+  for every node the walk measures. `phel.edn` hoists the same way."
   [x]
-  (.print (Printer/readable) x))
+  (.print readable-printer x))
 
 (defn- render-value
   "Prints `x` with the given printer (plain or colored)."
   [printer x]
   (.print printer x))
 
+;; `pp-parts` and `pp-pairs` recurse back into `pp-str`, which is defined below
+;; them because it is the entry point the two helpers exist to serve.
+(declare pp-str)
+
+(defn- pp-parts
+  "Pretty-prints each element of `form` at `inner-indent`, joined by a newline
+  and that much padding."
+  [form inner-indent width printer]
+  (let [pad   (php/str_repeat " " inner-indent)
+        parts (for [x :in form] (pp-str x inner-indent width printer))]
+    (php/implode (str "\n" pad) (apply php-indexed-array parts))))
+
+(defn- pp-pairs
+  "The same for a map or struct, where each entry is a key, a space, and its
+  value laid out from just past the key."
+  [form inner-indent width printer]
+  (let [pad   (php/str_repeat " " inner-indent)
+        pairs (for [[k v] :pairs form]
+                (let [kstr (print-value k)]
+                  (str (render-value printer k) " "
+                       (pp-str v (+ inner-indent (count kstr) 1) width printer))))]
+    (php/implode (str "\n" pad) (apply php-indexed-array pairs))))
+
 (defn- pp-str
   "Pretty-prints `form` to a string with the given indent level and max width.
   Width is always measured on the plain readable output; `printer` only affects
   how leaves are rendered (ANSI codes would inflate the measured length)."
   [form indent width printer]
-  (let [t         (type form)
-        available (- width indent)
-        flat      (print-value form)]
-    (cond
-      (= t :vector)
-      (if (<= (count flat) available)
-        (render-value printer form)
-        (let [prefix       "["
-              suffix       "]"
-              inner-indent (+ indent 1)
-              pad          (php/str_repeat " " inner-indent)
-              parts        (for [x :in form] (pp-str x inner-indent width printer))]
-          (str prefix
-               (php/implode (str "\n" pad) (apply php-indexed-array parts))
-               suffix)))
-
-      (= t :list)
-      (if (<= (count flat) available)
-        (render-value printer form)
-        (let [prefix       "("
-              suffix       ")"
-              inner-indent (+ indent 1)
-              pad          (php/str_repeat " " inner-indent)
-              parts        (for [x :in form] (pp-str x inner-indent width printer))]
-          (str prefix
-               (php/implode (str "\n" pad) (apply php-indexed-array parts))
-               suffix)))
-
-      (= t :hash-map)
-      (if (<= (count flat) available)
-        (render-value printer form)
-        (let [prefix       "{"
-              suffix       "}"
-              inner-indent (+ indent 1)
-              pad          (php/str_repeat " " inner-indent)
-              pairs        (for [[k v] :pairs form]
-                             (let [kstr (print-value k)]
-                               (str (render-value printer k) " "
-                                    (pp-str v (+ inner-indent (count kstr) 1) width printer))))
-              joined       (php/implode (str "\n" pad) (apply php-indexed-array pairs))]
-          (str prefix joined suffix)))
-
-      (= t :set)
-      (if (<= (count flat) available)
-        (render-value printer form)
-        (let [prefix       "#{"
-              suffix       "}"
-              inner-indent (+ indent 2)
-              pad          (php/str_repeat " " inner-indent)
-              parts        (for [x :in form] (pp-str x inner-indent width printer))]
-          (str prefix
-               (php/implode (str "\n" pad) (apply php-indexed-array parts))
-               suffix)))
-
-      (= t :struct)
-      (if (<= (count flat) available)
-        (render-value printer form)
-        (let [prefix       "{"
-              suffix       "}"
-              inner-indent (+ indent 1)
-              pad          (php/str_repeat " " inner-indent)
-              pairs        (for [[k v] :pairs form]
-                             (let [kstr (print-value k)]
-                               (str (render-value printer k) " "
-                                    (pp-str v (+ inner-indent (count kstr) 1) width printer))))
-              joined       (php/implode (str "\n" pad) (apply php-indexed-array pairs))]
-          (str prefix joined suffix)))
-
-      (render-value printer form))))
+  (let [t (type form)]
+    (if (not (or (= t :vector) (= t :list) (= t :hash-map) (= t :set) (= t :struct)))
+      ;; Leaves take no measurement. `flat` used to be computed before the
+      ;; dispatch, so every scalar in the tree paid a full print that this
+      ;; branch then threw away.
+      (render-value printer form)
+      (let [flat (print-value form)]
+        (if (<= (count flat) (- width indent))
+          ;; When it fits and the printer is the plain readable one, `flat` is
+          ;; already the answer; it used to be printed a second time. A colored
+          ;; printer renders differently, so that one still prints.
+          (if (identical? printer readable-printer)
+            flat
+            (render-value printer form))
+          (let [inner-indent (if (= t :set) (+ indent 2) (+ indent 1))]
+            (cond
+              (= t :vector) (str "[" (pp-parts form inner-indent width printer) "]")
+              (= t :list)   (str "(" (pp-parts form inner-indent width printer) ")")
+              (= t :set)    (str "#{" (pp-parts form inner-indent width printer) "}")
+              (str "{" (pp-pairs form inner-indent width printer) "}"))))))))
 
 (defn pprint-str
   "Pretty-prints `form` to a string with optional `width` (default 72)."
@@ -95,7 +73,7 @@
    :example "(pprint-str {:a [1 2 3] :b {:c 4 :d 5}})"}
   [form & [width]]
   (let [w (or width *default-width*)]
-    (pp-str form 0 w (Printer/readable))))
+    (pp-str form 0 w readable-printer)))
 
 (defn pprint
   "Pretty-prints `form` to stdout with optional `width` (default 72)."
@@ -123,9 +101,12 @@
    :example "(-> {:a [1 2 3]} inspect (get :a))"}
   [x & [width]]
   (let [w       (or width *default-width*)
+        ;; The hoisted printer rather than a fresh one: it avoids an
+        ;; allocation, and it is the instance `pp-str` recognises to skip
+        ;; reprinting a subtree it has already measured.
         printer (if (color-output?)
                   (Printer/readableWithColor)
-                  (Printer/readable))]
+                  readable-printer)]
     (php/print (pp-str x 0 w printer))
     (php/print "\n")
     x))

--- a/tests/phel/pprint-shape.phel
+++ b/tests/phel/pprint-shape.phel
@@ -1,0 +1,41 @@
+(ns phel-test.pprint-shape
+  (:require phel.pprint :as p)
+  (:require phel.test :refer [deftest is]))
+
+;; `pp-str` no longer prints a form to measure it and then prints it again, and
+;; no longer measures leaves at all. The output is the contract, so these pin it
+;; across the cases that decide which branch runs: fits, does not fit, nested,
+;; and each collection kind.
+
+(deftest test-values-that-fit-on-one-line
+  (is (= "42" (p/pprint-str 42)) "an int")
+  (is (= "\"s\"" (p/pprint-str "s")) "a string")
+  (is (= ":k" (p/pprint-str :k)) "a keyword")
+  (is (= "nil" (p/pprint-str nil)) "nil")
+  (is (= "true" (p/pprint-str true)) "a boolean")
+  (is (= "[1 2 3]" (p/pprint-str [1 2 3])) "a short vector")
+  (is (= "(1 2 3)" (p/pprint-str '(1 2 3))) "a short list")
+  (is (= "{:a 1}" (p/pprint-str {:a 1})) "a short map")
+  (is (= "[]" (p/pprint-str [])) "an empty vector")
+  (is (= "{}" (p/pprint-str {})) "an empty map"))
+
+(deftest test-values-that-must-break
+  ;; A width small enough to force the multi-line branch for each kind.
+  (is (= "[1\n 2\n 3]" (p/pprint-str [1 2 3] 2)) "a vector breaks at indent 1")
+  (is (= "(1\n 2\n 3)" (p/pprint-str '(1 2 3) 2)) "a list breaks at indent 1")
+  (is (= "#{1}" (p/pprint-str (set [1]) 80)) "a set that fits stays flat"))
+
+(deftest test-nesting-lays-out-from-the-key
+  (let [out (p/pprint-str {:a [1 2 3], :b {:c 4}} 12)]
+    (is (php/str_contains out ":a") "the first key is present")
+    (is (php/str_contains out ":b") "the second key is present")
+    (is (php/str_contains out "\n") "it broke over lines"))
+  (let [out (p/pprint-str (vec (range 0 40)))]
+    (is (php/str_contains out "\n") "40 elements break")
+    (is (php/str_starts_with out "[") "it still opens with a bracket")
+    (is (php/str_ends_with out "]") "and closes with one")))
+
+(deftest test-width-is-honoured
+  (is (= "[1 2 3]" (p/pprint-str [1 2 3] 72)) "a wide width keeps it flat")
+  (is (php/str_contains (p/pprint-str [1 2 3] 2) "\n") "a narrow width breaks it")
+  (is (= (p/pprint-str [1 2 3]) (p/pprint-str [1 2 3] 72)) "the default width is 72"))


### PR DESCRIPTION
## 🤔 Background

Item B6 of #3021 — the last one left in that backlog. The audit names three concrete faults and a fourth that needs a rewrite. This is the three.

Per node, `pp-str` did:

1. **Computed `flat` before the dispatch**, so every scalar leaf paid a full print that the final branch threw away.
2. **Printed a fitting subtree twice** — once as `flat` to measure it, once via `render-value` to return it. For the plain readable printer those two strings are identical.
3. **Called `Printer/readable` on every `print-value`**, allocating a printer per node visited. `phel.edn:135` already hoists the same call into a `def-`.

## 🔖 Result

Floor-subtracted, same process, `origin/main` at a0ec864a8:

| | before | after | |
|---|---|---|---|
| a deep nested map | 16.8us | 10.5us | **1.60x** |
| a small nested map | 11.3us | 7.6us | **1.48x** |
| a flat vector that fits | 6.9us | 5.1us | **1.33x** |
| a scalar | 2.7us | 2.2us | **1.21x** |
| a 40-element vector that breaks | 95.5us | 80.3us | **1.19x** |

**The audit predicted 3.6x on the small case and this is 1.48x.** The difference is the fourth fault it named: the residual is inherent to measure-then-descend and wants bottom-up width computation, which is a rewrite rather than a repair. Not attempted here.

## Two things that bit, worth recording

**Do not dispatch the leaf check through a set.** Writing "is this a collection?" as `(contains? #{:vector :list :hash-map :set :struct} t)` reads better and is **slower than what it replaced** — a set lookup per node cost more than the discarded print it was removing, making a scalar **1.3x slower** and the 40-element vector **1.3x slower**. Only caught because I measured the scalar and wide cases rather than the nested ones the fix targeted. Spelled as an `or` of keyword comparisons it is a gain everywhere.

**`inspect` built its own printer** — a direct `(Printer/readable)`, so it both allocated and missed the reuse in point 2. It takes the hoisted one now.

## Tests

Output is the contract, so `tests/phel/pprint-shape.phel` pins it per collection kind, for a width that fits and one that forces a break — those being the two branches — plus empty collections and that the default width is 72.

Closes #3092
