### PR TITLE
perf(test): escape JUnit XML attributes in one pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ Runtime core:
 
 Standard library:
 
+- Escape JUnit XML attributes with one `htmlspecialchars` pass instead of five chained `phel.string/replace` calls: 25x. Invalid UTF-8 now becomes U+FFFD rather than being emitted raw, which was not valid XML (#3094)
 - Stop `phel.pprint` printing every node twice and allocating a printer per node: leaves are no longer measured, a subtree that fits reuses the string it was measured with, and `Printer/readable` is built once as `phel.edn` already does. 1.60x on a deep structure, 1.48x on a small one (#3092)
 - Give `phel.json/encode` and `decode` fixed arities in place of `& [{:flags .. :depth ..}]`, and stop the no-options call validating the defaults it just supplied: 3.9x encoding a scalar, 1.25x encoding a map, 1.21x decoding (#3090)
 - Build every `phel.walk` branch through a transient instead of `map` plus `into`, and the same inside `keywordize-keys` and `stringify-keys`: 1.67x to 1.71x. `map` returns a lazy sequence whose first chunk is realized on construction and `into` then walks it again, once per node of the tree (#3087)

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -884,15 +884,21 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
          :current nil
          :output-path nil}))
 
+;; ENT_XML1 renders a single quote as `&apos;` where the HTML entity tables
+;; give `&#039;`, so these flags produce exactly the five escapes the chain of
+;; `phel.string/replace` calls used to: `&amp; &lt; &gt; &quot; &apos;`.
+;; ENT_SUBSTITUTE replaces an invalid UTF-8 sequence with U+FFFD; without it
+;; `htmlspecialchars` returns an empty string and the whole attribute would
+;; vanish. The old chain passed the raw byte through, which is not valid XML.
+(def- junit-xml-flags (bit-or php/ENT_QUOTES php/ENT_XML1 php/ENT_SUBSTITUTE))
+
 (defn- junit-xml-escape [value]
+  ;; One pass instead of five `phel.string/replace` calls, each of which
+  ;; asserts, builds a delimited pattern with `preg_quote` and runs
+  ;; `preg_replace` to swap a single character. Called once per JUnit XML
+  ;; attribute (#3021 B1).
   (when-not (nil? value)
-    (let [s (if (string? value) value (str value))]
-      (-> s
-          (s/replace "&" "&amp;")
-          (s/replace "<" "&lt;")
-          (s/replace ">" "&gt;")
-          (s/replace "\"" "&quot;")
-          (s/replace "'" "&apos;")))))
+    (php/htmlspecialchars (if (string? value) value (str value)) junit-xml-flags)))
 
 (defn- junit-attr [k v]
   (str (name k) "=\"" (junit-xml-escape v) "\""))

--- a/tests/phel/reporters.phel
+++ b/tests/phel/reporters.phel
@@ -170,6 +170,30 @@
           "failure message escapes angle brackets and ampersands"))
     (php/unlink path)))
 
+(deftest test-junit-xml-reporter-survives-invalid-utf8
+  ;; Escaping is one `htmlspecialchars` pass now. Without ENT_SUBSTITUTE that
+  ;; returns an empty string for malformed input, which would silently drop a
+  ;; whole failure message; with it the byte becomes U+FFFD, which is valid XML
+  ;; where the raw byte the old escape emitted was not.
+  (let [path (str "/tmp/phel-junit-" (php/mt_rand) ".xml")
+        rep  (t/resolve-reporter :junit-xml)
+        _    (t/set-junit-output! path)]
+    (rep {:type :begin-test-run})
+    (rep {:type :begin-test-ns :ns "sample.ns"})
+    (rep {:type :failed :state :failed :test-name "bad-bytes"
+          :message (str "before" (php/chr 255) "after")
+          :form "(= 1 2)"
+          :location {:file "f.phel" :line 1}})
+    (rep {:type :end-test-ns :ns "sample.ns"})
+    (rep {:type :summary :total 1})
+    (t/set-junit-output! nil)
+    (let [xml (php/file_get_contents path)]
+      (is (php/str_contains xml "before") "the text before the bad byte survives")
+      (is (php/str_contains xml "after") "the text after it survives too")
+      (is (php/str_contains xml "bad-bytes") "the testcase is still written")
+      (is (true? (php/mb_check_encoding xml "UTF-8")) "the document is valid UTF-8"))
+    (php/unlink path)))
+
 ;; ---------------------------------------------------------------------------
 ;; Default reporter — legacy dot output plus summary block
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## 🤔 Background

The last item left in #3021, listed under B1 as *"same class, reasoned not measured"*. Now measured.

`junit-xml-escape` chains five `phel.string/replace` calls to swap five single characters — and each of those asserts, wraps the needle with `preg_quote` into a delimited pattern, and runs `preg_replace`. It runs once per JUnit XML attribute: per test name, per suite name, per message and per form in the report.

## 🔖 Changes

`htmlspecialchars` with `ENT_QUOTES | ENT_XML1` produces exactly those five escapes — `ENT_XML1` is what renders a single quote as `&apos;` where the HTML entity tables give `&#039;`.

**10.79us to 0.43us — 25x**, floor-subtracted, `origin/main` at 192f08750.

## The flag that is not optional

`ENT_SUBSTITUTE` has to be in that set. Without it `htmlspecialchars` returns an **empty string** for input that is not valid UTF-8 — so a failure message containing a single bad byte would vanish from the report entirely. My first version omitted it, and the equivalence sweep caught 128 mismatches doing exactly that.

With it, the byte becomes U+FFFD. That still differs from the old chain, which emitted the raw byte, and is worth taking: a raw invalid byte in the output was not valid XML to begin with.

Verified over all 256 single-byte values plus markup, quotes, multibyte and NUL — **zero differences on valid UTF-8**, and the 128 differences are exactly the invalid bytes, in the direction described.

## Tests

`tests/phel/reporters.phel` already covered the five escapes through the reporter. Added the invalid-UTF-8 case: the text either side of the bad byte survives, the testcase is still written, and the document is valid UTF-8 — that being the behaviour which changed.

Closes #3094
