### PR TITLE
perf(schema): derive each map entry's shape once in validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ Runtime core:
 
 Standard library:
 
+- Derive each `[:map ...]` entry's shape once in `phel.schema/validate` instead of twice through two helpers, and index the entry loop rather than walking a seq over a vector: 1.23x on a four-field map, 1.20x on two, scaling with field count (#3096)
 - Escape JUnit XML attributes with one `htmlspecialchars` pass instead of five chained `phel.string/replace` calls: 25x. Invalid UTF-8 now becomes U+FFFD rather than being emitted raw, which was not valid XML (#3094)
 - Stop `phel.pprint` printing every node twice and allocating a printer per node: leaves are no longer measured, a subtree that fits reuses the string it was measured with, and `Printer/readable` is built once as `phel.edn` already does. 1.60x on a deep structure, 1.48x on a small one (#3092)
 - Give `phel.json/encode` and `decode` fixed arities in place of `& [{:flags .. :depth ..}]`, and stop the no-options call validating the defaults it just supplied: 3.9x encoding a scalar, 1.25x encoding a map, 1.21x decoding (#3090)

--- a/src/phel/schema/validator.phel
+++ b/src/phel/schema/validator.phel
@@ -184,20 +184,33 @@
   [value entries closed?]
   (if (not (map? value))
     false
-    (let [keys-ok?  (loop [es (seq entries)]
+    ;; Indexed rather than `(seq entries)` plus `first`/`next`: `entries` is
+    ;; the vector `schema-args` returned, so `seq` would build a ChunkedSeq
+    ;; over it (#3061) to walk something already random-access.
+    (let [entry-count (count entries)
+          keys-ok?  (loop [i 0]
                       (cond
-                        (nil? es) true
+                        (php/>= i entry-count) true
                         :else
-                        (let [entry (first es)
-                              k     (get entry 0)
-                              inner (map-entry-schema entry)
-                              opt?  (map-entry-optional? entry)]
+                        ;; The options position and the schema position are
+                        ;; decided by the same test. `map-entry-schema` runs
+                        ;; it, `map-entry-optional?` runs it again through
+                        ;; `map-entry-options`, and each is a separate call.
+                        ;; Once inline is enough, and this is per entry per
+                        ;; validation. The two helpers stay: they are public.
+                        (let [entry     (get entries i)
+                              k         (get entry 0)
+                              has-opts? (and (>= (count entry) 3) (map? (get entry 1)))
+                              inner     (if has-opts? (get entry 2) (get entry 1))
+                              opt?      (if has-opts?
+                                          (true? (get (get entry 1) :optional))
+                                          false)]
                           (cond
                             (not (contains? value k))
-                            (if opt? (recur (next es)) false)
+                            (if opt? (recur (php/+ i 1)) false)
                             (not (valid? inner (get value k)))
                             false
-                            :else                              (recur (next es))))))
+                            :else                              (recur (php/+ i 1))))))
           extra-ok? (if closed?
                       (let [declared (into (hash-set) (map (fn [e] (get e 0)) entries))]
                         (loop [ks (seq (keys value))]

--- a/tests/phel/schema/map-entry-shapes.phel
+++ b/tests/phel/schema/map-entry-shapes.phel
@@ -1,0 +1,45 @@
+(ns phel-test.schema.map-entry-shapes
+  (:require phel.schema :as sc)
+  (:require phel.test :refer [deftest is]))
+
+;; `validate-map` used to ask `map-entry-schema` and `map-entry-optional?` for
+;; each entry, and both re-derived the same "does this entry carry an options
+;; map?" test. That test is inline now, so every entry shape it distinguishes
+;; needs covering: with and without options, optional and required.
+
+(deftest test-entries-without-an-options-map
+  (is (true? (sc/validate [:map [:a :int]] {:a 1})) "one entry, matching")
+  (is (false? (sc/validate [:map [:a :int]] {:a "x"})) "one entry, wrong type")
+  (is (false? (sc/validate [:map [:a :int]] {})) "one entry, missing")
+  (is (true? (sc/validate [:map [:a :int] [:b :string]] {:a 1, :b "x"})) "two entries")
+  (is (false? (sc/validate [:map [:a :int] [:b :string]] {:a 1, :b 2})) "second entry wrong")
+  (is (false? (sc/validate [:map [:a :int] [:b :string]] {:a 1})) "second entry missing"))
+
+(deftest test-entries-with-an-options-map
+  (is (true? (sc/validate [:map [:a {:optional true} :int]] {:a 1})) "optional and present")
+  (is (true? (sc/validate [:map [:a {:optional true} :int]] {})) "optional and absent")
+  (is (false? (sc/validate [:map [:a {:optional true} :int]] {:a "x"})) "optional but wrong type")
+  (is (true? (sc/validate [:map [:a {:optional false} :int]] {:a 1})) "explicitly not optional")
+  (is (false? (sc/validate [:map [:a {:optional false} :int]] {})) "explicitly not optional, absent")
+  ;; An options map with no `:optional` key still shifts the schema position.
+  (is (true? (sc/validate [:map [:a {:title "x"} :int]] {:a 1})) "options without :optional")
+  (is (false? (sc/validate [:map [:a {:title "x"} :int]] {:a "s"})) "options without :optional, wrong type"))
+
+(deftest test-mixed-entry-shapes-in-one-schema
+  (let [s [:map [:a :int] [:b {:optional true} :string] [:c :keyword]]]
+    (is (true? (sc/validate s {:a 1, :b "x", :c :k})) "all present")
+    (is (true? (sc/validate s {:a 1, :c :k})) "optional omitted")
+    (is (false? (sc/validate s {:a 1, :b 2, :c :k})) "optional present but wrong")
+    (is (false? (sc/validate s {:b "x", :c :k})) "required omitted")))
+
+(deftest test-closed-maps
+  (is (true? (sc/validate [:map {:closed true} [:a :int]] {:a 1})) "closed and exact")
+  (is (false? (sc/validate [:map {:closed true} [:a :int]] {:a 1, :b 2})) "closed with an extra key")
+  (is (true? (sc/validate [:map [:a :int]] {:a 1, :b 2})) "open ignores extra keys"))
+
+(deftest test-nested-and-empty-maps
+  (is (true? (sc/validate [:map [:a [:map [:b :int]]]] {:a {:b 1}})) "a nested map schema")
+  (is (false? (sc/validate [:map [:a [:map [:b :int]]]] {:a {:b "x"}})) "nested, wrong type")
+  (is (true? (sc/validate [:map] {})) "an empty schema against an empty map")
+  (is (true? (sc/validate [:map] {:a 1})) "an empty open schema ignores keys")
+  (is (false? (sc/validate [:map [:a :int]] "not a map")) "a non-map value"))


### PR DESCRIPTION
## 🤔 Background

#3021's list is finished, so this comes from surveying the namespaces none of the earlier passes measured: `phel.router`, `phel.schema`, `phel.edn`, `phel.transit`, `phel.html`.

**Most of them are fine where it counts**, which is worth reporting too: `router` matches a path in **2.7us** (its 58us build is paid once at boot), `edn/write-string` is 4.1us, and `phel.string` after #3053 is 1.2-2.2us.

`phel.schema/validate` is the one that stands out, and it is a per-request path wherever schemas guard input — ~17us fixed plus **~10.7us per field**, where validating `:int` on its own costs 2.2us.

## 💡 Where the per-field cost went

`validate-map`'s loop asked two helpers about each entry:

```phel
inner (map-entry-schema entry)
opt?  (map-entry-optional? entry)
```

`map-entry-schema` runs `(and (>= (count entry) 3) (map? (get entry 1)))` to locate the options position. `map-entry-optional?` calls `map-entry-options`, which runs **the same test again**. So each entry paid that shape test twice, across three function calls, to pull two values out of a two-or-three element vector.

The loop also walked `(seq entries)` with `first`/`next` — and `entries` is the vector `schema-args` returned, so `seq` built a ChunkedSeq (#3061) over something already random-access.

## 🔖 Result

Floor-subtracted, same process, `origin/main` at cf53e16ec:

| | before | after | |
|---|---|---|---|
| four fields | 60.3us | 48.9us | **1.23x** |
| two fields | 36.7us | 30.5us | **1.20x** |
| one field | 26.7us | 23.0us | **1.17x** |
| `:int`, `:string`, `[:vector :int]` | 2.2 / 1.9 / 17.5us | unchanged | |

Per field: **10.7us to 7.9us**. Modest as a ratio, and it scales with field count, which is the direction that matters for a validation call. The remaining ~8us per field is `contains?`, `get` and the recursive `valid?` — actual work, not bookkeeping.

## Scope

`map-entry-schema` and `map-entry-optional?` are **public and stay** — the explainer, generator and coercer all use them. Those two repeat the same double derivation, but they are the error path and the property-testing path rather than the per-request one, so they keep the helpers.

## Tests

The inlined test distinguishes four entry shapes, so all four are covered: with and without an options map, optional and required — plus an options map carrying no `:optional` key at all, which still shifts the schema position, and closed maps, nesting, and a non-map value.

Closes #3096
