### PR TITLE
perf(html): join the runtime render with implode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ Runtime core:
 
 Standard library:
 
+- Join `phel.html`'s runtime render with `implode` over a PHP array instead of `apply str` over a lazy sequence: 1.51x on an attribute-heavy element, 1.42x on a five-node document. Only affects documents the `html` macro cannot compile at expansion time, which is any template built from data (#3098)
 - Derive each `[:map ...]` entry's shape once in `phel.schema/validate` instead of twice through two helpers, and index the entry loop rather than walking a seq over a vector: 1.23x on a four-field map, 1.20x on two, scaling with field count (#3096)
 - Escape JUnit XML attributes with one `htmlspecialchars` pass instead of five chained `phel.string/replace` calls: 25x. Invalid UTF-8 now becomes U+FFFD rather than being emitted raw, which was not valid XML (#3094)
 - Stop `phel.pprint` printing every node twice and allocating a printer per node: leaves are no longer measured, a subtree that fits reuses the string it was measured with, and `Printer/readable` is built once as `phel.edn` already does. 1.60x on a deep structure, 1.48x on a small one (#3092)

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -85,7 +85,14 @@
       (str " " (escape-html name) "=\""  (render-attribute-value name value) "\""))))
 
 (defn- render-attrs [attrs]
-  (apply str (for [[name value] :pairs attrs] (render-attribute name value))))
+  ;; Collected into a PHP array and imploded rather than `(apply str (for ...))`.
+  ;; The `for` builds a collection, `apply` spreads it into the variadic arm of
+  ;; `str`, and the join happens one Phel call at a time; `implode` does the
+  ;; whole thing in C. Measured 4.7x on the same shape.
+  (let [parts (php/array)]
+    (foreach [name value attrs]
+      (php/apush parts (render-attribute name value)))
+    (php/implode "" parts)))
 
 (defn- render-element
   "Renders an Element."
@@ -98,10 +105,20 @@
        "</" tag ">")
       (str "<" tag (render-attrs attrs) " />"))))
 
+(defn- render-children
+  "Renders each child and joins them. Same reason as `render-attrs`: `map`
+  returns a lazy sequence whose first chunk is realized on construction, and
+  `apply str` then spreads it through the variadic arm of `str`."
+  [element]
+  (let [parts (php/array)]
+    (foreach [child element]
+      (php/apush parts (render-html child)))
+    (php/implode "" parts)))
+
 (defn- render-html [element]
   (cond
     (vector? element)         (render-element element)
-    (indexed? element)        (apply str (map render-html element))
+    (indexed? element)        (render-children element)
     (raw-string? element)     (get element :s)
     (string? element)         (escape-html element)
     (nil? element)            ""

--- a/tests/phel/html.phel
+++ b/tests/phel/html.phel
@@ -109,3 +109,28 @@
   ;; ENT_SUBSTITUTE: invalid UTF-8 becomes U+FFFD rather than an empty string.
   (is (= "\u{FFFD}" (html/escape-html (php/chr 255))))
   (is (not= "" (html/escape-html (str "bad" (php/chr 255))))))
+
+;; --- render paths rebuilt on implode (#3098) ---
+
+(deftest test-dynamic-render-joins-children-and-attributes
+  ;; A non-literal document goes through `render-html` at runtime rather than
+  ;; being compiled by the macro, so these exercise the join paths directly.
+  (let [doc [:div {:class "x"} [:p "a"] [:span "b"]]]
+    (is (= "<div class=\"x\"><p>a</p><span>b</span></div>" (html doc))
+        "children join in order"))
+  (let [doc [:div {:a "1" :b "2" :c "3"} "t"]]
+    (is (= "<div a=\"1\" b=\"2\" c=\"3\">t</div>" (html doc))
+        "attributes join in order, each preceded by a space"))
+  (is (= "<div></div>" (html [:div])) "no attributes and no children")
+  (is (= "<div>abc</div>" (html [:div "a" "b" "c"])) "several string children")
+  (is (= "<div>x</div>" (html [:div nil "x" nil])) "nil children render as nothing")
+  (is (= "<ul><li>0</li><li>1</li></ul>" (html [:ul [:li "0"] [:li "1"]]))
+      "sibling elements join in order"))
+
+(deftest test-dynamic-render-still-escapes-and-self-closes
+  (is (= "<p>&amp;&lt;&gt;&quot;&#039;</p>" (html [:p "&<>\"'"])) "text is escaped")
+  (is (= "<br />" (html [:br])) "a void element self-closes")
+  (is (= "<div><b>raw</b></div>" (html [:div (raw-string "<b>raw</b>")]))
+      "a raw-string is not escaped")
+  (is (= "<div data-x=\"q&quot;uote\">t</div>" (html [:div {:data-x "q\"uote"} "t"]))
+      "attribute values are escaped"))


### PR DESCRIPTION
## 🤔 Background

Continues the stdlib survey after #3096.

`phel.html`'s `html` macro compiles a **literal** document at expansion time, so a static template costs nothing at runtime. A document that is *not* literal — which is any template built from data — goes through `render-html` instead, and that was **91us for a five-node document**.

Two joins did it:

```phel
(defn- render-attrs [attrs]
  (apply str (for [[name value] :pairs attrs] (render-attribute name value))))

;; and in render-html
(indexed? element) (apply str (map render-html element))
```

`map` returns a lazy sequence whose first chunk is realized on construction (#3061), `for` builds a collection, and `apply str` then spreads either into the variadic arm of `str` — joining one Phel call at a time.

## 🔖 Changes

I measured the three ways to build the same string from five parts before picking:

| | |
|---|---|
| `(apply str (map ...))` | 13.6us |
| accumulating with `str` into a one-slot PHP array | 8.1us |
| **`php/implode` over a PHP array** | **2.9us** |

`implode` does the whole join in C, and is what `phel.string/join` and `phel.pprint` already reach for.

Floor-subtracted, same process, `origin/main` at d82ebd614:

| | before | after | |
|---|---|---|---|
| a div with five attributes | 49.8us | 32.9us | **1.51x** |
| a five-node document | 91.2us | 64.4us | **1.42x** |
| a small document | 43.1us | 31.4us | **1.37x** |

**Output is byte-identical** — diffed over 14 documents covering attributes, style and class maps, boolean attributes, void elements, raw strings, string tags, nil children, escaping and nesting.

## Worth knowing, found while testing

A generated list of children **does not splice**. Neither `[:ul (map ...)]` nor `[:ul (vec (map ...))]` renders as list items — the first stringifies the sequence and escapes it, the second raises `[:li "0"] is not a valid element name`. The docstring does say children are "strings, keywords, raw strings, or nested vectors", so this is the documented shape and not a regression from this change (verified identical on `origin/main`), but it is a sharp edge for anyone rendering from data. Noted in #3098 rather than silently worked around.

Closes #3098
