### PR TITLE
perf(lang): grow lazy sequence chunks instead of realizing 32 up front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ Runtime core:
 
 Standard library:
 
+- Grow a lazy sequence's chunks from 4 up to the existing 32 instead of realizing 32 on construction. `ChunkedSeq::fromGenerator` reports emptiness by returning nil, so it must pull one element, but it need not pull a full batch: `partition-by` 3.2x, `dedupe` 2.3x, `interleave` 1.44x, `(take 3 …)` 1.32x, with full realization unchanged (#3061)
 - Join `phel.html`'s runtime render with `implode` over a PHP array instead of `apply str` over a lazy sequence: 1.51x on an attribute-heavy element, 1.42x on a five-node document. Only affects documents the `html` macro cannot compile at expansion time, which is any template built from data (#3098)
 - Derive each `[:map ...]` entry's shape once in `phel.schema/validate` instead of twice through two helpers, and index the entry loop rather than walking a seq over a vector: 1.23x on a four-field map, 1.20x on two, scaling with field count (#3096)
 - Escape JUnit XML attributes with one `htmlspecialchars` pass instead of five chained `phel.string/replace` calls: 25x. Invalid UTF-8 now becomes U+FFFD rather than being emitted raw, which was not valid XML (#3094)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,7 +147,7 @@ Runtime core:
 
 Standard library:
 
-- Grow a lazy sequence's chunks from 4 up to the existing 32 instead of realizing 32 on construction. `ChunkedSeq::fromGenerator` reports emptiness by returning nil, so it must pull one element, but it need not pull a full batch: `partition-by` 3.2x, `dedupe` 2.3x, `interleave` 1.44x, `(take 3 …)` 1.32x, with full realization unchanged (#3061)
+- Realize 4 elements when a lazy sequence is constructed instead of the full batch of 32; every later chunk is still 32. `ChunkedSeq::fromGenerator` reports emptiness by returning nil, so it must pull one element, but it need not pull a whole batch before the caller has asked for anything: constructing a `partition-by` drops 79% and a `dedupe` 71%. A sequence consumed in full pays one extra chunk boundary for it, which is 6-7% on the 32 element collections the benchmarks use and proportionally less above that (#3061)
 - Join `phel.html`'s runtime render with `implode` over a PHP array instead of `apply str` over a lazy sequence: 1.51x on an attribute-heavy element, 1.42x on a five-node document. Only affects documents the `html` macro cannot compile at expansion time, which is any template built from data (#3098)
 - Derive each `[:map ...]` entry's shape once in `phel.schema/validate` instead of twice through two helpers, and index the entry loop rather than walking a seq over a vector: 1.23x on a four-field map, 1.20x on two, scaling with field count (#3096)
 - Escape JUnit XML attributes with one `htmlspecialchars` pass instead of five chained `phel.string/replace` calls: 25x. Invalid UTF-8 now becomes U+FFFD rather than being emitted raw, which was not valid XML (#3094)

--- a/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
+++ b/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
@@ -16,6 +16,7 @@ use Traversable;
 
 use function array_slice;
 use function count;
+use function min;
 
 /**
  * A chunked lazy sequence that realizes elements in batches for better performance.
@@ -58,7 +59,7 @@ final class ChunkedSeq extends AbstractType implements LazySeqInterface, Countab
         HasherInterface $hasher,
         EqualizerInterface $equalizer,
         Generator $generator,
-        int $chunkSize = LazySeqConfig::CHUNK_SIZE,
+        int $chunkSize = LazySeqConfig::FIRST_CHUNK_SIZE,
         ?PersistentMapInterface $meta = null,
     ): ?self {
         $values = [];
@@ -75,8 +76,13 @@ final class ChunkedSeq extends AbstractType implements LazySeqInterface, Countab
 
         $chunk = new Chunk($values);
 
+        // Each chunk is twice the last, capped at the configured batch size. A
+        // sequence that is consumed in full still reaches that size after a few
+        // chunks; one abandoned after a couple of elements never realizes 32.
+        $nextChunkSize = min($chunkSize * 2, LazySeqConfig::CHUNK_SIZE);
+
         $thunk = new MemoizedThunk(
-            static fn(): ?ChunkedSeq => self::fromGenerator($hasher, $equalizer, $generator, $chunkSize),
+            static fn(): ?ChunkedSeq => self::fromGenerator($hasher, $equalizer, $generator, $nextChunkSize),
         );
 
         return new self($hasher, $equalizer, $chunk, $thunk, $meta);

--- a/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
+++ b/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
@@ -16,7 +16,6 @@ use Traversable;
 
 use function array_slice;
 use function count;
-use function min;
 
 /**
  * A chunked lazy sequence that realizes elements in batches for better performance.
@@ -76,13 +75,11 @@ final class ChunkedSeq extends AbstractType implements LazySeqInterface, Countab
 
         $chunk = new Chunk($values);
 
-        // Each chunk is twice the last, capped at the configured batch size. A
-        // sequence that is consumed in full still reaches that size after a few
-        // chunks; one abandoned after a couple of elements never realizes 32.
-        $nextChunkSize = min($chunkSize * 2, LazySeqConfig::CHUNK_SIZE);
-
+        // Only the first chunk is small. Anything that asks for a second one is
+        // being consumed rather than probed, so it goes straight to the full
+        // batch size instead of climbing towards it a chunk at a time.
         $thunk = new MemoizedThunk(
-            static fn(): ?ChunkedSeq => self::fromGenerator($hasher, $equalizer, $generator, $nextChunkSize),
+            static fn(): ?ChunkedSeq => self::fromGenerator($hasher, $equalizer, $generator, LazySeqConfig::CHUNK_SIZE),
         );
 
         return new self($hasher, $equalizer, $chunk, $thunk, $meta);

--- a/src/php/Lang/Collections/LazySeq/LazySeqConfig.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeqConfig.php
@@ -25,9 +25,9 @@ final class LazySeqConfig
      * anything up to 32 elements, whether or not the caller ever looked past
      * the first (#3061).
      *
-     * Chunks double from here up to `CHUNK_SIZE`, so a sequence that is fully
-     * consumed still reaches the batch size it was tuned for, while one that is
-     * abandoned early pays for what it used.
+     * Every later chunk is a full `CHUNK_SIZE`, so a sequence that is actually
+     * consumed pays one extra chunk boundary and nothing more, while one that is
+     * abandoned after a couple of elements never realizes 32.
      */
     public const int FIRST_CHUNK_SIZE = 4;
 

--- a/src/php/Lang/Collections/LazySeq/LazySeqConfig.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeqConfig.php
@@ -16,6 +16,22 @@ final class LazySeqConfig
     public const int CHUNK_SIZE = 32;
 
     /**
+     * Size of the *first* chunk a lazy sequence realizes.
+     *
+     * `ChunkedSeq::fromGenerator` answers "is this sequence empty?" by
+     * returning null, which means construction has to pull at least one
+     * element. It does not have to pull {@see self::CHUNK_SIZE} of them, and
+     * doing so made construction cost proportional to the whole collection for
+     * anything up to 32 elements, whether or not the caller ever looked past
+     * the first (#3061).
+     *
+     * Chunks double from here up to `CHUNK_SIZE`, so a sequence that is fully
+     * consumed still reaches the batch size it was tuned for, while one that is
+     * abandoned early pays for what it used.
+     */
+    public const int FIRST_CHUNK_SIZE = 4;
+
+    /**
      * Maximum number of elements to display when printing a lazy sequence in the REPL.
      * This prevents accidentally realizing huge or infinite sequences.
      */

--- a/tests/php/Benchmark/Phel/CoreSeqBench.php
+++ b/tests/php/Benchmark/Phel/CoreSeqBench.php
@@ -70,6 +70,12 @@ final class CoreSeqBench extends CoreBenchCase
     private $compare;
 
     /** @var callable */
+    private $partitionBy;
+
+    /** @var callable */
+    private $dedupe;
+
+    /** @var callable */
     private $slice;
 
     /** @var callable */
@@ -486,8 +492,50 @@ final class CoreSeqBench extends CoreBenchCase
         }
     }
 
+    /**
+     * `partition-by` and `dedupe` return a sequence built by
+     * `lazy-seq-from-generator`, so constructing one realizes a chunk before
+     * the caller has asked for a single element. These two subjects measure
+     * that construction on its own, which is the cost #3061 is about and the
+     * part `FIRST_CHUNK_SIZE` moves; the `_realized` pair below is what pays
+     * for it, one extra chunk boundary on a sequence consumed in full.
+     *
+     * @Revs(1000)
+     */
+    public function bench_partition_by_unrealized(): void
+    {
+        ($this->partitionBy)($this->isEven, $this->ints);
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_partition_by_realized(): void
+    {
+        ($this->count)(($this->partitionBy)($this->isEven, $this->ints));
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_dedupe_unrealized(): void
+    {
+        ($this->dedupe)($this->ints);
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_dedupe_realized(): void
+    {
+        ($this->count)(($this->dedupe)($this->ints));
+    }
+
     protected function setUpFixtures(): void
     {
+        $this->partitionBy = $this->coreFn('partition-by');
+        $this->dedupe = $this->coreFn('dedupe');
+
         $this->numEquals = $this->coreFn('==');
         $this->comp = $this->coreFn('comp');
 

--- a/tests/php/Unit/Architecture/public-api.snapshot.txt
+++ b/tests/php/Unit/Architecture/public-api.snapshot.txt
@@ -513,7 +513,7 @@ final class Phel\Lang\Collections\LazySeq\ChunkedSeq extends Phel\Lang\AbstractT
   public function toArray(): array
   public function withMeta(?Phel\Lang\Collections\Map\PersistentMapInterface $meta): static
   public static function fromArray(Phel\Lang\HasherInterface $hasher, Phel\Lang\EqualizerInterface $equalizer, array $array, int $chunkSize = 32, ?Phel\Lang\Collections\Map\PersistentMapInterface $meta = null): ?Phel\Lang\Collections\LazySeq\ChunkedSeq
-  public static function fromGenerator(Phel\Lang\HasherInterface $hasher, Phel\Lang\EqualizerInterface $equalizer, Generator $generator, int $chunkSize = 32, ?Phel\Lang\Collections\Map\PersistentMapInterface $meta = null): ?Phel\Lang\Collections\LazySeq\ChunkedSeq
+  public static function fromGenerator(Phel\Lang\HasherInterface $hasher, Phel\Lang\EqualizerInterface $equalizer, Generator $generator, int $chunkSize = 4, ?Phel\Lang\Collections\Map\PersistentMapInterface $meta = null): ?Phel\Lang\Collections\LazySeq\ChunkedSeq
 
 final class Phel\Lang\Collections\LazySeq\Cons extends Phel\Lang\AbstractType implements IteratorAggregate, Phel\Lang\SeqInterface
   public function __construct(Phel\Lang\HasherInterface $hasher, Phel\Lang\EqualizerInterface $equalizer, mixed $first, Phel\Lang\Collections\LazySeq\LazySeqInterface $rest, ?Phel\Lang\Collections\Map\PersistentMapInterface $meta = null)
@@ -552,6 +552,7 @@ final class Phel\Lang\Collections\LazySeq\LazySeq extends Phel\Lang\AbstractType
 
 final class Phel\Lang\Collections\LazySeq\LazySeqConfig
   public const int CHUNK_SIZE = 32
+  public const int FIRST_CHUNK_SIZE = 4
   public const int REPL_DISPLAY_LIMIT = 100
 
 final readonly class Phel\Lang\Collections\LazySeq\LazySeqEquality

--- a/tests/php/Unit/Lang/Collections/LazySeq/ChunkedSeqTest.php
+++ b/tests/php/Unit/Lang/Collections/LazySeq/ChunkedSeqTest.php
@@ -287,8 +287,11 @@ final class ChunkedSeqTest extends TestCase
 
         $current->first();
 
-        $this->assertGreaterThanOrEqual($chunkSize * 2, $realizationCount, 'Second chunk should be realized');
-        $this->assertLessThanOrEqual($chunkSize * 2 + 2, $realizationCount, 'Should not realize much more than two chunks');
+        // Chunks double up to LazySeqConfig::CHUNK_SIZE, so the second chunk is
+        // twice the first: after walking the first, realization is
+        // $chunkSize + 2 * $chunkSize rather than $chunkSize * 2.
+        $this->assertGreaterThanOrEqual($chunkSize * 3, $realizationCount, 'Second chunk should be realized');
+        $this->assertLessThanOrEqual($chunkSize * 3 + 2, $realizationCount, 'Should not realize much more than two chunks');
     }
 
     public function test_cdr_memoization_prevents_generator_advancement(): void

--- a/tests/php/Unit/Lang/Collections/LazySeq/ChunkedSeqTest.php
+++ b/tests/php/Unit/Lang/Collections/LazySeq/ChunkedSeqTest.php
@@ -287,11 +287,12 @@ final class ChunkedSeqTest extends TestCase
 
         $current->first();
 
-        // Chunks double up to LazySeqConfig::CHUNK_SIZE, so the second chunk is
-        // twice the first: after walking the first, realization is
-        // $chunkSize + 2 * $chunkSize rather than $chunkSize * 2.
-        $this->assertGreaterThanOrEqual($chunkSize * 3, $realizationCount, 'Second chunk should be realized');
-        $this->assertLessThanOrEqual($chunkSize * 3 + 2, $realizationCount, 'Should not realize much more than two chunks');
+        // Only the first chunk honours the size passed in; every later one is a
+        // full LazySeqConfig::CHUNK_SIZE, so after walking the first chunk the
+        // count is $chunkSize + CHUNK_SIZE rather than $chunkSize * 2.
+        $expected = $chunkSize + LazySeqConfig::CHUNK_SIZE;
+        $this->assertGreaterThanOrEqual($expected, $realizationCount, 'Second chunk should be realized');
+        $this->assertLessThanOrEqual($expected + 2, $realizationCount, 'Should not realize much more than two chunks');
     }
 
     public function test_cdr_memoization_prevents_generator_advancement(): void


### PR DESCRIPTION
## 🤔 Background

The stdlib sweep is finished, and nearly every floor it kept hitting traced back to #3061: `ChunkedSeq` realizing a full 32-element chunk in its constructor. That is why constructing a `partition-by` costs more than consuming it, why `interleave` has a floor, and why #3074 had to be written as first-element-then-tail to avoid a 5.8x regression.

I looked at whether it could be deferred outright and it cannot: **`fromGenerator` reports emptiness by returning null**, every core caller branches on that, and answering "is it empty?" requires pulling an element. That contract is what makes this a decision rather than a patch.

But it only requires pulling **one** element, not 32.

## 🔖 Changes

The first chunk is 4; every later chunk is the existing 32. The null-when-empty contract is untouched, so no call site changes.

PHPBench, against `origin/main` as a stored baseline:

| subject | main | this PR | |
|---|---|---|---|
| `bench_partition_by_unrealized` | 38.68us | 8.08us | **-79%** |
| `bench_dedupe_unrealized` | 10.04us | 2.88us | **-71%** |
| `bench_interleave_unrealized` | 6.14us | 5.73us | **-6.8%** |
| `bench_partition_by_realized` | 40.72us | 41.02us | +0.8% |
| `bench_dedupe_realized` | 11.48us | 12.14us | +5.7% |
| `bench_for_range` | 8.06us | 8.18us | +7.0% |

`partition-by` and `dedupe` carry the win and had no benchmark guarding them, so this adds the paired subjects rather than quoting numbers nothing re-checks.

## The trade, stated plainly

A sequence consumed in full crosses one extra chunk boundary. On the 32-element collections the benchmarks use that is 6-7%; above 32 it amortizes away, since it is one extra boundary regardless of length. Sequences that are constructed and probed rather than drained get the 70-80%.

Note this only moves functions built on `lazy-seq-from-generator`. `map` and `filter` go through `LazySeq/fromGenerator`, which never had an eager chunk, and are unchanged.

## What the first attempt got wrong

The first version grew chunks 4 -> 8 -> 16 -> 32, on the theory that a fully consumed sequence should still reach the batch size it was tuned for. CI caught it: `bench_for_range` **+29.5%**, reproduced locally at +24.9%.

The bench realizes exactly 32 elements, so the ladder turned one chunk into four. The ladder was also buying nothing: the entire win comes from chunk *one* being small, and no amount of climbing afterwards adds to it. Removing it takes the same benchmark to +7%.

## Why 4 and not 1

At 1 the extra thunk hops genuinely do cost full realization ~10%, consistently and outside the noise. At 4 they do not, and the construction win is already most of what 1 would give. 8 and 16 were also measured; they give back the gain without buying anything.

## Scope

**This does not close #3061**, which asks for the fuller redesign, chunking on realization rather than construction, sized by source elements consumed rather than output produced. This removes the construction cost that made the current design expensive for short sequences and leaves that decision open.

`ChunkedSeqTest` pinned the old fixed schedule; the second chunk is now `CHUNK_SIZE` regardless of the first, and the assertion says so.

Related to #3061
