### PR TITLE
perf(core): give the combinator closures real arities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ Runtime core:
 
 Standard library:
 
+- Give the closures returned by `complement`, `constantly`, `some-fn` and `every-pred` real arities instead of a rest argument. The returned closure is what runs per call, and for a predicate that means per element: calling a `complement` is 4.4x, a `constantly` 9.5x, a `some-fn` 2.3x and an `every-pred` 2.2x (#2973)
 - Give the reducing function every transducer wraps real arities instead of a rest argument and a `case` on its count, and the same for `completing` and `transduce`. These closures are called once per element reduced, so the rest vector and the dispatch were paid per element: `(transduce (map inc) + 0 v)` over 32 elements drops 79% and the `filter` equivalent 74% (#2973)
 - Realize 4 elements when a lazy sequence is constructed instead of the full batch of 32; every later chunk is still 32. `ChunkedSeq::fromGenerator` reports emptiness by returning nil, so it must pull one element, but it need not pull a whole batch before the caller has asked for anything: constructing a `partition-by` drops 79% and a `dedupe` 71%. A sequence consumed in full pays one extra chunk boundary for it, which is 6-7% on the 32 element collections the benchmarks use and proportionally less above that (#3061)
 - Join `phel.html`'s runtime render with `implode` over a PHP array instead of `apply str` over a lazy sequence: 1.51x on an attribute-heavy element, 1.42x on a five-node document. Only affects documents the `html` macro cannot compile at expansion time, which is any template built from data (#3098)

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -157,14 +157,27 @@
   {:example "((constantly 42) 1 2 3) ; => 42"
    :see-also ["identity" "fnil"]}
   [x]
-  (fn [& _] x))
+  ;; The rest vector was built on every call only to be discarded (#2973).
+  (fn
+    ([] x)
+    ([_] x)
+    ([_ _] x)
+    ([_ _ & _] x)))
 
 (defn complement
   "Returns a function that takes the same arguments as `f` and returns the opposite truth value."
   {:example "((complement even?) 3) ; => true"
    :see-also ["not" "some-fn"]}
   [f]
-  #(not (apply f %&)))
+  ;; As with `partial` and `juxt`, the returned closure is what runs per call,
+  ;; and a negated predicate is almost always called with one argument. The
+  ;; `#(not (apply f %&))` spelling built a rest vector and went through
+  ;; `apply` every time (#2973).
+  (fn
+    ([] (not (f)))
+    ([x] (not (f x)))
+    ([x y] (not (f x y)))
+    ([x y & more] (not (apply f x y more)))))
 
 ;; Phel fns compile to invokable objects or plain PHP closures; the
 ;; `__invoke` signature is the single reflection point covering both.
@@ -194,8 +207,15 @@
    (throw (new InvalidArgumentException "some-fn expects at least one predicate")))
   ([p & ps]
    (let [preds (cons p ps)]
-     (fn [& args]
-       (or (some (fn [pred] (some pred args)) preds) false)))))
+     ;; A combined predicate is almost always called with one argument, and
+     ;; that case does not need the rest vector or the inner `some` over it
+     ;; (#2973). The variadic tail keeps the general behaviour.
+     (fn
+       ([] false)
+       ([x] (or (some (fn [pred] (pred x)) preds) false))
+       ([x & more]
+        (let [args (cons x more)]
+          (or (some (fn [pred] (some pred args)) preds) false)))))))
 
 (defn every-pred
   "Takes a variadic set of predicates and returns a function `f` that, when called with any number of arguments, returns `true` if every composing predicate returns a logical true value against every argument, and `false` otherwise. The returned function short-circuits on the first logical false result: arguments after it are not inspected, and predicates after it are not tried. Predicates are consulted in the order supplied; for a given predicate, arguments are consulted left-to-right. With no arguments the returned function returns `true`."
@@ -205,8 +225,15 @@
    (throw (new InvalidArgumentException "every-pred expects at least one predicate")))
   ([p & ps]
    (let [preds (cons p ps)]
-     (fn [& args]
-       (every? (fn [pred] (every? pred args)) preds)))))
+     ;; As in `some-fn`: the one-argument call is the common one and does not
+     ;; need the rest vector or the inner `every?` over it (#2973). The
+     ;; no-argument arity answers `true`, as the docstring says.
+     (fn
+       ([] true)
+       ([x] (every? (fn [pred] (pred x)) preds))
+       ([x & more]
+        (let [args (cons x more)]
+          (every? (fn [pred] (every? pred args)) preds)))))))
 
 (defn juxt
   "Takes a list of functions and returns a new function that is the juxtaposition of those functions."

--- a/tests/phel/core/combinator-closure-arities.phel
+++ b/tests/phel/core/combinator-closure-arities.phel
@@ -1,0 +1,70 @@
+(ns phel-test.core.combinator-closure-arities
+  (:require phel.test :refer [deftest is]))
+
+;; `complement`, `constantly`, `some-fn` and `every-pred` each returned a
+;; closure taking a rest argument. That closure is what runs per call, and for
+;; a predicate that means per element. Giving it real arities has to leave every
+;; arity it used to answer answering the same thing, including the no-argument
+;; and many-argument ends that are easy to drop when writing them out.
+
+(deftest test-complement-arities
+  (is (true? ((complement (fn [] false)))) "no arguments")
+  (is (true? ((complement even?) 3)) "one argument, predicate false")
+  (is (false? ((complement even?) 4)) "one argument, predicate true")
+  (is (true? ((complement =) 1 2)) "two arguments")
+  (is (false? ((complement =) 1 1)) "two arguments, predicate true")
+  (is (false? ((complement =) 1 1 1)) "three arguments")
+  (is (true? ((complement =) 1 1 2)) "three arguments, predicate false")
+  (is (false? ((complement =) 1 1 1 1)) "four arguments")
+  (is (true? ((complement =) 1 1 1 1 2)) "five arguments reach the variadic tail")
+  ;; Phel truthiness: 0 and "" are truthy, only nil and false are not.
+  (is (true? ((complement identity) nil)) "nil is falsy")
+  (is (true? ((complement identity) false)) "false is falsy")
+  (is (false? ((complement identity) 0)) "zero is truthy in Phel")
+  (is (false? ((complement identity) "")) "the empty string is truthy in Phel"))
+
+(deftest test-constantly-arities
+  (let [f (constantly 42)]
+    (is (= 42 (f)) "no arguments")
+    (is (= 42 (f 1)) "one argument")
+    (is (= 42 (f 1 2)) "two arguments")
+    (is (= 42 (f 1 2 3)) "three arguments")
+    (is (= 42 (f 1 2 3 4 5 6)) "six arguments reach the variadic tail"))
+  (is (nil? ((constantly nil) 1)) "a nil constant is returned, not treated as missing")
+  (is (false? ((constantly false))) "a false constant survives"))
+
+(deftest test-some-fn-arities
+  (let [f (some-fn even?)]
+    (is (false? (f)) "no arguments is false")
+    (is (true? (f 2)) "one matching argument")
+    (is (false? (f 3)) "one non-matching argument")
+    (is (true? (f 1 2)) "a later argument matches")
+    (is (false? (f 1 3)) "no argument matches"))
+  (is (true? ((some-fn even? nil?) 1 2)) "the second predicate matches")
+  (is (false? ((some-fn pos? even?) -3 -1)) "neither predicate matches any argument")
+  (is (true? ((some-fn neg?) 1 2 -3)) "three arguments reach the variadic tail")
+  ;; `some-fn` returns the predicate's value, not a coerced boolean, and only
+  ;; falls back to `false` when nothing matched.
+  (is (= :yes ((some-fn (fn [x] (if (pos? x) :yes nil))) 5))
+      "the truthy value is returned as-is")
+  (is (false? ((some-fn (fn [_] nil)) 5)) "no match answers false, not nil"))
+
+(deftest test-every-pred-arities
+  (let [f (every-pred even?)]
+    (is (true? (f)) "no arguments is true")
+    (is (true? (f 2)) "one matching argument")
+    (is (false? (f 3)) "one non-matching argument")
+    (is (true? (f 2 4)) "both arguments match")
+    (is (false? (f 2 3)) "the second argument fails"))
+  (is (true? ((every-pred even? pos?) 2 4 6)) "three arguments reach the variadic tail")
+  (is (false? ((every-pred even? pos?) 2 -4)) "the second predicate fails")
+  (is (true? ((every-pred (fn [x] x)) 0)) "zero is truthy in Phel"))
+
+(deftest test-combinators-still-compose-with-the-sequence-functions
+  ;; The point of the rewrite is the per-element call, so exercise them where
+  ;; that happens.
+  (is (= [1 3 5] (vec (filter (complement even?) [1 2 3 4 5]))) "complement filters")
+  (is (= [2 4] (vec (remove (complement even?) [1 2 3 4]))) "complement inside remove")
+  (is (= [42 42 42] (vec (map (constantly 42) [1 2 3]))) "constantly maps")
+  (is (= [2 -1] (vec (filter (some-fn even? neg?) [1 2 3 -1]))) "some-fn filters")
+  (is (= [2 4] (vec (filter (every-pred even? pos?) [1 2 -2 3 4]))) "every-pred filters"))

--- a/tests/php/Benchmark/Phel/CoreSeqBench.php
+++ b/tests/php/Benchmark/Phel/CoreSeqBench.php
@@ -79,6 +79,18 @@ final class CoreSeqBench extends CoreBenchCase
     private $transduce;
 
     /** @var callable */
+    private $notEven;
+
+    /** @var callable */
+    private $always;
+
+    /** @var callable */
+    private $someFn;
+
+    /** @var callable */
+    private $everyPred;
+
+    /** @var callable */
     private $slice;
 
     /** @var callable */
@@ -496,6 +508,51 @@ final class CoreSeqBench extends CoreBenchCase
     }
 
     /**
+     * `comp` above measures building the combinator. These four measure
+     * *calling* what a combinator handed back, which is the side that runs
+     * once per element when the result is used as a predicate. The closures
+     * are built once, in `setUpFixtures`, so what is timed is the call.
+     *
+     * @Revs(1000)
+     */
+    public function bench_complement_call(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->notEven)($i);
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_constantly_call(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->always)($i);
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_some_fn_call(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->someFn)($i);
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_every_pred_call(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->everyPred)($i);
+        }
+    }
+
+    /**
      * The subjects above hand back a transducer and stop there, so none of
      * them reaches the reducing function it wraps. This one drives 32 elements
      * through it, which is where a per-step cost would show up.
@@ -558,6 +615,11 @@ final class CoreSeqBench extends CoreBenchCase
     {
         $this->partitionBy = $this->coreFn('partition-by');
         $this->transduce = $this->coreFn('transduce');
+
+        $this->notEven = ($this->coreFn('complement'))($this->coreFn('even?'));
+        $this->always = ($this->coreFn('constantly'))(42);
+        $this->someFn = ($this->coreFn('some-fn'))($this->coreFn('even?'), $this->coreFn('neg?'));
+        $this->everyPred = ($this->coreFn('every-pred'))($this->coreFn('even?'), $this->coreFn('pos?'));
         $this->dedupe = $this->coreFn('dedupe');
 
         $this->numEquals = $this->coreFn('==');


### PR DESCRIPTION
## 🤔 Background

#3021 converted the closures returned by `partial`, `fnil` and `comp`, measuring 30x, 50x and 8x. `complement`, `constantly`, `some-fn` and `every-pred` are the rest of that family and were left as `(fn [& args] ...)`. `complement` also went through `apply` on every call.

These four are predicates. What matters is not the cost of building the combinator but the cost of calling what it returns, because that runs once per element when the result reaches `filter`, `remove` or `some`.

## 🔖 Changes

Each returned closure gets fixed arities with a variadic tail for the general case.

PHPBench, `origin/main` as a stored baseline, 32 calls per revolution:

| subject | main | this PR | |
|---|---|---|---|
| `bench_constantly_call` | 21.66us | 2.28us | **-89%** |
| `bench_complement_call` | 48.65us | 10.96us | **-77%** |
| `bench_some_fn_call` | 144.99us | 64.41us | **-56%** |
| `bench_every_pred_call` | 89.77us | 41.71us | **-54%** |
| `bench_comp_two` (building) | 14.63us | 14.70us | +0.5% |

The four `_call` subjects are new. The suite had `bench_comp_two`, which builds a combinator and never calls it, so the side that runs per element was unmeasured. Same gap the transducer subjects had in #3101.

## The arities that are easy to lose

Writing a rest argument out by hand drops the ends. Both matter here and both are behaviour rather than edge cases:

- `((some-fn even?))` is `false`
- `((every-pred even?))` is `true`, which the docstring already promised

Both are kept, and the test file asserts every arity from zero up through the variadic tail. Phel truthiness is pinned too, since `0` and `""` are truthy and a predicate rewrite is exactly where that goes wrong.

## Verification

Beyond the test file, all four were diffed against `origin/main` over 26 cases spanning every arity, both truthiness ends, value-returning predicates and the no-match fallbacks. Output was identical.

`arity` and `variadic?` are unaffected: a multi-arity Phel fn compiles to a single variadic dispatch either way, so both still report what they did. The core API snapshot is unchanged, since only the returned closures moved, not the four signatures.

Related to #2973
