### PR TITLE
perf(core): compare two native ints in min and max without the tower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ Runtime core:
 
 Standard library:
 
+- Answer `min` and `max` of two native ints with one PHP comparison instead of two `numeric-nan?` calls and a `<`/`>`. Two ints cannot be NaN, so the fast path is sound and everything else still reaches the numeric tower: 3.0x on a pair, 2.4x on three arguments, 2.5x on four (#2973)
 - Answer `(get ds k)` on a map or vector without delegating to the three-argument arity or reading through core `aget`. With no default an absent key already reads as nil, so the lookup collapses to the read itself and drops two of the three Phel calls it used to make: 1.6x on a map, 1.8x on a vector, 1.2x on `get-in` (#2973)
 - Give the closures returned by `complement`, `constantly`, `some-fn` and `every-pred` real arities instead of a rest argument. The returned closure is what runs per call, and for a predicate that means per element: calling a `complement` is 4.4x, a `constantly` 9.5x, a `some-fn` 2.3x and an `every-pred` 2.2x (#2973)
 - Give the reducing function every transducer wraps real arities instead of a rest argument and a `case` on its count, and the same for `completing` and `transduce`. These closures are called once per element reduced, so the rest vector and the dispatch were paid per element: `(transduce (map inc) + 0 v)` over 32 elements drops 79% and the `filter` equivalent 74% (#2973)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -660,11 +660,16 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   ;; propagation stays in one place (#2991).
   ([x] x)
   ([x y]
-   (cond
-     (numeric-nan? x) ##NaN
-     (numeric-nan? y) ##NaN
-     (< x y)          x
-     :else            y))
+   ;; Two native ints cannot be NaN and do not need the numeric tower, so the
+   ;; common pair answers with one PHP comparison instead of two
+   ;; `numeric-nan?` calls and a `<` (#2973, same narrow fast path as #3030).
+   (if (and (php/is_int x) (php/is_int y))
+     (if (php/< x y) x y)
+     (cond
+       (numeric-nan? x) ##NaN
+       (numeric-nan? y) ##NaN
+       (< x y)          x
+       :else            y)))
   ;; Three and four arguments fold through the pair arity rather than restating
   ;; the NaN rules, exactly as the tail does, so propagation stays in one place
   ;; (#2991). What they avoid is the tail's rest-argument allocation and
@@ -682,11 +687,16 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   ;; propagation stays in one place (#2991).
   ([x] x)
   ([x y]
-   (cond
-     (numeric-nan? x) ##NaN
-     (numeric-nan? y) ##NaN
-     (> x y)          x
-     :else            y))
+   ;; Two native ints cannot be NaN and do not need the numeric tower, so the
+   ;; common pair answers with one PHP comparison instead of two
+   ;; `numeric-nan?` calls and a `>` (#2973, same narrow fast path as #3030).
+   (if (and (php/is_int x) (php/is_int y))
+     (if (php/> x y) x y)
+     (cond
+       (numeric-nan? x) ##NaN
+       (numeric-nan? y) ##NaN
+       (> x y)          x
+       :else            y)))
   ;; Three and four arguments fold through the pair arity rather than restating
   ;; the NaN rules, exactly as the tail does, so propagation stays in one place
   ;; (#2991). What they avoid is the tail's rest-argument allocation and

--- a/tests/phel/core/min-max-int-fast-path.phel
+++ b/tests/phel/core/min-max-int-fast-path.phel
@@ -1,0 +1,57 @@
+(ns phel-test.core.min-max-int-fast-path
+  (:require phel.test :refer [deftest is]))
+
+;; `min` and `max` answer a pair of native ints with one PHP comparison
+;; instead of two `numeric-nan?` calls and a `<`/`>`. Two ints cannot be NaN,
+;; which is the only reason the fast path may skip those checks, so everything
+;; that is *not* two native ints has to keep reaching the numeric tower.
+
+(deftest test-two-native-ints
+  (is (= 2 (max 1 2)) "max of two ints")
+  (is (= 1 (min 1 2)) "min of two ints")
+  (is (= 2 (max 2 1)) "max with the larger first")
+  (is (= 1 (min 2 1)) "min with the smaller first")
+  (is (= 1 (max 1 1)) "max of equal ints")
+  (is (= 1 (min 1 1)) "min of equal ints")
+  (is (= 0 (max -5 0)) "negative and zero")
+  (is (= -5 (min -5 0)) "min of negative and zero")
+  (is (= php/PHP_INT_MAX (max 1 php/PHP_INT_MAX)) "the largest native int")
+  (is (= php/PHP_INT_MIN (min 1 php/PHP_INT_MIN)) "the smallest native int"))
+
+(deftest test-nan-still-propagates
+  ;; NaN is a float, so it never takes the int fast path. If it ever did, these
+  ;; would answer a number instead.
+  (is (nan? (max 1 ##NaN)) "max with NaN second")
+  (is (nan? (max ##NaN 1)) "max with NaN first")
+  (is (nan? (min 1 ##NaN)) "min with NaN second")
+  (is (nan? (min ##NaN 1)) "min with NaN first")
+  (is (nan? (max ##NaN ##NaN)) "both NaN")
+  (is (nan? (max 1 2 ##NaN)) "NaN through the three-argument arity")
+  (is (nan? (min 1 2 3 ##NaN)) "NaN through the four-argument arity")
+  (is (nan? (max 1 2 3 4 ##NaN)) "NaN through the variadic tail"))
+
+(deftest test-mixed-and-non-native-numbers
+  (is (= 2.5 (max 1 2.5)) "int and float")
+  (is (= 1 (min 1 2.5)) "min of int and float")
+  (is (= 2 (max 1.5 2)) "float and int")
+  (is (= ##Inf (max 1 ##Inf)) "infinity")
+  (is (= ##-Inf (min 1 ##-Inf)) "negative infinity")
+  (is (= 1 (max 1 ##-Inf)) "max against negative infinity")
+  (let [big (bigint "99999999999999999999")]
+    (is (= big (max 1 big)) "a BigInt is larger than any native int")
+    (is (= 1 (min 1 big)) "min against a BigInt"))
+  (let [r (/ 3 4)]
+    (is (= 1 (max r 1)) "a Ratio compares against an int")
+    (is (= r (min r 1)) "min against a Ratio")))
+
+(deftest test-more-than-two-arguments
+  (is (= 3 (max 1 2 3)) "three arguments")
+  (is (= 1 (min 1 2 3)) "min of three")
+  (is (= 4 (max 1 2 3 4)) "four arguments")
+  (is (= 1 (min 1 2 3 4)) "min of four")
+  (is (= 9 (max 1 2 3 4 9)) "five arguments reach the variadic tail")
+  (is (= 0 (min 1 2 3 4 0)) "min through the variadic tail")
+  (is (= 7 (max 7)) "one argument")
+  (is (= 7 (min 7)) "one argument for min")
+  (is (= 5 (apply max (range 0 6))) "applied over a collection")
+  (is (= 0 (apply min (range 0 6))) "min applied over a collection"))


### PR DESCRIPTION
## 🤔 Background

`bench_max_two` sat at **19.2x** the raw PHP comparison, the worst ratio among the paired arithmetic subjects. #2991 already gave `min` and `max` fixed arities, so the rest-argument cost was gone; what remained was that the pair arity makes four Phel function calls to answer one comparison:

```
(max x y) -> max, (numeric-nan? x), (numeric-nan? y), (> x y)
```

## 🔖 Changes

Two native ints cannot be NaN. That is the whole argument: for that one case the guards answer nothing, so the pair is settled with a single PHP comparison. Every other input, floats included, still reaches the numeric tower untouched, which is what keeps NaN propagating.

PHPBench, `origin/main` as a stored baseline:

| subject | main | this PR | |
|---|---|---|---|
| `bench_max_two` | 12.23us | 4.01us | **-67%** |
| `bench_min_two` | 11.75us | 4.01us | **-66%** |
| `bench_max_four` | 38.20us | 15.08us | **-61%** |
| `bench_min_four` | 38.20us | 15.12us | **-61%** |
| `bench_max_three` | 26.53us | 10.78us | **-59%** |
| `bench_min_three` | 26.53us | 10.99us | **-58%** |
| `bench_max_two_raw` | 0.637us | 0.609us | -4.4% |

Wrapper overhead against the raw comparison: **19.2x to 6.6x**.

Three and four arguments improve without being touched: they fold through the pair arity, which is where #2991 deliberately put NaN propagation so it lives in one place.

## Verification

The risk here is a fast path that swallows NaN, so the check is exhaustive rather than illustrative. `min` and `max` were diffed against `origin/main` over **all 225 ordered pairs** drawn from 15 values: native ints (including `PHP_INT_MAX`, zero, negatives), floats, `##NaN`, `##Inf`, `##-Inf`, `BigInt`, `Ratio` and `BigDecimal`. Each pair was evaluated through the two, three and five argument spellings, catching throws as values. Every row was identical.

The test file pins the parts that would break silently: NaN through each arity, ties, both infinities, and the mixed int/float, int/BigInt and int/Ratio cases that must not take the fast path.

Related to #2973
