### PR TITLE
perf(core): reach a vector conj target without the predicate calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ Runtime core:
 
 Standard library:
 
+- Answer `conj` on a vector target, persistent or transient, in its own two-argument arity, and reach a transient vector in `conj-impl` by its own `instanceof` rather than through `vector-target?` calling `transient-vector?`. That branch runs once per element in every `into`, `frequencies`, `group-by` and `for :reduce` over a transient: `into` a vector 1.3x, `conj` on a vector 1.2x. A list target pays about 3% more for two extra `instanceof` (#2973)
 - Answer `min` and `max` of two native ints with one PHP comparison instead of two `numeric-nan?` calls and a `<`/`>`. Two ints cannot be NaN, so the fast path is sound and everything else still reaches the numeric tower: 3.0x on a pair, 2.4x on three arguments, 2.5x on four (#2973)
 - Answer `(get ds k)` on a map or vector without delegating to the three-argument arity or reading through core `aget`. With no default an absent key already reads as nil, so the lookup collapses to the read itself and drops two of the three Phel calls it used to make: 1.6x on a map, 1.8x on a vector, 1.2x on `get-in` (#2973)
 - Give the closures returned by `complement`, `constantly`, `some-fn` and `every-pred` real arities instead of a rest argument. The returned closure is what runs per call, and for a predicate that means per element: calling a `complement` is 4.4x, a `constantly` 9.5x, a `some-fn` 2.3x and an `every-pred` 2.2x (#2973)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -220,13 +220,26 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
     ;; not implement PersistentVectorInterface, so the MapEntry branch below
     ;; still sees every entry. Transients keep their original slot.
     (php/instanceof coll PersistentVectorInterface) (.append coll value)
+    ;; Transient vector second, by its own `instanceof` rather than through
+    ;; `vector-target?`. Every `into` on a vector target reduces `conj` over a
+    ;; transient, so this is the branch that runs per element there, and it used
+    ;; to be reached sixth, behind `vector-target?` calling `transient-vector?`:
+    ;; two function calls to answer one `instanceof`. The persistent half of
+    ;; `vector-target?` is the branch above, so the pair is exhaustive (#2973).
+    (php/instanceof coll TransientVectorInterface)  (.append coll value)
     (php/=== coll nil)                              (list value)
     (php/instanceof coll PersistentListInterface)   (cons value coll)
     (php/instanceof coll LazySeqInterface)          (cons value coll)
     (php/is_array coll)                             (do (php/apush coll value) coll)
-    (vector-target? coll)                           (.append coll value)
-    (set-target? coll)                              (.add coll value)
-    (map-target? coll)                              (conj-map-entry coll value)
+    ;; `set-target?` and `map-target?` spelled out for the same reason: each is
+    ;; an `or` of two `instanceof` and cost a call to answer it.
+    (or (php/instanceof coll PersistentHashSetInterface)
+        (php/instanceof coll TransientHashSetInterface))
+    (.add coll value)
+
+    (or (php/instanceof coll PersistentMapInterface)
+        (php/instanceof coll TransientMapInterface))
+    (conj-map-entry coll value)
     ;; MapEntry degrades to a 3-vector when grown; the result is no longer
     ;; an entry. Matches Clojure's MapEntry under conj.
     (php/instanceof coll MapEntry)
@@ -242,7 +255,15 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
   ([] [])
   ([coll] coll)
   ([coll value]
-   (conj-impl coll value))
+   ;; Appending to a vector, persistent or transient, is answered here rather
+   ;; than through `conj-impl`. `into`, `frequencies`, `group-by` and every
+   ;; `for :reduce` over a transient reduce this arity once per element, and
+   ;; the delegation was a whole function call to reach an `instanceof` the
+   ;; caller could make itself (#2973).
+   (if (or (php/instanceof coll PersistentVectorInterface)
+           (php/instanceof coll TransientVectorInterface))
+     (.append coll value)
+     (conj-impl coll value)))
   ([coll value & more]
    (reduce conj-impl (conj-impl coll value) more)))
 

--- a/tests/phel/core/conj-vector-fast-path.phel
+++ b/tests/phel/core/conj-vector-fast-path.phel
@@ -1,0 +1,56 @@
+(ns phel-test.core.conj-vector-fast-path
+  (:require phel.test :refer [deftest is]))
+
+(defstruct pt [x y])
+
+;; `conj` answers a vector target, persistent or transient, in its own
+;; two-argument arity, and `conj-impl` reaches a transient vector by its own
+;; `instanceof` rather than through `vector-target?`. Both changes move which
+;; branch a given collection lands on, so every target type has to keep
+;; answering what it did, and the ones that changed position most (transient
+;; vector, list, lazy seq, PHP array) get the closest attention.
+
+(deftest test-vector-targets
+  (is (= [1 2 3] (conj [1 2] 3)) "a persistent vector appends")
+  (is (= [3] (conj [] 3)) "an empty vector")
+  (is (= [1 2 3 4] (conj [1 2] 3 4)) "two values")
+  (is (= [1 2 nil] (conj [1 2] nil)) "a nil value is appended, not skipped")
+  (is (= [1 2 [3 4]] (conj [1 2] [3 4])) "a vector value nests"))
+
+(deftest test-transient-vector-target
+  ;; The branch every `into`, `frequencies` and `group-by` on a vector runs
+  ;; per element. It moved from sixth position to second.
+  (is (= [1 2 3] (persistent (conj (transient [1 2]) 3))) "a transient vector appends")
+  (is (= [3] (persistent (conj (transient []) 3))) "an empty transient vector")
+  (is (= [1 2 3 4] (persistent (conj (transient [1 2]) 3 4))) "two values")
+  (is (= [1 nil] (persistent (conj (transient [1]) nil))) "a nil value")
+  ;; `conj` on a transient mutates and returns the same transient rather than
+  ;; a fresh collection; losing that would break every `for :reduce` over one.
+  (let [t (transient [1])]
+    (is (identical? t (conj t 2)) "the transient itself comes back")))
+
+(deftest test-list-and-seq-targets
+  (is (= '(3 1 2) (conj '(1 2) 3)) "a list prepends")
+  (is (= '(3) (conj '() 3)) "an empty list")
+  (is (= '(4 3 1 2) (conj '(1 2) 3 4)) "two values prepend in order")
+  (is (= [3 1 2] (vec (conj (map identity [1 2]) 3))) "a lazy sequence prepends")
+  (is (= '(1) (conj nil 1)) "nil becomes a list"))
+
+(deftest test-set-and-map-targets
+  (is (= (set [1 2 3]) (conj (set [1 2]) 3)) "a set adds")
+  (is (= (set [1 2]) (conj (set [1 2]) 2)) "a set ignores a duplicate")
+  (is (= (set [1 2 3]) (persistent (conj (transient (set [1 2])) 3))) "a transient set adds")
+  (is (= {:a 1, :k :v} (conj {:a 1} [:k :v])) "a map takes a pair")
+  (is (= {:a 1, :k :v} (persistent (conj (transient {:a 1}) [:k :v]))) "a transient map takes a pair")
+  (is (= {:a 1, :b 2} (conj (sorted-map :a 1) [:b 2])) "a sorted map takes a pair")
+  (is (= 1 (get (conj (pt 1 2) [:x 1]) :x)) "a struct is a map target"))
+
+(deftest test-other-targets
+  (is (= [1 2 3] (vec (conj (php-indexed-array 1 2) 3))) "a PHP array pushes")
+  ;; A MapEntry grows into a plain 3-vector, matching Clojure.
+  (is (= [:a 1 :extra] (conj (first {:a 1}) :extra)) "a MapEntry degrades to a vector"))
+
+(deftest test-zero-and-one-argument-arities
+  (is (= [] (conj)) "no arguments is an empty vector")
+  (is (= [1 2] (conj [1 2])) "one argument returns the collection")
+  (is (nil? (conj nil)) "one nil argument returns nil"))


### PR DESCRIPTION
## 🤔 Background

`bench_into_vector` sat at **13x** the raw array build. `into` on a vector target reduces `conj` over a transient, so the per-element path was:

```
conj -> conj-impl -> (5 failed checks) -> vector-target? -> transient-vector? -> .append
```

Three Phel function calls and six `instanceof` to append one element. Two of those calls exist only to answer a single `instanceof`.

## 🔖 Changes

Two changes on the same path:

1. `conj`'s two-argument arity answers a vector target, persistent or transient, itself rather than delegating to `conj-impl`.
2. `conj-impl` reaches a transient vector by its own `instanceof`, in second position rather than sixth. `set-target?` and `map-target?` are spelled out as their `or` of two `instanceof` for the same reason.

PHPBench, `origin/main` as a stored baseline:

| subject | main | this PR | |
|---|---|---|---|
| `bench_into_vector` | 33.30us | 25.03us | **-25%** |
| `bench_conj_vector` | 18.10us | 14.79us | **-18%** |
| `bench_conj_list` | 17.67us | 18.19us | +3.0% |
| `bench_conj_vector_raw` | 8.06us | 8.03us | -0.5% |

## The regression is real and deliberate

`bench_conj_list` is about **3% slower**, reproduced across separate runs rather than a single noisy reading. A list now passes two extra `instanceof` before reaching its branch.

That is the trade: vectors are much the more common conj target, which is why `conj-impl` already ordered persistent vectors first and says so in its own comment. Paying 3% on lists to take 25% off every `into`, `frequencies`, `group-by` and `for :reduce` over a transient is the right side of it, but it is a cost, not a rounding error, so it is stated rather than buried.

## Why hoisting the transient check is safe

`vector-target?` is exactly `PersistentVectorInterface` or `TransientVectorInterface`. The persistent half is already the first branch of `conj-impl`, so testing the transient half immediately after covers the same set, and nothing between the old sixth position and the new second position can match a transient vector.

## Verification

`conj` was diffed against `origin/main` over **72 combinations**: all 18 collection shapes it accepts (persistent and transient vector, list, lazy seq, set, transient set, map, transient map, sorted map, sorted set, struct, MapEntry, PHP array, queue, string, nil, empties) crossed with 4 value shapes (int, pair, nil, vector), each through the two-argument and variadic spellings. Every row was identical.

The test file additionally pins that `conj` on a transient returns the *same* transient rather than a fresh collection, which is what every `for :reduce` over one depends on.

No new benchmark subject: `bench_into_vector`, `bench_conj_vector` and `bench_conj_list` already covered this, which is how the 13x was visible.

Related to #2973
