### PR TITLE
test(bench): cover the transient-map build path

### DIFF
--- a/tests/php/Benchmark/Phel/CoreSeqBench.php
+++ b/tests/php/Benchmark/Phel/CoreSeqBench.php
@@ -79,6 +79,12 @@ final class CoreSeqBench extends CoreBenchCase
     private $transduce;
 
     /** @var callable */
+    private $frequencies;
+
+    /** @var callable */
+    private $groupBy;
+
+    /** @var callable */
     private $notEven;
 
     /** @var callable */
@@ -130,6 +136,10 @@ final class CoreSeqBench extends CoreBenchCase
     private mixed $emptyVector = null;
 
     private mixed $map = null;
+
+    private mixed $emptyMap = null;
+
+    private mixed $pairs = null;
 
     /**
      * The all-int input, which is the shape `sort` can answer without calling
@@ -553,6 +563,34 @@ final class CoreSeqBench extends CoreBenchCase
     }
 
     /**
+     * `frequencies` and a map-target `into` both reduce `assoc!` over a
+     * transient map once per element, which no subject reached: the `into`
+     * pair above uses a vector target and so goes through `conj` instead.
+     *
+     * @Revs(1000)
+     */
+    public function bench_frequencies(): void
+    {
+        ($this->frequencies)($this->ints);
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_into_map(): void
+    {
+        ($this->into)($this->emptyMap, $this->pairs);
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_group_by(): void
+    {
+        ($this->groupBy)($this->isEven, $this->ints);
+    }
+
+    /**
      * The subjects above hand back a transducer and stop there, so none of
      * them reaches the reducing function it wraps. This one drives 32 elements
      * through it, which is where a per-step cost would show up.
@@ -615,6 +653,8 @@ final class CoreSeqBench extends CoreBenchCase
     {
         $this->partitionBy = $this->coreFn('partition-by');
         $this->transduce = $this->coreFn('transduce');
+        $this->frequencies = $this->coreFn('frequencies');
+        $this->groupBy = $this->coreFn('group-by');
 
         $this->notEven = ($this->coreFn('complement'))($this->coreFn('even?'));
         $this->always = ($this->coreFn('constantly'))(42);
@@ -663,5 +703,13 @@ final class CoreSeqBench extends CoreBenchCase
         ]);
         $this->emptyVector = Phel::vector([]);
         $this->map = Phel::map(Phel::keyword('a'), 1, Phel::keyword('b'), 2);
+        $this->emptyMap = Phel::map();
+
+        $pairs = [];
+        for ($i = 0; $i < self::SIZE; ++$i) {
+            $pairs[] = Phel::vector([$i, $i * 2]);
+        }
+
+        $this->pairs = Phel::vector($pairs);
     }
 }


### PR DESCRIPTION
## 🤔 Background

After #3105 took 25% off `into` a vector by hoisting the hot branch out of `conj-impl`, the obvious next step was the same hoist for `assoc!` and `conj!`, whose `assoc-bang-pair` and `conj-bang-single` delegations sit on exactly the same kind of per-element path.

I could not tell whether it worked, because **no benchmark subject reached that path**. `bench_into_vector` uses a vector target, which goes through `conj`; nothing exercised a transient *map*.

## 🔖 Changes

Three subjects for the transient-map build path, which `frequencies`, `group-by` and a map-target `into` all reduce `assoc!` over once per element:

| subject | timing |
|---|---|
| `bench_frequencies` | 102.65us |
| `bench_into_map` | 118.11us |
| `bench_group_by` | 69.28us |

Benchmarks only. No `src/` change.

## The result they produced is negative, and that is the point

With the subjects in place, hoisting the transient-map branch into `assoc!` and the transient-vector branch into `conj!` measured:

| subject | change |
|---|---|
| `bench_frequencies` | -0.7% |
| `bench_into_map` | -0.5% |
| `bench_group_by` | -1.1% |
| `bench_into_vector` | -2.3% |

Consistent in direction but around 1%, against 18-25% for the same shape of change in #3105. The difference is what the branch leads to: appending to a transient vector is cheap enough that the wrapper was a large fraction of it, whereas a HAMT `put` dominates whatever reaches it. So the code change was dropped and the duplication not taken.

The subjects stay regardless. A core build path with no subject is one CI cannot regress-test in either direction, and this is the second time in this sweep that a gap like that hid the thing being measured (#3101 found the same for transducer stepping).

Related to #2973
