### PR TITLE
perf(core): drop two per-element calls from the reduce loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ Runtime core:
 
 Standard library:
 
+- Test `reduced?` and the loop guard in `reduce` and `reduce-kv` as the PHP checks they are rather than through a function call, once per element: `reduce` 1.2x, and `transduce` with `map` a further 1.1x on top of #3101 (#2973)
 - Reach a vector `conj` target, persistent or transient, without the `vector-target?` and `transient-vector?` calls: `into` a vector 1.3x, `conj` on a vector 1.2x, a list target 3% slower (#2973)
 - Compare two native ints in `min` and `max` without the NaN guards or the numeric tower: 3.0x on a pair, 2.5x on four arguments (#2973)
 - Answer `(get ds k)` on a map or vector in the two-argument arity itself, instead of delegating to the three-argument one and reading through core `aget`: 1.6x on a map, 1.8x on a vector, 1.2x on `get-in` (#2973)

--- a/src/phel/core/transducers.phel
+++ b/src/phel/core/transducers.phel
@@ -68,11 +68,15 @@
        (f)
        (reduce f (first s) (next s)))))
   ([f init coll]
+   ;; `reduced?` and `not` spelled as the PHP checks they are. Both run once
+   ;; per element, and `reduced?` is `(php/instanceof x Reduced)` behind a
+   ;; function call; `done` only ever holds a bool, so the loop guard does not
+   ;; need Phel truthiness either (#2973).
    (let [acc  (new Volatile init)
          done (new Volatile false)]
-     (dofor [x :in coll :while (not (.deref done))]
+     (dofor [x :in coll :while (php/=== false (.deref done))]
        (let [result (f (.deref acc) x)]
-         (if (reduced? result)
+         (if (php/instanceof result Reduced)
            (do (.reset acc (.deref result))
                (.reset done true))
            (.reset acc result))))
@@ -85,9 +89,10 @@
   [f init coll]
   (let [acc  (new Volatile init)
         done (new Volatile false)]
-    (dofor [[k v] :pairs coll :while (not (.deref done))]
+    ;; Same two inlines as `reduce` above, for the same per-element reason.
+    (dofor [[k v] :pairs coll :while (php/=== false (.deref done))]
       (let [result (f (.deref acc) k v)]
-        (if (reduced? result)
+        (if (php/instanceof result Reduced)
           (do (.reset acc (.deref result))
               (.reset done true))
           (.reset acc result))))


### PR DESCRIPTION
## 🤔 Background

`reduce` is the loop most of the standard library is built on, and its three-argument body ran two avoidable calls per element:

- `(reduced? result)`, whose entire body is `(php/instanceof x Reduced)`
- `(not (.deref done))` as the `:while` guard, on a `Volatile` that only ever holds `true` or `false`

Neither is expensive on its own. Both run once per element, which is the whole point.

## 🔖 Changes

Both spelled as the PHP checks they already are, in `reduce` and in `reduce-kv`.

`reduced?` itself is untouched and remains the public predicate; this is only the two call sites inside the loops.

PHPBench, `origin/main` as a stored baseline:

| subject | main | this PR | |
|---|---|---|---|
| `bench_reduce_sum` | 19.86us | 16.72us | **-16%** |
| `bench_transduce_map` | 31.22us | 27.98us | **-10%** |
| `bench_into_vector` | 24.84us | 24.84us | 0.0% |
| `bench_reduce_sum_raw` | 0.186us | 0.181us | -3.0% |

`transduce` reduces through this loop, so it picks up a further 1.1x on top of what #3101 gave it. `into` is unchanged because it builds through `for :reduce`, not `reduce`.

## Why the loop guard may drop Phel truthiness

`done` is created as `false` and only ever `.reset` to `true`, both literals in this function. It is never handed a user value, so `(php/=== false ...)` and `(not ...)` cannot diverge on it. That is a property of these two loops specifically, not a general licence to swap `not` for a native check.

## Verification

Early termination is what these two lines control, so the check targets it: `reduce` and `reduce-kv` were diffed against `origin/main` over **25 cases**, including `reduced` returned at the first, middle and last element, a `reduced` wrapping `nil`, `false` and another `reduced`, accumulators that are themselves `nil`, `false` or `0` (all truthy or falsy in ways that would expose a bad guard), the no-init and empty-collection arities, and vector, map, set, string, lazy-seq and eduction sources. Every result was identical.

Related to #2973
