### PR TITLE
perf(core): answer even?, odd? and % without the call chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ Runtime core:
 
 Standard library:
 
+- Answer `even?` and `odd?` on a native int with one PHP modulo instead of reaching through `%` and `rem`, and stop `%` forwarding to `rem`: `even?` and `odd?` 5.9x, `%` 1.4x (#2973)
 - Test `reduced?` and the loop guard in `reduce` and `reduce-kv` as the PHP checks they are rather than through a function call, once per element: `reduce` 1.2x, and `transduce` with `map` a further 1.1x on top of #3101 (#2973)
 - Reach a vector `conj` target, persistent or transient, without the `vector-target?` and `transient-vector?` calls: `into` a vector 1.3x, `conj` on a vector 1.2x, a list target 3% slower (#2973)
 - Compare two native ints in `min` and `max` without the NaN guards or the numeric tower: 3.0x on a pair, 2.5x on four arguments (#2973)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -313,7 +313,11 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(% 11 2) ; => 1"
    :see-also ["rem" "quot" "mod"]}
   [dividend divisor]
-  (rem dividend divisor))
+  ;; Spelled out rather than forwarding to `rem`. An alias that calls its
+  ;; target pays a whole Phel call to move two arguments, which measured about
+  ;; a third of what `%` costs (#2973).
+  (assert-non-nil-2 dividend divisor)
+  (NumericOperations/rem dividend divisor))
 
 (defn **
   "Return `a` to the power of `x`."
@@ -393,14 +397,22 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(even? 4) ; => true"
    :see-also ["odd?" "zero?"]}
   [x]
-  (NumericOperations/isZero (% x 2)))
+  ;; A native int answers with one PHP modulo. Otherwise this cost three Phel
+  ;; calls, `even?` to `%` to `rem`, to reach the same question (#2973).
+  (if (php/is_int x)
+    (php/=== 0 (php/% x 2))
+    (NumericOperations/isZero (% x 2))))
 
 (defn odd?
   "Checks if `x` is odd."
   {:example "(odd? 3) ; => true"
    :see-also ["even?" "zero?"]}
   [x]
-  (not (even? x)))
+  ;; Its own fast path rather than negating `even?`: that was a fourth call on
+  ;; top of the three above (#2973).
+  (if (php/is_int x)
+    (php/!== 0 (php/% x 2))
+    (not (even? x))))
 
 (defn zero?
   "Checks if `x` is zero."

--- a/tests/phel/core/even-odd-int-fast-path.phel
+++ b/tests/phel/core/even-odd-int-fast-path.phel
@@ -1,0 +1,56 @@
+(ns phel-test.core.even-odd-int-fast-path
+  (:require phel.test :refer [deftest is]))
+
+;; `even?` and `odd?` answer a native int with one PHP modulo instead of
+;; reaching through `%` and `rem` (and, for `odd?`, `even?` on top). `%` no
+;; longer forwards to `rem`. Everything that is not a native int still goes
+;; through the numeric tower, so the two paths have to agree everywhere, and
+;; the sign of PHP's `%` is the part that is easy to get wrong.
+
+(deftest test-even-and-odd-on-native-ints
+  (is (true? (even? 0)) "zero is even")
+  (is (false? (odd? 0)) "zero is not odd")
+  (is (true? (even? 2)) "a positive even")
+  (is (true? (odd? 1)) "a positive odd")
+  (is (false? (even? 7)) "a positive odd is not even")
+  ;; PHP's `%` keeps the sign of the dividend, so a negative odd gives -1 and
+  ;; not 1. A fast path testing `=== 1` rather than `!== 0` would fail here.
+  (is (true? (even? -2)) "a negative even")
+  (is (true? (odd? -1)) "a negative odd")
+  (is (true? (odd? -3)) "another negative odd")
+  (is (false? (even? -3)) "a negative odd is not even")
+  (is (false? (odd? -2)) "a negative even is not odd")
+  (is (true? (even? php/PHP_INT_MIN)) "the smallest native int is even")
+  (is (true? (odd? php/PHP_INT_MAX)) "the largest native int is odd"))
+
+(deftest test-non-native-numbers-still-reach-the-tower
+  (is (true? (even? 4.0)) "an integral float is even")
+  (is (true? (odd? 3.0)) "an integral float is odd")
+  (is (true? (even? -4.0)) "a negative integral float")
+  (is (true? (even? 0.0)) "zero as a float")
+  (is (true? (even? (bigint "100000000000000000000"))) "an even BigInt")
+  (is (true? (odd? (bigint "100000000000000000001"))) "an odd BigInt")
+  (is (true? (even? (bigdec "4.0"))) "an even BigDecimal"))
+
+(deftest test-even-and-odd-stay-complementary
+  ;; Now that `odd?` no longer negates `even?`, nothing structural keeps them
+  ;; opposite; this is what would catch them drifting apart.
+  (foreach [x [0 1 2 -1 -2 -3 7 100 -100 php/PHP_INT_MAX php/PHP_INT_MIN]]
+    (is (not= (even? x) (odd? x)) (str "even? and odd? disagree on " x))))
+
+(deftest test-modulo-matches-rem
+  ;; `%` is documented as an alias for `rem` and now repeats its body rather
+  ;; than calling it, so the two must not drift.
+  (foreach [[a b] [[7 3] [-7 3] [7 -3] [-7 -3] [0 3] [10 5] [1 1]]]
+    (is (= (rem a b) (% a b)) (str "% and rem agree on " a " " b)))
+  (is (= 1 (% 7 3)) "a positive remainder")
+  (is (= -1 (% -7 3)) "the result takes the sign of the dividend")
+  (is (= 0 (% 10 5)) "an exact division"))
+
+(deftest test-nil-is-still-rejected
+  ;; The nil guard lives in the slow path for `even?`/`odd?` and inline in `%`.
+  (is (thrown? \InvalidArgumentException (% nil 3)) "% rejects a nil dividend")
+  (is (thrown? \InvalidArgumentException (% 3 nil)) "% rejects a nil divisor")
+  (is (thrown? \InvalidArgumentException (rem nil 3)) "rem rejects nil")
+  (is (thrown? \InvalidArgumentException (even? nil)) "even? rejects nil")
+  (is (thrown? \InvalidArgumentException (odd? nil)) "odd? rejects nil"))

--- a/tests/php/Benchmark/Phel/CoreArithmeticBench.php
+++ b/tests/php/Benchmark/Phel/CoreArithmeticBench.php
@@ -35,6 +35,18 @@ use PhpBench\Benchmark\Metadata\Annotations\Revs;
 final class CoreArithmeticBench extends CoreBenchCase
 {
     /** @var callable */
+    private $even;
+
+    /** @var callable */
+    private $odd;
+
+    /** @var callable */
+    private $rem;
+
+    /** @var callable */
+    private $modulo;
+
+    /** @var callable */
     private $inc;
 
     /** @var callable */
@@ -249,8 +261,82 @@ final class CoreArithmeticBench extends CoreBenchCase
         }
     }
 
+    /**
+     * `even?` reaches its answer through `%` and `rem`, and `odd?` through
+     * `even?` on top of that, so a three-call chain answers one modulo. These
+     * subjects are paired against the raw PHP the int case compiles to.
+     *
+     * @Revs(1000)
+     */
+    public function bench_even(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->even)($i);
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_even_raw(): void
+    {
+        $unused = false;
+        for ($i = 0; $i < self::INNER; ++$i) {
+            $unused = $i % 2 === 0;
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_odd(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->odd)($i);
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_rem(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->rem)($i, 3);
+        }
+    }
+
+    /**
+     * `%` is an alias for `rem`. Read against the subject above: the gap is the
+     * forwarding call and nothing else.
+     *
+     * @Revs(1000)
+     */
+    public function bench_modulo(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->modulo)($i, 3);
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_rem_raw(): void
+    {
+        $unused = 0;
+        for ($i = 0; $i < self::INNER; ++$i) {
+            $unused = $i % 3;
+        }
+    }
+
     protected function setUpFixtures(): void
     {
+        $this->even = $this->coreFn('even?');
+        $this->odd = $this->coreFn('odd?');
+        $this->rem = $this->coreFn('rem');
+        $this->modulo = $this->coreFn('%');
+
         $this->inc = $this->coreFn('inc');
         $this->dec = $this->coreFn('dec');
         $this->max = $this->coreFn('max');


### PR DESCRIPTION
## 🤔 Background

`even?` is a filter predicate, so it runs once per element. It was three Phel function calls deep to ask one modulo question:

```
even? -> % -> rem -> NumericOperations/rem
```

and `odd?` added a fourth by being `(not (even? x))`.

Separately, `%` is documented as an alias for `rem` and *called* it, paying a whole Phel call to move two arguments along.

None of this was measured: `even?`, `odd?`, `rem` and `%` had no benchmark subject.

## 🔖 Changes

A native int answers `even?`/`odd?` with one PHP modulo. Everything else still goes through the numeric tower unchanged. `%` repeats `rem`'s two-line body instead of forwarding, as the nil guards in this file already do for the same reason.

Six new subjects, with the raw PHP each compiles to for the int case:

| subject | main | this PR | |
|---|---|---|---|
| `bench_even` | 7.99us | 1.35us | **-83%** |
| `bench_odd` | 9.89us | 1.67us | **-83%** |
| `bench_modulo` | 3.17us | 2.31us | **-27%** |
| `bench_rem` | 2.34us | 2.30us | -1.8% |
| `bench_even_raw` | 0.493us | 0.484us | -1.8% |
| `bench_rem_raw` | 0.320us | 0.320us | +0.1% |

`even?` against the raw modulo: **16.2x to 2.8x**.

The `%` number is the forwarding call and nothing else, which is why `bench_modulo` and `bench_rem` now sit on top of each other (2.305 vs 2.300) where they were 0.83us apart.

## The sign trap

PHP's `%` takes the sign of the *dividend*, so `-3 % 2` is `-1`, not `1`. `odd?` therefore tests `!== 0` and not `=== 1`. A fast path written the obvious way would report `(odd? -3)` as false, and the test file covers both signs for exactly this reason.

Also worth flagging: `odd?` is no longer defined as the negation of `even?`, so nothing structural keeps the two complementary any more. A test asserts `(not= (even? x) (odd? x))` across both native bounds and both signs rather than relying on it.

## Verification

`even?`, `odd?`, `rem` and `%` were diffed against `origin/main` over **23 value shapes**: signed ints including `PHP_INT_MIN` and `PHP_INT_MAX`, integral and fractional floats, `##NaN`, `##Inf`, BigInt (even and odd), Ratio, BigDecimal, nil, string and bool, each through `even?`, `odd?`, `(% v 3)`, `(rem v 3)` and `(% 10 v)`, catching throws as values. Every row was identical, including the `InvalidArgumentException` that nil still raises.

Related to #2973
