### PR TITLE
perf(core): test the sign of a native int directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ Runtime core:
 
 Standard library:
 
+- Answer `zero?`, `pos?` and `neg?` on a native int with a direct PHP comparison rather than through `>`, `<` or the numeric tower: `pos?` and `neg?` 4.2x, `zero?` 1.5x (#2973)
 - Answer `even?` and `odd?` on a native int with one PHP modulo instead of reaching through `%` and `rem`, and stop `%` forwarding to `rem`: `even?` and `odd?` 5.9x, `%` 1.4x (#2973)
 - Test `reduced?` and the loop guard in `reduce` and `reduce-kv` as the PHP checks they are rather than through a function call, once per element: `reduce` 1.2x, and `transduce` with `map` a further 1.1x on top of #3101 (#2973)
 - Reach a vector `conj` target, persistent or transient, without the `vector-target?` and `transient-vector?` calls: `into` a vector 1.3x, `conj` on a vector 1.2x, a list target 3% slower (#2973)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -419,7 +419,11 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(zero? 0) ; => true"
    :see-also ["pos?" "neg?" "one?"]}
   [x]
-  (NumericOperations/isZero x))
+  ;; As `pos?` and `neg?` below: a native int compares against 0 directly
+  ;; rather than through the numeric tower (#2973).
+  (if (php/is_int x)
+    (php/=== 0 x)
+    (NumericOperations/isZero x)))
 
 (defn one?
   "Checks if `x` is one."
@@ -433,14 +437,22 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(pos? 3) ; => true"
    :see-also ["neg?" "zero?"]}
   [x]
-  (> x 0))
+  ;; A native int tests its own sign; otherwise `pos?` paid a second Phel call
+  ;; into `>` to ask it. `zero?` already reached `NumericOperations` directly
+  ;; and cost less than half as much as a result (#2973).
+  (if (php/is_int x)
+    (php/> x 0)
+    (> x 0)))
 
 (defn neg?
   "Checks if `x` is smaller than zero."
   {:example "(neg? -2) ; => true"
    :see-also ["pos?" "zero?"]}
   [x]
-  (< x 0))
+  ;; As `pos?` above.
+  (if (php/is_int x)
+    (php/< x 0)
+    (< x 0)))
 
 (defn nan?
   "Checks if `x` is not a number."

--- a/tests/phel/core/sign-predicates-int-fast-path.phel
+++ b/tests/phel/core/sign-predicates-int-fast-path.phel
@@ -1,0 +1,58 @@
+(ns phel-test.core.sign-predicates-int-fast-path
+  (:require phel.test :refer [deftest is]))
+
+;; `zero?`, `pos?` and `neg?` answer a native int with a direct PHP comparison.
+;; `pos?` and `neg?` previously reached `>` and `<`, and `zero?` the numeric
+;; tower. Everything that is not a native int still takes the old path, so the
+;; two have to agree on every other shape, and the float zeroes are where they
+;; would most easily diverge.
+
+(deftest test-native-ints
+  (is (true? (zero? 0)) "zero")
+  (is (false? (pos? 0)) "zero is not positive")
+  (is (false? (neg? 0)) "zero is not negative")
+  (is (true? (pos? 1)) "a positive int")
+  (is (false? (neg? 1)) "a positive int is not negative")
+  (is (true? (neg? -1)) "a negative int")
+  (is (false? (pos? -1)) "a negative int is not positive")
+  (is (false? (zero? 1)) "a non-zero int")
+  (is (true? (pos? php/PHP_INT_MAX)) "the largest native int is positive")
+  (is (true? (neg? php/PHP_INT_MIN)) "the smallest native int is negative")
+  (is (false? (zero? php/PHP_INT_MIN)) "the smallest native int is not zero"))
+
+(deftest test-float-zeroes
+  ;; Floats never take the fast path. Negative zero is the case that would
+  ;; expose a fast path applied too eagerly: it is zero, and neither positive
+  ;; nor negative.
+  (is (true? (zero? 0.0)) "positive zero as a float")
+  (is (true? (zero? -0.0)) "negative zero is still zero")
+  (is (false? (pos? -0.0)) "negative zero is not positive")
+  (is (false? (neg? -0.0)) "negative zero is not negative")
+  (is (false? (neg? 0.0)) "positive zero is not negative"))
+
+(deftest test-other-numeric-shapes
+  (is (true? (pos? 1.5)) "a positive float")
+  (is (true? (neg? -1.5)) "a negative float")
+  (is (false? (zero? 1.5)) "a non-zero float")
+  (is (true? (pos? ##Inf)) "infinity is positive")
+  (is (true? (neg? ##-Inf)) "negative infinity is negative")
+  ;; NaN compares false against everything, in all three directions.
+  (is (false? (pos? ##NaN)) "NaN is not positive")
+  (is (false? (neg? ##NaN)) "NaN is not negative")
+  (is (false? (zero? ##NaN)) "NaN is not zero")
+  (is (true? (zero? (bigint "0"))) "a zero BigInt")
+  (is (true? (pos? (bigint "100000000000000000000"))) "a positive BigInt")
+  (is (true? (neg? (bigint "-100000000000000000000"))) "a negative BigInt")
+  (is (true? (pos? (/ 3 4))) "a positive Ratio")
+  (is (true? (neg? (/ -3 4))) "a negative Ratio")
+  (is (true? (zero? (bigdec "0.00"))) "a zero BigDecimal")
+  (is (true? (neg? (bigdec "-1.5"))) "a negative BigDecimal"))
+
+(deftest test-the-three-stay-consistent
+  ;; Exactly one of the three holds for any real number.
+  (foreach [x [0 1 -1 php/PHP_INT_MAX php/PHP_INT_MIN 0.0 -0.0 1.5 -1.5 ##Inf ##-Inf]]
+    (let [hits (count (filter true? [(zero? x) (pos? x) (neg? x)]))]
+      (is (= 1 hits) (str "exactly one of zero?/pos?/neg? holds for " x))))
+  ;; NaN is the exception: none of them holds.
+  (is (= 0 (count (filter true? [(zero? ##NaN) (pos? ##NaN) (neg? ##NaN)])))
+      "none of the three holds for NaN"))

--- a/tests/php/Benchmark/Phel/CoreComparisonBench.php
+++ b/tests/php/Benchmark/Phel/CoreComparisonBench.php
@@ -35,6 +35,18 @@ use PhpBench\Benchmark\Metadata\Annotations\Revs;
 final class CoreComparisonBench extends CoreBenchCase
 {
     /** @var callable */
+    private $pos;
+
+    /** @var callable */
+    private $neg;
+
+    /** @var callable */
+    private $zero;
+
+    /** @var callable */
+    private $notEq;
+
+    /** @var callable */
     private $lt;
 
     /** @var callable */
@@ -155,8 +167,57 @@ final class CoreComparisonBench extends CoreBenchCase
         }
     }
 
+    /**
+     * `pos?` and `neg?` reach their answer through `>` and `<`, so a sign test
+     * is two Phel calls. `zero?` is here as the control: it already goes
+     * straight to `NumericOperations`, so it is what the other two can reach.
+     *
+     * @Revs(1000)
+     */
+    public function bench_pos(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->pos)($i);
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_neg(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->neg)($i);
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_zero(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->zero)($i);
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_not_equals(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->notEq)($i, 1);
+        }
+    }
+
     protected function setUpFixtures(): void
     {
+        $this->pos = $this->coreFn('pos?');
+        $this->neg = $this->coreFn('neg?');
+        $this->zero = $this->coreFn('zero?');
+        $this->notEq = $this->coreFn('not=');
+
         $this->lt = $this->coreFn('<');
         $this->lte = $this->coreFn('<=');
         $this->gt = $this->coreFn('>');


### PR DESCRIPTION
## 🤔 Background

`zero?`, `pos?` and `neg?` ask the simplest question in the numeric API, and two of them took the longest route to it:

- `pos?` was `(> x 0)` and `neg?` was `(< x 0)`, so a sign test was two Phel function calls
- `zero?` went straight to `NumericOperations/isZero`, one call

The result was that `pos?` cost **2.7x** what `zero?` cost, for a strictly simpler question. None of the three had a benchmark subject.

## 🔖 Changes

A native int is compared directly. Everything else keeps the old path exactly.

Four new subjects (`zero?` is the control the other two could already reach):

| subject | main | this PR | |
|---|---|---|---|
| `bench_pos` | 5.42us | 1.33us | **-75%** |
| `bench_neg` | 5.48us | 1.30us | **-76%** |
| `bench_zero` | 2.03us | 1.36us | **-33%** |
| `bench_not_equals` | 7.66us | 7.55us | -1.5% |

All three now cost about the same, which is what the shape of the problem says they should.

## Negative zero decides whether this is sound

`-0.0` is zero, and neither positive nor negative. A fast path that reached floats would have to get all three right; this one does not reach them, because only `php/is_int` selects it. The test file asserts `zero?`, `pos?` and `neg?` on `-0.0` directly rather than leaving that to inference, and also pins NaN, for which none of the three holds.

There is also a consistency test: exactly one of the three is true for any real number, and none is true for NaN. Nothing structural enforces that now the three are independent.

## `not=` measured but not changed

`bench_not_equals` is included because `not=` looked like the same shape, `(not (= a b))`. It moved 1.5%, inside noise: the emitter already lowers `not` over a bool-tagged call to a native `!`, so there was no second call to remove. The subject stays as coverage.

## Verification

Diffed against `origin/main` over **22 value shapes**: both native int bounds, positive and negative zero, positive and negative floats, a denormal, `##NaN`, both infinities, zero/positive/negative BigInt, positive and negative Ratio, zero/positive/negative BigDecimal, and nil. Every row identical.

Related to #2973
