### PR TITLE
perf(core): read a transient map through get's two-argument arity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ Runtime core:
 
 Standard library:
 
+- Answer a transient map in `get`'s two-argument arity as well, not only persistent maps and vectors. `group-by`, `frequencies` and every `for :reduce` accumulating into a transient read a key per element: `group-by` 1.1x (#2973)
 - Answer `zero?`, `pos?` and `neg?` on a native int with a direct PHP comparison rather than through `>`, `<` or the numeric tower: `pos?` and `neg?` 4.2x, `zero?` 1.5x (#2973)
 - Answer `even?` and `odd?` on a native int with one PHP modulo instead of reaching through `%` and `rem`, and stop `%` forwarding to `rem`: `even?` and `odd?` 5.9x, `%` 1.4x (#2973)
 - Test `reduced?` and the loop guard in `reduce` and `reduce-kv` as the PHP checks they are rather than through a function call, once per element: `reduce` 1.2x, and `transduce` with `map` a further 1.1x on top of #3101 (#2973)

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -108,6 +108,13 @@
      (php/instanceof ds PersistentVectorInterface)
      (if (integer? k) (php/aget ds k) nil)
 
+     ;; Transient maps too. `group-by`, `frequencies`, `into` a map and every
+     ;; other `for :reduce` that accumulates into one read a key per element,
+     ;; and without this they fall past both branches above into the
+     ;; three-argument arity to be tested a third time.
+     (php/instanceof ds TransientMapInterface)
+     (php/aget ds k)
+
      :else
      (get ds k nil)))
   ([ds k opt]

--- a/tests/phel/core/get-two-arity-fast-path.phel
+++ b/tests/phel/core/get-two-arity-fast-path.phel
@@ -50,10 +50,22 @@
     (is (= :DEF (get p :y :DEF)) "a nil field takes the default")
     (is (nil? (get p :nope)) "an absent field")))
 
+(deftest test-transient-map-target
+  ;; A transient map is answered by the two-argument arity too: `group-by`,
+  ;; `frequencies` and every other `for :reduce` accumulating into one read a
+  ;; key per element, and it used to fall past both branches above.
+  (let [tm (transient {:a 1, :b nil})]
+    (is (= 1 (get tm :a)) "a present key")
+    (is (nil? (get tm :missing)) "a missing key")
+    (is (= :DEF (get tm :missing :DEF)) "a missing key takes the default")
+    (is (nil? (get tm :b)) "a nil value reads as nil")
+    (is (= :DEF (get tm :b :DEF)) "a nil value takes the default, as for a persistent map")
+    (is (= 1 (get tm :a :DEF)) "a default is ignored when the key is present")))
+
 (deftest test-shapes-that-fall-through-to-the-three-arity
-  ;; None of these is a PersistentMapInterface or PersistentVectorInterface, so
-  ;; each must still reach the longer dispatch and answer what it always did.
-  (is (= 1 (get (transient {:a 1}) :a)) "a transient map")
+  ;; None of these is a PersistentMapInterface, PersistentVectorInterface or
+  ;; TransientMapInterface, so each must still reach the longer dispatch and
+  ;; answer what it always did.
   (is (= 10 (get (transient [10 20]) 0)) "a transient vector")
   (is (= :a (get (set [:a]) :a)) "a set returns the member itself")
   (is (nil? (get (set [:a]) :z)) "a set misses")


### PR DESCRIPTION
## 🤔 Background

#3103 gave `get` a two-argument fast path covering persistent maps and vectors. Re-profiling afterwards showed the transient map had been left behind: it matches neither branch, so it now pays both `instanceof` *and* the delegation to the three-argument arity, where it is tested a third time.

That is the read `group-by`, `frequencies` and every other `for :reduce` accumulating into a transient make once per element.

## 🔖 Changes

A third branch on the two-argument arity for `TransientMapInterface`.

PHPBench, `origin/main` as a stored baseline:

| subject | main | this PR | |
|---|---|---|---|
| `bench_group_by` | 63.52us | 56.58us | **-11%** |
| `bench_frequencies` | 107.01us | 103.15us | -3.6% |
| `bench_into_map` | 121.74us | 119.73us | -1.7% |

`group-by` gains most because it reads a key per element and then decides. `into` a map barely moves: it builds without reading back, so it only sees the branch it does not take.

These three subjects landed in #3106, which existed precisely because this path had no coverage.

## Why it is sound

The same reason the other two branches are: with no default, `opt` is nil and `php/aget` already answers nil for an absent key, so `(if (nil? res) opt res)` collapses to the read. A nil *value* and an absent key stay indistinguishable through `get`, which is pre-existing behaviour and preserved.

## Verification

Diffed against `origin/main` over the same **209 collection and key combinations** used for #3103, since this changes the same function. Every row identical. The test file gains a transient-map case covering present key, missing key, missing key with a default, and a nil value with and without a default.

Related to #2973
