### PR TITLE
fix(compiler): do not invoke unevaluated :inline metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Stop `phel lint` aborting the whole run with an uncaught `TypeError` on a namespace that both defines and calls an `:inline` function. Phel data types are invokable, so the `is_callable` guard let the unevaluated metadata through (#3055)
 - Go-to-definition on a namespace inside a `(:require ...)` form now jumps to that namespace's `ns` declaration; before, only the `:refer`red names resolved and the namespace itself returned nothing (#3059)
 - LSP definition, hover, find-references and rename now read a name spelled with the deprecated `\` separator as one word. The word scan stopped at the backslash, so `my-app\core` arrived as `my-app` and `my-app\core/greet` as `core/greet`, and neither matched anything in the index (#3059)
 - `phel.string/blank?` no longer reports invalid UTF-8 as blank; `preg_match` with `/u` returns `false` on malformed input and that read as a match (#3052)

--- a/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
+++ b/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Analyzer\Exceptions;
 
-use Exception;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -13,6 +12,7 @@ use Phel\Lang\TypeInterface;
 use Phel\Shared\Exceptions\AbstractLocatedException;
 use Phel\Shared\Exceptions\ErrorCode;
 use Phel\Shared\Printer\Printer;
+use Throwable;
 
 use function count;
 use function get_debug_type;
@@ -27,7 +27,7 @@ use function sprintf;
  */
 final class AnalyzerException extends AbstractLocatedException
 {
-    public static function withLocation(string $message, TypeInterface $type, ?Exception $nested = null): self
+    public static function withLocation(string $message, TypeInterface $type, ?Throwable $nested = null): self
     {
         return new self(
             $message,
@@ -157,7 +157,7 @@ final class AnalyzerException extends AbstractLocatedException
     public static function whenExpandingInlineFn(
         PersistentListInterface $list,
         GlobalVarNode $node,
-        Exception $exception,
+        Throwable $exception,
     ): self {
         $e = self::withLocation(
             self::formatMacroExpansionError(
@@ -182,7 +182,7 @@ final class AnalyzerException extends AbstractLocatedException
     public static function whenExpandingMacro(
         PersistentListInterface $list,
         GlobalVarNode $node,
-        Exception $exception,
+        Throwable $exception,
     ): self {
         $e = self::withLocation(
             self::formatMacroExpansionError(

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
-use Exception;
+use Closure;
 use Phel;
 use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
@@ -16,6 +16,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\ConstantFolder;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification\CallInliner;
+use Phel\Lang\AbstractFn;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
@@ -24,6 +25,7 @@ use Phel\Lang\SourceLocation;
 use Phel\Lang\TypeInterface;
 use Phel\Shared\Printer\Printer;
 use RuntimeException;
+use Throwable;
 
 use function count;
 use function get_debug_type;
@@ -213,17 +215,41 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
     {
         $meta = $node->getMeta();
 
-        if (!$meta[Keyword::create('inline')]) {
+        if (!$this->isExpandableFn($meta[Keyword::create('inline')])) {
             return false;
         }
 
         $arityFn = $meta[Keyword::create('inline-arity')];
 
-        if (!is_callable($arityFn)) {
+        if (!$this->isExpandableFn($arityFn)) {
             return true;
         }
 
-        return $arityFn($arity);
+        return (bool) $arityFn($arity);
+    }
+
+    /**
+     * Whether a value read from `:inline` / `:inline-arity` metadata is a
+     * function this analyzer may actually call.
+     *
+     * `is_callable()` is not that question. Phel's data types are invokable by
+     * design: a list, vector, map, set, keyword and symbol all implement
+     * `__invoke`, so every one of them satisfies `is_callable`. Metadata that
+     * has not been evaluated is still the reader's `PersistentList` for the
+     * `(fn ...)` form, and calling it lands on `PersistentList::__invoke($index)`
+     * instead (#3055). For `:inline-arity` that is worse than a crash: the
+     * arity is an int, so the list would accept it and return an element.
+     *
+     * Compiling a namespace evaluates the metadata first, so there the value is
+     * a real `AbstractFn`. Analyzing without evaluating, as `phel lint` does,
+     * leaves it as data, and the call site is expected to fall back to treating
+     * the form as an ordinary function call.
+     *
+     * @psalm-assert-if-true callable $fn
+     */
+    private function isExpandableFn(mixed $fn): bool
+    {
+        return $fn instanceof AbstractFn || $fn instanceof Closure;
     }
 
     /**
@@ -251,14 +277,14 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
         $meta = $node->getMeta();
         $fn = $meta[Keyword::create('inline')];
 
-        if (!is_callable($fn)) {
+        if (!$this->isExpandableFn($fn)) {
             throw AnalyzerException::whenExpandingInlineFn($list, $node, new RuntimeException('Inline metadata is not callable.'));
         }
 
         try {
             return $this->callInlineFn($fn, $list, $this->definitionLocation($node));
-        } catch (Exception $exception) {
-            throw AnalyzerException::whenExpandingInlineFn($list, $node, $exception);
+        } catch (Throwable $throwable) {
+            throw AnalyzerException::whenExpandingInlineFn($list, $node, $throwable);
         }
     }
 
@@ -310,8 +336,8 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
 
         try {
             return $this->callMacroFn($fn, $list, $env, $this->definitionLocation($macroNode));
-        } catch (Exception $exception) {
-            throw AnalyzerException::whenExpandingMacro($list, $macroNode, $exception);
+        } catch (Throwable $throwable) {
+            throw AnalyzerException::whenExpandingMacro($list, $macroNode, $throwable);
         }
     }
 

--- a/tests/php/Integration/Lint/Fixtures/inline_self_call.phel
+++ b/tests/php/Integration/Lint/Fixtures/inline_self_call.phel
@@ -1,0 +1,18 @@
+(ns lint-fixture.inline-self-call)
+
+;; A namespace that both defines an `:inline` function and calls it. Analyzing
+;; without evaluating leaves the `:inline` metadata as the reader's list, and
+;; the analyzer used to invoke it anyway, landing on `PersistentList::__invoke`
+;; and aborting the whole lint run with an uncaught TypeError (#3055).
+;;
+;; `:inline-arity` is here too: it is handed an int, which a list would accept
+;; and answer with an element rather than crashing.
+
+(defn shout
+  {:inline (fn [s] `(php/strtoupper ~s))
+   :inline-arity (fn [n] (php/=== 1 n))}
+  [s]
+  (php/strtoupper s))
+
+(defn caller [x]
+  (shout x))

--- a/tests/php/Integration/Lint/LintCommandTest.php
+++ b/tests/php/Integration/Lint/LintCommandTest.php
@@ -56,6 +56,26 @@ final class LintCommandTest extends TestCase
 
     #[PreserveGlobalState(false)]
     #[RunInSeparateProcess]
+    public function test_it_lints_a_namespace_that_defines_and_calls_an_inline_fn(): void
+    {
+        // #3055: linting analyses without evaluating, so `:inline` metadata is
+        // still the reader's list. Invoking it landed on
+        // `PersistentList::__invoke($index)` and aborted the whole run with an
+        // uncaught TypeError, losing every diagnostic rather than one file.
+        $this->bootstrap();
+
+        $tester = new CommandTester(new LintCommand());
+        $exit = $tester->execute([
+            'paths' => [__DIR__ . '/Fixtures/inline_self_call.phel'],
+            '--format' => 'json',
+            '--no-cache' => true,
+        ]);
+
+        self::assertSame(0, $exit, $tester->getDisplay());
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function test_it_fails_with_invocation_error_on_unknown_format(): void
     {
         $this->bootstrap();


### PR DESCRIPTION
## 🤔 Background

`phel lint` aborted with an uncaught `TypeError`, exit code 2 and **no diagnostics at all**, on any namespace that both defines a function with `:inline` metadata and calls it. The whole run was lost, not one file.

## 🔖 Changes

Linting analyses without evaluating, so `:inline` metadata is still the reader's `PersistentList` for the `(fn ...)` form.

The issue proposed guarding on `is_callable($fn)`. **That does not work**, and it is why the bug existed in the first place: the guard was already `is_callable()`. Phel's data types are invokable by design, so a list, vector, map, set, keyword and symbol *all* satisfy `is_callable`. The list passed the guard, was called, and landed on `PersistentList::__invoke($index)`.

The guard is now `instanceof AbstractFn || instanceof Closure`, which is what an evaluated `(fn ...)` actually is. `isInline()` uses the same predicate, so an unevaluated inline falls through to an ordinary function call rather than throwing.

`:inline-arity` had the same bug with a **worse** failure mode: it is handed an int, and `PersistentList::__invoke(?int $index)` accepts an int and returns an element. That is a silently wrong answer about whether to inline, not a crash.

The `catch (Exception)` also widens to `Throwable`, because the TypeError is an `Error` and escaped it. `AnalyzerException::whenExpandingInlineFn`, `whenExpandingMacro` and `withLocation` widen from `Exception` to `Throwable` to match; the base class already accepted `?Throwable`, so this only relaxes a needlessly narrow signature. An `Error` raised inside a genuine expansion is now a diagnostic rather than the end of the run.

## Why it was "not reproducible everywhere"

The issue flagged that `src/phel/string.phel` defines `assert-string` with `:inline`, calls it about twenty times, and lints clean, and asked for that to be understood before calling the fix done.

It is not about ordering within the file. It is whether the defining namespace is **already loaded**. Linting the same file under a different namespace name reproduces the crash exactly:

| file | namespace | before |
|---|---|---|
| `src/phel/string.phel` | `phel.string` (loaded by the core bootstrap) | 5 warnings, exit 0 |
| identical copy | `notloaded.stringcopy` | uncaught TypeError |

When the namespace is already in the registry, the `GlobalVarNode` metadata is the *evaluated* closure from the loaded copy, so the call works by accident. That means the bug hit precisely the case that matters for DX: a user linting their own namespace.

After the fix both report the same 5 warnings, so linting no longer depends on load state.

## Verification

- Minimal repro from the issue: exit 2 to exit 0.
- Fresh-namespace copy of `string.phel`: crash to the same 5 warnings the real one gives.
- Compilation unchanged: `caller` still emits `return strtoupper($x);`, confirmed in the generated PHP, so the inline is still expanded and the compile path pays nothing.
- New lint-level regression test with an `:inline` **and** an `:inline-arity` plus a call site, asserting exit 0. Verified red without the fix (exit 2) and green with it.

Closes #3055
