### PR TITLE
perf(compiler): skip the truthy adapter for a bool-tagged global call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Skip the `Truthy` adapter in an `if` test when the call is to a global whose return `:tag` is `bool`, which covers `<`, `>`, `<=`, `>=`, `=`, `not=`, `nil?` and `pos?` as well as any user `defn ^bool`. A `defn` whose arities disagree carries no tag, so it keeps the adapter (#2973)
 - Lower `(not x)` to a native `!` when `x` is a proven PHP bool: 3.7x, and an `if` test drops the `Truthy` adapter too (#3021)
 - Compile a literal `(list ...)`, `(vector ...)`, `(queue ...)`, `(hash-map ...)` or `(array-map ...)` straight to its `Phel` factory: 2.2 to 3.6 times faster (#3014)
 - Specialize `count` on a map-tagged local to a direct `->count()`, as `empty?` already did (#2985)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BooleanExprDetector.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BooleanExprDetector.php
@@ -6,9 +6,11 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\Cache;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\CallSpecialization;
+use Phel\Shared\TagResolver;
 
 use function in_array;
 use function is_bool;
@@ -94,6 +96,15 @@ final class BooleanExprDetector
             // Match both bare (`is_int`) and namespaced (`\is_int`) forms.
             $bare = str_starts_with($name, '\\') ? substr($name, 1) : $name;
             return in_array($bare, self::BOOL_PHP_FUNCTIONS, true);
+        }
+
+        // A call to a global whose return `:tag` is `bool`. `FnSymbol` emits
+        // that tag as a `: bool` return type on every arity's closure, so PHP
+        // enforces it on the way out and the value cannot be nil or anything
+        // else. A `defn` whose arities disagree carries no tag at all, so a
+        // partially bool-returning function is never mistaken for a total one.
+        if ($fn instanceof GlobalVarNode && TagResolver::fromMeta($fn->getMeta()) === 'bool') {
+            return true;
         }
 
         // A `CallNode` that the `CallSpecialization` layer lowers to a

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq-nil-param-stays-untagged.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq-nil-param-stays-untagged.test
@@ -9,7 +9,7 @@
 
     public function __invoke($x): int {
       static $__phel_call_0;
-      return (($__truthy = ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "="))->__invoke($x, null)) !== null && $__truthy !== false ? 0 : 1);
+      return ((($__phel_call_0 ??= \Phel::getDefinition("phel.core", "="))->__invoke($x, null)) ? 0 : 1);
 
     }
   },

--- a/tests/php/Integration/Fixtures/If/global-bool-tag-skips-truthy.test
+++ b/tests/php/Integration/Fixtures/If/global-bool-tag-skips-truthy.test
@@ -1,0 +1,13 @@
+--PHEL--
+(fn [x y] (if (< x y) :y :n))
+(fn [x] (if (= x nil) :y :n))
+--PHP--
+(function($x, $y) {
+  static $__phel_const_0, $__phel_const_1, $__phel_call_0;
+  return ((($__phel_call_0 ??= \Phel::getDefinition("phel.core", "<"))->__invoke($x, $y)) ? ($__phel_const_0 ??= \Phel\Lang\Keyword::create("y")) : ($__phel_const_1 ??= \Phel\Lang\Keyword::create("n")));
+
+});(function($x) {
+  static $__phel_const_0, $__phel_const_1, $__phel_call_0;
+  return ((($__phel_call_0 ??= \Phel::getDefinition("phel.core", "="))->__invoke($x, null)) ? ($__phel_const_0 ??= \Phel\Lang\Keyword::create("y")) : ($__phel_const_1 ??= \Phel\Lang\Keyword::create("n")));
+
+});

--- a/tests/php/Integration/Fixtures/Let/loop-recur-type-disagreement-bails.test
+++ b/tests/php/Integration/Fixtures/Let/loop-recur-type-disagreement-bails.test
@@ -5,7 +5,7 @@
   static $__phel_call_0, $__phel_call_1;
   $i_1 = 0;
   while (true) {
-    if (($__truthy = ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "<"))->__invoke($i_1, $n)) !== null && $__truthy !== false) {
+    if ((($__phel_call_0 ??= \Phel::getDefinition("phel.core", "<"))->__invoke($i_1, $n))) {
       $i_1 = ($__phel_call_1 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($i_1, 1.5);
       continue;
 

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/BooleanExprDetectorTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/BooleanExprDetectorTest.php
@@ -11,6 +11,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\BooleanExprDetector;
+use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use PHPUnit\Framework\TestCase;
 
@@ -99,5 +100,39 @@ final class BooleanExprDetectorTest extends TestCase
             [],
         );
         self::assertFalse(BooleanExprDetector::isBool($call));
+    }
+
+    public function test_global_call_with_bool_return_tag_is_bool(): void
+    {
+        // `FnSymbol` emits a `:tag bool` as a `: bool` return type on every
+        // arity's closure, so PHP enforces it and the value cannot be nil.
+        $call = new CallNode(
+            NodeEnvironment::empty(),
+            new GlobalVarNode(
+                NodeEnvironment::empty(),
+                'phel.core',
+                Symbol::create('<'),
+                Phel::map(Keyword::create('tag'), 'bool'),
+            ),
+            [],
+        );
+        self::assertTrue(BooleanExprDetector::isBool($call));
+    }
+
+    public function test_global_call_with_a_non_bool_return_tag_is_not_bool(): void
+    {
+        foreach (['int', 'string', 'float', 'array', '?bool'] as $tag) {
+            $call = new CallNode(
+                NodeEnvironment::empty(),
+                new GlobalVarNode(
+                    NodeEnvironment::empty(),
+                    'phel.core',
+                    Symbol::create('foo'),
+                    Phel::map(Keyword::create('tag'), $tag),
+                ),
+                [],
+            );
+            self::assertFalse(BooleanExprDetector::isBool($call), $tag . ' must not read as bool');
+        }
     }
 }


### PR DESCRIPTION
## 🤔 Background

I went looking for what is left after the `#2973` sweep and found the remaining paired ratios are mostly "the cost of being a function call" (`<` at 9.1x its raw comparison). The obvious lever was `:inline`, newly unblocked by #3111.

Two negative results on the way, both worth recording:

- **`:inline` on type predicates buys nothing.** `string?`, `int?`, `float?` and `boolean?` already emit `is_string($x)` and friends directly; the emitter inlines them without any metadata. I added `:inline` to all four, measured zero change, checked the generated PHP and reverted.
- **`coreFn()`-based subjects cannot measure `:inline` at all.** They resolve a callable and invoke it from PHP, which is not a Phel call site, so an inline expansion never applies.

What the generated code *did* show is this: `(if (< x y) ...)` still wraps a value PHP has already guaranteed to be a bool.

## 🔖 Changes

`BooleanExprDetector` recognised PHP infix operators, a list of PHP builtins and the call specialisations, but not a call to a global whose return `:tag` is `bool`. Now it does.

`FnSymbol` emits that tag as a `: bool` return type on **every** arity's closure, so PHP enforces it on the way out; the tag is a guarantee, not a hint.

Before:
```php
if (($__truthy = (\Phel::getDefinition("phel.core", "<"))->__invoke($x, $y)) !== null && $__truthy !== false) {
```
After:
```php
if (((\Phel::getDefinition("phel.core", "<"))->__invoke($x, $y))) {
```

Covers `<`, `>`, `<=`, `>=`, `=`, `not=`, `nil?`, `true?`, `false?` and `pos?` from core, plus any user `defn ^bool`, and the `and`/`or` short-circuit chains, which run through the same detector.

Interleaved A/B, three alternating pairs, consistent in direction every time:

| test slot | before | after | |
|---|---|---|---|
| `if` over `pos?` | 14.91us | 13.78us | **-7.5%** |
| `if` over `=` | 19.25us | 18.79us | -2.4% |
| `if` over `<` | 19.81us | 19.38us | -2.2% |

Small per call. It is also one of the most common shapes in Phel code, and the generated function loses its `$__truthy` temporary.

## The safety boundary

A `defn` whose arities disagree on the tag carries **no** tag at all, verified directly:

| definition | `:tag` |
|---|---|
| all arities `^bool` | `bool` |
| first arity `^bool`, second untagged | *(none)* |
| single `^bool` | `bool` |

So a partially bool-returning function can never be mistaken for a total one. A fixture pins that a mixed-arity call keeps the adapter, and a unit test pins that `int`, `string`, `float`, `array` and `?bool` tags do not read as bool.

## A bug the fixtures caught

My first version returned early for *any* `GlobalVarNode`, which short-circuited past `CallSpecialization::isBoolReturningSpecialisation`. That silently **re-added** the adapter to `(if (not (php/is_int x)) ...)`, undoing #3021 C5. Three existing fixtures failed and pointed straight at it; the branch now falls through instead.

Two fixtures recorded the old output for `<` and `=` and are updated to the new. A third is new and pins the boundary directly.

Related to #2973
