### PR TITLE
perf(core): keep the distinct transducer's seen set transient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ Standard library:
 - Answer `zero?`, `pos?` and `neg?` on a native int with a direct PHP comparison rather than through `>`, `<` or the numeric tower: `pos?` and `neg?` 4.2x, `zero?` 1.5x (#2973)
 - Answer `even?` and `odd?` on a native int with one PHP modulo instead of reaching through `%` and `rem`, and stop `%` forwarding to `rem`: `even?` and `odd?` 5.9x, `%` 1.4x (#2973)
 - Test `reduced?` and the loop guard in `reduce` and `reduce-kv` as the PHP checks they are rather than through a function call, once per element: `reduce` 1.2x, and `transduce` with `map` a further 1.1x on top of #3101 (#2973)
+- Track what the `distinct` transducer has seen in a transient set instead of a volatile holding a persistent one, which paid a copy-on-write per distinct element: 1.6x reducing 32 elements through it (#2973)
 - Reach a vector `conj` target, persistent or transient, without the `vector-target?` and `transient-vector?` calls: `into` a vector 1.3x, `conj` on a vector 1.2x, a list target 3% slower (#2973)
 - Compare two native ints in `min` and `max` without the NaN guards or the numeric tower: 3.0x on a pair, 2.5x on four arguments (#2973)
 - Answer `(get ds k)` on a map or vector in the two-argument arity itself, instead of delegating to the three-argument one and reading through core `aget`: 1.6x on a map, 1.8x on a vector, 1.2x on `get-in` (#2973)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -711,11 +711,15 @@ Creates intermediate maps if they don't exist."
   ;; with `first` to recover what the caller passed positionally (#2973, #3021).
   ([]
    (fn [rf]
-     (let [seen (volatile! (hash-set))]
+     ;; A transient set, not a volatile holding a persistent one. `seen` is
+     ;; private to this transducer instance and is never handed back, so it
+     ;; never has to become persistent again. The old spelling paid a
+     ;; copy-on-write `conj` plus a `vswap!` per distinct element (#2973).
+     (let [seen (transient (hash-set))]
        (xf-step rf (fn [result input]
-                     (if (contains? @seen input)
+                     (if (contains? seen input)
                        result
-                       (do (vswap! seen conj input) (rf result input))))))))
+                       (do (conj! seen input) (rf result input))))))))
   ([coll]
    (if (nil? coll)
      []

--- a/tests/phel/core/distinct-transducer-state.phel
+++ b/tests/phel/core/distinct-transducer-state.phel
@@ -1,0 +1,46 @@
+(ns phel-test.core.distinct-transducer-state
+  (:require phel.test :refer [deftest is]))
+
+;; The `distinct` transducer tracks what it has seen in a transient set rather
+;; than a volatile holding a persistent one. The set is private to one
+;; application of the transducer and is never made persistent, so the change is
+;; invisible from outside; these tests are what says so.
+
+(deftest test-distinct-transducer-removes-duplicates
+  (is (= [1 2 3 4] (transduce (distinct) (completing conj) [] [1 2 1 3 2 4 3])) "duplicates removed, order kept")
+  (is (= [] (transduce (distinct) (completing conj) [] [])) "an empty collection")
+  (is (= [7] (transduce (distinct) (completing conj) [] [7 7 7 7])) "every element the same")
+  (is (= 10 (transduce (distinct) + 0 [1 2 1 3 2 4 3])) "summing the distinct elements"))
+
+(deftest test-values-that-are-falsy-or-look-alike
+  ;; `seen` is consulted with `contains?`, so anything that hashes or compares
+  ;; loosely would show up here. Phel treats 0 and "" as truthy, and nil and
+  ;; false as distinct values.
+  (is (= [nil 1 2] (transduce (distinct) (completing conj) [] [nil 1 nil 2])) "nil is a value, seen once")
+  (is (= [false 1 true] (transduce (distinct) (completing conj) [] [false 1 false true])) "false and true are distinct")
+  (is (= [0 1 ""] (transduce (distinct) (completing conj) [] [0 1 0 ""])) "zero and the empty string are distinct")
+  (is (= [1 "1" :a 'a] (transduce (distinct) (completing conj) [] [1 "1" :a 'a 1]))
+      "an int, its string, a keyword and a symbol are four values"))
+
+(deftest test-collections-compare-by-value
+  (is (= [[1 2] {:a 1} #{1}]
+         (transduce (distinct) (completing conj) [] [[1 2] [1 2] {:a 1} {:a 1} #{1} #{1}]))
+      "equal collections are one value"))
+
+(deftest test-a-transducer-value-can-be-applied-more-than-once
+  ;; Each application builds its own `seen`. If the set leaked between them the
+  ;; second reduction would come back empty.
+  (let [xf (distinct)]
+    (is (= [1 2] (transduce xf (completing conj) [] [1 2 1])) "first application")
+    (is (= [1 2] (transduce xf (completing conj) [] [1 2 1])) "second application starts fresh")))
+
+(deftest test-composed-with-other-transducers
+  (is (= [2 3 4] (transduce (comp (map inc) (distinct)) (completing conj) [] [1 1 2 2 3])) "after map")
+  (is (= [2 4] (transduce (comp (distinct) (filter even?)) (completing conj) [] [1 2 2 4 4 3])) "before filter")
+  ;; `take` returns a `reduced`, which travels back out through the same step.
+  (is (= [5 6] (transduce (comp (distinct) (take 2)) (completing conj) [] [5 5 6 7 8])) "early termination")
+  (is (= [1 2 3] (into [] (distinct) [1 2 1 3])) "through into"))
+
+(deftest test-the-sequence-arity-is-unaffected
+  (is (= [1 2 3] (vec (distinct [1 2 1 3 2]))) "one argument returns a lazy sequence")
+  (is (= [] (vec (distinct nil))) "nil is an empty result"))

--- a/tests/php/Benchmark/Phel/CoreSeqBench.php
+++ b/tests/php/Benchmark/Phel/CoreSeqBench.php
@@ -611,6 +611,18 @@ final class CoreSeqBench extends CoreBenchCase
     }
 
     /**
+     * The `distinct` transducer actually stepping. `bench_distinct_transducer`
+     * above builds it and stops, so the `seen` accumulator it maintains per
+     * element was never measured.
+     *
+     * @Revs(1000)
+     */
+    public function bench_transduce_distinct(): void
+    {
+        ($this->transduce)(($this->distinct)(), $this->add, 0, $this->ints);
+    }
+
+    /**
      * `partition-by` and `dedupe` return a sequence built by
      * `lazy-seq-from-generator`, so constructing one realizes a chunk before
      * the caller has asked for a single element. These two subjects measure


### PR DESCRIPTION
## 🤔 Background

The call-shape work from #2973 is largely done, so I went looking for *algorithmic* costs instead: a persistent collection being rebuilt once per element.

There was exactly one left in `seq-fns`. The `distinct` transducer held a persistent hash-set in a volatile:

```phel
(let [seen (volatile! (hash-set))]
  ... (vswap! seen conj input) ...)
```

Every distinct element paid a copy-on-write `conj` plus a `vswap!`. Reducing 32 elements through it cost **191us**, against 28us for the same shape with `map`.

## 🔖 Changes

A transient set. `seen` is private to one application of the transducer and is never handed back or made persistent, so a transient is simply the right structure here.

| subject | main | this PR | |
|---|---|---|---|
| `bench_transduce_distinct` | 191.66us | 120.72us | **-37%** |
| `bench_distinct_transducer` (building) | 3.075us | 3.072us | -0.1% |

`bench_transduce_distinct` is new. The existing `bench_distinct_transducer` builds the transducer and stops, so the per-element accumulator was never reached, the same coverage gap #3101 and #3106 ran into.

## Why this is safe

The hazard with transients is reuse after `persistent!`. This one is never made persistent, and never escapes the closure it is created in.

The subtler question is whether state leaks between two uses of the same transducer *value*. It does not, and did not before: `(distinct)` returns `(fn [rf] ...)`, and `seen` is created when that is applied to a reducing function, so each application gets its own. A test applies one `xf` to two separate reductions and asserts the second still returns `[1 2]` rather than `[]`.

## Verification

Diffed against `origin/main` over **17 cases**: nil, `false`, `0` and `""` as elements (Phel treats the last two as truthy, so a sloppy `contains?` would show up), an int against its string against a keyword against a symbol, collections compared by value, composition before and after `map`/`filter`, early termination through `take`, `into`, the one-argument sequence arity, and the transducer-reuse case above. Every result identical.

Also checked and left alone: `set` already builds through a transient, and its remaining cost is HAMT insertion rather than anything the Phel side controls.

Related to #2973
