### PR TITLE
perf(core): build zipmap through a transient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ Standard library:
 - Answer `zero?`, `pos?` and `neg?` on a native int with a direct PHP comparison rather than through `>`, `<` or the numeric tower: `pos?` and `neg?` 4.2x, `zero?` 1.5x (#2973)
 - Answer `even?` and `odd?` on a native int with one PHP modulo instead of reaching through `%` and `rem`, and stop `%` forwarding to `rem`: `even?` and `odd?` 5.9x, `%` 1.4x (#2973)
 - Test `reduced?` and the loop guard in `reduce` and `reduce-kv` as the PHP checks they are rather than through a function call, once per element: `reduce` 1.2x, and `transduce` with `map` a further 1.1x on top of #3101 (#2973)
+- Build `zipmap` through a transient, as every other map builder in core already does; accumulating a persistent map paid a HAMT path copy per pair: 1.15x over 32 pairs (#2973)
 - Track what the `distinct` transducer has seen in a transient set instead of a volatile holding a persistent one, which paid a copy-on-write per distinct element: 1.6x reducing 32 elements through it (#2973)
 - Reach a vector `conj` target, persistent or transient, without the `vector-target?` and `transient-vector?` calls: `into` a vector 1.3x, `conj` on a vector 1.2x, a list target 3% slower (#2973)
 - Compare two native ints in `min` and `max` without the NaN guards or the numeric tower: 3.0x on a pair, 2.5x on four arguments (#2973)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1437,12 +1437,17 @@ Stops when the shorter of `keys` or `vals` is exhausted. Works safely with infin
   {:example "(zipmap [:a :b :c] [1 2 3]) ; => {:a 1, :b 2, :c 3}"
    :see-also ["zipcoll"]}
   [keys vals]
-  (loop [ks  (seq keys)
-         vs  (seq vals)
-         res {}]
-    (if (or (nil? ks) (nil? vs))
-      res
-      (recur (next ks) (next vs) (assoc res (first ks) (first vs))))))
+  ;; Built through a transient, as `select-keys`, `update-keys`, `update-vals`
+  ;; and `rename-keys` already are. Accumulating a persistent map paid a HAMT
+  ;; path copy per pair (#2973). The walk still stops at the shorter of the
+  ;; two, so an infinite lazy sequence on either side is still safe.
+  (persistent
+   (loop [ks  (seq keys)
+          vs  (seq vals)
+          res (transient {})]
+     (if (or (nil? ks) (nil? vs))
+       res
+       (recur (next ks) (next vs) (assoc! res (first ks) (first vs)))))))
 
 (defn zipcoll
   "Creates a map from two sequential data structures. Returns a new map."

--- a/tests/phel/core/zipmap-transient.phel
+++ b/tests/phel/core/zipmap-transient.phel
@@ -1,0 +1,44 @@
+(ns phel-test.core.zipmap-transient
+  (:require phel.test :refer [deftest is]))
+
+;; `zipmap` builds through a transient rather than accumulating a persistent
+;; map. The result is still a persistent map, and the walk still stops at the
+;; shorter of the two collections, which is what makes an infinite lazy
+;; sequence on either side safe.
+
+(deftest test-pairs-up-to-the-shorter-collection
+  (is (= {:a 1, :b 2, :c 3} (zipmap [:a :b :c] [1 2 3])) "equal lengths")
+  (is (= {:a 1, :b 2} (zipmap [:a :b :c] [1 2])) "more keys than values")
+  (is (= {:a 1, :b 2} (zipmap [:a :b] [1 2 3])) "more values than keys")
+  (is (= {} (zipmap [] [1 2])) "no keys")
+  (is (= {} (zipmap [:a] [])) "no values")
+  (is (= {} (zipmap [] [])) "neither")
+  (is (= {} (zipmap nil [1 2])) "nil keys")
+  (is (= {} (zipmap [:a] nil)) "nil values"))
+
+(deftest test-infinite-sequences-stay-safe
+  ;; The reason the loop is written as a walk rather than a `reduce` over both.
+  (is (= {0 1, 1 2, 2 3} (zipmap (range) [1 2 3])) "an infinite key sequence")
+  (is (= {:a 0, :b 1} (zipmap [:a :b] (range))) "an infinite value sequence")
+  (is (= 5 (count (zipmap (take 5 (range)) (repeat 5 :x)))) "both bounded by take"))
+
+(deftest test-values-and-keys-of-every-shape
+  (is (= {:a 2} (zipmap [:a :a] [1 2])) "a repeated key keeps the last value")
+  (is (= 1 (get (zipmap [nil :a] [1 2]) nil)) "nil is usable as a key")
+  (is (nil? (get (zipmap [:a :b] [nil 2]) :a)) "a nil value is stored")
+  (is (= {:a false} (zipmap [:a] [false])) "a false value is stored")
+  (is (= 4 (count (zipmap [1 "1" :a 'a] [1 2 3 4]))) "an int, a string, a keyword and a symbol are four keys")
+  (is (= :v1 (get (zipmap [[1 2] {:x 1}] [:v1 :v2]) [1 2])) "collections work as keys"))
+
+(deftest test-accepts-any-seqable-source
+  (is (= {:a 1, :b 2} (zipmap '(:a :b) '(1 2))) "lists")
+  (is (= {2 :x, 3 :y} (zipmap (map inc [1 2]) [:x :y])) "a lazy sequence of keys")
+  (is (= 2 (count (zipmap (set [:a :b]) [1 2]))) "a set of keys")
+  (is (= 1 (count (zipmap {:a 1} [:v]))) "a map as the key source"))
+
+(deftest test-the-result-is-a-persistent-map
+  ;; The transient must not escape: the result has to behave like any other map.
+  (let [m (zipmap [:a :b] [1 2])]
+    (is (map? m) "the result is a map")
+    (is (= {:a 1, :b 2, :c 3} (assoc m :c 3)) "it can be assoc'd onto")
+    (is (= {:a 1, :b 2} m) "and the original is unchanged")))

--- a/tests/php/Benchmark/Phel/CoreSeqBench.php
+++ b/tests/php/Benchmark/Phel/CoreSeqBench.php
@@ -79,6 +79,9 @@ final class CoreSeqBench extends CoreBenchCase
     private $transduce;
 
     /** @var callable */
+    private $zipmap;
+
+    /** @var callable */
     private $frequencies;
 
     /** @var callable */
@@ -623,6 +626,19 @@ final class CoreSeqBench extends CoreBenchCase
     }
 
     /**
+     * `zipmap` was the one map builder in core still accumulating a persistent
+     * map, so it paid a HAMT path copy per pair where `select-keys`,
+     * `update-keys`, `update-vals` and `rename-keys` all build through a
+     * transient.
+     *
+     * @Revs(1000)
+     */
+    public function bench_zipmap(): void
+    {
+        ($this->zipmap)($this->ints, $this->ints);
+    }
+
+    /**
      * `partition-by` and `dedupe` return a sequence built by
      * `lazy-seq-from-generator`, so constructing one realizes a chunk before
      * the caller has asked for a single element. These two subjects measure
@@ -665,6 +681,7 @@ final class CoreSeqBench extends CoreBenchCase
     {
         $this->partitionBy = $this->coreFn('partition-by');
         $this->transduce = $this->coreFn('transduce');
+        $this->zipmap = $this->coreFn('zipmap');
         $this->frequencies = $this->coreFn('frequencies');
         $this->groupBy = $this->coreFn('group-by');
 


### PR DESCRIPTION
## 🤔 Background

Continuing the sweep for *algorithmic* costs rather than call shapes: a persistent collection rebuilt once per element.

`select-keys`, `update-keys`, `update-vals` and `rename-keys` all build through a transient. `zipmap` was the one map builder in core still accumulating a persistent map:

```phel
(recur (next ks) (next vs) (assoc res (first ks) (first vs)))
```

That is a HAMT path copy per pair.

## 🔖 Changes

Built through a transient. The loop shape is untouched.

| subject | main | this PR | |
|---|---|---|---|
| `bench_zipmap` | 101.89us | 88.74us | **-13%** |

`bench_zipmap` is new; `zipmap` had no subject.

Smaller than the other transient conversions in this sweep, and worth saying why: the walk itself, two `seq` chains advanced in step with `next`/`first`, is a real part of what `zipmap` costs, so removing the copy only removes part of the work.

## Laziness is preserved

The loop still stops at the shorter of the two collections rather than reducing over either, which is what makes an infinite sequence on either side safe. `(zipmap (range) [1 2 3])` and `(zipmap [:a :b] (range))` are both covered by the tests, and would hang if that were lost.

## Verification

Diffed against `origin/main` over **21 cases**: unequal lengths in both directions, empty and nil sources, a repeated key (last value wins), nil and false as values, nil and collections as keys, an int against its string against a keyword against a symbol, list / set / map / lazy-sequence sources, and an infinite `(range)` on each side. Every result identical.

The test file also asserts the result behaves as a persistent map afterwards, since a transient escaping would be the failure mode worth catching.

Related to #2973
