### PR TITLE
perf(lang): walk the entries a splitting hash-map node holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ Standard library:
 - Answer `zero?`, `pos?` and `neg?` on a native int with a direct PHP comparison rather than through `>`, `<` or the numeric tower: `pos?` and `neg?` 4.2x, `zero?` 1.5x (#2973)
 - Answer `even?` and `odd?` on a native int with one PHP modulo instead of reaching through `%` and `rem`, and stop `%` forwarding to `rem`: `even?` and `odd?` 5.9x, `%` 1.4x (#2973)
 - Test `reduced?` and the loop guard in `reduce` and `reduce-kv` as the PHP checks they are rather than through a function call, once per element: `reduce` 1.2x, and `transduce` with `map` a further 1.1x on top of #3101 (#2973)
+- Walk the entries a hash-map node actually holds when it splits into an `ArrayNode`, instead of probing all 32 slots with `array_key_exists`: 1.06x on the put that triggers the split (#2973)
 - Build `zipmap` through a transient, as every other map builder in core already does; accumulating a persistent map paid a HAMT path copy per pair: 1.15x over 32 pairs (#2973)
 - Track what the `distinct` transducer has seen in a transient set instead of a volatile holding a persistent one, which paid a copy-on-write per distinct element: 1.6x reducing 32 elements through it (#2973)
 - Reach a vector `conj` target, persistent or transient, without the `vector-target?` and `transient-vector?` calls: `into` a vector 1.3x, `conj` on a vector 1.2x, a list target 3% slower (#2973)

--- a/src/php/Lang/Collections/Map/IndexedNode.php
+++ b/src/php/Lang/Collections/Map/IndexedNode.php
@@ -8,7 +8,6 @@ use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
 use Traversable;
 
-use function array_key_exists;
 use function count;
 
 /**
@@ -273,19 +272,22 @@ final readonly class IndexedNode implements HashMapNodeInterface
         /** @var array<int, ?HashMapNodeInterface<TKey, TValue>> $nodes */
         $nodes = []; // array_fill(0, 32, null);
         $empty = self::empty($this->hasher, $this->equalizer);
+        // Walk the entries this node actually holds rather than probing all 32
+        // slots: `$objects` is sparse and never has more than 16 entries here,
+        // so the slot scan ran twice the iterations and paid an
+        // `array_key_exists` for each. `$idx` is empty by construction, since
+        // `insertNewKey` only reaches this for a key that is not present, so
+        // the entry written above cannot be overwritten by the walk.
         $nodes[$idx] = $empty->put($shift + 5, $hash, $key, $value, $addedLeaf);
-        for ($i = 0; $i < 32; ++$i) {
-            if (array_key_exists($i, $this->objects)) {
-                [$k, $v] = $this->objects[$i];
-                if ($k === null) {
-                    /** @var HashMapNodeInterface<TKey, TValue> $childNode */
-                    $childNode = $v;
-                    $nodes[$i] = $childNode;
-                } else {
-                    /** @var TValue $leafValue */
-                    $leafValue = $v;
-                    $nodes[$i] = $empty->put($shift + 5, $this->hasher->hash($k), $k, $leafValue, $addedLeaf);
-                }
+        foreach ($this->objects as $i => [$k, $v]) {
+            if ($k === null) {
+                /** @var HashMapNodeInterface<TKey, TValue> $childNode */
+                $childNode = $v;
+                $nodes[$i] = $childNode;
+            } else {
+                /** @var TValue $leafValue */
+                $leafValue = $v;
+                $nodes[$i] = $empty->put($shift + 5, $this->hasher->hash($k), $k, $leafValue, $addedLeaf);
             }
         }
 

--- a/tests/php/Unit/Lang/Collections/Map/IndexedNodeTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/IndexedNodeTest.php
@@ -216,4 +216,30 @@ final class IndexedNodeTest extends TestCase
 
         self::assertSame($node1, $node2);
     }
+
+    public function test_split_carries_every_entry_into_the_array_node(): void
+    {
+        // `splitNode` used to probe all 32 slots with `array_key_exists`; it
+        // now walks the sparse entry array directly. An entry dropped or
+        // written to the wrong slot by that walk is invisible to the
+        // `assertInstanceOf` above, so read every key back afterwards.
+        $hasher = new ModuloHasher();
+        $node = IndexedNode::empty($hasher, new SimpleEqualizer());
+
+        for ($i = 0; $i <= 16; ++$i) {
+            $node = $node->put(0, $hasher->hash($i), $i, 'test' . $i, new Box(null));
+        }
+
+        self::assertInstanceOf(ArrayNode::class, $node);
+
+        for ($i = 0; $i <= 16; ++$i) {
+            self::assertSame(
+                'test' . $i,
+                $node->find(0, $hasher->hash($i), $i, null),
+                'entry ' . $i . ' survived the split',
+            );
+        }
+
+        self::assertNull($node->find(0, $hasher->hash(99), 99, null), 'an absent key stays absent');
+    }
 }


### PR DESCRIPTION
## 🤔 Background

With the Phel-side seams closed, I went a layer down to what the earlier sweeps concluded was structural: HAMT insertion.

`PersistentHashMapBench::bench_put` reads oddly at first glance:

| size | put |
|---|---|
| small (16) | 6.72us |
| medium (128) | 0.94us |
| boundary (1024) | 1.25us |

The small map is **7x slower** than the larger ones. That is not a bug: 16 entries is exactly the `IndexedNode` to `ArrayNode` promotion threshold, and because the map is immutable and never reassigned, every revolution redoes the split.

## 🔖 Changes

`splitNode` probed all 32 slots with `array_key_exists` to find the entries to carry into the new node. The entry array is sparse and never holds more than 16 at that point, so it ran twice the iterations it needed and paid a function call for each. It now walks the array directly.

| subject | main | this PR | |
|---|---|---|---|
| `bench_put` small (the split) | 6.72us | 6.34us | **-5.7%** |
| `bench_put` medium | 0.936us | 0.930us | -0.6% |
| `bench_put` boundary | 1.251us | 1.280us | +2.3% |

This also removes the last 32-slot scan in the collections, and the `array_key_exists` import with it.

## Honest sizing

**5.7%, and it will not get much better.** What the split actually costs is rebuilding each of the 17 entries into a child node, which is inherent to a HAMT. The loop overhead was the only removable part.

It is also smaller in practice than the benchmark suggests. A split happens once per 16 entries at a node and then amortizes; the `small` subject repeating it every revolution is the worst case, not the typical one. The `medium` and `boundary` numbers, which do not split, are flat as expected.

I am shipping it because it is also a simplification, not because the number is impressive.

## Why the slot written first is safe

`$nodes[$idx]` is assigned before the walk, and the walk could in principle overwrite it. It cannot here: `insertNewKey` only reaches `splitNode` for a key whose slot is empty, so `$idx` is never among the entries walked.

## Verification

428 existing map unit tests pass. Beyond those, maps and sets were grown across the boundary at 0, 1, 15, 16, 17, 31, 32, 33, 100 and 1000 entries, reading every key back and checking counts, with int, string and keyword keys (different hash paths), and after removing half the entries. Output identical to `origin/main`.

The existing split test only asserted the node became an `ArrayNode`, so an entry dropped or misplaced by the walk would have passed it. The new test reads all 17 keys back.

Related to #2973
