### PR TITLE
fix(string): name the pattern when split cannot use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Report the pattern by name when `phel.string/split` is given something PCRE rejects, instead of letting `preg_split` return false into `Phel/vector` and surfacing a `TypeError` about a bool. A bare separator such as `" "` is named separately from a delimited but malformed pattern
 - Stop `phel lint` aborting the whole run with an uncaught `TypeError` on a namespace that both defines and calls an `:inline` function. Phel data types are invokable, so the `is_callable` guard let the unevaluated metadata through (#3055)
 - Go-to-definition on a namespace inside a `(:require ...)` form now jumps to that namespace's `ns` declaration; before, only the `:refer`red names resolved and the namespace itself returned nothing (#3059)
 - LSP definition, hover, find-references and rename now read a name spelled with the deprecated `\` separator as one word. The word scan stopped at the backslash, so `my-app\core` arrived as `my-app` and `my-app\core/greet` as `core/greet`, and neither matched anything in the index (#3059)

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -24,14 +24,47 @@
   (when-not (string? x)
     (string-expected x)))
 
+(defn- pattern-error
+  "Diagnoses a `preg_split` failure. Reached only when PCRE has already
+  rejected the pattern, so nothing here runs on a successful split.
+
+  The common mistake is a bare separator such as \" \", which PCRE reads as an
+  empty pattern between two space delimiters; that is worth naming separately
+  from a pattern that is delimited but malformed."
+  [re]
+  (if (or (php/< (php/strlen re) 2)
+          (php/=== false (php/strpos re (php/substr re 0 1) 1)))
+    (throw (new InvalidArgumentException
+                (str "Expected a delimited regular expression, got " (pr-str re)
+                     ". Write a regex literal such as #\"\\s+\", or delimit the pattern "
+                     "yourself, for example \"/ /\". Note that `split` takes a regular "
+                     "expression, while `replace` also accepts a plain literal string.")))
+    (throw (new InvalidArgumentException
+                (str "Invalid regular expression " (pr-str re) ": " (php/preg_last_error_msg))))))
+
 (defn split
   "Splits string on a regular expression, returning a vector of parts."
   {:example "(split \"hello world foo bar\" #\"\\s+\") ; => [\"hello\" \"world\" \"foo\" \"bar\"]"}
   ;; `Phel/vector` over the `preg_split` result, not `vals`: the result is
   ;; already a list array, so `vals` walked it once only to hand the same
   ;; values to the same constructor. `chars` below has always done it directly.
-  ([s re] (assert-string s) (Phel/vector (php/preg_split re s -1)))
-  ([s re limit] (assert-string s) (Phel/vector (php/preg_split re s (or limit -1)))))
+  ;;
+  ;; The failure check is a `let` and an `if` rather than a guard function, so
+  ;; a successful split pays nothing for it. `preg_split` answers false for a
+  ;; pattern PCRE rejects, which `Phel/vector` would otherwise report as a
+  ;; TypeError about receiving a bool.
+  ([s re]
+   (assert-string s)
+   (let [parts (php/preg_split re s -1)]
+     (if (php/=== false parts)
+       (pattern-error re)
+       (Phel/vector parts))))
+  ([s re limit]
+   (assert-string s)
+   (let [parts (php/preg_split re s (or limit -1))]
+     (if (php/=== false parts)
+       (pattern-error re)
+       (Phel/vector parts)))))
 
 (defn chars
   "Returns a vector of characters from string s.

--- a/tests/phel/string/split-pattern-errors.phel
+++ b/tests/phel/string/split-pattern-errors.phel
@@ -1,0 +1,46 @@
+(ns phel-test.string.split-pattern-errors
+  (:require phel.test :refer [deftest is])
+  (:require phel.string :as s))
+
+;; `split` takes a regular expression. Given something PCRE rejects it used to
+;; let `preg_split` return false into `Phel/vector`, which reported a TypeError
+;; about receiving a bool, after PHP had already printed a raw warning. Neither
+;; named the pattern. These tests pin the messages, and that every pattern that
+;; worked before still works.
+
+(deftest test-a-bare-separator-is-named-as-the-problem
+  ;; The common mistake: PCRE reads " " as an empty pattern between two space
+  ;; delimiters.
+  (is (thrown? \InvalidArgumentException (s/split "a b c" " ")) "a bare space")
+  (is (thrown? \InvalidArgumentException (s/split "a,b" ",")) "a bare comma")
+  (is (thrown? \InvalidArgumentException (s/split "ab" "")) "an empty pattern")
+  (is (thrown? \InvalidArgumentException (s/split "a b" "/ ")) "a delimiter that never closes"))
+
+(deftest test-a-malformed-pattern-is-reported-separately
+  ;; Delimited, so the guidance above would be wrong; PCRE's own message is
+  ;; the useful one here.
+  (is (thrown? \InvalidArgumentException (s/split "abc" "/[/")) "an unclosed character class"))
+
+(deftest test-every-pattern-that-worked-still-works
+  (is (= ["a" "b" "c"] (s/split "a b  c" #"\s+")) "a regex literal")
+  (is (= ["a" "b" "c"] (s/split "a b c" "/ /")) "a slash-delimited pattern")
+  ;; Any character may delimit a PCRE pattern, not just `/`. This is the case
+  ;; that rules out simply treating a plain string as a literal.
+  (is (= ["a" "b" "c"] (s/split "a1b2c" "#[0-9]#")) "a hash-delimited pattern")
+  (is (= ["a" "b c"] (s/split "a b c" #"\s+" 2)) "a limit")
+  (is (= ["a" "b" "c"] (s/split "a b c" #"\s+" nil)) "a nil limit means no limit")
+  (is (= [""] (s/split "" #"\s+")) "an empty subject")
+  (is (= ["abc"] (s/split "abc" #"\s+")) "a pattern that does not match")
+  (is (= ["a" "b"] (s/split-lines "a\nb")) "split-lines is unaffected"))
+
+(deftest test-the-subject-guard-is-unchanged
+  (is (thrown? \InvalidArgumentException (s/split 42 #"\s+")) "a non-string subject")
+  (is (thrown? \InvalidArgumentException (s/split nil #"\s+")) "a nil subject"))
+
+(deftest test-replace-still-accepts-a-plain-string
+  ;; `replace` and `replace-first` wrap a non-delimited match as a literal.
+  ;; `split` deliberately does not, because a plain string cannot be told
+  ;; apart from a pattern delimited by something other than `/`.
+  (is (= "a_b" (s/replace "a b" " " "_")) "replace takes a literal")
+  (is (= "a_b b" (s/replace-first "a b b" " " "_")) "replace-first takes a literal")
+  (is (= "a_b" (s/replace "a b" #"\s+" "_")) "replace still takes a regex"))

--- a/tests/php/Benchmark/Phel/StdlibStringBench.php
+++ b/tests/php/Benchmark/Phel/StdlibStringBench.php
@@ -12,6 +12,7 @@ use PhpBench\Benchmark\Metadata\Annotations\Revs;
 
 use function implode;
 use function mb_strpos;
+use function preg_split;
 use function rtrim;
 use function str_pad;
 use function strlen;
@@ -63,9 +64,14 @@ final class StdlibStringBench extends CoreBenchCase
     /** @var callable */
     private $join;
 
+    /** @var callable */
+    private $split;
+
     private string $trailing = '';
 
     private string $haystack = '';
+
+    private string $sentence = '';
 
     private string $notBlank = '';
 
@@ -156,6 +162,26 @@ final class StdlibStringBench extends CoreBenchCase
     }
 
     /**
+     * `split` gained a pattern guard, so it is worth a subject: the guard runs
+     * on every call and the function is used per line or per field in most
+     * text handling.
+     *
+     * @Revs(1000)
+     */
+    public function bench_split(): void
+    {
+        ($this->split)($this->sentence, '/\s+/');
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_split_raw(): void
+    {
+        Phel::vector(preg_split('/\s+/', $this->sentence, -1));
+    }
+
+    /**
      * Unlike the pairs above this one does not converge: the residual is
      * `to-php-array`, which is `(apply php/array coll)` (item A6 of #3021) and
      * lives in `phel.core`. The gap is the measurement of that item.
@@ -192,10 +218,12 @@ final class StdlibStringBench extends CoreBenchCase
         $this->blank = $this->phelFn('phel.string', 'blank?');
         $this->padLeft = $this->phelFn('phel.string', 'pad-left');
         $this->join = $this->phelFn('phel.string', 'join');
+        $this->split = $this->phelFn('phel.string', 'split');
 
         $this->trailing = "hello world\n\r\n";
         $this->haystack = 'hello world world';
         $this->notBlank = '  hello  ';
         $this->parts = Phel::vector(['apple', 'banana', 'cherry']);
+        $this->sentence = 'the quick brown fox jumps over the lazy dog again and again';
     }
 }


### PR DESCRIPTION
## 🤔 Background

Found while profiling a string-heavy workload to check whether the collection-shaped benchmarks had biased what the `#2973` sweep was finding. The workload itself was wrong, and the way it failed is the bug:

```
PHP Warning:  preg_split(): Empty regular expression in .../phel.string__48b6e3d5.php on line 95
Phel::vector(): Argument #1 ($values) must be of type ?array, false given
```

Two messages, neither naming the pattern, and the second pointing at an internal constructor. The call was `(split text " ")`.

## 🔖 Changes

`split` checks the `preg_split` result and reports the pattern:

```
Expected a delimited regular expression, got " ". Write a regex literal such as
#"\s+", or delimit the pattern yourself, for example "/ /". Note that `split`
takes a regular expression, while `replace` also accepts a plain literal string.
```

A bare separator gets its own message because that is the common mistake and the fix differs: PCRE reads `" "` as an empty pattern between two space delimiters. A delimited but malformed pattern gets PCRE's own message instead:

```
Invalid regular expression "/[/": Internal error
```

## The first version cost 17%

I initially validated the pattern up front, in a guard that ran on every call. `bench_split` went from 1.748us to 2.041us, **+16.8%**, which is a bad trade for an error message.

Moving the whole diagnosis behind the `false` check, as a `let` and an `if` in the body rather than a guard function, makes a successful split pay **+0.13%**:

| subject | main | this PR | |
|---|---|---|---|
| `bench_split` | 1.748us | 1.750us | +0.13% |
| `bench_split_raw` | 1.606us | 1.610us | +0.27% |

`bench_split` is new; `split` had no subject.

## What I deliberately did not do

`replace` and `replace-first` accept a plain string as a literal (`as-pattern` wraps anything not slash-delimited in `preg_quote`). Making `split` match would be the tidier-looking fix and I decided against it: **any character can delimit a PCRE pattern**, so `"#[0-9]#"` is a working regex today, and treating plain strings as literals would silently turn it into a search for that text. Verified it currently works, and it stays working.

That leaves a real inconsistency in the library, where `split` takes only a regex and `replace` takes either. It is a semantics call rather than a bug fix, so the error message points at `replace` instead and the difference is left for a maintainer to decide.

## Verification

The test file covers both messages, and that every pattern that worked before still works: regex literal, slash-delimited, hash-delimited, the `limit` arity, a nil limit, an empty subject, a non-matching pattern, `split-lines`, and the existing non-string-subject guard.

Related to #2973
