### PR TITLE
perf(core): tag the core predicates that return an untagged bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Tag the fifteen core predicates that returned an untagged bool (`even?`, `odd?`, `zero?`, `empty?`, `some?`, `map?`, `list?`, `indexed?`, `contains?`, `truthy?`, `nan?`, `infinite?`, `subset?`, `superset?`, `not`) so an `if` over them skips the `Truthy` adapter, and so a function built on one is itself inferred to return `bool`: 1 to 5% per test, plus the return type it propagates (#2973)
 - Skip the `Truthy` adapter in an `if` test when the call is to a global whose return `:tag` is `bool`, which covers `<`, `>`, `<=`, `>=`, `=`, `not=`, `nil?` and `pos?` as well as any user `defn ^bool`. A `defn` whose arities disagree carries no tag, so it keeps the adapter (#2973)
 - Lower `(not x)` to a native `!` when `x` is a proven PHP bool: 3.7x, and an `if` test drops the `Truthy` adapter too (#3021)
 - Compile a literal `(list ...)`, `(vector ...)`, `(queue ...)`, `(hash-map ...)` or `(array-map ...)` straight to its `Phel` factory: 2.2 to 3.6 times faster (#3014)

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -174,7 +174,7 @@
 (defn not
   "Returns true if value is falsy (nil or false), false otherwise."
   {:example "(not nil) ; => true"}
-  [x]
+  ^bool [x]
   (if x false true))
 
 (defn not=
@@ -408,8 +408,8 @@
 (defn some?
   "With 1 arg, returns true if `x` is not nil (Clojure semantics). With 2 args, returns true if `pred` is true for at least one element in `coll`."
   {:example "(some? 1) ; => true\n(some? even? [1 3 5 6 7]) ; => true"}
-  ([x] (not (nil? x)))
-  ([pred coll]
+  (^bool [x] (not (nil? x)))
+  (^bool [pred coll]
    ;; Same walk as `all?`: a seq once, then `next` reports exhaustion, rather
    ;; than an `empty?` dispatch on the collection per element.
    ;; Same shape as `all?`, and the same reason.
@@ -465,7 +465,7 @@
   "Checks if `x` is truthy. Same as `x == true` in PHP."
   {:example "(truthy? 0) ; => true\n(truthy? nil) ; => false"
    :see-also ["true?" "false?" "nil?"]}
-  [x]
+  ^bool [x]
   (Truthy/isTruthy x))
 
 (defn false?
@@ -483,7 +483,7 @@
 (defn contains?
   "Returns true if key is present in collection (checks keys/indices, not values)."
   {:example "(contains? [10 20 30] 1) ; => true"}
-  [coll key]
+  ^bool [coll key]
   (cond
     (nil? coll) false
     (php/instanceof coll ContainsInterface) (.contains coll key)

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -94,7 +94,7 @@
 (defn subset?
   "Returns true if `s1` is a subset of `s2`, i.e. every element in `s1` is also in `s2`."
   {:example "(subset? (hash-set 1 2) (hash-set 1 2 3)) ; => true"}
-  [s1 s2]
+  ^bool [s1 s2]
   (if (> (count s1) (count s2))
     false
     (every? #(.contains s2 %) s1)))
@@ -102,7 +102,7 @@
 (defn superset?
   "Returns true if `s1` is a superset of `s2`, i.e. every element in `s2` is also in `s1`."
   {:example "(superset? (hash-set 1 2 3) (hash-set 1 2)) ; => true"}
-  [s1 s2]
+  ^bool [s1 s2]
   (subset? s2 s1))
 
 (defn select

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -396,7 +396,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   "Checks if `x` is even."
   {:example "(even? 4) ; => true"
    :see-also ["odd?" "zero?"]}
-  [x]
+  ^bool [x]
   ;; A native int answers with one PHP modulo. Otherwise this cost three Phel
   ;; calls, `even?` to `%` to `rem`, to reach the same question (#2973).
   (if (php/is_int x)
@@ -407,7 +407,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   "Checks if `x` is odd."
   {:example "(odd? 3) ; => true"
    :see-also ["even?" "zero?"]}
-  [x]
+  ^bool [x]
   ;; Its own fast path rather than negating `even?`: that was a fourth call on
   ;; top of the three above (#2973).
   (if (php/is_int x)
@@ -418,7 +418,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   "Checks if `x` is zero."
   {:example "(zero? 0) ; => true"
    :see-also ["pos?" "neg?" "one?"]}
-  [x]
+  ^bool [x]
   ;; As `pos?` and `neg?` below: a native int compares against 0 directly
   ;; rather than through the numeric tower (#2973).
   (if (php/is_int x)
@@ -458,7 +458,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   "Checks if `x` is not a number."
   {:example "(nan? ##NaN) ; => true"
    :see-also ["NaN?" "inf?"]}
-  [x]
+  ^bool [x]
   (if (nil? x)
     false
     (php/is_nan x)))
@@ -481,7 +481,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   "Checks if `x` is positive or negative infinity. Alias for `inf?`, matching Clojure's `infinite?` naming."
   {:example "(infinite? php/INF) ; => true\n(infinite? 1.0) ; => false"
    :see-also ["inf?" "nan?"]}
-  [x]
+  ^bool [x]
   (inf? x))
 
 (defn abs

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -318,7 +318,7 @@
   "Returns true if `x` is a hash map, false otherwise."
   {:example "(map? {:a 1}) ; => true\n(map? [1 2]) ; => false"
    :see-also ["vector?" "set?" "associative?"]}
-  [x]
+  ^bool [x]
   (and (php/instanceof x PersistentMapInterface)
        (not (php/instanceof x AbstractPersistentStruct))))
 
@@ -344,7 +344,7 @@
   "Returns true if `x` is a list, false otherwise. Returns false for the seq view of non-list collections produced by `seq`."
   {:example "(list? '(1 2)) ; => true\n(list? [1 2]) ; => false"
    :see-also ["vector?" "seq?" "sequential?"]}
-  [x]
+  ^bool [x]
   ;; A seq view over a vector or a map is also a `PersistentListInterface`, so
   ;; dropping either half makes `(list? (seq [1 2]))` return true.
   (and (php/instanceof x PersistentListInterface)
@@ -433,7 +433,7 @@ Unlike `seq?`, this predicate is true only for lazy sequences, not for realized 
 A non-countable iterable (an `eduction` pipeline, a PHP generator) is answered by pulling a single element, never by counting it."
   {:example "(empty? []) ; => true\n(empty? [1]) ; => false"
    :see-also ["not-empty" "empty" "count"]}
-  [x]
+  ^bool [x]
   ;; Collections are the common argument and were reached fifth, behind two
   ;; scalar checks. They move up, but only as far as the lazy branches: a
   ;; `LazySeq` *is* `Countable`, so putting the countable branch above it would
@@ -548,7 +548,7 @@ This function is useful for explicitly converting strings to sequences of charac
 
 Indexed sequences include lists, vectors, and indexed PHP arrays."
   {:example "(indexed? [1 2 3]) ; => true"}
-  [x]
+  ^bool [x]
   (or (php/instanceof x PersistentVectorInterface)
       (php/instanceof x PersistentListInterface)
       (indexed-php-array? x)))

--- a/tests/php/Integration/Fixtures/Call/contains-check-tagged.test
+++ b/tests/php/Integration/Fixtures/Call/contains-check-tagged.test
@@ -3,10 +3,10 @@
 (fn [^\Phel\Lang\Collections\Vector\PersistentVectorInterface v i] (contains? v i))
 (fn [^array a k] (contains? a k))
 --PHP--
-(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m, $k) {
+(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m, $k): bool {
   return ($m->contains($k));
-});(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v, $i) {
+});(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v, $i): bool {
   return ($v->contains($i));
-});(function(array $a, $k) {
+});(function(array $a, $k): bool {
   return array_key_exists($k, $a);
 });

--- a/tests/php/Integration/Fixtures/Call/empty-check-tagged.test
+++ b/tests/php/Integration/Fixtures/Call/empty-check-tagged.test
@@ -5,14 +5,14 @@
 (fn [^\Phel\Lang\Collections\Map\PersistentMapInterface m] (empty? m))
 (fn [^\Phel\Lang\Collections\Vector\PersistentVectorInterface v] (empty? v))
 --PHP--
-(function(array $a) {
+(function(array $a): bool {
   return ($a === []);
-});(function(string $s) {
+});(function(string $s): bool {
   return ($s === '');
-});(function(int $n) {
+});(function(int $n): bool {
   return ($n === 0);
-});(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m) {
+});(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m): bool {
   return ($m->count() === 0);
-});(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
+});(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v): bool {
   return ($v->count() === 0);
 });

--- a/tests/php/Integration/Fixtures/Call/multi-instanceof-predicate.test
+++ b/tests/php/Integration/Fixtures/Call/multi-instanceof-predicate.test
@@ -3,7 +3,7 @@
 (fn [x] (vector? x))
 (fn [x] (seq? x))
 --PHP--
-(function($x) {
+(function($x): bool {
   return (($x instanceof \Phel\Lang\Collections\Map\PersistentMapInterface) && !($x instanceof \Phel\Lang\Collections\Struct\AbstractPersistentStruct));
 });(function($x): bool {
   return (($x instanceof \Phel\Lang\Collections\Vector\PersistentVectorInterface) || ($x instanceof \Phel\Lang\Collections\Map\MapEntry));

--- a/tests/php/Integration/Fixtures/Call/nil-some-check-specialised.test
+++ b/tests/php/Integration/Fixtures/Call/nil-some-check-specialised.test
@@ -5,7 +5,7 @@
 --PHP--
 (function($x): bool {
   return ($x === null);
-});(function($x) {
+});(function($x): bool {
   return ($x !== null);
 });(function(array $a): int {
   return count($a);

--- a/tests/php/Integration/Fixtures/Call/not-eq-on-keyword-literal.test
+++ b/tests/php/Integration/Fixtures/Call/not-eq-on-keyword-literal.test
@@ -1,7 +1,7 @@
 --PHEL--
 (fn [x] (not (= x :foo)))
 --PHP--
-(function($x) {
+(function($x): bool {
   static $__phel_const_0;
   return ($x !== ($__phel_const_0 ??= \Phel\Lang\Keyword::create("foo")));
 });

--- a/tests/php/Integration/Fixtures/Call/not-eq-peephole.test
+++ b/tests/php/Integration/Fixtures/Call/not-eq-peephole.test
@@ -1,6 +1,6 @@
 --PHEL--
 (fn [^int a ^int b] (not (= a b)))
 --PHP--
-(function(int $a, int $b) {
+(function(int $a, int $b): bool {
   return ($a !== $b);
 });

--- a/tests/php/Integration/Fixtures/Call/not-over-bool-operand-in-test-slot.test
+++ b/tests/php/Integration/Fixtures/Call/not-over-bool-operand-in-test-slot.test
@@ -1,7 +1,7 @@
 --PHEL--
 (fn [x] (if (not (php/is_int x)) 1 2))
 --PHP--
-(function($x) {
+(function($x): int {
   return (((!(is_int($x)))) ? 1 : 2);
 
 });

--- a/tests/php/Integration/Fixtures/Call/not-over-bool-operand.test
+++ b/tests/php/Integration/Fixtures/Call/not-over-bool-operand.test
@@ -1,6 +1,6 @@
 --PHEL--
 (fn [x] (not (php/is_int x)))
 --PHP--
-(function($x) {
+(function($x): bool {
   return (!(is_int($x)));
 });

--- a/tests/php/Integration/Fixtures/Call/not-over-non-bool-operand-stays-generic.test
+++ b/tests/php/Integration/Fixtures/Call/not-over-non-bool-operand-stays-generic.test
@@ -1,7 +1,7 @@
 --PHEL--
 (fn [x] (not (php/strlen x)))
 --PHP--
-(function($x) {
+(function($x): bool {
   static $__phel_call_0;
   return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "not"))->__invoke(strlen($x));
 });

--- a/tests/php/Integration/Fixtures/Call/predicate-specialised.test
+++ b/tests/php/Integration/Fixtures/Call/predicate-specialised.test
@@ -10,9 +10,9 @@
   return ($x === true);
 });(function($x): bool {
   return ($x === false);
-});(function($x) {
+});(function($x): bool {
   return (($__truthy = $x) !== null && $__truthy !== false);
-});(function(int $n) {
+});(function(int $n): bool {
   return ($n === 0);
 });(function(int $n): bool {
   return ($n > 0);


### PR DESCRIPTION
## 🤔 Background

While building #3112 I noticed `even?` and `empty?` carried no `:tag bool` where `<`, `=`, `nil?` and `pos?` did, and noted it as a follow-up. This is that follow-up.

Auditing the core predicates found **fifteen** that return a bool and were untagged, so an `if` over them still paid the `Truthy` adapter that #3112 exists to remove:

`even?` `odd?` `zero?` `empty?` `some?` `map?` `list?` `indexed?` `contains?` `truthy?` `nan?` `infinite?` `subset?` `superset?` `not`

## 🔖 Changes

A `^bool` tag on each.

Interleaved A/B, both pairs consistent in direction:

| test slot | before | after | |
|---|---|---|---|
| `if` over `zero?` | 14.81us | 14.04us | **-5.2%** |
| `if` over `even?` | 15.52us | 14.90us | -4.0% |
| `if` over `empty?` | 25.78us | 25.09us | -2.7% |
| `if` over `contains?` | 34.50us | 34.17us | -1.0% |
| `if` over `not` | 8.28us | 8.32us | +0.5% |

`not` is flat because `CallSpecialization` already recognised it; it is tagged for consistency and for the second effect below.

## The second-order effect is the bigger one

The per-test saving is small. What the fixtures show is that a function whose body is one of these now has an **inferred `bool` return type of its own**:

```php
-(function(array $a) {
+(function(array $a): bool {
```

So its callers drop the adapter too, and PHP enforces the type at the boundary. That compounds through user code in a way this microbenchmark cannot show. Ten fixtures record a signature that gained `: bool` (one `: int`); **no emitted body changed**, 17 lines swapped for 17.

## Why this is safe

A `^bool` tag becomes a PHP `: bool` return type, so any path returning something else becomes a hard TypeError rather than a wrong answer. That is the whole risk, so it was checked rather than assumed:

- each of the fifteen against **34 value shapes** (ints, floats, NaN, infinities, strings, keywords, symbols, nil, both booleans, empty and non-empty vector/map/set/list/PHP-array, all three transients, BigInt, Ratio, BigDecimal, a lazy seq, a function, an atom, a struct, a MapEntry)
- the three binary ones against **all 34 by 34 pairs**
- throws were tolerated; non-bool *returns* were what the audit looked for, and there were none

`some?` is multi-arity, so both arities are tagged. A `defn` whose arities disagree carries no tag at all, which is what stops a partially bool-returning function being mistaken for a total one, so tagging only one arity would have silently done nothing.

Not tagged: `starts-with?`, `ends-with?`, `includes?` and `blank?` live in `phel.string`, not core, and are left for a separate pass.

Related to #2973
