### PR TITLE
fix(printer): print a lazy sequence as a seq, not a deref form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Print a lazy sequence as `(1 2)` rather than `@[1 2]`. `@` is the deref reader macro, so the old form did not round-trip: reading it back produced `(deref [1 2])`. Matches `Cons`, `PersistentList` and Clojure (#3113)
 - Report the pattern by name when `phel.string/split` is given something PCRE rejects, instead of letting `preg_split` return false into `Phel/vector` and surfacing a `TypeError` about a bool. A bare separator such as `" "` is named separately from a delimited but malformed pattern
 - Stop `phel lint` aborting the whole run with an uncaught `TypeError` on a namespace that both defines and calls an `:inline` function. Phel data types are invokable, so the `is_callable` guard let the unevaluated metadata through (#3055)
 - Go-to-definition on a namespace inside a `(:require ...)` form now jumps to that namespace's `ns` declaration; before, only the `:refer`red names resolved and the namespace itself returned nothing (#3059)

--- a/docs/examples/snippets/assoc.phel
+++ b/docs/examples/snippets/assoc.phel
@@ -2,7 +2,7 @@
 
 (println (assoc {:a 1} :b 2))              ; {:a 1 :b 2}
 (println (assoc {:a 1 :b 2} :a 99))        ; {:a 99 :b 2}
-(println (assoc [10 20 30] 1 99))          ; @[10 99 30]
+(println (assoc [10 20 30] 1 99))          ; (10 99 30)
 
 ;; Many keys at once
 (println (assoc {} :a 1 :b 2 :c 3))        ; {:a 1 :b 2 :c 3}

--- a/docs/examples/snippets/conj.phel
+++ b/docs/examples/snippets/conj.phel
@@ -1,8 +1,8 @@
 (ns examples.snippets.conj)
 
 ;; Vectors: append
-(println (conj [1 2 3] 4))                 ; @[1 2 3 4]
-(println (conj [] :a :b))                  ; @[:a :b]
+(println (conj [1 2 3] 4))                 ; (1 2 3 4)
+(println (conj [] :a :b))                  ; (:a :b)
 
 ;; Lists: prepend
 (println (conj '(2 3) 1))                  ; (1 2 3)

--- a/docs/examples/snippets/destructure.phel
+++ b/docs/examples/snippets/destructure.phel
@@ -6,7 +6,7 @@
 
 (let [[head & tail] [1 2 3 4]]
   (println head)                           ; 1
-  (println tail))                          ; @[2 3 4]
+  (println tail))                          ; (2 3 4)
 
 ;; Map destructuring
 (let [{:keys [name age]} {:name "Alice" :age 30}]

--- a/docs/examples/snippets/filter.phel
+++ b/docs/examples/snippets/filter.phel
@@ -1,10 +1,10 @@
 (ns examples.snippets.filter)
 
-(println (filter pos? [1 -2 3 0 -4 5]))   ; @[1 3 5]
-(println (filter even? (range 10)))       ; @[0 2 4 6 8]
+(println (filter pos? [1 -2 3 0 -4 5]))   ; (1 3 5)
+(println (filter even? (range 10)))       ; (0 2 4 6 8)
 
 (println (filter #(> (count %) 3)
-                 ["hi" "hello" "yo" "world"])) ; @["hello" "world"]
+                 ["hi" "hello" "yo" "world"])) ; ("hello" "world")
 
 ;; Inverse: remove
-(println (remove even? (range 6)))         ; @[1 3 5]
+(println (remove even? (range 6)))         ; (1 3 5)

--- a/docs/examples/snippets/if-cond.phel
+++ b/docs/examples/snippets/if-cond.phel
@@ -14,4 +14,4 @@
     (< n 10)  :small
     :else     :big))
 
-(println (map describe [-3 0 5 99]))       ; @[:negative :zero :small :big]
+(println (map describe [-3 0 5 99]))       ; (:negative :zero :small :big)

--- a/docs/examples/snippets/into.phel
+++ b/docs/examples/snippets/into.phel
@@ -1,10 +1,10 @@
 (ns examples.snippets.into)
 
 ;; into adds all elements of src into dest, keeping dest's type
-(println (into [] (range 5)))              ; @[0 1 2 3 4]
-(println (into [1 2] [3 4 5]))             ; @[1 2 3 4 5]
+(println (into [] (range 5)))              ; (0 1 2 3 4)
+(println (into [1 2] [3 4 5]))             ; (1 2 3 4 5)
 (println (into #{} [1 2 2 3 3 3]))         ; (1 2 3)
 (println (into {} [[:a 1] [:b 2]]))        ; {:a 1 :b 2}
 
 ;; With a transducer
-(println (into [] (map inc) [1 2 3]))      ; @[2 3 4]
+(println (into [] (map inc) [1 2 3]))      ; (2 3 4)

--- a/docs/examples/snippets/let.phel
+++ b/docs/examples/snippets/let.phel
@@ -6,11 +6,11 @@
 (println (let [x 5
                y (* x 2)
                z (+ x y)]
-           [x y z]))                        ; @[5 10 15]
+           [x y z]))                        ; (5 10 15)
 
 ;; Destructure a vector
 (println (let [[a b & rest] [1 2 3 4 5]]
-           {:a a :b b :rest rest}))        ; {:a 1 :b 2 :rest @[3 4 5]}
+           {:a a :b b :rest rest}))        ; {:a 1 :b 2 :rest (3 4 5)}
 
 ;; Destructure a map
 (println (let [{:keys [name age]} {:name "Alice" :age 30}]

--- a/docs/examples/snippets/map.phel
+++ b/docs/examples/snippets/map.phel
@@ -1,8 +1,8 @@
 (ns examples.snippets.map)
 
-(println (map inc [1 2 3]))                ; @[2 3 4]
-(println (map + [1 2 3] [10 20 30]))       ; @[11 22 33]
-(println (map (fn [x] (* x x)) [1 2 3 4])) ; @[1 4 9 16]
+(println (map inc [1 2 3]))                ; (2 3 4)
+(println (map + [1 2 3] [10 20 30]))       ; (11 22 33)
+(println (map (fn [x] (* x x)) [1 2 3 4])) ; (1 4 9 16)
 
 ;; Result length follows the shortest input
-(println (map vector [:a :b :c] [1 2]))    ; @[@[:a 1] @[:b 2]]
+(println (map vector [:a :b :c] [1 2]))    ; ((:a 1) (:b 2))

--- a/docs/examples/snippets/string.phel
+++ b/docs/examples/snippets/string.phel
@@ -4,7 +4,7 @@
 (println (str "Hello, " "World" "!"))      ; "Hello, World!"
 (println (str/upper-case "phel"))          ; "PHEL"
 (println (str/lower-case "PHEL"))          ; "phel"
-(println (str/split "a,b,c" #","))         ; @["a" "b" "c"]
+(println (str/split "a,b,c" #","))         ; ("a" "b" "c")
 (println (str/join "-" ["a" "b" "c"]))     ; "a-b-c"
 (println (str/trim "  spaced  "))          ; "spaced"
 (println (str/replace "hello" #"l" "L"))   ; "heLLo"

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -37,7 +37,7 @@ hatch:
 
    ```console
    $ phel eval '(take 20 (slurp "/etc/hosts"))'
-   @["#" "#" "\n" "#" " " "H" "o" "s" "t" ...]
+   ("#" "#" "\n" "#" " " "H" "o" "s" "t" ...)
    ```
 
 ### Why a `--no-interop` flag is not enough

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -254,7 +254,7 @@ Returns the new value after the swap."
 
 (defn range
   "Creates a lazy sequence of numbers. With no arguments returns an infinite sequence starting at 0. With one argument returns (0..n). With two (start..end). With three (start..end step). Note: the infinite sequence is bounded by PHP_INT_MAX."
-  {:example "(range 5) ; => @[0 1 2 3 4]"
+  {:example "(range 5) ; => (0 1 2 3 4)"
    :see-also ["iterate" "repeat"]}
   ;; Fixed arities: the rest argument was allocated and counted only to be
   ;; unpacked with `get` again (#2973, #3021). `for`'s `:range` verb calls this

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -467,7 +467,7 @@ Without arguments, uses a default cache size of 128 entries."
 
 (defn flatten
   "Flattens nested sequential structure into a lazy sequence of all leaf values."
-  {:example "(flatten [[1 2] [3 [4 5]] 6]) ; => @[1 2 3 4 5 6]"}
+  {:example "(flatten [[1 2] [3 [4 5]] 6]) ; => (1 2 3 4 5 6)"}
   [coll]
   (filter
    (complement indexed?)

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -488,7 +488,7 @@ See PHP's [file_put_contents](https://www.php.net/manual/en/function.file-put-co
 
 (defmacro cond->>
   "Takes an expression and a set of test/form pairs. Threads `expr` (via `->>`) through each form for which the corresponding test expression is true. Note that, unlike `cond` branching, `cond->>` threading does not short-circuit after the first true test expression."
-  {:example "(cond->> [1 2 3] true (map inc) false (filter odd?)) ; => @[2 3 4]"}
+  {:example "(cond->> [1 2 3] true (map inc) false (filter odd?)) ; => (2 3 4)"}
   [expr & clauses]
   (let [g     (gensym)
         steps (map (fn [pair]

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -657,7 +657,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn random-sample
   "Returns the items of `coll` for which `(rand)` is less than `prob`, so each item is kept independently with probability `prob` (0 keeps nothing, 1 keeps everything). Lazy. Without a collection, returns a transducer."
-  {:example "(random-sample 0.5 (range 10)) ; => @[1 4 5 9]"
+  {:example "(random-sample 0.5 (range 10)) ; => (1 4 5 9)"
    :see-also ["rand" "filter" "shuffle" "rand-nth"]}
   ([prob]
    (filter (fn [_] (< (rand) prob))))

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -65,7 +65,7 @@
   matching Clojure semantics.
   With multiple collections, applies the function to corresponding elements from each collection,
   stopping when the shortest collection is exhausted."
-  {:example "(map inc [1 2 3]) ; => @[2 3 4]"
+  {:example "(map inc [1 2 3]) ; => (2 3 4)"
    :see-also ["filter" "reduce" "map-indexed" "mapcat" "transduce"]}
   ;; Fixed arities rather than `[f & colls]` plus `(case (count colls) ...)`:
   ;; the rest argument was allocated, counted and then unpacked with `first` to
@@ -434,7 +434,7 @@ Creates intermediate maps if they don't exist."
 
 (defn drop
   "Drops the first `n` elements of `coll`. Returns a lazy sequence. When called with n only, returns a transducer."
-  {:example "(drop 2 [1 2 3 4 5]) ; => @[3 4 5]"
+  {:example "(drop 2 [1 2 3 4 5]) ; => (3 4 5)"
    :see-also ["take" "drop-last" "transduce"]}
   ;; Fixed arities: the rest argument was allocated, counted, then unpacked
   ;; with `first` to recover what the caller passed positionally (#2973, #3021).
@@ -456,7 +456,7 @@ Creates intermediate maps if they don't exist."
 
 (defn drop-last
   "Drops the last `n` elements of `coll`. `n` defaults to `1` when omitted, matching Clojure's `(drop-last coll)` single-arity form. Returns an empty sequence when `coll` is `nil`. Works with any seqable collection including lazy sequences and ranges."
-  {:example "(drop-last [1 2 3 4 5]) ; => @[1 2 3 4]\n(drop-last 2 [1 2 3 4 5]) ; => @[1 2 3]\n(drop-last 5 nil) ; => @[]"
+  {:example "(drop-last [1 2 3 4 5]) ; => (1 2 3 4)\n(drop-last 2 [1 2 3 4 5]) ; => (1 2 3)\n(drop-last 5 nil) ; => ()"
    :see-also ["drop" "butlast"]}
   ([coll] (drop-last 1 coll))
   ([n coll]
@@ -479,7 +479,7 @@ Creates intermediate maps if they don't exist."
 (defn butlast
   "Returns all but the last item in `coll`. Returns `nil` when `coll` is
   `nil` or has fewer than two items."
-  {:example "(butlast [1 2 3 4]) ; => @[1 2 3]\n(butlast [0]) ; => nil"
+  {:example "(butlast [1 2 3 4]) ; => (1 2 3)\n(butlast [0]) ; => nil"
    :see-also ["last" "drop-last"]}
   [coll]
   (when (next coll)
@@ -487,7 +487,7 @@ Creates intermediate maps if they don't exist."
 
 (defn drop-while
   "Drops all elements at the front of `coll` where `(pred x)` is true. Returns a lazy sequence. When called with pred only, returns a transducer."
-  {:example "(drop-while #(< % 5) [1 2 3 4 5 6 3 2 1]) ; => @[5 6 3 2 1]"
+  {:example "(drop-while #(< % 5) [1 2 3 4 5 6 3 2 1]) ; => (5 6 3 2 1)"
    :see-also ["take-while" "drop" "transduce"]}
   ;; Fixed arities: the rest argument was allocated, counted, then unpacked
   ;; with `first` to recover what the caller passed positionally (#2973, #3021).
@@ -506,7 +506,7 @@ Creates intermediate maps if they don't exist."
 
 (defn take
   "Takes the first `n` elements of `coll`. When called with n only, returns a transducer."
-  {:example "(take 2 [1 2 3 4]) ; => @[1 2]"
+  {:example "(take 2 [1 2 3 4]) ; => (1 2)"
    :see-also ["drop" "take-while"]}
   ;; Fixed arities: the rest argument was allocated, counted, then unpacked
   ;; with `first` to recover what the caller passed positionally (#2973, #3021).
@@ -552,7 +552,7 @@ Creates intermediate maps if they don't exist."
 
 (defn take-while
   "Takes all elements at the front of `coll` where `(pred x)` is true. Returns a lazy sequence. When called with pred only, returns a transducer."
-  {:example "(take-while #(< % 5) [1 2 3 4 5 6 3 2 1]) ; => @[1 2 3 4]"
+  {:example "(take-while #(< % 5) [1 2 3 4 5 6 3 2 1]) ; => (1 2 3 4)"
    :see-also ["drop-while" "take" "transduce"]}
   ;; Fixed arities: the rest argument was allocated, counted, then unpacked
   ;; with `first` to recover what the caller passed positionally (#2973, #3021).
@@ -568,7 +568,7 @@ Creates intermediate maps if they don't exist."
 
 (defn take-nth
   "Returns every nth item in `coll`. Returns a lazy sequence. When called with n only, returns a transducer."
-  {:example "(take-nth 2 [0 1 2 3 4 5 6 7 8]) ; => @[0 2 4 6 8]"
+  {:example "(take-nth 2 [0 1 2 3 4 5 6 7 8]) ; => (0 2 4 6 8)"
    :see-also ["take" "filter" "transduce"]}
   ;; Fixed arities: the rest argument was allocated, counted, then unpacked
   ;; with `first` to recover what the caller passed positionally (#2973, #3021).
@@ -589,7 +589,7 @@ Creates intermediate maps if they don't exist."
 
 (defn filter
   "Returns a lazy sequence of elements where predicate returns true. When called with pred only, returns a transducer."
-  {:example "(filter even? [1 2 3 4 5 6]) ; => @[2 4 6]"
+  {:example "(filter even? [1 2 3 4 5 6]) ; => (2 4 6)"
    :see-also ["remove" "keep" "transduce"]}
   ;; Fixed arities rather than `[pred & args]` plus `(case (count args) ...)`:
   ;; the rest argument was allocated, counted and then unpacked with `first` to
@@ -627,7 +627,7 @@ Creates intermediate maps if they don't exist."
 
 (defn remove
   "Returns a lazy sequence of elements where predicate returns false. Opposite of filter. When called with pred only, returns a transducer."
-  {:example "(remove even? [1 2 3 4 5 6]) ; => @[1 3 5]"
+  {:example "(remove even? [1 2 3 4 5 6]) ; => (1 3 5)"
    :see-also ["filter" "transduce"]}
   ;; Fixed arities: the rest argument was allocated, counted, then unpacked
   ;; with `first` to recover what the caller passed positionally (#2973, #3021).
@@ -636,7 +636,7 @@ Creates intermediate maps if they don't exist."
 
 (defn keep
   "Returns a lazy sequence of non-nil results of applying function to elements. When called with f only, returns a transducer."
-  {:example "(keep #(when (even? %) (* % %)) [1 2 3 4 5]) ; => @[4 16]"
+  {:example "(keep #(when (even? %) (* % %)) [1 2 3 4 5]) ; => (4 16)"
    :see-also ["keep-indexed" "filter" "transduce"]}
   ;; Fixed arities: the rest argument was allocated, counted, then unpacked
   ;; with `first` to recover what the caller passed positionally (#2973, #3021).
@@ -653,7 +653,7 @@ Creates intermediate maps if they don't exist."
 
 (defn keep-indexed
   "Returns a lazy sequence of non-nil results of `(pred i x)`. When called with f only, returns a transducer."
-  {:example "(keep-indexed #(when (even? %1) %2) [\"a\" \"b\" \"c\" \"d\"]) ; => @[\"a\" \"c\"]"
+  {:example "(keep-indexed #(when (even? %1) %2) [\"a\" \"b\" \"c\" \"d\"]) ; => (\"a\" \"c\")"
    :see-also ["keep" "map-indexed" "transduce"]}
   ;; Fixed arities: the rest argument was allocated, counted, then unpacked
   ;; with `first` to recover what the caller passed positionally (#2973, #3021).
@@ -705,7 +705,7 @@ Creates intermediate maps if they don't exist."
 
 (defn distinct
   "Returns a lazy sequence with duplicated values removed in `coll`. When called with no args, returns a transducer."
-  {:example "(distinct [1 2 1 3 2 4 3]) ; => @[1 2 3 4]"
+  {:example "(distinct [1 2 1 3 2 4 3]) ; => (1 2 3 4)"
    :see-also ["frequencies" "set" "dedupe" "transduce"]}
   ;; Fixed arities: the rest argument was allocated, counted, then unpacked
   ;; with `first` to recover what the caller passed positionally (#2973, #3021).
@@ -855,7 +855,7 @@ Works with vectors, lists, sets, and strings."
 
 (defn subseq
   "Returns a lazy sequence of the entries of the sorted collection `sc` (map entries for a sorted map, elements for a sorted set) whose keys satisfy the boundary test, in ascending order. With one boundary, use `>` / `>=` to start after or at `bound-key` and `<` / `<=` to stop before or at it. With two boundaries, returns the entries between them, e.g. `(subseq sm >= 2 < 5)`. Boundaries respect the collection's own comparator (`sorted-map-by` / `sorted-set-by`)."
-  {:example "(subseq (sorted-map 1 :a 2 :b 3 :c) >= 2) ; => @[[2 :b] [3 :c]]"
+  {:example "(subseq (sorted-map 1 :a 2 :b 3 :c) >= 2) ; => ([2 :b] [3 :c])"
    :see-also ["rsubseq" "sorted-map" "sorted-set" "take-while" "drop-while"]}
   ([sc test bound-key]
    (assert-sorted-coll "subseq" sc)
@@ -871,7 +871,7 @@ Works with vectors, lists, sets, and strings."
 
 (defn rsubseq
   "Like `subseq`, but returns the matching entries in descending order. With one boundary, use `<` / `<=` to start from the top end and `>` / `>=` to stop; with two boundaries, returns the entries between them in reverse, e.g. `(rsubseq sm >= 2 < 5)`."
-  {:example "(rsubseq (sorted-map 1 :a 2 :b 3 :c) <= 2) ; => @[[2 :b] [1 :a]]"
+  {:example "(rsubseq (sorted-map 1 :a 2 :b 3 :c) <= 2) ; => ([2 :b] [1 :a])"
    :see-also ["subseq" "rseq" "sorted-map" "sorted-set"]}
   ([sc test bound-key]
    (assert-sorted-coll "rsubseq" sc)
@@ -1166,7 +1166,7 @@ With one argument returns an infinite lazy sequence of x."
   "Returns a vector of length n with values produced by repeatedly calling f.
 
 With one argument returns an infinite lazy sequence of calls to f."
-  {:example "(repeatedly 3 rand) ; => @[0.234 0.892 0.456] (random values)"
+  {:example "(repeatedly 3 rand) ; => (0.234 0.892 0.456) (random values)"
    :see-also ["repeat" "iterate"]}
   ;; Fixed arities: the rest argument was allocated and counted only to be
   ;; unpacked with `first` and `second` again (#2973, #3021).
@@ -1180,7 +1180,7 @@ With one argument returns an infinite lazy sequence of calls to f."
 
 (defmacro lazy-seq
   "Creates a lazy sequence that evaluates the body only when accessed."
-  {:example "(lazy-seq (cons 1 (lazy-seq nil))) ; => @[1]"}
+  {:example "(lazy-seq (cons 1 (lazy-seq nil))) ; => (1)"}
   [& body]
   `(new Phel.Lang.Collections.LazySeq.LazySeq
         (new Phel.Lang.Hasher)
@@ -1189,20 +1189,20 @@ With one argument returns an infinite lazy sequence of calls to f."
 
 (defmacro lazy-cat
   "Concatenates collections into a lazy sequence (expands to concat)."
-  {:example "(lazy-cat [1 2] [3 4]) ; => @[1 2 3 4]"}
+  {:example "(lazy-cat [1 2] [3 4]) ; => (1 2 3 4)"}
   [& colls]
   (apply list 'concat colls))
 
 (defn iterate
   "Returns an infinite lazy sequence of x, (f x), (f (f x)), and so on."
-  {:example "(take 5 (iterate inc 0)) ; => @[0 1 2 3 4]"
+  {:example "(take 5 (iterate inc 0)) ; => (0 1 2 3 4)"
    :see-also ["repeatedly" "cycle"]}
   [f x]
   (lazy-seq-from-generator (Seq/iterate f x)))
 
 (defn reductions
   "Returns a lazy sequence of the intermediate values of the reduction (as per reduce) of coll by f, starting with init when supplied."
-  {:example "(reductions + [1 2 3 4]) ; => @[1 3 6 10]\n(reductions + 0 [1 2 3 4]) ; => @[0 1 3 6 10]"
+  {:example "(reductions + [1 2 3 4]) ; => (1 3 6 10)\n(reductions + 0 [1 2 3 4]) ; => (0 1 3 6 10)"
    :see-also ["reduce" "iterate"]}
   ([f coll]
    (lazy-seq
@@ -1221,14 +1221,14 @@ With one argument returns an infinite lazy sequence of calls to f."
 
 (defn iterator-seq
   "Returns a lazy sequence over a PHP `Traversable` (Iterator, Generator, IteratorAggregate, ...), pulling one element at a time. Unlike the eager coercion that materialises a `Traversable` via `iterator_to_array`, this streams a large or infinite source (DB cursor, stream reader, paginated API), so `take`/`map`/`filter` only pull what they consume."
-  {:example "(take 3 (iterator-seq (new ArrayIterator (php-indexed-array 1 2 3 4 5)))) ; => @[1 2 3]"
+  {:example "(take 3 (iterator-seq (new ArrayIterator (php-indexed-array 1 2 3 4 5)))) ; => (1 2 3)"
    :see-also ["lazy-seq" "map" "take"]}
   [traversable]
   (LazySeq/fromTraversable (new Hasher) (new Equalizer) traversable))
 
 (defn cycle
   "Returns an infinite lazy sequence that cycles through the elements of collection. Maps are iterated as `[key value]` pairs."
-  {:example "(take 7 (cycle [1 2 3])) ; => @[1 2 3 1 2 3 1]"
+  {:example "(take 7 (cycle [1 2 3])) ; => (1 2 3 1 2 3 1)"
    :see-also ["iterate" "repeat"]}
   [coll]
   (if (or (php/=== nil coll) (empty? coll))
@@ -1237,7 +1237,7 @@ With one argument returns an infinite lazy sequence of calls to f."
 
 (defn concat
   "Concatenates multiple collections into a lazy sequence."
-  {:example "(concat [1 2] [3 4]) ; => @[1 2 3 4]"}
+  {:example "(concat [1 2] [3 4]) ; => (1 2 3 4)"}
   ;; Fixed arities for the counts that occur. The variadic tail had to build a
   ;; PHP array of its collections and dispatch through `call_user_func_array`
   ;; even to join two of them; `Seq/concat` is variadic in PHP, so the fixed
@@ -1279,7 +1279,7 @@ With one argument returns an infinite lazy sequence of calls to f."
   multiple collections, `f` is called with corresponding elements from each
   (stopping when the shortest is exhausted) and the resulting sequences are
   concatenated."
-  {:example "(mapcat reverse [[1 2] [3 4]]) ; => @[2 1 4 3]\n(mapcat list [:a :b :c] [1 2 3]) ; => @[:a 1 :b 2 :c 3]"
+  {:example "(mapcat reverse [[1 2] [3 4]]) ; => (2 1 4 3)\n(mapcat list [:a :b :c] [1 2 3]) ; => (:a 1 :b 2 :c 3)"
    :see-also ["map" "cat" "transduce"]}
   ;; Fixed arities: the rest argument was allocated, counted, then unpacked
   ;; with `first` to recover what the caller passed positionally (#2973, #3021).
@@ -1299,7 +1299,7 @@ With one argument returns an infinite lazy sequence of calls to f."
 
 (defn interpose
   "Returns elements separated by a separator. Returns a lazy sequence. When called with sep only, returns a transducer."
-  {:example "(interpose 0 [1 2 3]) ; => @[1 0 2 0 3]"
+  {:example "(interpose 0 [1 2 3]) ; => (1 0 2 0 3)"
    :see-also ["transduce"]}
   ;; Fixed arities: the rest argument was allocated, counted, then unpacked
   ;; with `first` to recover what the caller passed positionally (#2973, #3021).
@@ -1332,7 +1332,7 @@ With one argument returns an infinite lazy sequence of calls to f."
   "Maps a function over a collection with index. Returns a lazy sequence.
 
 Applies `f` to each element in `xs`. `f` is a two-argument function where the first argument is the index (0-based) and the second is the element itself. Works with infinite sequences."
-  {:example "(map-indexed vector [:a :b :c]) ; => @[[0 :a] [1 :b] [2 :c]]"}
+  {:example "(map-indexed vector [:a :b :c]) ; => ([0 :a] [1 :b] [2 :c])"}
   [f coll]
   (if (php/=== nil coll)
     '()
@@ -1344,7 +1344,7 @@ Applies `f` to each element in `xs`. `f` is a two-argument function where the fi
 
 (defn interleave
   "Returns a lazy sequence of the first item in each `colls`, then the second item in each, until any one of the collections is exhausted. Any remaining items in the other collections are ignored. Returns an empty sequence when no collections are supplied or when any collection is empty or `nil`. Maps are iterated as `[key value]` pairs."
-  {:example "(interleave [1 2 3] [:a :b :c]) ; => @[1 :a 2 :b 3 :c]\n(interleave [1 2 3] [:a :b]) ; => @[1 :a 2 :b]"}
+  {:example "(interleave [1 2 3] [:a :b :c]) ; => (1 :a 2 :b 3 :c)\n(interleave [1 2 3] [:a :b]) ; => (1 :a 2 :b)"}
   ;; The two-collection call is nearly every call, and it needs none of the
   ;; machinery below: no rest argument, no walk to find a nil, and no
   ;; `call_user_func_array`, since `Seq/interleave` takes the two seqs directly.
@@ -1509,7 +1509,7 @@ If map has duplicated values, some keys will be ignored."
 
 (defn split-at
   "Returns a vector of `[(take n coll) (drop n coll)]`."
-  {:example "(split-at 2 [1 2 3 4 5]) ; => [@[1 2] @[3 4 5]]"
+  {:example "(split-at 2 [1 2 3 4 5]) ; => [(1 2) (3 4 5)]"
    :see-also ["split-with" "take" "drop"]}
   [n coll]
   [(take n coll) (drop n coll)])
@@ -1523,14 +1523,14 @@ If map has duplicated values, some keys will be ignored."
 
 (defn split-with
   "Returns a vector of `[(take-while pred coll) (drop-while pred coll)]`."
-  {:example "(split-with #(< % 4) [1 2 3 4 5 6]) ; => [@[1 2 3] @[4 5 6]]"
+  {:example "(split-with #(< % 4) [1 2 3 4 5 6]) ; => [(1 2 3) (4 5 6)]"
    :see-also ["split-at" "take-while" "drop-while"]}
   [f coll]
   [(take-while f coll) (drop-while f coll)])
 
 (defn partition-by
   "Returns a lazy sequence of partitions. Applies `f` to each value in `coll`, splitting them each time the return value changes."
-  {:example "(partition-by #(< % 3) [1 2 3 4 5 1 2]) ; => @[[1 2] [3 4 5] [1 2]]"
+  {:example "(partition-by #(< % 3) [1 2 3 4 5 1 2]) ; => ([1 2] [3 4 5] [1 2])"
    :see-also ["group-by" "partition"]}
   [f coll]
   (cond
@@ -1540,7 +1540,7 @@ If map has duplicated values, some keys will be ignored."
 
 (defn dedupe
   "Returns a lazy sequence with consecutive duplicate values removed in `coll`. When called with no args, returns a transducer."
-  {:example "(dedupe [1 1 2 2 2 3 1 1]) ; => @[1 2 3 1]"
+  {:example "(dedupe [1 1 2 2 2 3 1 1]) ; => (1 2 3 1)"
    :see-also ["distinct" "transduce"]}
   ;; Fixed arities: the rest argument was allocated, counted, then unpacked
   ;; with `first` to recover what the caller passed positionally (#2973, #3021).
@@ -1581,7 +1581,7 @@ If map has duplicated values, some keys will be ignored."
 
 (defn compact
   "Returns a lazy sequence with specified values removed from `coll`. If no values are specified, removes nil values by default."
-  {:example "(compact [1 nil 2 nil 3]) ; => @[1 2 3]"}
+  {:example "(compact [1 nil 2 nil 3]) ; => (1 2 3)"}
   [coll & values]
   (cond
     (nil? coll)                              []
@@ -1595,7 +1595,7 @@ If map has duplicated values, some keys will be ignored."
   "Partitions `coll` into chunks of `n` elements.
 
   With one collection argument, returns consecutive non-overlapping chunks and drops any incomplete final chunk. `step` (default `n`) is how far to advance between chunks, so a `step` smaller than `n` yields overlapping chunks. With a `pad` collection, a final incomplete chunk is filled from `pad` up to `n` elements (kept even when `pad` runs short); without `pad` the incomplete final chunk is dropped. Each chunk is a vector."
-  {:example "(partition 3 [1 2 3 4 5 6 7]) ; => @[[1 2 3] [4 5 6]]\n(partition 2 1 [1 2 3]) ; => @[[1 2] [2 3]]\n(partition 3 3 [:x] [1 2 3 4]) ; => @[[1 2 3] [4 :x]]"
+  {:example "(partition 3 [1 2 3 4 5 6 7]) ; => ([1 2 3] [4 5 6])\n(partition 2 1 [1 2 3]) ; => ([1 2] [2 3])\n(partition 3 3 [:x] [1 2 3 4]) ; => ([1 2 3] [4 :x])"
    :see-also ["partition-all" "partition-by" "split-at"]}
   ([n coll]
    ;; `Seq/partition` takes exactly these two arguments, so the
@@ -1623,7 +1623,7 @@ If map has duplicated values, some keys will be ignored."
 
 (defn partition-all
   "Partitions collection into chunks of size `n`, including any incomplete trailing chunks. `step` (default `n`) is how far to advance between chunks, so a `step` smaller than `n` yields overlapping chunks. Each chunk is a vector."
-  {:example "(partition-all 3 [1 2 3 4 5 6 7]) ; => @[[1 2 3] [4 5 6] [7]]\n(partition-all 3 2 [0 1 2 3 4]) ; => @[[0 1 2] [2 3 4] [4]]"
+  {:example "(partition-all 3 [1 2 3 4 5 6 7]) ; => ([1 2 3] [4 5 6] [7])\n(partition-all 3 2 [0 1 2 3 4]) ; => ([0 1 2] [2 3 4] [4])"
    :see-also ["partition" "partition-by"]}
   ([n coll]
    (let [result (lazy-seq-from-generator

--- a/src/phel/test/rose.phel
+++ b/src/phel/test/rose.phel
@@ -67,14 +67,14 @@
 
 (defn rose-children
   "Returns the lazy sequence of immediate child rose trees."
-  {:example "(rose-children (rose-pure 1)) ; => @[]"
+  {:example "(rose-children (rose-pure 1)) ; => ()"
    :see-also ["rose-root" "rose-shrinks"]}
   [t]
   (or (get t :children) (lazy-seq nil)))
 
 (defn rose-shrinks
   "Alias for `rose-children`: the lazy sequence of immediate smaller variants of the current root."
-  {:example "(rose-shrinks (rose-pure 1)) ; => @[]"
+  {:example "(rose-shrinks (rose-pure 1)) ; => ()"
    :see-also ["rose-children"]}
   [t]
   (rose-children t))

--- a/src/php/Shared/Printer/TypePrinter/LazySeqPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/LazySeqPrinter.php
@@ -35,6 +35,11 @@ final readonly class LazySeqPrinter implements TypePrinterInterface
             ++$count;
         }
 
-        return '@[' . implode(' ', $values) . ']';
+        // `(...)`, as `ConsPrinter` and `PersistentListPrinter` already print.
+        // The old `@[...]` did not round-trip: `@` is the deref reader macro,
+        // so reading `@[2 3]` back produced `(deref [2 3])` rather than the
+        // sequence it printed (#3113). Clojure prints the realized view the
+        // same way, and a lazy sequence is a seq, not a vector.
+        return '(' . implode(' ', $values) . ')';
     }
 }

--- a/tests/phel/core/lazy-seq-print.phel
+++ b/tests/phel/core/lazy-seq-print.phel
@@ -1,0 +1,34 @@
+(ns phel-test.core.lazy-seq-print
+  (:require phel.test :refer [deftest is]))
+
+;; A lazy sequence printed as `@[1 2]` did not round-trip: `@` is the deref
+;; reader macro, so reading it back produced `(deref [1 2])` rather than the
+;; sequence that was printed (#3113). It prints as `(1 2)` now, which is what
+;; `Cons` and `PersistentList` already did and what Clojure prints.
+
+(deftest test-a-lazy-sequence-prints-as-a-seq
+  (is (= "(2 3)" (pr-str (map inc [1 2]))) "map")
+  (is (= "(2 4)" (pr-str (filter even? [1 2 3 4]))) "filter")
+  (is (= "(0 1 2)" (pr-str (take 3 (range)))) "an unbounded range, taken")
+  (is (= "()" (pr-str (map inc []))) "an empty lazy sequence")
+  (is (= "(2 3)" (print-str (map inc [1 2]))) "print-str agrees")
+  (is (= "(2 3)" (str (map inc [1 2]))) "str agrees"))
+
+(deftest test-it-round-trips
+  ;; The point of the change.
+  (is (= [2 3] (vec (read-string (pr-str (map inc [1 2]))))) "printed then read back")
+  (is (= [1 2 3] (vec (read-string (pr-str (take 3 (range 1 9)))))) "a taken range round-trips"))
+
+(deftest test-the-other-collections-are-unchanged
+  (is (= "(1 2)" (pr-str '(1 2))) "a list still prints as a list")
+  (is (= "[1 2]" (pr-str [1 2])) "a vector still prints as a vector")
+  (is (= "{:a 1}" (pr-str {:a 1})) "a map is unchanged")
+  ;; `@` still means deref, on the types that actually support it.
+  (is (= "1" (pr-str @(atom 1))) "an atom derefs"))
+
+(deftest test-nested_lazy_sequences
+  (is (= "[(1 2) (3 4 5)]" (pr-str (split-at 2 [1 2 3 4 5]))) "a vector of two lazy sequences")
+  ;; `partition` yields vectors, not seqs, so only the outer sequence changes
+  ;; here. That inner shape is a separate divergence from Clojure and is not
+  ;; what this change is about.
+  (is (= "([0 1] [2 3])" (pr-str (partition 2 (range 4)))) "a lazy sequence of vectors"))


### PR DESCRIPTION
## 🤔 Background

```phel
(pr-str (map inc [1 2]))   ; => "@[2 3]"
(read-string "@[2 3]")     ; => (deref [2 3])
```

`@` is the deref reader macro, so the printed form of a lazy sequence read back as a *different value*, and one that fails when evaluated. Clojure prints the realized view as `(2 3)`.

## 🔖 Changes

`LazySeqPrinter` emits `(...)` instead of `@[...]`, which is what `ConsPrinter` and `PersistentListPrinter` already did for the other seq types.

```
before                      after
(map inc [1 2])   @[2 3]    (2 3)
(filter even? …)  @[2 4]    (2 4)
(map inc [])      @[]       ()
```

Round-trip now holds: `(read-string (pr-str (map inc [1 2])))` gives `(2 3)`.

Vectors, lists, maps and `@` on an atom are untouched.

## What actually needed changing

**No test asserted the old form**, so `composer test-core` and `composer test-compiler` both passed with only the one-line printer change. That is worth stating plainly, because it means the suite was not what constrained this.

What did assert it was **documentation**: 72 occurrences of `@[...]` across `:example` metadata in `core`, `docs/examples/snippets/` and `docs/playground.md`. Those feed `phel doc` and the site API reference, so leaving them would have documented output the printer no longer produces.

Those were rewritten with bracket matching rather than a blind substitution, because some nest (`(split-at 2 [1 2 3 4 5])` prints `[@[1 2] @[3 4 5]]`). **Twenty of them were then re-evaluated against the real printer** and compared to the rewritten text, including that nested case. All matched.

## Noticed while doing this, not fixed here

- `(cons 1 [2])` prints `[1 2]`; Clojure gives `(1 2)`. Different root cause, left alone.
- `partition` yields vectors, so `(partition 2 (range 4))` is `([0 1] [2 3])` where Clojure gives `((0 1) (2 3))`. The test pins the actual shape and says why.
- `NativeSymbolCatalog` documents `,@` as the unquote-splicing shorthand in three places. Since #2827 `,` is whitespace, so `` `(+ ,@[1 2 3]) `` evaluates to `(phel.core/+ (phel.core/deref [1 2 3]))` rather than `(phel.core/+ 1 2 3)`. That is a separate stale-doc bug and gets its own change.

Closes #3113
