### PR TITLE
docs(api): unquote shorthands are ~ and ~@, not , and ,@

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Document `~` and `~@` as the unquote and unquote-splicing shorthands in `phel doc`, not `,` and `,@`. Since #2827 `,` is whitespace, so the documented `` `(+ ,@[1 2 3]) `` evaluated to `(phel.core/+ (phel.core/deref [1 2 3]))` rather than the `(phel.core/+ 1 2 3)` the same entry claimed
 - Print a lazy sequence as `(1 2)` rather than `@[1 2]`. `@` is the deref reader macro, so the old form did not round-trip: reading it back produced `(deref [1 2])`. Matches `Cons`, `PersistentList` and Clojure (#3113)
 - Report the pattern by name when `phel.string/split` is given something PCRE rejects, instead of letting `preg_split` return false into `Phel/vector` and surfacing a `TypeError` about a bool. A bare separator such as `" "` is named separately from a delimited but malformed pattern
 - Stop `phel lint` aborting the whole run with an uncaught `TypeError` on a namespace that both defines and calls an `:inline` function. Phel data types are invokable, so the `is_callable` guard let the unevaluated metadata through (#3055)

--- a/src/php/Api/Infrastructure/NativeSymbolCatalog.php
+++ b/src/php/Api/Infrastructure/NativeSymbolCatalog.php
@@ -472,24 +472,24 @@ All expressions are evaluated and if no exception is thrown the value of the las
         Symbol::NAME_UNQUOTE => [
             'doc' => '```phel
 (unquote my-sym) ; Evaluates to my-sym
-,my-sym          ; Shorthand for (same as above)
+~my-sym          ; Shorthand for (same as above)
 ```
-Values that should be evaluated in a macro are marked with the unquote function. Shortcut: `,`',
+Values that should be evaluated in a macro are marked with the unquote function. Shortcut: `~`',
             'docUrl' => '/documentation/macros/#quasiquote',
             'signatures' => ['(unquote expr)'],
-            'desc' => 'Values that should be evaluated in a macro are marked with the unquote function. Shortcut: ,',
-            'example' => '`(+ 1 ,(+ 2 3)) ; => (phel.core/+ 1 5)',
+            'desc' => 'Values that should be evaluated in a macro are marked with the unquote function. Shortcut: ~',
+            'example' => '`(+ 1 ~(+ 2 3)) ; => (phel.core/+ 1 5)',
         ],
         Symbol::NAME_UNQUOTE_SPLICING => [
             'doc' => '```phel
 (unquote-splicing my-sym) ; Evaluates to my-sym
-,@my-sym                  ; Shorthand for (same as above)
+~@my-sym                  ; Shorthand for (same as above)
 ```
-Values that should be evaluated in a macro are marked with the unquote function. Shortcut: `,@`',
+Values that should be evaluated in a macro are marked with the unquote function. Shortcut: `~@`',
             'docUrl' => '/documentation/macros/#quasiquote',
             'signatures' => ['(unquote-splicing expr)'],
-            'desc' => 'Values that should be evaluated in a macro are marked with the unquote function. Shortcut: ,@',
-            'example' => '`(+ ,@[1 2 3]) ; => (phel.core/+ 1 2 3)',
+            'desc' => 'Values that should be evaluated in a macro are marked with the unquote function. Shortcut: ~@',
+            'example' => '`(+ ~@[1 2 3]) ; => (phel.core/+ 1 2 3)',
         ],
         Symbol::NAME_USE => [
             'doc' => '```phel


### PR DESCRIPTION
## 🤔 Background

Found while fixing #3113. `NativeSymbolCatalog` still documents `,` and `,@` as the unquote and unquote-splicing shorthands, in the doc block, the `desc` and the `example` of both entries.

#2827 made `,` plain whitespace. So the documented forms no longer do what the entries claim:

| documented form | documented result | actual result |
|---|---|---|
| `` `(+ 1 ,(+ 2 3)) `` | `(phel.core/+ 1 5)` | `(phel.core/+ 1 (phel.core/+ 2 3))` |
| `` `(+ ,@[1 2 3]) `` | `(phel.core/+ 1 2 3)` | `(phel.core/+ (phel.core/deref [1 2 3]))` |

The *expected outputs* in those same entries are exactly what `~` and `~@` produce, so the syntax was left behind at the removal while the results stayed correct. Both verified against the current compiler.

## 🔖 Changes

Eight occurrences across the two entries, `,` to `~` and `,@` to `~@`.

This feeds `phel doc unquote` and the site API reference, so it was actively telling users to write something that evaluates to a `deref`. After:

```
| core/unquote           | Shortcut: ~   |
| core/unquote-splicing  | Shortcut: ~@  |
```

`docs/migration/removed-deprecated-core-fns.md` also mentions `,@`, correctly, as the removed form in a before/after table. Left alone.

Related to #2827
