### PR TITLE
perf: recognise the PHP string predicates as bool-returning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Recognise `str_contains`, `str_starts_with` and `str_ends_with` as bool-returning, so an `if` over one of them or over `phel.string/includes?`, `starts-with?`, `ends-with?` and `contains?` skips the `Truthy` adapter: 7.3% on the raw interop call, 3 to 4.5% through the wrappers (#2973)
 - Tag the fifteen core predicates that returned an untagged bool (`even?`, `odd?`, `zero?`, `empty?`, `some?`, `map?`, `list?`, `indexed?`, `contains?`, `truthy?`, `nan?`, `infinite?`, `subset?`, `superset?`, `not`) so an `if` over them skips the `Truthy` adapter, and so a function built on one is itself inferred to return `bool`: 1 to 5% per test, plus the return type it propagates (#2973)
 - Skip the `Truthy` adapter in an `if` test when the call is to a global whose return `:tag` is `bool`, which covers `<`, `>`, `<=`, `>=`, `=`, `not=`, `nil?` and `pos?` as well as any user `defn ^bool`. A `defn` whose arities disagree carries no tag, so it keeps the adapter (#2973)
 - Lower `(not x)` to a native `!` when `x` is a proven PHP bool: 3.7x, and an `if` test drops the `Truthy` adapter too (#3021)

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -244,7 +244,7 @@ This is a convenience function for converting strings to character sequences. Pr
 (defn starts-with?
   "True if s starts with substr."
   {:example "(starts-with? \"hello world\" \"hello\") ; => true"}
-  [s substr]
+  ^bool [s substr]
   (assert-string s)
   (assert-string substr)
   (php/str_starts_with s substr))
@@ -252,7 +252,7 @@ This is a convenience function for converting strings to character sequences. Pr
 (defn ends-with?
   "True if s ends with substr."
   {:example "(ends-with? \"hello world\" \"world\") ; => true"}
-  [s substr]
+  ^bool [s substr]
   (assert-string s)
   (assert-string substr)
   (php/str_ends_with s substr))
@@ -261,7 +261,7 @@ This is a convenience function for converting strings to character sequences. Pr
   "True if s includes substr."
   {:example "(includes? \"hello world\" \"world\") ; => true"
    :see-also ["contains?" "starts-with?" "ends-with?" "index-of"]}
-  [s substr]
+  ^bool [s substr]
   (assert-string s)
   (assert-string substr)
   (php/str_contains s substr))
@@ -270,7 +270,7 @@ This is a convenience function for converting strings to character sequences. Pr
   "True if s contains substr. Synonym for `includes?`."
   {:example "(contains? \"hello world\" \"lo wo\") ; => true"
    :see-also ["includes?" "starts-with?" "ends-with?"]}
-  [s substr]
+  ^bool [s substr]
   ;; Spelled out rather than delegating to `includes?`: the delegation ran
   ;; `assert-string` on both arguments a second time, and paid a call to do it.
   (assert-string s)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BooleanExprDetector.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BooleanExprDetector.php
@@ -73,6 +73,9 @@ final class BooleanExprDetector
         'is_subclass_of',
         'method_exists',
         'property_exists',
+        'str_contains',
+        'str_ends_with',
+        'str_starts_with',
     ];
 
     public static function isBool(AbstractNode $node): bool

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/BooleanExprDetectorTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/BooleanExprDetectorTest.php
@@ -135,4 +135,34 @@ final class BooleanExprDetectorTest extends TestCase
             self::assertFalse(BooleanExprDetector::isBool($call), $tag . ' must not read as bool');
         }
     }
+
+    public function test_php_string_predicates_are_bool(): void
+    {
+        // `str_contains`, `str_starts_with` and `str_ends_with` return bool but
+        // were missing from the recognised list, so `phel.string/includes?` and
+        // friends kept the truthy adapter in an `if` test.
+        foreach (['str_contains', 'str_ends_with', 'str_starts_with'] as $fn) {
+            $call = new CallNode(
+                NodeEnvironment::empty(),
+                new PhpVarNode(NodeEnvironment::empty(), $fn),
+                [
+                    new LiteralNode(NodeEnvironment::empty(), 'haystack'),
+                    new LiteralNode(NodeEnvironment::empty(), 'needle'),
+                ],
+            );
+            self::assertTrue(BooleanExprDetector::isBool($call), $fn . ' should be bool');
+        }
+    }
+
+    public function test_a_non_bool_php_string_function_is_not_bool(): void
+    {
+        foreach (['str_replace', 'substr', 'strpos', 'implode'] as $fn) {
+            $call = new CallNode(
+                NodeEnvironment::empty(),
+                new PhpVarNode(NodeEnvironment::empty(), $fn),
+                [new LiteralNode(NodeEnvironment::empty(), 'x')],
+            );
+            self::assertFalse(BooleanExprDetector::isBool($call), $fn . ' must not read as bool');
+        }
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Follow-up to #3121, which tagged the core predicates. The `phel.string` ones were left for a separate pass; this is it, and the reason they were untagged turned out to be more general than the four functions.

`BooleanExprDetector` recognises the `is_*` builtins and `array_key_exists`, but **not `str_contains`, `str_starts_with` or `str_ends_with`**. PHP guarantees all three return bool, so an `if` over any of them was carrying the truthy adapter for nothing.

That is also *why* `starts-with?`, `ends-with?`, `includes?` and `contains?` had no inferred return type: each is a pair of `assert-string` guards followed by one of those calls.

## 🔖 Changes

Three entries added to the recogniser, plus an explicit `^bool` on the four wrappers so their own callers benefit too.

Interleaved A/B, both pairs consistent in direction:

| test slot | before | after | |
|---|---|---|---|
| `(if (php/str_contains …))` | 10.06us | 9.32us | **-7.3%** |
| `(if (starts-with? …))` | 16.66us | 15.90us | -4.5% |
| `(if (includes? …))` | 17.53us | 17.00us | -3.0% |

The interop line is the one that matters most: it applies to any Phel code calling those three directly, not just to the stdlib wrappers.

## A correction to my own assumption

I went in expecting to tag five functions. `blank?` turned out to be **already** `bool`, by inference rather than an explicit tag, so it is left alone rather than given a redundant one.

Worth recording how that surfaced: my first audit probe reported all five as having no metadata at all, because it did not `require phel.string`, so the namespace was never loaded into the registry. The metadata was there the whole time. Re-running with the require in place gave the real picture, which is the one above.

Adding the three PHP functions to the recogniser on its own does **not** give the four wrappers an inferred return type: the return-type inferrer is a separate mechanism from the `if`-slot detector. That is why both halves of this change are needed, and it is verified rather than assumed.

## Verification

A `^bool` tag becomes a PHP `: bool` return type, so a non-bool path becomes a TypeError. Each of the five was checked against **16 subject strings crossed with 8 needles**, including empty strings, whitespace-only, a tab/newline mix, non-ASCII (`héllo`), a non-breaking space and an em space. No non-bool result anywhere.

The detector gains two unit tests: the three new names read as bool, and `str_replace`, `substr`, `strpos` and `implode` still do not.

Related to #2973
