### PR TITLE
fix(compiler): do not inline a callee with tagged parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Stop the `-O2` call inliner splicing away a callee whose parameters carry a `:tag`. The tag is emitted as a PHP parameter type, so inlining dropped both the type enforcement and the native-arithmetic lowering it enables: `(dotted-tag 42)` stopped raising a `TypeError`, and a `^int` multiply promoted to `BigInt` instead of overflowing to float (#3126)
 - Document `~` and `~@` as the unquote and unquote-splicing shorthands in `phel doc`, not `,` and `,@`. Since #2827 `,` is whitespace, so the documented `` `(+ ,@[1 2 3]) `` evaluated to `(phel.core/+ (phel.core/deref [1 2 3]))` rather than the `(phel.core/+ 1 2 3)` the same entry claimed
 - Print a lazy sequence as `(1 2)` rather than `@[1 2]`. `@` is the deref reader macro, so the old form did not round-trip: reading it back produced `(deref [1 2])`. Matches `Cons`, `PersistentList` and Clojure (#3113)
 - Report the pattern by name when `phel.string/split` is given something PCRE rejects, instead of letting `preg_split` return false into `Phel/vector` and surfacing a `TypeError` about a bool. A bare separator such as `" "` is named separately from a delimited but malformed pattern

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
@@ -27,6 +27,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
+use Phel\Shared\TagResolver;
 
 use function array_key_exists;
 use function count;
@@ -119,6 +120,26 @@ final readonly class CallInliner
         }
 
         $params = $fnNode->getParams();
+
+        // A tagged parameter is load-bearing, not decoration. `FnSymbol` emits
+        // it as a PHP parameter type, which does two things the call site
+        // cannot: PHP enforces the type on the way in, and the emitter treats
+        // the parameter as proven so arithmetic on it lowers to native
+        // operators. Splicing the body at the call site drops the declaration
+        // and both go with it (#3126):
+        //
+        //   (defn dotted-tag ^Symbol [^Symbol s] s)
+        //   (dotted-tag 42)      ; raises TypeError, until it is inlined
+        //
+        //   (defn- mul [^int a ^int b] (* a b))
+        //   (mul 4000000000 4000000000)
+        //     ; 1.6E+19, a native overflow to float, until it is inlined and
+        //     ; the untagged call site promotes to BigInt instead
+        foreach ($params as $param) {
+            if (TagResolver::fromMeta($param->getMeta()) !== null) {
+                return null;
+            }
+        }
 
         $body = $fnNode->getBody();
         if (!$body instanceof DoNode || $body->getStmts() !== []) {

--- a/tests/php/Integration/Compiler/CallInlineRuntimeTest.php
+++ b/tests/php/Integration/Compiler/CallInlineRuntimeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Compiler;
 
+use Phel\Compiler\Domain\Evaluator\Exceptions\EvaluatedCodeException;
 use Phel\Shared\CompileOptions;
 
 /**
@@ -313,5 +314,45 @@ final class CallInlineRuntimeTest extends AbstractCompilerRuntimeTestCase
         self::assertStringContainsString('polyv', $variadic);
         self::assertSame(6, $this->compilerFacade->eval('(polyv 5)', $options));
         self::assertSame(5, $this->compilerFacade->eval('(polyv 5 6 7)', $options));
+    }
+
+    public function test_a_tagged_parameter_stops_the_inline(): void
+    {
+        // A `:tag` on a parameter is emitted as a PHP parameter type, which
+        // enforces the type on the way in. Splicing the body at the call site
+        // drops the declaration, so the call stops raising (#3126).
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval('(defn tagged-id [^\Phel\Lang\Symbol s] s)', $options);
+
+        // The contract is the enforcement itself: unoptimised, this raises.
+        // While the body was being inlined it quietly returned 42 instead.
+        // The evaluator wraps the TypeError, so match on the message.
+        $this->expectException(EvaluatedCodeException::class);
+        $this->expectExceptionMessageMatches('/must be of type .*Symbol, int given/');
+        $this->compilerFacade->eval('(tagged-id 42)', $options);
+    }
+
+    public function test_a_tagged_int_parameter_keeps_its_arithmetic_semantics(): void
+    {
+        // `^int` makes the emitter treat the parameter as proven, so `*`
+        // lowers to the native operator and overflows to float. Inlined at an
+        // untagged call site the same expression promotes to BigInt instead,
+        // which is a different value (#3126).
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval('(defn tagged-mul [^int a ^int b] (* a b))', $options);
+
+        $result = $this->compilerFacade->eval('(tagged-mul 4000000000 4000000000)', $options);
+
+        self::assertIsFloat($result, 'a tagged int multiply overflows to float, as it does unoptimised');
+    }
+
+    public function test_an_untagged_parameter_still_inlines(): void
+    {
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval('(defn untagged-mul [a b] (* a b))', $options);
+
+        $php = $this->compilerFacade->compile('(let [y 3] (untagged-mul y 2))', $options)->getPhpCode();
+
+        self::assertStringNotContainsString('untagged-mul', $php, 'the guard must not disable inlining generally');
     }
 }


### PR DESCRIPTION
## 🤔 Background

First fix for #3126. Compiling the standard library at `optimizationLevel: 2` fails 5 core tests; two of them have the same cause.

A `:tag` on a parameter is emitted by `FnSymbol` as a PHP parameter type. That does two things the call site cannot:

- PHP enforces the type on the way in
- the emitter treats the parameter as **proven**, so arithmetic on it lowers to native operators

`CallInliner` splices the body at the call site, which drops the declaration and both behaviours with it.

## The two divergences

```phel
(defn dotted-tag ^Phel.Lang.Symbol [^Phel.Lang.Symbol s] s)
(dotted-tag 42)
```
`TypeError` at `-O0`. At `-O2` it quietly returns `42`.

```phel
(defn- mul [^int a ^int b] (* a b))
(mul 4000000000 4000000000)
```
`1.6E+19` at `-O0`, a native overflow to float, which `tests/phel/core/pow-strength-reduction.phel` documents as the deliberate tag trade-off. At `-O2` it is `16000000000000000000`, promoted to `BigInt`, because the untagged call site no longer knows the operands are ints.

Visible directly in the emitted PHP:

```diff
-(\Phel::getDefinition("o2proj.main", "multiply-tagged"))->__invoke($a, $b)
+(\Phel::getDefinition("phel.core", "*"))->__invoke($a, $b)
```

The call is gone and so are the `int` parameter types that made `*` lower natively.

## 🔖 Changes

`CallInliner::tryInline` declines a callee with any tagged parameter. Untagged callees inline exactly as before, verified by a test that asserts an untagged `mul` still has its dispatch removed.

`composer test-core` at `-O2`: **5 failures to 3**.

## The remaining three

Not in this PR, and not the same bug. Recorded on #3126 with evidence:

- two in `phel.mock`, where inlining removes the call site that root-rebinding interception depends on
- one in `phel.http`, where an inlined body becomes an IIFE that captures a `preg_match` output array **by value** and has no `return`, so the by-reference write is lost

## Verification

Three tests added to `CallInlineRuntimeTest`, all confirmed red without the guard and green with it:

- a tagged parameter still enforces its type (the inline is declined)
- a `^int` multiply still overflows to float rather than promoting
- an untagged callee is still inlined, so the guard does not disable inlining generally

Full gate green at the default `-O0`, where none of this code runs.

Related to #3126
