### PR TITLE
fix(compiler): do not inline an argument holding a php interop call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Stop the `-O2` call inliner relocating an argument that contains a PHP interop call. Such a call may write through a by-reference parameter, and the closure the inlined body can end up in captures call-site locals by value, so the write was lost: `phel.http/uri-from-string` silently mis-parsed an IPv6 URI (#3126)
 - Stop the `-O2` call inliner splicing away a callee whose parameters carry a `:tag`. The tag is emitted as a PHP parameter type, so inlining dropped both the type enforcement and the native-arithmetic lowering it enables: `(dotted-tag 42)` stopped raising a `TypeError`, and a `^int` multiply promoted to `BigInt` instead of overflowing to float (#3126)
 - Document `~` and `~@` as the unquote and unquote-splicing shorthands in `phel doc`, not `,` and `,@`. Since #2827 `,` is whitespace, so the documented `` `(+ ,@[1 2 3]) `` evaluated to `(phel.core/+ (phel.core/deref [1 2 3]))` rather than the `(phel.core/+ 1 2 3)` the same entry claimed
 - Print a lazy sequence as `(1 2)` rather than `@[1 2]`. `@` is the deref reader macro, so the old form did not round-trip: reading it back produced `(deref [1 2])`. Matches `Cons`, `PersistentList` and Clojure (#3113)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
@@ -260,9 +260,11 @@ final readonly class CallInliner
             if ($this->containsPhpCall($node->getTestExpr())) {
                 return true;
             }
+
             if ($this->containsPhpCall($node->getThenExpr())) {
                 return true;
             }
+
             return $this->containsPhpCall($node->getElseExpr());
         }
 
@@ -282,6 +284,7 @@ final readonly class CallInliner
             if ($this->containsPhpCall($node->getBodyExpr())) {
                 return true;
             }
+
             return array_any($node->getBindings(), fn(BindingNode $binding): bool => $this->containsPhpCall($binding->getInitExpr()));
         }
 
@@ -289,6 +292,7 @@ final readonly class CallInliner
             if ($this->containsPhpCall($node->getRet())) {
                 return true;
             }
+
             return $this->anyContainsPhpCall($node->getStmts());
         }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
@@ -167,6 +167,14 @@ final readonly class CallInliner
         // them in its `use(...)` clause. Leaving them off the env would
         // make the closure capture the call-site locals only and read the
         // shadow as an undefined variable (issue #2622).
+        // See containsPhpCall(): an interop call in an argument may write
+        // through a by-reference parameter, which relocating it would lose.
+        foreach ($args as $arg) {
+            if ($this->containsPhpCall($arg)) {
+                return null;
+            }
+        }
+
         $bindings = [];
         $paramMap = [];
         $scopeEnv = $env;
@@ -209,6 +217,90 @@ final readonly class CallInliner
         $letNode = new LetNode($env, $bindings, $folded, false, $callLocation);
 
         return $this->letSimplifier->simplify($letNode);
+    }
+
+    /**
+     * Whether a node contains a call to a PHP function.
+     *
+     * Such a call may write through a by-reference parameter, and the inliner
+     * relocates argument expressions: either substituted into the callee body
+     * or bound ahead of it. When the body needs a `let` in expression context
+     * the emitter wraps it in a closure, and that closure captures call-site
+     * locals **by value**, so the write lands in the copy and is lost (#3126).
+     *
+     * `phel.http/uri-from-string` is the case that found this: it fills an
+     * array through `preg_match`'s third parameter, and inlining the `one?`
+     * around it produced
+     *
+     *     (function() use($url,$matches) { $x = preg_match(…, $matches); … })()
+     *
+     * leaving `$matches` empty outside and silently parsing the URI wrong.
+     *
+     * Whether a given PHP function takes a parameter by reference is not
+     * something the analyser knows, so any interop call in an argument
+     * declines the inline rather than guessing.
+     */
+    private function containsPhpCall(AbstractNode $node): bool
+    {
+        if ($node instanceof CallNode) {
+            if ($node->getFn() instanceof PhpVarNode) {
+                return true;
+            }
+
+            foreach ($node->getArguments() as $arg) {
+                if ($this->containsPhpCall($arg)) {
+                    return true;
+                }
+            }
+
+            return $this->containsPhpCall($node->getFn());
+        }
+
+        if ($node instanceof IfNode) {
+            if ($this->containsPhpCall($node->getTestExpr())) {
+                return true;
+            }
+            if ($this->containsPhpCall($node->getThenExpr())) {
+                return true;
+            }
+            return $this->containsPhpCall($node->getElseExpr());
+        }
+
+        if ($node instanceof VectorNode) {
+            return $this->anyContainsPhpCall($node->getArgs());
+        }
+
+        if ($node instanceof SetNode) {
+            return $this->anyContainsPhpCall($node->getValues());
+        }
+
+        if ($node instanceof MapNode) {
+            return $this->anyContainsPhpCall($node->getKeyValues());
+        }
+
+        if ($node instanceof LetNode) {
+            if ($this->containsPhpCall($node->getBodyExpr())) {
+                return true;
+            }
+            return array_any($node->getBindings(), fn(BindingNode $binding): bool => $this->containsPhpCall($binding->getInitExpr()));
+        }
+
+        if ($node instanceof DoNode) {
+            if ($this->containsPhpCall($node->getRet())) {
+                return true;
+            }
+            return $this->anyContainsPhpCall($node->getStmts());
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int, AbstractNode> $nodes
+     */
+    private function anyContainsPhpCall(array $nodes): bool
+    {
+        return array_any($nodes, fn(AbstractNode $node): bool => $this->containsPhpCall($node));
     }
 
     /**

--- a/tests/php/Integration/Compiler/CallInlineRuntimeTest.php
+++ b/tests/php/Integration/Compiler/CallInlineRuntimeTest.php
@@ -355,4 +355,33 @@ final class CallInlineRuntimeTest extends AbstractCompilerRuntimeTestCase
 
         self::assertStringNotContainsString('untagged-mul', $php, 'the guard must not disable inlining generally');
     }
+
+    public function test_an_argument_with_a_by_reference_interop_call_is_not_inlined(): void
+    {
+        // `preg_match` fills its third parameter by reference. Inlining moves
+        // the call into the callee body, and when that body needs a closure
+        // the capture is by value, so the write is lost (#3126).
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval('(defn is-one? [x] (or (= x 1) (= x 1.0)))', $options);
+
+        $result = $this->compilerFacade->eval(
+            '(let [m (php-indexed-array)]'
+            . ' (if (is-one? (php/preg_match "/(a)(b)/" "ab" m))'
+            . '   (aget m 1)'
+            . '   :no-match))',
+            $options,
+        );
+
+        self::assertSame('a', $result, 'the by-reference capture group survived');
+    }
+
+    public function test_an_argument_without_interop_still_inlines(): void
+    {
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval('(defn plus-two [x] (+ x 2))', $options);
+
+        $php = $this->compilerFacade->compile('(let [y 5] (plus-two y))', $options)->getPhpCode();
+
+        self::assertStringNotContainsString('plus-two', $php, 'the guard must stay scoped to interop arguments');
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Second fix for #3126, after #3127. This is the `phel.http` IPv6 failure, and the one with the worst shape: it produced **wrong output rather than an error**.

`uri-from-string` fills an array through `preg_match`'s third parameter, by reference, to protect a bracketed IPv6 host from URL encoding. At `-O2` the `one?` wrapping that call is inlined, and its body is `(or (= x 1) (= x 1.0))`, which expands to a `let` and so emits as a closure:

```php
$matches_2186 = array();
… (function() use($url,$matches_2186) {
      $x_2188 = preg_match("%^(.*://\[[0-9:a-f]+\])(.*?)$%", $url, $matches_2186);
      return …;
    })() …
```

`use($url,$matches_2186)` captures **by value**. `preg_match` writes into the closure's copy, the outer array stays empty, the branch that reads it is skipped, and the URI parses to nothing:

```
-O0  (phel.http.uri "http" nil "[2a00:f48:1008::212:183:10]" 56 nil "foo=bar" nil)
-O2  (phel.http.uri nil nil nil nil "" nil nil)
```

Worth noting the same generated file captures constants as `&$__phel_const_0`, so the emitter does use by-reference capture, just not for locals.

## 🔖 Changes

Whether a given PHP function takes a parameter by reference is not something the analyser knows. So rather than guess, `CallInliner` declines when an argument expression contains a PHP interop call anywhere in it.

Conservative on purpose, and scoped: an argument with no interop is unaffected, which a test asserts by checking `(plus-two y)` still has its dispatch removed.

`composer test-core` at `-O2`: **3 failures to 2**.

## A correction from my own triage

On #3126 I reported this closure as having "no `return`" as well as capturing by value. That was wrong, read off a truncated line. The IIFE returns correctly; the by-value capture is the whole bug. Corrected here rather than left standing.

## The remaining two

Both `phel.mock`, and not a defect in the inliner. `with-redefs` swaps a global's root binding and the test calls through it; once the call is inlined there is no call left to redirect, so the mock never fires. Same mechanism as `dotrace` in #3125.

That one needs a decision about what `-O2` is allowed to remove, not a patch, and it is on #3126.

## Verification

Two tests, both confirmed red without the guard and green with it:

- an argument holding `(php/preg_match … m)` keeps its by-reference write, asserted through `(aget m 1)` returning the captured group
- an argument with no interop still inlines

Full gate green at the default `-O0`, where none of this runs.

Related to #3126
