### PR TITLE
test(bench): cover counting a lazy sequence

### DIFF
--- a/tests/php/Benchmark/Phel/CoreSeqBench.php
+++ b/tests/php/Benchmark/Phel/CoreSeqBench.php
@@ -639,6 +639,19 @@ final class CoreSeqBench extends CoreBenchCase
     }
 
     /**
+     * Counting a lazy sequence. `count` dispatches to `Countable::count()`,
+     * which materialised every element into a PHP array only to measure it.
+     * The vector and map subjects in `CoreDispatchBench` are O(1) reads and so
+     * never reached this path.
+     *
+     * @Revs(1000)
+     */
+    public function bench_count_lazy_seq(): void
+    {
+        ($this->count)(($this->mapFn)($this->inc, $this->ints));
+    }
+
+    /**
      * `partition-by` and `dedupe` return a sequence built by
      * `lazy-seq-from-generator`, so constructing one realizes a chunk before
      * the caller has asked for a single element. These two subjects measure


### PR DESCRIPTION
## 🤔 Background

Profiling a struct and protocol workload put `count` at the top by self time, 134us per call. The calls were `(count (map …))` over 400 elements, so the path is `Countable::count()` on a lazy sequence, and both implementations do this:

```php
public function count(): int
{
    // Warning: This realizes the entire sequence!
    return count($this->toArray());
}
```

A full PHP array built to measure its length and thrown away. That looks like an obvious win.

## It is not a win

I wrote both alternatives and measured them:

- `ChunkedSeq::count()` walking chunk by chunk and summing `Chunk::count()`, so no generator yields and no array at all
- `LazySeq::count()` doing the same walk as `toArray()` but counting instead of collecting

Interleaved A/B, three alternating pairs:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| current | 56.31us | 56.52us | 57.21us |
| rewritten | 56.36us | 57.59us | 56.04us |

Overlapping ranges, no difference. Realization dominates: the walk allocates a `LazySeq` node per element through `cdr()`, and the result array is noise beside that.

A single earlier reading showed **-4.78%**, which is what prompted the interleaved run. It was drift.

So the rewrite is reverted. Roughly 80 lines duplicating an existing walk, for nothing measurable, is not worth carrying.

## 🔖 Changes

The subject only.

`count` on a lazy sequence had no coverage: the `count` pairs in `CoreDispatchBench` use a vector, a map and a string, all of which answer in constant time, so none of them reached the realizing path.

| subject | |
|---|---|
| `bench_count_lazy_seq` | 56.46us |

It stays for two reasons: a regression in lazy counting is currently invisible, and the next person tempted by that `toArray()` can see it has already been tried.

## Also checked

`Chunk::count()` is `count($values) - $offset`, which PHPStan cannot prove non-negative for `Countable`'s `int<0, max>`. The invariant does hold, since `drop()` returns an empty chunk when the offset would reach the end. That only came up as a consequence of the rewrite and is not needed without it, so it is not in this PR.
