### PR TITLE
perf(core): reach a map assoc target without the predicate calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Answer a map target in `assoc`'s three-argument arity itself rather than delegating to `assoc-pair`, and reach the map and vector branches inside `assoc-pair` by their own `instanceof` instead of through `map-target?` and `vector-target?`: `assoc` on a map 1.24x, `into` a map 1.06x (#2973)
 - Recognise `str_contains`, `str_starts_with` and `str_ends_with` as bool-returning, so an `if` over one of them or over `phel.string/includes?`, `starts-with?`, `ends-with?` and `contains?` skips the `Truthy` adapter: 7.3% on the raw interop call, 3 to 4.5% through the wrappers (#2973)
 - Tag the fifteen core predicates that returned an untagged bool (`even?`, `odd?`, `zero?`, `empty?`, `some?`, `map?`, `list?`, `indexed?`, `contains?`, `truthy?`, `nan?`, `infinite?`, `subset?`, `superset?`, `not`) so an `if` over them skips the `Truthy` adapter, and so a function built on one is itself inferred to return `bool`: 1 to 5% per test, plus the return type it propagates (#2973)
 - Skip the `Truthy` adapter in an `if` test when the call is to a global whose return `:tag` is `bool`, which covers `<`, `>`, `<=`, `>=`, `=`, `not=`, `nil?` and `pos?` as well as any user `defn ^bool`. A `defn` whose arities disagree carries no tag, so it keeps the adapter (#2973)

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -317,10 +317,14 @@
     (php-array? ds)
     (throw (new InvalidArgumentException "Cannot call assoc on pure PHP arrays. Use (aset ds key value)"))
 
-    (map-target? ds)
+    ;; `map-target?` and `vector-target?` spelled out: each is an `or` of two
+    ;; `instanceof` and cost a Phel call to answer it (#3105).
+    (or (php/instanceof ds PersistentMapInterface)
+        (php/instanceof ds TransientMapInterface))
     (.put ds key value)
 
-    (vector-target? ds)
+    (or (php/instanceof ds PersistentVectorInterface)
+        (php/instanceof ds TransientVectorInterface))
     (vector-assoc ds key value)
 
     ;; MapEntry degrades to a 2-vector once mutated, since the result no
@@ -342,7 +346,16 @@
   ;; The three-argument call is nearly every call, and its whole work is one
   ;; `assoc-pair`. On the variadic form it also allocated `more`, counted it,
   ;; bit-tested the count and entered a loop whose first act was `empty?`.
-  ([ds key value] (assoc-pair ds key value))
+  ([ds key value]
+   ;; The map case is answered here rather than through `assoc-pair`. `into` a
+   ;; map, `frequencies`, `group-by`, `zipmap` and every `for :reduce` building
+   ;; a map reduce this arity once per element, and the delegation was a whole
+   ;; function call to reach an `instanceof` the caller could make itself, as
+   ;; `conj` already does for vectors (#2973, #3105).
+   (if (or (php/instanceof ds PersistentMapInterface)
+           (php/instanceof ds TransientMapInterface))
+     (.put ds key value)
+     (assoc-pair ds key value)))
   ([ds key value & more]
    (when (php/!== 0 (php/& (count more) 1))
      (throw (new InvalidArgumentException

--- a/tests/phel/core/assoc-map-fast-path.phel
+++ b/tests/phel/core/assoc-map-fast-path.phel
@@ -1,0 +1,41 @@
+(ns phel-test.core.assoc-map-fast-path
+  (:require phel.test :refer [deftest is]))
+
+(defstruct pt [x y])
+
+;; `assoc`'s three-argument arity answers a map target itself instead of
+;; delegating to `assoc-pair`, and `assoc-pair` reaches its map and vector
+;; branches by their own `instanceof` rather than through `map-target?` and
+;; `vector-target?`. Both change which branch a collection lands on, so every
+;; target has to keep answering what it did.
+
+(deftest test-map-targets
+  (is (= {:a 1, :b 2} (assoc {:a 1} :b 2)) "a persistent map")
+  (is (= {:a 9} (assoc {:a 1} :a 9)) "an existing key is replaced")
+  (is (= {:b 2} (assoc {} :b 2)) "an empty map")
+  (is (= {:a nil} (assoc {} :a nil)) "a nil value is stored")
+  (is (nil? (get (assoc {} :a nil) :a)) "and reads back as nil")
+  (is (= 1 (get (assoc {} nil 1) nil)) "nil works as a key")
+  (is (= {:a 1, :b 2, :c 3} (assoc {:a 1} :b 2 :c 3)) "the variadic form still applies pairs in order"))
+
+(deftest test-other-map-flavours
+  (is (= 2 (get (assoc (sorted-map :a 1) :b 2) :b)) "a sorted map")
+  (is (= 9 (get (assoc (pt 1 2) :x 9) :x)) "a struct is a map target")
+  (is (= 2 (get (assoc (pt 1 2) :x 9) :y)) "the struct's other field survives")
+  (let [t (transient {:a 1})]
+    (is (= 2 (get (assoc t :b 2) :b)) "a transient map")
+    ;; `assoc` on a transient mutates and hands the same transient back.
+    (is (identical? t (assoc t :c 3)) "the transient itself comes back")))
+
+(deftest test-vector_targets
+  (is (= [9 20] (assoc [10 20] 0 9)) "an index is replaced")
+  (is (= [10 20 30] (assoc [10 20] 2 30)) "appending at the end")
+  (is (= [10 99] (persistent (assoc (transient [10 20]) 1 99))) "a transient vector")
+  (is (thrown? \InvalidArgumentException (assoc [10 20] :a 1)) "a non-integer index is rejected"))
+
+(deftest test-targets_that_are_not_maps_or_vectors
+  ;; Each of these must still reach the longer dispatch in `assoc-pair`.
+  (is (= {:a 1} (assoc nil :a 1)) "nil creates a fresh map, as in Clojure")
+  (is (thrown? \InvalidArgumentException (assoc (php-indexed-array 1 2) 0 9))
+      "a raw PHP array is rejected with the aset hint")
+  (is (= [:a 9] (assoc (first {:a 1}) 1 9)) "a MapEntry degrades to a vector"))


### PR DESCRIPTION
## 🤔 Background

Profiling a struct and protocol workload showed `assoc` and `assoc-pair` at 10025 calls each, a 1:1 delegation. That is the same shape #3105 fixed for `conj`, on the other half of the pair, and it had been left behind.

Two hops per call:

- `assoc`'s three-argument arity delegates to `assoc-pair` for work that is one `instanceof` away
- `assoc-pair` reaches its map and vector branches through `map-target?` and `vector-target?`, each an `or` of two `instanceof` behind a function call

## 🔖 Changes

The map target is answered in the three-argument arity, and both predicates are spelled out inside `assoc-pair`.

Interleaved A/B, two alternating pairs:

| subject | main | this PR | |
|---|---|---|---|
| `bench_assoc_map` | 33.91us, 34.49us | 27.19us, 28.15us | **-19.8%** |
| `bench_into_map` | 110.27us, 110.84us | 103.46us, 104.59us | **-6.2%** |
| `bench_frequencies` | 98.14us, 98.15us | 98.30us, 98.22us | flat |
| `bench_group_by` | 53.11us, 53.27us | 52.79us, 53.05us | flat |

Wrapper overhead against the raw map write: **1.68x to 1.36x**.

`frequencies` and `group-by` being flat is the expected result, not a miss: both build through `assoc!` rather than `assoc`, so neither touches this path. They are included because a change here that moved them would mean I had hit something I did not intend.

## Verification

Diffed against `origin/main` over **112 combinations**: every target `assoc` accepts (persistent map, empty map, sorted map, struct, transient map, vector, empty vector, transient vector, nil, MapEntry, PHP array, set, list, string) crossed with keyword, integer, nil and string keys plus a nil value, through both the three-argument and variadic spellings, catching throws as values. Every row identical.

The test file additionally pins the cases where a wrong branch would be silent rather than loud: a nil value stored and read back as nil, nil used as a key, a struct keeping its other field, and `assoc` on a transient returning the *same* transient rather than a copy.

Related to #2973
