### PR TITLE
perf(core): reach a map dissoc target without the predicate calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Answer a map target in `dissoc`'s two-argument arity itself rather than delegating to `dissoc-one`, and reach the map and set branches inside `dissoc-one` by their own `instanceof` instead of through `map-target?` and `set-target?`: 1.14x (#2973)
 - Answer a map target in `assoc`'s three-argument arity itself rather than delegating to `assoc-pair`, and reach the map and vector branches inside `assoc-pair` by their own `instanceof` instead of through `map-target?` and `vector-target?`: `assoc` on a map 1.24x, `into` a map 1.06x (#2973)
 - Recognise `str_contains`, `str_starts_with` and `str_ends_with` as bool-returning, so an `if` over one of them or over `phel.string/includes?`, `starts-with?`, `ends-with?` and `contains?` skips the `Truthy` adapter: 7.3% on the raw interop call, 3 to 4.5% through the wrappers (#2973)
 - Tag the fifteen core predicates that returned an untagged bool (`even?`, `odd?`, `zero?`, `empty?`, `some?`, `map?`, `list?`, `indexed?`, `contains?`, `truthy?`, `nan?`, `infinite?`, `subset?`, `superset?`, `not`) so an `if` over them skips the `Truthy` adapter, and so a function built on one is itself inferred to return `bool`: 1 to 5% per test, plus the return type it propagates (#2973)

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -377,10 +377,14 @@
     (php/is_array ds)
     (throw (new InvalidArgumentException "Cannot call dissoc on pure PHP arrays. Use (php/aunset ds key)"))
 
-    (map-target? ds)
+    ;; `map-target?` and `set-target?` spelled out: each is an `or` of two
+    ;; `instanceof` and cost a Phel call to answer it (#3105).
+    (or (php/instanceof ds PersistentMapInterface)
+        (php/instanceof ds TransientMapInterface))
     (.remove ds key)
 
-    (set-target? ds)
+    (or (php/instanceof ds PersistentHashSetInterface)
+        (php/instanceof ds TransientHashSetInterface))
     (.remove ds key)
 
     (throw (new InvalidArgumentException
@@ -393,7 +397,13 @@
   ;; needed neither the rest argument nor the loop to find that out (#2973,
   ;; #3021).
   ([ds] ds)
-  ([ds k] (dissoc-one ds k))
+  ([ds k]
+   ;; The map case is answered here rather than through `dissoc-one`, as
+   ;; `assoc` and `conj` already do for theirs (#2973, #3105, #3130).
+   (if (or (php/instanceof ds PersistentMapInterface)
+           (php/instanceof ds TransientMapInterface))
+     (.remove ds k)
+     (dissoc-one ds k)))
   ([ds k & ks]
    (loop [acc       (dissoc-one ds k)
           remaining ks]

--- a/tests/phel/core/dissoc-map-fast-path.phel
+++ b/tests/phel/core/dissoc-map-fast-path.phel
@@ -1,0 +1,43 @@
+(ns phel-test.core.dissoc-map-fast-path
+  (:require phel.test :refer [deftest is]))
+
+(defstruct pt [x y])
+
+;; `dissoc`'s two-argument arity answers a map target itself instead of
+;; delegating to `dissoc-one`, and `dissoc-one` reaches its map and set
+;; branches by their own `instanceof` rather than through `map-target?` and
+;; `set-target?`. Every target has to keep answering what it did.
+
+(deftest test-map-targets
+  (is (= {:a 1} (dissoc {:a 1, :b 2} :b)) "an existing key is removed")
+  (is (= {:a 1, :b 2} (dissoc {:a 1, :b 2} :z)) "an absent key is a no-op")
+  (is (= {} (dissoc {:a 1} :a)) "removing the last key")
+  (is (= {} (dissoc {} :a)) "an empty map")
+  (is (= {:b 2} (dissoc {:a 1, :b 2} :a)) "the other entries survive")
+  (is (= {:a 1} (dissoc {:a 1, :b 2, :c 3} :b :c)) "the variadic form removes several"))
+
+(deftest test-other-map-flavours
+  (is (= 1 (get (dissoc (sorted-map :a 1 :b 2) :b) :a)) "a sorted map")
+  (is (nil? (get (dissoc (sorted-map :a 1 :b 2) :b) :b)) "the sorted map key is gone")
+  (let [t (transient {:a 1, :b 2})]
+    (is (nil? (get (dissoc t :b) :b)) "a transient map")
+    ;; `dissoc` on a transient mutates and hands the same transient back.
+    (is (identical? t (dissoc t :a)) "the transient itself comes back")))
+
+(deftest test-set-targets
+  (is (= (set [1 :a]) (dissoc (set [1 2 :a]) 2)) "a hash set removes a member")
+  (is (= (set [1 2]) (dissoc (set [1 2]) 9)) "an absent member is a no-op")
+  (is (= 1 (count (dissoc (sorted-set 1 2) 2))) "a sorted set"))
+
+(deftest test-targets-that-are-rejected-or-pass-through
+  (is (nil? (dissoc nil :a)) "nil stays nil")
+  (is (thrown? \InvalidArgumentException (dissoc (php-indexed-array 1 2) 0))
+      "a raw PHP array is rejected with the aunset hint")
+  (is (thrown? \InvalidArgumentException (dissoc [10 20] 0)) "a vector is not a dissoc target")
+  (is (thrown? \InvalidArgumentException (dissoc "ab" 0)) "a string is not a dissoc target"))
+
+(deftest test-struct-behaviour-is-unchanged
+  ;; A struct is a PersistentMapInterface, so it takes the fast path. Removing
+  ;; a declared key is whatever it was before, not something this changes.
+  (let [before (try (print-str (dissoc (pt 1 2) :x)) (catch \Throwable e (php/get_class e)))]
+    (is (string? before) "a struct dissoc still answers the same way")))


### PR DESCRIPTION
## 🤔 Background

The last of the three functions that shared this shape, after `conj` (#3105) and `assoc` (#3130).

Two hops per call:

- `dissoc`'s two-argument arity delegates to `dissoc-one` for work that is one `instanceof` away
- `dissoc-one` reaches its map and set branches through `map-target?` and `set-target?`, each an `or` of two `instanceof` behind a function call

## 🔖 Changes

The map target is answered in the two-argument arity, and both predicates are spelled out inside `dissoc-one`.

Interleaved A/B, two alternating pairs:

| subject | main | this PR | |
|---|---|---|---|
| `bench_dissoc_one_key` | 26.00us, 26.51us | 22.97us, 22.69us | **-12.6%** |

## `disj` is deliberately left alone

It looks like the same pattern and is not. `disj-single` tests with `set?`, which the emitter already inlines to the `instanceof` it is, so there is no predicate call to remove. Only the delegation hop would go, and on its own that is the ~1% I measured for the transient helpers in #3106 and declined to ship.

## Verification

Diffed against `origin/main` over **78 combinations**: every target `dissoc` accepts (map, empty map, sorted map, struct, transient map, hash set, sorted set, transient set, nil, vector, PHP array, list, string) crossed with keyword, integer, nil and string keys, through the one-key, variadic and no-key spellings, catching throws as values. Every row identical.

The test file pins the parts that would fail quietly rather than loudly: an absent key staying a no-op, the other entries surviving, both set flavours still removing members, and `dissoc` on a transient returning the *same* transient rather than a copy.

Related to #2973
