### PR TITLE
perf(core): build vec in one construction instead of per-element appends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Build `vec`'s result by collecting into a PHP array and constructing the vector once, instead of appending through a transient per element: 3.1x over 32 elements and 3.5x over 500, so the gain holds as the collection grows (#2973)
 - Answer a map target in `dissoc`'s two-argument arity itself rather than delegating to `dissoc-one`, and reach the map and set branches inside `dissoc-one` by their own `instanceof` instead of through `map-target?` and `set-target?`: 1.14x (#2973)
 - Answer a map target in `assoc`'s three-argument arity itself rather than delegating to `assoc-pair`, and reach the map and vector branches inside `assoc-pair` by their own `instanceof` instead of through `map-target?` and `vector-target?`: `assoc` on a map 1.24x, `into` a map 1.06x (#2973)
 - Recognise `str_contains`, `str_starts_with` and `str_ends_with` as bool-returning, so an `if` over one of them or over `phel.string/includes?`, `starts-with?`, `ends-with?` and `contains?` skips the `Truthy` adapter: 7.3% on the raw interop call, 3 to 4.5% through the wrappers (#2973)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -348,16 +348,23 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
   {:example "(vec {:a 1 :b 2}) ; => [[:a 1] [:b 2]]"
    :see-also ["vector" "set" "into"]}
   [coll]
+  ;; Collect into a PHP array and build the vector once, rather than appending
+  ;; through a transient once per element. `Phel/vector` builds the trie in
+  ;; bulk, and a PHP array append is much cheaper than a transient one, so the
+  ;; per-element work drops to a push: 3.1x over 32 elements and 3.5x over 500,
+  ;; so the gain holds as the collection grows (#2973).
   (cond
     (php/=== nil coll)              []
     (or (map? coll) (struct? coll))
-    (persistent
-     (for [[k v] :pairs coll :reduce [acc (transient [])]]
-       (conj! acc [k v])))
+    (let [arr (php/array)]
+      (foreach [k v coll]
+        (php/apush arr [k v]))
+      (Phel/vector arr))
     :else
-    (persistent
-     (for [x :in coll :reduce [acc (transient [])]]
-       (conj! acc x)))))
+    (let [arr (php/array)]
+      (foreach [x coll]
+        (php/apush arr x))
+      (Phel/vector arr))))
 
 (defn- get-in-traversable?
   [x]

--- a/tests/phel/core/vec-bulk-construction.phel
+++ b/tests/phel/core/vec-bulk-construction.phel
@@ -1,0 +1,50 @@
+(ns phel-test.core.vec-bulk-construction
+  (:require phel.test :refer [deftest is]))
+
+(defstruct pt [x y])
+
+;; `vec` collects into a PHP array and builds the vector once instead of
+;; appending through a transient per element. Every source shape has to keep
+;; producing the same vector, and the map and struct branch still has to yield
+;; `[key value]` pairs rather than bare values.
+
+(deftest test-sequential-sources
+  (is (= [1 2 3] (vec [1 2 3])) "a vector")
+  (is (= [] (vec [])) "an empty vector")
+  (is (= [1 2 3] (vec '(1 2 3))) "a list")
+  (is (= [] (vec '())) "an empty list")
+  (is (= [2 3 4] (vec (map inc [1 2 3]))) "a lazy sequence")
+  (is (= [] (vec (map inc []))) "an empty lazy sequence")
+  (is (= [0 1 2 3] (vec (take 4 (range)))) "a taken range")
+  (is (= [1 2 3] (vec (concat [1 2] [3]))) "a concatenation")
+  (is (= [1 2 3] (vec (php-indexed-array 1 2 3))) "a PHP array")
+  (is (= [] (vec nil)) "nil is an empty vector"))
+
+(deftest test-associative-sources-yield-pairs
+  (is (= [[:a 1] [:b 2]] (vec {:a 1, :b 2})) "a map yields key-value pairs")
+  (is (= [] (vec {})) "an empty map")
+  (is (= [[:a 1] [:b 2]] (vec (sorted-map :b 2 :a 1))) "a sorted map yields pairs in order")
+  (is (= 2 (count (vec (pt 1 2)))) "a struct yields one pair per field")
+  (is (= [:x 1] (first (vec (pt 1 2)))) "the struct pair is [key value]"))
+
+(deftest test-values-that-could-be-dropped
+  ;; A nil element must survive the collection, not truncate it.
+  (is (= [nil 1 nil] (vec [nil 1 nil])) "nil elements are kept")
+  (is (= 3 (count (vec [nil 1 nil]))) "and counted")
+  (is (= [false 0 ""] (vec [false 0 ""])) "falsy values are kept")
+  (is (= [[1 2] {:a 1}] (vec [[1 2] {:a 1}])) "nested collections are not flattened"))
+
+(deftest test-other-sources
+  (is (= ["a" "b" "c"] (vec "abc")) "a string becomes its characters")
+  (is (= 3 (count (vec (set [3 1 2])))) "a set yields its members")
+  (is (= [1 2 3] (vec (sorted-set 3 1 2))) "a sorted set yields them in order")
+  (is (= [:a 1] (vec (first {:a 1}))) "a MapEntry is already a 2-vector")
+  ;; A transient is not seqable, so `vec` rejects it. Pre-existing behaviour,
+  ;; unchanged here, and pinned so the bulk collection is not blamed for it.
+  (is (thrown? \InvalidArgumentException (vec (transient [1 2]))) "a transient vector is rejected"))
+
+(deftest test-the-result-is-a-persistent-vector
+  (let [v (vec '(1 2))]
+    (is (vector? v) "the result is a vector")
+    (is (= [1 2 3] (conj v 3)) "it can be conj'd onto")
+    (is (= [1 2] v) "and the original is unchanged")))

--- a/tests/php/Benchmark/Phel/CoreSeqBench.php
+++ b/tests/php/Benchmark/Phel/CoreSeqBench.php
@@ -79,6 +79,9 @@ final class CoreSeqBench extends CoreBenchCase
     private $transduce;
 
     /** @var callable */
+    private $vec;
+
+    /** @var callable */
     private $zipmap;
 
     /** @var callable */
@@ -652,6 +655,26 @@ final class CoreSeqBench extends CoreBenchCase
     }
 
     /**
+     * `vec` and `into []` build a vector from a collection. Both appended
+     * through a transient once per element; the raw pair below is the single
+     * bulk construction the same result can be built with.
+     *
+     * @Revs(1000)
+     */
+    public function bench_vec_from_vector(): void
+    {
+        ($this->vec)($this->ints);
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_vec_from_vector_raw(): void
+    {
+        Phel::vector($this->intArray);
+    }
+
+    /**
      * `partition-by` and `dedupe` return a sequence built by
      * `lazy-seq-from-generator`, so constructing one realizes a chunk before
      * the caller has asked for a single element. These two subjects measure
@@ -694,6 +717,7 @@ final class CoreSeqBench extends CoreBenchCase
     {
         $this->partitionBy = $this->coreFn('partition-by');
         $this->transduce = $this->coreFn('transduce');
+        $this->vec = $this->coreFn('vec');
         $this->zipmap = $this->coreFn('zipmap');
         $this->frequencies = $this->coreFn('frequencies');
         $this->groupBy = $this->coreFn('group-by');


### PR DESCRIPTION
## 🤔 Background

`bench_into_vector` sits at roughly 10x its raw pair, the largest untouched ratio left in the suite. Chasing it led to `vec` rather than `into`: both build a vector by appending through a transient once per element, while the raw pair builds the whole thing in one `Phel::vector($array)` call.

Testing the idea in Phel before touching core:

| | transient appends | PHP array then one construction |
|---|---|---|
| 32 elements, from a vector | 20.8us | 6.8us |
| 32 elements, from a list | 19.2us | 5.3us |
| 500 elements | 297.7us | 85.5us |

Holding at ~3.5x for 500 says this is per-element work removed, not a fixed cost amortised away.

## 🔖 Changes

`vec` collects into a PHP array and hands it to `Phel/vector`. A PHP array push is much cheaper than a transient append, and the trie is then built in bulk.

Interleaved A/B, two alternating pairs:

| subject | main | this PR | |
|---|---|---|---|
| `bench_vec_from_vector` | 21.65us, 22.09us | 7.04us, 7.07us | **3.1x** |

Wrapper overhead against the raw construction: **8.3x to 2.6x**.

`bench_vec_from_vector` and its raw pair are new; `vec` had no subject.

## Not done here

`into` a vector was the original lead and is left alone. It appends to an *existing* vector, so the bulk construction only applies when the target is empty, and that is a narrower change than it first looked. Worth doing separately if the empty-target case turns out to be the common one.

## Verification

Diffed against `origin/main` over **21 source shapes**: vector, list, map, sorted map, struct, set, sorted set, lazy sequence, taken range, concatenation, string, PHP array, MapEntry, transient vector, nil, the empty case of each, a nested collection and a sequence containing nils. Every row identical.

The test file pins the parts that would fail quietly: nil elements surviving rather than truncating the result, falsy values (`false`, `0`, `""`) kept, nested collections not flattened, and the map/struct branch still yielding `[key value]` pairs rather than bare values.

`vec` on a transient throws, before and after. My first draft of the test asserted it should work; the equivalence run showed it throwing on both sides, so the test now pins the real behaviour rather than my assumption.

Related to #2973
