### PR TITLE
perf(core): build kvs and php->phel in one construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Build `kvs` and the indexed branch of `php->phel` the same way as `vec`, collecting into a PHP array and constructing the vector once: `kvs` 1.65x, `php->phel` on an indexed array 1.97x (#2973)
 - Build `vec`'s result by collecting into a PHP array and constructing the vector once, instead of appending through a transient per element: 3.1x over 32 elements and 3.5x over 500, so the gain holds as the collection grows (#2973)
 - Answer a map target in `dissoc`'s two-argument arity itself rather than delegating to `dissoc-one`, and reach the map and set branches inside `dissoc-one` by their own `instanceof` instead of through `map-target?` and `set-target?`: 1.14x (#2973)
 - Answer a map target in `assoc`'s three-argument arity itself rather than delegating to `assoc-pair`, and reach the map and vector branches inside `assoc-pair` by their own `instanceof` instead of through `map-target?` and `vector-target?`: `assoc` on a map 1.24x, `into` a map 1.06x (#2973)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -905,11 +905,12 @@ Works with vectors, lists, sets, and strings."
   {:example "(kvs {:a 1 :b 2}) ; => [:a 1 :b 2]"
    :see-also ["pairs" "keys" "values"]}
   [coll]
-  (let [res (transient [])]
+  ;; Collected into a PHP array and built once, as `vec` is (#3134).
+  (let [arr (php/array)]
     (foreach [k v coll]
-      (.append res k)
-      (.append res v))
-    (copy-meta coll (persistent res))))
+      (php/apush arr k)
+      (php/apush arr v))
+    (copy-meta coll (Phel/vector arr))))
 
 (defn php-array-to-map
   "Converts a PHP Array to a Phel map."
@@ -972,10 +973,11 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps."
   [x]
   (cond
     (indexed-php-array? x)
-    (let [res (transient [])]
+    ;; Collected into a PHP array and built once, as `vec` is (#3134).
+    (let [arr (php/array)]
       (foreach [v x]
-        (conj res (php->phel v)))
-      (persistent res))
+        (php/apush arr (php->phel v)))
+      (Phel/vector arr))
 
     (php-array? x)
     (let [res (transient {})]

--- a/tests/phel/core/bulk-vector-builders.phel
+++ b/tests/phel/core/bulk-vector-builders.phel
@@ -1,0 +1,48 @@
+(ns phel-test.core.bulk-vector-builders
+  (:require phel.test :refer [deftest is]))
+
+(defstruct pt [x y])
+
+(defn- idx [& xs]
+  (let [a (php/array)]
+    (foreach [x xs] (php/apush a x))
+    a))
+
+;; `kvs` and the indexed branch of `php->phel` collect into a PHP array and
+;; build the vector once, as `vec` does since #3134, instead of appending
+;; through a transient per element. The results must be unchanged, including
+;; the values that a collection walk can silently drop.
+
+(deftest test-kvs-flattens-pairs
+  (is (= [:a 1 :b 2] (kvs {:a 1, :b 2})) "a map flattens to k v k v")
+  (is (= [] (kvs {})) "an empty map")
+  (is (= [:a 1 :b 2] (kvs (sorted-map :b 2 :a 1))) "a sorted map keeps its order")
+  (is (= 4 (count (kvs (pt 1 2)))) "a struct yields two entries flattened")
+  (is (= ["a" 1] (kvs {"a" 1})) "string keys"))
+
+(deftest test-kvs-keeps-values-that-could-be-dropped
+  (is (= [:a nil :b 2] (kvs {:a nil, :b 2})) "a nil value is kept in place")
+  (is (= 4 (count (kvs {:a nil, :b 2}))) "and counted")
+  (is (= [:a [1 2]] (kvs {:a [1 2]})) "a collection value is not flattened"))
+
+(deftest test-php-to-phel-indexed
+  (is (= [1 2 3] (php->phel (idx 1 2 3))) "an indexed PHP array becomes a vector")
+  (is (= [] (php->phel (php/array))) "an empty PHP array")
+  (is (= [nil 1 nil] (php->phel (idx nil 1 nil))) "nil elements survive")
+  (is (= 3 (count (php->phel (idx nil 1 nil)))) "and are counted")
+  (is (= [[1 2] 3] (php->phel (idx (idx 1 2) 3))) "nested arrays convert recursively")
+  (is (= ["a" 1 true] (php->phel (idx "a" 1 true))) "mixed element types"))
+
+(deftest test-php-to-phel-other-shapes-are-unchanged
+  (is (= {"a" 1, "b" 2} (php->phel (php-associative-array "a" 1 "b" 2))) "an associative array becomes a map")
+  (is (= 42 (php->phel 42)) "a scalar passes through")
+  (is (nil? (php->phel nil)) "nil passes through")
+  (is (= "abc" (php->phel "abc")) "a string passes through"))
+
+(deftest test-results-are-persistent-vectors
+  (let [v (kvs {:a 1})]
+    (is (vector? v) "kvs returns a vector")
+    (is (= [:a 1 :b] (conj v :b)) "which can be conj'd onto"))
+  (let [v (php->phel (idx 1 2))]
+    (is (vector? v) "php->phel returns a vector")
+    (is (= [1 2] v) "with the expected contents")))

--- a/tests/php/Benchmark/Phel/CoreSeqBench.php
+++ b/tests/php/Benchmark/Phel/CoreSeqBench.php
@@ -82,6 +82,12 @@ final class CoreSeqBench extends CoreBenchCase
     private $vec;
 
     /** @var callable */
+    private $kvs;
+
+    /** @var callable */
+    private $phpToPhel;
+
+    /** @var callable */
     private $zipmap;
 
     /** @var callable */
@@ -675,6 +681,27 @@ final class CoreSeqBench extends CoreBenchCase
     }
 
     /**
+     * `kvs` and the indexed branch of `php->phel` build a vector the same way
+     * `vec` did before #3134: one transient append per element. `php->phel` is
+     * an interop boundary, so it sits on the path of anything decoding PHP
+     * data.
+     *
+     * @Revs(1000)
+     */
+    public function bench_kvs(): void
+    {
+        ($this->kvs)($this->map);
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_php_to_phel_indexed(): void
+    {
+        ($this->phpToPhel)($this->intArray);
+    }
+
+    /**
      * `partition-by` and `dedupe` return a sequence built by
      * `lazy-seq-from-generator`, so constructing one realizes a chunk before
      * the caller has asked for a single element. These two subjects measure
@@ -718,6 +745,8 @@ final class CoreSeqBench extends CoreBenchCase
         $this->partitionBy = $this->coreFn('partition-by');
         $this->transduce = $this->coreFn('transduce');
         $this->vec = $this->coreFn('vec');
+        $this->kvs = $this->coreFn('kvs');
+        $this->phpToPhel = $this->coreFn('php->phel');
         $this->zipmap = $this->coreFn('zipmap');
         $this->frequencies = $this->coreFn('frequencies');
         $this->groupBy = $this->coreFn('group-by');


### PR DESCRIPTION
## 🤔 Background

#3134 made `vec` build its result in one construction rather than appending through a transient per element, and measured 3.1x. This is the same shape in the two other places it appears.

- `kvs` appended to a transient **twice per entry**, once for the key and once for the value
- the indexed branch of `php->phel` appended once per element

## 🔖 Changes

Both collect into a PHP array and hand it to `Phel/vector`.

Interleaved A/B, two alternating pairs:

| subject | main | this PR | |
|---|---|---|---|
| `bench_php_to_phel_indexed` | 14.49us, 14.30us | 7.24us, 7.35us | **1.97x** |
| `bench_kvs` | 2.396us, 2.404us | 1.429us, 1.464us | **1.65x** |

Both subjects are new; neither function had one.

`php->phel` is the more useful of the two. It is an interop boundary, so it sits on the path of anything decoding PHP data rather than being reached only when called directly.

Smaller than `vec`'s 3.1x, and worth saying why: these two already used `.append` and `conj` on the transient directly, where `vec` went through `conj!`, so there was less per-element dispatch to remove.

## Verification

Diffed against `origin/main` over **17 cases**.

For `kvs`: a map, an empty map, a sorted map, a struct, string keys, a nil value and a collection value.

For `php->phel`: an indexed array, an empty one, one containing nils, a nested array, mixed element types, an associative array, a scalar, nil and a string. Every row identical.

The test file pins what a collection walk can drop silently: nil elements surviving and being counted, and a collection value not being flattened into its parent.

Related to #2973
