### PR TITLE
perf(core): sort an all-string collection natively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Sort an all-string collection natively instead of calling back into Phel per comparison, as `sort` already did for an all-int one: 22.7x. The default `SORT_REGULAR` is used and not `SORT_STRING`, because `compare` settles two strings with PHP's `<=>`, which orders numeric strings by value (#2973)
 - Build `kvs` and the indexed branch of `php->phel` the same way as `vec`, collecting into a PHP array and constructing the vector once: `kvs` 1.65x, `php->phel` on an indexed array 1.97x (#2973)
 - Build `vec`'s result by collecting into a PHP array and constructing the vector once, instead of appending through a transient per element: 3.1x over 32 elements and 3.5x over 500, so the gain holds as the collection grows (#2973)
 - Answer a map target in `dissoc`'s two-argument arity itself rather than delegating to `dissoc-one`, and reach the map and set branches inside `dissoc-one` by their own `instanceof` instead of through `map-target?` and `set-target?`: 1.14x (#2973)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1043,6 +1043,24 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps."
         php/break))
     (php/aget found 0)))
 
+(defn- all-native-strings?
+  "True when every element is a PHP string. `sort` with the default
+  `SORT_REGULAR` then produces exactly the order `compare` produces, because
+  both settle a pair of strings with PHP's `<=>`.
+
+  `SORT_STRING` would be the obvious choice and is wrong: it compares
+  lexicographically, where `<=>` compares two numeric strings numerically.
+  `[\"10\" \"9\" \"2\"]` sorts to `[\"2\" \"9\" \"10\"]` under `compare` and to
+  `[\"10\" \"2\" \"9\"]` under `SORT_STRING`."
+  [php-array]
+  ;; Same shape and same early exit as `all-native-ints?` above.
+  (let [found (php/array true)]
+    (foreach [x php-array]
+      (when-not (php/is_string x)
+        (php/aset found 0 false)
+        php/break))
+    (php/aget found 0)))
+
 (defn- sorted-vector
   [coll comp]
   (let [php-array (to-php-array coll)]
@@ -1060,8 +1078,9 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps."
   ;; fallback to `sorted-vector` would convert a second time, which made every
   ;; non-int sort slower than before the fast path existed.
   (let [php-array (to-php-array coll)]
-    (if (all-native-ints? php-array)
-      (php/sort (php/ref php-array) php/SORT_NUMERIC)
+    (cond
+      (all-native-ints? php-array)    (php/sort (php/ref php-array) php/SORT_NUMERIC)
+      (all-native-strings? php-array) (php/sort (php/ref php-array))
       (php/usort php-array (sort-comparator nil)))
     (copy-meta coll (Phel/vector php-array))))
 

--- a/tests/phel/core/sort-native-strings.phel
+++ b/tests/phel/core/sort-native-strings.phel
@@ -1,0 +1,53 @@
+(ns phel-test.core.sort-native-strings
+  (:require phel.test :refer [deftest is]))
+
+;; `sort` with no comparator sorts an all-string collection natively, the way
+;; it already did for an all-int one. The order has to stay exactly what
+;; `compare` produces, and the interesting part is that PHP's `<=>` compares
+;; two numeric strings *numerically*.
+
+(deftest test-numeric-strings-sort-numerically
+  ;; The reason the fast path uses the default SORT_REGULAR and not
+  ;; SORT_STRING. Lexicographically these would be ["1" "10" "100" "2" "9"].
+  (is (= ["1" "2" "9" "10" "100"] (sort ["10" "9" "2" "100" "1"]))
+      "numeric strings order by value, not lexically")
+  ;; "7" and "007" compare equal numerically, so their relative order is
+  ;; whatever PHP's sort leaves; it is the same before and after this change.
+  (is (= ["7" "007" "8" "08"] (sort ["8" "08" "7" "007"]))
+      "leading zeros compare equal and keep PHP's tie order")
+  (is (= ["99" "1e2" "100"] (sort ["1e2" "100" "99"]))
+      "exponent notation is read as a number")
+  (is (= ["-10" "-1" "2"] (sort ["-1" "-10" "2"]))
+      "negative numeric strings"))
+
+(deftest test-plain-strings
+  (is (= ["apple" "banana" "cherry"] (sort ["banana" "apple" "cherry"])) "words")
+  (is (= ["Apple" "Banana" "apple" "banana"] (sort ["apple" "Apple" "banana" "Banana"]))
+      "uppercase sorts before lowercase, as byte order gives")
+  (is (= ["" "" "a"] (sort ["" "a" ""])) "empty strings first")
+  (is (= [" a" "a" "a "] (sort ["a " " a" "a"])) "leading and trailing space")
+  (is (= ["x" "x" "y"] (sort ["y" "x" "x"])) "duplicates are kept")
+  (is (= ["solo"] (sort ["solo"])) "a single element")
+  (is (= [] (sort [])) "an empty collection")
+  (is (= ["1.10" "1.5" "1.9"] (sort ["1.5" "1.10" "1.9"])) "decimal-looking strings"))
+
+(deftest test-collections-that-must-not-take-the-fast-path
+  ;; One non-string is enough to send the whole collection back to `compare`.
+  (is (= [1 2 3] (sort [3 1 2])) "ints still sort")
+  (is (= [0.5 1.5 2.5] (sort [1.5 0.5 2.5])) "floats still sort")
+  (is (= [:a :b :c] (sort [:b :a :c])) "keywords still sort")
+  (is (= [nil nil "a"] (sort [nil "a" nil])) "nil sorts before a string")
+  ;; `compare` refuses incomparable categories; unchanged by the fast path,
+  ;; which only engages when every element is a string.
+  (is (thrown? \InvalidArgumentException (sort ["a" 1 "b"]))
+      "a string mixed with a number is still rejected")
+  (is (= [["a"] ["b"]] (sort [["b"] ["a"]])) "vectors compare element-wise"))
+
+(deftest test-an-explicit-comparator-is-still-honoured
+  ;; The fast path must only apply when no comparator was supplied.
+  (is (= ["c" "b" "a"] (sort (fn [a b] (compare b a)) ["a" "c" "b"]))
+      "a reversing comparator is not bypassed")
+  (is (= ["10" "9" "2"] (sort (fn [a b] (compare b a)) ["2" "10" "9"]))
+      "and applies to numeric strings too")
+  (is (= ["a" "bb" "ccc"] (sort-by count ["ccc" "a" "bb"]))
+      "sort-by is unaffected"))


### PR DESCRIPTION
## 🤔 Background

Recomputing the paired ratios after the recent work put `bench_sort_strings` at **16.1x** its raw pair, the largest addressable gap left.

`sort` with no comparator already had a fast path for an all-int collection (#3003). Everything else fell to `usort` with a Phel callback, which calls back into Phel twice per comparison, O(n log n) times. Strings are the other common case and had none.

## 🔖 Changes

An `all-native-strings?` check mirroring `all-native-ints?`, including its early exit, then `php/sort` with the default sort flags.

Interleaved A/B, two alternating pairs:

| subject | main | this PR | |
|---|---|---|---|
| `bench_sort_strings` | 126.89us, 126.31us | 5.58us, 5.54us | **22.7x** |
| `bench_sort_ints` | 4.92us, 4.93us | 4.90us, 4.91us | unchanged |
| `bench_sort_explicit_comparator` | 105.02us, 104.31us | 104.56us, 105.35us | unchanged |

It is now *faster than its own raw pair* (5.54us against 7.74us), because `php/sort` beats `usort` with a PHP closure.

The two unchanged subjects are the controls: the int path must not regress, and a supplied comparator must never be bypassed.

## SORT_STRING is the obvious choice and is wrong

Worth stating, because it is the trap this could have shipped with.

`compare` settles two strings with PHP's `<=>`, which compares **numeric strings by value**. `SORT_STRING` compares lexicographically. Measured against `compare` before writing any code:

| input | `compare` | `SORT_STRING` | `SORT_REGULAR` |
|---|---|---|---|
| `["10" "9" "2" "100" "1"]` | `1 2 9 10 100` | `1 10 100 2 9` | `1 2 9 10 100` |
| `["007" "7" "08" "8"]` | `007 7 08 8` | `007 08 7 8` | `007 7 08 8` |
| `["1e2" "100" "99"]` | `99 1e2 100` | `100 1e2 99` | `99 1e2 100` |

So the fast path uses the default `SORT_REGULAR`, and the helper's docblock records why.

## Verification

Diffed against `origin/main` over **23 collections**: numeric strings, leading zeros, exponent notation, decimal-looking strings, negatives, mixed case, unicode, empty strings, leading and trailing whitespace, duplicates, symbols, a single element and an empty collection, plus the ones that must keep the comparator path (ints, floats, keywords, nils, booleans, nested vectors, and a string mixed with a number). Every row identical, with and without an explicit comparator.

Equal-element ordering was checked separately across three different input orders of the same leading-zero set, since ties are where a sort swap would show. Identical in all three.

Two of my own test expectations were wrong and are corrected rather than worked around: `["8" "08" "7" "007"]` sorts to `["7" "007" "8" "08"]`, not what I first assumed, and `(sort ["a" 1 "b"])` raises rather than sorting. Both behave that way on `main` too.

Related to #2973
