### PR TITLE
perf(core): build into a vector in one construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Build `into` a vector by collecting into a PHP array seeded from the target and constructing once, as `vec` does: 3.5x. The target's metadata is copied explicitly, since the transient this replaces carried it through `persistent` (#2973)
 - Sort an all-string collection natively instead of calling back into Phel per comparison, as `sort` already did for an all-int one: 22.7x. The default `SORT_REGULAR` is used and not `SORT_STRING`, because `compare` settles two strings with PHP's `<=>`, which orders numeric strings by value (#2973)
 - Build `kvs` and the indexed branch of `php->phel` the same way as `vec`, collecting into a PHP array and constructing the vector once: `kvs` 1.65x, `php->phel` on an indexed array 1.97x (#2973)
 - Build `vec`'s result by collecting into a PHP array and constructing the vector once, instead of appending through a transient per element: 3.1x over 32 elements and 3.5x over 500, so the gain holds as the collection grows (#2973)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -164,10 +164,14 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
             ;; Fast paths: persistent vector/set/hash-map targets build via transients,
             ;; turning O(N log N) repeated copy-on-write into O(N).
          (vector? to)
-         (persistent
-          (for [value :in entries
-                :reduce [acc (transient to)]]
-            (conj acc value)))
+         ;; Collected into a PHP array seeded from `to` and built once, as
+         ;; `vec` is (#3134). `copy-meta` because the transient this replaces
+         ;; carried `to`'s metadata through `persistent`, where a fresh
+         ;; `Phel/vector` would not.
+         (let [arr (to-php-array to)]
+           (foreach [value entries]
+             (php/apush arr value))
+           (copy-meta to (Phel/vector arr)))
 
          (set? to)
          (persistent

--- a/tests/phel/core/into-vector-bulk.phel
+++ b/tests/phel/core/into-vector-bulk.phel
@@ -1,0 +1,42 @@
+(ns phel-test.core.into-vector-bulk
+  (:require phel.test :refer [deftest is]))
+
+(defstruct pt [x y])
+
+;; `into` a vector target collects into a PHP array seeded from the target and
+;; builds the result once, as `vec` does since #3134. The transient it replaces
+;; carried the target's metadata through `persistent`, so that has to be copied
+;; explicitly now.
+
+(deftest test-into-an-empty-vector
+  (is (= [1 2 3] (into [] [1 2 3])) "from a vector")
+  (is (= [1 2 3] (into [] '(1 2 3))) "from a list")
+  (is (= [2 3] (into [] (map inc [1 2]))) "from a lazy sequence")
+  (is (= [["a" 1]] (into [] {"a" 1})) "from a map, as key-value pairs")
+  (is (= ["a" "b"] (into [] "ab")) "from a string")
+  (is (= [1 2] (into [] (php-indexed-array 1 2))) "from a PHP array")
+  (is (= [] (into [] [])) "from an empty collection")
+  (is (= [] (into [] nil)) "from nil"))
+
+(deftest test-into-a-seeded-vector
+  (is (= [:a 1 2] (into [:a] [1 2])) "the target's elements come first")
+  (is (= [:a] (into [:a] [])) "an empty source leaves the target")
+  (is (= [:a] (into [:a] nil)) "a nil source leaves the target")
+  (is (= [1 2] (into (into [] [1]) [2])) "chained")
+  (is (= [1 2] (into [1 2])) "the one-argument arity returns the target"))
+
+(deftest test-the-target-keeps-its-metadata
+  ;; The transient round trip preserved this; a fresh vector would not.
+  (is (= {:t 1} (meta (into (with-meta [:a] {:t 1}) [1]))) "a seeded target keeps its meta")
+  (is (= {:m 2} (meta (into (with-meta [] {:m 2}) [1]))) "an empty target keeps its meta"))
+
+(deftest test-values-that-could-be-dropped
+  (is (= [nil 1 nil] (into [] [nil 1 nil])) "nil elements survive")
+  (is (= 3 (count (into [] [nil 1 nil]))) "and are counted")
+  (is (= [false 0 ""] (into [] [false 0 ""])) "falsy values survive")
+  (is (= [[1 2] {:a 1}] (into [] [[1 2] {:a 1}])) "nested collections are not flattened"))
+
+(deftest test-other-targets-are-unaffected
+  (is (= {:a 1, :b 2} (into {:a 1} [[:b 2]])) "a map target still builds through its own branch")
+  (is (= 3 (count (into (set [1]) [2 3]))) "a set target")
+  (is (= [:a 1 2] (persistent (into (transient [:a]) [1 2]))) "a transient vector target"))


### PR DESCRIPTION
## 🤔 Background

`bench_into_vector` was the last large addressable ratio in the suite at 9.6x, and the one I flagged in #3134 as needing separate work. It turned out to need less care than I expected: I had assumed the bulk construction would only apply to an empty target, but seeding the PHP array from the target's own elements works for both.

| | transient appends | PHP array, one construction |
|---|---|---|
| `(into [] src)` | 23.5us | 6.4us |
| `(into [:a] src)` | 23.1us | 7.0us |

## 🔖 Changes

The vector branch seeds a PHP array from the target, pushes the entries onto it and builds once.

Interleaved A/B, two alternating pairs:

| subject | main | this PR | |
|---|---|---|---|
| `bench_into_vector` | 24.59us, 25.06us | 7.11us, 7.23us | **3.5x** |
| `bench_into_map` | 102.32us, 102.46us | 102.93us, 103.57us | unchanged |

`into` a map is the control: it builds through its own branch and must not move.

## The metadata trap

The transient this replaces **carried the target's metadata through `persistent`**, which a fresh `Phel/vector` does not. Checked before writing the change rather than after:

```
(meta (into (with-meta [:a] {:t 1}) [1]))
  transient path   => {:t 1}
  bare Phel/vector => nil
```

So `copy-meta` is explicit in the new branch. No existing test covered this, so a silent loss would have shipped; two tests now pin it, for a seeded and an empty target.

## Verification

Diffed against `origin/main` over **21 cases**: empty and seeded targets; sources that are a vector, list, lazy sequence, set, map, string, PHP array, struct, nil and empty; nil and falsy elements; nested collections; a transient target; the one-argument arity; chaining; and both metadata cases. Every row identical.

Related to #2973
