### PR TITLE
perf(core): order sort-by natively when the keys allow it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Order `sort-by` natively with `array_multisort` when the keys are all native ints or all native strings and no comparator other than `compare` was given, instead of running a closure per comparison: 2.1x on int keys and 13.7x on string keys, which had no fast path at all. A position column keeps ties in input order (#2973)
 - Build `into` a vector by collecting into a PHP array seeded from the target and constructing once, as `vec` does: 3.5x. The target's metadata is copied explicitly, since the transient this replaces carried it through `persistent` (#2973)
 - Sort an all-string collection natively instead of calling back into Phel per comparison, as `sort` already did for an all-int one: 22.7x. The default `SORT_REGULAR` is used and not `SORT_STRING`, because `compare` settles two strings with PHP's `<=>`, which orders numeric strings by value (#2973)
 - Build `kvs` and the indexed branch of `php->phel` the same way as `vec`, collecting into a PHP array and constructing the vector once: `kvs` 1.65x, `php->phel` on an indexed array 1.97x (#2973)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1126,30 +1126,48 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps."
         ;; yields its `[key value]` entries, which is what `sort` and `sort-by`
         ;; have always sorted.
         values (to-php-array coll)
-        pairs  (php-indexed-array)]
+        ks     (php/array)
+        vs     (php/array)
+        idx    (php/array)
+        pos    (php/array 0)]
+    ;; One pass, so `keyfn` runs exactly n times whichever sort follows. The
+    ;; position column is filled here too rather than in a second loop; the
+    ;; comparator path ignores it.
     (foreach [v values]
-      (php/apush pairs (php-indexed-array (keyfn v) v)))
-    ;; `usort` is stable as of PHP 8.0, so ties keep their input order, which is
-    ;; what the undecorated result has to preserve.
-    ;; When the derived keys are all native ints and no comparator was
-    ;; supplied, order them with native comparisons rather than calling back
-    ;; into Phel. `usort` still runs a closure per comparison either way, but
-    ;; this one's body is `php/` interop and reaches no registry, where `cmp`
-    ;; is a Phel function wrapping `compare`. Same idea as
-    ;; `sorted-vector-natural`, and the same narrowness: ints only, because a
-    ;; float brings NaN and a mixed pair does not order the way `compare` does.
-    (if (and (identical? comp compare) (all-int-first-elements? pairs))
-      (php/usort pairs (fn [a b]
-                         (let [ka (php/aget a 0)
-                               kb (php/aget b 0)]
-                           (if (php/< ka kb)
-                             -1
-                             (if (php/> ka kb) 1 0)))))
-      (php/usort pairs (fn [a b] (cmp (php/aget a 0) (php/aget b 0)))))
-    (let [result (php-indexed-array)]
-      (foreach [p pairs]
-        (php/apush result (php/aget p 1)))
-      (copy-meta coll (Phel/vector result)))))
+      (php/apush ks (keyfn v))
+      (php/apush vs v)
+      (php/apush idx (php/aget pos 0))
+      (php/aset pos 0 (php/+ 1 (php/aget pos 0))))
+    (if (and (identical? comp compare)
+             (or (all-native-ints? ks) (all-native-strings? ks)))
+      ;; Native sort, no callback at all. `array_multisort` orders `vs` by `ks`
+      ;; without running a comparator, where `usort` runs a closure per
+      ;; comparison even when its body is pure interop.
+      ;;
+      ;; The index column is what keeps it stable. `array_multisort` gives no
+      ;; ordering guarantee for equal keys, and the undecorated result has to
+      ;; preserve input order for ties, so position breaks them.
+      ;;
+      ;; Narrow for the same reason `sorted-vector-natural` is: all ints or all
+      ;; strings, because those are the two cases where PHP's own comparison
+      ;; orders exactly as `compare` does. A float brings NaN and a mixed pair
+      ;; does not.
+      (do
+        (php/array_multisort (php/ref ks) php/SORT_ASC php/SORT_REGULAR
+                             (php/ref idx) php/SORT_ASC php/SORT_REGULAR
+                             (php/ref vs))
+        (copy-meta coll (Phel/vector vs)))
+      ;; Everything else keeps the decorated `usort`, which is stable as of
+      ;; PHP 8.0 so ties keep their input order.
+      (let [pairs (php/array)
+            n     (php/count ks)]
+        (dofor [i :range [0 n]]
+          (php/apush pairs (php-indexed-array (php/aget ks i) (php/aget vs i))))
+        (php/usort pairs (fn [a b] (cmp (php/aget a 0) (php/aget b 0))))
+        (let [result (php/array)]
+          (foreach [p pairs]
+            (php/apush result (php/aget p 1)))
+          (copy-meta coll (Phel/vector result)))))))
 
 (defn sort
   "Returns a sorted vector. If no comparator is supplied compare is used."

--- a/tests/phel/core/sort-by-native-keys.phel
+++ b/tests/phel/core/sort-by-native-keys.phel
@@ -1,0 +1,51 @@
+(ns phel-test.core.sort-by-native-keys
+  (:require phel.test :refer [deftest is]))
+
+(defstruct pt [x y])
+
+;; `sort-by` orders natively with `array_multisort` when no comparator other
+;; than `compare` was supplied and every derived key is a native int or a
+;; native string. `usort` ran a closure per comparison even on the int fast
+;; path; this runs none. Ties must still keep their input order, which the
+;; position column is there to guarantee.
+
+(deftest test-int-keys
+  (is (= [1 2 3] (sort-by identity [3 1 2])) "identity over ints")
+  (is (= ["a" "bb" "ccc"] (sort-by count ["ccc" "a" "bb"])) "count as the key")
+  (is (= [3 2 1] (sort-by (fn [x] (php/* -1 x)) [1 2 3])) "a negating key")
+  (is (= [] (sort-by identity [])) "an empty collection")
+  (is (= [:solo] (sort-by identity [:solo])) "a single element"))
+
+(deftest test-string-keys
+  (is (= ["a" "b" "c"] (sort-by identity ["b" "a" "c"])) "identity over strings")
+  ;; PHP's `<=>` compares numeric strings by value, and `compare` agrees, so
+  ;; the native path has to preserve that rather than ordering lexically.
+  (is (= ["2" "9" "10"] (sort-by identity ["10" "9" "2"])) "numeric strings order by value"))
+
+(deftest test-ties-keep-input-order
+  ;; What the position column exists for: `array_multisort` gives no guarantee
+  ;; for equal keys on its own.
+  ;; Keys are 2, 2, 1. "c" sorts first, and the two length-2 strings keep the
+  ;; order they arrived in, "bb" before "aa".
+  (is (= ["c" "bb" "aa"] (sort-by count ["bb" "aa" "c"])) "equal keys keep input order")
+  (is (= [:a :b :c :d] (sort-by (fn [_] 0) [:a :b :c :d])) "every key equal keeps the whole order")
+  (is (= [1 1 2 2] (sort-by identity [2 1 2 1])) "duplicate keys and values"))
+
+(deftest test-keys-that-must-not-take-the-native-path
+  (is (= [1 2 3] (sort-by (fn [x] (php/* 1.5 x)) [1 2 3])) "float keys use the comparator")
+  (is (= [1 2 3] (sort-by (fn [x] (keyword (str x))) [1 2 3])) "keyword keys use the comparator")
+  (is (= [1 2] (sort-by (fn [_] nil) [1 2])) "nil keys use the comparator")
+  (is (= 2 (count (sort-by :x [(pt 2 0) (pt 1 0)]))) "a struct field as the key"))
+
+(deftest test-an-explicit-comparator
+  ;; Passing `compare` itself is identical? to the default, so it still takes
+  ;; the native path. A different comparator must not.
+  (is (= ["a" "bb" "ccc"] (sort-by count compare ["ccc" "a" "bb"])) "compare passed explicitly")
+  (is (= [3 2 1] (sort-by identity (fn [a b] (compare b a)) [1 3 2])) "a reversing comparator is honoured")
+  (is (= ["c" "b" "a"] (sort-by identity (fn [a b] (compare b a)) ["a" "c" "b"])) "and on string keys"))
+
+(deftest test-sources-and-metadata
+  (is (= [1 2 3] (sort-by identity '(3 1 2))) "from a list")
+  (is (= [2 3 4] (sort-by identity (map inc [3 1 2]))) "from a lazy sequence")
+  (is (= 3 (count (sort-by identity (set [3 1 2])))) "from a set")
+  (is (= {:m 1} (meta (sort-by identity (with-meta [2 1] {:m 1})))) "the source metadata is kept"))


### PR DESCRIPTION
## 🤔 Background

#3136 gave `sort` a native path for all-string collections. `sort-by` was the remaining half: it ran `usort` with a closure per comparison, O(n log n) times, even on the int fast path from #3080 where the closure body was pure interop but still a closure. String keys had no fast path at all and fell back to `compare`.

## 🔖 Changes

`array_multisort` orders the values by the key column with **no callback at all**, when no comparator other than `compare` was supplied and every derived key is a native int or a native string.

Interleaved A/B, two alternating pairs:

| subject | main | this PR | |
|---|---|---|---|
| `bench_sort_by_cheap_key` | 16.03us, 16.29us | 7.51us, 7.58us | **2.1x** |
| `bench_sort_by_counting_key` | 16.67us, 16.85us | 9.72us, 9.91us | **1.7x** |
| `bench_sort_by_explicit_comparator` | 16.88us, 17.17us | 10.20us, 10.16us | **1.7x** |

String keys are the larger win and the benchmark understates it, because all three subjects derive int keys. Measured directly: **107us to 7.8us**.

## Why the "explicit comparator" subject moved

It should look wrong at first glance, so: that subject passes `compare` **itself** as the comparator, which is `identical?` to the default, so it legitimately takes the native path. A genuinely different comparator does not, and keeps the decorated `usort`. The tests cover `(fn [a b] (compare b a))` on both int and string keys and assert the reversed order still comes out.

## Stability

`array_multisort` gives no ordering guarantee for equal keys, and the undecorated result has to keep ties in input order. A position column is sorted alongside as the tiebreak.

Filling that column in the same pass as the keys and values, rather than a second loop, is what closed the gap between my first attempt (11.2us) and the prototype (6.0us).

`keyfn` still runs exactly n times, which is the property #3006 introduced and the reason this stayed a decorate-sort-undecorate rather than becoming a comparator again.

## Verification

Diffed against `origin/main` over **22 cases**: int, string, numeric-string, float, keyword, nil and struct-field keys; ties including an all-equal key and duplicate values; empty and single-element collections; list, map, set and lazy-sequence sources; a reversing comparator on both int and string keys; and the source metadata. Every row identical.

Two of my test expectations were wrong and are corrected rather than worked around: `(php/- x)` is not unary negation, and `(sort-by count ["bb" "aa" "c"])` is `["c" "bb" "aa"]`, which is the stable answer I meant to assert in the first place.

Related to #2973
