### PR TITLE
perf(core): merge two maps through the collection's bulk merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Merge two maps through the collection's own bulk `merge` instead of adding the right map's entries one at a time with `conj`: 2.6x on two 32-entry maps (#2973)
 - Order `sort-by` natively with `array_multisort` when the keys are all native ints or all native strings and no comparator other than `compare` was given, instead of running a closure per comparison: 2.1x on int keys and 13.7x on string keys, which had no fast path at all. A position column keeps ties in input order (#2973)
 - Build `into` a vector by collecting into a PHP array seeded from the target and constructing once, as `vec` does: 3.5x. The target's metadata is copied explicitly, since the transient this replaces carried it through `persistent` (#2973)
 - Sort an all-string collection natively instead of calling back into Phel per comparison, as `sort` already did for an all-int one: 22.7x. The default `SORT_REGULAR` is used and not `SORT_STRING`, because `compare` settles two strings with PHP's `<=>`, which orders numeric strings by value (#2973)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1511,6 +1511,10 @@ Stops when the shorter of `keys` or `vals` is exhausted. Works safely with infin
   (cond
     (nil? left)  (when-not (nil? right) (conj {} right))
     (nil? right) (if (map? left) left (conj left right))
+    ;; Two maps merge through the collection's own `merge`, which bulk-builds
+    ;; the result through a transient. `conj` reaches the same result by adding
+    ;; the right map's entries one at a time, each a Phel call (#2973).
+    (and (map? left) (map? right)) (.merge left right)
     :else        (conj left right)))
 
 (defn merge

--- a/tests/phel/core/merge-native-maps.phel
+++ b/tests/phel/core/merge-native-maps.phel
@@ -1,0 +1,44 @@
+(ns phel-test.core.merge-native-maps
+  (:require phel.test :refer [deftest is]))
+
+(defstruct pt [x y])
+
+;; Two maps merge through the collection's own `merge`, which bulk-builds the
+;; result through a transient, instead of adding the right map's entries one at
+;; a time with `conj`. Every other shape `merge` accepts keeps its old path.
+
+(deftest test-two-maps
+  (is (= {:a 1, :b 2} (merge {:a 1} {:b 2})) "disjoint keys combine")
+  (is (= {:a 1, :b 3} (merge {:a 1, :b 2} {:b 3})) "the right map wins on a shared key")
+  (is (= {:a 1, :b 2, :c 3} (merge {:a 1} {:b 2} {:c 3})) "three maps fold left to right")
+  (is (= {:a 1} (merge {} {:a 1})) "an empty left")
+  (is (= {:a 1} (merge {:a 1} {})) "an empty right")
+  (is (= {} (merge {} {})) "both empty"))
+
+(deftest test-nil-handling
+  (is (= {:a 1} (merge nil {:a 1})) "a nil left is treated as empty")
+  (is (= {:a 1} (merge {:a 1} nil)) "a nil right leaves the left")
+  (is (nil? (merge nil nil)) "both nil")
+  (is (nil? (merge)) "no arguments")
+  (is (= {:a 1} (merge {:a 1})) "one argument")
+  (is (= {:a 1, :c 3} (merge {:a 1} nil {:c 3})) "a nil in the middle is skipped")
+  ;; A nil *value* is a value, not an absence, so it replaces.
+  (is (nil? (get (merge {:a 1} {:a nil}) :a)) "a nil value overwrites"))
+
+(deftest test-map-flavours-and-metadata
+  (is (= 2 (get (merge (sorted-map :a 1) {:b 2}) :b)) "a sorted map on the left")
+  ;; The result is a hash-map, not a sorted-map. Pre-existing behaviour,
+  ;; unchanged here, and pinned so the native path is not blamed for it.
+  (is (= :hash-map (type (merge (sorted-map :a 1) {:b 2})))
+      "merging a sorted map with a hash map gives a hash map")
+  (is (= 1 (get (merge {:a 1} (sorted-map :b 2)) :a)) "a sorted map on the right")
+  (is (= {:m 1} (meta (merge (with-meta {:a 1} {:m 1}) {:b 2})))
+      "the left map's metadata is kept"))
+
+(deftest test-shapes-that-keep-the-conj-path
+  ;; A struct is a map, so it takes the native path; a vector is not.
+  (is (= 9 (get (merge (pt 1 2) {:x 9}) :x)) "a struct on the left")
+  ;; A vector on the right goes through `conj`, which rejects it: its elements
+  ;; are the entries, and `[[:b 2]]` offers one entry of length 1.
+  (is (thrown? \InvalidArgumentException (merge {:a 1} [[:b 2]]))
+      "a vector on the right still reaches conj and is rejected"))

--- a/tests/php/Benchmark/Phel/CoreSeqBench.php
+++ b/tests/php/Benchmark/Phel/CoreSeqBench.php
@@ -82,6 +82,9 @@ final class CoreSeqBench extends CoreBenchCase
     private $vec;
 
     /** @var callable */
+    private $merge;
+
+    /** @var callable */
     private $kvs;
 
     /** @var callable */
@@ -150,6 +153,10 @@ final class CoreSeqBench extends CoreBenchCase
     private mixed $map = null;
 
     private mixed $emptyMap = null;
+
+    private mixed $bigMapA = null;
+
+    private mixed $bigMapB = null;
 
     private mixed $pairs = null;
 
@@ -702,6 +709,18 @@ final class CoreSeqBench extends CoreBenchCase
     }
 
     /**
+     * `merge` had no subject, which is why it went unnoticed that merging two
+     * maps added the right one's entries through `conj`, one Phel call each,
+     * rather than using the collection's own bulk merge.
+     *
+     * @Revs(1000)
+     */
+    public function bench_merge_two_maps(): void
+    {
+        ($this->merge)($this->bigMapA, $this->bigMapB);
+    }
+
+    /**
      * `partition-by` and `dedupe` return a sequence built by
      * `lazy-seq-from-generator`, so constructing one realizes a chunk before
      * the caller has asked for a single element. These two subjects measure
@@ -745,6 +764,7 @@ final class CoreSeqBench extends CoreBenchCase
         $this->partitionBy = $this->coreFn('partition-by');
         $this->transduce = $this->coreFn('transduce');
         $this->vec = $this->coreFn('vec');
+        $this->merge = $this->coreFn('merge');
         $this->kvs = $this->coreFn('kvs');
         $this->phpToPhel = $this->coreFn('php->phel');
         $this->zipmap = $this->coreFn('zipmap');
@@ -799,6 +819,18 @@ final class CoreSeqBench extends CoreBenchCase
         $this->emptyVector = Phel::vector([]);
         $this->map = Phel::map(Phel::keyword('a'), 1, Phel::keyword('b'), 2);
         $this->emptyMap = Phel::map();
+
+        $kvA = [];
+        $kvB = [];
+        for ($i = 0; $i < self::SIZE; ++$i) {
+            $kvA[] = Phel::keyword('a' . $i);
+            $kvA[] = $i;
+            $kvB[] = Phel::keyword('b' . $i);
+            $kvB[] = $i;
+        }
+
+        $this->bigMapA = Phel::map(...$kvA);
+        $this->bigMapB = Phel::map(...$kvB);
 
         $pairs = [];
         for ($i = 0; $i < self::SIZE; ++$i) {


### PR DESCRIPTION
## 🤔 Background

The benched functions are all at their floors now, so I went at the blind spot instead: of 438 core public functions, **51 have a benchmark subject and 387 do not**. Measuring the likely-hot ones directly, `merge` stood out immediately at **125us** to merge two 32-entry maps, roughly 4us per entry.

The cause: `merge-right` reaches every case through `conj`, which adds the right map's entries one at a time, each a Phel call. Meanwhile `PersistentHashMap` and `PersistentArrayMap` opt into `TransientMergeStrategyTrait`, which builds the result through a transient in one go. Nothing was using it.

## 🔖 Changes

Two maps merge with the collection's own `merge`. Everything else is untouched.

Interleaved A/B, two alternating pairs:

| subject | main | this PR | |
|---|---|---|---|
| `bench_merge_two_maps` | 130.39us, 130.07us | 49.32us, 49.53us | **2.6x** |

The subject is new and lands with the change, since its absence is why this survived this long.

## Scope

Only the both-maps case takes the new path. `nil` on either side, a vector on the right, and anything else keep the `conj` route, because `conj` is what defines what those mean.

## Verification

Diffed against `origin/main` over **22 cases**: disjoint and overlapping keys, three-map folds, empty maps on each side and both, `nil` in every position including between two maps, a `nil` *value* overwriting a real one, sorted maps on each side, a struct, a vector, metadata, and the result type.

Two of my test expectations were wrong and are corrected rather than worked around, both confirmed pre-existing by the diff:

- `(type (merge (sorted-map :a 1) {:b 2}))` is `:hash-map`, not `:sorted-map`
- `(merge {:a 1} [[:b 2]])` raises, because `conj` reads `[[:b 2]]` as one entry of length 1

Both now pinned, so the native path cannot be blamed for either later.

Related to #2973
