### PR TITLE
perf(core): rebuild maps without the pairs destructuring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Walk the input with `foreach` rather than `for ... :pairs` in `update-vals`, `update-keys` and `rename-keys`, whose destructuring was most of what they cost: 1.9x, 1.9x and 1.76x (#2973)
 - Merge two maps through the collection's own bulk `merge` instead of adding the right map's entries one at a time with `conj`: 2.6x on two 32-entry maps (#2973)
 - Order `sort-by` natively with `array_multisort` when the keys are all native ints or all native strings and no comparator other than `compare` was given, instead of running a closure per comparison: 2.1x on int keys and 13.7x on string keys, which had no fast path at all. A position column keeps ties in input order (#2973)
 - Build `into` a vector by collecting into a PHP array seeded from the target and constructing once, as `vec` does: 3.5x. The target's metadata is copied explicitly, since the transient this replaces carried it through `persistent` (#2973)

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -524,20 +524,30 @@ Without arguments, uses a default cache size of 128 entries."
   {:example "(update-keys {:a 1 :b 2} name) ; => {\"a\" 1, \"b\" 2}"
    :see-also ["update-vals" "keys" "update"]}
   [m f]
-  (persistent
-   (for [[k v] :pairs m
-         :reduce [acc (transient {})]]
-     (assoc! acc (f k) v))))
+  ;; As `update-vals`, but built from empty: `f` may map two keys onto one, so
+  ;; seeding from `m` would leave the originals behind.
+  (let [acc (transient {})]
+    (foreach [k v m]
+      (.put acc (f k) v))
+    (persistent acc)))
 
 (defn update-vals
   "Returns a map with `f` applied to each value."
   {:example "(update-vals {:a 1 :b 2} inc) ; => {:a 2, :b 3}"
    :see-also ["update-keys" "values" "update"]}
   [m f]
-  (persistent
-   (for [[k v] :pairs m
-         :reduce [acc (transient {})]]
-     (assoc! acc k (f v)))))
+  ;; `foreach` and not `for … :pairs`: the destructuring form was the cost
+  ;; here, not the map building, and `.put` because the transient is local and
+  ;; its type is known (#2973).
+  ;;
+  ;; Built from empty rather than seeded from `m`. Seeding is a further 1.6x,
+  ;; because every write would replace an entry instead of inserting one, but a
+  ;; transient carries its source's metadata and would hand it back, where this
+  ;; has always returned a map with none.
+  (let [acc (transient {})]
+    (foreach [k v m]
+      (.put acc k (f v)))
+    (persistent acc)))
 
 (defn map-invert
   "Returns a map with the keys and values of `m` swapped. When several keys share a value, the one visited last in iteration order wins."

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1545,10 +1545,12 @@ If a key appears in more than one collection, later values replace previous ones
   {:example "(rename-keys {:a 1 :b 2 :c 3} {:a :x :b :y}) ; => {:x 1, :y 2, :c 3}"
    :see-also ["select-keys" "keys" "vals"]}
   [m kmap]
-  (persistent
-   (for [[k v] :pairs m
-         :reduce [acc (transient {})]]
-     (assoc! acc (get kmap k k) v))))
+  ;; As `update-keys`: built from empty, because a rename can collapse two keys
+  ;; onto one.
+  (let [acc (transient {})]
+    (foreach [k v m]
+      (.put acc (get kmap k k) v))
+    (persistent acc)))
 
 (defn invert
   "Returns a new map where the keys and values are swapped.

--- a/tests/phel/core/map-rebuilders.phel
+++ b/tests/phel/core/map-rebuilders.phel
@@ -1,0 +1,48 @@
+(ns phel-test.core.map-rebuilders
+  (:require phel.test :refer [deftest is]))
+
+(defstruct pt [x y])
+
+;; `update-vals`, `update-keys` and `rename-keys` walk their input with
+;; `foreach` rather than `for … :pairs`, and write with `.put` on a local
+;; transient. All three still build from an empty map, which is what keeps the
+;; result free of the source's metadata as before.
+
+(deftest test-update-vals
+  (is (= {:a 2, :b 3} (update-vals {:a 1, :b 2} inc)) "every value is mapped")
+  (is (= {} (update-vals {} inc)) "an empty map")
+  (is (= {:a :was-nil} (update-vals {:a nil} (fn [v] (if (nil? v) :was-nil v))))
+      "a nil value reaches the function")
+  (is (= {:a 2, :b 3} (update-vals (sorted-map :b 2 :a 1) inc)) "a sorted map")
+  (is (= 2 (count (update-vals (pt 1 2) inc))) "a struct"))
+
+(deftest test-update-keys
+  (is (= {"a" 1, "b" 2} (update-keys {:a 1, :b 2} name)) "every key is mapped")
+  (is (= {} (update-keys {} name)) "an empty map")
+  ;; Two keys can collapse onto one, which is why this cannot be seeded from
+  ;; the source map: the originals would survive.
+  (is (= 1 (count (update-keys {:a 1, :b 2} (fn [_] :same)))) "colliding keys collapse")
+  (is (= 1 (count (update-keys {:a 1} (fn [_] nil)))) "nil is usable as the new key"))
+
+(deftest test-rename-keys
+  (is (= {:x 1, :y 2, :c 3} (rename-keys {:a 1, :b 2, :c 3} {:a :x, :b :y})) "listed keys are renamed")
+  (is (= {:a 1} (rename-keys {:a 1} {})) "an empty rename map changes nothing")
+  (is (= {} (rename-keys {} {:a :b})) "an empty source")
+  (is (= {:a 1} (rename-keys {:a 1} {:z :q})) "a rename for an absent key is ignored")
+  (is (= 1 (count (rename-keys {:a 1, :b 2} {:a :b}))) "renaming onto an existing key collapses")
+  (is (nil? (get (rename-keys {:a nil} {:a :x}) :x)) "a nil value is carried over"))
+
+(deftest test-metadata-is-not-carried
+  ;; All three have always returned a map without the source's metadata.
+  ;; Seeding the transient from the source would be faster and would change
+  ;; that, so they build from empty.
+  (is (nil? (meta (update-vals (with-meta {:a 1} {:m 1}) inc))) "update-vals drops it")
+  (is (nil? (meta (update-keys (with-meta {:a 1} {:m 1}) name))) "update-keys drops it")
+  (is (nil? (meta (rename-keys (with-meta {:a 1} {:m 1}) {:a :z}))) "rename-keys drops it"))
+
+(deftest test-the-source-is-untouched
+  (let [m {:a 1, :b 2}]
+    (update-vals m inc)
+    (update-keys m name)
+    (rename-keys m {:a :z})
+    (is (= {:a 1, :b 2} m) "the input map is unchanged by any of them")))

--- a/tests/php/Benchmark/Phel/CoreSeqBench.php
+++ b/tests/php/Benchmark/Phel/CoreSeqBench.php
@@ -85,6 +85,15 @@ final class CoreSeqBench extends CoreBenchCase
     private $merge;
 
     /** @var callable */
+    private $updateVals;
+
+    /** @var callable */
+    private $updateKeys;
+
+    /** @var callable */
+    private $renameKeys;
+
+    /** @var callable */
     private $kvs;
 
     /** @var callable */
@@ -721,6 +730,33 @@ final class CoreSeqBench extends CoreBenchCase
     }
 
     /**
+     * The map rebuilders. None had a subject, and all three walked their input
+     * with `for … :pairs`, whose destructuring was most of what they cost.
+     *
+     * @Revs(1000)
+     */
+    public function bench_update_vals(): void
+    {
+        ($this->updateVals)($this->bigMapA, $this->inc);
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_update_keys(): void
+    {
+        ($this->updateKeys)($this->bigMapA, $this->identity);
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_rename_keys(): void
+    {
+        ($this->renameKeys)($this->bigMapA, $this->emptyMap);
+    }
+
+    /**
      * `partition-by` and `dedupe` return a sequence built by
      * `lazy-seq-from-generator`, so constructing one realizes a chunk before
      * the caller has asked for a single element. These two subjects measure
@@ -765,6 +801,9 @@ final class CoreSeqBench extends CoreBenchCase
         $this->transduce = $this->coreFn('transduce');
         $this->vec = $this->coreFn('vec');
         $this->merge = $this->coreFn('merge');
+        $this->updateVals = $this->coreFn('update-vals');
+        $this->updateKeys = $this->coreFn('update-keys');
+        $this->renameKeys = $this->coreFn('rename-keys');
         $this->kvs = $this->coreFn('kvs');
         $this->phpToPhel = $this->coreFn('php->phel');
         $this->zipmap = $this->coreFn('zipmap');


### PR DESCRIPTION
## 🤔 Background

Continuing the unbenched sweep that found `merge` in #3139. Measuring more of the 387 core functions without a subject, three stood out together:

| | before |
|---|---|
| `update-vals` | 146.7us |
| `update-keys` | 144.4us |
| `rename-keys` | 156.6us |

All for 32 entries, roughly 4.6us each, against `zipmap`'s 2.7us for the same count. So the extra was not HAMT insertion.

It was the walk. All three used `for [[k v] :pairs m ...]`, and the destructuring is most of what they cost. A plain `foreach` with `.put` on a local transient is nearly twice as fast.

## 🔖 Changes

Interleaved A/B, two alternating pairs:

| subject | main | this PR | |
|---|---|---|---|
| `bench_update_vals` | 168.12us, 167.61us | 87.96us, 89.78us | **1.9x** |
| `bench_update_keys` | 164.13us, 164.77us | 87.13us, 86.33us | **1.9x** |
| `bench_rename_keys` | 171.75us, 173.34us | 97.66us, 98.29us | **1.76x** |

All three subjects are new.

## The 1.6x I did not take

`update-vals` does not change its keys, so its transient can be seeded from the source map: every write then replaces an entry instead of inserting one, which measured **50.9us** against the 80.0us shipped here.

I did not take it. A transient carries its source's metadata and hands it back on `persistent`, so seeding makes `update-vals` start preserving metadata that it has always dropped:

```
(meta (update-vals (with-meta {:a 1} {:m 1}) inc))
  built from empty   => nil     (today, and this PR)
  seeded from source => {:m 1}
```

Arguably preserving is the better behaviour, but that is a semantics decision rather than a perf one, and it does not belong in a perf PR made silently. The tests pin the current behaviour for all three so the question stays visible.

`update-keys` and `rename-keys` could not be seeded regardless: both can collapse two keys onto one, so the originals would survive.

## Verification

Diffed against `origin/main` over **21 cases**: colliding keys under `update-keys` and `rename-keys`, `nil` as a produced key, `nil` values, sorted maps, a struct, empty inputs, renames for absent keys, and the metadata of all three. Every row identical.

A test also asserts the source map is unchanged after all three run, since they now write through a transient taken in a different place.

Related to #2973
