### PR TITLE
perf(core): drop the pairs destructuring from merge-with and map-invert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Walk with `foreach` rather than `for ... :pairs` in `merge-with` and `map-invert` too: 2.16x and 1.99x (#2973)
 - Walk the input with `foreach` rather than `for ... :pairs` in `update-vals`, `update-keys` and `rename-keys`, whose destructuring was most of what they cost: 1.9x, 1.9x and 1.76x (#2973)
 - Merge two maps through the collection's own bulk `merge` instead of adding the right map's entries one at a time with `conj`: 2.6x on two 32-entry maps (#2973)
 - Order `sort-by` natively with `array_multisort` when the keys are all native ints or all native strings and no comparator other than `compare` was given, instead of running a closure per comparison: 2.1x on int keys and 13.7x on string keys, which had no fast path at all. A position column keeps ties in input order (#2973)

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -474,12 +474,16 @@ Without arguments, uses a default cache size of 128 entries."
    (rest (tree-seq indexed? identity coll))))
 
 (defn- merge-with-2 [f left right]
-  (persistent
-   (for [[k v] :pairs right
-         :reduce [acc (transient left)]]
-     (if (contains? acc k)
-       (assoc! acc k (f (get acc k) v))
-       (assoc! acc k v)))))
+  ;; `foreach` and not `for … :pairs`, as the map rebuilders in #3140: the
+  ;; destructuring was most of the cost. Seeding from `left` is the merge
+  ;; itself, not an optimisation, so the metadata question that stopped
+  ;; `update-vals` seeding does not arise here.
+  (let [acc (transient left)]
+    (foreach [k v right]
+      (if (contains? acc k)
+        (.put acc k (f (get acc k) v))
+        (.put acc k v)))
+    (persistent acc)))
 
 (defn merge-with
   "Merges multiple maps into one new map. If a key appears in more than one collection, the result of `(f current-val next-val)` is used."
@@ -554,7 +558,9 @@ Without arguments, uses a default cache size of 128 entries."
   {:example "(map-invert {:a 1 :b 2}) ; => {1 :a, 2 :b}"
    :see-also ["update-keys" "update-vals" "select-keys"]}
   [m]
-  (persistent
-   (for [[k v] :pairs m
-         :reduce [acc (transient {})]]
-     (assoc! acc v k))))
+  ;; As above. Built from empty: the values become the keys, so there is
+  ;; nothing to seed from.
+  (let [acc (transient {})]
+    (foreach [k v m]
+      (.put acc v k))
+    (persistent acc)))

--- a/tests/phel/core/merge-with-map-invert.phel
+++ b/tests/phel/core/merge-with-map-invert.phel
@@ -1,0 +1,32 @@
+(ns phel-test.core.merge-with-map-invert
+  (:require phel.test :refer [deftest is]))
+
+;; `merge-with` and `map-invert` walk with `foreach` rather than
+;; `for … :pairs`, as the rebuilders in #3140. `merge-with` still seeds its
+;; transient from the left map, which is the merge itself rather than an
+;; optimisation; `map-invert` builds from empty, since the values become keys.
+
+(deftest test-merge-with
+  (is (= {:a 11, :b 2} (merge-with + {:a 1, :b 2} {:a 10})) "a shared key is combined")
+  (is (= {:a 1, :b 2} (merge-with + {:a 1} {:b 2})) "disjoint keys are not combined")
+  (is (= {:a 6} (merge-with + {:a 1} {:a 2} {:a 3})) "three maps fold left to right")
+  (is (= {:a 1} (merge-with + {:a 1})) "one map")
+  ;; `merge-with` answers `{}` with no maps, where `merge` answers nil.
+  (is (= {} (merge-with +)) "no maps gives an empty map, not nil")
+  (is (= {:a 1} (merge-with + {} {:a 1})) "an empty left")
+  (is (= {:a 1} (merge-with + {:a 1} {})) "an empty right")
+  ;; Argument order reaches the function as (left, right).
+  (is (= {:a "L-R"} (merge-with (fn [a b] (str a "-" b)) {:a "L"} {:a "R"}))
+      "the left value is the first argument")
+  (is (= [nil 1] (get (merge-with (fn [a b] [a b]) {:a nil} {:a 1}) :a))
+      "a nil left value still counts as present")
+  (is (= {:m 1} (meta (merge-with + (with-meta {:a 1} {:m 1}) {:b 2})))
+      "the left map's metadata is kept"))
+
+(deftest test-map-invert
+  (is (= {1 :a, 2 :b} (map-invert {:a 1, :b 2})) "keys and values swap")
+  (is (= {} (map-invert {})) "an empty map")
+  (is (= 1 (count (map-invert {:a 1, :b 1}))) "duplicate values collapse to one key")
+  (is (= :a (get (map-invert {:a nil}) nil)) "nil is usable as the new key")
+  (is (= {:a 1, :b 2} (map-invert (map-invert {:a 1, :b 2}))) "inverting twice round-trips")
+  (is (nil? (meta (map-invert (with-meta {:a 1} {:m 1})))) "the source metadata is not carried"))

--- a/tests/php/Benchmark/Phel/CoreSeqBench.php
+++ b/tests/php/Benchmark/Phel/CoreSeqBench.php
@@ -85,6 +85,12 @@ final class CoreSeqBench extends CoreBenchCase
     private $merge;
 
     /** @var callable */
+    private $mergeWith;
+
+    /** @var callable */
+    private $mapInvert;
+
+    /** @var callable */
     private $updateVals;
 
     /** @var callable */
@@ -757,6 +763,24 @@ final class CoreSeqBench extends CoreBenchCase
     }
 
     /**
+     * The last two map builders that walked with `for … :pairs`.
+     *
+     * @Revs(1000)
+     */
+    public function bench_merge_with(): void
+    {
+        ($this->mergeWith)($this->add, $this->bigMapA, $this->bigMapB);
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_map_invert(): void
+    {
+        ($this->mapInvert)($this->bigMapA);
+    }
+
+    /**
      * `partition-by` and `dedupe` return a sequence built by
      * `lazy-seq-from-generator`, so constructing one realizes a chunk before
      * the caller has asked for a single element. These two subjects measure
@@ -801,6 +825,8 @@ final class CoreSeqBench extends CoreBenchCase
         $this->transduce = $this->coreFn('transduce');
         $this->vec = $this->coreFn('vec');
         $this->merge = $this->coreFn('merge');
+        $this->mergeWith = $this->coreFn('merge-with');
+        $this->mapInvert = $this->coreFn('map-invert');
         $this->updateVals = $this->coreFn('update-vals');
         $this->updateKeys = $this->coreFn('update-keys');
         $this->renameKeys = $this->coreFn('rename-keys');


### PR DESCRIPTION
## 🤔 Background

#3140 found that `for [[k v] :pairs m ...]` costs most of what a map rebuilder costs, and that a plain `foreach` is nearly twice as fast. That is a *shape*, so I grepped for it rather than profiling again.

Two more in core: `merge-with-2` and `map-invert`. Neither had a benchmark subject.

## 🔖 Changes

Interleaved A/B, two alternating pairs:

| subject | main | this PR | |
|---|---|---|---|
| `bench_merge_with` | 151.84us, 149.36us | 69.53us, 69.88us | **2.16x** |
| `bench_map_invert` | 152.14us, 149.39us | 75.32us, 76.32us | **1.99x** |

Both subjects are new.

## On seeding

`merge-with` keeps seeding its transient from the left map. Unlike `update-vals` in #3140, that is not an optimisation to weigh against a metadata change: the result is *defined* as the left map plus the right one, so carrying the left map's metadata is what it already did and what it should do. A test pins it.

`map-invert` builds from empty. The values become the keys, so there is nothing to seed from.

## Verification

Diffed against `origin/main` over **20 cases**, including the ones where a rewrite could go wrong quietly:

- argument order reaching the combining function as `(left, right)`, checked with a non-commutative `(fn [a b] (str a "-" b))` rather than `+`
- a `nil` *value* on the left still counting as present, so the function runs rather than the right value simply replacing it
- duplicate values collapsing to one key under inversion
- `nil` as an inverted key
- metadata of both

Every row identical.

One of my test expectations was wrong and is corrected: `(merge-with +)` answers `{}`, where `(merge)` answers `nil`. Same on `main`.

Related to #2973
