### PR TITLE
perf(walk): rebuild collections without the pairs destructuring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Rebuild collections in `phel.walk` with `foreach` and a single vector construction rather than `for ... :pairs` and per-element appends: `keywordize-keys` 2.4x, `stringify-keys` 2.45x, `postwalk` 2.29x. Both run over a whole decoded tree, so the rebuild happens once per collection in it (#2973)
 - Walk with `foreach` rather than `for ... :pairs` in `merge-with` and `map-invert` too: 2.16x and 1.99x (#2973)
 - Walk the input with `foreach` rather than `for ... :pairs` in `update-vals`, `update-keys` and `rename-keys`, whose destructuring was most of what they cost: 1.9x, 1.9x and 1.76x (#2973)
 - Merge two maps through the collection's own bulk `merge` instead of adding the right map's entries one at a time with `conj`: 2.6x on two 32-entry maps (#2973)

--- a/src/phel/walk.phel
+++ b/src/phel/walk.phel
@@ -19,12 +19,19 @@
                                (conj! acc (inner x)))))
 
      (vector? form)
-     (persistent (for [x :in form :reduce [acc (transient [])]]
-                   (conj! acc (inner x))))
+     ;; Collected into a PHP array and built once, as `vec` is (#3134).
+     (let [arr (php/array)]
+       (foreach [x form]
+         (php/apush arr (inner x)))
+       (php/:: Phel (vector arr)))
 
      (or (map? form) (struct? form))
-     (persistent (for [[k v] :pairs form :reduce [acc (transient {})]]
-                   (assoc! acc (inner k) (inner v))))
+     ;; `foreach` and not `for … :pairs`: the destructuring was most of the
+     ;; cost (#3140). Built from empty because `inner` may rewrite the keys.
+     (let [acc (transient {})]
+       (foreach [k v form]
+         (.put acc (inner k) (inner v)))
+       (persistent acc))
 
      (set? form)
      (persistent (for [x :in form :reduce [acc (transient (hash-set))]]
@@ -78,9 +85,10 @@
        ;; Built through a transient for the same reason `walk` is: the pair
        ;; vector and `into`'s second walk are both avoidable, and this runs
        ;; once per map in the tree.
-       (persistent
-        (for [[k v] :pairs form :reduce [acc (transient {})]]
-          (assoc! acc (if (string? k) (keyword k) k) v)))
+       (let [acc (transient {})]
+         (foreach [k v form]
+           (.put acc (if (string? k) (keyword k) k) v))
+         (persistent acc))
        form))
    m))
 
@@ -96,8 +104,9 @@
        ;; Built through a transient for the same reason `walk` is: the pair
        ;; vector and `into`'s second walk are both avoidable, and this runs
        ;; once per map in the tree.
-       (persistent
-        (for [[k v] :pairs form :reduce [acc (transient {})]]
-          (assoc! acc (if (keyword? k) (name k) k) v)))
+       (let [acc (transient {})]
+         (foreach [k v form]
+           (.put acc (if (keyword? k) (name k) k) v))
+         (persistent acc))
        form))
    m))

--- a/tests/phel/walk-rebuild.phel
+++ b/tests/phel/walk-rebuild.phel
@@ -1,0 +1,40 @@
+(ns phel-test.walk-rebuild
+  (:require phel.test :refer [deftest is])
+  (:require phel.walk :as w))
+
+(defstruct pt [x y])
+
+;; `phel.walk` rebuilds each collection it visits. The map branches walk with
+;; `foreach` rather than `for … :pairs`, and the vector branch collects into a
+;; PHP array and builds once. Both are shape changes only; every traversal has
+;; to produce what it did.
+
+(deftest test-keywordize-keys
+  (is (= {:a 1, :b 2} (w/keywordize-keys {"a" 1, "b" 2})) "flat string keys")
+  (is (= {:a {:b {:c 1}}} (w/keywordize-keys {"a" {"b" {"c" 1}}})) "nested maps")
+  (is (= {:a [{:b 1}]} (w/keywordize-keys {"a" [{"b" 1}]})) "maps inside a vector")
+  (is (= {} (w/keywordize-keys {})) "an empty map")
+  (is (nil? (get (w/keywordize-keys {"a" nil}) :a)) "a nil value is carried")
+  ;; Only string keys convert; everything else is left alone.
+  (is (= 3 (count (w/keywordize-keys {"a" 1, :b 2, 3 :c}))) "non-string keys are untouched")
+  (is (= [1 2] (w/keywordize-keys [1 2])) "a non-map passes through"))
+
+(deftest test-stringify-keys
+  (is (= {"a" 1, "b" 2} (w/stringify-keys {:a 1, :b 2})) "flat keyword keys")
+  (is (= {"a" {"b" 1}} (w/stringify-keys {:a {:b 1}})) "nested maps")
+  (is (= {"a" {"b" 1}} (w/stringify-keys (w/keywordize-keys {"a" {"b" 1}}))) "round trips"))
+
+(deftest test-postwalk-and-prewalk-preserve-shape
+  (is (= {:a [1 {:b 2}]} (w/postwalk identity {:a [1 {:b 2}]})) "postwalk with identity")
+  (is (= {:a [1 {:b 2}]} (w/prewalk identity {:a [1 {:b 2}]})) "prewalk with identity")
+  (is (= {:a [2 3]} (w/postwalk (fn [x] (if (int? x) (inc x) x)) {:a [1 2]})) "a transform reaches leaves")
+  (is (= [1 [2 [3]]] (w/postwalk identity [1 [2 [3]]])) "nested vectors")
+  (is (= '(1 2 3) (w/postwalk identity '(1 2 3))) "a list")
+  (is (= 3 (count (w/postwalk identity (set [1 2 3])))) "a set")
+  (is (= 2 (count (w/postwalk identity (pt 1 2)))) "a struct"))
+
+(deftest test-values-that-a-rebuild-could-drop
+  (is (= [nil 1 nil] (w/postwalk identity [nil 1 nil])) "nil elements survive")
+  (is (= 3 (count (w/postwalk identity [nil 1 nil]))) "and are counted")
+  (is (= [false 0 ""] (w/postwalk identity [false 0 ""])) "falsy values survive")
+  (is (= {:a {:b {:c {:d [1 2]}}}} (w/postwalk identity {:a {:b {:c {:d [1 2]}}}})) "a deep tree"))

--- a/tests/php/Benchmark/Phel/StdlibWalkBench.php
+++ b/tests/php/Benchmark/Phel/StdlibWalkBench.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Phel;
+
+use Override;
+use Phel;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+
+/**
+ * `phel.walk`, which had no benchmark at all.
+ *
+ * `keywordize-keys` and `stringify-keys` are the interop-boundary pair: both
+ * run over decoded JSON or an HTTP payload, so they see a whole tree rather
+ * than one collection. `postwalk` with `identity` is the floor underneath
+ * them, the traversal with no transformation of its own.
+ *
+ * The fixture is deliberately a tree and not a flat map: the map rebuild these
+ * measure runs once per map in the structure, so a flat input would hide most
+ * of the cost.
+ *
+ * {@see CoreBenchCase} for the conventions every subject here follows.
+ *
+ * @BeforeMethods("setUp")
+ */
+final class StdlibWalkBench extends CoreBenchCase
+{
+    private const int WIDTH = 16;
+
+    /** @var callable */
+    private $keywordizeKeys;
+
+    /** @var callable */
+    private $stringifyKeys;
+
+    /** @var callable */
+    private $postwalk;
+
+    /** @var callable */
+    private $identity;
+
+    private mixed $stringKeyed = null;
+
+    private mixed $keywordKeyed = null;
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_keywordize_keys(): void
+    {
+        ($this->keywordizeKeys)($this->stringKeyed);
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_stringify_keys(): void
+    {
+        ($this->stringifyKeys)($this->keywordKeyed);
+    }
+
+    /**
+     * The traversal on its own, with nothing to rewrite.
+     *
+     * @Revs(1000)
+     */
+    public function bench_postwalk_identity(): void
+    {
+        ($this->postwalk)($this->identity, $this->stringKeyed);
+    }
+
+    #[Override]
+    protected function extraNamespaces(): array
+    {
+        return ['phel.walk'];
+    }
+
+    protected function setUpFixtures(): void
+    {
+        $this->keywordizeKeys = $this->phelFn('phel.walk', 'keywordize-keys');
+        $this->stringifyKeys = $this->phelFn('phel.walk', 'stringify-keys');
+        $this->postwalk = $this->phelFn('phel.walk', 'postwalk');
+        $this->identity = $this->coreFn('identity');
+
+        $inner = [];
+        for ($i = 0; $i < self::WIDTH; ++$i) {
+            $inner[] = 'k' . $i;
+            $inner[] = $i;
+        }
+
+        $rows = [];
+        for ($i = 0; $i < self::WIDTH; ++$i) {
+            $rows[] = Phel::map('x', $i, 'y', (string) $i);
+        }
+
+        $this->stringKeyed = Phel::map(
+            'a', Phel::map(...$inner),
+            'b', Phel::vector($rows),
+            'c', 'leaf',
+        );
+
+        $this->keywordKeyed = ($this->keywordizeKeys)($this->stringKeyed);
+    }
+}

--- a/tests/php/Benchmark/Phel/StdlibWalkBench.php
+++ b/tests/php/Benchmark/Phel/StdlibWalkBench.php
@@ -96,9 +96,12 @@ final class StdlibWalkBench extends CoreBenchCase
         }
 
         $this->stringKeyed = Phel::map(
-            'a', Phel::map(...$inner),
-            'b', Phel::vector($rows),
-            'c', 'leaf',
+            'a',
+            Phel::map(...$inner),
+            'b',
+            Phel::vector($rows),
+            'c',
+            'leaf',
         );
 
         $this->keywordKeyed = ($this->keywordizeKeys)($this->stringKeyed);


### PR DESCRIPTION
## 🤔 Background

Both shapes fixed in core are now exhausted there, so I grepped for them in the stdlib. `phel.walk` uses both, and it is the place where they matter most: it **rebuilds every collection it visits**, so the cost is once per collection in the tree rather than once per call.

- the map branches of `walk`, `keywordize-keys` and `stringify-keys` walked with `for [[k v] :pairs ...]`
- the vector branch of `walk` appended through a transient

`keywordize-keys` and `stringify-keys` sit on the interop boundary, so this is on the path of anything handling decoded JSON or an HTTP payload.

## 🔖 Changes

Interleaved A/B, two alternating pairs:

| subject | main | this PR | |
|---|---|---|---|
| `bench_keywordize_keys` | 522.54us, 520.85us | 216.35us, 215.56us | **2.4x** |
| `bench_stringify_keys` | 508.31us, 505.82us | 208.70us, 206.33us | **2.45x** |
| `bench_postwalk_identity` | 280.80us, 279.34us | 121.76us, 122.20us | **2.29x** |

`phel.walk` had no benchmark at all. `StdlibWalkBench` lands with the change, and `postwalk` with `identity` is included as the floor: the traversal with nothing to rewrite.

Its fixture is a **tree, not a flat map**, on purpose. A flat input exercises the rebuild once and would have hidden most of what these cost.

All three map branches build from empty, since all three rewrite keys.

## Verification

Diffed against `origin/main` over **23 cases**: flat and nested maps, maps inside vectors, mixed key types where only strings convert, sets, lists, structs, deep trees, nil and falsy elements, metadata, non-map inputs passing through, and a stringify/keywordize round trip. Every row identical.

## Note

The local quality gate passed before the new benchmark file, then failed on it. The `.php-cs-fixer.cache` was warm and did not see the new file; clearing it reproduced the failure immediately. Same trap as the rector cache earlier in this branch of work, and worth a second mention because both times the local gate was green while CI would not have been.

Related to #2973
