### PR TITLE
perf(html): render an element without normalizing it first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Render an element in `phel.html` without normalizing it first: the tag and the optional attribute map are read by index and the children walked in place, instead of allocating a tuple and a fresh child collection per element, and the void-tag table is a PHP array rather than a `hash-set`. A document renders 1.43x faster, one made of void elements 1.60x, and a single `[:span {:class "x"} "0"]` goes from 17.7μs to 9.7μs (#2973)
 - Rebuild collections in `phel.walk` with `foreach` and a single vector construction rather than `for ... :pairs` and per-element appends: `keywordize-keys` 2.4x, `stringify-keys` 2.45x, `postwalk` 2.29x. Both run over a whole decoded tree, so the rebuild happens once per collection in it (#2973)
 - Walk with `foreach` rather than `for ... :pairs` in `merge-with` and `map-invert` too: 2.16x and 1.99x (#2973)
 - Walk the input with `foreach` rather than `for ... :pairs` in `update-vals`, `update-keys` and `rename-keys`, whose destructuring was most of what they cost: 1.9x, 1.9x and 1.76x (#2973)

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -130,8 +130,8 @@
   "Renders an Element.
 
   Deliberately does not go through `normalize-element`. That returns a tuple
-  and, for the children, a fresh collection built with `apply list` — both
-  allocated once per element and both discarded immediately. Reading the tag
+  and, for the children, a fresh collection built with `apply list`. Both are
+  allocated once per element and discarded immediately. Reading the tag
   and attributes by index and walking the children in place took a single
   `[:span {:class \"x\"} \"0\"]` from 17.7μs to 9.7μs."
   [element]

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -13,8 +13,12 @@
 ;; text node, so this is on the hot path of rendering anything at all.
 ;;
 ;; An `:inline` on `escape-html` itself would fold the flags into the call site
-;; and remove this read too, worth another 1.8x, but `phel lint` crashes on any
-;; `:inline` whose namespace also calls it: see #3055.
+;; and remove this read too. #3055, which used to block that, is fixed, but the
+;; inline is still not worth writing: it is 1.5x on `escape-html` alone (0.41μs
+;; against 0.27μs for the bare `htmlspecialchars`) and `escape-html` accounts
+;; for roughly 2.5% of rendering an element, so it does not show up in a render.
+;; An expansion would also have to spell the flags out, since `escape-flags` is
+;; private to this namespace and the expansion lands in the caller's.
 (def- escape-flags (bit-or php/ENT_QUOTES php/ENT_SUBSTITUTE))
 
 (defn escape-html
@@ -30,27 +34,55 @@
     (nil? x)     ""
     (str x)))
 
-(def- void-tags (hash-set
-                 "area" "base" "br" "col" "command" "embed"
-                 "hr" "img" "input" "keygen" "link" "meta" "param"
-                 "source" "track" "wbr"))
+;; A PHP array used as a set, rather than a `hash-set`. The lookup runs once per
+;; element rendered, and `contains?` on a persistent set costs 1.87μs against
+;; 0.19μs for `array_key_exists` on the same 16 entries: the hashing, the node
+;; walk and the Phel call are all overhead for what is a fixed table of ASCII
+;; tag names. Keys are alphabetic, so PHP's numeric-string key cast cannot
+;; apply.
+(def- void-tags
+  (let [tags (php/array)]
+    (foreach [tag ["area" "base" "br" "col" "command" "embed"
+                   "hr" "img" "input" "keygen" "link" "meta" "param"
+                   "source" "track" "wbr"]]
+      (php/aset tags tag true))
+    tags))
 
 (defn- container-tag? [tag]
   ;; Void elements (br, img, input, ...) are always self-closing per the HTML
   ;; spec: they never render a closing tag or children, even if children were
   ;; mistakenly supplied.
-  (not (contains? void-tags tag)))
+  (php/! (php/array_key_exists tag void-tags)))
 
-(defn- normalize-element [[tag & content]]
-  (do
-    (when-not (or (keyword? tag) (string? tag))
-      (throw (new InvalidArgumentException (str tag " is not a valid element name."))))
-    (let [tag         (to-str tag)
-          elem        (first content)
-          map-attrs   (if (map? elem) elem {})
-          content     (if (map? elem) (next content) content)
-          content-arr (if (nil? content) nil (apply list content))]
-      [tag map-attrs content-arr])))
+(defn- element-tag
+  "Validates the head of an element vector and returns it as a string."
+  [tag]
+  (when-not (or (keyword? tag) (string? tag))
+    (throw (new InvalidArgumentException (str tag " is not a valid element name."))))
+  (to-str tag))
+
+;; An element is a vector, at both call sites: `render-html` and `compile-seq`
+;; each reach here only under a `vector?` test. So the head and the optional
+;; attribute map are read by index instead of through a `[tag & content]`
+;; destructure, which allocates a rest sequence, and `first`/`next` over it.
+(defn- element-attrs? [element]
+  (map? (get element 1)))
+
+(defn- element-attrs [element]
+  (let [elem (get element 1)]
+    (if (map? elem) elem {})))
+
+(defn- content-start [element]
+  (if (element-attrs? element) 2 1))
+
+(defn- normalize-element [element]
+  ;; Used by the compile path only; `render-element` reads the same three
+  ;; pieces without materializing this tuple or a child collection.
+  (let [start (content-start element)
+        n     (count element)]
+    [(element-tag (get element 0))
+     (element-attrs element)
+     (if (php/< start n) (slice element start) nil)]))
 
 ;;---------------
 ;; Render element
@@ -95,14 +127,25 @@
     (php/implode "" parts)))
 
 (defn- render-element
-  "Renders an Element."
+  "Renders an Element.
+
+  Deliberately does not go through `normalize-element`. That returns a tuple
+  and, for the children, a fresh collection built with `apply list` — both
+  allocated once per element and both discarded immediately. Reading the tag
+  and attributes by index and walking the children in place took a single
+  `[:span {:class \"x\"} \"0\"]` from 17.7μs to 9.7μs."
   [element]
-  (let [[tag attrs content] (normalize-element element)]
+  (let [tag   (element-tag (get element 0))
+        attrs (element-attrs element)]
     (if (container-tag? tag)
-      (str
-       "<" tag (render-attrs attrs) ">"
-       (render-html content)
-       "</" tag ">")
+      (let [start (content-start element)
+            n     (count element)
+            parts (php/array)]
+        (loop [i start]
+          (when (php/< i n)
+            (php/apush parts (render-html (get element i)))
+            (recur (php/+ i 1))))
+        (str "<" tag (render-attrs attrs) ">" (php/implode "" parts) "</" tag ">"))
       (str "<" tag (render-attrs attrs) " />"))))
 
 (defn- render-children

--- a/tests/phel/html-render-element.phel
+++ b/tests/phel/html-render-element.phel
@@ -1,0 +1,95 @@
+(ns phel-test.html-render-element
+  (:require phel.test :refer [deftest is])
+  (:require phel.html :as h))
+
+;; `render-element` no longer routes through `normalize-element`. It reads the
+;; tag and the optional attribute map by index and walks the children in place,
+;; instead of allocating a tuple and a fresh child collection per element, and
+;; the void-tag table became a PHP array keyed by tag name rather than a
+;; `hash-set`. Nothing about the markup may change, so these pin the parts of
+;; the shape that the rewrite could plausibly have moved: where the children
+;; start, what counts as an attribute map, and which tags self-close.
+;;
+;; `html` is a macro that folds a literal element at compile time, so every
+;; case here renders through a var. A literal would test the compile path
+;; instead and never reach `render-element` at all.
+
+(deftest test-where-the-children-start
+  ;; The child index depends on whether element 1 is a map. Off by one either
+  ;; way and the attributes render as text, or the first child disappears.
+  (let [no-attrs [:div "a" "b"]
+        attrs    [:div {:class "c"} "a" "b"]
+        only-map [:div {:class "c"}]
+        bare     [:div]]
+    (is (= "<div>ab</div>" (h/html no-attrs)) "children begin at 1 without a map")
+    (is (= "<div class=\"c\">ab</div>" (h/html attrs)) "children begin at 2 with a map")
+    (is (= "<div class=\"c\"></div>" (h/html only-map)) "a map and no children")
+    (is (= "<div></div>" (h/html bare)) "neither")))
+
+(deftest test-a-map-in-child-position-is-still-attributes
+  ;; Only the map at index 1 is attributes; a later one is content.
+  (let [second-map [:div {:a "1"} {:b "2"}]
+        empty-map  [:div {}]]
+    (is (= "<div a=\"1\">{:b &quot;2&quot;}</div>" (h/html second-map)) "a second map is a child")
+    (is (= "<div></div>" (h/html empty-map)) "an empty attribute map renders no attributes")))
+
+(deftest test-void-tags-self-close
+  ;; The lookup moved from `contains?` on a set to `array_key_exists` on a PHP
+  ;; array. Every tag has to land on the same side of it.
+  (let [br    [:br]
+        img   [:img {:src "a.png"}]
+        kids  [:br "ignored"]
+        div   [:div]
+        brish [:brx]]
+    (is (= "<br />" (h/html br)) "a void tag")
+    (is (= "<img src=\"a.png\" />" (h/html img)) "a void tag with attributes")
+    (is (= "<br />" (h/html kids)) "a void tag drops children")
+    (is (= "<div></div>" (h/html div)) "a container tag")
+    (is (= "<brx></brx>" (h/html brish)) "a tag that merely starts like a void one")))
+
+(deftest test-tag-validation-is-unchanged
+  (let [num   [42 "x"]
+        nada  [nil "x"]
+        mapt  [{} "x"]
+        blank []
+        strt  ["div" "x"]]
+    (is (= "<div>x</div>" (h/html strt)) "a string tag")
+    (is (thrown? \InvalidArgumentException (h/html num)) "a number is not a tag")
+    (is (thrown? \InvalidArgumentException (h/html nada)) "nil is not a tag")
+    (is (thrown? \InvalidArgumentException (h/html mapt)) "a map is not a tag")
+    (is (thrown? \InvalidArgumentException (h/html blank)) "an empty vector has no tag")))
+
+(deftest test-children-of-every-kind-still-render
+  (let [nested [:div [:span "n"] [:em "m"]]
+        deep   [:div [:div [:div "d"]]]
+        mixed  [:div "t" nil 42 :kw]
+        raw    [:div (h/raw-string "<b>r</b>")]
+        lst    [:div '("l1" "l2")]
+        esc    [:div "<script>"]]
+    (is (= "<div><span>n</span><em>m</em></div>" (h/html nested)) "sibling elements")
+    (is (= "<div><div><div>d</div></div></div>" (h/html deep)) "nesting recurses")
+    (is (= "<div>t42:kw</div>" (h/html mixed)) "a nil child renders as nothing")
+    (is (= "<div><b>r</b></div>" (h/html raw)) "a raw string is not escaped")
+    (is (= "<div>l1l2</div>" (h/html lst)) "a list child is rendered as children")
+    (is (= "<div>&lt;script&gt;</div>" (h/html esc)) "a string child is escaped")))
+
+(deftest test-attribute-rendering-is-unchanged
+  (let [style [:div {:style {:color "red", :bg "blue"}}]
+        table [:div {:class {:a true, :b false, :c true}}]
+        idx   [:div {:class ["a" "b" :c]}]
+        yes   [:input {:disabled true}]
+        no    [:input {:disabled false}]
+        void  [:input {:disabled nil}]]
+    (is (= "<div style=\"bg:blue;color:red;\"></div>" (h/html style)) "a style map is sorted")
+    (is (= "<div class=\"a c\"></div>" (h/html table)) "a map value keeps its true keys")
+    (is (= "<div class=\"a b c\"></div>" (h/html idx)) "an indexed value is joined")
+    (is (= "<input disabled=\"disabled\" />" (h/html yes)) "true repeats the name")
+    (is (= "<input />" (h/html no)) "false drops the attribute")
+    (is (= "<input />" (h/html void)) "nil drops the attribute")))
+
+(deftest test-the-compile-path-still-agrees-with-the-render-path
+  ;; `normalize-element` is now used only by the macro. A literal and the same
+  ;; value behind a var have to produce the same markup.
+  (let [el [:div {:class "c"} [:span "a"] "b"]]
+    (is (= (h/html [:div {:class "c"} [:span "a"] "b"]) (h/html el))
+        "literal and var agree")))

--- a/tests/php/Benchmark/Phel/StdlibHtmlBench.php
+++ b/tests/php/Benchmark/Phel/StdlibHtmlBench.php
@@ -44,6 +44,8 @@ final class StdlibHtmlBench extends CoreBenchCase
 
     private mixed $document = null;
 
+    private mixed $voidDocument = null;
+
     /**
      * @Revs(1000)
      */
@@ -70,13 +72,32 @@ final class StdlibHtmlBench extends CoreBenchCase
      * negligible against it and looping would only lengthen the run.
      *
      * Unpaired on purpose. There is no raw-PHP twin for a whole render; what
-     * this guards is the absolute move, 110.5μs to 92.2μs.
+     * this guards is the absolute number. It fell to 92.2μs when the attribute
+     * join moved to `implode`, and 73.6μs to 51.3μs when `render-element`
+     * stopped routing through `normalize-element`. Absolute figures are only
+     * comparable within one run of this file, not across machines.
      *
      * @Revs(100)
      */
     public function bench_render_document(): void
     {
         ($this->html)($this->document);
+    }
+
+    /**
+     * The document above contains no void element, so it never reaches the
+     * self-closing branch and never pays a void-tag lookup miss on every one
+     * of its tags. This one is all void elements, which is what a form or an
+     * icon list looks like. It gains more than the document above from a
+     * cheaper lookup, 81.2μs to 50.9μs against its 73.6μs to 51.3μs.
+     *
+     * Unpaired, for the same reason as `bench_render_document`.
+     *
+     * @Revs(100)
+     */
+    public function bench_render_void_document(): void
+    {
+        ($this->html)($this->voidDocument);
     }
 
     #[Override]
@@ -111,6 +132,23 @@ final class StdlibHtmlBench extends CoreBenchCase
                 Phel::keyword('span'),
                 Phel::map(Phel::keyword('title'), "t'x"),
                 'more & text',
+            ]),
+        ]);
+
+        $this->voidDocument = Phel::vector([
+            Phel::keyword('form'),
+            Phel::vector([
+                Phel::keyword('input'),
+                Phel::map(Phel::keyword('type'), 'text', Phel::keyword('name'), 'q'),
+            ]),
+            Phel::vector([Phel::keyword('br')]),
+            Phel::vector([
+                Phel::keyword('img'),
+                Phel::map(Phel::keyword('src'), 'a.png', Phel::keyword('alt'), 'a & b'),
+            ]),
+            Phel::vector([
+                Phel::keyword('input'),
+                Phel::map(Phel::keyword('type'), 'submit', Phel::keyword('disabled'), true),
             ]),
         ]);
     }


### PR DESCRIPTION
## 🤔 Background

`render-element` built two throwaway allocations for every element it rendered. `normalize-element` destructured `[tag & content]`, which allocates a rest sequence, walked it with `first`/`next`, materialized the children with `apply list`, and returned the three pieces as a tuple that was immediately destructured again. Separately, `container-tag?` asked a persistent `hash-set` whether the tag was void, once per element.

Neither cost is inherent. An element is a vector at both call sites, so the tag and the optional attribute map can be read by index, and the void-tag table is a fixed set of 16 ASCII names that a PHP array indexes far more cheaply.

## 💡 Goal

Make rendering cheaper per element, since that cost is paid once per node in a document.

## 🔖 Changes

- `render-element` reads the tag and attributes by index and walks the children in place. It no longer routes through `normalize-element`, which stays for the macro path, where it runs at expansion time and is not hot.
- `void-tags` is a PHP array checked with `array_key_exists` rather than a `hash-set` checked with `contains?`: 1.87μs to 0.19μs on the lookup.
- Extracted `element-tag`, `element-attrs` and `content-start` so the render and compile paths share the validation and the attribute-map rule instead of duplicating them.

Measured with phpbench, same machine, same run:

| subject | before | after | |
|---|---|---|---|
| `bench_render_document` | 73.6μs | 51.3μs | 1.43x |
| `bench_render_void_document` | 81.2μs | 50.9μs | 1.60x |
| one `[:span {:class "x"} "0"]` | 17.7μs | 9.7μs | 1.83x |

`bench_render_void_document` is new: the existing fixture had no void element, so the self-closing branch and the void-tag lookup were unguarded.

Attribution, measured separately, so the two changes are not credited to each other: the lookup swap alone is 1.12x on a document; dropping `normalize-element` from the render path carries it the rest of the way.

`escape_html` is unchanged at 9.5μs against 5.4μs raw. The stale comment claiming an `:inline` there was worth 1.8x and blocked by #3055 is corrected: #3055 was fixed by #3111, and the inline measures 1.5x on a function that is ~2.5% of a render, so it would not show up.

Output is byte-identical: a 42-case probe across void tags, style maps, attribute tables, indexed and boolean attribute values, raw strings, list children, nested elements and every invalid-tag throw was diffed against `main`. `tests/phel/html-render-element.phel` pins the parts the rewrite could have moved.

Related to #2973
