### PR TITLE
fix(tests): select the PHPUnit rector set from the installed version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `rector.php` selects its PHPUnit rule set with `PHPUnitSetList::COMPOSER_BASED` instead of the pinned `PHPUNIT_100`. The pinned constant is absent from some `rector-phpunit` builds, where it aborted `composer test-quality` with a fatal `Undefined constant` rather than a findable error, and it applied the PHPUnit 10 migration rules to a repository that requires PHPUnit 11 or newer. A unit test now asserts every set constant named in `rector.php` exists (#3133)
 - Drop `log2` from the compiler's `php/*` return-type table. PHP has no `log2` function (it has `log10`, and `log($x, 2)`), so the entry described a call that could never succeed (#2712)
 - `phel.html` renders a `raw-string` holding a non-string with Phel's spelling again. The runtime render joins children with `php/implode`, which casts with PHP's rules, so `(raw-string true)` came out as `1` instead of `true`, `(raw-string false)` as the empty string instead of `false`, and `(raw-string 0.0)` as `0` instead of `0.0`. A regression from the `implode` change in #3099; only the runtime path was affected, not a literal folded by the `html` macro (#3099)
 - Stop the `-O2` call inliner relocating an argument that contains a PHP interop call. Such a call may write through a by-reference parameter, and the closure the inlined body can end up in captures call-site locals by value, so the write was lost: `phel.http/uri-from-string` silently mis-parsed an IPv6 URI (#3126)

--- a/rector.php
+++ b/rector.php
@@ -84,6 +84,15 @@ return RectorConfig::configure()
         SetList::INSTANCEOF,
         LevelSetList::UP_TO_PHP_84,
         PHPUnitSetList::PHPUNIT_CODE_QUALITY,
-        PHPUnitSetList::PHPUNIT_100,
+        // `COMPOSER_BASED`, not a pinned `PHPUNIT_<version>` set. Two reasons.
+        // It reads the PHPUnit version out of `composer.json`, so the set
+        // always matches what the suite actually runs: this was pinned to
+        // `PHPUNIT_100` while the repo requires `^11.0|^12.0|^13.0` and runs
+        // PHPUnit 13, applying the PHPUnit 10 migration rules to a codebase
+        // six majors past them. And the versioned constants are not stable
+        // across `rector-phpunit` releases, so a contributor whose install
+        // resolves a build without them cannot run `composer test-quality` at
+        // all (#3133).
+        PHPUnitSetList::COMPOSER_BASED,
     ])
     ->withImportNames(removeUnusedImports: true);

--- a/tests/php/Unit/Architecture/RectorSetListConstantsTest.php
+++ b/tests/php/Unit/Architecture/RectorSetListConstantsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Architecture;
+
+use PHPUnit\Framework\TestCase;
+
+use function defined;
+use function end;
+use function explode;
+use function file_get_contents;
+use function preg_match_all;
+use function sprintf;
+use function str_contains;
+
+/**
+ * Every `*SetList::CONSTANT` named in `rector.php` has to exist in the
+ * installed Rector.
+ *
+ * Rector removes set constants between minor releases, and `rector.php` names
+ * them as PHP constants, so a removed one is a fatal `Undefined constant` that
+ * takes down the whole `composer test-quality` run rather than reporting a
+ * findable error. It has happened twice: `SetList::STRICT_BOOLEANS` vanished in
+ * Rector 2.6, and `PHPUnitSetList::PHPUNIT_100` is absent from some
+ * `rector-phpunit` builds, which is #3133.
+ *
+ * A unit test catches it as a named failure on the machine that has the
+ * offending version, instead of as a stack trace from a quality tool.
+ */
+final class RectorSetListConstantsTest extends TestCase
+{
+    private const string CONFIG = __DIR__ . '/../../../../rector.php';
+
+    public function test_every_set_list_constant_named_in_rector_config_exists(): void
+    {
+        $source = (string) file_get_contents(self::CONFIG);
+
+        $imports = $this->importedClassesByShortName($source);
+
+        preg_match_all('/\b(\w*SetList)::(\w+)\b/', $source, $matches, PREG_SET_ORDER);
+        self::assertNotEmpty($matches, 'No set list constants found in rector.php; has the config moved?');
+
+        foreach ($matches as [$reference, $shortName, $constant]) {
+            self::assertArrayHasKey(
+                $shortName,
+                $imports,
+                sprintf('%s is used in rector.php but not imported', $shortName),
+            );
+
+            self::assertTrue(
+                defined($imports[$shortName] . '::' . $constant),
+                sprintf(
+                    '%s does not exist in the installed Rector. A removed set constant is a fatal error '
+                    . 'that aborts `composer test-quality`, so it has to be replaced, not left in place.',
+                    $reference,
+                ),
+            );
+        }
+    }
+
+    /**
+     * Short class name to fully qualified name, for the `use` statements the
+     * config declares. Only these can appear as `Foo::BAR` in the file.
+     *
+     * @return array<string, string>
+     */
+    private function importedClassesByShortName(string $source): array
+    {
+        preg_match_all('/^use ([^;]+);$/m', $source, $useMatches);
+
+        $imports = [];
+        foreach ($useMatches[1] as $fqn) {
+            if (str_contains($fqn, ' as ')) {
+                continue;
+            }
+
+            $parts = explode('\\', $fqn);
+            $imports[end($parts)] = $fqn;
+        }
+
+        return $imports;
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`composer test-quality` aborts for some contributors with a fatal `Undefined constant Rector\PHPUnit\Set\PHPUnitSetList::PHPUNIT_100`, taking the whole quality run down rather than reporting a findable error.

Worth correcting the diagnosis in the issue: the constant has **not** been removed from Rector 2.6.1. This repo pins Rector 2.6.1 and `PHPUNIT_100` is present here, alongside `PHPUNIT_40` through `PHPUNIT_130`. The reporter's constant list contains only the five unversioned sets, so their install resolved a `rector-phpunit` build without the versioned ones. The pin is still wrong, just not for the stated reason.

The version-independent problem is more interesting: the set was pinned to `PHPUNIT_100`, the PHPUnit **10** migration set, while `composer.json` requires `^11.0|^12.0|^13.0` and the suite runs PHPUnit 13. The repository has been applying migration rules six majors behind itself.

## 💡 Goal

Stop naming a PHPUnit version in the Rector config, and make a stale set constant fail as a test rather than as a crashed tool.

## 🔖 Changes

- `PHPUnitSetList::PHPUNIT_100` becomes `PHPUnitSetList::COMPOSER_BASED`, which reads the PHPUnit version from `composer.json` and loads the matching rules. `COMPOSER_BASED` is present in both constant lists, the reporter's and this one, so it resolves the crash as well as the staleness.
- New `RectorSetListConstantsTest`: every `*SetList::CONSTANT` named in `rector.php` must exist in the installed Rector.

`COMPOSER_BASED` is not a quieter set. It pulled in the PHPUnit 11 and 12 rule groups and immediately flagged a static method in the new test, which is applied here. `composer test` is green.

## ✅ On the new test

This is the second time a Rector set constant has gone stale in this config: `SetList::STRICT_BOOLEANS` vanished in Rector 2.6 and its removal is still commented in `rector.php`. Because the config names sets as PHP constants, a removed one is a fatal error during a quality run, not a diagnostic. The test turns that into a named failure on whichever machine has the offending version.

Verified it is not vacuous: it makes 21 assertions on the current config, still passes when `PHPUNIT_100` is restored (it exists here), and fails with `PHPUnitSetList::PHPUNIT_999 does not exist in the installed Rector` when given a bogus one.

The mandatory refactor pass surfaced no changes beyond the Rector fix already applied above, so there is no separate `ref` commit.

Closes #3133
