### PR TITLE
perf(core): write into's set and map targets through the transient methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ All notable changes to this project will be documented in this file.
 
 Compiler:
 
+- Write `into`'s set and map targets through `.add` and `.put` on the transient they already build, rather than `conj` and `assoc`. `bench_into_set` 1.23x, `bench_into_map` 1.14x; the map target gains less because a HAMT insertion dominates what is left (#2973)
 - Build `flatten` from a PHP generator instead of `(filter (complement indexed?) (rest (tree-seq indexed? identity coll)))`. `tree-seq` is eager and materialised every node, branches included, into a transient vector, so `flatten` walked the whole tree at construction despite handing back a lazy sequence. Constructing one is now 38.0μs to 0.63μs, `(take 3 (flatten ...))` 47.6μs to 7.5μs, and realizing 64 leaves 120.5μs to 69.3μs (#2973)
 - Apply the remaining single-use lowerings to any typed target: `reduce` over a vector 1.93x, `get-in` 2.79x, plus `dissoc` with literal keys, the named accessors (`name`/`namespace`), the numeric type predicates and the `php/array` and string gates. Only three lowerings still require a bare variable, and each emits its target more than once: `last` (three times), `second` and `contains?` (twice) (#3042)
 - Apply the `get`, `empty?` and `assoc`/`conj`/`dissoc` lowerings to any target the emitter can type as well, on the same rule: each emits its target once. `(get (mkmap) :a)` 1.78x, `(empty? (mkvec))` 1.47x, `(assoc (mkmap) :c 3)` 1.41x. `contains?` is deliberately excluded, emitting its target twice (#3042)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -125,6 +125,20 @@
     (for [entry :pairs from] entry)
     from))
 
+(defn- put-into-entry
+  "`assoc-into-entry` for a transient map target, writing with `.put`.
+
+  Kept beside it rather than folded in: the generic helper also serves a raw
+  PHP array and a persistent `map-into-target?`, neither of which has `.put`."
+  [acc entry]
+  (if (not (indexed? entry))
+    (throw (new InvalidArgumentException
+                "into expects a collection of [key value] pairs"))
+    (if (php/!= (count entry) 2)
+      (throw (new InvalidArgumentException
+                  "into expects a collection of [key value] pairs"))
+      (.put acc (first entry) (second entry)))))
+
 (defn- assoc-into-entry
   [acc entry]
   (if (not (indexed? entry))
@@ -173,17 +187,23 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
              (php/apush arr value))
            (copy-meta to (Phel/vector arr)))
 
+         ;; `.add` and `.put` straight onto the transient, as `frequencies`,
+         ;; `group-by`, `select-keys`, `invert` and `set` already do (#3149,
+         ;; #3150): `conj` and `assoc` dispatch on the target before reaching
+         ;; the same methods, once per element. The set target gains 80.6μs to
+         ;; 59.8μs over 32 elements; the map target only 99.6μs to 93.0μs,
+         ;; because a HAMT insertion dominates what is left.
          (set? to)
-         (persistent
-          (for [value :in entries
-                :reduce [acc (transient to)]]
-            (conj acc value)))
+         (let [acc (transient to)]
+           (foreach [value entries]
+             (.add acc value))
+           (persistent acc))
 
          (map? to)
-         (persistent
-          (for [entry :in entries
-                :reduce [acc (transient to)]]
-            (assoc-into-entry acc entry)))
+         (let [acc (transient to)]
+           (foreach [entry entries]
+             (put-into-entry acc entry))
+           (persistent acc))
 
          (map-into-target? to)
          (for [entry :in entries
@@ -196,9 +216,10 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
            (conj acc value))
 
          (transient-set? to)
-         (for [value :in entries
-               :reduce [acc to]]
-           (conj acc value))
+         (do
+           (foreach [value entries]
+             (.add to value))
+           to)
 
          (php/instanceof to PushInterface)
          (for [value :in entries

--- a/tests/phel/core/into-transient-methods.phel
+++ b/tests/phel/core/into-transient-methods.phel
@@ -1,0 +1,63 @@
+(ns phel-test.core.into-transient-methods
+  (:require phel.test :refer [deftest is]))
+
+;; `into`'s set and map targets write through `.add` and `.put` on the
+;; transient they already build, rather than `conj` and `assoc`, which dispatch
+;; on the target first. Same change as #3149 and #3150.
+;;
+;; The pair validation is what could drift: a map target still has to reject
+;; anything that is not a two-element indexed entry, with the same message, and
+;; the other target kinds still take the generic path.
+
+(deftest test-a-map-target
+  (is (= {1 2} (into {} [[1 2]])) "one pair")
+  (is (= {1 2, 3 4} (into {} [[1 2] [3 4]])) "two pairs")
+  (is (= {} (into {} [])) "nothing to add")
+  (is (= {:z 9, 1 2} (into {:z 9} [[1 2]])) "the target is seeded from")
+  (is (= {1 2} (into {} '([1 2]))) "a list of pairs")
+  (is (= {:a 1} (into {} {:a 1})) "a map source is a sequence of pairs"))
+
+(deftest test-map-entries-with-falsy-parts
+  (is (= 1 (get (into {} [[nil 1]]) nil)) "a nil key")
+  (is (= 1 (get (into {} [[false 1]]) false)) "a false key")
+  (is (nil? (get (into {} [[1 nil]]) 1)) "a nil value")
+  (is (true? (contains? (into {} [[1 nil]]) 1)) "and the key is really present")
+  (is (= {0 0} (into {} [[0 0]])) "zero on both sides"))
+
+(deftest test-a-map-target-rejects-a-non-pair
+  (is (thrown? \InvalidArgumentException (into {} [1 2])) "a bare value is not a pair")
+  (is (thrown? \InvalidArgumentException (into {} [[1 2 3]])) "three elements is not a pair")
+  (is (thrown? \InvalidArgumentException (into {} [[1]])) "one element is not a pair"))
+
+(deftest test-a-set-target
+  (is (= #{1 2} (into (set []) [1 2])) "two elements")
+  (is (= #{1 2} (into (set []) [1 1 2])) "duplicates collapse")
+  (is (= #{} (into (set []) [])) "nothing to add")
+  (is (= #{9 1} (into (set [9]) [1])) "the target is seeded from")
+  (is (= 1 (count (into (set []) [nil nil]))) "nil is one element")
+  (is (= 2 (count (into (set []) [false true]))) "false and true are distinct")
+  (is (= 2 (count (into (set []) "ab"))) "a string source"))
+
+(deftest test-the-other-targets-still-work
+  (is (= [1 2] (into [] [1 2])) "a vector target")
+  (is (= [1 2 3] (into [1] [2 3])) "a seeded vector target")
+  (is (= [1 2] (persistent (into (transient []) [1 2]))) "a transient vector target")
+  (is (= #{1 2} (persistent (into (transient (set [])) [1 2 1]))) "a transient set target")
+  (is (= {} (into {} nil)) "a nil source returns the target"))
+
+(deftest test-metadata-and-type-are-unchanged
+  (is (= {:m 1} (meta (into (with-meta {} {:m 1}) [[1 2]]))) "a map target keeps its metadata")
+  (is (= {:m 1} (meta (into (with-meta (set []) {:m 1}) [1]))) "a set target keeps its metadata")
+  (is (= :set (type (into (set []) [1]))) "a set target stays a set")
+  (is (= :hash-map (type (into {} [[1 2]]))) "a map target stays a map")
+  ;; Pre-existing and unchanged by this: a sorted map's transient is a hash
+  ;; map, so `into` degrades it. Recorded rather than asserted as desirable.
+  (is (= :hash-map (type (into (sorted-map) [[1 2]]))) "a sorted map target degrades to a hash map"))
+
+(deftest test-the-transients-do-not-escape
+  (let [m (into {} [[1 2]])
+        s (into (set []) [1])]
+    (is (= {1 2, 3 4} (assoc m 3 4)) "the map can be assoc'd onto")
+    (is (= {1 2} m) "and is unchanged")
+    (is (= #{1 2} (conj s 2)) "the set can be conj'd onto")
+    (is (= #{1} s) "and is unchanged")))

--- a/tests/php/Benchmark/Phel/CoreSeqBench.php
+++ b/tests/php/Benchmark/Phel/CoreSeqBench.php
@@ -172,6 +172,8 @@ final class CoreSeqBench extends CoreBenchCase
     /** @var callable */
     private $reductions;
 
+    private mixed $emptySet = null;
+
     /** @var callable */
     private $invert;
 
@@ -641,6 +643,19 @@ final class CoreSeqBench extends CoreBenchCase
     }
 
     /**
+     * The set target, which the map subject above does not reach: it writes
+     * through `.add` on a transient set rather than `.put` on a transient map,
+     * and gains more, 80.6μs to 59.8μs in-language, because a hash-set
+     * insertion leaves more room than a HAMT one.
+     *
+     * @Revs(1000)
+     */
+    public function bench_into_set(): void
+    {
+        ($this->into)($this->emptySet, $this->ints);
+    }
+
+    /**
      * @Revs(1000)
      */
     public function bench_into_map(): void
@@ -933,6 +948,7 @@ final class CoreSeqBench extends CoreBenchCase
         $this->frequencies = $this->coreFn('frequencies');
         $this->groupBy = $this->coreFn('group-by');
         $this->reductions = $this->coreFn('reductions');
+        $this->emptySet = ($this->coreFn('set'))(Phel::vector([]));
         $this->invert = $this->coreFn('invert');
         $this->selectKeys = $this->coreFn('select-keys');
         $this->setFn = $this->coreFn('set');


### PR DESCRIPTION
## 🤔 Background

`into`'s set and map targets already build a transient, but wrote to it with `conj` and `assoc`, each of which dispatches on the target's type before arriving at the very method the code was going to use. Same shape #3149 and #3150 fixed in `frequencies`, `group-by`, `select-keys`, `invert` and `set`; `into` was the one left.

## 🔖 Changes

- The set target walks with `foreach` and writes with `.add`; the transient-set target does the same.
- The map target writes with `.put`, through a `put-into-entry` helper kept beside the existing `assoc-into-entry`. They are not folded together: the generic one also serves a raw PHP array and a persistent `map-into-target?`, neither of which has `.put`.

| subject | before | after | |
|---|---|---|---|
| `bench_into_set` | 85.1μs | 69.0μs | 1.23x |
| `bench_into_map` | 110.7μs | 97.3μs | 1.14x |
| `bench_into_vector` | 7.76μs | 7.57μs | untouched, unchanged |

`bench_into_set` is new; only the map and vector targets had subjects.

Reported plainly: **the map target gains least of any of these conversions**, because a HAMT insertion dominates what is left. It is included for consistency rather than for its number. Leaving one branch of the same `cond` converted and its neighbour not is exactly the drift that left `invert` at twice the cost of `map-invert` until #3150.

## ✅ Checking

`composer test` green (8925 core assertions). **clojure-test-suite at its pinned SHA against this branch: 5591 passed, 0 failed.** A 31-case probe over both targets, seeded and empty, falsy keys and values, every source shape and each rejection case was diffed against `main` and is identical.

The pair validation is what could have drifted, so the tests pin that a map target still rejects a bare value, a three-element entry and a one-element entry, each with the same exception.

One thing recorded rather than changed: `(into (sorted-map) [[1 2]])` returns a `:hash-map`, because a sorted map's transient is a hash map. That is pre-existing, identical on `main`, and now has a test saying so.

Related to #2973
