### PR TITLE
fix(core): keep metadata on the collection flatten was given

### DIFF
--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -482,12 +482,17 @@ Without arguments, uses a default cache size of 128 entries."
   ;; is eager and materialises every node (branches included) into a transient
   ;; vector, then filtered that through a `complement` closure allocated per
   ;; call. So it walked the whole tree at construction despite handing back a
-  ;; lazy sequence. The generator yields leaves on demand. 121.3μs to 24.8μs
+  ;; lazy sequence. The generator yields leaves on demand. 120.5μs to 69.3μs
   ;; over 64 leaves.
-  (LazySeq/fromGenerator
-   (new Hasher)
-   (new Equalizer)
-   (Seq/flatten coll)))
+  ;;
+  ;; `copy-meta` because the old spelling went through `filter`, which carries
+  ;; it, and every other generator-backed seq fn does the same.
+  (copy-meta
+   coll
+   (LazySeq/fromGenerator
+    (new Hasher)
+    (new Equalizer)
+    (Seq/flatten coll))))
 
 (defn- merge-with-2 [f left right]
   ;; `foreach` and not `for … :pairs`, as the map rebuilders in #3140: the

--- a/tests/phel/core/flatten-generator.phel
+++ b/tests/phel/core/flatten-generator.phel
@@ -41,12 +41,20 @@
 (deftest test-it-is-lazy-now-rather-than-only-in-appearance
   ;; `tree-seq` ran the whole walk at construction. A generator does not, so
   ;; only what is pulled is computed.
-  (let [visits (atom 0)
+  (let [visits  (atom 0)
         counted (fn [x] (do (swap! visits inc) x))]
     (let [s (flatten [[1 2] [3 4]])]
       (is (= 0 (deref visits)) "nothing is pulled before it is asked for")
       (is (= [1 2] (vec (take 2 s))) "taking two elements works")))
   (is (= [1 2 3 4] (vec (flatten [[1 2] [3 4]]))) "and taking all of them still works"))
+
+(deftest test-metadata-on-the-input-survives
+  ;; The old spelling went through `filter`, which copies it, so dropping it
+  ;; here would be a silent regression. Every other generator-backed seq
+  ;; function copies it too.
+  (is (= {:tag :foo} (meta (flatten (with-meta [[1 2] 3] {:tag :foo})))) "a nested input")
+  (is (= {:tag :foo} (meta (flatten (with-meta [1 2] {:tag :foo})))) "an already flat input")
+  (is (nil? (meta (flatten [[1 2] 3]))) "and nothing is invented when there is none"))
 
 (deftest test-the-result-is-an-ordinary-sequence
   (let [s (flatten [[1 2] [3]])]


### PR DESCRIPTION
## 🤔 Background

#3163 rebuilt `flatten` on a PHP generator. The body it replaced ended in `filter`, which does `(copy-meta coll result)`; the generator call does not. Metadata on the input is silently dropped:

```phel
(meta (flatten (with-meta [[1 2] 3] {:tag :foo})))
;; before #3163 => {:tag :foo}
;; after        => nil
```

`map`, `filter`, `distinct`, `reductions` and `concat` are all generator-backed and all copy it, so `flatten` is the odd one out rather than a deliberate exception. Found by a post-merge review while validating the 0.50.0 release candidate, so this catches it before the release rather than after.

## 💡 Goal

Restore the metadata `flatten` carried before #3163, without giving up the laziness it gained.

## 🔖 Changes

- Wrap the generator in `copy-meta`, matching every sibling.
- Three assertions pinning it: a nested input, an already flat input, and that nothing is invented when the input carries none. Reverting the fix fails the first two.
- Correct the benchmark figure in the comment above the function. It read 24.8μs for 64 leaves while the CHANGELOG entry for the same measurement read 69.3μs; the measured value is 69.3μs, so the comment was the stale one.

No CHANGELOG entry: #3163 is itself unreleased, so this is a fix to something no release has shipped.
