### PR TITLE
fix(tests): regenerate the public API snapshot for v0.50.0

### DIFF
--- a/tests/php/Unit/Architecture/public-api.snapshot.txt
+++ b/tests/php/Unit/Architecture/public-api.snapshot.txt
@@ -2306,7 +2306,7 @@ final class Phel\Shared\TagResolver
   public static function normalizeScalar(mixed $tag): ?string
 
 final class Phel\Shared\VersionFinder
-  public const string LATEST_VERSION = 'v0.49.0'
+  public const string LATEST_VERSION = 'v0.50.0'
   public function __construct(string $tagCommitHash, string $currentCommit, bool $isOfficialRelease = false)
   public function getVersion(): string
 


### PR DESCRIPTION
## 🤔 Background

`main` is red. The `Tests` workflow has failed since `e11c7a08` (`chore(release): v0.50.0`):

```
PublicApiSurfaceTest::test_the_public_api_matches_the_committed_snapshot
- public const string LATEST_VERSION = 'v0.49.0'
+ public const string LATEST_VERSION = 'v0.50.0'
```

`VersionFinder::LATEST_VERSION` is a public constant, so it is part of the API surface the snapshot pins. `tools/release.sh` bumps the constant but does not regenerate the snapshot, so every release leaves this test failing until someone runs `composer api-surface:update`.

It fails locally too, which is what I hit: `composer test` is red on a clean checkout of `main`.

## 🔖 Changes

Ran `composer api-surface:update`. One line.

## 💡 Worth fixing upstream

This will recur on 0.51.0. Two options, neither in this PR because the release script is a protected file and this should land now:

- add `composer api-surface:update` to `tools/release.sh` after it writes `VersionFinder.php`, or
- exclude `LATEST_VERSION` from the snapshot, since its value is not an API shape and changing it is never a breaking change.

The second is probably right: the snapshot exists to catch a removed or narrowed symbol, and a version string moving is neither. Happy to do whichever you prefer as a follow-up.

`composer test` green with this applied.
