### PR TITLE
perf(string): reverse and escape natively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Compiler:
 
 Runtime core:
 
+- Reverse and escape a string natively in `phel.string`: `reverse` reversed the split array through a Phel sequence and back (`bench_reverse` 8.7x), and `escape` called a closure per character that invoked the character map itself (`bench_escape` 5.8x) (#2973)
 - Replace rest-argument dispatch with real arities across `phel.core`: the arithmetic and comparison operators, `str`, the collection constructors and accessors, the seq and transducer functions, and the nil-rejecting arithmetic guards. 1.03x to 25x by how much work sits behind the call, `round` and `floor` 25x, `str` at four and five arguments 3.9x and 4.1x (#2941 #2962 #2964 #2974 #2975 #2978 #2979 #2981 #2989 #2991 #3010 #3017 #3018 #3021 #3065 #3067 #3069)
 - Give every closure-returning combinator real arities: `partial` 30x, `fnil` 50x, `constantly` 9.5x, `comp` 8x, `juxt` 4.3 to 5.8x, `complement` 4.4x, `some-fn` 2.3x, `every-pred` 2.2x, plus every transducer's reducing function, `completing` and `transduce` (with `map` 4.8x, with `filter` 3.8x) (#2973 #3021 #3026 #3083)
 - **BREAKING** `sort-by` now calls its key function once per element instead of twice per comparison, so an *impure* key function runs far fewer times (100 rather than about 1114 when sorting 100 elements). The sorted result is unchanged. Up to 2.2 times faster; recorded in `docs/spec/clojure-divergences.md` since Clojure calls per comparison (#3006)

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -106,8 +106,11 @@ This is a convenience function for converting strings to character sequences. Pr
   {:example "(reverse \"hello\") ; => \"olleh\""}
   [s]
   (assert-string s)
-  (let [chars (php/mb_str_split s)]
-    (join (core/reverse chars))))
+  ;; `array_reverse` and `implode` on the split array directly. The old
+  ;; spelling converted three times: `mb_str_split` gives a PHP array,
+  ;; `core/reverse` turns it into a Phel sequence, and `join` turns that back
+  ;; into a PHP array to `implode` it. `bench_reverse` 7.23μs to 0.83μs.
+  (php/implode "" (php/array_reverse (php/mb_str_split s))))
 
 (defn repeat
   "Returns a string containing n copies of s."
@@ -289,9 +292,28 @@ This is a convenience function for converting strings to character sequences. Pr
   {:example "(escape \"hello\" {\"h\" \"H\" \"o\" \"O\"}) ; => \"HellO\""}
   [s cmap]
   (assert-string s)
-  (let [chars  (php/mb_str_split s)
-        mapped (php/array_map (fn [ch] (or (cmap ch) ch)) chars)]
-    (php/implode "" mapped)))
+  ;; `cmap` is read once into a PHP array and then indexed per character. The
+  ;; old spelling called a closure per character, and that closure invoked the
+  ;; Phel map itself, so a 43-character string paid 43 map invocations plus 43
+  ;; closure calls. `bench_escape` 20.05μs to 3.48μs.
+  ;;
+  ;; `(if hit hit ch)` and not `??`: this has to keep `or`'s rule, where only
+  ;; nil and false fall through. A character mapped to `""` maps to `""`, since
+  ;; the empty string is truthy in Phel.
+  (let [lookup (php/array)]
+    (foreach [k v cmap]
+      ;; String keys only. A PHP array cannot be keyed by a `Keyword`, and the
+      ;; per-character lookup this replaces could never match a non-string key
+      ;; anyway: the characters come from `mb_str_split`, so they are strings.
+      ;; The Clojure suite passes a map holding an int, a nil and a keyword
+      ;; alongside the real entries, which is what says so.
+      (when (string? k)
+        (php/aset lookup k v)))
+    (let [out (php/array)]
+      (foreach [ch (php/mb_str_split s)]
+        (let [hit (php/aget lookup ch)]
+          (php/apush out (if hit hit ch))))
+      (php/implode "" out))))
 
 (defn index-of
   "Returns the index of the first occurrence of value in s, or nil if not found. The optional from-index sets where the search begins; a negative from-index counts back from the end of s."

--- a/tests/phel/string/native-reverse-escape.phel
+++ b/tests/phel/string/native-reverse-escape.phel
@@ -1,0 +1,61 @@
+(ns phel-test.string.native-reverse-escape
+  (:require phel.test :refer [deftest is])
+  (:require phel.string :as s))
+
+;; `reverse` reverses the split array natively instead of routing it through a
+;; Phel sequence and back, and `escape` reads its character map once into a PHP
+;; array instead of invoking the map per character.
+;;
+;; Both are multibyte-aware through `mb_str_split`, so the character cases
+;; matter. `escape` also has to keep `or`'s falsy rule: only nil and false fall
+;; back to the original character, and the empty string is truthy in Phel.
+
+(deftest test-reverse
+  (is (= "" (s/reverse "")) "an empty string")
+  (is (= "a" (s/reverse "a")) "one character")
+  (is (= "ba" (s/reverse "ab")) "two characters")
+  (is (= "olleh" (s/reverse "hello")) "a word")
+  (is (= "olléh" (s/reverse "héllo")) "a multibyte character keeps its identity")
+  (is (= "語本日" (s/reverse "日本語")) "an all-multibyte string")
+  (is (= "b\na" (s/reverse "a\nb")) "a newline is an ordinary character")
+  (is (= "  " (s/reverse "  ")) "whitespace")
+  (is (= "hello" (s/reverse (s/reverse "hello"))) "reversing twice is the identity"))
+
+(deftest test-reverse-rejects-a-non-string
+  (is (thrown? \InvalidArgumentException (s/reverse 42)) "an int")
+  (is (thrown? \InvalidArgumentException (s/reverse nil)) "nil"))
+
+(deftest test-escape-maps-characters
+  (is (= "Hello" (s/escape "hello" {"h" "H"})) "one mapping")
+  (is (= "HellO" (s/escape "hello" {"h" "H", "o" "O"})) "two mappings")
+  (is (= "hello" (s/escape "hello" {})) "an empty map changes nothing")
+  (is (= "" (s/escape "" {"a" "b"})) "an empty subject")
+  (is (= "12b" (s/escape "ab" {"a" "12"})) "a mapping may be longer than one character")
+  (is (= "X本" (s/escape "日本" {"日" "X"})) "a multibyte character can be mapped"))
+
+(deftest test-escape-keeps-ors-falsy-rule
+  ;; `(or (cmap ch) ch)` fell back only for nil and false. The empty string is
+  ;; truthy in Phel, so a character mapped to it really does disappear.
+  (is (= "" (s/escape "aaa" {"a" ""})) "mapped to the empty string, which is truthy")
+  (is (= "aaa" (s/escape "aaa" {"a" false})) "mapped to false falls back")
+  (is (= "aaa" (s/escape "aaa" {"a" nil})) "mapped to nil falls back")
+  (is (= "5b" (s/escape "ab" {"a" 5})) "a non-string replacement is used as-is"))
+
+(deftest test-escape-only-matches-whole-characters
+  ;; The walk is per character, so a multi-character key can never match.
+  (is (= "ab" (s/escape "ab" {"ab" "Z"})) "a two-character key does not match")
+  (is (= "ab" (s/escape "ab" {"" "Z"})) "an empty key does not match"))
+
+(deftest test-escape-rejects-a-non-string
+  (is (thrown? \InvalidArgumentException (s/escape 42 {})) "an int subject"))
+
+(deftest test-escape-tolerates-a-map-with-non-string-keys
+  ;; A PHP array cannot be keyed by a `Keyword`, and the per-character lookup
+  ;; could never match a non-string key anyway. Skipping them is what keeps
+  ;; the Clojure suite's mixed map working.
+  (is (= "A_AbC_C" (s/escape "abc" {"a" "A_A", "c" "C_C", 97 1, nil 'junk, :garbage 42.42}))
+      "real entries apply, the junk ones are ignored")
+  (is (= "abc" (s/escape "abc" {97 "X"})) "an int key never matches a character")
+  (is (= "abc" (s/escape "abc" {:a "X"})) "a keyword key never matches")
+  (is (= "abc" (s/escape "abc" {nil "X"})) "a nil key never matches")
+  (is (= "Xa" (s/escape "1a" {"1" "X"})) "a numeric string key still matches its character"))

--- a/tests/php/Benchmark/Phel/StdlibStringBench.php
+++ b/tests/php/Benchmark/Phel/StdlibStringBench.php
@@ -65,6 +65,14 @@ final class StdlibStringBench extends CoreBenchCase
     private $join;
 
     /** @var callable */
+    private $reverse;
+
+    /** @var callable */
+    private $escape;
+
+    private mixed $escapeMap = null;
+
+    /** @var callable */
     private $split;
 
     private string $trailing = '';
@@ -162,6 +170,30 @@ final class StdlibStringBench extends CoreBenchCase
     }
 
     /**
+     * `reverse` converted three times: `mb_str_split` to a PHP array,
+     * `core/reverse` to a Phel sequence, `join` back to a PHP array. Now
+     * `array_reverse` and `implode` on the split array. 7.23μs to 0.83μs.
+     *
+     * @Revs(1000)
+     */
+    public function bench_reverse(): void
+    {
+        ($this->reverse)($this->sentence);
+    }
+
+    /**
+     * `escape` called a closure per character, and that closure invoked the
+     * Phel map itself. The map is now read once into a PHP array and indexed.
+     * 20.05μs to 3.48μs.
+     *
+     * @Revs(1000)
+     */
+    public function bench_escape(): void
+    {
+        ($this->escape)($this->sentence, $this->escapeMap);
+    }
+
+    /**
      * `split` gained a pattern guard, so it is worth a subject: the guard runs
      * on every call and the function is used per line or per field in most
      * text handling.
@@ -219,6 +251,9 @@ final class StdlibStringBench extends CoreBenchCase
         $this->padLeft = $this->phelFn('phel.string', 'pad-left');
         $this->join = $this->phelFn('phel.string', 'join');
         $this->split = $this->phelFn('phel.string', 'split');
+        $this->reverse = $this->phelFn('phel.string', 'reverse');
+        $this->escape = $this->phelFn('phel.string', 'escape');
+        $this->escapeMap = Phel::map('o', '0', 'e', '3');
 
         $this->trailing = "hello world\n\r\n";
         $this->haystack = 'hello world world';


### PR DESCRIPTION
## 🤔 Background

A sweep of `phel.string` put two functions well above their neighbours: `escape` at 20μs and `reverse` at 7μs, against sub-microsecond for most of the file.

Both were doing work in Phel that PHP does natively.

`reverse` converted three times: `mb_str_split` gives a PHP array, `core/reverse` turns it into a Phel sequence, and `join` turns that back into a PHP array to `implode`.

`escape` called a closure per character, and that closure invoked the Phel map itself, so a 43-character subject paid 43 map invocations plus 43 closure calls.

## 🔖 Changes

- `reverse` is `(php/implode "" (php/array_reverse (php/mb_str_split s)))`.
- `escape` reads `cmap` once into a PHP array and indexes it per character.

| subject | before | after | |
|---|---|---|---|
| `bench_reverse` | 7.23μs | 0.83μs | 8.7x |
| `bench_escape` | 20.05μs | 3.48μs | 5.8x |

Both subjects are new.

## 🐛 Caught by the clojure-test-suite, not by my probe

The first version of `escape` broke on a character map with **non-string keys**:

```
(str/escape "abc" {"a" "A_A", "c" "C_C", (int "a") 1, nil 'junk, :garbage 42.42})
TypeError: Cannot access offset of type Phel\Lang\Keyword on array
```

A PHP array cannot be keyed by a `Keyword`. The per-character lookup it replaces could never match a non-string key anyway, since the characters come from `mb_str_split`, so the fix is to skip them when building the lookup. My probe covered non-string *values* and missed non-string *keys*.

## ⚠️ Two behaviours the rewrite had to keep

`escape` must keep `or`'s falsy rule: only nil and false fall back to the original character, so a character mapped to `""` really does disappear, the empty string being truthy in Phel. That is why the lookup uses `(if hit hit ch)` and not `??`.

The walk is per character, so a multi-character key can never match. `(escape "ab" {"ab" "Z"})` is `"ab"`, before and after.

## ✅ Checking

`composer test` green (8957 core assertions). **clojure-test-suite: 5591 passed, 0 failed** (it is what found the bug above). A 28-case probe over both functions, multibyte input, empty input, every falsy mapping and every non-string key kind was diffed against `main` and is identical.

Related to #2973
