### PR TITLE
fix(tests): stop the API snapshot going stale on every release

### DIFF
--- a/tests/php/Support/PublicApiSurface.php
+++ b/tests/php/Support/PublicApiSurface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Support;
 
 use BackedEnum;
+use Phel\Shared\VersionFinder;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionClass;
@@ -66,6 +67,34 @@ final readonly class PublicApiSurface
      * the base one of its own.
      */
     private const string RUNTIME_CLASS = 'Phel';
+
+    /**
+     * Constant *values* are part of the surface, not just their names: several
+     * are the literal keys Gacela reads out of a project's `phel-config.php`, so
+     * changing one silently changes what an existing config file means.
+     *
+     * @return list<string>
+     */
+    /**
+     * Constants whose *value* moves on a schedule of its own, rendered with a
+     * placeholder instead.
+     *
+     * The snapshot exists to catch a symbol that was removed or narrowed. A
+     * version string moving is neither, but it is a public constant, so every
+     * release used to leave this test failing until somebody ran
+     * `composer api-surface:update`. `tools/release.sh` bumps the constant and
+     * does not regenerate the snapshot, so `main` went red on the release
+     * commit itself: v0.50.0 did exactly that (#3168).
+     *
+     * The symbol stays in the surface, so removing or renaming it is still
+     * caught. Only the literal is elided. Contrast the `phel-config.php` keys
+     * described below, whose values *are* the contract and must stay pinned.
+     *
+     * @var array<string, true>
+     */
+    private const array VOLATILE_CONSTANT_VALUES = [
+        VersionFinder::class . '::LATEST_VERSION' => true,
+    ];
 
     public function __construct(
         private string $repositoryRoot,
@@ -360,13 +389,6 @@ final readonly class PublicApiSurface
         return $lines;
     }
 
-    /**
-     * Constant *values* are part of the surface, not just their names: several
-     * are the literal keys Gacela reads out of a project's `phel-config.php`, so
-     * changing one silently changes what an existing config file means.
-     *
-     * @return list<string>
-     */
     private function renderConstants(ReflectionClass $class): array
     {
         $declaredBy = $this->foldedAncestorsOf($class);
@@ -388,13 +410,16 @@ final readonly class PublicApiSurface
             }
 
             $type = $constant->getType();
+            $qualified = $constant->getDeclaringClass()->getName() . '::' . $constant->getName();
 
             $lines[] = sprintf(
                 '  %s const %s%s = %s',
                 $this->visibilityOf($constant),
                 $type instanceof ReflectionType ? $this->renderType($type) . ' ' : '',
                 $constant->getName(),
-                $this->renderValue($constant->getValue()),
+                isset(self::VOLATILE_CONSTANT_VALUES[$qualified])
+                    ? '<volatile>'
+                    : $this->renderValue($constant->getValue()),
             );
         }
 

--- a/tests/php/Unit/Architecture/PublicApiSurfaceTest.php
+++ b/tests/php/Unit/Architecture/PublicApiSurfaceTest.php
@@ -9,6 +9,7 @@ use Phel\Compiler\Application\Lexer;
 use Phel\Compiler\CompilerFactory;
 use Phel\Run\Infrastructure\Command\ReplCommand;
 use Phel\Run\RunProvider;
+use Phel\Shared\VersionFinder;
 use PhelTest\Support\PublicApiSurface;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
@@ -99,6 +100,28 @@ final class PublicApiSurfaceTest extends TestCase
                 sprintf('%s is internal but the surface rules select it as public.', $className),
             );
         }
+    }
+
+    /**
+     * The version constant's value is elided, so a release that bumps it does
+     * not leave this snapshot stale. The symbol itself must still be pinned:
+     * removing or renaming it is a breaking change and has to be caught.
+     */
+    public function test_the_version_constant_is_pinned_without_its_value(): void
+    {
+        $snapshot = PublicApiSurface::fromRepositoryRoot(PublicApiSurface::repositoryRoot())->render();
+
+        self::assertStringContainsString(
+            'public const string LATEST_VERSION = <volatile>',
+            $snapshot,
+            'The version constant should appear without its literal value.',
+        );
+
+        self::assertStringNotContainsString(
+            VersionFinder::LATEST_VERSION,
+            $snapshot,
+            'The version string itself must not reach the snapshot, or every release makes it stale.',
+        );
     }
 
     /**

--- a/tests/php/Unit/Architecture/public-api.snapshot.txt
+++ b/tests/php/Unit/Architecture/public-api.snapshot.txt
@@ -2306,7 +2306,7 @@ final class Phel\Shared\TagResolver
   public static function normalizeScalar(mixed $tag): ?string
 
 final class Phel\Shared\VersionFinder
-  public const string LATEST_VERSION = 'v0.50.0'
+  public const string LATEST_VERSION = <volatile>
   public function __construct(string $tagCommitHash, string $currentCommit, bool $isOfficialRelease = false)
   public function getVersion(): string
 


### PR DESCRIPTION
## 🤔 Background

Follow-up to #3168, which unblocked `main` after v0.50.0 left it red.

`VersionFinder::LATEST_VERSION` is a public constant, so the API-surface snapshot pins its literal value. `tools/release.sh` bumps the constant and does not regenerate the snapshot, so **every release breaks this test on the release commit itself** until somebody notices. v0.50.0 did; 0.51.0 would too.

I offered two fixes in #3168 and said this was the one I preferred: the snapshot exists to catch a symbol that was removed or narrowed, and a version string moving is neither.

## 🔖 Changes

`renderConstants()` renders `<volatile>` in place of the literal for constants listed in a small `VOLATILE_CONSTANT_VALUES` table, currently just `VersionFinder::LATEST_VERSION`:

```
-  public const string LATEST_VERSION = 'v0.50.0'
+  public const string LATEST_VERSION = <volatile>
```

The symbol stays in the surface, so removing or renaming it is still a snapshot failure. Only the literal is elided.

This is deliberately a table and not a blanket rule. The `phel-config.php` key constants right below it in that class have values that **are** the contract, as its docblock says: changing one silently changes what an existing config file means. Those stay pinned.

## ✅ Checking

A new test asserts both halves: the constant appears as `<volatile>`, and `VersionFinder::LATEST_VERSION`'s actual string does not appear in the snapshot at all, which is what would make it stale again.

Verified it does what it is for: with `LATEST_VERSION` temporarily edited to `'v0.51.0'`, `PublicApiSurfaceTest` stays green (4 tests, 25 assertions). On `main` that same edit fails.

`composer test` green.

No CHANGELOG entry: this is test infrastructure, with no user-visible effect.

## 💭 The other option, still open

`tools/release.sh` could run `composer api-surface:update` after writing `VersionFinder.php`. That also works and keeps the value pinned. It is a protected file so I have not touched it; if you would rather have that, this PR can be dropped.
