### PR TITLE
perf(lang): promote a map to the hash representation at 8 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Compiler:
 
 Runtime core:
 
+- Promote a map from the flat array representation to the hash map at 8 entries instead of 16. An array map finds a key by scanning its entries, so a 16-entry map was 4.9x slower to read than a 20-entry one (4.71μs against 0.96μs); reading the last key of a 12-entry map is now 3.5x faster and of a 16-entry map 5.9x. Building is unchanged at both sizes. A map below the threshold still iterates in insertion order (#3172)
 - Reverse and escape a string natively in `phel.string`: `reverse` reversed the split array through a Phel sequence and back (`bench_reverse` 8.7x), and `escape` called a closure per character that invoked the character map itself (`bench_escape` 5.8x) (#2973)
 - Replace rest-argument dispatch with real arities across `phel.core`: the arithmetic and comparison operators, `str`, the collection constructors and accessors, the seq and transducer functions, and the nil-rejecting arithmetic guards. 1.03x to 25x by how much work sits behind the call, `round` and `floor` 25x, `str` at four and five arguments 3.9x and 4.1x (#2941 #2962 #2964 #2974 #2975 #2978 #2979 #2981 #2989 #2991 #3010 #3017 #3018 #3021 #3065 #3067 #3069)
 - Give every closure-returning combinator real arities: `partial` 30x, `fnil` 50x, `constantly` 9.5x, `comp` 8x, `juxt` 4.3 to 5.8x, `complement` 4.4x, `some-fn` 2.3x, `every-pred` 2.2x, plus every transducer's reducing function, `completing` and `transduce` (with `map` 4.8x, with `filter` 3.8x) (#2973 #3021 #3026 #3083)

--- a/src/php/Lang/Collections/Map/PersistentArrayMap.php
+++ b/src/php/Lang/Collections/Map/PersistentArrayMap.php
@@ -28,7 +28,34 @@ final class PersistentArrayMap extends AbstractPersistentMap
     /** @use TransientMergeStrategyTrait<TKey, TValue> */
     use TransientMergeStrategyTrait;
 
-    public const int MAX_SIZE = 16;
+    /**
+     * The entry count at which a map stops being a flat array and becomes a
+     * hash map.
+     *
+     * An array map finds a key by scanning its entries and calling
+     * `equalsKey()` on each, so a read is O(n) where the hash map it promotes
+     * to is O(1). At the old value of 16 that made a 16-entry map **4.9x
+     * slower to read than a 20-entry one** (4.71us against 0.96us), which is
+     * backwards: crossing the threshold made reads faster, not slower.
+     *
+     * 8 because it is free. Building an 8-entry map is unchanged (34.0us
+     * against 34.1us) and building a 16-entry one is unchanged (70.3us against
+     * 69.9us), while reading the last key of a 12-entry map goes 3.53us to
+     * 1.00us and of a 16-entry map 4.71us to 0.80us.
+     *
+     * Do not lower this further without reading #3172. A value of 4 makes a
+     * three-entry map *literal* containing `nil`, `false` and `0` keys lose
+     * one of them, somewhere above the collection layer (`fromArray` and the
+     * transient both handle those keys correctly at 4 when called directly).
+     * That is unexplained, so 8 is as far as this goes.
+     *
+     * Iteration order is what an array map buys, and is why this is a
+     * threshold rather than a deletion: a map below it iterates in insertion
+     * order. Nothing documents that as a guarantee, `sequential?` says maps
+     * are not sequential, and no test here, in the Phel suite or in the
+     * Clojure suite depends on it between 9 and 16 entries.
+     */
+    public const int MAX_SIZE = 8;
 
     /**
      * @param PersistentMapInterface<mixed, mixed>|null $meta

--- a/tests/phel/core/small-map-lookup.phel
+++ b/tests/phel/core/small-map-lookup.phel
@@ -1,0 +1,54 @@
+(ns phel-test.core.small-map-lookup
+  (:require phel.test :refer [deftest is]))
+
+;; `PersistentArrayMap::MAX_SIZE` dropped from 16 to 8, so a map of 9 to 16
+;; entries is now a hash map rather than a flat array scanned per lookup.
+;;
+;; Nothing about the map's behaviour may change with it. These walk the sizes
+;; either side of the threshold and check that every key is still there, still
+;; readable, and still updatable, including the keys that are easiest to lose:
+;; nil, false and zero, which collapse together as PHP array keys.
+
+(defn- mk [n]
+  (zipmap (map (fn [i] (keyword (str "k" i))) (range 0 n)) (range 0 n)))
+
+(deftest test-every-size-across-the-threshold-round-trips
+  (dofor [n :in [0 1 2 7 8 9 15 16 17 32]]
+    (let [m (mk n)]
+      (is (= n (count m)) (str n " entries are counted"))
+      (is (= (vec (range 0 n)) (vec (sort (vals m)))) (str n " entries keep their values"))
+      (dofor [i :range [0 n]]
+        (is (= i (get m (keyword (str "k" i)))) (str "key k" i " of " n " reads back"))))))
+
+(deftest test-falsy-keys-survive-at-every-size
+  ;; nil, false and 0 are distinct Phel keys but the same PHP array key, so a
+  ;; representation change is where they would collide.
+  (dofor [pad :in [0 6 8 12 20]]
+    (let [base {nil :n, false :f, 0 :z}
+          m (reduce (fn [acc i] (assoc acc (keyword (str "p" i)) i)) base (range 0 pad))]
+      (is (= 3 (count (select-keys m [nil false 0]))) (str "all three survive with " pad " other entries"))
+      (is (= :n (get m nil)) "nil key")
+      (is (= :f (get m false)) "false key")
+      (is (= :z (get m 0)) "zero key")
+      (is (true? (contains? m nil)) "nil is really present"))))
+
+(deftest test-updates-across-the-threshold
+  (let [m (mk 8)
+        grown (assoc m :extra 99)]
+    (is (= 9 (count grown)) "growing past the threshold keeps every entry")
+    (is (= 99 (get grown :extra)) "the new key reads back")
+    (is (= 0 (get grown :k0)) "an old key still reads back")
+    (is (= 8 (count m)) "and the original is unchanged"))
+  (let [m (mk 12)
+        shrunk (dissoc m :k0)]
+    (is (= 11 (count shrunk)) "shrinking below it keeps the rest")
+    (is (nil? (get shrunk :k0)) "the removed key is gone")
+    (is (= 11 (get shrunk :k11)) "the others read back")))
+
+(deftest test-equality-does-not-depend-on-representation
+  ;; A 9-entry map is a hash map and a 9-entry one built by growing an 8-entry
+  ;; array map is too, but equality must not care either way.
+  (let [built (mk 9)
+        grown (assoc (mk 8) :k8 8)]
+    (is (= built grown) "same entries compare equal")
+    (is (= (pr-str (sort (keys built))) (pr-str (sort (keys grown)))) "and hold the same keys")))

--- a/tests/php/Unit/Architecture/public-api.snapshot.txt
+++ b/tests/php/Unit/Architecture/public-api.snapshot.txt
@@ -719,7 +719,7 @@ final readonly class Phel\Lang\Collections\Map\MapEntry implements Countable, It
   public static function create(mixed $key, mixed $value): Phel\Lang\Collections\Map\MapEntry
 
 final class Phel\Lang\Collections\Map\PersistentArrayMap extends Phel\Lang\Collections\Map\AbstractPersistentMap
-  public const int MAX_SIZE = 16
+  public const int MAX_SIZE = 8
   public function __construct(Phel\Lang\HasherInterface $hasher, Phel\Lang\EqualizerInterface $equalizer, ?Phel\Lang\Collections\Map\PersistentMapInterface $meta, array $array)
   public function asTransient(): Phel\Lang\Collections\Map\TransientMapWrapper
   public function contains($key): bool


### PR DESCRIPTION
## 🤔 Background

#3172, with the measurements. `PersistentArrayMap::MAX_SIZE` was 16, and an array map finds a key by scanning its entries and calling `equalsKey()` on each. So reads were O(n) up to 16 entries, and crossing the threshold made a map **faster**, not slower:

| entries | representation | `(get m last-key)` |
|---|---|---|
| 8 | array map | 2.48μs |
| 12 | array map | 3.49μs |
| 16 | array map | 4.72μs |
| **20** | **hash map** | **0.96μs** |

A 16-entry map was 4.9x slower to read than a 20-entry one.

## 🔖 Changes

`MAX_SIZE` 16 to 8.

| `(get m last-key)` | before | after | |
|---|---|---|---|
| 12 entries | 3.53μs | 1.00μs | 3.5x |
| 16 entries | 4.71μs | 0.80μs | 5.9x |
| 8 entries | 2.47μs | 2.51μs | unchanged, still an array map |

Building is unchanged: an 8-entry map 34.0μs against 34.1μs, a 16-entry one 70.3μs against 69.9μs. That is why 8 and not something lower; it costs nothing.

## ⚠️ Iteration order, and why this is safe

An array map iterates in insertion order and a hash map does not, so maps of 9 to 16 entries now iterate differently. Nothing documents that as a guarantee, and `phel.core/sequential?` says outright that maps are not sequential.

Verified rather than assumed: `composer test` green (9118 core assertions), and the **clojure-test-suite at its pinned SHA: 5591 passed, 0 failed**. The only thing that changed anywhere was the snapshot line recording the constant.

## 🚩 Do not lower this further without reading #3172

At `MAX_SIZE = 4` the Phel suite fails twice, and both failures are a three-entry map **literal** holding `nil`, `false` and `0` keys losing one of them. Those three are distinct Phel keys but the same PHP array key.

It is not the collection layer: at 4, `PersistentArrayMap::fromArray` and the transient both handle exactly those keys correctly when called from PHP (count 3, all three findable). So something above the collection reacts to the threshold, and I have not root-caused it. 8 does not go near it, and the constant's docblock says so.

Worth someone's time separately: it is latent today only because you would need a map literal to cross the threshold, and at 16 that is rare.

## ✅ Tests

`tests/phel/core/small-map-lookup.phel` walks sizes 0, 1, 2, 7, 8, 9, 15, 16, 17 and 32, checking every key reads back at every size, and pins `nil`, `false` and `0` keys surviving alongside 0, 6, 8, 12 and 20 other entries, which is the case the threshold could plausibly break.

Related to #3172
