### PR TITLE
docs(lang): the MAX_SIZE hazard is resolved, record the trade instead

### DIFF
--- a/src/php/Lang/Collections/Map/PersistentArrayMap.php
+++ b/src/php/Lang/Collections/Map/PersistentArrayMap.php
@@ -43,11 +43,17 @@ final class PersistentArrayMap extends AbstractPersistentMap
      * 69.9us), while reading the last key of a 12-entry map goes 3.53us to
      * 1.00us and of a 16-entry map 4.71us to 0.80us.
      *
-     * Do not lower this further without reading #3172. A value of 4 makes a
-     * three-entry map *literal* containing `nil`, `false` and `0` keys lose
-     * one of them, somewhere above the collection layer (`fromArray` and the
-     * transient both handle those keys correctly at 4 when called directly).
-     * That is unexplained, so 8 is as far as this goes.
+     * Lowering this further is now a trade rather than a hazard. The reason
+     * it used to be a hazard is fixed: a value of 4 made a three-entry literal
+     * holding `nil`, `false` and `0` keys lose one, because the literal
+     * crossed into the hash representation during compilation and
+     * `PersistentHashMap::getIterator()` skipped the `nil` key, so the
+     * compiler never emitted that pair (#3174).
+     *
+     * With that fixed, 4 is correct and measurably faster to read: a 5-entry
+     * map 2.0x, a 6-entry 2.3x, an 8-entry 2.9x. It costs on the build,
+     * though, 21% for a 5-entry map and 6% for an 8-entry one, which is why
+     * it is not the value here. See #3172 for the numbers and the call.
      *
      * Iteration order is what an array map buys, and is why this is a
      * threshold rather than a deletion: a map below it iterates in insertion


### PR DESCRIPTION
## 🤔 Background

#3173 set `PersistentArrayMap::MAX_SIZE` to 8 and its docblock warned against lowering it further, because at 4 a three-entry literal holding `nil`, `false` and `0` keys lost one and I could not explain why.

#3174 explains it and fixes it. The literal crossed into the hash representation *during compilation*, the compiler iterated it to emit the pairs, and `PersistentHashMap::getIterator()` skipped the `nil` key. So the compiler never emitted that pair. It was never about the threshold.

## 🔖 Changes

The docblock. The warning becomes a record of the trade-off, since lowering is now safe but not free.

Verified at `MAX_SIZE = 4` on top of #3174: the three-entry literal keeps all three keys, and `composer test-core` is green at 9177 assertions.

Measured 4 against the current 8:

| | 8 | 4 | |
|---|---|---|---|
| `(get m k)` on 5 entries | 1.74μs | 0.86μs | 2.0x |
| `(get m k)` on 6 entries | 1.97μs | 0.86μs | 2.3x |
| `(get m k)` on 8 entries | 2.52μs | 0.87μs | 2.9x |
| building a 5-entry map | 23.3μs | 28.2μs | **21% slower** |
| building an 8-entry map | 36.7μs | 39.1μs | **6% slower** |

Unlike the move from 16 to 8, which was free, 4 trades build cost for read speed. Five-entry maps are common enough that a 21% build regression is worth a decision rather than an assumption, so I have left the constant at 8 and written the numbers down where the next person will find them.

My own read is that reads outnumber writes enough to justify 4, but that is a judgement about this language's workloads and it is yours to make. Say the word and it is a one-line change.

Related to #3172
