### PR TITLE
fix(json): keep a JSON object a map when decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- `phel.json/decode` reads with `assoc = false`, so a JSON object stays a map instead of collapsing to a vector. `{}` now round-trips (`(= {} (decode (encode {})))`), a nested `{}` keeps its shape at any depth, and an object whose keys are all numeric (`{"0":"a"}`) decodes as `{:0 "a"}` rather than `["a"]`. `decode-value` still turns a PHP associative array into a map for callers that reach for it directly (#3089)
+
 ### Changed
 
 - `apply` spreads a vector in one walk instead of stepping it element by element: `(apply + [1 2 3])` is 2.1x faster. Other source kinds are unchanged (#3181)

--- a/src/phel/json.phel
+++ b/src/phel/json.phel
@@ -25,7 +25,7 @@
       (when-not (valid-key? k)
         (throw (new JsonException "Key can only be an integer, float, symbol, keyword or a string.")))
       ;; `php/aset` and not `aset`: the array is a PHP array here by
-       ;; construction, and this runs once per key of every object encoded.
+      ;; construction, and this runs once per key of every object encoded.
       (php/aset arr (encode-key k) (encode-value v)))
     arr))
 
@@ -36,7 +36,8 @@
   [x]
   (cond
     ;; An empty map must encode as a JSON object `{}`, not the `[]` an empty
-    ;; php/array would produce; a stdClass forces object encoding.
+    ;; php/array would produce; a stdClass forces object encoding. It is the
+    ;; same type `decode-value` reads an object back from, at the other end.
     (and (map? x) (empty? x)) (new \stdClass)
     (php/is_iterable x)       (encode-value-iterable x)
     (symbol? x)               (name x)

--- a/src/phel/json.phel
+++ b/src/phel/json.phel
@@ -7,6 +7,7 @@
   [v]
   (or (int? v) (float? v) (symbol? v) (keyword? v) (string? v)))
 
+(declare decode-value)
 (declare encode-value)
 
 (defn- encode-key
@@ -61,21 +62,35 @@
      (when-not (> depth 0) (throw (new JsonException "Depth must be greater than zero.")))
      (php/json_encode (encode-value value) flags depth))))
 
+(defn- json-object-to-map
+  "Builds a map from the key/value pairs of a decoded JSON object.
+
+  JSON object keys are strings, but a PHP array coerces numeric ones to ints,
+  so both `php/json_decode` and `php/get_object_vars` can hand back an int
+  here; stringify first so `(keyword k)` never collapses them to a single nil
+  key."
+  [pairs]
+  (let [hashmap (transient {})]
+    (foreach [k v pairs]
+      (.put hashmap (keyword (str k)) (decode-value v)))
+    (persistent hashmap)))
+
 (defn decode-value
   "Converts a JSON value to Phel format."
   {:example "(decode-value [1 2 3]) ; => [1 2 3]"
    :see-also ["decode" "encode-value"]}
   [x]
   (cond
-    (indexed? x)   (for [v :in x] (decode-value v))
-    (php-array? x) (let [hashmap (transient {})]
-                     (foreach [k v x]
-                       ;; JSON object keys are strings, but php/json_decode coerces
-                       ;; numeric keys to ints; stringify first so `(keyword k)`
-                       ;; never collapses them to a single nil key.
-                       (.put hashmap (keyword (str k)) (decode-value v)))
-                     (persistent hashmap))
-    true           x))
+    ;; `decode` reads with assoc=false, so a JSON object arrives as a
+    ;; `stdClass`. That is the only place it is still distinguishable from a
+    ;; JSON array: assoc=true maps `{}` and `[]` onto the same empty PHP array
+    ;; and the object reads back as a vector (#3089).
+    (php/instanceof x \stdClass) (json-object-to-map (php/get_object_vars x))
+    (indexed? x)                 (for [v :in x] (decode-value v))
+    ;; A PHP associative array still decodes as a map, for a caller that
+    ;; reaches for `decode-value` on its own rather than through `decode`.
+    (php-array? x)               (json-object-to-map x)
+    true                         x))
 
 (defn decode
   "Decodes a JSON string to a Phel value."
@@ -83,7 +98,7 @@
   ;; Same split as `encode`, and for the same reasons.
   ([json]
    (when-not (string? json) (throw (new JsonException "Json must be a string.")))
-   (decode-value (php/json_decode json true 512 0)))
+   (decode-value (php/json_decode json false 512 0)))
   ([json {:flags flags, :depth depth}]
    (let [flags (or flags 0)
          depth (or depth 512)]
@@ -91,4 +106,4 @@
      (when-not (int? flags) (throw (new JsonException "Flags must be an integer.")))
      (when-not (int? depth) (throw (new JsonException "Depth must be an integer.")))
      (when-not (> depth 0) (throw (new JsonException "Depth must be greater than zero.")))
-     (decode-value (php/json_decode json true depth flags)))))
+     (decode-value (php/json_decode json false depth flags)))))

--- a/tests/phel/json/arities.phel
+++ b/tests/phel/json/arities.phel
@@ -49,14 +49,17 @@
   (is (thrown? \Exception (j/decode "{}" {:depth 0})) "a depth of zero"))
 
 (deftest test-round-trip
-  (foreach [v [{:a 1} [1 2 3] "s" 42 {:a {:b [1 2]}} []]]
+  (foreach [v [{:a 1} [1 2 3] "s" 42 {:a {:b [1 2]}} [] {} {:a {}} {:a []} [{} []]]]
     (is (= v (j/decode (j/encode v))) (str "round-trips " (j/encode v)))))
 
-(deftest test-empty-object-does-not-round-trip
-  ;; Pre-existing and unrelated to the arity split, recorded so the next reader
-  ;; does not take it for a regression: `php/json_decode` with assoc=true maps
-  ;; both `{}` and `[]` onto the same empty PHP array, so the object/array
-  ;; distinction `encode` preserves is lost on the way back. See #3089.
-  (is (= "{}" (j/encode {})) "an empty map still encodes as an object")
-  (is (= [] (j/decode "{}")) "but decodes back as an empty vector")
-  (is (= (j/decode "[]") (j/decode "{}")) "empty object and empty array decode alike"))
+(deftest test-an-empty-object-round-trips
+  ;; `php/json_decode` with assoc=true maps both `{}` and `[]` onto the same
+  ;; empty PHP array, which lost the object/array distinction `encode` goes out
+  ;; of its way to preserve. `decode` reads with assoc=false now, so a JSON
+  ;; object arrives as a `stdClass` and stays a map. See #3089.
+  (is (= "{}" (j/encode {})) "an empty map encodes as an object")
+  (is (= {} (j/decode "{}")) "and decodes back as an empty map")
+  (is (= [] (j/decode "[]")) "an empty array still decodes as an empty vector")
+  (is (not= (j/decode "[]") (j/decode "{}")) "the two are no longer the same value")
+  (is (map? (j/decode "{}")) "the empty object is a map")
+  (is (vector? (j/decode "[]")) "the empty array is a vector"))

--- a/tests/phel/json/decode/value.phel
+++ b/tests/phel/json/decode/value.phel
@@ -43,3 +43,32 @@
   ;; php/json_decode coerces numeric object keys to ints; they must still
   ;; become keywords, not collapse to a single nil key.
   (is (= {:1 "one" :2 "two"} (json/decode "{\"1\":\"one\",\"2\":\"two\"}"))))
+
+(deftest test-json-objects-stay-maps-at-every-depth
+  ;; `decode` reads with assoc=false, so an object arrives as a `stdClass` and
+  ;; an array as a PHP array. Under assoc=true both collapsed to a PHP array
+  ;; and anything that looked indexed came back a vector (#3089).
+  (is (= {} (json/decode "{}")) "an empty object")
+  (is (= [] (json/decode "[]")) "an empty array")
+  (is (= {:a {}} (json/decode "{\"a\":{}}")) "an empty object nested in an object")
+  (is (= {:a []} (json/decode "{\"a\":[]}")) "an empty array nested in an object")
+  (is (= [{} []] (json/decode "[{},[]]")) "both nested in an array")
+  (is (= {:a {:b [1 {}]}} (json/decode "{\"a\":{\"b\":[1,{}]}}")) "three levels down")
+  (is (map? (get (json/decode "{\"a\":{}}") :a)) "the nested empty object is a map")
+  (is (vector? (get (json/decode "{\"a\":[]}") :a)) "the nested empty array is a vector"))
+
+(deftest test-an-object-with-only-numeric-keys-is-still-an-object
+  ;; Under assoc=true these decoded to a vector, because the PHP array they
+  ;; landed in looked indexed. JSON says object, so the result is a map.
+  (is (= {:0 "a"} (json/decode "{\"0\":\"a\"}")) "one zero-based numeric key")
+  (is (= {:0 "a", :1 "b"} (json/decode "{\"0\":\"a\",\"1\":\"b\"}")) "consecutive numeric keys")
+  (is (map? (json/decode "{\"0\":\"a\"}")) "the result is a map, not a vector")
+  (is (= ["a"] (json/decode "[\"a\"]")) "and the array spelling is still a vector"))
+
+(deftest test-decode-value-still-accepts-a-php-associative-array
+  ;; `decode-value` is public and reachable without `decode`, so the PHP-array
+  ;; branch stays for a caller that hands it one directly.
+  (is (= {:a 1} (json/decode-value (php-associative-array "a" 1))) "an associative array is a map")
+  (is (= [1 2 3] (json/decode-value [1 2 3])) "a vector is unchanged")
+  (is (= 5 (json/decode-value 5)) "a scalar is unchanged")
+  (is (nil? (json/decode-value nil)) "nil is unchanged"))


### PR DESCRIPTION
## 🤔 What is the problem?

`(= {} (phel.json/decode (phel.json/encode {})))` was `false`. `encode` goes out of its way to keep an empty map an object, then `decode` threw the distinction away: it called `php/json_decode` with `assoc = true`, which maps both `{}` and `[]` onto the same empty PHP array, so `decode-value` saw something indexed and produced a vector. Anything reading back what it wrote, a config file or a cached payload, got a vector where it stored a map.

## 🤓 How do I solve it?

Read with `assoc = false`. An object arrives as a `stdClass` and an array as a PHP array, which keeps them apart at every nesting depth, and `decode-value` converts the `stdClass` to a map.

One further behaviour change falls out: an object whose keys are all numeric decodes as a map now, so `{"0":"a"}` gives `{:0 "a"}` rather than `["a"]`. Under `assoc = true` the PHP array it landed in looked indexed, which is the same defect. The PHP-associative-array branch stays in `decode-value` for callers that reach for it directly rather than through `decode`.

## 🧪 How to verify it?

`tests/phel/json/decode/value.phel` covers nesting at three levels, both empty shapes side by side, numeric-key objects, and the direct `decode-value` entry point. `tests/phel/json/arities.phel` had a test pinning the old behaviour as a known bug; it now asserts the round trip, and the round-trip loop gained `{}`, `{:a {}}`, `{:a []}` and `[{} []]`.

Refactor pass: extracted the shared map-building loop the two `decode-value` branches would otherwise duplicate, cross-referenced the two `stdClass` sites, straightened one comment indent.