### PR TITLE
fix(compiler): let a defn opt out of inlining with ^:redef, and run CI at -O2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,6 +71,30 @@ jobs:
       - name: Run tests to the core library
         run: php -d memory_limit=256M ./bin/phel test ${{ matrix.exclude-tags }}
 
+  # `optimizationLevel` defaults to 0, so without this job nothing in CI ever
+  # runs `CallInliner` or `TailCallRewriter`. That is how -O2 came to fail five
+  # core tests on main while every check stayed green (#3126). The level is a
+  # documented, reachable configuration, so it gets a suite.
+  #
+  # One job, one PHP version: this guards the optimiser, not the platform
+  # matrix, and the same tests already run at -O0 above.
+  core-tests-optimised:
+    name: Core tests at -O2
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-phel
+        with:
+          php-version: '8.4'
+
+      - name: Run the core library compiled at optimizationLevel 2
+        env:
+          PHEL_OPTIMIZATION_LEVEL: '2'
+        run: |
+          rm -rf ./.phel/cache
+          php -d memory_limit=256M ./bin/phel test
+
   # Windows is the "Best effort" tier in docs/stability.md: bugs are accepted and
   # fixed, but a Windows-only failure does not block a release, so this job reports
   # without gating. Promoting it to blocking means deleting `continue-on-error`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `^:redef` metadata on a `defn` opts it out of inlining at `optimizationLevel` 2, so `with-redefs` and `phel.mock` still intercept the call. Inlining splices the callee's body into the caller, which leaves no global read to intercept; this is the same tension Clojure's direct linking has, answered the same way (#3126)
+- A `Core tests at -O2` CI job. `optimizationLevel` defaults to 0, so nothing in CI exercised `CallInliner` or `TailCallRewriter`, which is how the level came to fail five core tests while every check stayed green. The repository's `phel-config.php` reads `PHEL_OPTIMIZATION_LEVEL`, so a local repro is `PHEL_OPTIMIZATION_LEVEL=2 ./bin/phel test` (#3126)
+
 ### Changed
 
 - `atom` and `symbol` have fixed arities for the shapes callers actually use. `(atom v)` is 6.1x faster: it used to allocate a rest argument and `apply` `hash-map` over it on every creation just to find there were no options. `symbol` is 1.9x to 2.3x faster; it used `[name-or-ns & [name]]`, which built a rest argument and destructured one value back out of it. Both are behaviour-preserving, including `symbol` going on ignoring a third argument. `atom` with options is 3% slower, from the extra arity dispatch (#2973)

--- a/phel-config.php
+++ b/phel-config.php
@@ -11,4 +11,9 @@ return PhelConfig::forProject(ProjectLayout::Nested)
     // Under tests/ that loads PHPUnit classes standalone, which fatals; the
     // Gacela modules all live in src/php anyway (#2787).
     ->withAppModulePaths(['src/php'])
-    ->withIgnoreWhenBuilding(['src/phel/local.phel']);
+    ->withIgnoreWhenBuilding(['src/phel/local.phel'])
+    // `optimizationLevel` defaults to 0, so nothing exercised `CallInliner` or
+    // `TailCallRewriter` until #3126 raised it by hand and found five failing
+    // core tests. Reading it from the environment gives CI a job at -O2 and
+    // makes a local repro one variable: `PHEL_OPTIMIZATION_LEVEL=2 ./bin/phel test`.
+    ->withOptimizationLevel((int) (getenv('PHEL_OPTIMIZATION_LEVEL') ?: '0'));

--- a/resources/agents/RULES.md
+++ b/resources/agents/RULES.md
@@ -37,6 +37,7 @@ Use these when appropriate; stable and tested.
 | Return inference | Tagged params + tail primitive op (`(php/+ ...)` -> `int`, `(php/. ...)` -> `string`, comparisons -> `bool`) infers return; `if` / `let` / `loop` propagate. Explicit `:tag` always wins | main |
 | `^:async` defn | `(defn ^:async fetch [url] (await (http-get url)))`; body wrapped in `async`, returns `Amp\Future` | main |
 | `^:memoize` / `^{:memoize-lru N}` | `(defn ^{:memoize-lru 32} fib [^int n] ...)`; opt-in caching by arg vector, LRU bound optional | main |
+| `^:redef` defn | `(defn ^:redef fetch [url] ...)`; opts out of inlining at `optimizationLevel` 2 so `with-redefs` and `phel.mock` still intercept the call | main |
 
 `:tag` reader shorthands:
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
@@ -97,6 +97,15 @@ final readonly class CallInliner
             return null;
         }
 
+        // Inlining splices the callee's body at the call site, so there is no
+        // longer a global read for `with-redefs` or `phel.mock` to intercept.
+        // That is inherent to direct linking rather than a defect in it, and
+        // Clojure answers the same tension the same way: `^:redef` opts a
+        // definition out, and the call keeps going through the var (#3126).
+        if ($this->isRedefinable($f->getMeta())) {
+            return null;
+        }
+
         // The side-table holds single-arity (`FnNode`) and multi-arity
         // (`MultiFnNode`) defs; `arityFor` resolves the fixed arity whose
         // parameter count matches the call (#2218), or `null` when the
@@ -393,6 +402,20 @@ final readonly class CallInliner
         }
 
         return $count;
+    }
+
+    /**
+     * A definition that asks to stay interceptable.
+     *
+     * The call site keeps reading the global, so rebinding its root with
+     * `with-redefs` or `phel.mock` is still observed after the optimiser has
+     * run. It costs the inlining, which is the point.
+     *
+     * @param PersistentMapInterface<mixed, mixed> $meta
+     */
+    private function isRedefinable(PersistentMapInterface $meta): bool
+    {
+        return (bool) $meta[Keyword::create('redef')];
     }
 
     /**

--- a/tests/phel/mock.phel
+++ b/tests/phel/mock.phel
@@ -158,7 +158,10 @@
 ;; Integration Tests
 ;; -----------
 
-(defn fetch-user [http-client id]
+;; `^:redef` keeps the call going through the global instead of being
+;; inlined at `-O2`, which is what `with-redefs` needs in order to be seen.
+;; Without it these tests pass at the default level and fail at `-O2` (#3126).
+(defn ^:redef fetch-user [http-client id]
   "Simulates fetching a user via HTTP"
   (http-client (str "/users/" id)))
 
@@ -275,7 +278,7 @@
 ;; Real-world Example Tests
 ;; -----------
 
-(defn send-email [email-service to subject body]
+(defn ^:redef send-email [email-service to subject body]
   "Simulates sending an email"
   (email-service to subject body))
 
@@ -291,7 +294,7 @@
       (is (called-with? mock-email "user@example.com" "Welcome!" "Thanks for signing up")
           "sends correct email"))))
 
-(defn fetch-from-api [url]
+(defn ^:redef fetch-from-api [url]
   "Simulates API call"
   {:url url :status 200})
 
@@ -326,7 +329,7 @@
 ;; Interop/External Function Mocking Tests
 ;; -----------
 
-(defn call-external-service [http-fn endpoint]
+(defn ^:redef call-external-service [http-fn endpoint]
   "Simulates calling an external service (could be PHP, Clojure, or any foreign function)"
   (http-fn endpoint))
 

--- a/tests/php/Integration/CallInlinerRedefTest.php
+++ b/tests/php/Integration/CallInlinerRedefTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompileOptions;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+/**
+ * `^:redef` opts a definition out of inlining so its call sites keep reading
+ * the global.
+ *
+ * Inlining splices the callee's body into the caller, which leaves nothing for
+ * `with-redefs` or `phel.mock` to intercept. That is inherent to direct
+ * linking rather than a defect in it, and it is why `-O2` used to fail two
+ * `phel.mock` tests while every check stayed green (#3126). Clojure answers the
+ * same tension the same way, with a per-definition opt-out.
+ *
+ * What is pinned here is the guarantee: a `^:redef` callee still observes a
+ * rebinding at `-O2`, and nothing changes at the default level. The converse,
+ * that an ordinary callee is inlined past `with-redefs`, is deliberately not
+ * asserted here: whether a given call site inlines depends on its position, and
+ * a test that pinned one such site would pin the inliner's current shape rather
+ * than this contract. `tests/phel/mock.phel` is the real evidence for it. Those
+ * tests failed at `-O2` before `^:redef` existed and pass with it, and the
+ * `Core tests at -O2` CI job is what keeps that true.
+ */
+final class CallInlinerRedefTest extends TestCase
+{
+    private CompilerFacade $compilerFacade;
+
+    protected function setUp(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+        new BuildFacade()->compileFile(
+            __DIR__ . '/../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core'),
+        );
+        $this->compilerFacade = new CompilerFacade();
+    }
+
+    public function test_a_redef_annotated_callee_still_sees_with_redefs_at_level_two(): void
+    {
+        $this->compileAtLevelTwo($this->program());
+
+        self::assertEquals(
+            Keyword::create('redefined'),
+            $this->evalAtLevelTwo('mockable-result'),
+        );
+    }
+
+    /**
+     * At the default level nothing is inlined, so both spellings observe the
+     * rebinding. `^:redef` costs nothing here and changes nothing.
+     */
+    public function test_both_see_with_redefs_at_the_default_level(): void
+    {
+        $opt0 = new CompileOptions()->setSource('inliner-redef-0');
+
+        BuildFacade::enableBuildMode();
+        try {
+            $this->compilerFacade->compile($this->program(), $opt0);
+        } finally {
+            BuildFacade::disableBuildMode();
+        }
+
+        foreach (['plain-result', 'mockable-result'] as $name) {
+            self::assertEquals(
+                Keyword::create('redefined'),
+                $this->compilerFacade->eval(
+                    $name,
+                    new CompileOptions()->setSource('inliner-redef-0-eval'),
+                ),
+                sprintf('%s observes the rebinding at level 0', $name),
+            );
+        }
+    }
+
+    private function compileAtLevelTwo(string $program): void
+    {
+        $opt2 = new CompileOptions()->setSource('inliner-redef')->setOptimizationLevel(2);
+
+        BuildFacade::enableBuildMode();
+        try {
+            $this->compilerFacade->compile($program, $opt2);
+        } finally {
+            BuildFacade::disableBuildMode();
+        }
+    }
+
+    private function evalAtLevelTwo(string $code): mixed
+    {
+        return $this->compilerFacade->eval(
+            $code,
+            new CompileOptions()->setSource('inliner-redef-eval')->setOptimizationLevel(2),
+        );
+    }
+
+    private function program(): string
+    {
+        return <<<'PHEL'
+        (defn plain [x] :original)
+        (defn ^:redef mockable [x] :original)
+
+        ;; Two things this shape has to get right. The `with-redefs` must sit in
+        ;; the same compilation unit as the definition it rebinds, because that
+        ;; is the only time the inliner can see the callee. And the call must
+        ;; not be in return position inside a `defn`, which the inliner declines
+        ;; for its own reasons (#3125), so it would pass here without proving
+        ;; anything about `^:redef`.
+        (def plain-result (with-redefs [plain (fn [x] :redefined)] (plain 1)))
+        (def mockable-result (with-redefs [mockable (fn [x] :redefined)] (mockable 1)))
+        PHEL;
+    }
+}


### PR DESCRIPTION
## 🤔 What is the problem?

`optimizationLevel: 2` failed five core tests on `main`, and nothing noticed, because the level defaults to 0 and no CI job raised it. No suite exercised `CallInliner` or `TailCallRewriter` at all.

Three of the five have been fixed since the issue was written (#3127 for the tagged parameters, and the inliner's by-reference capture and missing `return` are both gone). The two `phel.mock` failures remained, and they are not a defect: inlining splices the callee's body into the caller, so there is no longer a global read for `with-redefs` or `phel.mock` to intercept.

## 🤓 How do I solve it?

The same way Clojure answers the same tension with direct linking: a per-definition opt-out. `(defn ^:redef f ...)` keeps the call going through the global, at the cost of the inlining. The four `with-redefs` targets in `tests/phel/mock.phel` carry it now.

For the gap itself, a `Core tests at -O2` job. The repository's own `phel-config.php` reads `PHEL_OPTIMIZATION_LEVEL`, so the job is one env var and a local repro is `PHEL_OPTIMIZATION_LEVEL=2 ./bin/phel test` rather than an edit to a tracked file.

`test-core` is green at both levels: **9871 passed at 0 and at 2**.

## 🧪 How to verify it?

`tests/php/Integration/CallInlinerRedefTest.php` pins the guarantee: a `^:redef` callee still observes a rebinding at `-O2`, and nothing changes at level 0.

It deliberately does not assert the converse. Whether a given call site inlines depends on its position, so pinning one such site would pin the inliner's current shape rather than this contract; `(plain 1)` in return position inside a `defn` is not inlined today for reasons that belong to #3125. The real evidence is `tests/phel/mock.phel`, checked both ways: dropping `^:redef` from those four definitions turns the two tests red at `-O2` again, and restoring it turns them green. The new CI job is what keeps that honest.