### PR TITLE
perf(compiler): inline a call in return position at -O2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- `CallInliner` inlines a call in return position at `optimizationLevel` 2. Every `fn` body opens a recur frame, and the tail-slot guard tested for the frame's presence, so it declined the most common shape there is: `(defn c [x] (add1 x))` never inlined while `(defn c [x] [(add1 x)])` did. The guard now also requires `RecurFrame::isActive()`, set when a `recur` actually targets the frame, which is what "the tail slot of a `loop`" always meant. A two-hop call chain in return position is 3.1x faster. One consequence, inherent to direct linking: a call site that inlines is no longer there to intercept, so `dotrace`, `with-redefs` and `phel.mock` need `^:redef` on the callee more often at `-O2` than they did (#3125)
 - `atom` and `symbol` have fixed arities for the shapes callers actually use. `(atom v)` is 6.1x faster: it used to allocate a rest argument and `apply` `hash-map` over it on every creation just to find there were no options. `symbol` is 1.9x to 2.3x faster; it used `[name-or-ns & [name]]`, which built a rest argument and destructured one value back out of it. Both are behaviour-preserving, including `symbol` going on ignoring a third argument. `atom` with options is 3% slower, from the extra arity dispatch (#2973)
 
 ### Fixed

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/ArgumentBindings.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/ArgumentBindings.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\BindingNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+
+/**
+ * How {@see CallInliner} matched a call's arguments to the callee's
+ * parameters: the `let` bindings the arguments that could not be substituted
+ * need (empty when every argument went straight into the body), the
+ * parameter-name to node substitution map the body rebase walks with, and the
+ * call-site environment extended with each binding's shadow.
+ *
+ * @internal
+ */
+final readonly class ArgumentBindings
+{
+    /**
+     * @param list<BindingNode>           $bindings
+     * @param array<string, AbstractNode> $paramMap
+     */
+    public function __construct(
+        public array $bindings,
+        public array $paramMap,
+        public NodeEnvironmentInterface $scopeEnv,
+    ) {}
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
@@ -93,81 +93,144 @@ final readonly class CallInliner
             return null;
         }
 
-        if ($this->isMemoisedOrAsync($f->getMeta())) {
+        if ($this->isMemoisedOrAsync($f->getMeta()) || $this->isRedefinable($f->getMeta())) {
             return null;
         }
 
-        // Inlining splices the callee's body at the call site, so there is no
-        // longer a global read for `with-redefs` or `phel.mock` to intercept.
-        // That is inherent to direct linking rather than a defect in it, and
-        // Clojure answers the same tension the same way: `^:redef` opts a
-        // definition out, and the call keeps going through the var (#3126).
-        if ($this->isRedefinable($f->getMeta())) {
+        $fnNode = $this->spliceableArity($f, $args, $analyzer);
+        if (!$fnNode instanceof FnNode) {
             return null;
         }
 
-        // The side-table holds single-arity (`FnNode`) and multi-arity
-        // (`MultiFnNode`) defs; `arityFor` resolves the fixed arity whose
-        // parameter count matches the call (#2218), or `null` when the
-        // callee is unknown, not a `defn`, or only matches a variadic
-        // arity.
+        if ($this->isInActiveRecurTailSlot($env)) {
+            return null;
+        }
+
+        $params = $fnNode->getParams();
+        if ($this->hasTaggedParam($params)) {
+            return null;
+        }
+
+        $ret = $this->spliceableRet($fnNode, $f);
+        if (!$ret instanceof AbstractNode) {
+            return null;
+        }
+
+        // See containsPhpCall(): an interop call in an argument may write
+        // through a by-reference parameter, which relocating it would lose.
+        if ($this->anyContainsPhpCall($args)) {
+            return null;
+        }
+
+        $bound = $this->bindArguments($params, $args, $ret, $env, $callLocation);
+
+        // The body of a binding-wrapping `let` emits under the let body's
+        // context (return when the call site is an expression, so the
+        // generated IIFE returns the value); the unwrapped splice keeps
+        // the call site's own context byte-for-byte.
+        $bodyContext = ($bound->bindings !== [] && $env->isContext(NodeEnvironment::CONTEXT_EXPRESSION))
+            ? NodeEnvironment::CONTEXT_RETURN
+            : $env->getContext();
+
+        // `rebase` can still abort (returning `null`) if the body holds a
+        // node type outside the whitelist or a non-parameter local.
+        $inlined = $this->rebase($ret, new RebaseContext($bound->scopeEnv, $bodyContext, $callLocation, $bound->paramMap, true));
+        if (!$inlined instanceof AbstractNode) {
+            return null;
+        }
+
+        $folded = $this->fold($inlined);
+        if ($bound->bindings === []) {
+            return $folded;
+        }
+
+        $letNode = new LetNode($env, $bound->bindings, $folded, false, $callLocation);
+
+        return $this->letSimplifier->simplify($letNode);
+    }
+
+    /**
+     * The fixed arity a spliceable callee offers for this call, or `null` when
+     * the call must keep dispatching.
+     *
+     * The side-table holds single-arity (`FnNode`) and multi-arity
+     * (`MultiFnNode`) defs; `arityFor` resolves the fixed arity whose parameter
+     * count matches the call (#2218), or `null` when the callee is unknown, not
+     * a `defn`, or only matches a variadic arity. An arity containing `recur`
+     * is a loop rather than an expression, so it is never spliced.
+     *
+     * @param list<AbstractNode> $args
+     */
+    private function spliceableArity(GlobalVarNode $f, array $args, AnalyzerInterface $analyzer): ?FnNode
+    {
         $fnNode = $analyzer->getDefFnNode($f->getNamespace(), $f->getName())?->arityFor(count($args));
         if (!$fnNode instanceof FnNode) {
             return null;
         }
 
-        if ($fnNode->getRecurs()) {
-            return null;
-        }
+        return $fnNode->getRecurs() ? null : $fnNode;
+    }
 
-        // Stay out of the tail slot of an enclosing `loop`/`recur` frame so we
-        // never disturb tail-call semantics.
-        //
-        // The frame has to be *active*, not merely present. Every `fn` body
-        // opens a recur frame because every `fn` body may contain `recur`, so
-        // testing for the frame alone declined every call in return position in
-        // any function, which is the single most common shape there is:
-        // `(defn c [x] (add1 x))` never inlined while `(defn c [x] [(add1 x)])`
-        // did. `isActive()` is set when a `recur` actually targets the frame,
-        // which is what the paragraph above means (#3125).
+    /**
+     * Whether the call occupies the tail slot of an enclosing `loop`/`recur`
+     * frame, where splicing could disturb tail-call semantics.
+     *
+     * The frame has to be *active*, not merely present. Every `fn` body opens a
+     * recur frame because every `fn` body may contain `recur`, so testing for
+     * the frame alone declined every call in return position in any function,
+     * which is the single most common shape there is: `(defn c [x] (add1 x))`
+     * never inlined while `(defn c [x] [(add1 x)])` did. `isActive()` is set
+     * when a `recur` actually targets the frame, which is what the sentence
+     * above means (#3125).
+     */
+    private function isInActiveRecurTailSlot(NodeEnvironmentInterface $env): bool
+    {
         $recurFrame = $env->getCurrentRecurFrame();
-        if ($recurFrame instanceof RecurFrame
+
+        return $recurFrame instanceof RecurFrame
             && $recurFrame->isActive()
-            && $env->isContext(NodeEnvironment::CONTEXT_RETURN)
-        ) {
-            return null;
-        }
+            && $env->isContext(NodeEnvironment::CONTEXT_RETURN);
+    }
 
-        $params = $fnNode->getParams();
+    /**
+     * A tagged parameter is load-bearing, not decoration. `FnSymbol` emits it
+     * as a PHP parameter type, which does two things the call site cannot: PHP
+     * enforces the type on the way in, and the emitter treats the parameter as
+     * proven so arithmetic on it lowers to native operators. Splicing the body
+     * at the call site drops the declaration and both go with it (#3126):
+     *
+     *   (defn dotted-tag ^Symbol [^Symbol s] s)
+     *   (dotted-tag 42)      ; raises TypeError, until it is inlined
+     *
+     *   (defn- mul [^int a ^int b] (* a b))
+     *   (mul 4000000000 4000000000)
+     *     ; 1.6E+19, a native overflow to float, until it is inlined and
+     *     ; the untagged call site promotes to BigInt instead
+     *
+     * @param list<Symbol> $params
+     */
+    private function hasTaggedParam(array $params): bool
+    {
+        return array_any($params, static fn(Symbol $param): bool => TagResolver::fromMeta($param->getMeta()) !== null);
+    }
 
-        // A tagged parameter is load-bearing, not decoration. `FnSymbol` emits
-        // it as a PHP parameter type, which does two things the call site
-        // cannot: PHP enforces the type on the way in, and the emitter treats
-        // the parameter as proven so arithmetic on it lowers to native
-        // operators. Splicing the body at the call site drops the declaration
-        // and both go with it (#3126):
-        //
-        //   (defn dotted-tag ^Symbol [^Symbol s] s)
-        //   (dotted-tag 42)      ; raises TypeError, until it is inlined
-        //
-        //   (defn- mul [^int a ^int b] (* a b))
-        //   (mul 4000000000 4000000000)
-        //     ; 1.6E+19, a native overflow to float, until it is inlined and
-        //     ; the untagged call site promotes to BigInt instead
-        foreach ($params as $param) {
-            if (TagResolver::fromMeta($param->getMeta()) !== null) {
-                return null;
-            }
-        }
-
+    /**
+     * The single expression the callee body reduces to, or `null` when the body
+     * cannot be spliced.
+     *
+     * The body must be one pure expression: a `DoNode` with no leading
+     * statements, whose return expression is structurally pure. A `^:pure`
+     * callee asserts its own body is side-effect-free, so the annotation is
+     * trusted instead. Either way the rebaser still aborts on any unsupported
+     * node type.
+     */
+    private function spliceableRet(FnNode $fnNode, GlobalVarNode $f): ?AbstractNode
+    {
         $body = $fnNode->getBody();
         if (!$body instanceof DoNode || $body->getStmts() !== []) {
             return null;
         }
 
-        // A `^:pure` callee asserts its own body is side-effect-free, so we
-        // trust the annotation instead of structurally proving the body
-        // pure. The rebaser still aborts on any unsupported node type.
         $ret = $body->getRet();
         if (!$this->purity->isPureAnnotated($f->getMeta())
             && !$this->purity->isPure($ret)
@@ -175,28 +238,37 @@ final readonly class CallInliner
             return null;
         }
 
-        // Pure args substitute straight into the body (folding-friendly);
-        // impure or pure-but-multi-use args bind to a fresh gensym `let`
-        // so they evaluate exactly once, left to right.
-        //
-        // Each binding's shadow is also registered as a local on the env
-        // threaded into the body rebase: those shadows are assigned ahead
-        // of the body, so any nested node that emits a closure (a `let`
-        // in expression context, an `or`/`and`/`cond` IIFE) must capture
-        // them in its `use(...)` clause. Leaving them off the env would
-        // make the closure capture the call-site locals only and read the
-        // shadow as an undefined variable (issue #2622).
-        // See containsPhpCall(): an interop call in an argument may write
-        // through a by-reference parameter, which relocating it would lose.
-        foreach ($args as $arg) {
-            if ($this->containsPhpCall($arg)) {
-                return null;
-            }
-        }
+        return $ret;
+    }
 
+    /**
+     * Matches each argument to the parameter it fills.
+     *
+     * Pure args substitute straight into the body (folding-friendly); impure or
+     * pure-but-multi-use args bind to a fresh gensym `let` so they evaluate
+     * exactly once, left to right (#2215).
+     *
+     * Each binding's shadow is also registered as a local on the env threaded
+     * into the body rebase: those shadows are assigned ahead of the body, so
+     * any nested node that emits a closure (a `let` in expression context, an
+     * `or`/`and`/`cond` IIFE) must capture them in its `use(...)` clause.
+     * Leaving them off the env would make the closure capture the call-site
+     * locals only and read the shadow as an undefined variable (#2622).
+     *
+     * @param list<Symbol>       $params
+     * @param list<AbstractNode> $args
+     */
+    private function bindArguments(
+        array $params,
+        array $args,
+        AbstractNode $ret,
+        NodeEnvironmentInterface $env,
+        ?SourceLocation $callLocation,
+    ): ArgumentBindings {
         $bindings = [];
         $paramMap = [];
         $scopeEnv = $env;
+
         foreach ($params as $i => $param) {
             $arg = $args[$i];
             $name = $param->getName();
@@ -213,29 +285,7 @@ final readonly class CallInliner
             $paramMap[$name] = $arg;
         }
 
-        // The body of a binding-wrapping `let` emits under the let body's
-        // context (return when the call site is an expression, so the
-        // generated IIFE returns the value); the unwrapped splice keeps
-        // the call site's own context byte-for-byte.
-        $bodyContext = ($bindings !== [] && $env->isContext(NodeEnvironment::CONTEXT_EXPRESSION))
-            ? NodeEnvironment::CONTEXT_RETURN
-            : $env->getContext();
-
-        // `rebase` can still abort (returning `null`) if the body holds a
-        // node type outside the whitelist or a non-parameter local.
-        $inlined = $this->rebase($ret, new RebaseContext($scopeEnv, $bodyContext, $callLocation, $paramMap, true));
-        if (!$inlined instanceof AbstractNode) {
-            return null;
-        }
-
-        $folded = $this->fold($inlined);
-        if ($bindings === []) {
-            return $folded;
-        }
-
-        $letNode = new LetNode($env, $bindings, $folded, false, $callLocation);
-
-        return $this->letSimplifier->simplify($letNode);
+        return new ArgumentBindings($bindings, $paramMap, $scopeEnv);
     }
 
     /**
@@ -420,6 +470,10 @@ final readonly class CallInliner
      * The call site keeps reading the global, so rebinding its root with
      * `with-redefs` or `phel.mock` is still observed after the optimiser has
      * run. It costs the inlining, which is the point.
+     *
+     * Splicing a body leaves no global read to intercept, which is inherent to
+     * direct linking rather than a defect in it; Clojure answers the same
+     * tension the same way (#3126).
      *
      * @param PersistentMapInterface<mixed, mixed> $meta
      */

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/CallInliner.php
@@ -120,9 +120,19 @@ final readonly class CallInliner
             return null;
         }
 
-        // Stay out of the tail slot of an enclosing `loop`/`recur` frame
-        // so we never disturb tail-call semantics.
-        if ($env->getCurrentRecurFrame() instanceof RecurFrame
+        // Stay out of the tail slot of an enclosing `loop`/`recur` frame so we
+        // never disturb tail-call semantics.
+        //
+        // The frame has to be *active*, not merely present. Every `fn` body
+        // opens a recur frame because every `fn` body may contain `recur`, so
+        // testing for the frame alone declined every call in return position in
+        // any function, which is the single most common shape there is:
+        // `(defn c [x] (add1 x))` never inlined while `(defn c [x] [(add1 x)])`
+        // did. `isActive()` is set when a `recur` actually targets the frame,
+        // which is what the paragraph above means (#3125).
+        $recurFrame = $env->getCurrentRecurFrame();
+        if ($recurFrame instanceof RecurFrame
+            && $recurFrame->isActive()
             && $env->isContext(NodeEnvironment::CONTEXT_RETURN)
         ) {
             return null;

--- a/tests/phel/trace.phel
+++ b/tests/phel/trace.phel
@@ -101,7 +101,10 @@
 ;; dotrace
 ;; -------
 
-(defn- plain-add [a b] (+ a b))
+;; `^:redef` keeps the call reading the global instead of being inlined at
+;; `-O2`, which is what `dotrace` needs in order to intercept it. Same reason
+;; the `with-redefs` targets in mock.phel carry it (#3126, #3125).
+(defn- ^:redef plain-add [a b] (+ a b))
 
 (deftest test-dotrace-traces-within-body-only
   (let [[result lines] (capture-trace (fn [] (dotrace [plain-add] (plain-add 1 2))))]

--- a/tests/php/Integration/Compiler/CallInlineRuntimeTest.php
+++ b/tests/php/Integration/Compiler/CallInlineRuntimeTest.php
@@ -356,6 +356,54 @@ final class CallInlineRuntimeTest extends AbstractCompilerRuntimeTestCase
         self::assertStringNotContainsString('untagged-mul', $php, 'the guard must not disable inlining generally');
     }
 
+    public function test_a_call_in_return_position_is_inlined(): void
+    {
+        // A single-expression `defn` body *is* return position, and every `fn`
+        // body opens a recur frame, so the tail-slot guard used to decline the
+        // most common shape there is (#3125).
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval('(defn ret-add1 [x] (+ x 1))', $options);
+
+        // `compile` registers the definition in the analyzer environment but
+        // never runs it, so the runtime half needs a name of its own.
+        $php = $this->compilerFacade->compile('(defn ret-caller [x] (ret-add1 x))', $options)->getPhpCode();
+        self::assertStringNotContainsString('ret-add1', $php, 'the callee dispatch should be gone');
+
+        $this->compilerFacade->eval('(defn ret-caller-run [x] (ret-add1 x))', $options);
+        self::assertSame(6, $this->compilerFacade->eval('(ret-caller-run 5)', $options));
+    }
+
+    public function test_a_call_in_the_tail_slot_of_a_loop_keeps_dispatching(): void
+    {
+        // The `recur` marks the loop's frame active, so the call sharing that
+        // tail slot is left alone and tail-call semantics stay untouched.
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval('(defn loop-add1 [x] (+ x 1))', $options);
+
+        $body = '[n] (loop [i 0] (if (< i n) (recur (inc i)) (loop-add1 i)))';
+        $php = $this->compilerFacade->compile('(defn in-loop ' . $body . ')', $options)->getPhpCode();
+        self::assertStringContainsString('loop-add1', $php, 'the loop tail slot must keep dispatching');
+
+        $this->compilerFacade->eval('(defn in-loop-run ' . $body . ')', $options);
+        self::assertSame(6, $this->compilerFacade->eval('(in-loop-run 5)', $options));
+    }
+
+    public function test_a_self_tail_call_still_becomes_a_loop_after_a_sibling_inline(): void
+    {
+        // The other half of the guard: with an inlinable call spliced into one
+        // branch, `TailCallRewriter` must still recognise the self tail call in
+        // the other. The depth is what proves it — a real recursion at 50k
+        // frames blows the default PHP stack.
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval('(defn tail-add1 [x] (+ x 1))', $options);
+        $this->compilerFacade->eval(
+            '(defn tail-down [n] (if (zero? n) (tail-add1 0) (tail-down (dec n))))',
+            $options,
+        );
+
+        self::assertSame(1, $this->compilerFacade->eval('(tail-down 50000)', $options));
+    }
+
     public function test_an_argument_with_a_by_reference_interop_call_is_not_inlined(): void
     {
         // `preg_match` fills its third parameter by reference. Inlining moves

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/CallInlinerTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/CallInlinerTest.php
@@ -16,9 +16,11 @@ use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MultiFnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\RecurFrame;
 use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification\CallInliner;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
@@ -93,6 +95,58 @@ final class CallInlinerTest extends TestCase
         $this->seedDefn('my-loop', ['x'], $this->plusBody('x', 1), recurs: true);
 
         self::assertNull($this->inline('my-loop', [new LiteralNode($this->env, 5)]));
+    }
+
+    public function test_inlines_a_call_in_return_position(): void
+    {
+        // Every `fn` body opens a recur frame, and a single-expression body is
+        // return position, so gating on the frame's mere presence declined the
+        // most common shape there is: `(defn c [x] (my-inc x))` (#3125).
+        $this->seedDefn('my-inc', ['x'], $this->plusBody('x', 1));
+
+        $env = NodeEnvironment::empty()
+            ->withReturnContext()
+            ->withAddedRecurFrame(new RecurFrame([Symbol::create('x')]));
+
+        $result = $this->inline('my-inc', [new LiteralNode($env, 5)], env: $env);
+
+        self::assertInstanceOf(LiteralNode::class, $result);
+        self::assertSame(6, $result->getValue());
+    }
+
+    public function test_declines_in_the_tail_slot_of_an_active_recur_frame(): void
+    {
+        // A frame goes active once a `recur` targets it, which is the tail slot
+        // the guard is actually about.
+        $this->seedDefn('my-inc', ['x'], $this->plusBody('x', 1));
+
+        $frame = new RecurFrame([Symbol::create('i')]);
+        $frame->setIsActive(true);
+
+        $env = NodeEnvironment::empty()
+            ->withReturnContext()
+            ->withAddedRecurFrame($frame);
+
+        self::assertNull($this->inline('my-inc', [new LiteralNode($env, 5)], env: $env));
+    }
+
+    public function test_inlines_outside_the_tail_slot_of_an_active_recur_frame(): void
+    {
+        // Same active frame, but the call is an argument rather than the tail
+        // expression: nothing about `recur` is at stake.
+        $this->seedDefn('my-inc', ['x'], $this->plusBody('x', 1));
+
+        $frame = new RecurFrame([Symbol::create('i')]);
+        $frame->setIsActive(true);
+
+        $env = NodeEnvironment::empty()
+            ->withExpressionContext()
+            ->withAddedRecurFrame($frame);
+
+        $result = $this->inline('my-inc', [new LiteralNode($env, 5)], env: $env);
+
+        self::assertInstanceOf(LiteralNode::class, $result);
+        self::assertSame(6, $result->getValue());
     }
 
     public function test_declines_on_arity_mismatch(): void
@@ -320,11 +374,16 @@ final class CallInlinerTest extends TestCase
     /**
      * @param list<AbstractNode> $args
      */
-    private function inline(string $name, array $args, ?PersistentMapInterface $meta = null): ?AbstractNode
-    {
-        $f = new GlobalVarNode($this->env, 'user', Symbol::create($name), $meta ?? Phel::map());
+    private function inline(
+        string $name,
+        array $args,
+        ?PersistentMapInterface $meta = null,
+        ?NodeEnvironmentInterface $env = null,
+    ): ?AbstractNode {
+        $env ??= $this->env;
+        $f = new GlobalVarNode($env, 'user', Symbol::create($name), $meta ?? Phel::map());
 
-        return $this->inliner->tryInline($f, $args, $this->env, $this->analyzer);
+        return $this->inliner->tryInline($f, $args, $env, $this->analyzer);
     }
 
     private function plusBody(string $param, int $addend): DoNode


### PR DESCRIPTION
## 🤔 Background

`CallInliner` declined every call in return position, so the shape the inliner was written for never fired: `(defn c [x] (add1 x))` kept dispatching while `(defn c [x] [(add1 x)])` inlined. The cause is that the tail-slot guard tested whether a recur frame exists, and every `fn` body opens one because every `fn` body may contain `recur`.

## 💡 Goal

Make the guard mean what its comment says: stay out of the tail slot of a `loop`, not out of every function body.

## 🔖 Changes

- The guard now also requires `RecurFrame::isActive()`, which is set when a `recur` actually targets the frame.
- A two-hop call chain in return position is 3.1x faster (300k iterations, 197ms to 63ms, baseline a0cbb3b7d). Core tests are green at `-O2` and at the default level, with the same test total.
- The `dotrace` core test gains `^:redef`: once a call site is inlined there is no global read left to intercept, the same tension #3126 answered for `phel.mock`. This widens that consequence from argument position to return position, so `-O2` users of `dotrace`, `with-redefs` and `phel.mock` need `^:redef` on the callee more often.

Closes #3125
