### PR TITLE
fix(compiler): read Clojure's binding-first map destructuring order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `^:redef` metadata on a `defn` opts it out of inlining at `optimizationLevel` 2, so `with-redefs` and `phel.mock` still intercept the call. Inlining splices the callee's body into the caller, which leaves no global read to intercept; this is the same tension Clojure's direct linking has, answered the same way (#3126)
+- Map destructuring reads Clojure's binding-first order: `(let [{{:keys [c]} :inner} {:inner {:c 42}}] c)` evaluates to `42` where it used to fail with `Cannot destructure Phel\Lang\Keyword`. Each non-directive pair is decided by which side can be bound, so `{local :key}`, `{[x y] :point}` and `{n "name"}` all work alongside the existing key-first spelling; `:keys`, `:strs`, `:syms`, `:as` and `:or` are written the same way in both and are unchanged. A pair where neither side binds anything (`{:a :b}`) is now rejected with a message showing both spellings instead of failing further down (#3115)
 - A `Core tests at -O2` CI job. `optimizationLevel` defaults to 0, so nothing in CI exercised `CallInliner` or `TailCallRewriter`, which is how the level came to fail five core tests while every check stayed green. The repository's `phel-config.php` reads `PHEL_OPTIMIZATION_LEVEL`, so a local repro is `PHEL_OPTIMIZATION_LEVEL=2 ./bin/phel test` (#3126)
 
 ### Changed
 
 - `CallInliner` inlines a call in return position at `optimizationLevel` 2. Every `fn` body opens a recur frame, and the tail-slot guard tested for the frame's presence, so it declined the most common shape there is: `(defn c [x] (add1 x))` never inlined while `(defn c [x] [(add1 x)])` did. The guard now also requires `RecurFrame::isActive()`, set when a `recur` actually targets the frame, which is what "the tail slot of a `loop`" always meant. A two-hop call chain in return position is 3.1x faster. One consequence, inherent to direct linking: a call site that inlines is no longer there to intercept, so `dotrace`, `with-redefs` and `phel.mock` need `^:redef` on the callee more often at `-O2` than they did (#3125)
 - `atom` and `symbol` have fixed arities for the shapes callers actually use. `(atom v)` is 6.1x faster: it used to allocate a rest argument and `apply` `hash-map` over it on every creation just to find there were no options. `symbol` is 1.9x to 2.3x faster; it used `[name-or-ns & [name]]`, which built a rest argument and destructured one value back out of it. Both are behaviour-preserving, including `symbol` going on ignoring a third argument. `atom` with options is 3% slower, from the extra arity dispatch (#2973)
+
+### Deprecated
+
+- Key-first map destructuring pairs (`{:key local}`). They keep working unchanged; `--warn-deprecations` reports each one with the binding-first spelling that replaces it, and the order will be removed in a future release. An ambiguous pair whose two sides both bind (`{k v}`, where the left side is evaluated as the lookup key) keeps its current meaning and warns that it will follow at the next major (#3115)
 
 ### Fixed
 

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -158,6 +158,7 @@ Detectors detect and nothing else — they hold no flag, no dedup table, and no 
 | `Domain/Reader/QuasiquoteTransformer` | `$` auto-gensym |
 | `Domain/Analyzer/Environment/BackslashSeparatorDeprecator` | `\` namespace separator |
 | `Domain/Analyzer/Environment/DeprecatedDefinitionWarner` | any resolved definition whose meta carries `:deprecated` (`:superseded-by` names the replacement); works for project code too |
+| `.../SpecialForm/Binding/Deconstructor/MapBindingDeconstructor` | a map-destructuring pair still written key-first (`{:key local}`), and the ambiguous pair whose both sides bind (`{k v}`), which keeps its key-first meaning until the next major (#3115) |
 | `Domain/Deprecation/SupersededFormDeprecator` | a list head that is `php/new`, `php/->`, `php/::` or `set-var` — special forms Phel already says the Clojure way (#2877, #2888). Runs in `AnalyzePersistentList::analyze()` **before** the shorthand expansions, which rewrite `(.m obj)` into `(php/-> obj (m))`; after them every shorthand would warn. It also ignores an unlocated head, which is how `QualifiedMemberExpander`'s synthesized `php/::` form stays quiet |
 
 - Never suppress a notice with `@`: that hides it unconditionally, so a `--warn-deprecations` run prints nothing. Call `warn()` / `warnForSource()` / `warnOnceForSource()` / `warnSyntax()` instead.

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
@@ -8,10 +8,12 @@ use Phel;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\DeconstructorInterface;
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
+use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
 use Phel\Shared\Printer\Printer;
@@ -79,8 +81,7 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
                 continue;
             }
 
-            $this->rejectReversedPair($binding, $key, $bindTo);
-            $normalBindings[] = [$key, $bindTo];
+            $normalBindings[] = $this->resolveNormalPair($binding, $key, $bindTo);
         }
 
         $this->orDefaults = [];
@@ -220,36 +221,132 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
     }
 
     /**
-     * Catches Clojure-style `{local :keyword}` pairs at the top of map
-     * destructuring. Phel writes them the other way (`{:keyword local}`),
-     * so a `(Symbol, Keyword)` ordering is almost always a reflex typo
-     * from a Clojure user. Surface a targeted "did you mean" suggestion
-     * before downstream code blows up with the opaque
-     * "Cannot destructure Phel\\Lang\\Keyword".
+     * Resolves one non-directive pair to `[lookupKey, bindingForm]`.
+     *
+     * Phel has always written a pair key-first (`{:keyword local}`); Clojure
+     * writes it binding-first (`{local :keyword}`). Both are read here, decided
+     * per pair by which side can actually be bound, since only a symbol, a
+     * vector or a map is a binding form (#3115):
+     *
+     *   {:kw local}   key not bindable, value is    -> key-first (deprecated)
+     *   {local :kw}   key bindable, value not       -> binding-first
+     *   {a b}         both bindable                 -> key-first, ambiguous
+     *   {:a :b}       neither bindable              -> rejected
+     *
+     * The ambiguous case keeps its current meaning: a symbol key is evaluated,
+     * so `{k v}` looks up whatever `k` holds, and there is no way to tell that
+     * from a Clojure-order pair binding `k`. Flipping it silently would change
+     * what working code does, so it warns and stays as it is until the next
+     * major.
      *
      * @param PersistentMapInterface<mixed, mixed> $binding
+     *
+     * @return array{mixed, mixed}
      */
-    private function rejectReversedPair(
+    private function resolveNormalPair(
         PersistentMapInterface $binding,
         mixed $key,
         mixed $bindTo,
-    ): void {
-        if (!$key instanceof Symbol || !$bindTo instanceof Keyword) {
-            return;
+    ): array {
+        $keyBinds = $this->isBindingForm($key);
+        $valueBinds = $this->isBindingForm($bindTo);
+
+        if ($keyBinds && !$valueBinds) {
+            return [$bindTo, $key];
         }
 
-        $flipped = Phel::map($bindTo, $key);
+        if (!$keyBinds && !$valueBinds) {
+            $this->rejectUnbindablePair($binding, $key, $bindTo);
+        }
+
+        $this->warnKeyFirstPair($binding, $key, $bindTo, ambiguous: $keyBinds);
+
+        return [$key, $bindTo];
+    }
+
+    /**
+     * Whether a form can be bound to. `:keys`-style directives aside, this is
+     * what tells the two pair orders apart, so it has to agree with what
+     * {@see Deconstructor::deconstructBindings()} accepts.
+     */
+    private function isBindingForm(mixed $form): bool
+    {
+        return $form instanceof Symbol
+            || $form instanceof PersistentVectorInterface
+            || $form instanceof PersistentMapInterface;
+    }
+
+    /**
+     * Neither side binds anything, so the pair cannot be either order. This is
+     * where a mistyped pattern lands (`{:a :b}`, `{"x" "y"}`), and the message
+     * shows both spellings rather than the opaque "Cannot destructure
+     * Phel\\Lang\\Keyword" the deconstructor would raise further down.
+     *
+     * @param PersistentMapInterface<mixed, mixed> $binding
+     */
+    private function rejectUnbindablePair(
+        PersistentMapInterface $binding,
+        mixed $key,
+        mixed $bindTo,
+    ): never {
         $message = sprintf(
-            'Cannot destructure: expected map destructure pattern {:keyword local}, '
-            . "got reversed pair starting with symbol '%s'.\n\n"
-            . "Did you mean:\n  %s\n\n"
-            . "(Phel's destructure order is :keyword first, then local — "
-            . "opposite of Clojure's {local :keyword}.)",
-            $key->getName(),
-            Printer::readable()->print($flipped),
+            "Cannot destructure: neither side of the pair %s binds anything.\n\n"
+            . "A map destructuring pair binds a symbol, a vector or a map to a lookup key,\n"
+            . "written either way round:\n"
+            . "  {local :key}   ; Clojure order\n"
+            . '  {:key local}   ; Phel order, deprecated',
+            Printer::readable()->print(Phel::map($key, $bindTo)),
         );
 
         throw AnalyzerException::withLocation($message, $binding);
+    }
+
+    /**
+     * Reports a pair still written key-first, pointing at the Clojure-order
+     * spelling that replaces it.
+     *
+     * Gated like every other deprecation: silent unless `--warn-deprecations`
+     * is on, deduped per `(file, pair)`, and attributed to the macro that wrote
+     * the pattern rather than to the call site.
+     *
+     * @param PersistentMapInterface<mixed, mixed> $binding
+     */
+    private function warnKeyFirstPair(
+        PersistentMapInterface $binding,
+        mixed $key,
+        mixed $bindTo,
+        bool $ambiguous,
+    ): void {
+        $location = $binding->getStartLocation();
+        if (!$location instanceof SourceLocation) {
+            return;
+        }
+
+        $written = Printer::readable()->print(Phel::map($key, $bindTo));
+        $flipped = Printer::readable()->print(Phel::map($bindTo, $key));
+
+        DeprecationWarnings::warnOnceAtOrigin(
+            $location,
+            'map-destructure-key-first|' . $written,
+            static fn(string $file, int $line): string => $ambiguous
+                ? sprintf(
+                    'Ambiguous map destructuring pair %s at %s:%d: both sides are binding forms, '
+                    . 'so it is read key-first (the lookup key is what the left side evaluates to). '
+                    . 'Clojure-order pairs are read binding-first, and this shape will follow at the '
+                    . 'next major; write the lookup key as a keyword or string to keep it unambiguous.',
+                    $written,
+                    $file,
+                    $line,
+                )
+                : sprintf(
+                    'Key-first map destructuring pair %s at %s:%d is deprecated; write it '
+                    . 'binding-first, as %s. The key-first order will be removed in a future release.',
+                    $written,
+                    $file,
+                    $line,
+                    $flipped,
+                ),
+        );
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
@@ -328,24 +328,42 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
         DeprecationWarnings::warnOnceAtOrigin(
             $location,
             'map-destructure-key-first|' . $written,
-            static fn(string $file, int $line): string => $ambiguous
-                ? sprintf(
-                    'Ambiguous map destructuring pair %s at %s:%d: both sides are binding forms, '
-                    . 'so it is read key-first (the lookup key is what the left side evaluates to). '
-                    . 'Clojure-order pairs are read binding-first, and this shape will follow at the '
-                    . 'next major; write the lookup key as a keyword or string to keep it unambiguous.',
-                    $written,
-                    $file,
-                    $line,
-                )
-                : sprintf(
-                    'Key-first map destructuring pair %s at %s:%d is deprecated; write it '
-                    . 'binding-first, as %s. The key-first order will be removed in a future release.',
-                    $written,
-                    $file,
-                    $line,
-                    $flipped,
-                ),
+            fn(string $file, int $line): string => $ambiguous
+                ? $this->ambiguousPairMessage($written, $file, $line)
+                : $this->keyFirstPairMessage($written, $flipped, $file, $line),
+        );
+    }
+
+    /**
+     * The pair has a replacement spelling, so the notice names it.
+     */
+    private function keyFirstPairMessage(string $written, string $flipped, string $file, int $line): string
+    {
+        return sprintf(
+            'Key-first map destructuring pair %s at %s:%d is deprecated; write it binding-first, '
+            . 'as %s. The key-first order will be removed in a future release.',
+            $written,
+            $file,
+            $line,
+            $flipped,
+        );
+    }
+
+    /**
+     * Both sides bind, so there is no mechanical replacement to suggest: the
+     * flip would change which side is the lookup key. The notice says what the
+     * pair means today and what to write instead.
+     */
+    private function ambiguousPairMessage(string $written, string $file, int $line): string
+    {
+        return sprintf(
+            'Ambiguous map destructuring pair %s at %s:%d: both sides are binding forms, so it is '
+            . 'read key-first and the lookup key is what the left side evaluates to. Binding-first '
+            . 'is how every other pair is read, and this shape will follow at the next major; write '
+            . 'the lookup key as a keyword or a string to keep it unambiguous.',
+            $written,
+            $file,
+            $line,
         );
     }
 

--- a/tests/phel/core/destructuring.phel
+++ b/tests/phel/core/destructuring.phel
@@ -13,6 +13,19 @@
   (is (= 3 (let [{:keys [a b]} {:a 1 :b 2}] (+ a b))) "destructure hash map with :keys")
   (is (= {:a 1 :b 2} (let [{:keys [a b] :as user} {:a 1 :b 2}] user)) "destructure hash map with :keys and :as"))
 
+(deftest destructure-hash-map-clojure-order
+  (is (= 3 (let [{a :a b :b} {:a 1 :b 2}] (+ a b))) "binding first, as Clojure writes it")
+  (is (= 42 (let [{{:keys [c]} :inner} {:inner {:c 42}}] c)) "nested map pattern")
+  (is (= 3 (let [{[a1 a2] :a} {:a [1 2]}] (+ a1 a2))) "nested vector pattern")
+  (is (= "Alice" (let [{n "name"} {"name" "Alice"}] n)) "string lookup key")
+  (is (= 42 (let [{b :b :or {b 42}} {:a 1}] b)) ":or default for an absent key")
+  (is (= {:a 1} (let [{a :a :as m} {:a 1}] m)) ":as alongside a binding-first pair")
+  (is (= 3 (let [{a :a :keys [b]} {:a 1 :b 2}] (+ a b))) "mixed with a :keys directive"))
+
+(deftest destructure-hash-map-ambiguous-pair-stays-key-first
+  ;; Both sides bind, so the left one is still evaluated as the lookup key.
+  (is (= 1 (let [k :a] (let [{k v} {:a 1}] v))) "symbol key is evaluated"))
+
 (deftest destructure-hash-map-or-defaults
   ;; :or with :keys — default applied when key is absent
   (is (= 42 (let [{:keys [a b] :or {b 42}} {:a 1}] b))

--- a/tests/php/Integration/Fixtures/Let/let-destructure-map-clojure-order.test
+++ b/tests/php/Integration/Fixtures/Let/let-destructure-map-clojure-order.test
@@ -1,0 +1,32 @@
+--PHEL--
+(ns test)
+
+(let [{n :name {:keys [city]} :address} {:name "Alice" :address {:city "Berlin"}}]
+  [n city])
+--PHP--
+namespace test;
+require_once __DIR__ . '/phel/core.php';
+\Phel::addDefinition(
+  "phel.core",
+  "*file*",
+  "Let/let-destructure-map-clojure-order.test"
+);
+\Phel::addDefinition(
+  "phel.core",
+  "*ns*",
+  "test"
+);
+/** @var \Phel\Lang\Collections\Map\PersistentMapInterface $__phel_1_6 */
+$__phel_1_6 = \Phel::map(
+  \Phel\Lang\Keyword::create("name"), "Alice",
+  \Phel\Lang\Keyword::create("address"), \Phel::map(
+    \Phel\Lang\Keyword::create("city"), "Berlin"
+  )
+);
+$__phel_2_7 = (($__phel_1_6)[(\Phel\Lang\Keyword::create("name"))] ?? null);
+$n_8 = $__phel_2_7;
+$__phel_3_9 = (($__phel_1_6)[(\Phel\Lang\Keyword::create("address"))] ?? null);
+$__phel_4_10 = $__phel_3_9;
+$__phel_5_11 = (($__phel_4_10)[(\Phel\Lang\Keyword::create("city"))] ?? null);
+$city_12 = $__phel_5_11;
+\Phel::vector([$n_8, $city_12]);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
@@ -9,12 +9,17 @@ use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\BindingValidatorInterface;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor\MapBindingDeconstructor;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
+use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
+use PhelTest\Support\CapturesDeprecationsTrait;
 use PHPUnit\Framework\TestCase;
 
 final class MapBindingDeconstructorTest extends TestCase
 {
+    use CapturesDeprecationsTrait;
+
     private MapBindingDeconstructor $deconstructor;
 
     protected function setUp(): void
@@ -26,6 +31,11 @@ final class MapBindingDeconstructorTest extends TestCase
                 $this->createStub(BindingValidatorInterface::class),
             ),
         );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->stopCapturingDeprecations();
     }
 
     public function test_deconstruct_table(): void
@@ -526,42 +536,159 @@ final class MapBindingDeconstructorTest extends TestCase
         ], $bindings);
     }
 
-    public function test_reversed_pair_suggests_did_you_mean(): void
+    public function test_binding_first_pair_reads_the_keyword_as_the_lookup_key(): void
     {
-        // Clojure-style {local :keyword} should surface a targeted suggestion
-        // rather than the opaque "Cannot destructure Phel\\Lang\\Keyword".
+        // Clojure order: (let [{tops :tops} x]) binds `tops` from key :tops,
+        // which used to be rejected outright (#3115).
         $binding = Phel::map(
             Symbol::create('tops'),
             Keyword::create('tops'),
-        );
-
-        $this->expectException(AnalyzerException::class);
-        $this->expectExceptionMessage(
-            'Cannot destructure: expected map destructure pattern {:keyword local}, '
-            . "got reversed pair starting with symbol 'tops'.",
         );
 
         $bindings = [];
         $this->deconstructor->deconstruct($bindings, $binding, Symbol::create('x'));
+
+        self::assertEquals([
+            [Symbol::create('__phel_1'), Symbol::create('x')],
+            [
+                Symbol::create('__phel_2'),
+                Phel::list([
+                    Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
+                    Symbol::create('__phel_1'),
+                    Keyword::create('tops'),
+                ]),
+            ],
+            [Symbol::create('tops'), Symbol::create('__phel_2')],
+        ], $bindings);
     }
 
-    public function test_reversed_pair_message_renders_flipped_pair(): void
+    public function test_binding_first_pair_reads_a_string_as_the_lookup_key(): void
     {
+        // (let [{n "name"} x]) — the same order with a string key.
+        $binding = Phel::map(Symbol::create('n'), 'name');
+
+        $bindings = [];
+        $this->deconstructor->deconstruct($bindings, $binding, Symbol::create('x'));
+
+        self::assertEquals([
+            [Symbol::create('__phel_1'), Symbol::create('x')],
+            [
+                Symbol::create('__phel_2'),
+                Phel::list([
+                    Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
+                    Symbol::create('__phel_1'),
+                    'name',
+                ]),
+            ],
+            [Symbol::create('n'), Symbol::create('__phel_2')],
+        ], $bindings);
+    }
+
+    public function test_binding_first_pair_binds_a_nested_map_pattern(): void
+    {
+        // (let [{{:keys [c]} :inner} x]) — the shape reported in #3115.
         $binding = Phel::map(
-            Symbol::create('tops'),
-            Keyword::create('tops'),
+            Phel::map(Keyword::create('keys'), Phel::vector([Symbol::create('c')])),
+            Keyword::create('inner'),
         );
+
+        $bindings = [];
+        $this->deconstructor->deconstruct($bindings, $binding, Symbol::create('x'));
+
+        // The inner pattern destructures the value read at :inner, so `c` ends
+        // up bound and the lookup chain runs :inner then :c.
+        self::assertSame('c', $bindings[array_key_last($bindings)][0]->getName());
+        self::assertEquals(
+            Phel::list([
+                Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
+                Symbol::create('__phel_1'),
+                Keyword::create('inner'),
+            ]),
+            $bindings[1][1],
+        );
+    }
+
+    public function test_ambiguous_pair_keeps_the_key_first_meaning(): void
+    {
+        // (let [{k v} x]) — both sides bind, so the lookup key stays whatever
+        // `k` evaluates to, as it did before Clojure order was accepted.
+        $binding = Phel::map(Symbol::create('k'), Symbol::create('v'));
+
+        $bindings = [];
+        $this->deconstructor->deconstruct($bindings, $binding, Symbol::create('x'));
+
+        self::assertEquals(
+            Phel::list([
+                Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
+                Symbol::create('__phel_1'),
+                Symbol::create('k'),
+            ]),
+            $bindings[1][1],
+        );
+        self::assertEquals([Symbol::create('v'), Symbol::create('__phel_2')], $bindings[2]);
+    }
+
+    public function test_key_first_pair_reports_the_binding_first_spelling(): void
+    {
+        $this->startCapturingDeprecations();
+
+        $bindings = [];
+        $this->deconstructor->deconstruct(
+            $bindings,
+            $this->located(Phel::map(Keyword::create('name'), Symbol::create('n'))),
+            Symbol::create('x'),
+        );
+
+        $captured = $this->capturedDeprecations();
+        self::assertCount(1, $captured);
+        self::assertStringContainsString('{:name n}', $captured[0]);
+        self::assertStringContainsString('{n :name}', $captured[0]);
+        self::assertStringContainsString('/app/user.phel:7', $captured[0]);
+    }
+
+    public function test_ambiguous_pair_reports_that_it_stays_key_first(): void
+    {
+        $this->startCapturingDeprecations();
+
+        $bindings = [];
+        $this->deconstructor->deconstruct(
+            $bindings,
+            $this->located(Phel::map(Symbol::create('k'), Symbol::create('v'))),
+            Symbol::create('x'),
+        );
+
+        $captured = $this->capturedDeprecations();
+        self::assertCount(1, $captured);
+        self::assertStringContainsString('Ambiguous map destructuring pair {k v}', $captured[0]);
+    }
+
+    public function test_binding_first_pair_reports_nothing(): void
+    {
+        $this->startCapturingDeprecations();
+
+        $bindings = [];
+        $this->deconstructor->deconstruct(
+            $bindings,
+            $this->located(Phel::map(Symbol::create('n'), Keyword::create('name'))),
+            Symbol::create('x'),
+        );
+
+        self::assertSame([], $this->capturedDeprecations());
+    }
+
+    public function test_pair_that_binds_nothing_is_rejected_with_both_spellings(): void
+    {
+        // (let [{:a :b} x]) — a keyword cannot be bound either way round.
+        $binding = Phel::map(Keyword::create('a'), Keyword::create('b'));
 
         try {
             $bindings = [];
             $this->deconstructor->deconstruct($bindings, $binding, Symbol::create('x'));
             self::fail('Expected AnalyzerException');
         } catch (AnalyzerException $analyzerException) {
-            self::assertStringContainsString('{:tops tops}', $analyzerException->getMessage());
-            self::assertStringContainsString(
-                "Phel's destructure order is :keyword first, then local",
-                $analyzerException->getMessage(),
-            );
+            self::assertStringContainsString('{:a :b} binds anything', $analyzerException->getMessage());
+            self::assertStringContainsString('{local :key}', $analyzerException->getMessage());
+            self::assertStringContainsString('{:key local}', $analyzerException->getMessage());
         }
     }
 
@@ -606,5 +733,18 @@ final class MapBindingDeconstructorTest extends TestCase
 
         $bindings = [];
         $this->deconstructor->deconstruct($bindings, $binding, Symbol::create('x'));
+    }
+
+    /**
+     * A deprecation is only reported against a form that knows where it was
+     * written, and only when that file is the user's own.
+     *
+     * @param PersistentMapInterface<mixed, mixed> $binding
+     *
+     * @return PersistentMapInterface<mixed, mixed>
+     */
+    private function located(PersistentMapInterface $binding): PersistentMapInterface
+    {
+        return $binding->setStartLocation(new SourceLocation('/app/user.phel', 7, 3));
     }
 }


### PR DESCRIPTION
## 🤔 Background

Phel writes a map destructuring pair key-first (`{:key local}`); Clojure writes it binding-first (`{local :key}`). The Clojure spelling was a compile error, and the nested shape reported in the issue failed with the opaque `Cannot destructure Phel\Lang\Keyword` rather than the targeted suggestion the flat shape got.

## 💡 Goal

Read both orders, so Clojure code and habits port over, without changing what any working Phel program does.

## 🔖 Changes

- Each non-directive pair is decided by which side can be bound, since only a symbol, a vector or a map is a binding form: `{:kw local}` stays key-first, `{local :kw}` reads binding-first, `{k v}` (both bindable) keeps its key-first meaning because a symbol key is evaluated, and `{:a :b}` (neither bindable) is rejected with a message showing both spellings. `:keys`, `:strs`, `:syms`, `:as` and `:or` are spelled the same way in both languages and are untouched.
- Key-first pairs are deprecated through the existing gate: silent unless `--warn-deprecations`, deduped per (file, pair), attributed to the macro that wrote the pattern. Nothing that compiles today stops compiling.
- Tests: unit coverage for each pair shape and both notices, Phel end-to-end cases, and a `--PHEL--`/`--PHP--` fixture. Full suite green, plus core tests at `-O2`.
- The stdlib and shipped examples still use the key-first spelling; flipping those is a follow-up so this PR stays reviewable.

Closes #3115
