### PR TITLE
fix(core): merge an associative PHP array by key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `merge` and `conj` treat an associative PHP array as the map-like value the rest of core already reads it as, instead of appending at the next integer index. `(merge #php {"a" 1} #php {"b" 2})` returns `#php {"a" 1 "b" 2}` rather than putting the right operand at key `0`, and `(merge arr nil)` no longer appends `nil`. The left operand's type is preserved, matching `into`. Indexed PHP arrays still append, and conj-ing a value that is not a `[key value]` pair or an associative collection onto an associative array now throws, as it does for a map. `merge-with` no longer crashes with "Call to a member function asTransient() on array" when given one (#3114)
 - `phel.json/decode` reads with `assoc = false`, so a JSON object stays a map instead of collapsing to a vector. `{}` now round-trips (`(= {} (decode (encode {})))`), a nested `{}` keeps its shape at any depth, and an object whose keys are all numeric (`{"0":"a"}`) decodes as `{:0 "a"}` rather than `["a"]`. `decode-value` still turns a PHP associative array into a map for callers that reach for it directly (#3089)
 
 ### Changed

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -499,12 +499,22 @@ Without arguments, uses a default cache size of 128 entries."
   ;; destructuring was most of the cost. Seeding from `left` is the merge
   ;; itself, not an optimisation, so the metadata question that stopped
   ;; `update-vals` seeding does not arise here.
-  (let [acc (transient left)]
-    (foreach [k v right]
-      (if (contains? acc k)
-        (.put acc k (f (get acc k) v))
-        (.put acc k v)))
-    (persistent acc)))
+  ;;
+  ;; A PHP array has no transient, so seeding one used to fail with "Call to a
+  ;; member function asTransient() on array" (#3114). PHP array assignment
+  ;; copies, which gives the same fresh-result guarantee a transient does, and
+  ;; writing through `aset` keeps the array the caller passed in.
+  (if (php/is_array left)
+    (let [acc left]
+      (foreach [k v right]
+        (aset acc k (if (php/array_key_exists k acc) (f (aget acc k) v) v)))
+      acc)
+    (let [acc (transient left)]
+      (foreach [k v right]
+        (if (contains? acc k)
+          (.put acc k (f (get acc k) v))
+          (.put acc k v)))
+      (persistent acc))))
 
 (defn merge-with
   "Merges multiple maps into one new map. If a key appears in more than one collection, the result of `(f current-val next-val)` is used."

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -494,27 +494,35 @@ Without arguments, uses a default cache size of 128 entries."
     (new Equalizer)
     (Seq/flatten coll))))
 
+(defn- merge-with-into-array
+  "A PHP array has no transient, so seeding one failed with \"Call to a member
+  function asTransient() on array\" (#3114). PHP array assignment copies, which
+  gives the same fresh-result guarantee a transient does, and writing through
+  `aset` keeps the array type the caller passed in."
+  [f left right]
+  (let [acc left]
+    (foreach [k v right]
+      (aset acc k (if (php/array_key_exists k acc) (f (aget acc k) v) v)))
+    acc))
+
+(defn- merge-with-into-transient
+  [f left right]
+  (let [acc (transient left)]
+    (foreach [k v right]
+      (if (contains? acc k)
+        (.put acc k (f (get acc k) v))
+        (.put acc k v)))
+    (persistent acc)))
+
 (defn- merge-with-2 [f left right]
   ;; `foreach` and not `for … :pairs`, as the map rebuilders in #3140: the
   ;; destructuring was most of the cost. Seeding from `left` is the merge
   ;; itself, not an optimisation, so the metadata question that stopped
   ;; `update-vals` seeding does not arise here.
   ;;
-  ;; A PHP array has no transient, so seeding one used to fail with "Call to a
-  ;; member function asTransient() on array" (#3114). PHP array assignment
-  ;; copies, which gives the same fresh-result guarantee a transient does, and
-  ;; writing through `aset` keeps the array the caller passed in.
   (if (php/is_array left)
-    (let [acc left]
-      (foreach [k v right]
-        (aset acc k (if (php/array_key_exists k acc) (f (aget acc k) v) v)))
-      acc)
-    (let [acc (transient left)]
-      (foreach [k v right]
-        (if (contains? acc k)
-          (.put acc k (f (get acc k) v))
-          (.put acc k v)))
-      (persistent acc))))
+    (merge-with-into-array f left right)
+    (merge-with-into-transient f left right)))
 
 (defn merge-with
   "Merges multiple maps into one new map. If a key appears in more than one collection, the result of `(f current-val next-val)` is used."

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -255,7 +255,18 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
     (php/=== coll nil)                              (list value)
     (php/instanceof coll PersistentListInterface)   (cons value coll)
     (php/instanceof coll LazySeqInterface)          (cons value coll)
-    (php/is_array coll)                             (do (php/apush coll value) coll)
+    ;; A PHP array is a push target only when it is a list. An associative one
+    ;; is the map-like shape the rest of core already reads associatively
+    ;; (`php->phel`, `into`, `get`, `keys`, `count`), so it takes the map path
+    ;; and merges by key instead of appending the whole right operand at the
+    ;; next integer index (#3114). An empty array counts as indexed, which is
+    ;; what `(merge [] {:b 2})` relies on. The test is spelled out rather than
+    ;; calling `indexed-php-array?`, which would repeat the `is_array` above
+    ;; and add a call to this branch (#2973).
+    (php/is_array coll)
+    (if (or (php/empty coll) (php/array_is_list coll))
+      (do (php/apush coll value) coll)
+      (conj-map-entry coll value))
     ;; `set-target?` and `map-target?` spelled out for the same reason: each is
     ;; an `or` of two `instanceof` and cost a call to answer it.
     (or (php/instanceof coll PersistentHashSetInterface)
@@ -1553,18 +1564,20 @@ Stops when the shorter of `keys` or `vals` is exhausted. Works safely with infin
 (defn- merge-right
   [left right]
   (cond
-    (nil? left)  (when-not (nil? right) (conj {} right))
-    (nil? right) (if (map? left) left (conj left right))
+    (nil? left)                    (when-not (nil? right) (conj {} right))
+    (nil? right)                   (if (map? left) left (conj left right))
     ;; Two maps merge through the collection's own `merge`, which bulk-builds
     ;; the result through a transient. `conj` reaches the same result by adding
     ;; the right map's entries one at a time, each a Phel call (#2973).
     (and (map? left) (map? right)) (.merge left right)
-    :else        (conj left right)))
+    :else                          (conj left right)))
 
 (defn merge
   "Merges multiple maps into one new map.
 
-If a key appears in more than one collection, later values replace previous ones."
+If a key appears in more than one collection, later values replace previous ones.
+
+An associative PHP array merges by key and keeps its type; an indexed one is appended to, the way a vector is."
   {:example "(merge {:a 1 :b 2} {:b 3 :c 4}) ; => {:a 1, :b 3, :c 4}"}
   ([] nil)
   ([map] map)

--- a/tests/phel/core/merge-php-arrays.phel
+++ b/tests/phel/core/merge-php-arrays.phel
@@ -1,0 +1,79 @@
+(ns phel-test.core.merge-php-arrays
+  (:require phel.test :refer [deftest is thrown?]))
+
+;; `merge` is repeated `conj`, and `conj` treated every PHP array as a push
+;; target, so an associative array on the left had the whole right operand
+;; appended at integer key 0 (#3114). The rest of core already reads an
+;; associative PHP array as map-like: `php->phel` turns it into a map, `into`
+;; merges into it by key, and `get`/`keys`/`count` all answer associatively.
+;; What has to hold: associative arrays merge by key, indexed ones still
+;; append, and neither operand is mutated.
+
+(defn- assoc-array
+  ([] (php-associative-array))
+  ([k v] (php-associative-array k v))
+  ([k1 v1 k2 v2] (php-associative-array k1 v1 k2 v2)))
+
+(deftest test-merge-associative-php-arrays
+  (let [merged (merge (assoc-array "a" 1) (assoc-array "b" 2))]
+    (is (= 1 (get merged "a")) "the left key survives")
+    (is (= 2 (get merged "b")) "the right key is merged in, not appended")
+    (is (= ["a" "b"] (keys merged)) "no integer key was introduced")
+    (is (= :php/array (type merged)) "the left operand's type is preserved")))
+
+(deftest test-merge-right-operand-wins-on-a-shared-key
+  (is (= 2 (get (merge (assoc-array "a" 1) (assoc-array "a" 2)) "a"))
+      "the later value replaces the earlier one")
+  (is (= 9 (get (merge (assoc-array "a" 1) (assoc-array "b" 2) (assoc-array "a" 9)) "a"))
+      "three-way fold, last one wins"))
+
+(deftest test-merge-with-nil
+  (let [merged (merge (assoc-array "a" 1) nil)]
+    (is (= 1 (get merged "a")) "the array survives")
+    (is (= ["a"] (keys merged)) "nil is not appended at key 0"))
+  (is (= {"b" 2} (merge nil (php-associative-array "b" 2)))
+      "a nil left still seeds a Phel map"))
+
+(deftest test-merge-across-the-boundary
+  (is (= {:a 1 "b" 2} (merge {:a 1} (php-associative-array "b" 2)))
+      "an array on the right of a map already worked")
+  (let [merged (merge (assoc-array "a" 1) {"b" 2})]
+    (is (= 2 (get merged "b")) "a string-keyed Phel map merges into an array")
+    (is (= :php/array (type merged)) "and the array type is kept")))
+
+(deftest test-indexed-php-arrays-still-append
+  (is (= [1 2 3] (php->phel (merge (php-indexed-array 1 2) 3)))
+      "an indexed array appends, as a vector does")
+  (is (= [nil] (php->phel (merge (php-indexed-array) nil)))
+      "an empty array counts as indexed, so nil is appended as it always was")
+  (is (= [nil {} 1 {:a "c"}] (merge [] nil {} 1 {:a "c"}))
+      "the documented vector fold is unchanged"))
+
+(deftest test-conj-on-an-associative-php-array
+  (let [conjed (conj (assoc-array "a" 1) ["b" 2])]
+    (is (= 2 (get conjed "b")) "a [key value] pair is assigned")
+    (is (= ["a" "b"] (keys conjed)) "and not appended"))
+  (is (thrown? \InvalidArgumentException (conj (php-associative-array "a" 1) 3))
+      "a non-entry value is rejected, as it is for a map"))
+
+(deftest test-operands-are-not-mutated
+  (let [left   (php-associative-array "a" 1)
+        right  (php-associative-array "b" 2)
+        merged (merge left right)]
+    (is (= 2 (get merged "b")) "the merge is correct")
+    (is (= ["a"] (keys left)) "the left array is untouched")
+    (is (= ["b"] (keys right)) "the right array is untouched")))
+
+(deftest test-merge-with-on-php-arrays
+  ;; `merge-with` seeded a transient from its left operand, which a PHP array
+  ;; cannot provide: it crashed with "Call to a member function asTransient()".
+  (let [merged (merge-with + (assoc-array "a" 1 "b" 2) (assoc-array "a" 10 "c" 3))]
+    (is (= 11 (get merged "a")) "the shared key is combined")
+    (is (= 2 (get merged "b")) "a left-only key survives")
+    (is (= 3 (get merged "c")) "a right-only key is added")
+    (is (= :php/array (type merged)) "the array type is kept"))
+  (is (= 6 (get (merge-with + (php-associative-array "a" 1) {"a" 5}) "a"))
+      "a Phel map on the right combines too")
+  (let [left (php-associative-array "a" 1)]
+    (merge-with + left (php-associative-array "a" 2))
+    (is (= 1 (get left "a")) "the left array is not mutated")))


### PR DESCRIPTION
## 🤔 Background

`(merge #php {"a" 1} #php {"b" 2})` returned `<PHP-Array ["a":1, 0:<PHP-Array ["b":2]>]>`: the right operand appended at integer key `0`, so `(get merged "b")` was nil. `merge` is repeated `conj`, and `conj`'s PHP-array branch treated every PHP array as a push target. That branch predates the indexed/associative distinction the rest of core already makes, which is why the same call worked with the array on the right of a Phel map.

## 💡 Goal

Make an associative PHP array behave in `merge` and `conj` the way `into`, `php->phel`, `get`, `keys` and `count` already treat it: as a map-like value keyed by its own keys.

## 🔖 Changes

- `conj` dispatches on whether the array is a list. Indexed arrays still append; associative ones take the map path, preserving the left operand's type exactly as `into` does. `(merge arr nil)` stops appending a literal `nil`.
- `merge-with` no longer crashes with "Call to a member function asTransient() on array": the PHP-array case folds through `aset`, keeping the array type and leaving the caller's array untouched.
- Behaviour change worth calling out: conj-ing a value that is not a `[key value]` pair or an associative collection onto an associative array now throws, as it does for a map, where it used to append.
- New `tests/phel/core/merge-php-arrays.phel` covers the reported symptoms, the boundary directions, immutability of both operands, and pins that indexed arrays still append. Full suite and quality gate green.
- `deep-merge` silently returns only its right operand for a PHP array; that is a design gap rather than this bug, so it is left for a follow-up issue.

Closes #3114
