### PR TITLE
feat(core): make to-array canonical and deprecate to-php-array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### Deprecated
 
+- `to-php-array` in favour of `to-array`, the Clojure-aligned name that already existed as its alias. Behaviour is identical for every input, `nil` included, which both answer with an empty PHP array; `--warn-deprecations` reports each call site with the replacement, and the alias will be removed at the next major. `to-array` yields an **indexed** array, so a map becomes an array of `[key value]` pairs, exactly as `to-php-array` did; `phel->php` remains the conversion that produces an associative array. The bundled agent docs claimed `to-php-array` produced an associative array from a map, which it never did, and now point at `phel->php` (#3076)
 - Key-first map destructuring pairs (`{:key local}`). They keep working unchanged; `--warn-deprecations` reports each one with the binding-first spelling that replaces it, and the order will be removed in a future release. An ambiguous pair whose two sides both bind (`{k v}`, where the left side is evaluated as the lookup key) keeps its current meaning and warns that it will follow at the next major (#3115)
 
 ### Fixed

--- a/docs/migration/deprecated-surface.md
+++ b/docs/migration/deprecated-surface.md
@@ -133,6 +133,32 @@ therefore needs a non-public primitive to take that over first.
 
 Tracked in [#2888](https://github.com/phel-lang/phel-lang/issues/2888).
 
+## `to-php-array`
+
+`to-array` is the Clojure-aligned spelling, and it already existed as an alias
+of `to-php-array`. The names have swapped roles: `to-array` holds the
+conversion and `to-php-array` is the deprecated alias, to be removed at the
+next major.
+
+```phel
+(to-php-array coll)                   (to-array coll)
+```
+
+Behaviour is identical for every input, `nil` included, which both spellings
+answer with an empty PHP array.
+
+Both give an **indexed** array. A map becomes an indexed array of `[key value]`
+pairs, not an associative array, and that has not changed either:
+
+```phel
+(to-array {:a 1})                     ; => [[:a 1]]
+(phel->php {:a 1})                    ; => ["a" => 1]
+```
+
+`phel->php` is the conversion that produces an associative array, recursively.
+
+Tracked in [#3076](https://github.com/phel-lang/phel-lang/issues/3076).
+
 ## Deprecating your own definitions
 
 The mechanism is not phel-specific. Any `def`/`defn` carrying

--- a/resources/agents/RULES.md
+++ b/resources/agents/RULES.md
@@ -12,7 +12,7 @@ Single source for every skill adapter.
 6. Only `false` and `nil` are falsy. `0`, `""`, `[]` truthy.
 7. Namespaces need ≥ 2 segments. Prefer `.` separator (`app.main`); `\` still parses but is deprecated. File path matches ns under src dir.
 8. Comments: `;` inline, `;;` standalone, `#_` skips the next form.
-9. PHP assoc array: `#php {:k "v"}` stringifies keyword keys; use `(to-php-array m)` for an existing Phel map.
+9. PHP assoc array: `#php {:k "v"}` stringifies keyword keys; use `(phel->php m)` for an existing Phel map (`to-array` gives an indexed array of `[k v]` pairs).
 10. Catch PHP: `(catch SomeException e ...)`.
 11. Annotate hot-path `defn` with `:tag` on params + return for PHP type emission, JIT-friendly call shape, and compile-time mismatch diagnostics. See `tasks/typed-defn.md`.
 

--- a/resources/agents/tasks/common-gotchas.md
+++ b/resources/agents/tasks/common-gotchas.md
@@ -48,11 +48,12 @@ PHP interop returns raw PHP arrays, not Phel collections. Convert:
 
 ```phel
 (vec (php/explode "," "a,b,c"))   ; PHP array  → Phel vector
-(to-php-array ["a" "b" "c"])      ; Phel vec   → PHP indexed array
+(to-array ["a" "b" "c"])          ; Phel vec   → PHP indexed array
+(phel->php {:a 1})                ; Phel map   → PHP assoc array
 (php-array-to-map arr)            ; PHP assoc  → Phel map
 ```
 
-`to-list` and `to-vec` don't exist. Use `vec` / `to-php-array`.
+`to-list` and `to-vec` don't exist. Use `vec` / `to-array`.
 
 ## 6. Record fields use `get`, not `.-prop`
 

--- a/resources/agents/tasks/debug-errors.md
+++ b/resources/agents/tasks/debug-errors.md
@@ -61,7 +61,7 @@ Use `some->`:
 
 ```phel
 (php/array_merge #php {:a 1} #php {:b 2})        ; OK
-(php/array_merge (to-php-array {:a 1}) ...)    ; OK
+(php/array_merge (phel->php {:a 1}) ...)       ; OK
 (php-array-to-map arr)                         ; reverse
 ```
 

--- a/resources/agents/tasks/typed-defn.md
+++ b/resources/agents/tasks/typed-defn.md
@@ -15,7 +15,7 @@
 (defn ^string   greet   [^string name]       (str "Hello, " name "!"))
 (defn ^bool     valid?  [^string s]          (php/!== "" s))
 (defn ^DateTimeImmutable now [] (new DateTimeImmutable))
-(defn ^{:tag "array"} pairs [m] (to-php-array m))
+(defn ^{:tag "array"} pairs [m] (to-array m))
 ```
 
 | Shorthand | Compiles to |

--- a/resources/agents/tasks/use-php-libs.md
+++ b/resources/agents/tasks/use-php-libs.md
@@ -55,7 +55,7 @@ composer require guzzlehttp/guzzle
 
 (defn query-all [pdo sql params]
   (let [stmt (.prepare pdo sql)]
-    (.execute stmt (to-php-array params))
+    (.execute stmt (to-array params))
     (map php-array-to-map (.fetchAll stmt PDO/FETCH_ASSOC))))
 ```
 
@@ -63,8 +63,9 @@ composer require guzzlehttp/guzzle
 
 | Direction | Call |
 |-----------|------|
-| Phel map → PHP assoc | `(to-php-array {:a 1})` |
-| Phel vec → PHP indexed | `(to-php-array [1 2])` |
+| Phel map → PHP assoc | `(phel->php {:a 1})` |
+| Phel vec → PHP indexed | `(to-array [1 2])` |
+| Phel map → `[k v]` pairs | `(to-array {:a 1})` |
 | Keyword → string | `(name :foo)` |
 | PHP assoc → Phel map | `(php-array-to-map arr)` |
 
@@ -77,7 +78,7 @@ composer require guzzlehttp/guzzle
 
 ## Gotchas
 
-- Convert maps for PHP libs; use `#php {}` or `to-php-array`.
+- Convert maps for PHP libs; use `#php {}` or `phel->php`.
 - Method chain: `(-> obj (.a) (.b))`, not `(-> obj .a .b)`.
 - `php/new`, `php/->` and `php/::` are deprecated; the spellings above are the only ones to write.
 - Static constants need `:use` or full path.

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -341,7 +341,7 @@ Useful for building multi-turn conversations."
   [schema]
   (let [lines (for [[k v] :pairs schema]
                 (str "  \"" (name k) "\": " (if (string? v) v (str v))))]
-    (str "{\n" (php/implode ",\n" (to-php-array lines)) "\n}")))
+    (str "{\n" (php/implode ",\n" (to-array lines)) "\n}")))
 
 (defn- schema-prop-spec
   "Resolves a schema field value into a JSON Schema property spec."

--- a/src/phel/core/arrays.phel
+++ b/src/phel/core/arrays.phel
@@ -63,7 +63,7 @@
   array (accessible via `aget`/`aset`) since PHP has no typed
   array distinction."
   {:example "(object-array 3) ; => <PHP-Array [nil, nil, nil]>\n(object-array [1 2 3]) ; => <PHP-Array [1, 2, 3]>"
-   :see-also ["php-indexed-array" "to-php-array"]}
+   :see-also ["php-indexed-array" "to-array"]}
   [size-or-seq]
   (if (php/is_int size-or-seq)
     (if (php/< size-or-seq 0)
@@ -71,16 +71,10 @@
       (if (php/=== 0 size-or-seq)
         (php/array)
         (php/array_fill 0 size-or-seq nil)))
-    (to-php-array size-or-seq)))
+    (to-array size-or-seq)))
 
-(defn to-array
-  "Returns a PHP array containing the elements of `coll`. Accepts any collection (vector, list, set, map, PHP array) or `nil`, which yields an empty PHP array. Matches Clojure's `to-array` for `.cljc` interop — in Phel the result is a plain PHP array since PHP has no `Object[]`."
-  {:example "(to-array [1 2 3]) ; => <PHP-Array [1, 2, 3]>\n(to-array nil) ; => <PHP-Array []>"
-   :see-also ["to-php-array" "object-array"]}
-  [coll]
-  (if (php/=== coll nil)
-    (php/array)
-    (to-php-array coll)))
+;; `to-array` itself lives in `defs.phel`: `defexception`'s expansion needs it,
+;; and that file loads first (#3076).
 
 (defn into-array
   "Returns a PHP array containing the elements of `aseq`. Accepts any
@@ -121,7 +115,7 @@
 
 (defn- typed-array-coerce-seq
   [coerce-fn size seq-src]
-  (let [src (to-php-array seq-src)
+  (let [src (to-array seq-src)
         n   (php/count src)
         len (if (php/=== nil size)
               n

--- a/src/phel/core/async.phel
+++ b/src/phel/core/async.phel
@@ -55,10 +55,10 @@
   {:example "(await-all [(async 1) (async 2)])"
    :see-also ["await" "await-any" "pmap"]}
   [futures]
-  (let [php-futures (to-php-array (map unwrap-future futures))
+  (let [php-futures (to-array (map unwrap-future futures))
         ;; `Amp\\Future\\await` preserves the original integer keys but
         ;; fills the result array in *completion* order, so we re-read by
-        ;; index (0..n-1, contiguous from `to-php-array`) to restore the
+        ;; index (0..n-1, contiguous from `to-array`) to restore the
         ;; caller's input order — `pmap` and `.cljc` parity rely on it.
         results     (php/amp\future\await php-futures)]
     (for [i :in (range (php/count results))]
@@ -69,7 +69,7 @@
   {:example "(await-any [(async 1) (async 2)])"
    :see-also ["await" "await-all"]}
   [futures]
-  (let [php-futures (to-php-array (map unwrap-future futures))]
+  (let [php-futures (to-array (map unwrap-future futures))]
     (php/amp\future\awaitfirst php-futures)))
 
 (defn pmap

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -20,22 +20,44 @@
 ;; Basic macros
 ;; ------------
 
-(def to-php-array
-  {:doc "Creates a PHP Array from a sequential data structure."
-   :see-also ["to-array" "php-array-to-map" "phel->php"]}
+(def to-array
+  {:doc "Returns a PHP array containing the elements of `coll`. Accepts any collection (vector, list, set, map, PHP array) or `nil`, which yields an empty PHP array. A map yields an indexed array of `[key value]` pairs; `phel->php` is the conversion that yields an associative array. Matches Clojure's `to-array` for `.cljc` interop — in Phel the result is a plain PHP array since PHP has no `Object[]`."
+   :example "(to-array [1 2 3]) ; => <PHP-Array [1, 2, 3]>\n(to-array nil) ; => <PHP-Array []>"
+   :see-also ["php-array-to-map" "phel->php" "object-array"]}
   (fn [coll]
-    (if (php/is_array coll)
-      coll
-      ;; `SeqInterface` declares `toArray`, and every sequential type reaches
-      ;; it: `PersistentVectorInterface` and `PersistentListInterface` both
-      ;; extend it, as do the lazy seqs and `Cons`. Going through `apply`
-      ;; instead spread the collection into a variadic call and rebuilt the
-      ;; array from the iterator. Maps, sets and strings have no `toArray` and
-      ;; keep the old path, which is also the only one that can flatten a map
-      ;; into pairs.
-      (if (php/instanceof coll SeqInterface)
-        (.toArray coll)
-        (apply php/array coll)))))
+    (if (php/=== coll nil)
+      (php/array)
+      (if (php/is_array coll)
+        coll
+        ;; `SeqInterface` declares `toArray`, and every sequential type reaches
+        ;; it: `PersistentVectorInterface` and `PersistentListInterface` both
+        ;; extend it, as do the lazy seqs and `Cons`. Going through `apply`
+        ;; instead spread the collection into a variadic call and rebuilt the
+        ;; array from the iterator. Maps, sets and strings have no `toArray` and
+        ;; keep the old path, which is also the only one that can flatten a map
+        ;; into pairs.
+        (if (php/instanceof coll SeqInterface)
+          (.toArray coll)
+          (apply php/array coll))))))
+
+;; The two names have always been the same conversion: `to-array` was defined
+;; as `(if (nil? coll) (php/array) (to-php-array coll))`, and `to-php-array`
+;; reached `(apply php/array nil)`, which is also an empty array. `to-array` is
+;; the Clojure-aligned spelling, so it holds the body and this name stays as an
+;; alias until the next major (#3076).
+(def to-php-array
+  {:doc "Deprecated alias of `to-array`."
+   :deprecated "0.51.0"
+   :superseded-by "to-array"
+   ;; A `def` of an existing fn carries no arglist of its own, and the API
+   ;; surface snapshot would record the alias as `<value>`, which reads as a
+   ;; function that stopped being callable. It is spelled out so `phel doc` and
+   ;; the snapshot keep showing the signature until the alias goes. The key is
+   ;; the string `"arglists"`, which is what the analyzer writes and what
+   ;; `PhelFnNormalizer` reads.
+   "arglists" "[coll]"
+   :see-also ["to-array" "php-array-to-map" "phel->php"]}
+  to-array)
 
 (def defn-builder
   {:macro true, :private true}

--- a/src/phel/core/interop.phel
+++ b/src/phel/core/interop.phel
@@ -67,7 +67,7 @@
   [target method & args]
   (let [callable (php-indexed-array target method)]
     (if (php/is_callable callable)
-      (php/call_user_func_array callable (to-php-array args))
+      (php/call_user_func_array callable (to-array args))
       (throw (new InvalidArgumentException
                   (str "Call to undefined method "
                        (invoke-target-name target)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -798,7 +798,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   ;; The fallback spreads `arr` rather than `xs`: the conversion has already
   ;; happened by then, and re-walking the original collection made a non-int
   ;; sum measurably slower than before the fast path existed.
-  (let [arr (to-php-array xs)]
+  (let [arr (to-array xs)]
     (if (all-native-ints? arr)
       (let [total (php/array_sum arr)]
         (if (php/is_int total)
@@ -818,7 +818,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(median [3 1 2]) ; => 2\n(median [1 2 3 4]) ; => 2.5"
    :see-also ["mean" "sum"]}
   [xs]
-  (let [arr (to-php-array xs)
+  (let [arr (to-array xs)
         cnt (count arr)]
     (when (zero? cnt)
       (throw (new InvalidArgumentException "Cannot compute median of empty sequence")))

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -508,7 +508,7 @@ This function is useful for explicitly converting strings to sequences of charac
    :see-also ["count"]}
   [coll]
   ;; Most of what this function costs is the conversion at the bottom, not the
-  ;; dispatch: on a vector, `to-php-array` plus `seqList` is the bulk of it and
+  ;; dispatch: on a vector, `to-array` plus `seqList` is the bulk of it and
   ;; no ordering changes that. What the dispatch can stop paying for is the
   ;; `seq?` call and core `count`, which is what the two changes below remove.
   (cond
@@ -536,7 +536,7 @@ This function is useful for explicitly converting strings to sequences of charac
     (seq-list coll)
 
     true
-    (seq-list (to-php-array coll))))
+    (seq-list (to-array coll))))
 
 (defn- indexed-php-array?
   [x]

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -182,7 +182,7 @@ When `from` is associative, it is treated as a sequence of key-value pairs. Supp
          ;; `vec` is (#3134). `copy-meta` because the transient this replaces
          ;; carried `to`'s metadata through `persistent`, where a fresh
          ;; `Phel/vector` would not.
-         (let [arr (to-php-array to)]
+         (let [arr (to-array to)]
            (foreach [value entries]
              (php/apush arr value))
            (copy-meta to (Phel/vector arr)))
@@ -805,7 +805,7 @@ Creates intermediate maps if they don't exist."
   [coll]
   (let [arr    (if (string? coll)
                  (php/mb_str_split coll)
-                 (to-php-array coll))
+                 (to-array coll))
         result (Phel/vector (php/array_reverse arr))]
     (copy-meta coll result)))
 
@@ -959,7 +959,7 @@ Works with vectors, lists, sets, and strings."
 (defn php-array-to-map
   "Converts a PHP Array to a Phel map."
   {:example "(php-array-to-map (php-associative-array \"a\" 1 \"b\" 2)) ; => {\"a\" 1, \"b\" 2}"
-   :see-also ["to-php-array" "php->phel"]}
+   :see-also ["to-array" "php->phel"]}
   [arr]
   (let [res (transient {})]
     (foreach [k v arr]
@@ -1107,7 +1107,7 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps."
 
 (defn- sorted-vector
   [coll comp]
-  (let [php-array (to-php-array coll)]
+  (let [php-array (to-array coll)]
     (php/usort php-array comp)
     (copy-meta coll (Phel/vector php-array))))
 
@@ -1121,7 +1121,7 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps."
   ;; The array is converted once and reused by both branches. Delegating the
   ;; fallback to `sorted-vector` would convert a second time, which made every
   ;; non-int sort slower than before the fast path existed.
-  (let [php-array (to-php-array coll)]
+  (let [php-array (to-array coll)]
     (cond
       (all-native-ints? php-array)    (php/sort (php/ref php-array) php/SORT_NUMERIC)
       (all-native-strings? php-array) (php/sort (php/ref php-array))
@@ -1160,12 +1160,12 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps."
   the transform buys."
   [keyfn coll comp]
   (let [cmp    (sort-comparator comp)
-        ;; `to-php-array` and not `foreach` over `coll` directly: it is the
+        ;; `to-array` and not `foreach` over `coll` directly: it is the
         ;; conversion `sorted-vector` used, and it is what decides what an
         ;; element *is*. Iterating a map yields its values, while converting one
         ;; yields its `[key value]` entries, which is what `sort` and `sort-by`
         ;; have always sorted.
-        values (to-php-array coll)
+        values (to-array coll)
         ks     (php/array)
         vs     (php/array)
         idx    (php/array)
@@ -1237,7 +1237,7 @@ If no comparator is supplied compare is used."
   "Returns a random permutation of coll."
   {:example "(shuffle [1 2 3 4 5]) ; => [2 3 5 1 4]"}
   [coll]
-  (let [php-array (to-php-array coll)]
+  (let [php-array (to-array coll)]
     (php/shuffle php-array)
     (copy-meta coll (Phel/vector php-array))))
 

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -95,7 +95,7 @@
     (apply str (sort kvs))))
 
 (defn- ^string render-attr-table [value]
-  (escape-html (php/implode " " (to-php-array (for [[k v] :pairs value :when v] (to-str k))))))
+  (escape-html (php/implode " " (to-array (for [[k v] :pairs value :when v] (to-str k))))))
 
 (defn- ^string render-attribute-value [name value]
   (cond
@@ -104,7 +104,7 @@
     (map? value)
     (render-attr-table value)
     (indexed? value)
-    (escape-html (php/implode " " (to-php-array (map to-str value))))
+    (escape-html (php/implode " " (to-array (map to-str value))))
     (escape-html (to-str value))))
 
 (defn- ^string render-attribute [name value]

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -735,9 +735,9 @@ Returns nil. Prints one name per line, sorted alphabetically."
         public-names (sort (keys publics))
         alias-lines  (for [[alias-name target-ns] :pairs aliases]
                        (str "  " alias-name " -> " target-ns))
-        fn-summary   (php/implode ", " (to-php-array (take 50 public-names)))]
+        fn-summary   (php/implode ", " (to-array (take 50 public-names)))]
     (str "Current namespace: " ns "\n"
-         "Aliases:\n" (php/implode "\n" (to-php-array alias-lines)) "\n"
+         "Aliases:\n" (php/implode "\n" (to-array alias-lines)) "\n"
          "Available functions (first 50): " fn-summary)))
 
 (defn- build-symbol-context
@@ -851,7 +851,7 @@ Options are passed through to `ai/embed`."
                       :doc doc
                       :text (str fn-name ": " doc)})
         texts      (map #(get % :text) entries)
-        embeddings (ai/embed (to-php-array texts) opts)]
+        embeddings (ai/embed (to-array texts) opts)]
     (map (fn [entry embedding]
            (assoc entry :embedding embedding))
          entries embeddings)))

--- a/src/phel/schema/explainer.phel
+++ b/src/phel/schema/explainer.phel
@@ -260,5 +260,5 @@
     (let [header (str "Schema " (print-str (get result :schema))
                       " failed for value " (print-str (get result :value)))
           lines  (into [] (map format-error (get result :errors)))
-          body   (php/implode "\n" (to-php-array lines))]
+          body   (php/implode "\n" (to-array lines))]
       (str header "\n" body))))

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -79,8 +79,8 @@ This is a convenience function for converting strings to character sequences. Pr
 (defn join
   "Returns a string of all elements in coll, separated by an optional separator."
   {:example "(join \", \" [\"apple\" \"banana\" \"cherry\"]) ; => \"apple, banana, cherry\""}
-  ([coll] (php/implode "" (to-php-array coll)))
-  ([separator coll] (php/implode separator (to-php-array coll))))
+  ([coll] (php/implode "" (to-array coll)))
+  ([separator coll] (php/implode separator (to-array coll))))
 
 (defn subs
   "Returns the substring of s from start (inclusive) to end (exclusive)."

--- a/src/phel/watch.phel
+++ b/src/phel/watch.phel
@@ -41,5 +41,5 @@
       (aset phpOpts "poll" (get opts :poll)))
     (when (and opts (get opts :debounce))
       (aset phpOpts "debounce" (get opts :debounce)))
-    (.watch facade (to-php-array paths) phpOpts)
+    (.watch facade (to-array paths) phpOpts)
     nil))

--- a/tests/phel/ai.phel
+++ b/tests/phel/ai.phel
@@ -810,7 +810,7 @@
       (let [original @ai/config]
         (ai/configure {:provider :openai :api-key "k"})
         (let [index (ai/build-index ["hello" "world"])
-              items (to-php-array index)]
+              items (to-array index)]
           (is (= 2 (count index)) "builds two index entries")
           (is (= "hello" (get (aget items 0) :text)) "first text preserved")
           (is (= [0.1 0.9] (get (aget items 0) :embedding)) "first embedding attached"))

--- a/tests/phel/core/sequence-functions.phel
+++ b/tests/phel/core/sequence-functions.phel
@@ -424,24 +424,35 @@
   (is (= [:a 1 :b 2 :c 3] (kvs {:a 1 :b 2 :c 3})) "kvs of maps")
   (is (= [0 3 1 2 2 1] (kvs [3 2 1])) "kvs of vector"))
 
-(deftest test-to-php-array
-  (is (= (php-indexed-array 3 2 1) (to-php-array [3 2 1])) "to-php-array")
-  (is (= (php-indexed-array "a" "b" "c") (to-php-array "abc")) "to-php-array string characters"))
+(deftest test-to-array
+  (is (= (php-indexed-array 3 2 1) (to-array [3 2 1])) "to-array")
+  (is (= (php-indexed-array "a" "b" "c") (to-array "abc")) "to-array string characters"))
 
-(deftest test-to-php-array-over-every-input-shape
+(deftest test-to-array-over-every-input-shape
   ;; Sequential types now go through `SeqInterface::toArray`; everything else
   ;; keeps the `apply` path. Both must answer what they always did.
-  (is (= (php-indexed-array 1 2 3) (to-php-array '(1 2 3))) "list")
-  (is (= (php-indexed-array) (to-php-array [])) "empty vector")
-  (is (= (php-indexed-array) (to-php-array '())) "empty list")
-  (is (= (php-indexed-array 1 2 3) (to-php-array (subvec [0 1 2 3] 1 4))) "subvector")
-  (is (= (php-indexed-array 1 2 3) (to-php-array (cons 1 '(2 3)))) "cons")
-  (is (= (php-indexed-array 2 3 4) (to-php-array (map inc [1 2 3]))) "lazy seq")
-  (is (= (php-indexed-array 0 1 2) (to-php-array (range 0 3))) "range")
-  (is (= (php-indexed-array 1 2) (to-php-array (php-indexed-array 1 2))) "a PHP array passes through")
+  (is (= (php-indexed-array 1 2 3) (to-array '(1 2 3))) "list")
+  (is (= (php-indexed-array) (to-array [])) "empty vector")
+  (is (= (php-indexed-array) (to-array '())) "empty list")
+  (is (= (php-indexed-array 1 2 3) (to-array (subvec [0 1 2 3] 1 4))) "subvector")
+  (is (= (php-indexed-array 1 2 3) (to-array (cons 1 '(2 3)))) "cons")
+  (is (= (php-indexed-array 2 3 4) (to-array (map inc [1 2 3]))) "lazy seq")
+  (is (= (php-indexed-array 0 1 2) (to-array (range 0 3))) "range")
+  (is (= (php-indexed-array 1 2) (to-array (php-indexed-array 1 2))) "a PHP array passes through")
   ;; A map has no `toArray`, and only the `apply` path flattens it to pairs.
-  (is (= 2 (php/count (to-php-array {:a 1, :b 2}))) "map yields one entry per pair")
-  (is (= [:a 1] (php/aget (to-php-array {:a 1}) 0)) "map entries stay key/value vectors"))
+  (is (= 2 (php/count (to-array {:a 1, :b 2}))) "map yields one entry per pair")
+  (is (= [:a 1] (php/aget (to-array {:a 1}) 0)) "map entries stay key/value vectors")
+  (is (= (php-indexed-array) (to-array nil)) "nil yields an empty array"))
+
+(deftest test-to-php-array-is-a-deprecated-alias
+  ;; The old name keeps working until the next major, and answers identically
+  ;; on every input shape (#3076).
+  (is (= (to-array [1 2]) (to-php-array [1 2])) "vector")
+  (is (= (to-array nil) (to-php-array nil)) "nil")
+  ;; Through `php->phel`, because `=` compares the objects inside a PHP array
+  ;; by identity, so two equal arrays of pair vectors are not `=`.
+  (is (= (php->phel (to-array {:a 1})) (php->phel (to-php-array {:a 1}))) "map")
+  (is (= (to-array "ab") (to-php-array "ab")) "string"))
 
 (deftest test-sort
   (is (= [] (sort nil)) "sort nil")

--- a/tests/php/Benchmark/Phel/CoreConstructionBench.php
+++ b/tests/php/Benchmark/Phel/CoreConstructionBench.php
@@ -39,7 +39,7 @@ final class CoreConstructionBench extends CoreBenchCase
     private $str;
 
     /** @var callable */
-    private $toPhpArray;
+    private $toArray;
 
     /** @var callable */
     private $atom;
@@ -190,7 +190,7 @@ final class CoreConstructionBench extends CoreBenchCase
     }
 
     /**
-     * `to-php-array` over a sequential collection (#3021 A6). It used to be
+     * `to-array` over a sequential collection (#3021 A6). It used to be
      * `(apply php/array coll)`, which spread the collection into a variadic
      * call and rebuilt the array from the iterator; `SeqInterface::toArray`
      * does it directly.
@@ -199,12 +199,16 @@ final class CoreConstructionBench extends CoreBenchCase
      * barely does: 1.08μs to 0.47μs at three elements, 10.61μs to 1.39μs at a
      * hundred, against a ~0.18μs empty-closure floor.
      *
+     * The subject keeps its `to_php_array` name after the function was renamed
+     * (#3076): the benchmark gate compares subjects by name against a stored
+     * baseline, and renaming one drops it to "new subject, nothing to compare".
+     *
      * @Revs(1000)
      */
     public function bench_to_php_array_small(): void
     {
         for ($i = 0; $i < self::INNER; ++$i) {
-            ($this->toPhpArray)($this->smallVector);
+            ($this->toArray)($this->smallVector);
         }
     }
 
@@ -216,7 +220,7 @@ final class CoreConstructionBench extends CoreBenchCase
      */
     public function bench_to_php_array_large(): void
     {
-        ($this->toPhpArray)($this->largeVector);
+        ($this->toArray)($this->largeVector);
     }
 
     /**
@@ -229,7 +233,7 @@ final class CoreConstructionBench extends CoreBenchCase
     public function bench_to_php_array_map(): void
     {
         for ($i = 0; $i < self::INNER; ++$i) {
-            ($this->toPhpArray)($this->map);
+            ($this->toArray)($this->map);
         }
     }
 
@@ -292,7 +296,7 @@ final class CoreConstructionBench extends CoreBenchCase
         $this->symbol = $this->coreFn('symbol');
         $this->metaKeyword = Phel::keyword('meta');
 
-        $this->toPhpArray = $this->coreFn('to-php-array');
+        $this->toArray = $this->coreFn('to-array');
         $this->smallVector = Phel::vector(['a', 'b', 'c']);
         $this->largeVector = Phel::vector(range(0, 99));
         $this->map = Phel::map(Phel::keyword('a'), 1, Phel::keyword('b'), 2);

--- a/tests/php/Benchmark/Phel/CoreDispatchBench.php
+++ b/tests/php/Benchmark/Phel/CoreDispatchBench.php
@@ -197,7 +197,7 @@ final class CoreDispatchBench extends CoreBenchCase
     /**
      * A floor, not a target, and the only pair here that is not like for like.
      *
-     * `seq` on a vector falls through to `(seq-list (to-php-array coll))`, so
+     * `seq` on a vector falls through to `(seq-list (to-array coll))`, so
      * it materialises a *list*. No single native call does that, and the gap
      * between this subject and `bench_seq_vector` is mostly `Phel::seqList`
      * building the result, which is the value `seq` exists to return rather

--- a/tests/php/Benchmark/Phel/StdlibStringBench.php
+++ b/tests/php/Benchmark/Phel/StdlibStringBench.php
@@ -215,7 +215,7 @@ final class StdlibStringBench extends CoreBenchCase
 
     /**
      * Unlike the pairs above this one does not converge: the residual is
-     * `to-php-array`, which is `(apply php/array coll)` (item A6 of #3021) and
+     * `to-array`, which is `(apply php/array coll)` (item A6 of #3021) and
      * lives in `phel.core`. The gap is the measurement of that item.
      *
      * @Revs(1000)

--- a/tests/php/Integration/Compiler/DeprecatedCoreAliasTest.php
+++ b/tests/php/Integration/Compiler/DeprecatedCoreAliasTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Compiler;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
+use Phel\Compiler\Domain\Deprecation\DeprecationWarnings;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompileOptions;
+use PHPUnit\Framework\TestCase;
+
+use function restore_error_handler;
+use function set_error_handler;
+use function sys_get_temp_dir;
+use function tempnam;
+
+use const E_USER_DEPRECATED;
+
+/**
+ * `to-php-array` is the first `phel.core` definition to carry `:deprecated`
+ * metadata, so this pins that the generic definition-level channel actually
+ * reaches a stdlib alias: the notice fires at a *user* call site, names the
+ * replacement, and stays silent when the flag is off (#3076).
+ *
+ * The mechanism itself is covered by `DeprecatedDefinitionWarnerTest`; what is
+ * specific here is that the deprecation is announced from the standard library,
+ * whose own sources are suppressed.
+ */
+final class DeprecatedCoreAliasTest extends TestCase
+{
+    private static GlobalEnvironmentInterface $globalEnv;
+
+    private CompilerFacade $compilerFacade;
+
+    public static function setUpBeforeClass(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Symbol::resetGen();
+        $globalEnv = GlobalEnvironmentSingleton::initializeNew();
+        new BuildFacade()->compileFile(
+            __DIR__ . '/../../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core'),
+        );
+        self::$globalEnv = $globalEnv;
+    }
+
+    protected function setUp(): void
+    {
+        $this->compilerFacade = new CompilerFacade();
+        self::$globalEnv->setNs('user');
+        Symbol::resetGen();
+        DeprecationWarnings::reset();
+        DeprecationWarnings::enable();
+    }
+
+    protected function tearDown(): void
+    {
+        DeprecationWarnings::reset();
+    }
+
+    public function test_calling_the_deprecated_alias_names_its_replacement(): void
+    {
+        $warnings = $this->compileCapturingDeprecations('(to-php-array [1 2])');
+
+        self::assertCount(1, $warnings);
+        self::assertStringContainsString('phel.core/to-php-array', $warnings[0]);
+        self::assertStringContainsString("Use 'to-array' instead", $warnings[0]);
+    }
+
+    public function test_the_replacement_does_not_warn(): void
+    {
+        self::assertSame([], $this->compileCapturingDeprecations('(to-array [1 2])'));
+    }
+
+    public function test_nothing_is_reported_when_warnings_are_disabled(): void
+    {
+        DeprecationWarnings::disable();
+
+        self::assertSame([], $this->compileCapturingDeprecations('(to-php-array [1 2])'));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function compileCapturingDeprecations(string $phelCode): array
+    {
+        $warnings = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$warnings): bool {
+            $warnings[] = $errstr;
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $this->compilerFacade
+                ->compile($phelCode, new CompileOptions()->setSource('/app/user.phel'))
+                ->getPhpCode();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $warnings;
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`to-array` was defined as `(if (nil? coll) (php/array) (to-php-array coll))`, and `to-php-array` already answered `nil` with an empty array through `(apply php/array nil)`. The two names have always been the same conversion, and `to-array` is the Clojure-aligned one, so generated code and docs kept teaching the PHP-flavoured spelling.

## 💡 Goal

Make `to-array` the canonical name and put `to-php-array` on the standard deprecation path, with no behaviour change for either.

## 🔖 Changes

- The bodies swap: `to-array` holds the conversion in `defs.phel`, where `defexception`'s expansion needs it, and `to-php-array` becomes an alias carrying `:deprecated "0.51.0"` and `:superseded-by "to-array"`. Every user call site reports the replacement under `--warn-deprecations`; nothing changes with the flag off. This is the first `phel.core` definition to use that channel, so a new integration test pins that it fires from the standard library and stays silent when disabled.
- The alias keeps `arglists` metadata, so `phel doc` and the API surface snapshot still read `(to-php-array coll)` instead of a bare value. The snapshot is byte-identical.
- Every stdlib call site moved to `to-array`, `defexception`'s expansion included, so generated code stops emitting the deprecated name.
- Docs bug fixed along the way: the bundled agent docs claimed `to-php-array` converted a Phel map into a PHP **associative** array. It never did; a map becomes an indexed array of `[key value]` pairs, and `phel->php` is the associative conversion. Four files said the wrong thing and now say this.
- `docs/migration/deprecated-surface.md` gains the entry; removal is at the next major, tracked by this issue.

Related to #3076
