### PR TITLE
test(bench): measure small-map reads through both construction paths

### DIFF
--- a/tests/phel/bench/core.phel
+++ b/tests/phel/bench/core.phel
@@ -45,6 +45,14 @@
 (defbench bench-get-in
   (get-in nested [:a :b :c]))
 
+;; A six-entry map built by growing, which is where the representation a map
+;; ends up with is decided (#3172). `bench-get-in` reads two-entry maps and
+;; never reaches that size.
+(def- grown-map (zipmap [:k0 :k1 :k2 :k3 :k4 :k5] [0 1 2 3 4 5]))
+
+(defbench bench-get-grown-map
+  (get grown-map :k5))
+
 (defbench bench-str-three
   (str "a" "b" "c"))
 

--- a/tests/php/Benchmark/Lang/Collections/Map/PersistentArrayMapBench.php
+++ b/tests/php/Benchmark/Lang/Collections/Map/PersistentArrayMapBench.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Lang\Collections\Map;
+
+use Phel\Lang\Collections\Map\PersistentArrayMap;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Equalizer;
+use Phel\Lang\Hasher;
+use Phel\Lang\Keyword;
+use Phel\Lang\TypeFactory;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\ParamProviders;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+
+/**
+ * Small-map reads, measured through the two construction paths a small map
+ * actually comes from.
+ *
+ * {@see PersistentHashMapBench} measures a forced hash map, and the existing
+ * `phel.core` subjects use two-entry maps, so the size range where the
+ * representation is chosen — and where the linear scan in
+ * `PersistentArrayMap::findIndex()` costs an `Equalizer::equalsKey()` per entry
+ * — was unmeasured (#3172).
+ *
+ * Two things here are deliberate:
+ *
+ * - **The sizes are literals, not derived from `MAX_SIZE`.** A corpus that
+ *   moves with the constant stops being a corpus: the numbers before and after
+ *   a threshold change would describe different inputs.
+ * - **Both paths are built.** `TypeFactory::persistentMapFromArray()` is what a
+ *   `{...}` literal compiles to, and a transient `put` chain is what `assoc`,
+ *   `into` and `zipmap` do. Which representation each ends up with is the
+ *   thing under measurement, so neither subject forces a class.
+ *
+ * Keys are keywords, the common case in Phel code and the one whose equality
+ * goes through `Keyword::equals` rather than a native `===`.
+ */
+final class PersistentArrayMapBench
+{
+    private PersistentMapInterface $literalMap;
+
+    private PersistentMapInterface $grownMap;
+
+    private Keyword $lastKey;
+
+    private Keyword $absentKey;
+
+    /**
+     * The last key, so the array-map scan runs to the end: the first key is the
+     * best case and would hide the linear walk.
+     *
+     * @BeforeMethods("setUpMaps")
+     *
+     * @ParamProviders("provideSizes")
+     *
+     * @Revs(1000)
+     *
+     * @Iterations(10)
+     */
+    public function bench_find_last_in_literal_map(): void
+    {
+        $this->literalMap->find($this->lastKey);
+    }
+
+    /**
+     * The same map built by growing, which is the path `assoc`/`into` take.
+     * Paired with the subject above: the two disagreeing is the symptom.
+     *
+     * @BeforeMethods("setUpMaps")
+     *
+     * @ParamProviders("provideSizes")
+     *
+     * @Revs(1000)
+     *
+     * @Iterations(10)
+     */
+    public function bench_find_last_in_grown_map(): void
+    {
+        $this->grownMap->find($this->lastKey);
+    }
+
+    /**
+     * A miss is the array map's worst case: the whole array is scanned and no
+     * entry matches.
+     *
+     * @BeforeMethods("setUpMaps")
+     *
+     * @ParamProviders("provideSizes")
+     *
+     * @Revs(1000)
+     *
+     * @Iterations(10)
+     */
+    public function bench_find_absent_in_grown_map(): void
+    {
+        $this->grownMap->find($this->absentKey);
+    }
+
+    /**
+     * The write side, so a threshold change that speeds reads up is not
+     * reported without what it costs to build.
+     *
+     * @BeforeMethods("setUpMaps")
+     *
+     * @ParamProviders("provideSizes")
+     *
+     * @Revs(1000)
+     *
+     * @Iterations(10)
+     */
+    public function bench_put_into_grown_map(): void
+    {
+        $this->grownMap->put($this->absentKey, 1);
+    }
+
+    /**
+     * Full traversal, which is the other half of what the representation
+     * decides: an array map walks a flat array, a hash map descends the trie.
+     *
+     * @BeforeMethods("setUpMaps")
+     *
+     * @ParamProviders("provideSizes")
+     *
+     * @Revs(1000)
+     *
+     * @Iterations(10)
+     */
+    public function bench_iterate_grown_map(): void
+    {
+        foreach ($this->grownMap as $key => $value) {
+            // Traversal is the measurement; the pair is deliberately unused.
+        }
+    }
+
+    /**
+     * Sizes around the threshold, written out rather than computed: 2 and 4 sit
+     * below it, 5 is where a `{...}` literal promotes today, and 8 is where a
+     * grown map does.
+     *
+     * @return array<string, array{size: int}>
+     */
+    public function provideSizes(): array
+    {
+        return [
+            'size 2' => ['size' => 2],
+            'size 4' => ['size' => 4],
+            'size 5' => ['size' => 5],
+            'size 8' => ['size' => 8],
+        ];
+    }
+
+    /**
+     * @param array{size: int} $params
+     */
+    public function setUpMaps(array $params): void
+    {
+        $size = $params['size'];
+        $typeFactory = new TypeFactory(new Hasher(), new Equalizer());
+
+        $kvs = [];
+        for ($i = 0; $i < $size; ++$i) {
+            $kvs[] = Keyword::create('k' . $i);
+            $kvs[] = $i;
+        }
+
+        $this->literalMap = $typeFactory->persistentMapFromArray($kvs);
+
+        $transient = PersistentArrayMap::empty(new Hasher(), new Equalizer())->asTransient();
+        for ($i = 0; $i < $size; ++$i) {
+            $transient->put(Keyword::create('k' . $i), $i);
+        }
+
+        $this->grownMap = $transient->persistent();
+        $this->lastKey = Keyword::create('k' . ($size - 1));
+        $this->absentKey = Keyword::create('absent');
+    }
+}


### PR DESCRIPTION
## 🤔 Background

#3172 is about how a small map is represented and how fast it reads. The benchmark suite could not see it: `PersistentHashMapBench` measures a forced hash map, and the `phel.core` subjects read two-entry maps, so the sizes where the representation is actually chosen were unmeasured, and so was the linear scan an array map pays per entry.

The repository rule is that the corpus lands before the change that measures against it, so this PR is the corpus only.

## 💡 Goal

Be able to measure the fix in #3172 against a baseline that exists.

## 🔖 Changes

- `PersistentArrayMapBench` builds each size through both paths a small map comes from: `TypeFactory::persistentMapFromArray()`, which is what a `{...}` literal compiles to, and a transient `put` chain, which is what `assoc`, `into` and `zipmap` do. Subjects read the last key (so the scan runs to the end), a missing key (the worst case), write, and iterate. Keys are keywords, whose equality goes through `Keyword::equals` rather than a native `===`.
- Sizes are written as literals, not derived from `MAX_SIZE`: a corpus that moves with the constant would describe different inputs before and after a threshold change.
- `bench-get-grown-map` adds the Phel-level half, a six-entry map built with `zipmap`.
- It reproduces the reported problem immediately: at five and eight entries the same map reads 3.4x and 5.4x slower when grown than when written as a literal (0.835µs vs 0.247µs, 1.348µs vs 0.249µs).

No behaviour change.

Related to #3172
