### PR TITLE
chore(quality): drop the unused foreach key in the array-map bench

### DIFF
--- a/tests/php/Benchmark/Lang/Collections/Map/PersistentArrayMapBench.php
+++ b/tests/php/Benchmark/Lang/Collections/Map/PersistentArrayMapBench.php
@@ -130,8 +130,8 @@ final class PersistentArrayMapBench
      */
     public function bench_iterate_grown_map(): void
     {
-        foreach ($this->grownMap as $key => $value) {
-            // Traversal is the measurement; the pair is deliberately unused.
+        foreach ($this->grownMap as $value) {
+            // Traversal is the measurement; the value is deliberately unused.
         }
     }
 


### PR DESCRIPTION
## 🤔 Background

The bench corpus merged in #3194 left an unused `foreach` key, which Rector rejects and the Coding Guidelines job runs over `tests/php/Benchmark` as well as `src/`. That job is red on main.

## 💡 Goal

Green main.

## 🔖 Changes

- `foreach ($this->grownMap as $value)`, since the subject measures the traversal and never reads the pair.
- Verified with the full `composer test-quality` exit code rather than by reading its output, which is how the failure slipped through in the first place.

Related to #3172