### PR TITLE
docs(agents): a raw php/ call in core can be the correct spelling

### DIFF
--- a/resources/agents/tasks/common-gotchas.md
+++ b/resources/agents/tasks/common-gotchas.md
@@ -82,6 +82,23 @@ Same for `recur` args vs binding tags and tail literal vs declared return tag. S
 
 `^?int` parses as a symbol named `?int`, not a nullable-int tag.
 
+## 9. A `php/` call is not always a missing wrapper
+
+Prefer the core fn when one exists, but a raw `php/` call in `phel.core` is
+sometimes the *correct* spelling because the semantics differ, exactly as
+Clojure's own core keeps `(.length s)` and `Math/floor` where a wrapper would
+lie:
+
+```phel
+(int 1e30)                 ; throws, like Clojure's (int 1e30)
+(php/intval 1e30)          ; coerces to garbage; only right when you want lossy
+(phel.string/replace s "." "-") ; regex, like clojure.string/replace
+(php/str_replace "." "-" s)     ; literal, and much faster for a literal
+```
+
+Reach for the wrapper first; keep the `php/` call when its behaviour is the
+one you actually need. See #2941.
+
 ## See also
 
 - [`RULES.md`](../RULES.md) for the one-liner rule each gotcha references.


### PR DESCRIPTION
## 🤔 Background

#2941 asked for less raw PHP interop in `phel.core`. Its own thread found the actual rule: a core spelling is only an improvement once the wrapper is as fast as the raw call, and the slow wrappers were fixed in #2942 through #2958. What is left, `php/intval` and `php/str_replace`, stays raw for a reason: `int` throws where `intval` coerces (matching Clojure's `(int 1e30)`), and `phel.string/replace` is regex where `str_replace` is literal.

Clojure's own core keeps host calls in exactly those cases: `(.length s)`, `Math/floor`, `System/nanoTime`. The idiom is to wrap when the wrapper adds value and call the host when a wrapper would lie.

## 💡 Goal

Record that rule where an agent generating Phel will read it, so the two remaining `php/` sites are understood as decisions rather than re-raised as oversights.

## 🔖 Changes

- One new gotcha in `resources/agents/tasks/common-gotchas.md`, with the two concrete pairs and why each side exists.

Closes #2941