### PR TITLE
perf(ai): make the retry backoff sleep injectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project will be documented in this file.
 - Binding-first map destructuring, as in Clojure: `{local :key}`, `{[x y] :point}`, `{n "name"}` and nested `{{:keys [c]} :inner}` work next to the existing key-first spelling. `:keys`, `:strs`, `:syms`, `:as` and `:or` are unchanged. A pair where neither side binds (`{:a :b}`) is rejected with a message showing both spellings (#3115)
 - `^:redef` on a `defn` keeps it out of `-O2` inlining, so `with-redefs`, `phel.mock` and `dotrace` still intercept the call (#3126)
 
+#### Library
+
+- `phel.ai/*sleep-fn*`, the retry backoff seam next to `*http-post*`: rebind it in tests so a 429/5xx retry records its delay instead of sleeping. The repository's own retry tests slept ~3s of a ~4.9s `phel test` pass; `composer test-core` goes from ~5.6s to ~3.1s serial. A blank `ANTHROPIC_API_KEY=` (or `OPENAI_API_KEY=`, `VOYAGE_API_KEY=`) now reads as a missing key, which throws before any request, instead of being sent as an empty key (#3204)
+
 #### CI
 
 - `Core tests at -O2` job; nothing exercised `CallInliner` or `TailCallRewriter` before. Local repro: `PHEL_OPTIMIZATION_LEVEL=2 ./bin/phel test` (#3126)

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -67,13 +67,19 @@
     :voyageai "VOYAGE_API_KEY"
     "ANTHROPIC_API_KEY"))
 
+(defn- present-key
+  "The key when it is a non-blank string, otherwise nil. `ANTHROPIC_API_KEY=` in a shell reads as an empty string, and an empty key is a missing key, not one to send."
+  [key]
+  (when (and (string? key) (not (s/blank? key)))
+    key))
+
 (defn- resolve-api-key
   "Resolves the API key from config or environment variables. Supports :anthropic, :openai, and :voyageai providers."
   [cfg]
   (let [provider (get cfg :provider)
         env-var  (provider-env-var provider)]
-    (or (get cfg :api-key)
-        (php/getenv env-var)
+    (or (present-key (get cfg :api-key))
+        (present-key (php/getenv env-var))
         (throw (new RuntimeException
                     (str "No API key configured for provider " provider
                          ". Use (ai/configure {:api-key \"...\"}) or set "
@@ -154,12 +160,17 @@
   [status]
   (or (= 429 status) (and (>= status 500) (< status 600))))
 
+(def ^:dynamic *sleep-fn*
+  {:doc "Retry backoff seam: called with the delay in milliseconds before each retry. Rebind with `binding` in tests so a retry does not really sleep. Tagged `^:dynamic` like `*http-post*`."
+   :example "(binding [*sleep-fn* (fn [ms] nil)] ...)"}
+  (fn [ms] (php/usleep (php/intval (* ms 1000)))))
+
 (defn- backoff-sleep
-  "Sleeps using exponential backoff. attempt is 0-based."
+  "Waits before retry `attempt` (0-based) with exponential backoff: 500ms, 1000ms, 2000ms, ..."
   [attempt]
   (let [base-ms  500
         delay-ms (* base-ms (php/pow 2 attempt))]
-    (php/usleep (php/intval (* delay-ms 1000)))))
+    (*sleep-fn* delay-ms)))
 
 (defn- post-with-retry
   "Posts with retry on 429 / 5xx up to max-retries."

--- a/tests/phel/ai.phel
+++ b/tests/phel/ai.phel
@@ -72,14 +72,22 @@
 ;; --- API key resolution ---
 
 (deftest test-missing-api-key-throws
-  (let [original @ai/config]
+  (let [original  @ai/config
+        transport (mock-fn (fn [_ _] (throw (new RuntimeException "no HTTP call is expected without a key"))))]
     (ai/configure {:api-key nil})
     (let [saved-key (php/getenv "ANTHROPIC_API_KEY")]
+      ;; `KEY=` leaves the variable set to an empty string, which is how a
+      ;; shell usually "unsets" it; the resolver must treat that as missing
+      ;; instead of sending an empty key over the wire.
       (php/putenv "ANTHROPIC_API_KEY=")
-      (is (thrown? RuntimeException (ai/complete "test"))
-          "missing API key throws RuntimeException")
-      (when saved-key
-        (php/putenv (str "ANTHROPIC_API_KEY=" saved-key))))
+      (binding [ai/*http-post* transport]
+        (is (thrown-with-msg? RuntimeException "No API key configured for provider :anthropic. Use (ai/configure {:api-key \"...\"}) or set ANTHROPIC_API_KEY env var."
+                              (ai/complete "test"))
+            "missing API key throws before any HTTP call")
+        (is (= 0 (call-count transport)) "no request leaves the process"))
+      (if saved-key
+        (php/putenv (str "ANTHROPIC_API_KEY=" saved-key))
+        (php/putenv "ANTHROPIC_API_KEY")))
     (reset! ai/config original)))
 
 ;; --- Response extraction ---
@@ -706,34 +714,49 @@
 
 ;; --- Retry / backoff ---
 
+;; A retry really sleeps through `*sleep-fn*`; the tests record the delays
+;; instead, so the schedule is asserted rather than waited for.
+
+(defn- recording-sleep [delays]
+  (fn [ms] (swap! delays conj ms)))
+
 (deftest test-retry-recovers-from-429
-  (let [n    (atom 0)
-        fake (mock-fn (fn [_ _]
-                        (swap! n + 1)
-                        (if (= @n 1)
-                          (status-response 429 {:error "rate limited"})
-                          (ok-response {:content [{:type "text" :text "ok"}]}))))]
-    (binding [ai/*http-post* fake]
+  (let [n      (atom 0)
+        delays (atom [])
+        fake   (mock-fn (fn [_ _]
+                          (swap! n + 1)
+                          (if (= @n 1)
+                            (status-response 429 {:error "rate limited"})
+                            (ok-response {:content [{:type "text" :text "ok"}]}))))]
+    (binding [ai/*http-post* fake
+              ai/*sleep-fn*  (recording-sleep delays)]
       (is (= "ok" (ai/complete "hi" {:api-key "k" :max-retries 2})) "recovers after 429")
-      (is (= 2 (call-count fake)) "makes exactly 2 calls"))))
+      (is (= 2 (call-count fake)) "makes exactly 2 calls")
+      (is (= [500] @delays) "waits once, 500ms, before the single retry"))))
 
 (deftest test-retry-recovers-from-500
-  (let [n    (atom 0)
-        fake (mock-fn (fn [_ _]
-                        (swap! n + 1)
-                        (if (<= @n 2)
-                          (status-response 503 {:error "unavailable"})
-                          (ok-response {:content [{:type "text" :text "ok"}]}))))]
-    (binding [ai/*http-post* fake]
+  (let [n      (atom 0)
+        delays (atom [])
+        fake   (mock-fn (fn [_ _]
+                          (swap! n + 1)
+                          (if (<= @n 2)
+                            (status-response 503 {:error "unavailable"})
+                            (ok-response {:content [{:type "text" :text "ok"}]}))))]
+    (binding [ai/*http-post* fake
+              ai/*sleep-fn*  (recording-sleep delays)]
       (is (= "ok" (ai/complete "hi" {:api-key "k" :max-retries 3})) "recovers after 503")
-      (is (= 3 (call-count fake)) "makes exactly 3 calls"))))
+      (is (= 3 (call-count fake)) "makes exactly 3 calls")
+      (is (= [500 1000] @delays) "backs off exponentially between retries"))))
 
 (deftest test-retry-gives-up-after-max-retries
-  (let [fake (mock-fn (fn [_ _] (status-response 500 {:error "boom"})))]
-    (binding [ai/*http-post* fake]
+  (let [delays (atom [])
+        fake   (mock-fn (fn [_ _] (status-response 500 {:error "boom"})))]
+    (binding [ai/*http-post* fake
+              ai/*sleep-fn*  (recording-sleep delays)]
       (is (thrown? RuntimeException (ai/complete "hi" {:api-key "k" :max-retries 1}))
           "throws after exhausting retries")
-      (is (= 2 (call-count fake)) "calls = initial + max-retries"))))
+      (is (= 2 (call-count fake)) "calls = initial + max-retries")
+      (is (= [500] @delays) "sleeps once per retry, never after the last attempt"))))
 
 (deftest test-retry-does-not-retry-on-4xx-other-than-429
   (let [fake (mock-fn (fn [_ _] (status-response 401 {:error {:message "bad key"}})))]

--- a/tests/php/Integration/Api/core-api.snapshot.txt
+++ b/tests/php/Integration/Api/core-api.snapshot.txt
@@ -8,6 +8,7 @@
 # as surely as one that disappears, so both are visible here.
 
 phel.ai/*http-post*  <value>
+phel.ai/*sleep-fn*  (*sleep-fn* ms)
 phel.ai/build-index  (build-index texts & [opts])
 phel.ai/chat  (chat messages & [{:keys [system], :as opts}])
 phel.ai/chat-with-history  (chat-with-history history user-message & [opts])


### PR DESCRIPTION
## 🤔 Background

Four tests in `tests/phel/ai.phel` slept through the real retry backoff of `phel.ai`, ~3s of the ~4.9s warm execution pass of `phel test`; every other namespace is at most 0.03s. `test-missing-api-key-throws` was slow for a different reason: `ANTHROPIC_API_KEY=` leaves an empty string, the resolver took it as a key, and the test passed by making a real HTTP request that came back 401.

## 💡 Goal

Keep the retry coverage, drop the waiting, and stop the missing-key test from touching the network.

## 🔖 Changes

- `phel.ai/*sleep-fn*`, a `^:dynamic` seam next to `*http-post*`, receives the delay in milliseconds before each retry; the tests record the delays and assert the schedule (`[500]`, `[500 1000]`) instead of sleeping through it.
- A blank API key from the environment counts as missing and throws before any request; the test binds a transport that fails on use and asserts zero calls.
- `phel-test.ai` goes from ~3.0s to under 20ms; `composer test-core` from ~5.6s to ~3.1s serial (main `e354b60c3`), 1.5s with `--parallel=4` on top of #3215.
- Public API snapshot updated for the new var; CHANGELOG under Unreleased.
- Refactor pass over the touched files surfaced no changes.

Closes #3204
