### PR TITLE
fix(test): flush the cache index before spawning parallel workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+#### PHP API
+
+- `BuildFacadeInterface::flushCompiledCodeCache()` and `RunFacadeInterface::flushCompiledCodeCache()`: write the compiled-code cache index to disk now instead of at process shutdown. `phel test --parallel` calls it after evaluating the shared namespaces, so the workers find them in the cache instead of each recompiling the same files at once, which is a race the analyzer does not survive on a cold cache (a namespace was retried on a fresh worker) (#3203)
+
 #### Language
 
 - Binding-first map destructuring, as in Clojure: `{local :key}`, `{[x y] :point}`, `{n "name"}` and nested `{{:keys [c]} :inner}` work next to the existing key-first spelling. `:keys`, `:strs`, `:syms`, `:as` and `:or` are unchanged. A pair where neither side binds (`{:a :b}`) is rejected with a message showing both spellings (#3115)

--- a/src/php/Build/BuildFacade.php
+++ b/src/php/Build/BuildFacade.php
@@ -162,6 +162,11 @@ final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
             ->evalFile($src);
     }
 
+    public function flushCompiledCodeCache(): void
+    {
+        $this->getFactory()->flushCompiledCodeCache();
+    }
+
     /**
      * @return list<CompiledFile>
      */

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -154,6 +154,16 @@ final class BuildFactory extends AbstractFactory
         return $this->getProvidedDependency(CommandFacadeInterface::class);
     }
 
+    /**
+     * The index only flushes at shutdown ({@see Infrastructure\Cache\DeferredFlushTrait}); a parent
+     * about to hand work to subprocesses flushes it early so they see its
+     * entries. Same singleton the evaluator writes through, so nothing is lost.
+     */
+    public function flushCompiledCodeCache(): void
+    {
+        $this->createCompiledCodeCache()?->save();
+    }
+
     private function createSecondaryFileHarvester(): SecondaryFileHarvester
     {
         // Always present: with the compiled-code cache off it falls back to the

--- a/src/php/Build/CLAUDE.md
+++ b/src/php/Build/CLAUDE.md
@@ -10,6 +10,7 @@ Compiles Phel projects to PHP: namespace extraction, dependency ordering, and ca
 | `getDependenciesForNamespace(array $dirs, array $ns)` | Topologically sorted dependencies. Seeds, index keys and declared dependencies are canonicalised with `Munge::canonicalNs`, so either namespace separator resolves (`Watch` hands over the backslash form). Throws `ExtractorException` when a resolved namespace's `(:require ...)` names a missing **user** namespace (no source file, no `clojure.*`→bundled-`phel.*` remap, not already in the registry) — a typo'd require is a fast error, not a silent drop. Framework-provided `phel.*`/`clojure.*` requires stay tolerated (precompiled+lazy-loaded stdlib / clojure-compat shims aren't in the source scan downstream). Unresolved *seeds* also stay tolerated (callers like the REPL check the empty result themselves) |
 | `compileFile(src, dest)` | Compile to PHP, write output |
 | `evalFile(src)` | Same as `compileFile` but skips writing output |
+| `flushCompiledCodeCache()` | Writes the compiled-code cache index to disk now (it otherwise flushes once at shutdown); a parent about to spawn workers calls it so they find what it compiled |
 | `compileProject(BuildOptions)` | Returns `CompiledFile[]` |
 | `clearCache()` | Returns `string[]` paths cleared from temp/cache dirs |
 | `getHealthCheck()` | Cache, output, source dir checks |

--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -6,7 +6,7 @@ Runtime execution: runs Phel namespaces/files, REPL, evaluation, test runner, an
 
 | Group | Methods |
 |-------|---------|
-| Execution | `runNamespace(string)`, `runFile(string)`, `evalFile(NamespaceInformation)`, `eval(string, CompileOptions): mixed`, `structuredEval(string, CompileOptions): EvalResult` (never throws), `loadPhelNamespaces(?string)` (core + startup file) |
+| Execution | `runNamespace(string)`, `runFile(string)`, `evalFile(NamespaceInformation)`, `eval(string, CompileOptions): mixed`, `structuredEval(string, CompileOptions): EvalResult` (never throws), `loadPhelNamespaces(?string)` (core + startup file), `flushCompiledCodeCache()` (index to disk before spawning workers) |
 | Namespaces | `getNamespaceFromFile`, `getDependenciesForNamespace` (topologically sorted), `getDependenciesFromPaths` |
 | Query | `getAllPhelDirectories`, `getLoadedNamespaces`, `getAllNamespaces` (distinct sorted ns across source/test/vendor; via `ProjectNamespaceLister`; powers `phel run`/`phel test` shell completion), `getVersion`, `autoDetectEntryPoint` (prefers `main.phel`, falls back to `core.phel`) |
 | Debugging | `enableDebugLineTap(?string $phelFileFilter, string $logPath)`, `disableDebugLineTap`, `breakpoint(PersistentMapInterface): void` (interactive `(break)` sub-REPL; blocks until resume) |

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -247,6 +247,9 @@ HELP)
                     $feedback,
                 );
                 $this->reportCompileErrors($output, $compileErrors);
+                // The cache index only reaches disk at shutdown; the workers
+                // need it now, or they recompile the shared prefix themselves.
+                $this->getFacade()->flushCompiledCodeCache();
 
                 $namespacesToRun = $this->withoutPhpUnitFixtures($namespacesInformation);
                 if ($namespacesToRun === []) {

--- a/src/php/Run/RunFacade.php
+++ b/src/php/Run/RunFacade.php
@@ -68,6 +68,13 @@ final class RunFacade extends AbstractFacade implements RunFacadeInterface
             ->evalFile($info->getFile());
     }
 
+    public function flushCompiledCodeCache(): void
+    {
+        $this->getFactory()
+            ->getBuildFacade()
+            ->flushCompiledCodeCache();
+    }
+
     public function eval(string $phelCode, CompileOptions $compileOptions = new CompileOptions()): mixed
     {
         return $this->getFactory()

--- a/src/php/Shared/Facade/BuildFacadeInterface.php
+++ b/src/php/Shared/Facade/BuildFacadeInterface.php
@@ -59,6 +59,13 @@ interface BuildFacadeInterface
     public function evalFile(string $src): CompiledFile;
 
     /**
+     * Writes the compiled-code cache index to disk now instead of at process
+     * shutdown, so a subprocess spawned afterwards finds what this process
+     * has compiled so far. No-op when nothing is pending or the cache is off.
+     */
+    public function flushCompiledCodeCache(): void;
+
+    /**
      * Returns the module's health check for diagnostics (`phel doctor`).
      */
     public function getHealthCheck(): ModuleHealthCheckInterface;

--- a/src/php/Shared/Facade/RunFacadeInterface.php
+++ b/src/php/Shared/Facade/RunFacadeInterface.php
@@ -57,6 +57,12 @@ interface RunFacadeInterface
     public function evalFile(NamespaceInformation $info): void;
 
     /**
+     * Writes the compiled-code cache index to disk now, so a subprocess
+     * spawned afterwards finds what this process has evaluated so far.
+     */
+    public function flushCompiledCodeCache(): void;
+
+    /**
      * @param list<string> $paths
      *
      * @return list<NamespaceInformation>

--- a/tests/php/Unit/Architecture/public-api.snapshot.txt
+++ b/tests/php/Unit/Architecture/public-api.snapshot.txt
@@ -72,6 +72,7 @@ final class Phel\Build\BuildFacade extends Gacela\Framework\AbstractFacade imple
   public function compileFile(string $src, string $dest): Phel\Shared\CompiledFile
   public function compileProject(Phel\Build\Domain\Compile\BuildOptions $options): array
   public function evalFile(string $src): Phel\Shared\CompiledFile
+  public function flushCompiledCodeCache(): void
   public function getDependenciesForNamespace(array $directories, array $ns): array
   public function getHealthCheck(): Gacela\Framework\Health\ModuleHealthCheckInterface
   public function getNamespaceFromDirectories(array $directories): array
@@ -1530,6 +1531,7 @@ final class Phel\Run\RunFacade extends Gacela\Framework\AbstractFacade implement
   public function enableDebugLineTap(?string $phelFileFilter = null, string $logPath = './phel-debug.log'): void
   public function eval(string $phelCode, Phel\Shared\CompileOptions $compileOptions = object(Phel\Shared\CompileOptions)): mixed
   public function evalFile(Phel\Shared\NamespaceInformation $info): void
+  public function flushCompiledCodeCache(): void
   public function getAllNamespaces(): array
   public function getAllPhelDirectories(): array
   public function getDependenciesForNamespace(array $directories, array $ns): array
@@ -1831,6 +1833,7 @@ interface Phel\Shared\Facade\ApiFacadeInterface
 interface Phel\Shared\Facade\BuildFacadeInterface
   public function compileFile(string $src, string $dest): Phel\Shared\CompiledFile
   public function evalFile(string $src): Phel\Shared\CompiledFile
+  public function flushCompiledCodeCache(): void
   public function getDependenciesForNamespace(array $directories, array $ns): array
   public function getHealthCheck(): Gacela\Framework\Health\ModuleHealthCheckInterface
   public function getNamespaceFromDirectories(array $directories): array
@@ -1896,6 +1899,7 @@ interface Phel\Shared\Facade\RunFacadeInterface
   public function breakpoint(Phel\Lang\Collections\Map\PersistentMapInterface $locals): void
   public function eval(string $phelCode, Phel\Shared\CompileOptions $compileOptions): mixed
   public function evalFile(Phel\Shared\NamespaceInformation $info): void
+  public function flushCompiledCodeCache(): void
   public function getAllNamespaces(): array
   public function getAllPhelDirectories(): array
   public function getDependenciesForNamespace(array $directories, array $ns): array

--- a/tests/php/Unit/Watch/Application/ReloadOrchestratorTest.php
+++ b/tests/php/Unit/Watch/Application/ReloadOrchestratorTest.php
@@ -238,6 +238,8 @@ final readonly class FakeBuildFacade implements BuildFacadeInterface
         throw new RuntimeException('not implemented');
     }
 
+    public function flushCompiledCodeCache(): void {}
+
     public function compileProject(BuildOptions $options): array
     {
         return [];
@@ -274,6 +276,8 @@ final class FakeRunFacade implements RunFacadeInterface
             throw new RuntimeException('boom');
         }
     }
+
+    public function flushCompiledCodeCache(): void {}
 
     public function structuredEval(string $phelCode, CompileOptions $compileOptions): EvalResult
     {


### PR DESCRIPTION
## 🤔 Background

#3215 has the parent of `phel test --parallel` evaluate the namespaces every worker needs, so a cold cache is warmed once instead of raced. That only works if the workers can find the result: the compiled-code cache index flushes to disk once at process shutdown (`DeferredFlushTrait`), so the workers started with an index that did not list what the parent had just compiled and recompiled the same files concurrently. On a cold cache that race makes a worker fail transiently ("Retried: 1 namespace(s)"), which is what the `Compat tests on symfony/console ^8.0` job caught on #3216.

## 💡 Goal

Make the parent's warm-up visible to the workers.

## 🔖 Changes

- `BuildFacadeInterface::flushCompiledCodeCache()` (and the `RunFacadeInterface` passthrough) writes the index now through the same singleton the evaluator writes through.
- `TestCommand` calls it right after evaluating the shared namespaces, before the pool spawns.
- Public PHP API snapshot updated (additive); CHANGELOG under Unreleased; module docs.
- Refactor pass over the touched files surfaced no changes.

Related to #3203
