### PR TITLE
feat(test): attribute coverage per test with --coverage=per-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 
 - `BuildFacadeInterface::flushCompiledCodeCache()` and `RunFacadeInterface::flushCompiledCodeCache()`: write the compiled-code cache index to disk now instead of at process shutdown. `phel test --parallel` calls it after evaluating the shared namespaces, so the workers find them in the cache instead of each recompiling the same files at once, which is a race the analyzer does not survive on a cold cache (a namespace was retried on a fresh worker) (#3203)
 
+#### Testing
+
+- `phel test --coverage=per-test`: JSON with the `.phel` lines each test executed (`tests`) and the tests behind each line (`lines`), the input for test impact analysis and mutation testing. On this repository it costs no more than `--coverage` (26s against 28s with xdebug). `phel.test` now emits `:begin-test` and `:end-test` events around every test (the end event carries `:duration-ms`), and `phel.test/*event-hook*` observes every event of a run next to the configured reporters, which is how the PHP runner attributes coverage without replacing them (#3207)
+
 #### Language
 
 - Binding-first map destructuring, as in Clojure: `{local :key}`, `{[x y] :point}`, `{n "name"}` and nested `{{:keys [c]} :inner}` work next to the existing key-first spelling. `:keys`, `:strs`, `:syms`, `:as` and `:or` are unchanged. A pair where neither side binds (`{:a :b}`) is rejected with a message showing both spellings (#3115)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -167,7 +167,10 @@ parameters:
         -
             identifier: gacela.facadeInterfaceDrift
             path: src/php/Run/RunFacade.php
-            count: 7
+            # 7 + `buildPerTestCoverageReport()` (#3207): like the other
+            # coverage methods it returns a Run-internal report type, which
+            # the Shared contract must not name.
+            count: 8
         # LazySeq::cdr() checks instanceof SeqInterface for runtime safety
         # even though PHPDoc inference says the type is already narrowed.
         -

--- a/resources/agents/tasks/add-tests.md
+++ b/resources/agents/tasks/add-tests.md
@@ -55,6 +55,8 @@ Namespace: `tests.<name>-test`.
 ./vendor/bin/phel test --filter=test-add     # by name substring
 ./vendor/bin/phel test --testdox
 ./vendor/bin/phel test --fail-fast
+./vendor/bin/phel test --coverage                       # .phel line coverage (pcov or XDEBUG_MODE=coverage)
+./vendor/bin/phel test --coverage=per-test --coverage-output=var/coverage/per-test.json  # which tests cover which lines
 ```
 
 ## Assertion forms (inside `is`)

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -109,13 +109,22 @@
                  s
                  (update s :failed conj data)))))))
 
+(def ^:dynamic *event-hook*
+  {:doc "Observer for every reporter event of a run, called after the configured reporters with the same event map; nil by default. Lets a host observe a run without replacing its reporters: the PHP test runner installs one to attribute coverage per test through the `:begin-test` and `:end-test` events."
+   :example "(binding [*event-hook* (fn [event] (when (= :end-test (:type event)) (println (:test-name event))))]\n  (run-tests {} 'my-app.test))"
+   :see-also ["report" "set-reporters!" "add-reporter!"]}
+  nil)
+
 (defn- fan-out! [event]
   (dofor [reporter :in (deref *reporters*)]
-    (reporter event)))
+    (reporter event))
+  (when-let [hook *event-hook*]
+    (hook event)))
 
 ;; `report` is the public multimethod dispatched on the event `:type`.
 ;; Built-in event types include:
 ;;   :pass, :failed, :error — assertion outcomes emitted by `is`
+;;   :begin-test, :end-test — lifecycle events around each test
 ;;   :begin-test-ns, :end-test-ns — lifecycle events around each namespace run
 ;;   :begin-test-run, :summary — lifecycle events around the whole run
 ;;
@@ -125,8 +134,8 @@
 (defmulti report
   "Records a test-framework event and dispatches it to the active
   reporters. `data` must contain a `:type` key (`:pass`, `:failed`,
-  `:error`, `:begin-test-ns`, `:end-test-ns`, `:begin-test-run`,
-  `:summary`, or a user-defined event). The default methods for
+  `:error`, `:begin-test`, `:end-test`, `:begin-test-ns`, `:end-test-ns`,
+  `:begin-test-run`, `:summary`, or a user-defined event). The default methods for
   assertion outcomes update the internal stats and invoke every
   registered reporter. Other event types flow straight through to the
   reporter set. Extend by registering
@@ -172,8 +181,8 @@
 
 ;; Lifecycle events that flow straight through to every registered
 ;; reporter without touching the stats atom.
-(dofor [event-type :in [:begin-test-ns :end-test-ns :begin-test-run
-                        :summary :defspec-failed]]
+(dofor [event-type :in [:begin-test :end-test :begin-test-ns :end-test-ns
+                        :begin-test-run :summary :defspec-failed]]
   (swap! report-methods assoc event-type fan-out!))
 
 (defmethod report :skipped [data]
@@ -1274,15 +1283,17 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
    (vec (filter (visible-test-pred options ns) (find-test-vars ns)))))
 
 (defn- run-one-test! [options ns each-wrap {:fn f, :meta m}]
-  (let [test-name      (:test-name m)
-        track-slowest? (pos? (or (:slowest options) 0))
-        t0             (when track-slowest? (php/microtime true))
-        c0             (failure-count)]
-    (each-wrap f)
-    (when track-slowest?
-      (record-test-time! ns test-name (* 1000.0 (- (php/microtime true) t0))))
-    (when (> (failure-count) c0)
-      (swap! failed-tests conj (str ns "/" test-name)))))
+  (let [test-name (:test-name m)
+        c0        (failure-count)]
+    (report {:type :begin-test, :ns ns, :test-name test-name})
+    (let [t0          (php/microtime true)
+          _           (each-wrap f)
+          duration-ms (* 1000.0 (- (php/microtime true) t0))]
+      (when (pos? (or (:slowest options) 0))
+        (record-test-time! ns test-name duration-ms))
+      (when (> (failure-count) c0)
+        (swap! failed-tests conj (str ns "/" test-name)))
+      (report {:type :end-test, :ns ns, :test-name test-name, :duration-ms duration-ms}))))
 
 (defn- repeat-count
   "Returns the validated `:repeat` count from `options`, defaulting to 1."

--- a/src/php/Run/Application/Test/Coverage/CoverageAggregator.php
+++ b/src/php/Run/Application/Test/Coverage/CoverageAggregator.php
@@ -6,8 +6,11 @@ namespace Phel\Run\Application\Test\Coverage;
 
 use Phel\Shared\Facade\CommandFacadeInterface;
 
+use function array_key_exists;
+use function array_keys;
 use function ksort;
 use function realpath;
+use function sort;
 use function str_starts_with;
 
 /**
@@ -68,6 +71,113 @@ final readonly class CoverageAggregator
         }
 
         return new CoverageReport($files, $this->driver);
+    }
+
+    /**
+     * Per-test attribution: which project `.phel` lines each test executed,
+     * and which tests executed each line. Every compiled PHP file is mapped
+     * to its source once, however many tests hit it.
+     *
+     * @param array<string, array<string, list<int>>> $hitLinesByTest testId => compiledPhpFile => PHP lines with hits
+     */
+    public function attribute(array $hitLinesByTest): PerTestCoverageReport
+    {
+        $normalizedDirs = $this->normalizedProjectDirs();
+        /** @var array<string, array{filename: string, lines: array<int, int>}|null> $mapsByPhpFile null = not a project file */
+        $mapsByPhpFile = [];
+        /** @var array<string, array<string, array<int, true>>> $linesByTest */
+        $linesByTest = [];
+        /** @var array<string, array<int, array<string, true>>> $testsByLine */
+        $testsByLine = [];
+
+        foreach ($hitLinesByTest as $testId => $hitsByPhpFile) {
+            $linesByTest[$testId] = [];
+            foreach ($hitsByPhpFile as $phpFile => $phpLines) {
+                if (!array_key_exists($phpFile, $mapsByPhpFile)) {
+                    $mapsByPhpFile[$phpFile] = $this->projectLineMap($phpFile, $normalizedDirs);
+                }
+
+                $map = $mapsByPhpFile[$phpFile];
+                if ($map === null) {
+                    continue;
+                }
+
+                foreach ($phpLines as $phpLine) {
+                    $phelLine = $map['lines'][$phpLine] ?? null;
+                    if ($phelLine === null) {
+                        continue;
+                    }
+
+                    $linesByTest[$testId][$map['filename']][$phelLine] = true;
+                    $testsByLine[$map['filename']][$phelLine][$testId] = true;
+                }
+            }
+        }
+
+        return new PerTestCoverageReport(
+            $this->sortedLinesByTest($linesByTest),
+            $this->sortedTestsByLine($testsByLine),
+            $this->driver,
+        );
+    }
+
+    /**
+     * @param list<string> $normalizedDirs
+     *
+     * @return array{filename: string, lines: array<int, int>}|null
+     */
+    private function projectLineMap(string $phpFile, array $normalizedDirs): ?array
+    {
+        $map = $this->commandFacade->getCompiledFileLineMap($phpFile);
+        if ($map['filename'] === '' || !$this->isProjectFile($map['filename'], $normalizedDirs)) {
+            return null;
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array<string, array<string, array<int, true>>> $linesByTest
+     *
+     * @return array<string, array<string, list<int>>>
+     */
+    private function sortedLinesByTest(array $linesByTest): array
+    {
+        ksort($linesByTest);
+        $out = [];
+        foreach ($linesByTest as $testId => $files) {
+            ksort($files);
+            $out[$testId] = [];
+            foreach ($files as $file => $lines) {
+                $sorted = array_keys($lines);
+                sort($sorted);
+                $out[$testId][$file] = $sorted;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<string, array<int, array<string, true>>> $testsByLine
+     *
+     * @return array<string, array<int, list<string>>>
+     */
+    private function sortedTestsByLine(array $testsByLine): array
+    {
+        ksort($testsByLine);
+        $out = [];
+        foreach ($testsByLine as $file => $byLine) {
+            ksort($byLine);
+            $out[$file] = [];
+            foreach ($byLine as $line => $tests) {
+                $sorted = array_keys($tests);
+                sort($sorted);
+                $out[$file][$line] = $sorted;
+            }
+        }
+
+        return $out;
     }
 
     /**

--- a/src/php/Run/Application/Test/Coverage/CoverageAggregator.php
+++ b/src/php/Run/Application/Test/Coverage/CoverageAggregator.php
@@ -46,16 +46,12 @@ final readonly class CoverageAggregator
         $perPhelFile = [];
 
         foreach ($rawCoverage as $phpFile => $hits) {
-            $map = $this->commandFacade->getCompiledFileLineMap($phpFile);
+            $map = $this->projectLineMap($phpFile, $normalizedDirs);
+            if ($map === null) {
+                continue;
+            }
+
             $phelFile = $map['filename'];
-            if ($phelFile === '') {
-                continue;
-            }
-
-            if (!$this->isProjectFile($phelFile, $normalizedDirs)) {
-                continue;
-            }
-
             foreach ($map['lines'] as $phpLine => $phelLine) {
                 $covered = ($hits[$phpLine] ?? 0) > 0;
                 $existing = $perPhelFile[$phelFile][$phelLine] ?? false;

--- a/src/php/Run/Application/Test/Coverage/PerTestCoverageCollector.php
+++ b/src/php/Run/Application/Test/Coverage/PerTestCoverageCollector.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application\Test\Coverage;
+
+use Closure;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Registry;
+
+use function is_string;
+
+/**
+ * Attributes raw line coverage to the test that produced it. Installed as
+ * `phel.test/*event-hook*`, it sees every reporter event of the run:
+ * `:begin-test` starts the driver, `:end-test` stops it and files the lines
+ * that were hit under `ns/test-name`. Only lines with hits are kept, so the
+ * per-test payload stays small however many files the process has loaded;
+ * mapping to `.phel` happens once at the end ({@see CoverageAggregator::attribute()}).
+ *
+ * @internal
+ */
+final class PerTestCoverageCollector
+{
+    private const string PHEL_TEST_NAMESPACE = 'phel.test';
+
+    private const string EVENT_HOOK_VAR = '*event-hook*';
+
+    /** @var array<string, array<string, list<int>>> testId => compiledPhpFile => PHP lines with hits */
+    private array $hitLinesByTest = [];
+
+    /**
+     * @param Closure(): void                           $start
+     * @param Closure(): array<string, array<int, int>> $stop  returns compiledPhpFile => [line => hitCount]
+     */
+    public function __construct(
+        private readonly Closure $start,
+        private readonly Closure $stop,
+        private readonly string $driverName,
+    ) {}
+
+    /**
+     * Receives one `phel.test` reporter event; everything but the per-test
+     * lifecycle pair is ignored.
+     */
+    public function __invoke(mixed $event): void
+    {
+        if (!$event instanceof PersistentMapInterface) {
+            return;
+        }
+
+        $type = $event->find(Keyword::create('type'));
+        if (!$type instanceof Keyword) {
+            return;
+        }
+
+        if ($type->getName() === 'begin-test') {
+            ($this->start)();
+            return;
+        }
+
+        if ($type->getName() === 'end-test') {
+            $this->hitLinesByTest[$this->testId($event)] = $this->hitLines(($this->stop)());
+        }
+    }
+
+    public static function forDriver(CoverageDriver $driver): self
+    {
+        return new self($driver->start(...), $driver->stop(...), $driver->name());
+    }
+
+    /**
+     * Makes this collector the `phel.test/*event-hook*` of the process. The
+     * var must already exist, i.e. `phel.test` must be loaded.
+     */
+    public function install(): void
+    {
+        Registry::getInstance()
+            ->getVar(self::PHEL_TEST_NAMESPACE, self::EVENT_HOOK_VAR)
+            ->alterRoot(fn(): self => $this);
+    }
+
+    public function driverName(): string
+    {
+        return $this->driverName;
+    }
+
+    /**
+     * @return array<string, array<string, list<int>>> testId => compiledPhpFile => PHP lines with hits
+     */
+    public function hitLinesByTest(): array
+    {
+        return $this->hitLinesByTest;
+    }
+
+    /**
+     * @param PersistentMapInterface<mixed, mixed> $event
+     */
+    private function testId(PersistentMapInterface $event): string
+    {
+        $ns = $event->find(Keyword::create('ns'));
+        $name = $event->find(Keyword::create('test-name'));
+
+        return (is_string($ns) ? $ns : '') . '/' . (is_string($name) ? $name : '');
+    }
+
+    /**
+     * @param array<string, array<int, int>> $raw
+     *
+     * @return array<string, list<int>>
+     */
+    private function hitLines(array $raw): array
+    {
+        $out = [];
+        foreach ($raw as $phpFile => $hits) {
+            $lines = [];
+            foreach ($hits as $line => $count) {
+                if ($count > 0) {
+                    $lines[] = $line;
+                }
+            }
+
+            if ($lines !== []) {
+                $out[$phpFile] = $lines;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/php/Run/Application/Test/Coverage/PerTestCoverageReport.php
+++ b/src/php/Run/Application/Test/Coverage/PerTestCoverageReport.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application\Test\Coverage;
+
+use function json_encode;
+
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+
+/**
+ * Which `.phel` lines each test executed, and the inverse: which tests
+ * executed each line. Both indexes are shipped in one JSON document so a
+ * consumer (test impact analysis, a mutation runner picking the tests
+ * that cover a mutated line) never has to invert one into the other.
+ *
+ * @internal
+ */
+final readonly class PerTestCoverageReport
+{
+    /**
+     * @param array<string, array<string, list<int>>> $linesByTest testId => phelFile => sorted lines
+     * @param array<string, array<int, list<string>>> $testsByLine phelFile => phelLine => sorted testIds
+     */
+    public function __construct(
+        private array $linesByTest,
+        private array $testsByLine,
+        private string $driver,
+    ) {}
+
+    /**
+     * @return array<string, array<string, list<int>>>
+     */
+    public function linesByTest(): array
+    {
+        return $this->linesByTest;
+    }
+
+    /**
+     * @return array<string, array<int, list<string>>>
+     */
+    public function testsByLine(): array
+    {
+        return $this->testsByLine;
+    }
+
+    public function driverName(): string
+    {
+        return $this->driver;
+    }
+
+    /**
+     * Compact on purpose: on a 3000-test project the pretty-printed document
+     * is three times the size, and it is read by tools, not people.
+     */
+    public function toJson(): string
+    {
+        $tests = [];
+        foreach ($this->linesByTest as $testId => $files) {
+            $tests[$testId] = (object) $files;
+        }
+
+        $lines = [];
+        foreach ($this->testsByLine as $file => $byLine) {
+            $lines[$file] = (object) $byLine;
+        }
+
+        return json_encode(
+            [
+                'driver' => $this->driver,
+                'tests' => (object) $tests,
+                'lines' => (object) $lines,
+            ],
+            JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES,
+        ) . "\n";
+    }
+}

--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -12,7 +12,7 @@ Runtime execution: runs Phel namespaces/files, REPL, evaluation, test runner, an
 | Debugging | `enableDebugLineTap(?string $phelFileFilter, string $logPath)`, `disableDebugLineTap`, `breakpoint(PersistentMapInterface): void` (interactive `(break)` sub-REPL; blocks until resume) |
 | Parallel test | `createParallelTestOrchestrator()`, `createCpuCountDetector()` |
 | Watch test | `runTestWatchLoop(callable $runTests, OutputInterface): int` |
-| Coverage | `detectCoverageDriver(): ?CoverageDriver`, `buildCoverageReport(array, string): CoverageReport` |
+| Coverage | `detectCoverageDriver(): ?CoverageDriver`, `buildCoverageReport(array, string): CoverageReport`, `buildPerTestCoverageReport(array, string): PerTestCoverageReport` |
 | Errors | `writeLocatedException`, `writeStackTrace` |
 | Doctor | `getModuleHealthChecks()` (surfaced by `phel doctor`) |
 
@@ -42,7 +42,7 @@ The `Phel` import closes the `Phel <-> Run` cycle: the composition root wires `R
 ## Structure
 
 - `Infrastructure/Command/`: 11 user-facing Symfony commands (incl. `config` — dumps effective merged config, and `bench` — runs `defbench` benchmarks) + 1 hidden `_test-worker` (`TestWorkerCommand`).
-- `Application/Test/Coverage/`: `CoverageDriver`, `CoverageAggregator`, `CoverageReport`, `CoverageFile`, `HtmlCoverageRenderer`.
+- `Application/Test/Coverage/`: `CoverageDriver`, `CoverageAggregator`, `CoverageReport`, `CoverageFile`, `HtmlCoverageRenderer`, `PerTestCoverageCollector` (the `phel.test/*event-hook*`), `PerTestCoverageReport`.
 - `Runtime/PhelSourceLoader`: cached-PHP boot entry.
 
 ## Key Constraints
@@ -55,7 +55,7 @@ The `Phel` import closes the `Phel <-> Run` cycle: the composition root wires `R
 - **File dedup**: `NamespaceFileTracker` (process-wide static) dedupes evaluated files across eager startup and lazy loads. `NamespaceLoader::reset()` clears it.
 - **Script bundles**: `FileRunner` uses `BundledNamespaceDetector` to seed only bundles referenced via fully qualified form (`phel.json/encode`) or Clojure-compatible requires (`clojure.test` → `phel.test`), avoiding cold-start cost for scripts that don't reach bundled modules.
 - **Benchmarks**: `BenchCommand` (`phel bench`) mirrors `TestCommand`'s shape — resolve paths through `getDependenciesFromPaths()`, `evalFile()` each namespace (skipping `tests/php/`), then `eval()` a generated `(phel.bench/run-benchmarks {...} 'ns ...)` form. The measurement lives in `phel.bench`, in Phel, so no language boundary sits inside the measured region. `run-benchmarks` returns a boolean verdict which becomes the exit code; a `--tolerance` regression is the only way it returns false. String options are `json_encode`d with `JSON_UNESCAPED_SLASHES` — without it, every `/` of a POSIX path reaches the reader as `\/`.
-- **Coverage**: `phel test --coverage[=text|clover|html]` wraps the serial test eval with the driver, maps raw PHP line coverage to `.phel` via `CommandFacade::getCompiledFileLineMap`, filters to project source dirs. Coverage **forces serial execution** (parallel workers can't merge). `html` writes a self-contained static report (`HtmlCoverageRenderer`) to `var/coverage/` by default; override the directory with `html:<dir>` or `--coverage-output`.
+- **Coverage**: `phel test --coverage[=text|clover|html]` wraps the serial test eval with the driver, maps raw PHP line coverage to `.phel` via `CommandFacade::getCompiledFileLineMap`, filters to project source dirs. Coverage **forces serial execution** (parallel workers can't merge). `--coverage=per-test` installs `PerTestCoverageCollector` as `phel.test/*event-hook*` (via `PhelVar::alterRoot`, after the namespaces are loaded, so the `def` does not overwrite it) and lets it start/stop the driver on the `:begin-test`/`:end-test` events instead of one run-wide window; the JSON has `tests` (test to file to lines) and `lines` (file to line to tests). `html` writes a self-contained static report (`HtmlCoverageRenderer`) to `var/coverage/` by default; override the directory with `html:<dir>` or `--coverage-output`.
 - **Parallel testing**: `ParallelTestOrchestrator` spawns a `phel _test-worker` subprocess pool, one ns per length-prefixed JSON work frame; per-ns output is buffered and flushed in input order. `CpuCountDetector` honours `PHEL_TEST_WORKERS`, falls back to `nproc`/`sysctl`/`/proc/cpuinfo`, caps at 8. The parent evaluates only `SharedNamespaces` (what another namespace of the run requires) before dispatching, so a cold cache is warmed once for anything two workers could compile at the same time; every frame carries its `LoadOrderResolver` list (requires + every bundled `phel.*`, dependencies first) and the worker evaluates each file once and never walks dependencies or calls `loadPhelNamespaces()` itself (#3203). A `CompilerException` in a worker is a failed namespace, not a retried worker error.
 - **Watch testing**: `runTestWatchLoop` (`phel test --watch`) polls project src/test dirs for `.phel`/`phel-config.php` mtime changes every 500ms, re-invoking `$runTests` as a subprocess per change.
 - **Completion unaffected by lazy load**: the Api completer builds its catalog from `ApiConfig::allNamespaces()`, not from what the REPL loaded.

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -10,6 +10,7 @@ use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Run\Application\Test\Coverage\CoverageDriver;
 use Phel\Run\Application\Test\Coverage\CoverageReport;
 use Phel\Run\Application\Test\Coverage\HtmlCoverageRenderer;
+use Phel\Run\Application\Test\Coverage\PerTestCoverageCollector;
 use Phel\Run\Application\Test\SharedNamespaces;
 use Phel\Run\Domain\Test\TestCommandOptions;
 use Phel\Run\Domain\Test\TestNamespacePruner;
@@ -178,9 +179,9 @@ HELP)
                 self::OPT_COVERAGE,
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Collect line coverage (via pcov or xdebug) mapped back to .phel sources. Value is the format: "text" (default), "clover", or "html". "html" writes a static report to var/coverage/ (override with "html:<dir>").',
+                'Collect line coverage (via pcov or xdebug) mapped back to .phel sources. Value is the format: "text" (default), "clover", "html", or "per-test". "html" writes a static report to var/coverage/ (override with "html:<dir>"). "per-test" writes JSON with the lines each test executed and the tests behind each line.',
                 false,
-                ['text', 'clover', 'html'],
+                ['text', 'clover', 'html', 'per-test'],
             )->addOption(
                 self::OPT_COVERAGE_OUTPUT,
                 null,
@@ -283,14 +284,31 @@ HELP)
 
             $phelCode = $this->generatePhelTestCodeFromOptions($options, $filteredNamespaces);
             $compileOptions = new CompileOptions()->setIsEnabledSourceMaps(false);
+            $coverageFormat = ScalarCoercion::toString($input->getOption(self::OPT_COVERAGE));
 
-            $coverageDriver?->start();
+            // Per-test attribution starts and stops the driver around every
+            // test through the `phel.test` event hook, so it must own the
+            // driver: a run-wide start would be cut short by the first stop.
+            $perTestCoverage = null;
+            if ($coverageDriver instanceof CoverageDriver && $this->isPerTestCoverage($coverageFormat)) {
+                $perTestCoverage = PerTestCoverageCollector::forDriver($coverageDriver);
+                $perTestCoverage->install();
+            } else {
+                $coverageDriver?->start();
+            }
+
             $result = $this->getFacade()->eval($phelCode, $compileOptions);
-            if ($coverageDriver instanceof CoverageDriver) {
+            if ($perTestCoverage instanceof PerTestCoverageCollector) {
+                $this->writeReport(
+                    $output,
+                    $this->getFacade()->buildPerTestCoverageReport($perTestCoverage->hitLinesByTest(), $perTestCoverage->driverName())->toJson(),
+                    $input->getOption(self::OPT_COVERAGE_OUTPUT),
+                );
+            } elseif ($coverageDriver instanceof CoverageDriver) {
                 $this->renderCoverage(
                     $output,
                     $this->getFacade()->buildCoverageReport($coverageDriver->stop(), $coverageDriver->name()),
-                    ScalarCoercion::toString($input->getOption(self::OPT_COVERAGE)),
+                    $coverageFormat,
                     $input->getOption(self::OPT_COVERAGE_OUTPUT),
                 );
             }
@@ -402,10 +420,24 @@ HELP)
             return;
         }
 
-        $content = $format === 'clover'
-            ? $report->toClover(time())
-            : $report->toText();
+        $this->writeReport(
+            $output,
+            $format === 'clover' ? $report->toClover(time()) : $report->toText(),
+            $outputPath,
+        );
+    }
 
+    private function isPerTestCoverage(string $format): bool
+    {
+        return strtolower($format) === 'per-test';
+    }
+
+    /**
+     * Writes a rendered coverage report to `$outputPath` when one was given,
+     * otherwise to the console.
+     */
+    private function writeReport(OutputInterface $output, string $content, mixed $outputPath): void
+    {
         if (is_string($outputPath) && $outputPath !== '') {
             if (@file_put_contents($outputPath, $content) === false) {
                 $output->writeln(sprintf('<error>Cannot write coverage report to %s</error>', $outputPath));

--- a/src/php/Run/RunFacade.php
+++ b/src/php/Run/RunFacade.php
@@ -10,6 +10,7 @@ use Gacela\Framework\ServiceResolver\ServiceMap;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Run\Application\Test\Coverage\CoverageDriver;
 use Phel\Run\Application\Test\Coverage\CoverageReport;
+use Phel\Run\Application\Test\Coverage\PerTestCoverageReport;
 use Phel\Run\Application\Test\CpuCountDetector;
 use Phel\Run\Application\Test\ParallelTestOrchestrator;
 use Phel\Shared\CompileOptions;
@@ -244,5 +245,18 @@ final class RunFacade extends AbstractFacade implements RunFacadeInterface
         return $this->getFactory()
             ->createCoverageAggregator($driverName)
             ->aggregate($rawCoverage);
+    }
+
+    /**
+     * Attribute the PHP lines each test executed to `.phel` lines: which
+     * lines each test covers and which tests cover each line.
+     *
+     * @param array<string, array<string, list<int>>> $hitLinesByTest testId => compiledPhpFile => PHP lines with hits
+     */
+    public function buildPerTestCoverageReport(array $hitLinesByTest, string $driverName): PerTestCoverageReport
+    {
+        return $this->getFactory()
+            ->createCoverageAggregator($driverName)
+            ->attribute($hitLinesByTest);
     }
 }

--- a/tests/phel/test-events.phel
+++ b/tests/phel/test-events.phel
@@ -1,0 +1,34 @@
+(ns phel-test.test-events
+  (:require phel.test :as t :refer [deftest is])
+  (:require phel-test.fixtures.run-harness :as h :refer [events-of])
+  (:require phel-test.fixtures.tagged-tests))
+
+;; `run-tests` brackets every test with a `:begin-test` / `:end-test`
+;; event, and `*event-hook*` observes every event of a run next to the
+;; configured reporters. Both are what a host (the PHP runner attributing
+;; coverage per test) builds on.
+
+(def- fixture-ns 'phel-test.fixtures.tagged-tests)
+
+(deftest test-every-test-is-bracketed-by-begin-and-end-events
+  (let [{:events events} (h/snapshot-run fixture-ns {:reporters []})
+        begins           (events-of events :begin-test)
+        ends             (events-of events :end-test)]
+    (is (= 3 (count begins)) "one :begin-test per fixture test")
+    (is (= 3 (count ends)) "one :end-test per fixture test")
+    (is (= (map :test-name begins) (map :test-name ends)) "begin and end name the same tests, in order")
+    (is (every? (fn [e] (= "phel-test.fixtures.tagged-tests" (:ns e))) begins) "events carry the namespace")
+    (is (every? (fn [e] (number? (:duration-ms e))) ends) "the end event carries the duration")))
+
+(deftest test-begin-test-precedes-the-tests-assertions
+  (let [{:events events}       (h/snapshot-run fixture-ns {:reporters []})
+        before-first-assertion (take-while (fn [e] (not (contains? e :state))) events)]
+    (is (some (fn [e] (= :begin-test (:type e))) before-first-assertion)
+        ":begin-test arrives before the first assertion of the run")))
+
+(deftest test-the-event-hook-sees-every-event-without-replacing-the-reporters
+  (let [seen             (atom [])
+        {:events events} (binding [t/*event-hook* (fn [e] (swap! seen conj (:type e)))]
+                           (h/snapshot-run fixture-ns {:reporters []}))]
+    (is (= (map :type events) @seen) "the hook receives the same events the reporters do, in order")
+    (is (some (fn [type] (= :end-test type)) @seen) "including the per-test lifecycle events")))

--- a/tests/php/Integration/Api/core-api.snapshot.txt
+++ b/tests/php/Integration/Api/core-api.snapshot.txt
@@ -922,6 +922,7 @@ phel.test.shrink/args->rose  (args->rose args)
 phel.test.shrink/shrink  (shrink pred tree)
 phel.test.shrink/shrink-args  (shrink-args property args)
 phel.test.shrink/value->rose  (value->rose v)
+phel.test/*event-hook*  <value>
 phel.test/*testing-contexts*  <value>
 phel.test/add-reporter!  (add-reporter! reporter-fn)
 phel.test/are  (are argv expr & args)

--- a/tests/php/Integration/Run/Command/Test/TestCommandCoverage/TestCommandCoverageTest.php
+++ b/tests/php/Integration/Run/Command/Test/TestCommandCoverage/TestCommandCoverageTest.php
@@ -7,6 +7,8 @@ namespace PhelTest\Integration\Run\Command\Test\TestCommandCoverage;
 use Override;
 use PHPUnit\Framework\TestCase;
 
+use function array_intersect;
+use function array_keys;
 use function bin2hex;
 use function dirname;
 use function escapeshellarg;
@@ -15,12 +17,16 @@ use function file_get_contents;
 use function file_put_contents;
 use function glob;
 use function implode;
+use function json_decode;
 use function mkdir;
 use function random_bytes;
+use function realpath;
 use function simplexml_load_string;
 use function sprintf;
 use function str_contains;
 use function sys_get_temp_dir;
+
+use const JSON_THROW_ON_ERROR;
 
 /**
  * End-to-end coverage of `phel test --coverage`. The actual collection needs a
@@ -126,6 +132,50 @@ final class TestCommandCoverageTest extends TestCase
         self::assertNotFalse($filePages);
         self::assertCount(1, $filePages);
         self::assertStringContainsString('class="covered"', (string) file_get_contents($filePages[0]));
+    }
+
+    public function test_per_test_coverage_attributes_each_line_to_the_test_that_ran_it(): void
+    {
+        // A second function and a second test, so attribution has something
+        // to tell apart: `add` is only ever called by `add-works`, `mul` only
+        // by `mul-works`, and `unused-fn` by nobody.
+        file_put_contents(
+            $this->projectDir . '/src/calc.phel',
+            "(ns app.calc)\n\n(defn add [a b]\n  (+ a b))\n\n(defn mul [a b]\n  (* a b))\n\n(defn unused-fn [x]\n  (* x 100))\n",
+        );
+        file_put_contents(
+            $this->projectDir . '/tests/calc_test.phel',
+            "(ns app.calc-test\n  (:require phel.test :refer [deftest is])\n  (:require app.calc))\n"
+            . "(deftest add-works\n  (is (= 3 (app.calc/add 1 2))))\n"
+            . "(deftest mul-works\n  (is (= 6 (app.calc/mul 2 3))))\n",
+        );
+        $jsonPath = $this->projectDir . '/per-test.json';
+
+        [$exitCode, $output] = $this->runPhelTest(['--coverage=per-test', '--coverage-output=' . $jsonPath]);
+
+        $this->skipIfNoDriver($output);
+        self::assertSame(0, $exitCode, $output);
+        self::assertFileExists($jsonPath);
+        $json = (string) file_get_contents($jsonPath);
+        $this->skipIfNothingWasInstrumented($json);
+
+        $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+        self::assertSame(['driver', 'tests', 'lines'], array_keys($decoded));
+        self::assertIsArray($decoded['tests']);
+        self::assertIsArray($decoded['lines']);
+
+        $calc = realpath($this->projectDir . '/src/calc.phel');
+        self::assertIsString($calc);
+        $addLines = $decoded['tests']['app.calc-test/add-works'][$calc] ?? [];
+        $mulLines = $decoded['tests']['app.calc-test/mul-works'][$calc] ?? [];
+        self::assertNotSame([], $addLines, 'add-works executed lines of calc.phel: ' . $json);
+        self::assertNotSame([], $mulLines, 'mul-works executed lines of calc.phel: ' . $json);
+        self::assertSame([], array_intersect($addLines, $mulLines), 'the two tests touch disjoint functions');
+
+        foreach ($addLines as $line) {
+            self::assertSame(['app.calc-test/add-works'], $decoded['lines'][$calc][(string) $line] ?? null);
+        }
     }
 
     private function skipIfNoDriver(string $output): void

--- a/tests/php/Unit/Architecture/public-api.snapshot.txt
+++ b/tests/php/Unit/Architecture/public-api.snapshot.txt
@@ -1524,6 +1524,7 @@ final class Phel\Run\RunFacade extends Gacela\Framework\AbstractFacade implement
   public function autoDetectEntryPoint(): ?string
   public function breakpoint(Phel\Lang\Collections\Map\PersistentMapInterface $locals): void
   public function buildCoverageReport(array $rawCoverage, string $driverName): Phel\Run\Application\Test\Coverage\CoverageReport
+  public function buildPerTestCoverageReport(array $hitLinesByTest, string $driverName): Phel\Run\Application\Test\Coverage\PerTestCoverageReport
   public function createCpuCountDetector(): Phel\Run\Application\Test\CpuCountDetector
   public function createParallelTestOrchestrator(): Phel\Run\Application\Test\ParallelTestOrchestrator
   public function detectCoverageDriver(): ?Phel\Run\Application\Test\Coverage\CoverageDriver

--- a/tests/php/Unit/Run/Application/Test/Coverage/CoverageAggregatorTest.php
+++ b/tests/php/Unit/Run/Application/Test/Coverage/CoverageAggregatorTest.php
@@ -81,6 +81,36 @@ final class CoverageAggregatorTest extends TestCase
         self::assertSame([], $report->files());
     }
 
+    public function test_attributes_phel_lines_to_the_tests_that_hit_them(): void
+    {
+        // calc.php lines 10,11 map to calc.phel:2 (add); 12,13 to calc.phel:3 (unused);
+        // a vendor file is mapped too and must be dropped.
+        $commandFacade = $this->commandFacade([
+            '/cache/calc.php' => ['filename' => $this->calcPhel, 'lines' => [10 => 2, 11 => 2, 12 => 3, 13 => 3]],
+            '/cache/lib.php' => ['filename' => $this->vendorPhel, 'lines' => [5 => 1]],
+        ]);
+
+        $report = new CoverageAggregator($commandFacade, [$this->projectDir], 'xdebug')->attribute([
+            'app.calc-test/add-works' => ['/cache/calc.php' => [10, 11], '/cache/lib.php' => [5]],
+            'app.calc-test/unused-works' => ['/cache/calc.php' => [12]],
+            'app.calc-test/touches-nothing' => ['/cache/lib.php' => [5]],
+        ]);
+
+        self::assertSame('xdebug', $report->driverName());
+        self::assertSame(
+            [
+                'app.calc-test/add-works' => [$this->calcPhel => [2]],
+                'app.calc-test/touches-nothing' => [],
+                'app.calc-test/unused-works' => [$this->calcPhel => [3]],
+            ],
+            $report->linesByTest(),
+        );
+        self::assertSame(
+            [$this->calcPhel => [2 => ['app.calc-test/add-works'], 3 => ['app.calc-test/unused-works']]],
+            $report->testsByLine(),
+        );
+    }
+
     /**
      * @param array<string, array{filename: string, lines: array<int, int>}> $maps
      */

--- a/tests/php/Unit/Run/Application/Test/Coverage/PerTestCoverageCollectorTest.php
+++ b/tests/php/Unit/Run/Application/Test/Coverage/PerTestCoverageCollectorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Application\Test\Coverage;
+
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\TypeFactory;
+use Phel\Run\Application\Test\Coverage\PerTestCoverageCollector;
+use PHPUnit\Framework\TestCase;
+
+final class PerTestCoverageCollectorTest extends TestCase
+{
+    public function test_files_the_hit_lines_of_each_test_between_begin_and_end(): void
+    {
+        $started = 0;
+        $window = [];
+        $collector = new PerTestCoverageCollector(
+            static function () use (&$started): void {
+                ++$started;
+            },
+            static function () use (&$window): array {
+                return $window;
+            },
+            'fake',
+        );
+
+        $window = ['/cache/calc.php' => [10 => 1, 11 => 0, 12 => 3], '/cache/lib.php' => [5 => 0]];
+        $collector($this->event('begin-test', 'app.calc-test', 'add-works'));
+        $collector($this->event('binary', 'app.calc-test', 'add-works'));
+        $collector($this->event('end-test', 'app.calc-test', 'add-works'));
+
+        $window = [];
+        $collector($this->event('begin-test', 'app.calc-test', 'nothing'));
+        $collector($this->event('end-test', 'app.calc-test', 'nothing'));
+
+        self::assertSame(2, $started, 'the driver starts once per test');
+        self::assertSame(
+            [
+                'app.calc-test/add-works' => ['/cache/calc.php' => [10, 12]],
+                'app.calc-test/nothing' => [],
+            ],
+            $collector->hitLinesByTest(),
+        );
+    }
+
+    public function test_ignores_events_that_are_not_maps_or_carry_no_type(): void
+    {
+        $collector = new PerTestCoverageCollector(
+            static function (): never {
+                self::fail('must not start');
+            },
+            static fn(): array => [],
+            'fake',
+        );
+
+        $collector('begin-test');
+        $collector(TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('ns'), 'x'));
+
+        self::assertSame([], $collector->hitLinesByTest());
+    }
+
+    private function event(string $type, string $ns, string $testName): PersistentMapInterface
+    {
+        return TypeFactory::getInstance()->persistentMapFromKVs(
+            Keyword::create('type'),
+            Keyword::create($type),
+            Keyword::create('ns'),
+            $ns,
+            Keyword::create('test-name'),
+            $testName,
+        );
+    }
+}

--- a/tests/php/Unit/Run/Application/Test/Coverage/PerTestCoverageReportTest.php
+++ b/tests/php/Unit/Run/Application/Test/Coverage/PerTestCoverageReportTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Application\Test\Coverage;
+
+use Phel\Run\Application\Test\Coverage\PerTestCoverageReport;
+use PHPUnit\Framework\TestCase;
+
+use function json_decode;
+
+final class PerTestCoverageReportTest extends TestCase
+{
+    public function test_json_carries_both_indexes_with_string_keyed_lines(): void
+    {
+        $report = new PerTestCoverageReport(
+            [
+                'app.t/a' => ['/p/src/calc.phel' => [2, 3]],
+                'app.t/b' => [],
+            ],
+            ['/p/src/calc.phel' => [2 => ['app.t/a'], 3 => ['app.t/a']]],
+            'pcov',
+        );
+
+        $decoded = json_decode($report->toJson(), true);
+
+        self::assertSame(
+            [
+                'driver' => 'pcov',
+                'tests' => [
+                    'app.t/a' => ['/p/src/calc.phel' => [2, 3]],
+                    'app.t/b' => [],
+                ],
+                'lines' => ['/p/src/calc.phel' => ['2' => ['app.t/a'], '3' => ['app.t/a']]],
+            ],
+            $decoded,
+        );
+    }
+
+    public function test_an_empty_report_is_still_valid_json_with_both_indexes(): void
+    {
+        $decoded = json_decode(new PerTestCoverageReport([], [], 'xdebug')->toJson(), true);
+
+        self::assertSame(['driver' => 'xdebug', 'tests' => [], 'lines' => []], $decoded);
+    }
+}

--- a/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
+++ b/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
@@ -138,7 +138,7 @@ final class TestCommandOptionsWiringTest extends TestCase
     {
         $tester = new CommandCompletionTester(new TestCommand());
 
-        self::assertSame(['text', 'clover', 'html'], $tester->complete(['--coverage', '']));
+        self::assertSame(['text', 'clover', 'html', 'per-test'], $tester->complete(['--coverage', '']));
     }
 
     public function test_reporter_option_completes_builtins(): void


### PR DESCRIPTION
## 🤔 Background

`phel test --coverage` collected one coverage window around the whole run, so it could say which `.phel` lines ran but never which tests ran them. Per-test attribution is what test impact analysis (#3210) and mutation testing (#3208, #3209) need, and every piece but one was already there: the PHP-line to `.phel`-line mapping, the driver abstraction, and the per-test bracket in `run-one-test!`. The missing piece was a way for the runner to be told when a test starts and ends.

## 💡 Goal

`phel test --coverage=per-test [--coverage-output=file.json]` writes JSON with `tests` (test to file to lines) and `lines` (file to line to tests), without changing the existing text, clover and html formats.

## 🔖 Changes

- `phel.test` emits `:begin-test` and `:end-test` around every test (`:end-test` carries `:duration-ms`), and exposes `*event-hook*`, an observer called with every event of a run after the configured reporters. Existing reporters use `cond` without a default branch and ignore the new types.
- `PerTestCoverageCollector` is installed as that hook through `PhelVar::alterRoot` once the namespaces are loaded; it starts and stops the driver per test and keeps only the lines with hits. `CoverageAggregator::attribute()` maps each compiled file to its source once at the end and builds both indexes; `PerTestCoverageReport::toJson()` is compact on purpose (31 MB pretty-printed on this repository).
- Measured here with xdebug: `--coverage` 28.5s, `--coverage=per-test` 26s (3014 tests, 63 source files attributed). pcov is untested on this machine.
- Tests: Phel (`tests/phel/test-events.phel`) for the events and the hook; PHPUnit unit tests for the collector, the aggregation and the JSON; an integration test on a fixture project asserting two tests attribute to disjoint lines (skips without a driver, like its siblings).
- Public API snapshots updated for `phel.test/*event-hook*` and `RunFacade::buildPerTestCoverageReport()`; docs and CHANGELOG under Unreleased.
- Refactor pass: both aggregations now share one line-map lookup.

Closes #3207
