### PR TITLE
chore(test): drop the memory_limit flags bin/phel overrides anyway

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,7 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Run tests to the core library
-        run: php -d memory_limit=256M ./bin/phel test ${{ matrix.exclude-tags }}
+        run: php ./bin/phel test ${{ matrix.exclude-tags }}
 
   # `optimizationLevel` defaults to 0, so without this job nothing in CI ever
   # runs `CallInliner` or `TailCallRewriter`. That is how -O2 came to fail five
@@ -93,7 +93,7 @@ jobs:
           PHEL_OPTIMIZATION_LEVEL: '2'
         run: |
           rm -rf ./.phel/cache
-          php -d memory_limit=256M ./bin/phel test
+          php ./bin/phel test
 
   # Windows is the "Best effort" tier in docs/stability.md: bugs are accepted and
   # fixed, but a Windows-only failure does not block a release, so this job reports
@@ -130,7 +130,7 @@ jobs:
       - name: Run tests to the core library
         id: core
         continue-on-error: true
-        run: php -d memory_limit=256M bin/phel test
+        run: php bin/phel test
 
       - name: Report the outcome
         run: |

--- a/bin/phel
+++ b/bin/phel
@@ -3,7 +3,11 @@
 
 declare(strict_types=1);
 
-// Raise memory limit for compiler/tokenizer workloads (mirrors composer bin behavior).
+// Lift the memory limit for compiler workloads (mirrors composer bin behavior).
+// Unconditional on purpose: a `-d memory_limit=…` or php.ini ceiling is
+// overridden too, so a compile never dies on a limit tuned for web requests
+// (a cold `phel test` here peaks near 1 GB, a warm one under 250 MB). A
+// memory_limit flag on a `phel` invocation therefore does nothing.
 if (function_exists('ini_set')) {
     @ini_set('memory_limit', '-1');
 }

--- a/composer.json
+++ b/composer.json
@@ -119,8 +119,8 @@
         "test-integration:serial": "./vendor/bin/phpunit --testsuite=integration",
         "test-agents": "./tools/validate-agents.sh",
         "test-tools": "./tools/bashunit tools/*-test.sh --simple",
-        "test-core": "php -d memory_limit=256M ./bin/phel test",
-        "test-core:parallel": "php -d memory_limit=256M ./bin/phel test --parallel=auto",
+        "test-core": "php ./bin/phel test",
+        "test-core:parallel": "php ./bin/phel test --parallel=auto",
         "test-quality": [
             "@csrun",
             "@psalm",


### PR DESCRIPTION
## 🤔 Background

`composer test-core`, `test-core:parallel` and three jobs in `tests.yml` ran `php -d memory_limit=256M ./bin/phel test`, but `bin/phel` does `@ini_set('memory_limit', '-1')` unconditionally, so the flag never held: a run with `-d memory_limit=64M` peaks at ~172 MB and does not error. Anyone reading `composer.json` believed a ceiling was enforced that was not.

## 💡 Goal

Make `composer.json`, the workflows and `bin/phel` agree.

## 🔖 Changes

- The dead `-d memory_limit=256M` flags are gone from `composer.json` (2) and `.github/workflows/tests.yml` (3). Zero behaviour change.
- `bin/phel` says in a short comment why the limit is lifted and that it is unconditional on purpose.

Why not enforce a limit instead: a cold `phel test` of this repository peaks near 1 GB (compile retention, PR #3227 brought it down from 1.4 GB) while a warm one stays under 250 MB, and the CI core-test jobs run cold. Any honest ceiling would be ~1.5 GB, which catches nothing a memory regression in `phel.test` would show, and making `bin/phel` honour `-d`/php.ini limits would turn every host limit tuned for web requests into a compile failure for users. If a memory gate is wanted, a measured budget in the bench suite is the right tool.

No changelog entry: nothing user-facing changed. The mandatory refactor pass over the touched files surfaced no changes.

Closes #3213
