### PR TITLE
feat(format): --exclude globs and the format-exclude config key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ All notable changes to this project will be documented in this file.
 
 - `phel.ai/*sleep-fn*`, the retry backoff seam next to `*http-post*`: rebind it in tests so a 429/5xx retry records its delay instead of sleeping. The repository's own retry tests slept ~3s of a ~4.9s `phel test` pass; `composer test-core` goes from ~5.6s to ~3.1s serial. A blank `ANTHROPIC_API_KEY=` (or `OPENAI_API_KEY=`, `VOYAGE_API_KEY=`) now reads as a missing key, which throws before any request, instead of being sent as an empty key (#3204)
 
+#### CLI
+
+- `phel format --exclude=<glob>` (repeatable) and the `format-exclude` config key (`PhelConfig::withFormatExclude([...])`), unioned: a discovered `.phel` file matching a glob is left alone and reported in neither list, `-v` names it. Globs are `fnmatch`ed against the path as found and relative to the working directory, `*` spans directories as in `phel lint`. For generated data files and vendored trees that live beside their consumers (#3233)
+
 #### CI
 
 - `Core tests at -O2` job; nothing exercised `CallInliner` or `TailCallRewriter` before. Local repro: `PHEL_OPTIMIZATION_LEVEL=2 ./bin/phel test` (#3126)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -116,7 +116,14 @@ phel completion zsh       # (optional) enable tab-completion
 ```sh
 phel test --watch         # re-run tests on change
 phel watch                # hot-reload namespaces instead
+phel format --dry-run     # check formatting; --exclude='src/*_data.phel' skips generated files
 ```
+
+`phel format` walks `format-dirs`; a glob passed as `--exclude` (repeatable) or
+listed under the `format-exclude` config key is skipped, matched against each
+path as found and relative to the working directory, with `*` spanning
+directories. Use it for baked data files and vendored trees that live beside
+their consumers.
 
 Both reuse the compiled-code cache, so a one-file edit recompiles only the
 affected namespaces. `phel repl` (or `phel nrepl` from your editor) for

--- a/resources/agents/RULES.md
+++ b/resources/agents/RULES.md
@@ -70,7 +70,7 @@ See [`tasks/common-gotchas.md`](tasks/common-gotchas.md) for details. Quick summ
 | Test | `./vendor/bin/phel test [path]` |
 | Build | `./vendor/bin/phel build` |
 | Doc | `./vendor/bin/phel doc <fn>` |
-| Format | `./vendor/bin/phel format <file>` |
+| Format | `./vendor/bin/phel format <file>` (`--dry-run` to check; `--exclude='<glob>'` or `format-exclude` config skips generated files) |
 | Fix parens | `./vendor/bin/phel balance <file> --fix` |
 | Profile | `./vendor/bin/phel profile <path> [--format=text\|json\|both] [--output=<file>]` |
 | Install skill | `./vendor/bin/phel agent-install <platform>\|--all` |

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -45,6 +45,8 @@ final readonly class PhelConfig implements JsonSerializable
 
     public const string FORMAT_DIRS = 'format-dirs';
 
+    public const string FORMAT_EXCLUDE = 'format-exclude';
+
     public const string APP_MODULE_PATHS = 'app-module-paths';
 
     public const string ASSERTS_ENABLED = 'asserts-enabled';
@@ -82,6 +84,7 @@ final readonly class PhelConfig implements JsonSerializable
      * @param list<string> $ignoreWhenBuilding
      * @param list<string> $noCacheWhenBuilding
      * @param list<string> $formatDirs
+     * @param list<string> $formatExclude
      * @param list<string> $appModulePaths
      */
     public function __construct(
@@ -97,6 +100,7 @@ final readonly class PhelConfig implements JsonSerializable
         ?string $tempDir = null,
         string $cacheDir = self::DEFAULT_CACHE_DIR,
         public array $formatDirs = ['src', 'tests'],
+        public array $formatExclude = [],
         public array $appModulePaths = [],
         public bool $enableAsserts = true,
         public bool $warnDeprecations = false,
@@ -209,6 +213,14 @@ final readonly class PhelConfig implements JsonSerializable
     public function getFormatDirs(): array
     {
         return $this->formatDirs;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getFormatExclude(): array
+    {
+        return $this->formatExclude;
     }
 
     /**
@@ -488,6 +500,19 @@ final readonly class PhelConfig implements JsonSerializable
     }
 
     /**
+     * Globs `phel format` skips, matched against each discovered path as given
+     * and relative to the working directory (`*` spans directories, as in
+     * `phel lint`): generated data files, vendored trees. Unioned with
+     * `--exclude`. Default: none.
+     *
+     * @param list<string> $patterns
+     */
+    public function withFormatExclude(array $patterns): self
+    {
+        return $this->with(['formatExclude' => $patterns]);
+    }
+
+    /**
      * Directories Gacela scans for app modules (facades, factories, providers).
      *
      * Default `[]` keeps Gacela's own default: walk the whole project root.
@@ -621,6 +646,7 @@ final readonly class PhelConfig implements JsonSerializable
             self::KEEP_GENERATED_TEMP_FILES => $this->keepGeneratedTempFiles,
             self::TEMP_DIR => $this->tempDir,
             self::FORMAT_DIRS => $this->formatDirs,
+            self::FORMAT_EXCLUDE => $this->formatExclude,
             self::APP_MODULE_PATHS => $this->appModulePaths,
             self::ASSERTS_ENABLED => $this->enableAsserts,
             self::WARN_DEPRECATIONS => $this->warnDeprecations,
@@ -658,6 +684,7 @@ final readonly class PhelConfig implements JsonSerializable
      *     tempDir?: string,
      *     cacheDir?: string,
      *     formatDirs?: list<string>,
+     *     formatExclude?: list<string>,
      *     appModulePaths?: list<string>,
      *     enableAsserts?: bool,
      *     warnDeprecations?: bool,
@@ -684,6 +711,7 @@ final readonly class PhelConfig implements JsonSerializable
             tempDir: $overrides['tempDir'] ?? $this->tempDir,
             cacheDir: $overrides['cacheDir'] ?? $this->cacheDir,
             formatDirs: $overrides['formatDirs'] ?? $this->formatDirs,
+            formatExclude: $overrides['formatExclude'] ?? $this->formatExclude,
             appModulePaths: $overrides['appModulePaths'] ?? $this->appModulePaths,
             enableAsserts: $overrides['enableAsserts'] ?? $this->enableAsserts,
             warnDeprecations: $overrides['warnDeprecations'] ?? $this->warnDeprecations,

--- a/src/php/Formatter/Application/PathsFormatter.php
+++ b/src/php/Formatter/Application/PathsFormatter.php
@@ -7,6 +7,7 @@ namespace Phel\Formatter\Application;
 use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
 use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
 use Phel\Formatter\Domain\Exception\FilePathException;
+use Phel\Formatter\Domain\ExcludePatterns;
 use Phel\Formatter\Domain\FormatterInterface;
 use Phel\Formatter\Domain\IO\ValidatedFileIoInterface;
 use Phel\Formatter\Domain\PathFilterInterface;
@@ -47,14 +48,27 @@ final readonly class PathsFormatter
      * that only printed the errors and returned success made `phel format
      * --dry-run` usable as a green CI gate over unparsable sources.
      *
+     * A path matching one of `$exclude` (see {@see ExcludePatterns}) is
+     * skipped before it is read and lands in neither bucket; `-v` names it.
+     *
      * @param list<string> $paths
+     * @param list<string> $exclude
      */
-    public function format(array $paths, OutputInterface $output, bool $dryRun = false): FormatResult
+    public function format(array $paths, OutputInterface $output, bool $dryRun = false, array $exclude = []): FormatResult
     {
         $formattedFilePaths = [];
         $failedFilePaths = [];
+        $excluded = ExcludePatterns::fromWorkingDirectory($exclude);
 
         foreach ($this->pathFilter->filterPaths($paths) as $path) {
+            if ($excluded->matches($path)) {
+                if ($output->isVerbose()) {
+                    $output->writeln('Excluded: ' . $path);
+                }
+
+                continue;
+            }
+
             try {
                 $wasFormatted = $this->formatFile($path, $dryRun);
                 if ($wasFormatted) {

--- a/src/php/Formatter/CLAUDE.md
+++ b/src/php/Formatter/CLAUDE.md
@@ -6,7 +6,7 @@ Code formatter for `phel format`: lex/parse Phel source to a parse tree, apply o
 
 | Method | Notes |
 |--------|-------|
-| `format(array $paths, OutputInterface $output, bool $dryRun = false): FormatResult` | Discovers `.phel` files under `$paths` and formats each one. |
+| `format(array $paths, OutputInterface $output, bool $dryRun = false, array $exclude = []): FormatResult` | Discovers `.phel` files under `$paths` and formats each one; a file matching an `$exclude` glob (`Domain/ExcludePatterns`: `fnmatch` against the path as found and relative to cwd, `*` spans directories) is skipped and lands in neither result list, named under `-v`. |
 | `formatString(string $source, string $uri = FormatterInterface::DEFAULT_SOURCE): string` | Formats in memory; no filesystem access. |
 
 ### `FormatResult` contract
@@ -25,7 +25,7 @@ Each path lands in at most one bucket; an already-formatted file appears in neit
 
 - `CompilerFacadeInterface::class` — lex + parse to parse tree (`lexString`, `parseAll`).
 - `CommandFacadeInterface::class` — CLI output.
-- Config — `FormatterConfig.getFormatDirs()` reads `PhelConfig::FORMAT_DIRS`, defaults to `['src', 'tests']`.
+- Config — `FormatterConfig.getFormatDirs()` reads `PhelConfig::FORMAT_DIRS`, defaults to `['src', 'tests']`; `getFormatExclude()` reads `PhelConfig::FORMAT_EXCLUDE` (default none), which `FormatCommand` unions with `--exclude`.
 
 Both getters return the Shared contract, never a concrete facade, and `SatelliteFactoryFacadeInjectionTest` pins the return types. The residual `Formatter -> Compiler` imports are exception types named in `@throws` (`LexerValueException`, `AbstractParserException`), not behaviour.
 
@@ -57,6 +57,7 @@ Symbol lists live as `FormatterFactory` constants; `createIndentRule()` instanti
 | `Application/Formatter.php` | Runs the rule pipeline over one source string |
 | `Application/PathsFormatter.php` | Discovers files, formats each, reports changes |
 | `Application/PhelPathFilter.php` | Recursively finds `.phel` files (impl of `PathFilterInterface`) |
+| `Domain/ExcludePatterns.php` | The globs `phel format` skips (`--exclude` + `format-exclude`) |
 | `Domain/Rules/` | Rule classes + `IndentRule` |
 | `Domain/Rules/Indenter/` | `BlockIndenter`, `InnerIndenter`, `LineIndenter`, `ListIndenter`; `FormSymbolMatcherTrait` reads a location's head symbol and matches it against the indenter's symbol |
 | `Domain/Rules/Pair/PairAligner.php` | Backing logic for `AlignPairsRule` |

--- a/src/php/Formatter/Domain/ExcludePatterns.php
+++ b/src/php/Formatter/Domain/ExcludePatterns.php
@@ -45,11 +45,6 @@ final readonly class ExcludePatterns
         return new self($patterns, is_string($cwd) ? $cwd : '');
     }
 
-    public function isEmpty(): bool
-    {
-        return $this->patterns === [];
-    }
-
     public function matches(string $path): bool
     {
         if ($this->patterns === []) {

--- a/src/php/Formatter/Domain/ExcludePatterns.php
+++ b/src/php/Formatter/Domain/ExcludePatterns.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Formatter\Domain;
+
+use function fnmatch;
+use function getcwd;
+use function is_string;
+use function rtrim;
+use function str_starts_with;
+use function strlen;
+use function substr;
+
+use const DIRECTORY_SEPARATOR;
+use const FNM_NOESCAPE;
+
+/**
+ * The paths `phel format` leaves alone: `--exclude` globs and the
+ * `format-exclude` config key, unioned. A pattern is `fnmatch`ed against the
+ * path as it was discovered and against the same path relative to the
+ * working directory, so `src/gen/*` skips a generated tree whether `phel
+ * format` was given `src` or an absolute path. `*` spans directories, as it
+ * does for `phel lint`'s exclude, so `src/*_data.phel` reaches any depth.
+ *
+ * @internal
+ */
+final readonly class ExcludePatterns
+{
+    /**
+     * @param list<string> $patterns
+     */
+    public function __construct(
+        private array $patterns,
+        private string $workingDirectory,
+    ) {}
+
+    /**
+     * @param list<string> $patterns
+     */
+    public static function fromWorkingDirectory(array $patterns): self
+    {
+        $cwd = getcwd();
+
+        return new self($patterns, is_string($cwd) ? $cwd : '');
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->patterns === [];
+    }
+
+    public function matches(string $path): bool
+    {
+        if ($this->patterns === []) {
+            return false;
+        }
+
+        $relative = $this->relativeToWorkingDirectory($path);
+        foreach ($this->patterns as $pattern) {
+            if ($pattern === '') {
+                continue;
+            }
+
+            if (fnmatch($pattern, $path, FNM_NOESCAPE) || fnmatch($pattern, $relative, FNM_NOESCAPE)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function relativeToWorkingDirectory(string $path): string
+    {
+        if ($this->workingDirectory === '') {
+            return $path;
+        }
+
+        $root = rtrim($this->workingDirectory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+
+        return str_starts_with($path, $root) ? substr($path, strlen($root)) : $path;
+    }
+}

--- a/src/php/Formatter/FormatterConfig.php
+++ b/src/php/Formatter/FormatterConfig.php
@@ -34,4 +34,22 @@ final class FormatterConfig extends AbstractConfig
             $formatDirs,
         ));
     }
+
+    /**
+     * Globs the `format-exclude` config key names; see `PhelConfig::withFormatExclude()`.
+     *
+     * @return list<string>
+     */
+    public function getFormatExclude(): array
+    {
+        $patterns = $this->get(PhelConfig::FORMAT_EXCLUDE, []);
+        if (!is_array($patterns)) {
+            return [];
+        }
+
+        return array_values(array_map(
+            static fn(mixed $pattern): string => ScalarCoercion::toString($pattern),
+            $patterns,
+        ));
+    }
 }

--- a/src/php/Formatter/FormatterFacade.php
+++ b/src/php/Formatter/FormatterFacade.php
@@ -19,12 +19,13 @@ final class FormatterFacade extends AbstractFacade implements FormatterFacadeInt
 {
     /**
      * @param list<string> $paths
+     * @param list<string> $exclude
      */
-    public function format(array $paths, OutputInterface $output, bool $dryRun = false): FormatResult
+    public function format(array $paths, OutputInterface $output, bool $dryRun = false, array $exclude = []): FormatResult
     {
         return $this->getFactory()
             ->createPathsFormatter()
-            ->format($paths, $output, $dryRun);
+            ->format($paths, $output, $dryRun, $exclude);
     }
 
     /**

--- a/src/php/Formatter/Infrastructure/Command/FormatCommand.php
+++ b/src/php/Formatter/Infrastructure/Command/FormatCommand.php
@@ -14,6 +14,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function array_unique;
+use function array_values;
 use function count;
 use function sprintf;
 
@@ -29,6 +31,8 @@ final class FormatCommand extends Command
 {
     use ServiceResolverAwareTrait;
 
+    private const string OPT_EXCLUDE = 'exclude';
+
     protected function configure(): void
     {
         $this->setName('format')
@@ -39,6 +43,7 @@ Reformats `.phel` files in place (defaults to the project's format dirs).
 <info>Examples:</info>
   <comment>phel format</comment>                Format all configured directories
   <comment>phel format src/main.phel --dry-run</comment>   Preview changes only
+  <comment>phel format --exclude='src/*_data.phel'</comment>   Leave generated data files alone
 HELP)
             ->setAliases(['fmt'])
             ->addArgument(
@@ -52,6 +57,12 @@ HELP)
                 null,
                 InputOption::VALUE_NONE,
                 'Report files that would be reformatted without modifying them. Exits non-zero when any file would change.',
+            )
+            ->addOption(
+                self::OPT_EXCLUDE,
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Skip files matching this glob (fnmatch; `*` spans directories), matched against the path as found and relative to the working directory. Repeatable; unioned with the `format-exclude` config key.',
             );
     }
 
@@ -60,8 +71,11 @@ HELP)
         /** @var list<string> $paths */
         $paths = $input->getArgument('paths');
         $dryRun = (bool) $input->getOption('dry-run');
+        /** @var list<string> $excludeOption */
+        $excludeOption = (array) $input->getOption(self::OPT_EXCLUDE);
+        $exclude = array_values(array_unique([...$this->getConfig()->getFormatExclude(), ...$excludeOption]));
 
-        $result = $this->getFacade()->format($paths, $output, $dryRun);
+        $result = $this->getFacade()->format($paths, $output, $dryRun, $exclude);
 
         if ($result->hasChanges()) {
             $output->writeln($dryRun ? 'Would reformat:' : 'Formatted files:');

--- a/src/php/Run/Domain/Config/ConfigDiagnostics.php
+++ b/src/php/Run/Domain/Config/ConfigDiagnostics.php
@@ -173,6 +173,7 @@ final class ConfigDiagnostics
             PhelConfig::SRC_DIRS,
             PhelConfig::TEST_DIRS,
             PhelConfig::FORMAT_DIRS,
+            PhelConfig::FORMAT_EXCLUDE,
             PhelConfig::IGNORE_WHEN_BUILDING,
             PhelConfig::NO_CACHE_WHEN_BUILDING,
         ];

--- a/src/php/Run/Domain/Config/EffectiveConfigReader.php
+++ b/src/php/Run/Domain/Config/EffectiveConfigReader.php
@@ -47,6 +47,7 @@ final class EffectiveConfigReader
         PhelConfig::KEEP_GENERATED_TEMP_FILES,
         PhelConfig::TEMP_DIR,
         PhelConfig::FORMAT_DIRS,
+        PhelConfig::FORMAT_EXCLUDE,
         PhelConfig::ASSERTS_ENABLED,
         PhelConfig::WARN_DEPRECATIONS,
         PhelConfig::ENABLE_NAMESPACE_CACHE,

--- a/src/php/Shared/Facade/FormatterFacadeInterface.php
+++ b/src/php/Shared/Facade/FormatterFacadeInterface.php
@@ -18,9 +18,14 @@ interface FormatterFacadeInterface
      * {@see FormatResult::failedPaths()} instead of aborting the batch, so
      * callers can still exit non-zero.
      *
+     * `$exclude` are `fnmatch` globs; a discovered file matching one, by its
+     * path as given or relative to the working directory, is skipped and
+     * lands in neither list (#3233).
+     *
      * @param list<string> $paths
+     * @param list<string> $exclude
      */
-    public function format(array $paths, OutputInterface $output, bool $dryRun = false): FormatResult;
+    public function format(array $paths, OutputInterface $output, bool $dryRun = false, array $exclude = []): FormatResult;
 
     /**
      * Format a Phel source string in memory without touching the filesystem.

--- a/tests/php/Integration/Formatter/Command/Format/FormatCommandTest.php
+++ b/tests/php/Integration/Formatter/Command/Format/FormatCommandTest.php
@@ -117,6 +117,41 @@ TXT;
     }
 
     /**
+     * A generated file beside its consumers is left alone by `--exclude` or the
+     * `format-exclude` config key (#3233); the two are unioned.
+     */
+    public function test_exclude_option_and_config_key_skip_matching_files(): void
+    {
+        $dir = sys_get_temp_dir() . '/phel-format-exclude-' . uniqid();
+        mkdir($dir . '/gen', 0o755, true);
+        $badFormat = "(ns probe.a)\n(defn  f  []\n1)\n";
+        file_put_contents($dir . '/a.phel', $badFormat);
+        file_put_contents($dir . '/gen/table_data.phel', $badFormat);
+        file_put_contents($dir . '/vendored.phel', $badFormat);
+
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addAppConfigKeyValue(PhelConfig::FORMAT_EXCLUDE, ['*/vendored.phel']);
+        });
+
+        try {
+            $tester = $this->createCommandTester();
+            $exitCode = $tester->execute(['paths' => [$dir], '--dry-run' => true, '--exclude' => ['*/gen/*']]);
+
+            self::assertSame(Command::FAILURE, $exitCode, $tester->getDisplay());
+            self::assertStringContainsString($dir . '/a.phel', $tester->getDisplay(), 'the plain file still needs formatting');
+            self::assertStringNotContainsString('table_data.phel', $tester->getDisplay(), '--exclude skips the generated file');
+            self::assertStringNotContainsString('vendored.phel', $tester->getDisplay(), 'format-exclude skips the vendored file');
+            self::assertStringContainsString('1 file(s) need reformatting.', $tester->getDisplay());
+        } finally {
+            unlink($dir . '/a.phel');
+            unlink($dir . '/gen/table_data.phel');
+            unlink($dir . '/vendored.phel');
+            rmdir($dir . '/gen');
+            rmdir($dir);
+        }
+    }
+
+    /**
      * The fixture is unparsable on purpose, so it must not live inside the
      * repository: `phel format` walks `tests/` and would trip over it.
      */

--- a/tests/php/Unit/Architecture/public-api.snapshot.txt
+++ b/tests/php/Unit/Architecture/public-api.snapshot.txt
@@ -166,6 +166,7 @@ final readonly class Phel\Config\PhelConfig implements JsonSerializable
   public const string ERROR_LOG_FILE = 'error-log-file'
   public const string EXPORT_CONFIG = 'export'
   public const string FORMAT_DIRS = 'format-dirs'
+  public const string FORMAT_EXCLUDE = 'format-exclude'
   public const string IGNORE_WHEN_BUILDING = 'ignore-when-building'
   public const string KEEP_GENERATED_TEMP_FILES = 'keep-generated-temp-files'
   public const string NO_CACHE_WHEN_BUILDING = 'no-cache-when-building'
@@ -181,6 +182,7 @@ final readonly class Phel\Config\PhelConfig implements JsonSerializable
   public readonly Phel\Config\PhelExportConfig $exportConfig
   public readonly array $appModulePaths
   public readonly array $formatDirs
+  public readonly array $formatExclude
   public readonly array $ignoreWhenBuilding
   public readonly array $noCacheWhenBuilding
   public readonly array $srcDirs
@@ -198,13 +200,14 @@ final readonly class Phel\Config\PhelConfig implements JsonSerializable
   public readonly string $phelDir
   public readonly string $tempDir
   public readonly string $vendorDir
-  public function __construct(array $srcDirs = ['src'], array $testDirs = ['tests'], string $vendorDir = 'vendor', string $errorLogFile = '.phel/error.log', Phel\Config\PhelExportConfig $exportConfig = object(Phel\Config\PhelExportConfig), Phel\Config\PhelBuildConfig $buildConfig = object(Phel\Config\PhelBuildConfig), array $ignoreWhenBuilding = [], array $noCacheWhenBuilding = [], bool $keepGeneratedTempFiles = false, ?string $tempDir = null, string $cacheDir = '.phel/cache', array $formatDirs = ['src', 'tests'], array $appModulePaths = [], bool $enableAsserts = true, bool $warnDeprecations = false, bool $enableNamespaceCache = true, bool $enableCompiledCodeCache = true, bool $enableIntermediateCache = false, string $phelDir = '', int $optimizationLevel = 0, bool $stripSymbolMeta = false)
+  public function __construct(array $srcDirs = ['src'], array $testDirs = ['tests'], string $vendorDir = 'vendor', string $errorLogFile = '.phel/error.log', Phel\Config\PhelExportConfig $exportConfig = object(Phel\Config\PhelExportConfig), Phel\Config\PhelBuildConfig $buildConfig = object(Phel\Config\PhelBuildConfig), array $ignoreWhenBuilding = [], array $noCacheWhenBuilding = [], bool $keepGeneratedTempFiles = false, ?string $tempDir = null, string $cacheDir = '.phel/cache', array $formatDirs = ['src', 'tests'], array $formatExclude = [], array $appModulePaths = [], bool $enableAsserts = true, bool $warnDeprecations = false, bool $enableNamespaceCache = true, bool $enableCompiledCodeCache = true, bool $enableIntermediateCache = false, string $phelDir = '', int $optimizationLevel = 0, bool $stripSymbolMeta = false)
   public function getAppModulePaths(): array
   public function getBuildConfig(): Phel\Config\PhelBuildConfig
   public function getCacheDir(): string
   public function getErrorLogFile(): string
   public function getExportConfig(): Phel\Config\PhelExportConfig
   public function getFormatDirs(): array
+  public function getFormatExclude(): array
   public function getIgnoreWhenBuilding(): array
   public function getKeepGeneratedTempFiles(): bool
   public function getNoCacheWhenBuilding(): array
@@ -235,6 +238,7 @@ final readonly class Phel\Config\PhelConfig implements JsonSerializable
   public function withExportNamespacePrefix(string $prefix): Phel\Config\PhelConfig
   public function withExportTargetDirectory(string $dir): Phel\Config\PhelConfig
   public function withFormatDirs(array $list): Phel\Config\PhelConfig
+  public function withFormatExclude(array $patterns): Phel\Config\PhelConfig
   public function withIgnoreWhenBuilding(array $list): Phel\Config\PhelConfig
   public function withKeepGeneratedTempFiles(bool $flag = true): Phel\Config\PhelConfig
   public function withLayout(Phel\Config\ProjectLayout $layout): Phel\Config\PhelConfig
@@ -313,7 +317,7 @@ interface Phel\Filesystem\FilesystemFacadeInterface
   public function getTempDir(): string
 
 final class Phel\Formatter\FormatterFacade extends Gacela\Framework\AbstractFacade implements Phel\Shared\Facade\FormatterFacadeInterface
-  public function format(array $paths, Symfony\Component\Console\Output\OutputInterface $output, bool $dryRun = false): Phel\Shared\Formatter\FormatResult
+  public function format(array $paths, Symfony\Component\Console\Output\OutputInterface $output, bool $dryRun = false, array $exclude = []): Phel\Shared\Formatter\FormatResult
   public function formatString(string $source, string $uri = 'string'): string
 
 final class Phel\Interop\InteropFacade extends Gacela\Framework\AbstractFacade implements Phel\Shared\Facade\InteropFacadeInterface
@@ -1905,7 +1909,7 @@ interface Phel\Shared\Facade\ConsoleFacadeInterface
   public function runConsole(): void
 
 interface Phel\Shared\Facade\FormatterFacadeInterface
-  public function format(array $paths, Symfony\Component\Console\Output\OutputInterface $output, bool $dryRun = false): Phel\Shared\Formatter\FormatResult
+  public function format(array $paths, Symfony\Component\Console\Output\OutputInterface $output, bool $dryRun = false, array $exclude = []): Phel\Shared\Formatter\FormatResult
   public function formatString(string $source, string $uri = 'string'): string
 
 interface Phel\Shared\Facade\InteropFacadeInterface

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -37,6 +37,7 @@ final class PhelConfigTest extends TestCase
             PhelConfig::KEEP_GENERATED_TEMP_FILES => false,
             PhelConfig::TEMP_DIR => sys_get_temp_dir() . '/phel/tmp',
             PhelConfig::FORMAT_DIRS => ['src', 'tests'],
+            PhelConfig::FORMAT_EXCLUDE => [],
             PhelConfig::APP_MODULE_PATHS => [],
             PhelConfig::ASSERTS_ENABLED => true,
             PhelConfig::WARN_DEPRECATIONS => false,
@@ -223,6 +224,7 @@ final class PhelConfigTest extends TestCase
             ->withKeepGeneratedTempFiles(true)
             ->withTempDir('/tmp/custom')
             ->withFormatDirs(['src', 'tests', 'phel'])
+            ->withFormatExclude(['src/*_data.phel'])
             ->withEnableAsserts(false)
             ->withWarnDeprecations(true)
             ->withCacheDir('.cache')
@@ -249,6 +251,7 @@ final class PhelConfigTest extends TestCase
             PhelConfig::KEEP_GENERATED_TEMP_FILES => true,
             PhelConfig::TEMP_DIR => '/tmp/custom',
             PhelConfig::FORMAT_DIRS => ['src', 'tests', 'phel'],
+            PhelConfig::FORMAT_EXCLUDE => ['src/*_data.phel'],
             PhelConfig::APP_MODULE_PATHS => [],
             PhelConfig::ASSERTS_ENABLED => false,
             PhelConfig::WARN_DEPRECATIONS => true,

--- a/tests/php/Unit/Formatter/Application/PathsFormatterTest.php
+++ b/tests/php/Unit/Formatter/Application/PathsFormatterTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
+use function getcwd;
 use function sprintf;
 
 final class PathsFormatterTest extends TestCase
@@ -78,6 +79,57 @@ final class PathsFormatterTest extends TestCase
             $this->pathFilter(['a.phel']),
             $io,
         )->format(['ignored'], new BufferedOutput());
+    }
+
+    /**
+     * A generated data file or a vendored tree beside its consumers can be
+     * left alone (#3233): patterns are `fnmatch`ed against the path as
+     * discovered and against its form relative to the working directory, and
+     * `*` spans directories, as in `phel lint`'s exclude.
+     */
+    public function test_excluded_paths_are_skipped_and_land_in_no_bucket(): void
+    {
+        $io = $this->fileIo(['src/a.phel' => '(a)', 'src/gen/table_data.phel' => '(t)', 'src/b.phel' => '(b)']);
+
+        $result = new PathsFormatter(
+            $this->commandFacade(),
+            $this->formatterThrowing(null, null),
+            $this->pathFilter(['src/a.phel', 'src/gen/table_data.phel', 'src/b.phel']),
+            $io,
+        )->format(['src'], new BufferedOutput(), false, ['src/*_data.phel']);
+
+        self::assertSame(['src/a.phel', 'src/b.phel'], $result->changedPaths());
+        self::assertSame([], $result->failedPaths());
+    }
+
+    public function test_an_absolute_discovered_path_matches_a_pattern_relative_to_the_working_directory(): void
+    {
+        $absolute = getcwd() . '/src/gen/table_data.phel';
+        $io = $this->fileIo([$absolute => '(t)']);
+
+        $result = new PathsFormatter(
+            $this->commandFacade(),
+            $this->formatterThrowing(null, null),
+            $this->pathFilter([$absolute]),
+            $io,
+        )->format([$absolute], new BufferedOutput(), false, ['src/gen/*']);
+
+        self::assertSame([], $result->changedPaths());
+    }
+
+    public function test_an_excluded_file_is_named_under_verbose_output(): void
+    {
+        $io = $this->fileIo(['src/gen/table_data.phel' => '(t)']);
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE);
+
+        new PathsFormatter(
+            $this->commandFacade(),
+            $this->formatterThrowing(null, null),
+            $this->pathFilter(['src/gen/table_data.phel']),
+            $io,
+        )->format(['src/gen/table_data.phel'], $output, false, ['*_data.phel']);
+
+        self::assertStringContainsString('Excluded: src/gen/table_data.phel', $output->fetch());
     }
 
     /**


### PR DESCRIPTION
## 🤔 Background

`phel format` had no way to skip a file or a subtree: `format-dirs` is a directory allow-list, so a generated data file (baked assets, lookup tables) or a vendored tree living beside its consumers could not be left alone without restructuring the source tree. Asked for in #3218 as the DX half of that report; the quadratic walk was fixed by #3232.

## 💡 Goal

Skip generated or vendored `.phel` files from the CLI and from the project config, with one glob semantic.

## 🔖 Changes

- `phel format --exclude=<glob>` (repeatable) and the `format-exclude` config key (`PhelConfig::withFormatExclude([...])`, `getFormatExclude()`); `FormatCommand` unions the two. `phel config` lists the key and warns when it is not a list, like `format-dirs`.
- `Formatter\Domain\ExcludePatterns`: a glob is `fnmatch`ed against the path as discovered and against the same path relative to the working directory, so `src/gen/*` skips the tree whether `phel format` was given `src` or an absolute path; `*` spans directories, as `phel lint`'s exclude does. `PathsFormatter` skips a match before reading it, it lands in neither `changedPaths()` nor `failedPaths()`, and `-v` prints `Excluded: <path>`.
- `FormatterFacadeInterface::format()` gains an optional `array $exclude = []` (public API snapshot updated).
- Tests: `PathsFormatterTest` (skipped and in no bucket, absolute path vs relative pattern, verbose notice), `FormatCommandTest` (`--exclude` and the config key together on a temp tree), `PhelConfigTest` serialisation.
- `docs/cli-reference.md`, `resources/agents/RULES.md`, `src/php/Formatter/CLAUDE.md`, CHANGELOG under Unreleased.

The final `ref` commit dropped an unused accessor from `ExcludePatterns`.

Closes #3233
