### PR TITLE
feat(html): support id and class shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Add `^:redef` to prevent `-O2` inlining where calls must remain interceptable. (#3126)
 - Add `phel.ai/*sleep-fn*` as a bindable retry backoff seam. (#3204)
 - Add public APIs for per-test coverage and immediate compiled-code cache flushing. (#3203 #3209)
+- Add CSS-style id and class shorthand to `phel.html` element tags. (#3240)
 
 ### Changed
 

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -97,15 +97,23 @@
     (php/implode " " (to-array (map to-str value)))
     (to-str value)))
 
+(defn- attr-key [attrs keyword-key string-key]
+  (cond
+    (contains? attrs keyword-key) keyword-key
+    (contains? attrs string-key)  string-key
+    keyword-key))
+
 (defn- merge-tag-attrs [attrs id classes]
-  (let [attrs (if classes
-                (assoc attrs :class
-                       (if-let [explicit-classes (get attrs :class)]
-                         (str classes " " (class-value-to-str explicit-classes))
-                         classes))
-                attrs)]
+  (let [class-key (attr-key attrs :class "class")
+        id-key    (attr-key attrs :id "id")
+        attrs     (if classes
+                    (assoc attrs class-key
+                           (if-let [explicit-classes (get attrs class-key)]
+                             (str classes " " (class-value-to-str explicit-classes))
+                             classes))
+                    attrs)]
     (if id
-      (assoc attrs :id (or (get attrs :id) id))
+      (assoc attrs id-key (or (get attrs id-key) id))
       attrs)))
 
 (defn- normalize-tag [tag attrs]

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -121,15 +121,15 @@
 (defn- normalize-element [element]
   ;; Used by the compile path only; `render-element` reads the same three
   ;; pieces without materializing this tuple or a child collection.
-  (let [start      (content-start element)
-        n          (count element)
-        tag        (element-tag (get element 0))
-        attrs      (element-attrs element)
-        parsed-tag (when-not (php/=== false (php/strpbrk tag "#.")) (parse-tag tag))
-        attrs      (if parsed-tag
-                     (merge-tag-attrs attrs (get parsed-tag 1) (get parsed-tag 2))
-                     attrs)
-        tag        (if parsed-tag (get parsed-tag 0) tag)]
+  (let [start       (content-start element)
+        n           (count element)
+        tag         (element-tag (get element 0))
+        attrs       (element-attrs element)
+        parsed-tag  (when-not (php/=== false (php/strpbrk tag "#.")) (parse-tag tag))
+        attrs       (if parsed-tag
+                      (merge-tag-attrs attrs (get parsed-tag 1) (get parsed-tag 2))
+                      attrs)
+        ^string tag (if parsed-tag (get parsed-tag 0) tag)]
     [tag
      attrs
      (if (php/< start n) (slice element start) nil)]))
@@ -185,13 +185,13 @@
   and attributes by index and walking the children in place took a single
   `[:span {:class \"x\"} \"0\"]` from 17.7μs to 9.7μs."
   [element]
-  (let [tag        (element-tag (get element 0))
-        attrs      (element-attrs element)
-        parsed-tag (when-not (php/=== false (php/strpbrk tag "#.")) (parse-tag tag))
-        attrs      (if parsed-tag
-                     (merge-tag-attrs attrs (get parsed-tag 1) (get parsed-tag 2))
-                     attrs)
-        tag        (if parsed-tag (get parsed-tag 0) tag)]
+  (let [tag         (element-tag (get element 0))
+        attrs       (element-attrs element)
+        parsed-tag  (when-not (php/=== false (php/strpbrk tag "#.")) (parse-tag tag))
+        attrs       (if parsed-tag
+                      (merge-tag-attrs attrs (get parsed-tag 1) (get parsed-tag 2))
+                      attrs)
+        ^string tag (if parsed-tag (get parsed-tag 0) tag)]
     (if (container-tag? tag)
       (let [start (content-start element)
             n     (count element)

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -72,16 +72,57 @@
   (let [elem (get element 1)]
     (if (map? elem) elem {})))
 
+(defn- parse-tag [tag]
+  (let [tag         (element-tag tag)
+        id-index    (php/strpos tag "#")
+        id-index    (when (and (not (php/=== false id-index)) (pos? id-index)) id-index)
+        class-index (php/strpos tag ".")
+        class-index (when (and (not (php/=== false class-index)) (pos? class-index)) class-index)]
+    [(cond
+       id-index    (php/substr tag 0 id-index)
+       class-index (php/substr tag 0 class-index)
+       :else       tag)
+     (when id-index
+       (if class-index
+         (php/substr tag (inc id-index) (- class-index (inc id-index)))
+         (php/substr tag (inc id-index))))
+     (when class-index
+       (php/str_replace "." " " (php/substr tag (inc class-index))))]))
+
+(defn- class-value-to-str [value]
+  (cond
+    (map? value)
+    (php/implode " " (to-array (for [[k v] :pairs value :when v] (to-str k))))
+    (indexed? value)
+    (php/implode " " (to-array (map to-str value)))
+    (to-str value)))
+
+(defn- merge-tag-attrs [attrs id classes]
+  (let [attrs (if classes
+                (assoc attrs :class
+                       (if-let [explicit-classes (get attrs :class)]
+                         (str classes " " (class-value-to-str explicit-classes))
+                         classes))
+                attrs)]
+    (if id
+      (assoc attrs :id (or (get attrs :id) id))
+      attrs)))
+
+(defn- normalize-tag [tag attrs]
+  (let [[tag id classes] (parse-tag tag)]
+    [tag (merge-tag-attrs attrs id classes)]))
+
 (defn- content-start [element]
   (if (element-attrs? element) 2 1))
 
 (defn- normalize-element [element]
   ;; Used by the compile path only; `render-element` reads the same three
   ;; pieces without materializing this tuple or a child collection.
-  (let [start (content-start element)
-        n     (count element)]
-    [(element-tag (get element 0))
-     (element-attrs element)
+  (let [start       (content-start element)
+        n           (count element)
+        [tag attrs] (normalize-tag (get element 0) (element-attrs element))]
+    [tag
+     attrs
      (if (php/< start n) (slice element start) nil)]))
 
 ;;---------------
@@ -135,8 +176,7 @@
   and attributes by index and walking the children in place took a single
   `[:span {:class \"x\"} \"0\"]` from 17.7μs to 9.7μs."
   [element]
-  (let [tag   (element-tag (get element 0))
-        attrs (element-attrs element)]
+  (let [[tag attrs] (normalize-tag (get element 0) (element-attrs element))]
     (if (container-tag? tag)
       (let [start (content-start element)
             n     (count element)
@@ -235,9 +275,10 @@
 (defmacro html
   "Compiles nested Phel vectors to HTML strings at compile-time. A vector
   `[tag attrs? children*]` becomes an element; `tag` is a keyword or string,
-  the optional `attrs` is a map, and children are strings, keywords, raw
-  strings, or nested vectors. Special list forms `for`, `if`, `when`, and
-  `when-not` are supported for dynamic content."
+  and may include CSS-style id and class shorthand such as
+  `:div#app.main.selected`. The optional `attrs` is a map, and children are
+  strings, keywords, raw strings, or nested vectors. Special list forms `for`,
+  `if`, `when`, and `when-not` are supported for dynamic content."
   {:example "(html [:div \"Hello\"]) ; => \"<div>Hello</div>\""
    :see-also ["raw-string" "doctype"]}
   [& content]

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -73,8 +73,7 @@
     (if (map? elem) elem {})))
 
 (defn- parse-tag [tag]
-  (let [tag         (element-tag tag)
-        id-index    (php/strpos tag "#")
+  (let [id-index    (php/strpos tag "#")
         id-index    (when (and (not (php/=== false id-index)) (pos? id-index)) id-index)
         class-index (php/strpos tag ".")
         class-index (when (and (not (php/=== false class-index)) (pos? class-index)) class-index)]
@@ -116,19 +115,21 @@
       (assoc attrs id-key (or (get attrs id-key) id))
       attrs)))
 
-(defn- normalize-tag [tag attrs]
-  (let [[tag id classes] (parse-tag tag)]
-    [tag (merge-tag-attrs attrs id classes)]))
-
 (defn- content-start [element]
   (if (element-attrs? element) 2 1))
 
 (defn- normalize-element [element]
   ;; Used by the compile path only; `render-element` reads the same three
   ;; pieces without materializing this tuple or a child collection.
-  (let [start       (content-start element)
-        n           (count element)
-        [tag attrs] (normalize-tag (get element 0) (element-attrs element))]
+  (let [start      (content-start element)
+        n          (count element)
+        tag        (element-tag (get element 0))
+        attrs      (element-attrs element)
+        parsed-tag (when-not (php/=== false (php/strpbrk tag "#.")) (parse-tag tag))
+        attrs      (if parsed-tag
+                     (merge-tag-attrs attrs (get parsed-tag 1) (get parsed-tag 2))
+                     attrs)
+        tag        (if parsed-tag (get parsed-tag 0) tag)]
     [tag
      attrs
      (if (php/< start n) (slice element start) nil)]))
@@ -184,7 +185,13 @@
   and attributes by index and walking the children in place took a single
   `[:span {:class \"x\"} \"0\"]` from 17.7μs to 9.7μs."
   [element]
-  (let [[tag attrs] (normalize-tag (get element 0) (element-attrs element))]
+  (let [tag        (element-tag (get element 0))
+        attrs      (element-attrs element)
+        parsed-tag (when-not (php/=== false (php/strpbrk tag "#.")) (parse-tag tag))
+        attrs      (if parsed-tag
+                     (merge-tag-attrs attrs (get parsed-tag 1) (get parsed-tag 2))
+                     attrs)
+        tag        (if parsed-tag (get parsed-tag 0) tag)]
     (if (container-tag? tag)
       (let [start (content-start element)
             n     (count element)

--- a/src/php/Compiler/Application/Lexer.php
+++ b/src/php/Compiler/Application/Lexer.php
@@ -48,7 +48,7 @@ final class Lexer implements LexerInterface
         '(#\()', // hash fn (index: 19)
         '("(?:[^"\\\\]++|\\\\.)*+")', // String (index: 20)
         '(\\\\(?:space|newline|tab|formfeed|backspace|return|u[0-9a-fA-F]{4}|o[0-7]{1,3}|[^\s])(?![A-Za-z0-9_\-\\\\]))', // Character literal (index: 21 = T_CHAR) - Clojure-style \a, \A, \1, \space, \newline, \uNNNN, \oNNN, \(, \), etc. Must precede the atom rule so it wins on unambiguous cases; falls through to atom when followed by identifier continuation or another backslash (preserving FQN parsing for \Phel\Lang\Symbol).
-        "([^\(\)\[\]\{\},`@ \n\r\t\#]+\#?)", // Atom (index: 22), trailing # allowed for gensym syntax (e.g. foo#); leading ' is claimed by the quote rule above so only mid/trailing ' reaches here (e.g. a', foo'')
+        "(:[^\(\)\[\]\{\},`@ \n\r\t\#]+\#[^\(\)\[\]\{\},`@ \n\r\t\#]+|[^\(\)\[\]\{\},`@ \n\r\t\#]+\#?)", // Atom (index: 22), HTML shorthand keywords may contain one interior # (e.g. :div#app.main); trailing # remains available for gensym syntax (e.g. foo#); leading ' is claimed by the quote rule above so only mid/trailing ' reaches here (e.g. a', foo'')
         '(@)', // deref (index: 23)
         '(#"(?:[^"\\\\]++|\\\\.)*+")', // regex literal (index: 24)
         '(#\?\()', // reader conditional (index: 25 = T_READER_COND)

--- a/tests/phel/html.phel
+++ b/tests/phel/html.phel
@@ -78,7 +78,10 @@
 
   (is (= "<div id=\"explicit-id\" class=\"short explicit selected\"></div>"
          (html [:div#short-id.short {:id "explicit-id" :class [:explicit :selected]}]))
-      "explicit ids win and explicit classes follow shorthand classes"))
+      "explicit ids win and explicit classes follow shorthand classes")
+  (is (= "<div id=\"explicit-id\" class=\"short explicit\"></div>"
+         (html [:div#short-id.short {"id" "explicit-id" "class" "explicit"}]))
+      "string attribute keys merge without duplicate id or class attributes"))
 
 (deftest css-styles
   (is (=

--- a/tests/phel/html.phel
+++ b/tests/phel/html.phel
@@ -61,6 +61,25 @@
   (is (= "<div class=\"a b\"></div>" (html [:div {:class [:a "b"]}])))
   (is (= "<div class=\"a\"></div>" (html [:div {:class {:a true :b false}}]))))
 
+(deftest tag-id-and-class-shorthand
+  (is (= "<div id=\"element-id\"></div>" (html [:div#element-id])))
+  (is (= "<div class=\"class1 class2\"></div>" (html [:div.class1.class2])))
+  (is (= "<div class=\"class1 class2\" id=\"element-id\"></div>"
+         (html [:div#element-id.class1.class2])))
+
+  ;; A value in a binding takes the runtime render path instead of the macro's
+  ;; compile path. Both paths must normalize the shorthand identically.
+  (let [with-id      [:div#element-id]
+        with-classes [:div.class1.class2]
+        with-both    [:div#element-id.class1.class2]]
+    (is (= "<div id=\"element-id\"></div>" (html with-id)))
+    (is (= "<div class=\"class1 class2\"></div>" (html with-classes)))
+    (is (= "<div class=\"class1 class2\" id=\"element-id\"></div>" (html with-both))))
+
+  (is (= "<div id=\"explicit-id\" class=\"short explicit selected\"></div>"
+         (html [:div#short-id.short {:id "explicit-id" :class [:explicit :selected]}]))
+      "explicit ids win and explicit classes follow shorthand classes"))
+
 (deftest css-styles
   (is (=
        "<div style=\"background:green;color:red;\">bar</div>"

--- a/tests/php/Unit/Compiler/Lexer/LexerTest.php
+++ b/tests/php/Unit/Compiler/Lexer/LexerTest.php
@@ -324,6 +324,15 @@ final class LexerTest extends TestCase
         self::assertSame(Token::T_EOF, $tokens[1]->getType());
     }
 
+    public function test_html_shorthand_keyword_with_hash_is_single_token(): void
+    {
+        $tokens = $this->lex(':div#element-id.class1.class2');
+
+        self::assertSame(Token::T_ATOM, $tokens[0]->getType());
+        self::assertSame(':div#element-id.class1.class2', $tokens[0]->getCode());
+        self::assertSame(Token::T_EOF, $tokens[1]->getType());
+    }
+
     public function test_atom_with_trailing_hash_followed_by_reader_conditional(): void
     {
         $tokens = $this->lex('report-success# #?(:phel 1 :default 2)');


### PR DESCRIPTION
## 🤔 Background

`phel.html` requires verbose attribute maps for element ids and classes.

## 💡 Goal

Support the familiar Hiccup CSS-style tag shorthand.

## 🔖 Changes

- Parse id and class shorthand in keyword element tags.
- Keep literal and runtime rendering consistent with explicit attributes.
- Cover lexer behavior and HTML output.

Closes #3240