### PR TITLE
feat(interop): make the embedding path answerable, defended and legible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Runtime data structures:
 
 ### Fixed
 
+- Name the namespace and the fix when an exported wrapper cannot resolve its definition, instead of failing with `Value of type null is not callable`. (#3244)
 - Avoid redundant project walks and cache races in `phel test --parallel`, making parallel runs faster. (#3203)
 - Format collection literals in linear time with byte-identical output. (#3218)
 - Replay deprecation warnings from warm compiled-code caches. (#3222)

--- a/docs/internals/benchmarks.md
+++ b/docs/internals/benchmarks.md
@@ -4,11 +4,17 @@ This page is the PHPBench suite, which measures the compiler and the runtime.
 To benchmark **Phel code**, use `defbench` and `phel bench`, documented in
 [Benchmarking](../benchmarking.md).
 
-[PHPBench](https://phpbench.readthedocs.io/) (in `require-dev`) measures four
+[PHPBench](https://phpbench.readthedocs.io/) (in `require-dev`) measures five
 areas: CLI commands (`phel run`, `phel test` end to end), persistent collections
 (vector and hash-map hot ops), core bootstrap (loading and executing
-`phel.core`, tracking compiler startup), and the dispatch cost of the hot
-`phel.core` functions themselves (`Phel/Core*Bench`).
+`phel.core`, tracking compiler startup), the dispatch cost of the hot
+`phel.core` functions themselves (`Phel/Core*Bench`), and the boundary a PHP
+host calls Phel across (`Interop/ExportedCallBench`).
+
+`Phel::bootstrap()` is not a subject anywhere, and cannot be: it memoizes, so
+only the first call in a process pays, while the CI job runs with `--warmup=2`.
+The load term that dominates a cold host is gated by `Run/ReplBootBench`
+instead, which re-enters cleanly.
 
 ## What the core subjects are for
 

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -75,6 +75,44 @@ Each top-level form compiles + evaluates before the next is analysed, so both st
 
 Changing a signature requires auditing `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/*Emitter.php`.
 
+## What embedding costs
+
+A PHP application that calls Phel pays on three lines, and only the third is
+per call. One snapshot, PHP 8.4 on macOS, warm `.phel/cache`, calling
+`phel.core/str`:
+
+| | no opcache | opcache file cache |
+|---|---|---|
+| `vendor/autoload.php` | 11ms | 8ms |
+| `Phel::bootstrap()` | 5ms | 4ms |
+| load `phel.core` | 491ms | 37ms |
+| **first call reachable after** | **508ms** | **49ms** |
+| peak memory | 48MB | 28MB |
+| per call after that | 0.2µs | 0.2µs |
+
+The shape matters more than the figures. The boundary is free, the load is
+everything, and opcache is worth more than an order of magnitude on it, which
+is why [`phel doctor`](../cli-reference.md) checks for it. A host that boots
+per request (PHP-FPM) pays the whole column; a worker runtime pays it once.
+
+Reproduce with any namespace of your own:
+
+```php
+require 'vendor/autoload.php';
+Phel\Phel::bootstrap(__DIR__);
+$t = hrtime(true);
+new Phel\Run\RunFacade()->runNamespace('phel.core');
+printf("%.1f ms, %.1f MB\n", (hrtime(true) - $t) / 1e6, memory_get_peak_usage(true) / 1048576);
+```
+
+Two of the three lines are gated: `Run/ReplBootBench` guards namespace
+loading, `Interop/ExportedCallBench` guards the per-call boundary. Bootstrap
+is not gated, because it memoizes and cannot be re-entered in one process
+([benchmarks.md](benchmarks.md)).
+
+Deployment shapes for each, worker runtimes included:
+<https://phel-lang.org/documentation/deployment/>.
+
 ## Reader tags (`#tag`)
 
 `Lang/TagHandlers/` implementations registered in `Lang/TagRegistry.php`. Built-ins: `#inst` (`InstTagHandler`), `#regex` (`RegexTagHandler`), `#uuid` (`UUIDTagHandler`). The `#php` tag is handled directly in the reader, not via `TagRegistry`. Add custom tags: `TagRegistry::register('mything', new MyHandler())`.

--- a/src/php/Interop/CLAUDE.md
+++ b/src/php/Interop/CLAUDE.md
@@ -31,6 +31,7 @@ One non-facade edge: **Config** — `InteropConfig` imports `PhelConfig` and `Ph
 | `Domain/DirectoryRemover/DirectoryRemover` | Wipes target dir before regen |
 | `Domain/ReadModel/FunctionToExport` | Value object (`Wrapper` lives in `Phel\Shared\Interop`) |
 | `PhelCallerTrait` | Mixed into every wrapper; `callPhel(ns, def, ...args)` |
+| `ExportedDefinitionNotFoundException` | Raised by the trait when resolution fails; separates "namespace not loaded" from "stale wrapper" |
 
 ## Key Constraints
 
@@ -40,3 +41,4 @@ One non-facade edge: **Config** — `InteropConfig` imports `PhelConfig` and `Ph
 - `CompiledPhpMethodBuilder` reflects the compiled fn class's `BOUND_TO` constant + `__invoke` signature; do not bypass — params/return type/ns come from there. Native param/return types (compiled from `:tag`) are mirrored into the wrapper signature plus an `@param`/`@return` docblock; multi-arity fns reflect an untyped `__invoke(...$args)`, so their `@return` comes from the return `:tag` that `FunctionToExport` carries from the definition metadata. Fns without any type info keep a docblock-free `mixed` wrapper.
 - `^{:php/attr [...]}` on an exported `defn` is threaded through `FunctionToExport` and rendered via `Phel\Shared\PhpAttributeRenderer` as PHP 8 attributes above the wrapper method (e.g. `#[\…\Route('/p')]`).
 - `PhelCallerTrait` caches resolved definitions in a process-wide static keyed by `namespace::definitionName`, never invalidated. Safe for CLI / per-request FPM; a wrapper keeps calling the originally resolved definition if the runtime redefines it mid-process.
+- A wrapper resolves, it never loads: the host must evaluate the namespace first. Failing that, the trait raises `ExportedDefinitionNotFoundException` naming the source spelling of the namespace (`my-app.billing`, not the munged `my_app.billing`) and which of the two fixes applies.

--- a/src/php/Interop/ExportedDefinitionNotFoundException.php
+++ b/src/php/Interop/ExportedDefinitionNotFoundException.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Interop;
+
+use RuntimeException;
+
+use function sprintf;
+
+/**
+ * Raised when a generated wrapper cannot resolve the definition it wraps.
+ *
+ * A wrapper class is plain PHP: it resolves its Phel definition from the
+ * registry on first call and never loads anything itself. In a host process
+ * that forgot to evaluate the namespace, the registry answers `null` and the
+ * failure used to surface one frame later as `Value of type null is not
+ * callable`, which names neither the namespace nor the fix. The two causes
+ * need different fixes, so they get different messages.
+ *
+ * @internal the generated wrappers are the only place this is raised from
+ */
+final class ExportedDefinitionNotFoundException extends RuntimeException
+{
+    public static function namespaceNotLoaded(string $phelNamespace, string $definitionName): self
+    {
+        return new self(sprintf(
+            'Cannot call "%s/%s": the namespace "%s" is not loaded in this process. '
+            . 'A generated wrapper resolves a definition, it does not load it. Evaluate the namespace '
+            . 'during boot, either by requiring the entry point that "phel build" wrote or by calling '
+            . 'Phel::run($projectRootDir, "%s").',
+            $phelNamespace,
+            $definitionName,
+            $phelNamespace,
+            $phelNamespace,
+        ));
+    }
+
+    public static function definitionMissing(string $phelNamespace, string $definitionName): self
+    {
+        return new self(sprintf(
+            'Cannot call "%s/%s": the namespace "%s" is loaded but defines no "%s". '
+            . 'The wrapper is stale if the function was renamed or removed; re-run "phel export".',
+            $phelNamespace,
+            $definitionName,
+            $phelNamespace,
+            $definitionName,
+        ));
+    }
+}

--- a/src/php/Interop/PhelCallerTrait.php
+++ b/src/php/Interop/PhelCallerTrait.php
@@ -16,6 +16,10 @@ use Phel;
  * FPM) but a wrapper will keep calling the originally resolved definition even if
  * the Phel runtime redefines it mid-process.
  *
+ * The resolution itself can fail, and the host that hits it is PHP code that may
+ * never have seen a Phel stack trace, so an unresolved definition is reported as
+ * {@see ExportedDefinitionNotFoundException} naming the namespace and the fix.
+ *
  * @internal
  */
 trait PhelCallerTrait
@@ -28,12 +32,29 @@ trait PhelCallerTrait
         $cacheKey = $namespace . '::' . $definitionName;
 
         if (!isset(self::$definitionCache[$cacheKey])) {
-            $phelNs = str_replace(['\\', '-'], ['.', '_'], $namespace);
-            self::$definitionCache[$cacheKey] = Phel::getDefinition($phelNs, $definitionName);
+            // The source spelling is what an error message has to quote, the
+            // munged one is what the registry is keyed by.
+            $phelNs = str_replace('\\', '.', $namespace);
+            self::$definitionCache[$cacheKey] = self::resolvePhelDefinition($phelNs, $definitionName);
         }
 
         $fn = self::$definitionCache[$cacheKey];
 
         return $fn(...$arguments);
+    }
+
+    private static function resolvePhelDefinition(string $phelNs, string $definitionName): mixed
+    {
+        $definition = Phel::getDefinition(str_replace('-', '_', $phelNs), $definitionName);
+
+        if ($definition !== null) {
+            return $definition;
+        }
+
+        if (!Phel::isNamespaceLoaded($phelNs)) {
+            throw ExportedDefinitionNotFoundException::namespaceNotLoaded($phelNs, $definitionName);
+        }
+
+        throw ExportedDefinitionNotFoundException::definitionMissing($phelNs, $definitionName);
     }
 }

--- a/tests/php/Benchmark/Interop/ExportedCallBench.php
+++ b/tests/php/Benchmark/Interop/ExportedCallBench.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Interop;
+
+use Closure;
+use Phel\Lang\Registry;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+
+/**
+ * What a PHP host pays per call into Phel.
+ *
+ * An application that keeps its business logic in Phel, or that calls a few
+ * exported functions from an existing PHP codebase, reaches Phel through
+ * `PhelCallerTrait::callPhel()` and nothing else: `phel export` writes one
+ * wrapper method per function and every one of them is that call. Nothing in
+ * the suite timed it. `GlobalVarReadBench` times the `\Phel::getDefinition()`
+ * underneath, and the `phel.core` subjects time functions reached from Phel
+ * rather than from PHP.
+ *
+ * The reviewable number is the ratio to `bench_direct_call`, which is the same
+ * function invoked without the wrapper. That gap is what the boundary costs:
+ * the cache key concatenation, the static cache lookup and the variadic
+ * spread. It is the number to defend when someone proposes making resolution
+ * smarter, and the one that says whether "call Phel from PHP" is affordable
+ * per request.
+ *
+ * Process boot is deliberately not a subject here. `Phel::bootstrap()`
+ * memoizes, so a second call in the same process returns in about 0.25ms
+ * against roughly 5ms for the first, and the benchmark job runs with
+ * `--warmup=2`, which would hand every measured revolution the memoized path.
+ * The load term that dominates a cold host is gated instead by
+ * {@see \PhelTest\Benchmark\Run\ReplBootBench}, which times namespace closure
+ * evaluation and re-enters cleanly.
+ *
+ * Revs are looped internally so timer overhead is amortised rather than
+ * measured, matching {@see \PhelTest\Benchmark\Lang\GlobalVarReadBench}.
+ *
+ * @BeforeMethods("setUp")
+ */
+final class ExportedCallBench
+{
+    private const int INNER = 32;
+
+    /** Registry keys are munged, so the wrapper's `bench-embed.host` lands here. */
+    private const string REGISTRY_NS = 'bench_embed.host';
+
+    private const string NAME = 'identity';
+
+    private Closure $definition;
+
+    public function setUp(): void
+    {
+        $this->definition = static fn(mixed $value): mixed => $value;
+
+        Registry::getInstance()->addDefinition(self::REGISTRY_NS, self::NAME, $this->definition);
+    }
+
+    /**
+     * A PHP host calling an exported function, steady state.
+     *
+     * @Revs(1000)
+     *
+     * @Iterations(10)
+     */
+    public function bench_exported_call(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ExportedWrapperFixture::identity($i);
+        }
+    }
+
+    /**
+     * The same function without the wrapper: the floor the ratio is against.
+     *
+     * @Revs(1000)
+     *
+     * @Iterations(10)
+     */
+    public function bench_direct_call(): void
+    {
+        $fn = $this->definition;
+
+        for ($i = 0; $i < self::INNER; ++$i) {
+            $fn($i);
+        }
+    }
+}

--- a/tests/php/Benchmark/Interop/ExportedWrapperFixture.php
+++ b/tests/php/Benchmark/Interop/ExportedWrapperFixture.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Interop;
+
+use Phel\Interop\PhelCallerTrait;
+
+/**
+ * Stands in for a class `phel export` generates: one trait call per exported
+ * function, which is the only shape a PHP host ever calls Phel with.
+ */
+final class ExportedWrapperFixture
+{
+    use PhelCallerTrait;
+
+    public static function identity(mixed $value): mixed
+    {
+        return self::callPhel('bench-embed\\host', 'identity', $value);
+    }
+}

--- a/tests/php/Integration/Interop/UnresolvedWrapperCallTest.php
+++ b/tests/php/Integration/Interop/UnresolvedWrapperCallTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Interop;
+
+use Phel\Build\BuildFacade;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Interop\ExportedDefinitionNotFoundException;
+use Phel\Phel;
+use PHPUnit\Framework\TestCase;
+
+use function sys_get_temp_dir;
+use function tempnam;
+
+/**
+ * A PHP host calling an exported function is the one place where a Phel error
+ * reaches somebody who may never have written Phel, so the two ways resolution
+ * fails have to name themselves rather than surface as `null is not callable`.
+ */
+final class UnresolvedWrapperCallTest extends TestCase
+{
+    private UnresolvedWrapperFixture $wrapper;
+
+    protected function setUp(): void
+    {
+        Phel::bootstrap(__DIR__);
+
+        GlobalEnvironmentSingleton::initializeNew();
+
+        new BuildFacade()->compileFile(
+            __DIR__ . '/../../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core'),
+        );
+        $this->wrapper = new UnresolvedWrapperFixture();
+    }
+
+    public function test_it_names_the_namespace_the_host_never_loaded(): void
+    {
+        $this->expectException(ExportedDefinitionNotFoundException::class);
+        $this->expectExceptionMessage('the namespace "my-app.billing" is not loaded in this process');
+
+        $this->wrapper->intoUnloadedNamespace();
+    }
+
+    public function test_it_points_at_a_stale_wrapper_when_the_namespace_is_loaded(): void
+    {
+        $this->expectException(ExportedDefinitionNotFoundException::class);
+        $this->expectExceptionMessage('re-run "phel export"');
+
+        $this->wrapper->intoMissingDefinition();
+    }
+}

--- a/tests/php/Integration/Interop/UnresolvedWrapperFixture.php
+++ b/tests/php/Integration/Interop/UnresolvedWrapperFixture.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Interop;
+
+use Phel\Interop\PhelCallerTrait;
+
+/**
+ * Two calls a generated wrapper can make that never resolve: one into a
+ * namespace the host never evaluated, one into a loaded namespace whose
+ * definition is gone.
+ */
+final class UnresolvedWrapperFixture
+{
+    use PhelCallerTrait;
+
+    public function intoUnloadedNamespace(): mixed
+    {
+        return $this->callPhel('my-app\\billing', 'total', 1);
+    }
+
+    public function intoMissingDefinition(): mixed
+    {
+        return $this->callPhel('phel\\core', 'renamed-away', 1);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

A question about running Phel in production, either as a company's business logic or as isolated functions called from an existing PHP application, turned into an audit of what this repository actually offers such a host. Most of it held up: the website documents deployment and worker runtimes, `docs/stability.md` defines the embedding surface, `phel doctor` checks OPcache, and uncaught exceptions already map back to `.phel` lines.

Three gaps did not.

Measured on one machine (PHP 8.4, warm `.phel/cache`), the cost of reaching the first call from a PHP host:

| | no opcache | opcache file cache |
|---|---|---|
| `vendor/autoload.php` | 11ms | 8ms |
| `Phel::bootstrap()` | 5ms | 4ms |
| load `phel.core` | 491ms | 37ms |
| **first call reachable after** | **508ms** | **49ms** |
| peak memory | 48MB | 28MB |
| per call after that | 0.2µs | 0.2µs |

The boundary is free and the load is everything. That number appeared nowhere in the repository, no benchmark subject guarded the boundary, and the first error a host hits when it forgets to load a namespace named neither the namespace nor the fix.

## 💡 Goal

Make the embedding path answerable and defended: say what it costs, gate what can be gated, and fail with a message a PHP developer can act on.

## 🔖 Changes

- **`fix(interop)`**: a generated wrapper resolves a definition, it never loads one. A host that forgot to evaluate the namespace used to get `Error: Value of type null is not callable` one frame later. Resolution now raises `ExportedDefinitionNotFoundException` and separates the two causes: an unloaded namespace points at the built entry point or `Phel::run`, a missing definition in a loaded namespace points at re-running `phel export`. Both quote the source spelling (`my-app.billing`, not the munged `my_app.billing`).
- **`test(bench)`**: `Interop/ExportedCallBench` times `PhelCallerTrait::callPhel()` against the same function invoked directly, so the boundary is a ratio rather than a duration. Process boot is deliberately not a subject: `Phel::bootstrap()` memoizes (about 5ms first call, 0.25ms second) and the benchmark job runs with `--warmup=2`, so such a subject would gate nothing. `ReplBootBench` already covers the namespace-load term and re-enters cleanly.
- **`docs(internals)`**: the table above, its reproduction, and which of the three lines a benchmark guards, on the runtime page. `benchmarks.md` gains the fifth area and the note about why boot is absent.

Verified: full `composer test-all` green locally (cs-fixer, psalm, phpstan, rector, 4873 unit, 1290 integration, 10090 core).

Related #2859. The remaining 1.0 items in that tracker live outside this repository (the website stability page and the ecosystem re-tag) and are untouched here.
