### PR TITLE
perf(lang): stop paying twice for a key test, a sentinel and an emptiness check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Dispatch / call sites:
 Runtime data structures:
 
 - Promote every map construction path at the same size, making grown map reads up to 5.5x faster. (#3172)
+- Answer `contains?`, map lookups and realized lazy sequences without repeating work already done, up to 22% faster.
 
 ### Deprecated
 

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -468,6 +468,14 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
      */
     private function isEmptySeq(mixed $seq): bool
     {
+        // A `Cons` carries a mandatory `first`, so it is non-empty by
+        // construction. Without this it falls to `Seq::isEmpty()` below, which
+        // answers the same question by building a generator and advancing it
+        // once, per element of every realized lazy seq.
+        if ($seq instanceof Cons) {
+            return false;
+        }
+
         if ($seq instanceof Countable && !$seq instanceof LazySeqInterface) {
             return count($seq) === 0;
         }

--- a/src/php/Lang/Collections/Map/PersistentHashMap.php
+++ b/src/php/Lang/Collections/Map/PersistentHashMap.php
@@ -109,7 +109,9 @@ final class PersistentHashMap extends AbstractPersistentMap
             return false;
         }
 
-        return $this->root->find(0, $this->hasher->hash($key), $key, self::getNotFound()) !== self::getNotFound();
+        $notFound = self::getNotFound();
+
+        return $this->root->find(0, $this->hasher->hash($key), $key, $notFound) !== $notFound;
     }
 
     /**

--- a/src/php/Lang/Equalizer.php
+++ b/src/php/Lang/Equalizer.php
@@ -45,6 +45,13 @@ final class Equalizer implements EqualizerInterface
 
     public function equalsKey(mixed $a, mixed $b): bool
     {
+        // Identity is `equals()`'s own first test, and it answers most key
+        // comparisons in a trie descent or an array-map scan, so testing it
+        // here saves the call rather than adding a check.
+        if ($a === $b) {
+            return true;
+        }
+
         if ($this->equals($a, $b)) {
             return true;
         }


### PR DESCRIPTION
## 🤔 Background

A profiling sweep across the compiler, the runtime, the boot path and the standard library turned up a long candidate list. This PR lands the three cheapest items from it, all in the runtime, all of the same shape: code that asks a question it has already answered. Each is provable on a benchmark subject that already exists.

## 💡 Goal

Remove redundant work from the hottest runtime paths without changing a single semantic.

## 🔖 Changes

- **`Equalizer::equalsKey()` tests identity directly.** It delegated to `equals()`, whose own first line is `$a === $b`. In a map-heavy profile, 23,653 `equalsKey` calls produced 23,653 nested `equals` calls, and an instrumented run found **71.9% of them are pure identity**. The NaN, BigInt and `EqualsInterface` branches stay in the same order behind the new test, so this removes a call rather than adding a check.
- **`PersistentHashMap::contains()` hoists the sentinel.** `self::getNotFound()` was evaluated on both sides of one comparison: 26,624 calls for 13,312 lookups.
- **`LazySeq::isEmptySeq()` short-circuits a `Cons`.** It fell through to `Seq::isEmpty()`, which answers the question by building a generator and advancing it once. A `Cons` takes a mandatory `first` in its constructor, so it is non-empty by construction. That was one generator allocation and five calls per element of every realized lazy sequence.

## Measurements

Existing subjects, baseline and branch run adjacently on a quiet machine, and the result confirmed by a third run (an earlier attempt showed a uniform +5% drift across every subject, so only adjacent runs are quoted):

| subject | baseline | branch | delta |
|---|---|---|---|
| `bench_contains` small / medium / boundary | 0.292 / 0.379 / 0.465µs | 0.227 / 0.307 / 0.410µs | −22.3% / −19.0% / −11.8% |
| `bench_find` small / medium / boundary | 0.215 / 0.300 / 0.381µs | 0.191 / 0.278 / 0.368µs | −11.2% / −7.3% / −3.4% |
| `bench_map_realized` | 36.2µs | 31.8µs | −12.2% |
| `bench_concat_realized` | 40.2µs | 35.1µs | −12.8% |

`bench_put` and `bench_reduce_sum` are flat, as expected. No new subject is needed: `PersistentHashMapBench` and `CoreSeqBench` already cover every path touched.

Verified: full `composer test-all` green locally (cs-fixer, psalm, phpstan, rector, 4873 unit, 1290 integration, 10090 core).

One candidate from the same sweep was deliberately left out: inlining `mask()` at its six call sites measured 0.64% of Lang self cost and that figure is an upper bound, since the profiler inflates per-call overhead. That is churn against noise.
