### PR TITLE
perf(compiler): stop emitting, rebuilding and re-deriving what is already known

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ All notable changes to this project will be documented in this file.
 
 Compile-time folding / hoisting:
 
+- Emit each form once under `phel compile --emit-only`, 24% faster, with byte-identical output.
+- Reuse the lists a macro expansion leaves unchanged instead of rebuilding them, 5% faster analysis of macro-heavy source.
+- Resolve a call's `phel.core` identity once per node instead of once per specialisation probe, 4% faster emission.
 - Compile `is` arms through one runtime helper, reducing generated size, compile time, and memory. (#3212)
 - Inline `-O2` calls in return position; use `^:redef` where interception is required. (#3125)
 

--- a/src/php/Compiler/Application/CodeCompiler.php
+++ b/src/php/Compiler/Application/CodeCompiler.php
@@ -228,19 +228,30 @@ final readonly class CodeCompiler implements CodeCompilerInterface
      */
     private function emitNode(AbstractNode $node, CompileOptions $compileOptions): void
     {
+        $genCounterBefore = Symbol::genCounter();
         $this->fileEmitter->emitNode($node);
-
-        $phpCode = $this->statementEmitter
-            ->emitNode($node, $compileOptions->isSourceMapsEnabled())
-            ->getCodeWithSourceMap();
 
         if ($compileOptions->isEmitOnly()) {
             // `phel compile` advertises "Does not evaluate"; skipping the
             // evaluator preserves the dry-run contract. Same-snippet
             // defmacros will not be available to later forms in this
             // mode, which is the documented trade-off.
+            //
+            // The statement emission is skipped with it: its only consumer is
+            // the evaluator, so in this mode it emitted a whole second copy of
+            // every form to throw away. What it did leave behind is the gensym
+            // ids it consumed, and the next form's temporaries are numbered
+            // after those, so the counter is advanced by the same delta the
+            // file pass just used. Both passes walk the same nodes through the
+            // same emitters here, so the deltas match; measuring rather than
+            // assuming the delta keeps that true if they ever stop matching.
+            Symbol::advanceGenCounter(Symbol::genCounter() - $genCounterBefore);
             return;
         }
+
+        $phpCode = $this->statementEmitter
+            ->emitNode($node, $compileOptions->isSourceMapsEnabled())
+            ->getCodeWithSourceMap();
 
         $this->evaluator->eval($phpCode);
     }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -431,8 +431,26 @@ final readonly class InvokeSymbol implements SpecialFormAnalyzerInterface
         SourceLocation $origin,
     ): TypeInterface {
         $result = [];
+        $changed = false;
         foreach ($list->getIterator() as $item) {
-            $result[] = $this->enrichLocation($item, $parent, $origin);
+            $enriched = $this->enrichLocation($item, $parent, $origin);
+            if ($enriched !== $item) {
+                $changed = true;
+            }
+
+            $result[] = $enriched;
+        }
+
+        // A list whose children all came back identical, and which already
+        // carries both of its own locations, rebuilds into a copy of itself:
+        // same elements, same meta, same positions, and the stamping below
+        // then finds nothing to stamp. Most of a macro expansion is that
+        // case, and each rebuild allocates a list and a meta wrapper for it.
+        if (!$changed
+            && $list->getStartLocation() instanceof SourceLocation
+            && $list->getEndLocation() instanceof SourceLocation
+        ) {
+            return $list;
         }
 
         // The rebuilt list must keep the position of the one it replaces:

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/PhelCoreCall.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/PhelCoreCall.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Shared\CompilerConstants;
+use WeakMap;
 
 /**
  * Shared shape check for a `CallNode` whose target resolves to a
@@ -16,8 +17,22 @@ use Phel\Shared\CompilerConstants;
  *
  * @internal
  */
-final readonly class PhelCoreCall
+final class PhelCoreCall
 {
+    /**
+     * Answers already given, keyed by the node that asked. `CallEmitter`
+     * probes eleven specialisation families in turn and each one opens with
+     * this question about the same node, so the second probe onwards is a
+     * lookup. A `WeakMap` rather than an id-keyed array: object ids are
+     * reused after collection, and an AST node is short-lived.
+     *
+     * `false` stands for "asked, and it is not a phel.core call", which `null`
+     * could not, since that is also the answer being cached.
+     *
+     * @var WeakMap<CallNode, false|string>|null
+     */
+    private static ?WeakMap $answers = null;
+
     private function __construct() {}
 
     /**
@@ -25,6 +40,43 @@ final readonly class PhelCoreCall
      * when the call target is not a `phel.core` global var.
      */
     public static function nameOf(CallNode $node): ?string
+    {
+        $answers = self::answers();
+        $cached = $answers[$node] ?? null;
+        if ($cached !== null) {
+            return $cached === false ? null : $cached;
+        }
+
+        $name = self::resolveNameOf($node);
+        $answers[$node] = $name ?? false;
+
+        return $name;
+    }
+
+    /**
+     * Whether this call resolves to `phel.core/<fnName>`.
+     */
+    public static function is(CallNode $node, string $fnName): bool
+    {
+        return self::nameOf($node) === $fnName;
+    }
+
+    /**
+     * @return WeakMap<CallNode, false|string>
+     */
+    private static function answers(): WeakMap
+    {
+        if (self::$answers instanceof WeakMap) {
+            return self::$answers;
+        }
+
+        /** @var WeakMap<CallNode, false|string> $answers */
+        $answers = new WeakMap();
+
+        return self::$answers = $answers;
+    }
+
+    private static function resolveNameOf(CallNode $node): ?string
     {
         $fn = $node->getFn();
         if (!$fn instanceof GlobalVarNode) {
@@ -36,13 +88,5 @@ final readonly class PhelCoreCall
         }
 
         return $fn->getName()->getName();
-    }
-
-    /**
-     * Whether this call resolves to `phel.core/<fnName>`.
-     */
-    public static function is(CallNode $node, string $fnName): bool
-    {
-        return self::nameOf($node) === $fnName;
     }
 }

--- a/tests/php/Benchmark/Compiler/MacroExpansionCompileBench.php
+++ b/tests/php/Benchmark/Compiler/MacroExpansionCompileBench.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Lexer\LexerInterface;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\LoadClasspath;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompileOptions;
+use Phel\Shared\Parser\Node\NodeInterface;
+use Phel\Shared\Parser\Node\TriviaNodeInterface;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+
+use function implode;
+use function sprintf;
+
+/**
+ * What macro-heavy source costs to analyze and to compile.
+ *
+ * Almost every form a real program writes is a macro call: `when`, `cond`,
+ * `->`, `if-let`, `for`, `case`. Expanding one walks the expansion to stamp
+ * the call site onto the forms it synthesised, and that walk rebuilds every
+ * list it passes. The existing compiler subjects do not reach it:
+ * `WideLetAnalysisBench` analyzes one `let` with no macro in it,
+ * `EmitterCaptureBench` drives the emitter alone, and `CallInliningBench` is
+ * about `-O2`.
+ *
+ * Two subjects, because the two phases move independently:
+ *
+ * - `bench_analyze_macro_heavy` stops after analysis, so it isolates the
+ *   expansion walk from anything the emitter does.
+ * - `bench_compile_emit_only` runs the whole `phel compile` path, which emits
+ *   without evaluating. That mode has to emit each form exactly once: its
+ *   second emission existed only to feed an evaluator it then skipped.
+ *
+ * The fixture is built inline from a fixed shape, never read from `src/`, so
+ * the subject measures compilation rather than the size of whatever file it
+ * happened to point at.
+ *
+ * @BeforeMethods("setUp")
+ */
+final class MacroExpansionCompileBench
+{
+    private const int FORM_COUNT = 25;
+
+    private const string FIXTURE_NS = 'phel.bench.macroexpansion';
+
+    private CompilerFacade $compilerFacade;
+
+    private string $fixtureSource = '';
+
+    public function setUp(): void
+    {
+        $projectRoot = __DIR__ . '/../../../../';
+
+        Phel::bootstrap($projectRoot);
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+        LoadClasspath::publish([$projectRoot . 'src/phel']);
+
+        new BuildFacade()->evalFile($projectRoot . 'src/phel/core.phel');
+        BuildFacade::enableBuildMode();
+
+        $this->compilerFacade = new CompilerFacade();
+        $this->fixtureSource = $this->buildFixtureSource();
+    }
+
+    /**
+     * @Revs(20)
+     *
+     * @Iterations(5)
+     */
+    public function bench_analyze_macro_heavy(): void
+    {
+        $stream = $this->compilerFacade->lexString($this->fixtureSource, LexerInterface::DEFAULT_SOURCE);
+
+        while (true) {
+            $parseTree = $this->compilerFacade->parseNext($stream);
+            if (!$parseTree instanceof NodeInterface) {
+                break;
+            }
+
+            if ($parseTree instanceof TriviaNodeInterface) {
+                continue;
+            }
+
+            $readerResult = $this->compilerFacade->read($parseTree);
+            $this->compilerFacade->analyze(
+                $readerResult->getAst(),
+                NodeEnvironment::empty()->withReturnContext(),
+            );
+        }
+    }
+
+    /**
+     * @Revs(20)
+     *
+     * @Iterations(5)
+     */
+    public function bench_compile_emit_only(): void
+    {
+        $this->compilerFacade->compile(
+            $this->fixtureSource,
+            new CompileOptions()->setEmitOnly(true),
+        );
+    }
+
+    /**
+     * Builds `FORM_COUNT` functions whose bodies are nested macro calls:
+     * threading, conditionals, binding conditionals and a comprehension, each
+     * expanding into several synthesised lists. The shape is fixed, so the
+     * only thing that varies between runs is the compiler.
+     */
+    private function buildFixtureSource(): string
+    {
+        $forms = [];
+        for ($i = 0; $i < self::FORM_COUNT; ++$i) {
+            $forms[] = sprintf(
+                <<<'PHEL'
+                    (defn shape-%1$d [xs n]
+                      (when (pos? n)
+                        (let [tally (for [x :in xs :when (pos? x)] (* x n))]
+                          (cond
+                            (empty? tally) nil
+                            (= 1 (count tally)) (first tally)
+                            (if-let [head (first tally)]
+                              (-> head (+ n) (* 2))
+                              n)))))
+                    PHEL,
+                $i,
+            );
+        }
+
+        return '(ns ' . self::FIXTURE_NS . ")\n\n" . implode("\n\n", $forms) . "\n";
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Follow-up to #3245, from the same profiling sweep. Three places where the compiler does work it then discards or repeats. Each was found by call-count profiling, and each is verified by compiling the standard library and comparing the emitted PHP byte for byte, because "faster compiler, same output" is the only acceptable result here.

## 💡 Goal

Remove discarded and repeated work from the analyze and emit phases without changing a single emitted byte.

## 🔖 Changes

- **`phel compile --emit-only` no longer emits everything twice.** The command returns the file emitter's output and advertises that it does not evaluate, yet it ran the statement emitter over every form, called `getCodeWithSourceMap()` on the result, and only then hit the `isEmitOnly()` check that returns before the evaluator sees it. There is one consequence worth naming: emission consumes gensym ids, so the discarded pass was numbering the temporaries of every form after it. The counter is now advanced by the delta the surviving pass consumed, which is the same mechanism `compileString` already uses to replay a read phase's gensym delta on a warm cache.
- **Unchanged macro expansions are no longer rebuilt.** Enriching an expansion walks every list and rebuilds it, plus its meta wrapper and both locations. Over a 25-namespace compile, **33,417 of 48,120 rebuilds (69.4%)** returned a list structurally identical to their input. Those now return the original. The only observable difference is the object identity of a list nothing changed.
- **A call's `phel.core` identity is resolved once per node.** `CallEmitter` probes eleven specialisation families in turn and each opens with the same question about the same immutable node. The answer now lives in a `WeakMap` keyed by that node, weak rather than id-keyed because object ids are reused after collection.

## Measurements

New subject `MacroExpansionCompileBench` plus the existing `EmitterCaptureBench`. Baseline and branch run adjacently on a quiet machine, each result reproduced by a second run, all rstdev under 1%:

| subject | baseline | branch | delta |
|---|---|---|---|
| `bench_compile_emit_only` | 51.13ms | 38.75ms | **−24.2%** |
| `bench_analyze_macro_heavy` | 29.22ms | 27.64ms | **−5.4%** |
| `bench_emit_capture_dense` | 12.76ms | 12.24ms | **−4.0%** |

The memo was measured on its own, by reverting only that file between two runs, because its evidence was a call count and a `WeakMap` lookup could plausibly have cost more than the three cheap operations it replaces. It does not: −4.0%, reproduced twice.

`MacroExpansionCompileBench` is new because nothing reached this code: `WideLetAnalysisBench` analyzes one `let` with no macro in it, `EmitterCaptureBench` drives the emitter alone, and `CallInliningBench` is about `-O2`. Its fixture is built inline from a fixed shape rather than read from `src/`, so it measures the compiler rather than the size of whatever file it points at.

## Correctness

All 25 standard-library namespaces compiled in emit-only mode before and after: **byte-identical output**, same lengths, same hashes. Re-verified after the review fixes, since the memo was restructured for Psalm.

Full `composer test-all` green locally: cs-fixer, psalm, phpstan, rector, 4873 unit, 1290 integration, 10090 core.

## Not included

The larger finding behind this one is that the **cache path emits every form twice as well**, and 98% of those bytes are identical between the two passes. That is worth roughly 18-20% of every cold compile, but it needs the per-form source map sliced out of the file-mode state, and getting that wrong fails silently into wrong `.phel` line numbers rather than into a test failure. It deserves its own pull request with an explicit map-equality assertion, not a ride-along here.
