### PR TITLE
perf(test): rebuild the counts map once per assertion, not twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ Compile-time folding / hoisting:
 - Compile `is` arms through one runtime helper, reducing generated size, compile time, and memory. (#3212)
 - Inline `-O2` calls in return position; use `^:redef` where interception is required. (#3125)
 
+Test framework:
+
+- Record an assertion against one rebuild of the counts map instead of two nested walks, halving the per-assertion bookkeeping.
+
 Dispatch / call sites:
 
 - Read non-dynamic globals directly from the registry, up to 1.9x faster. (#3179)

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -92,8 +92,10 @@
       (assoc data :test-name *current-test-name*)
       data)))
 
-(defn- bump-stat [s path]
-  (update-in s path inc))
+(defn- inc-count
+  "Increments one counter of the `:counts` map."
+  [counts k]
+  (assoc counts k (inc (get counts k))))
 
 (defn- record-stats!
   "Mutates the internal stats atom based on an assertion-result event."
@@ -102,9 +104,13 @@
         ok?   (= state :pass)]
     (swap! stats
            (fn [s]
-             (let [s (-> s
-                         (bump-stat [:counts :total])
-                         (bump-stat [:counts state]))]
+             ;; One rebuild of `:counts` for both counters. Two `update-in`
+             ;; calls walked the same nested path twice per assertion, which
+             ;; profiling put at a third of the cost of running a test.
+             (let [counts (get s :counts)
+                   s (assoc s :counts (-> counts
+                                          (inc-count :total)
+                                          (inc-count state)))]
                (if ok?
                  s
                  (update s :failed conj data)))))))
@@ -176,7 +182,7 @@
   (swap! stats
          (fn [s]
            (-> s
-               (bump-stat [:counts :skipped])
+               (assoc :counts (inc-count (get s :counts) :skipped))
                (update :skipped conj data)))))
 
 ;; Lifecycle events that flow straight through to every registered

--- a/tests/php/Benchmark/Phel/StdlibTestBench.php
+++ b/tests/php/Benchmark/Phel/StdlibTestBench.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Phel;
+
+use Override;
+use Phel;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+
+/**
+ * What recording a test result costs, which nothing measured before.
+ *
+ * `phel test` calls `report` once per assertion, and a profile of a real
+ * suite put two thirds of a run's time inside that call rather than inside
+ * the assertion bodies. The expensive half is the stats bookkeeping: an
+ * assertion event updates counters on the internal atom, a lifecycle event
+ * does not.
+ *
+ * That difference is the pair this bench is built on, in the spirit of the
+ * `bench_x` / `bench_x_raw` convention {@see CoreBenchCase} describes:
+ *
+ * - `bench_report_pass` reports a passing assertion, counters and all;
+ * - `bench_report_lifecycle` reports `:begin-test`, which flows straight
+ *   through to the reporter set without touching the atom.
+ *
+ * The reviewable number is the gap between them, which is the per-assertion
+ * bookkeeping cost. Reporters are cleared in `setUpFixtures`, so neither
+ * subject measures a dot printer writing to stdout.
+ *
+ * @BeforeMethods("setUp")
+ */
+final class StdlibTestBench extends CoreBenchCase
+{
+    /** @var callable */
+    private $report;
+
+    private mixed $passEvent = null;
+
+    private mixed $lifecycleEvent = null;
+
+    /**
+     * @Revs(1000)
+     *
+     * @Iterations(10)
+     */
+    public function bench_report_pass(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->report)($this->passEvent);
+        }
+    }
+
+    /**
+     * @Revs(1000)
+     *
+     * @Iterations(10)
+     */
+    public function bench_report_lifecycle(): void
+    {
+        for ($i = 0; $i < self::INNER; ++$i) {
+            ($this->report)($this->lifecycleEvent);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    #[Override]
+    protected function extraNamespaces(): array
+    {
+        return ['phel.test'];
+    }
+
+    #[Override]
+    protected function setUpFixtures(): void
+    {
+        $this->report = $this->phelFn('phel.test', 'report');
+        ($this->phelFn('phel.test', 'clear-reporters!'))();
+
+        $keyword = Phel::keyword(...);
+
+        $this->passEvent = Phel::map(
+            $keyword('type'),
+            $keyword('pass'),
+            $keyword('message'),
+            'bench assertion',
+        );
+
+        $this->lifecycleEvent = Phel::map(
+            $keyword('type'),
+            $keyword('begin-test'),
+            $keyword('test-name'),
+            'bench-test',
+        );
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Third pull request from the profiling sweep, after #3245 and #3246. This one is in `phel.test`, and it is the largest single finding of the sweep by share.

Profiling `./bin/phel test` over five real namespaces (392 tests, 1905 assertions doing actual seq, math and type work) put **34.2% of test execution inside two counter increments**. The same measurement over 2000 trivial `(is (= i i))` assertions gave 44.9%, and the per-assertion cost differed by only 12% between the two, so this is fixed overhead rather than an artifact of empty test bodies.

The wider finding, worth recording somewhere even though this PR does not act on all of it: on that real suite only ~31% of test execution was the assertion bodies' own work. The other 69% was the reporting path.

## 💡 Goal

Stop rebuilding the same nested map twice for every assertion.

## 🔖 Changes

Recording an assertion bumped `[:counts :total]` and `[:counts <state>]` with one `update-in` each. Both walk the same nested path and rebuild the same inner map, and each drags `assoc`, `get`, `first`, `next`, a vector construction and the `apply` machinery behind it: 4000 `update-in` calls for 2000 assertions, and with them 8000 `assoc`, 8000 `get`, 8000 `Phel::vector` and 8000 `Seq::toApplyArguments`.

The counters are now incremented against one fetch of `:counts` and written back once. `record-skip!`, which bumps a single counter through the same helper, moves with them.

The second increment still reads the map the first one produced, so the result is identical even for a state key that would alias `:total`, which is the one case where a naive rewrite would have diverged.

## Measurements

New subject `StdlibTestBench`. Each variant was run with a cleared `.phel/cache` and a discarded warm-up run first, because changing a `.phel` file changes its compiled artifact and a stale cache would otherwise time the old code:

| subject | baseline | branch | delta |
|---|---|---|---|
| `bench_report_pass` | 1.047ms | 0.544ms | **−47%** |
| `bench_report_lifecycle` (control) | 102µs | 103µs | flat |

Per 32 events. The bookkeeping alone, which is the gap between the two subjects, goes from 945µs to 446µs. The control being flat is what says the difference is the stats work and not the dispatch around it.

`StdlibTestBench` is new: nothing in `tests/php/Benchmark/Phel` covered `phel.test` at all, which is how the framework's own overhead grew to two thirds of a run without anyone noticing. Its pair follows the convention the core subjects use, an operation against the same operation minus the work being measured.

Verified: full `composer test-all` green locally (cs-fixer, psalm, phpstan, rector, 4873 unit, 1290 integration, 10090 core). The core suite exercises this code on every one of those 10090 assertions.
