### PR TITLE
perf(stdlib): build the walked list and the pprint joins once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Add `phel mutate` with 11 mutators, parallel and changed-file modes, coverage selection, and MSI gates. (#3208 #3209)
-- Add `phel test --changed[=<ref>]` to run tests affected by Git changes. (#3210)
-- Add skipped and focused tests through metadata, `skip!`, `--fail-on-focus`, and reporter support. (#3211)
-- Add `phel test --reporter=github` with annotations, groups, warnings, and job summaries. (#3214)
-- Add per-test coverage JSON, lifecycle events, and `phel.test/*event-hook*`. (#3207 #3209)
-- Add repeatable `phel format --exclude=<glob>` and the `format-exclude` config key. (#3233)
-- Add `cache-env-vars` to include selected environment values in compiled-code cache keys. (#3236)
-- Add Clojure-style binding-first map destructuring, including nested bindings. (#3115)
-- Resolve bare local `defexception` names in `catch`. (#3211)
-- Add `^:redef` to prevent `-O2` inlining where calls must remain interceptable. (#3126)
-- Add `phel.ai/*sleep-fn*` as a bindable retry backoff seam. (#3204)
-- Add public APIs for per-test coverage and immediate compiled-code cache flushing. (#3203 #3209)
-- Add CSS-style id and class shorthand to `phel.html` element tags. (#3240)
-- Add `Shared\Process\PhelBinaryLocator` and `Shared\DeprecationResolver`, the shared halves of plumbing that Run, Mutate, Api and Lint each carried a copy of. (#3243)
+- `phel mutate`: mutation testing for Phel with 11 mutators, parallel and changed-file modes, coverage selection, and MSI gates. (#3208 #3209)
+- `phel test` gains `--changed[=<ref>]`, `--reporter=github`, per-test coverage JSON, `^:skip` / `^:focus` / `skip!` with `--fail-on-focus`, and `phel.test/*event-hook*`. (#3207 #3209 #3210 #3211 #3214)
+- `phel format --exclude=<glob>` and the matching `format-exclude` config key. (#3233)
+- `cache-env-vars`: environment values that take part in the compiled-code cache key. (#3236)
+- Clojure-style binding-first map destructuring, nested bindings included. (#3115)
+- `^:redef`, which keeps a call interceptable where `-O2` would inline it. (#3126)
+- CSS-style id and class shorthand in `phel.html` element tags. (#3240)
+- `phel.ai/*sleep-fn*`, a bindable retry backoff seam. (#3204)
+- A bare local `defexception` name now resolves in `catch`. (#3211)
+- Public API: `Shared\Process\PhelBinaryLocator`, `Shared\DeprecationResolver`, per-test coverage, and immediate compiled-code cache flushing. (#3203 #3209 #3243)
 
 ### Changed
 
@@ -28,50 +24,32 @@ All notable changes to this project will be documented in this file.
 
 ### Performance
 
-Compile-time folding / hoisting:
-
-- Emit each form once under `phel compile --emit-only`, 24% faster, with byte-identical output.
-- Reuse the lists a macro expansion leaves unchanged instead of rebuilding them, 5% faster analysis of macro-heavy source.
-- Resolve a call's `phel.core` identity once per node instead of once per specialisation probe, 4% faster emission.
-- Compile `is` arms through one runtime helper, reducing generated size, compile time, and memory. (#3212)
-- Inline `-O2` calls in return position; use `^:redef` where interception is required. (#3125)
-
-Test framework:
-
-- Record an assertion against one rebuild of the counts map instead of two nested walks, halving the per-assertion bookkeeping.
-
-Dispatch / call sites:
-
-- Read non-dynamic globals directly from the registry, up to 1.9x faster. (#3179)
-- Spread vectors in `apply` in one pass, 2.1x faster for `(apply + [1 2 3])`. (#3181)
-- Use fixed arities in hot core functions, up to 22x faster without behavior changes. (#2973)
-- Write `into`'s targets through transient methods, and reverse and escape natively in `phel.string`. (#2973)
-- Skip Gacela's event dispatch when no listener is registered; a host that wants the events sets `GacelaConfig::setEventDispatcher()`.
-
-Runtime data structures:
-
-- Promote every map construction path at the same size, making grown map reads up to 5.5x faster. (#3172)
-- Answer `contains?`, map lookups and realized lazy sequences without repeating work already done, up to 22% faster.
+- **Compiler**: emit each form once under `phel compile --emit-only` (24% faster, byte-identical output); reuse the lists a macro expansion leaves unchanged (5% faster analysis); resolve a call's `phel.core` identity once per node rather than once per specialisation probe (4% faster emission).
+- **Compiler**: compile `is` arms through one runtime helper, cutting generated size, compile time and memory (#3212); inline `-O2` calls in return position (#3125).
+- **Runtime**: stop repeating work already done in `contains?`, map lookups and realized lazy sequences (up to 22% faster); promote every map construction path at the same size, making grown map reads up to 5.5x faster (#3172); read non-dynamic globals straight from the registry, 1.9x (#3179); spread vectors into `apply` in one pass, 2.1x (#3181); give hot core functions fixed arities, up to 22x (#2973).
+- **Standard library**: build the walked list and the `pprint` joins once instead of through a spread (57% and 23% faster); write `into`'s targets through transient methods and reverse and escape natively in `phel.string` (#2973).
+- **Test framework**: record an assertion against one rebuild of the counts map instead of two nested walks, halving the per-assertion bookkeeping.
+- **Boot**: skip Gacela's event dispatch when no listener is registered; a host that wants the events sets `GacelaConfig::setEventDispatcher()`.
 
 ### Deprecated
 
-- Deprecate `to-php-array`; use its Clojure-aligned alias `to-array`. (#3076)
-- Deprecate key-first map destructuring (`{:key local}`); use binding-first (`{local :key}`). (#3115)
+- `to-php-array`; use its Clojure-aligned alias `to-array`. (#3076)
+- Key-first map destructuring (`{:key local}`); use binding-first (`{local :key}`). (#3115)
 
 ### Fixed
 
 - Name the namespace and the fix when an exported wrapper cannot resolve its definition, instead of failing with `Value of type null is not callable`. (#3244)
-- Avoid redundant project walks and cache races in `phel test --parallel`, making parallel runs faster. (#3203)
-- Format collection literals in linear time with byte-identical output. (#3218)
-- Replay deprecation warnings from warm compiled-code caches. (#3222)
+- Iterate a hash map's `nil` key, which `keys`, `vals`, `for ... :pairs` and `into` dropped while `count` still counted it. (#3172)
+- Treat associative PHP arrays as maps in `merge`, `merge-with`, and `conj`. (#3114)
+- Preserve JSON objects as maps during `phel.json/decode`, including empty objects. (#3089)
 - Preserve assertion source locations through macro expansion. (#3228)
 - Preserve outer `--slowest` and `--last-failed` state across nested test runs. (#3206)
+- Avoid redundant project walks and cache races in `phel test --parallel`. (#3203)
 - Invalidate the scan-index cache when a configured source or test directory appears. (#3205)
 - Load dependencies for test and benchmark files outside configured source directories. (#3187)
-- Treat associative PHP arrays as maps in `merge`, `merge-with`, and `conj`. (#3114)
-- Iterate a hash map's `nil` key, which `keys`, `vals`, `for ... :pairs` and `into` dropped while `count` still counted it. (#3172)
 - Skip the build output directory when indexing, so navigation prefers a source over its copy in `out/`. (#3155)
-- Preserve JSON objects as maps during `phel.json/decode`, including empty objects. (#3089)
+- Format collection literals in linear time with byte-identical output. (#3218)
+- Replay deprecation warnings from warm compiled-code caches. (#3222)
 - Reject blank AI provider API keys before making a request. (#3204)
 
 ## [0.50.0](https://github.com/phel-lang/phel-lang/compare/v0.49.0...v0.50.0) - 2026-08-14

--- a/src/phel/pprint.phel
+++ b/src/phel/pprint.phel
@@ -25,20 +25,28 @@
   "Pretty-prints each element of `form` at `inner-indent`, joined by a newline
   and that much padding."
   [form inner-indent width printer]
+  ;; Collected into a PHP array and imploded rather than spread through
+  ;; `apply`: the `for` built a transient vector only for `apply` to flatten
+  ;; it back into call arguments. Same shape `render-attrs` fixed in `html`.
   (let [pad   (php/str_repeat " " inner-indent)
-        parts (for [x :in form] (pp-str x inner-indent width printer))]
-    (php/implode (str "\n" pad) (apply php-indexed-array parts))))
+        parts (php/array)]
+    (foreach [x form]
+      (php/apush parts (pp-str x inner-indent width printer)))
+    (php/implode (str "\n" pad) parts)))
 
 (defn- pp-pairs
   "The same for a map or struct, where each entry is a key, a space, and its
   value laid out from just past the key."
   [form inner-indent width printer]
+  ;; `foreach` and not `for … :pairs`, for the same two reasons as
+  ;; `pp-parts`: no spread through `apply`, and no destructuring per entry.
   (let [pad   (php/str_repeat " " inner-indent)
-        pairs (for [[k v] :pairs form]
-                (let [kstr (print-value k)]
-                  (str (render-value printer k) " "
-                       (pp-str v (+ inner-indent (count kstr) 1) width printer))))]
-    (php/implode (str "\n" pad) (apply php-indexed-array pairs))))
+        pairs (php/array)]
+    (foreach [k v form]
+      (let [kstr (print-value k)]
+        (php/apush pairs (str (render-value printer k) " "
+                              (pp-str v (+ inner-indent (count kstr) 1) width printer)))))
+    (php/implode (str "\n" pad) pairs)))
 
 (defn- pp-str
   "Pretty-prints `form` to a string with the given indent level and max width.

--- a/src/phel/walk.phel
+++ b/src/phel/walk.phel
@@ -15,8 +15,13 @@
   (outer
    (cond
      (list? form)
-     (apply list (persistent (for [x :in form :reduce [acc (transient [])]]
-                               (conj! acc (inner x)))))
+     ;; Collected into a PHP array and built once, as the vector branch is.
+     ;; Building a transient vector, persisting it, and spreading it through
+     ;; `apply` put five intermediates between the walk and the list.
+     (let [arr (php/array)]
+       (foreach [x form]
+         (php/apush arr (inner x)))
+       (php/:: Phel (list arr)))
 
      (vector? form)
      ;; Collected into a PHP array and built once, as `vec` is (#3134).

--- a/tests/php/Benchmark/Phel/StdlibPprintBench.php
+++ b/tests/php/Benchmark/Phel/StdlibPprintBench.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Phel;
+
+use Override;
+use Phel;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+
+/**
+ * `phel.pprint`, which had no benchmark at all.
+ *
+ * It is not only a REPL convenience: `inspect` and the failure diffs
+ * `phel.test` prints both come through here, so it runs on the unhappy path
+ * of every test run.
+ *
+ * Two shapes, because the layout code only runs on one of them. A form that
+ * fits the width returns from the fast path at the top of `pp-str` without
+ * ever laying anything out, so a fitting fixture would measure the printer
+ * and nothing else. `bench_pprint_nested` is deliberately wider than the
+ * 72-column default at every level; `bench_pprint_fits` guards the fast path
+ * against a regression that would only show there.
+ *
+ * {@see CoreBenchCase} for the conventions every subject here follows.
+ *
+ * @BeforeMethods("setUp")
+ */
+final class StdlibPprintBench extends CoreBenchCase
+{
+    private const int WIDTH = 12;
+
+    /** @var callable */
+    private $pprintStr;
+
+    private mixed $nested = null;
+
+    private mixed $small = null;
+
+    /**
+     * @Revs(100)
+     */
+    public function bench_pprint_nested(): void
+    {
+        ($this->pprintStr)($this->nested);
+    }
+
+    /**
+     * @Revs(1000)
+     */
+    public function bench_pprint_fits(): void
+    {
+        ($this->pprintStr)($this->small);
+    }
+
+    /**
+     * @return list<string>
+     */
+    #[Override]
+    protected function extraNamespaces(): array
+    {
+        return ['phel.pprint'];
+    }
+
+    #[Override]
+    protected function setUpFixtures(): void
+    {
+        $this->pprintStr = $this->phelFn('phel.pprint', 'pprint-str');
+
+        $rows = [];
+        for ($i = 0; $i < self::WIDTH; ++$i) {
+            $cells = [];
+            for ($j = 0; $j < self::WIDTH; ++$j) {
+                $cells[] = Phel::keyword('cell-' . $j);
+                $cells[] = 'value-' . $i . '-' . $j;
+            }
+
+            $rows[] = Phel::map(...$cells);
+        }
+
+        $this->nested = Phel::map(
+            Phel::keyword('rows'),
+            Phel::vector($rows),
+            Phel::keyword('names'),
+            Phel::list(['alpha', 'beta', 'gamma']),
+        );
+
+        $this->small = Phel::map(Phel::keyword('a'), 1, Phel::keyword('b'), 2);
+    }
+}

--- a/tests/php/Benchmark/Phel/StdlibWalkBench.php
+++ b/tests/php/Benchmark/Phel/StdlibWalkBench.php
@@ -45,6 +45,8 @@ final class StdlibWalkBench extends CoreBenchCase
 
     private mixed $keywordKeyed = null;
 
+    private mixed $nestedList = null;
+
     /**
      * @Revs(1000)
      */
@@ -69,6 +71,18 @@ final class StdlibWalkBench extends CoreBenchCase
     public function bench_postwalk_identity(): void
     {
         ($this->postwalk)($this->identity, $this->stringKeyed);
+    }
+
+    /**
+     * The list branch, which the map-and-vector fixture above never reaches.
+     * A walked list was rebuilt through a transient vector, a persistent one
+     * and an `apply` spread; the other branches build once.
+     *
+     * @Revs(1000)
+     */
+    public function bench_postwalk_list(): void
+    {
+        ($this->postwalk)($this->identity, $this->nestedList);
     }
 
     #[Override]
@@ -105,5 +119,12 @@ final class StdlibWalkBench extends CoreBenchCase
         );
 
         $this->keywordKeyed = ($this->keywordizeKeys)($this->stringKeyed);
+
+        $leaves = [];
+        for ($i = 0; $i < self::WIDTH; ++$i) {
+            $leaves[] = Phel::list([$i, 'n' . $i]);
+        }
+
+        $this->nestedList = Phel::list($leaves);
     }
 }


### PR DESCRIPTION
## 🤔 Background

Fourth pull request from the profiling sweep, after #3245, #3246 and #3247. Two places in the standard library kept a shape that `walk`'s own vector branch (#3134) and `html/render-attrs` had already replaced, and neither had a benchmark that could see it.

## 💡 Goal

Build each collection once, and give both paths a subject so they cannot regress unnoticed.

## 🔖 Changes

- **`postwalk` over a list.** It built a transient vector, persisted it, spread it through `apply` into `list`'s rest argument, and flattened that back into a PHP array: five intermediates between the walk and its result, where the vector branch immediately below it collects into a PHP array and builds once. Roughly 17 PHP calls per element, and a walker pays them once per node of the tree.
- **`pp-parts` and `pp-pairs`.** Both built a lazy sequence of rendered parts only for `apply php-indexed-array` to flatten it into call arguments before `implode` ran. `pp-pairs` also paid a `[[k v] :pairs …]` destructure per entry, the cost #3140 named.

## Measurements

Two new subjects plus one added to an existing bench. Each variant ran with a cleared `.phel/cache` and a discarded warm-up first, since changing a `.phel` file changes its compiled artifact:

| subject | baseline | branch | delta |
|---|---|---|---|
| `bench_postwalk_list` | 95.6µs | 41.0µs | **−57%** |
| `bench_pprint_nested` | 1.756ms | 1.330ms | **−23%** |
| `bench_pprint_fits` (control) | 4.45µs | 4.52µs | flat |
| `bench_postwalk_identity` (control) | 111.0µs | 109.5µs | flat |
| `bench_keywordize_keys`, `bench_stringify_keys` (controls) | — | — | flat |

`StdlibPprintBench` is new: `phel.pprint` had no benchmark, and it is not only a REPL convenience, since `inspect` and the failure diffs `phel.test` prints both come through it. Its two subjects separate the layout code from the fast path that returns as soon as a form fits the width, because a fitting fixture would measure the printer and nothing else. `StdlibWalkBench` gained a list subject: it covered maps and vectors, which is how the list branch stayed slow.

Verified: full `composer test-all` green locally (cs-fixer, psalm, phpstan, rector, 4873 unit, 1290 integration, 10090 core).

## Also in here

A changelog commit, requested separately: the Unreleased section had grown to 40 bullets across four Performance subheadings. It is now 33, with the test tooling of one release cycle reading as one entry rather than five, and Performance grouped by area on a bold label. Every issue and pull-request reference is preserved; entries were merged, not dropped.

## Not included

`pprint` also prints every subtree once per ancestor level, which is O(n·depth) and was the larger finding here. It is **not** fixed by this PR, and the fix originally proposed for it does not work: the parent's flat print already traverses the child's subtree, so moving who calls the printer changes the call count without changing the traversals. A real fix needs the printer itself to be able to measure with an early bail-out once the output exceeds the remaining width, which is a change in `Phel\Shared\Printer` rather than in `pprint`. Worth its own issue.
