### PR TITLE
perf(compiler): pay for definition metadata when it is read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- `Registry::addDefinition()` also accepts a `Closure` returning the metadata map. Widening a parameter is not breaking, and the eager form still works, so an artifact compiled earlier stays loadable.
 - Resolve bare all-caps PHP names by position instead of autoload state. See [ADR 0016](docs/adr/0016-a-bare-all-caps-host-name-reads-by-position.md). (#3064)
 - Expose compiler environment and deprecation controls through `CompilerFacadeInterface`. (#3048)
 
@@ -29,7 +30,7 @@ All notable changes to this project will be documented in this file.
 - **Runtime**: stop repeating work already done in `contains?`, map lookups and realized lazy sequences (up to 22% faster); promote every map construction path at the same size, making grown map reads up to 5.5x faster (#3172); read non-dynamic globals straight from the registry, 1.9x (#3179); spread vectors into `apply` in one pass, 2.1x (#3181); give hot core functions fixed arities, up to 22x (#2973).
 - **Standard library**: build the walked list and the `pprint` joins once instead of through a spread (57% and 23% faster); write `into`'s targets through transient methods and reverse and escape natively in `phel.string` (#2973).
 - **Test framework**: record an assertion against one rebuild of the counts map instead of two nested walks, halving the per-assertion bookkeeping.
-- **Boot**: skip Gacela's event dispatch when no listener is registered; a host that wants the events sets `GacelaConfig::setEventDispatcher()`.
+- **Boot**: carry a definition's metadata as a thunk forced on first read, so loading a namespace no longer builds a map per definition (loading `phel.core` 20% faster, 22MB to 20MB peak); skip Gacela's event dispatch when no listener is registered, and let a host that wants the events set `GacelaConfig::setEventDispatcher()`.
 
 ### Deprecated
 

--- a/src/php/Build/Domain/Compile/SymbolMetaStripper.php
+++ b/src/php/Build/Domain/Compile/SymbolMetaStripper.php
@@ -67,6 +67,8 @@ final readonly class SymbolMetaStripper
             ++$j;
         }
 
+        $j = self::skipThunkPrefix($tokens, $tokenCount, $j);
+
         if (
             $j + 3 >= $tokenCount
             || !is_array($tokens[$j]) || $tokens[$j][1] !== '\Phel'
@@ -90,5 +92,50 @@ final readonly class SymbolMetaStripper
         }
 
         return null;
+    }
+
+    /**
+     * The meta argument is emitted as `static fn() => \Phel::locationMeta(…)`
+     * so loading a namespace does not build a map per definition (DefEmitter).
+     * Skipping the prefix lets the same matcher recognise both that form and
+     * the bare call an older artifact carries.
+     *
+     * @param list<array{int, string, int}|string> $tokens
+     */
+    private static function skipThunkPrefix(array $tokens, int $tokenCount, int $index): int
+    {
+        $expected = [T_STATIC, T_FN];
+        $j = $index;
+
+        foreach ($expected as $tokenType) {
+            if ($j >= $tokenCount || !is_array($tokens[$j]) || $tokens[$j][0] !== $tokenType) {
+                return $index;
+            }
+
+            ++$j;
+            while ($j < $tokenCount && is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
+                ++$j;
+            }
+        }
+
+        if ($j + 1 >= $tokenCount || $tokens[$j] !== '(' || $tokens[$j + 1] !== ')') {
+            return $index;
+        }
+
+        $j += 2;
+        while ($j < $tokenCount && is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
+            ++$j;
+        }
+
+        if ($j >= $tokenCount || !is_array($tokens[$j]) || $tokens[$j][0] !== T_DOUBLE_ARROW) {
+            return $index;
+        }
+
+        ++$j;
+        while ($j < $tokenCount && is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
+            ++$j;
+        }
+
+        return $j;
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEmitter.php
@@ -71,6 +71,13 @@ final class DefEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitNode($node->getInit());
         if ($node->getMeta()->getKeyValues() !== []) {
             $this->outputEmitter->emitLine(',');
+            // Deferred, not because the map is large but because there are so
+            // many of them: loading a namespace builds one per definition, and
+            // the readers (`phel doc`, `(meta …)`, the LSP, and the analyzer
+            // asking about `:macro` or `:inline`) touch a small fraction of
+            // them. `Registry::getDefinitionMetaData()` forces the closure on
+            // first read and replaces it with the map.
+            $this->outputEmitter->emitStr('static fn() => ', $node->getStartSourceLocation());
             $this->outputEmitter->emitNode($node->getMeta());
         }
 

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Lang;
 
+use Closure;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use RuntimeException;
 
@@ -78,9 +79,16 @@ final class Registry
      * is an `AbstractFn`, the stored value is the profiling wrapper, not the
      * original function. Also clears the dynamic-flag cache for the slot.
      *
-     * @param PersistentMapInterface<mixed, mixed>|null $metaData
+     * `$metaData` may arrive as a `Closure` returning the map instead of the
+     * map itself. Compiled code emits that form: building a definition's meta
+     * costs three persistent maps, and loading a namespace pays it for every
+     * definition while almost nothing reads it. The closure is forced, and
+     * replaced by its result, on the first read in {@see self::getDefinitionMetaData}.
+     * The eager form still works, so an artifact compiled before this stays loadable.
+     *
+     * @param Closure():(PersistentMapInterface<mixed, mixed>|null)|PersistentMapInterface<mixed, mixed>|null $metaData
      */
-    public function addDefinition(string $ns, string $name, mixed $value, ?PersistentMapInterface $metaData = null): PhelVar
+    public function addDefinition(string $ns, string $name, mixed $value, Closure|PersistentMapInterface|null $metaData = null): PhelVar
     {
         if (self::$profilerHook instanceof ProfilerHookInterface && $value instanceof AbstractFn) {
             $value = self::$profilerHook->wrapFn($value);
@@ -189,9 +197,17 @@ final class Registry
             return null;
         }
 
+        $meta = $this->definitionsMetaData[$ns][$name] ?? null;
+
+        if ($meta instanceof Closure) {
+            /** @var PersistentMapInterface<mixed, mixed>|null $forced */
+            $forced = $meta();
+            $this->definitionsMetaData[$ns][$name] = $forced;
+            $meta = $forced;
+        }
+
         /** @var PersistentMapInterface<mixed, mixed>|null $meta */
-        $meta = $this->definitionsMetaData[$ns][$name] ?? TypeFactory::getInstance()->persistentMapFromArray([]);
-        return $meta;
+        return $meta ?? TypeFactory::getInstance()->persistentMapFromArray([]);
     }
 
     /**

--- a/tests/php/Integration/Fixtures/BareHost/callable-on-a-class-that-is-not-loadable.test
+++ b/tests/php/Integration/Fixtures/BareHost/callable-on-a-class-that-is-not-loadable.test
@@ -25,7 +25,7 @@ require_once __DIR__ . '/phel/core.php';
       return (\WP_CLI_FIXTURE::log(...));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("BareHost/callable-on-a-class-that-is-not-loadable.test", 3, 0),
     \Phel::location("BareHost/callable-on-a-class-that-is-not-loadable.test", 3, 49),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(probe)\n```\n",

--- a/tests/php/Integration/Fixtures/BareHost/new-on-a-class-that-is-not-loadable.test
+++ b/tests/php/Integration/Fixtures/BareHost/new-on-a-class-that-is-not-loadable.test
@@ -25,7 +25,7 @@ require_once __DIR__ . '/phel/core.php';
       return (new \WP_CLI_FIXTURE());
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("BareHost/new-on-a-class-that-is-not-loadable.test", 3, 0),
     \Phel::location("BareHost/new-on-a-class-that-is-not-loadable.test", 3, 40),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(probe)\n```\n",

--- a/tests/php/Integration/Fixtures/BareHost/php-prefixed-name-stays-the-constant.test
+++ b/tests/php/Integration/Fixtures/BareHost/php-prefixed-name-stays-the-constant.test
@@ -29,7 +29,7 @@ require_once __DIR__ . '/phel/core.php';
       return new $target_1();
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("BareHost/php-prefixed-name-stays-the-constant.test", 3, 0),
     \Phel::location("BareHost/php-prefixed-name-stays-the-constant.test", 3, 44),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(probe)\n```\n",

--- a/tests/php/Integration/Fixtures/BareHost/static-call-on-a-class-that-is-not-loadable.test
+++ b/tests/php/Integration/Fixtures/BareHost/static-call-on-a-class-that-is-not-loadable.test
@@ -25,7 +25,7 @@ require_once __DIR__ . '/phel/core.php';
       return (\WP_CLI_FIXTURE::log("x"));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("BareHost/static-call-on-a-class-that-is-not-loadable.test", 3, 0),
     \Phel::location("BareHost/static-call-on-a-class-that-is-not-loadable.test", 3, 40),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(probe)\n```\n",

--- a/tests/php/Integration/Fixtures/BareHost/value-position-is-the-constant.test
+++ b/tests/php/Integration/Fixtures/BareHost/value-position-is-the-constant.test
@@ -25,7 +25,7 @@ require_once __DIR__ . '/phel/core.php';
       return WP_CLI_FIXTURE;
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("BareHost/value-position-is-the-constant.test", 3, 0),
     \Phel::location("BareHost/value-position-is-the-constant.test", 3, 30),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(probe)\n```\n",

--- a/tests/php/Integration/Fixtures/Call/apply-fixed-arity-direct.test
+++ b/tests/php/Integration/Fixtures/Call/apply-fixed-arity-direct.test
@@ -13,7 +13,7 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, $b, $c);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Call/apply-fixed-arity-direct.test", 1, 0),
     \Phel::location("Call/apply-fixed-arity-direct.test", 1, 29),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(add3 a b c)\n```\n",

--- a/tests/php/Integration/Fixtures/Call/call-multi-arity-global-shortcut.test
+++ b/tests/php/Integration/Fixtures/Call/call-multi-arity-global-shortcut.test
@@ -35,7 +35,7 @@
       return ($this->fn1)($a1, $a2);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Call/call-multi-arity-global-shortcut.test", 1, 0),
     \Phel::location("Call/call-multi-arity-global-shortcut.test", 1, 41),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(my-add a)\n(my-add a b)\n```\n",
@@ -56,7 +56,7 @@
       return (($__phel_call_0 ??= \Phel::getDefinition("user", "my-add")) instanceof \Phel\Lang\AbstractFn ? ($__phel_call_0 ??= \Phel::getDefinition("user", "my-add"))->invokeArity2($x, $x) : ($__phel_call_0 ??= \Phel::getDefinition("user", "my-add"))->__invoke($x, $x));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Call/call-multi-arity-global-shortcut.test", 2, 0),
     \Phel::location("Call/call-multi-arity-global-shortcut.test", 2, 30),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",

--- a/tests/php/Integration/Fixtures/Call/core-constructor-lowering.test
+++ b/tests/php/Integration/Fixtures/Call/core-constructor-lowering.test
@@ -7,17 +7,17 @@
   "user",
   "xs",
   \Phel::list([1, 2, 3]),
-  \Phel::locationMeta(\Phel::location("Call/core-constructor-lowering.test", 1, 0), \Phel::location("Call/core-constructor-lowering.test", 1, 21))
+  static fn() => \Phel::locationMeta(\Phel::location("Call/core-constructor-lowering.test", 1, 0), \Phel::location("Call/core-constructor-lowering.test", 1, 21))
 );
 \Phel::addDefinition(
   "user",
   "m",
   \Phel::map([\Phel\Lang\Keyword::create("a"), 1]),
-  \Phel::locationMeta(\Phel::location("Call/core-constructor-lowering.test", 2, 0), \Phel::location("Call/core-constructor-lowering.test", 2, 23))
+  static fn() => \Phel::locationMeta(\Phel::location("Call/core-constructor-lowering.test", 2, 0), \Phel::location("Call/core-constructor-lowering.test", 2, 23))
 );
 \Phel::addDefinition(
   "user",
   "v",
   \Phel::vector([]),
-  \Phel::locationMeta(\Phel::location("Call/core-constructor-lowering.test", 3, 0), \Phel::location("Call/core-constructor-lowering.test", 3, 16))
+  static fn() => \Phel::locationMeta(\Phel::location("Call/core-constructor-lowering.test", 3, 0), \Phel::location("Call/core-constructor-lowering.test", 3, 16))
 );

--- a/tests/php/Integration/Fixtures/Call/global-call.test
+++ b/tests/php/Integration/Fixtures/Call/global-call.test
@@ -13,7 +13,7 @@
       return 1;
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Call/global-call.test", 1, 0),
     \Phel::location("Call/global-call.test", 1, 18),
     "min-arity", 1,

--- a/tests/php/Integration/Fixtures/Call/non-fn-global-call-skipped.test
+++ b/tests/php/Integration/Fixtures/Call/non-fn-global-call-skipped.test
@@ -6,7 +6,7 @@
   "user",
   "k",
   \Phel\Lang\Keyword::create("a"),
-  \Phel::locationMeta(\Phel::location("Call/non-fn-global-call-skipped.test", 1, 0), \Phel::location("Call/non-fn-global-call-skipped.test", 1, 10))
+  static fn() => \Phel::locationMeta(\Phel::location("Call/non-fn-global-call-skipped.test", 1, 0), \Phel::location("Call/non-fn-global-call-skipped.test", 1, 10))
 );
 (\Phel\Lang\Registry::readRoot("user", "k"))(\Phel::map(
   \Phel\Lang\Keyword::create("a"), 1

--- a/tests/php/Integration/Fixtures/Call/php-fn-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-fn-reference.test
@@ -13,7 +13,7 @@
       return ($f)(...\Phel\Lang\Seq::toApplyArguments($xs));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Call/php-fn-reference.test", 1, 0),
     \Phel::location("Call/php-fn-reference.test", 1, 44),
     "min-arity", 2,

--- a/tests/php/Integration/Fixtures/Call/php-oset-statement.test
+++ b/tests/php/Integration/Fixtures/Call/php-oset-statement.test
@@ -6,6 +6,6 @@
   "user",
   "o",
   (new \stdClass()),
-  \Phel::locationMeta(\Phel::location("Call/php-oset-statement.test", 1, 0), \Phel::location("Call/php-oset-statement.test", 1, 27))
+  static fn() => \Phel::locationMeta(\Phel::location("Call/php-oset-statement.test", 1, 0), \Phel::location("Call/php-oset-statement.test", 1, 27))
 );
 \Phel\Lang\Registry::readRoot("user", "o")->name = "test";

--- a/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
@@ -6,6 +6,6 @@
   "user",
   "arr",
   array(1, 2, 3),
-  \Phel::locationMeta(\Phel::location("Call/php-push-global-reference.test", 1, 0), \Phel::location("Call/php-push-global-reference.test", 1, 27))
+  static fn() => \Phel::locationMeta(\Phel::location("Call/php-push-global-reference.test", 1, 0), \Phel::location("Call/php-push-global-reference.test", 1, 27))
 );
 (\Phel::getDefinitionReference("user", "arr"))[] = 4;

--- a/tests/php/Integration/Fixtures/Call/self-call-direct.test
+++ b/tests/php/Integration/Fixtures/Call/self-call-direct.test
@@ -11,7 +11,7 @@
       return $this($n);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Call/self-call-direct.test", 1, 0),
     \Phel::location("Call/self-call-direct.test", 1, 22),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n",

--- a/tests/php/Integration/Fixtures/Call/self-call-with-if.test
+++ b/tests/php/Integration/Fixtures/Call/self-call-with-if.test
@@ -12,7 +12,7 @@
 
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Call/self-call-with-if.test", 1, 0),
     \Phel::location("Call/self-call-with-if.test", 1, 52),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n",

--- a/tests/php/Integration/Fixtures/Call/str-concat-global-return-tag.test
+++ b/tests/php/Integration/Fixtures/Call/str-concat-global-return-tag.test
@@ -12,7 +12,7 @@
       return strtoupper($s);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Call/str-concat-global-return-tag.test", 1, 0),
     \Phel::location("Call/str-concat-global-return-tag.test", 1, 43),
     \Phel\Lang\Keyword::create("tag"), "string",
@@ -33,7 +33,7 @@
       return ("<" . ($__phel_call_0 ??= \Phel::getDefinition("user", "shout"))->__invoke($s) . ">");
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Call/str-concat-global-return-tag.test", 2, 0),
     \Phel::location("Call/str-concat-global-return-tag.test", 2, 39),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(wrap s)\n```\n",

--- a/tests/php/Integration/Fixtures/Call/str-concat-mixed-arity-tags-bail.test
+++ b/tests/php/Integration/Fixtures/Call/str-concat-mixed-arity-tags-bail.test
@@ -35,7 +35,7 @@
       return ($this->fn1)($a1, $a2);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Call/str-concat-mixed-arity-tags-bail.test", 1, 0),
     \Phel::location("Call/str-concat-mixed-arity-tags-bail.test", 1, 46),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(mixed x)\n(mixed x y)\n```\n",
@@ -56,7 +56,7 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "str"))->__invoke("<", (($__phel_call_1 ??= \Phel::getDefinition("user", "mixed")) instanceof \Phel\Lang\AbstractFn ? ($__phel_call_1 ??= \Phel::getDefinition("user", "mixed"))->invokeArity2($x, $y) : ($__phel_call_1 ??= \Phel::getDefinition("user", "mixed"))->__invoke($x, $y)), ">");
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Call/str-concat-mixed-arity-tags-bail.test", 2, 0),
     \Phel::location("Call/str-concat-mixed-arity-tags-bail.test", 2, 43),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(wrap x y)\n```\n",

--- a/tests/php/Integration/Fixtures/ConstantHoisting/map-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/map-in-fn-body.test
@@ -15,7 +15,7 @@
       ));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 0),
     \Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 27),
     "min-arity", 0,

--- a/tests/php/Integration/Fixtures/ConstantHoisting/multiple-pure-literals.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/multiple-pure-literals.test
@@ -18,7 +18,7 @@
 
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("ConstantHoisting/multiple-pure-literals.test", 1, 0),
     \Phel::location("ConstantHoisting/multiple-pure-literals.test", 2, 22),
     "min-arity", 1,

--- a/tests/php/Integration/Fixtures/ConstantHoisting/set-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/set-in-fn-body.test
@@ -12,7 +12,7 @@
       return ($__phel_const_0 ??= \Phel::set([1, 2, 3]));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 0),
     \Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 24),
     "min-arity", 0,

--- a/tests/php/Integration/Fixtures/ConstantHoisting/vector-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/vector-in-fn-body.test
@@ -12,7 +12,7 @@
       return ($__phel_const_0 ??= \Phel::vector([1, 2, 3]));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 0),
     \Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 23),
     "min-arity", 0,

--- a/tests/php/Integration/Fixtures/Def/basic-def.test
+++ b/tests/php/Integration/Fixtures/Def/basic-def.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   1,
-  \Phel::locationMeta(\Phel::location("Def/basic-def.test", 1, 0), \Phel::location("Def/basic-def.test", 1, 9))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/basic-def.test", 1, 0), \Phel::location("Def/basic-def.test", 1, 9))
 );

--- a/tests/php/Integration/Fixtures/Def/bigdec-literal.test
+++ b/tests/php/Integration/Fixtures/Def/bigdec-literal.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   \Phel\Lang\BigDecimal::fromString("1.5"),
-  \Phel::locationMeta(\Phel::location("Def/bigdec-literal.test", 1, 0), \Phel::location("Def/bigdec-literal.test", 1, 12))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/bigdec-literal.test", 1, 0), \Phel::location("Def/bigdec-literal.test", 1, 12))
 );

--- a/tests/php/Integration/Fixtures/Def/bigint-literal-negative.test
+++ b/tests/php/Integration/Fixtures/Def/bigint-literal-negative.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   -123,
-  \Phel::locationMeta(\Phel::location("Def/bigint-literal-negative.test", 1, 0), \Phel::location("Def/bigint-literal-negative.test", 1, 13))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/bigint-literal-negative.test", 1, 0), \Phel::location("Def/bigint-literal-negative.test", 1, 13))
 );

--- a/tests/php/Integration/Fixtures/Def/bigint-literal-oversize.test
+++ b/tests/php/Integration/Fixtures/Def/bigint-literal-oversize.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   \Phel\Lang\BigInt::fromString("9223372036854775808"),
-  \Phel::locationMeta(\Phel::location("Def/bigint-literal-oversize.test", 1, 0), \Phel::location("Def/bigint-literal-oversize.test", 1, 28))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/bigint-literal-oversize.test", 1, 0), \Phel::location("Def/bigint-literal-oversize.test", 1, 28))
 );

--- a/tests/php/Integration/Fixtures/Def/bigint-literal.test
+++ b/tests/php/Integration/Fixtures/Def/bigint-literal.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   1,
-  \Phel::locationMeta(\Phel::location("Def/bigint-literal.test", 1, 0), \Phel::location("Def/bigint-literal.test", 1, 10))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/bigint-literal.test", 1, 0), \Phel::location("Def/bigint-literal.test", 1, 10))
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-alpha.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-alpha.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   "a",
-  \Phel::locationMeta(\Phel::location("Def/char-literal-alpha.test", 1, 0), \Phel::location("Def/char-literal-alpha.test", 1, 10))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/char-literal-alpha.test", 1, 0), \Phel::location("Def/char-literal-alpha.test", 1, 10))
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-named-newline.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-named-newline.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   "\n",
-  \Phel::locationMeta(\Phel::location("Def/char-literal-named-newline.test", 1, 0), \Phel::location("Def/char-literal-named-newline.test", 1, 16))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/char-literal-named-newline.test", 1, 0), \Phel::location("Def/char-literal-named-newline.test", 1, 16))
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-named-space.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-named-space.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   " ",
-  \Phel::locationMeta(\Phel::location("Def/char-literal-named-space.test", 1, 0), \Phel::location("Def/char-literal-named-space.test", 1, 14))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/char-literal-named-space.test", 1, 0), \Phel::location("Def/char-literal-named-space.test", 1, 14))
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-octal.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-octal.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   "A",
-  \Phel::locationMeta(\Phel::location("Def/char-literal-octal.test", 1, 0), \Phel::location("Def/char-literal-octal.test", 1, 13))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/char-literal-octal.test", 1, 0), \Phel::location("Def/char-literal-octal.test", 1, 13))
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-punctuation.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-punctuation.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   "(",
-  \Phel::locationMeta(\Phel::location("Def/char-literal-punctuation.test", 1, 0), \Phel::location("Def/char-literal-punctuation.test", 1, 10))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/char-literal-punctuation.test", 1, 0), \Phel::location("Def/char-literal-punctuation.test", 1, 10))
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-unicode.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-unicode.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   "Ω",
-  \Phel::locationMeta(\Phel::location("Def/char-literal-unicode.test", 1, 0), \Phel::location("Def/char-literal-unicode.test", 1, 14))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/char-literal-unicode.test", 1, 0), \Phel::location("Def/char-literal-unicode.test", 1, 14))
 );

--- a/tests/php/Integration/Fixtures/Def/def-collection-literal-with-meta.test
+++ b/tests/php/Integration/Fixtures/Def/def-collection-literal-with-meta.test
@@ -8,7 +8,7 @@
   \Phel::set([1, 2])->withMeta(\Phel::map(
     \Phel\Lang\Keyword::create("a"), 1
   )),
-  \Phel::locationMeta(\Phel::location("Def/def-collection-literal-with-meta.test", 1, 0), \Phel::location("Def/def-collection-literal-with-meta.test", 1, 22))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/def-collection-literal-with-meta.test", 1, 0), \Phel::location("Def/def-collection-literal-with-meta.test", 1, 22))
 );
 \Phel::addDefinition(
   "user",
@@ -16,5 +16,5 @@
   \Phel::vector([3, 4])->withMeta(\Phel::map(
     \Phel\Lang\Keyword::create("b"), 2
   )),
-  \Phel::locationMeta(\Phel::location("Def/def-collection-literal-with-meta.test", 2, 0), \Phel::location("Def/def-collection-literal-with-meta.test", 2, 21))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/def-collection-literal-with-meta.test", 2, 0), \Phel::location("Def/def-collection-literal-with-meta.test", 2, 21))
 );

--- a/tests/php/Integration/Fixtures/Def/def-no-value.test
+++ b/tests/php/Integration/Fixtures/Def/def-no-value.test
@@ -5,5 +5,5 @@
   "user",
   "baz",
   null,
-  \Phel::locationMeta(\Phel::location("Def/def-no-value.test", 1, 0), \Phel::location("Def/def-no-value.test", 1, 9))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/def-no-value.test", 1, 0), \Phel::location("Def/def-no-value.test", 1, 9))
 );

--- a/tests/php/Integration/Fixtures/Def/def-php-class-reference.test
+++ b/tests/php/Integration/Fixtures/Def/def-php-class-reference.test
@@ -7,6 +7,6 @@ PHPChildT
   "user",
   "PHPChildT",
   \RecursiveArrayIterator::class,
-  \Phel::locationMeta(\Phel::location("Def/def-php-class-reference.test", 2, 0), \Phel::location("Def/def-php-class-reference.test", 2, 38))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/def-php-class-reference.test", 2, 0), \Phel::location("Def/def-php-class-reference.test", 2, 38))
 );
 \Phel\Lang\Registry::readRoot("user", "PHPChildT");

--- a/tests/php/Integration/Fixtures/Def/def-php-function-reference.test
+++ b/tests/php/Integration/Fixtures/Def/def-php-function-reference.test
@@ -5,5 +5,5 @@
   "user",
   "uc",
   (function(...$args) { return \strtoupper(...$args);}),
-  \Phel::locationMeta(\Phel::location("Def/def-php-function-reference.test", 1, 0), \Phel::location("Def/def-php-function-reference.test", 1, 24))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/def-php-function-reference.test", 1, 0), \Phel::location("Def/def-php-function-reference.test", 1, 24))
 );

--- a/tests/php/Integration/Fixtures/Def/def-trailing-quote-in-name.test
+++ b/tests/php/Integration/Fixtures/Def/def-trailing-quote-in-name.test
@@ -5,5 +5,5 @@
   "user",
   "a'",
   42,
-  \Phel::locationMeta(\Phel::location("Def/def-trailing-quote-in-name.test", 1, 0), \Phel::location("Def/def-trailing-quote-in-name.test", 1, 11))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/def-trailing-quote-in-name.test", 1, 0), \Phel::location("Def/def-trailing-quote-in-name.test", 1, 11))
 );

--- a/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
@@ -41,7 +41,7 @@ interface IPlayer {
 
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/definterface-instance-of.test", 3, 0),
     \Phel::location("Def/definterface-instance-of.test", 5, 31),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs",
@@ -69,7 +69,7 @@ interface IPlayer {
 
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/definterface-instance-of.test", 3, 0),
     \Phel::location("Def/definterface-instance-of.test", 5, 31),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n",

--- a/tests/php/Integration/Fixtures/Def/definterface.test
+++ b/tests/php/Integration/Fixtures/Def/definterface.test
@@ -39,7 +39,7 @@ interface IPlayer {
 
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/definterface.test", 3, 0),
     \Phel::location("Def/definterface.test", 5, 31),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs",
@@ -67,7 +67,7 @@ interface IPlayer {
 
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/definterface.test", 3, 0),
     \Phel::location("Def/definterface.test", 5, 31),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n",

--- a/tests/php/Integration/Fixtures/Def/defmacro-skips-type-inference.test
+++ b/tests/php/Integration/Fixtures/Def/defmacro-skips-type-inference.test
@@ -12,7 +12,7 @@
       return (\Phel\Lang\Registry::readRoot("phel.core", "list"))(...\Phel\Lang\Seq::toApplyArguments(($__phel_call_0 ??= \Phel::getDefinition("phel.core", "concat"))->__invoke(\Phel::list([(\Phel\Lang\Symbol::create("php/+"))]), \Phel::list([$x]), \Phel::list([1]))));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/defmacro-skips-type-inference.test", 1, 0),
     \Phel::location("Def/defmacro-skips-type-inference.test", 1, 34),
     \Phel\Lang\Keyword::create("macro"), true,

--- a/tests/php/Integration/Fixtures/Def/defn-inferred-param-tag.test
+++ b/tests/php/Integration/Fixtures/Def/defn-inferred-param-tag.test
@@ -11,7 +11,7 @@
       return ($x + 1);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/defn-inferred-param-tag.test", 1, 0),
     \Phel::location("Def/defn-inferred-param-tag.test", 1, 27),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(add1 x)\n```\n",

--- a/tests/php/Integration/Fixtures/Def/defn-meta.test
+++ b/tests/php/Integration/Fixtures/Def/defn-meta.test
@@ -11,7 +11,7 @@
       return $x;
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/defn-meta.test", 1, 0),
     \Phel::location("Def/defn-meta.test", 1, 36),
     \Phel\Lang\Keyword::create("export"), true,

--- a/tests/php/Integration/Fixtures/Def/defn-multi-arity-infers-return.test
+++ b/tests/php/Integration/Fixtures/Def/defn-multi-arity-infers-return.test
@@ -34,7 +34,7 @@
       return ($this->fn1)($a1, $a2);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/defn-multi-arity-infers-return.test", 1, 0),
     \Phel::location("Def/defn-multi-arity-infers-return.test", 1, 49),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(poly a)\n(poly a b)\n```\n",

--- a/tests/php/Integration/Fixtures/Def/defn-no-params-infers-return.test
+++ b/tests/php/Integration/Fixtures/Def/defn-no-params-infers-return.test
@@ -11,7 +11,7 @@
       return (1 + 1);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/defn-no-params-infers-return.test", 1, 0),
     \Phel::location("Def/defn-no-params-infers-return.test", 1, 25),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(two)\n```\n",

--- a/tests/php/Integration/Fixtures/Def/defn-rand-range-fully-inferred.test
+++ b/tests/php/Integration/Fixtures/Def/defn-rand-range-fully-inferred.test
@@ -13,7 +13,7 @@
       return ($lo + ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "rand-int"))->__invoke(($hi - $lo)));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/defn-rand-range-fully-inferred.test", 1, 0),
     \Phel::location("Def/defn-rand-range-fully-inferred.test", 2, 30),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(rand-range lo hi)\n```\n",

--- a/tests/php/Integration/Fixtures/Def/defn-return-from-grafted-params.test
+++ b/tests/php/Integration/Fixtures/Def/defn-return-from-grafted-params.test
@@ -11,7 +11,7 @@
       return (($a + $b) + 0);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/defn-return-from-grafted-params.test", 1, 0),
     \Phel::location("Def/defn-return-from-grafted-params.test", 1, 39),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(add2 a b)\n```\n",

--- a/tests/php/Integration/Fixtures/Def/defn-return-type-name.test
+++ b/tests/php/Integration/Fixtures/Def/defn-return-type-name.test
@@ -11,7 +11,7 @@
       return ($x + $y);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/defn-return-type-name.test", 1, 0),
     \Phel::location("Def/defn-return-type-name.test", 1, 43),
     \Phel\Lang\Keyword::create("tag"), "int",

--- a/tests/php/Integration/Fixtures/Def/defn-typed-params.test
+++ b/tests/php/Integration/Fixtures/Def/defn-typed-params.test
@@ -11,7 +11,7 @@
       return ($x + $y);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/defn-typed-params.test", 1, 0),
     \Phel::location("Def/defn-typed-params.test", 1, 56),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(add x y)\n```\n",

--- a/tests/php/Integration/Fixtures/Def/defn-untagged-param-infers-return.test
+++ b/tests/php/Integration/Fixtures/Def/defn-untagged-param-infers-return.test
@@ -11,7 +11,7 @@
       return (1 + 1);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/defn-untagged-param-infers-return.test", 1, 0),
     \Phel::location("Def/defn-untagged-param-infers-return.test", 1, 32),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(const-two x)\n```\n",

--- a/tests/php/Integration/Fixtures/Def/defonce-redefine.test
+++ b/tests/php/Integration/Fixtures/Def/defonce-redefine.test
@@ -6,7 +6,7 @@ if (!\Phel::isDefined("user", "counter")) {
     "user",
     "counter",
     0,
-    \Phel::locationMeta(\Phel::location("Def/defonce-redefine.test", 1, 0), \Phel::location("Def/defonce-redefine.test", 1, 19))
+    static fn() => \Phel::locationMeta(\Phel::location("Def/defonce-redefine.test", 1, 0), \Phel::location("Def/defonce-redefine.test", 1, 19))
   );
 }
 if (!\Phel::isDefined("user", "counter")) {
@@ -14,6 +14,6 @@ if (!\Phel::isDefined("user", "counter")) {
     "user",
     "counter",
     99,
-    \Phel::locationMeta(\Phel::location("Def/defonce-redefine.test", 1, 20), \Phel::location("Def/defonce-redefine.test", 1, 40))
+    static fn() => \Phel::locationMeta(\Phel::location("Def/defonce-redefine.test", 1, 20), \Phel::location("Def/defonce-redefine.test", 1, 40))
   );
 }

--- a/tests/php/Integration/Fixtures/Def/defonce.test
+++ b/tests/php/Integration/Fixtures/Def/defonce.test
@@ -6,6 +6,6 @@ if (!\Phel::isDefined("user", "counter")) {
     "user",
     "counter",
     0,
-    \Phel::locationMeta(\Phel::location("Def/defonce.test", 1, 0), \Phel::location("Def/defonce.test", 1, 19))
+    static fn() => \Phel::locationMeta(\Phel::location("Def/defonce.test", 1, 0), \Phel::location("Def/defonce.test", 1, 19))
   );
 }

--- a/tests/php/Integration/Fixtures/Def/defstruct-inside-fn-body.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-inside-fn-body.test
@@ -29,7 +29,7 @@
 
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/defstruct-inside-fn-body.test", 1, 0),
     \Phel::location("Def/defstruct-inside-fn-body.test", 3, 33),
     "min-arity", 0,

--- a/tests/php/Integration/Fixtures/Def/doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/doc-def.test
@@ -5,7 +5,7 @@
   "user",
   "x",
   1,
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/doc-def.test", 1, 0),
     \Phel::location("Def/doc-def.test", 1, 21),
     \Phel\Lang\Keyword::create("doc"), "my number"

--- a/tests/php/Integration/Fixtures/Def/hash-php-map-literal.test
+++ b/tests/php/Integration/Fixtures/Def/hash-php-map-literal.test
@@ -10,5 +10,5 @@
     ($__phel_1_2)[("b")] = 2;
     return $__phel_1_2;
   })(),
-  \Phel::locationMeta(\Phel::location("Def/hash-php-map-literal.test", 1, 0), \Phel::location("Def/hash-php-map-literal.test", 1, 26))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/hash-php-map-literal.test", 1, 0), \Phel::location("Def/hash-php-map-literal.test", 1, 26))
 );

--- a/tests/php/Integration/Fixtures/Def/hash-php-vector-literal.test
+++ b/tests/php/Integration/Fixtures/Def/hash-php-vector-literal.test
@@ -5,5 +5,5 @@
   "user",
   "arr",
   array(1, 2, 3),
-  \Phel::locationMeta(\Phel::location("Def/hash-php-vector-literal.test", 1, 0), \Phel::location("Def/hash-php-vector-literal.test", 1, 22))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/hash-php-vector-literal.test", 1, 0), \Phel::location("Def/hash-php-vector-literal.test", 1, 22))
 );

--- a/tests/php/Integration/Fixtures/Def/namespace-def.test
+++ b/tests/php/Integration/Fixtures/Def/namespace-def.test
@@ -19,5 +19,5 @@ require_once __DIR__ . '/../phel/core.php';
   "my.ns",
   "x",
   1,
-  \Phel::locationMeta(\Phel::location("Def/namespace-def.test", 3, 0), \Phel::location("Def/namespace-def.test", 3, 9))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/namespace-def.test", 3, 0), \Phel::location("Def/namespace-def.test", 3, 9))
 );

--- a/tests/php/Integration/Fixtures/Def/negative-hex-int-min.test
+++ b/tests/php/Integration/Fixtures/Def/negative-hex-int-min.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   (-9223372036854775807 - 1),
-  \Phel::locationMeta(\Phel::location("Def/negative-hex-int-min.test", 1, 0), \Phel::location("Def/negative-hex-int-min.test", 1, 27))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/negative-hex-int-min.test", 1, 0), \Phel::location("Def/negative-hex-int-min.test", 1, 27))
 );

--- a/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
+++ b/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
@@ -13,13 +13,13 @@
         "user",
         "x",
         1,
-        ($__phel_const_0 ??= \Phel::locationMeta(\Phel::location("Def/nested-def-inside-fn.test", 1, 14), \Phel::location("Def/nested-def-inside-fn.test", 1, 23)))
+        static fn() => ($__phel_const_0 ??= \Phel::locationMeta(\Phel::location("Def/nested-def-inside-fn.test", 1, 14), \Phel::location("Def/nested-def-inside-fn.test", 1, 23)))
       );
 
       return \Phel\Lang\Registry::readRoot("user", "x");
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/nested-def-inside-fn.test", 1, 0),
     \Phel::location("Def/nested-def-inside-fn.test", 1, 27),
     "min-arity", 0,

--- a/tests/php/Integration/Fixtures/Def/private-def-meta.test
+++ b/tests/php/Integration/Fixtures/Def/private-def-meta.test
@@ -5,7 +5,7 @@
   "user",
   "x",
   1,
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/private-def-meta.test", 1, 0),
     \Phel::location("Def/private-def-meta.test", 1, 38),
     \Phel\Lang\Keyword::create("private"), true,

--- a/tests/php/Integration/Fixtures/Def/private-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-def.test
@@ -5,7 +5,7 @@
   "user",
   "x",
   1,
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/private-def.test", 1, 0),
     \Phel::location("Def/private-def.test", 1, 18),
     \Phel\Lang\Keyword::create("private"), true

--- a/tests/php/Integration/Fixtures/Def/private-doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-doc-def.test
@@ -5,7 +5,7 @@
   "user",
   "x",
   1,
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Def/private-doc-def.test", 1, 0),
     \Phel::location("Def/private-doc-def.test", 1, 42),
     \Phel\Lang\Keyword::create("private"), true,

--- a/tests/php/Integration/Fixtures/Def/radix-binary.test
+++ b/tests/php/Integration/Fixtures/Def/radix-binary.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   15,
-  \Phel::locationMeta(\Phel::location("Def/radix-binary.test", 1, 0), \Phel::location("Def/radix-binary.test", 1, 14))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/radix-binary.test", 1, 0), \Phel::location("Def/radix-binary.test", 1, 14))
 );

--- a/tests/php/Integration/Fixtures/Def/radix-hex.test
+++ b/tests/php/Integration/Fixtures/Def/radix-hex.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   255,
-  \Phel::locationMeta(\Phel::location("Def/radix-hex.test", 1, 0), \Phel::location("Def/radix-hex.test", 1, 13))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/radix-hex.test", 1, 0), \Phel::location("Def/radix-hex.test", 1, 13))
 );

--- a/tests/php/Integration/Fixtures/Def/radix-negative.test
+++ b/tests/php/Integration/Fixtures/Def/radix-negative.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   -15,
-  \Phel::locationMeta(\Phel::location("Def/radix-negative.test", 1, 0), \Phel::location("Def/radix-negative.test", 1, 15))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/radix-negative.test", 1, 0), \Phel::location("Def/radix-negative.test", 1, 15))
 );

--- a/tests/php/Integration/Fixtures/Def/ratio-literal-negative.test
+++ b/tests/php/Integration/Fixtures/Def/ratio-literal-negative.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   \Phel\Lang\Ratio::create(\Phel\Lang\BigInt::fromString("-3"), \Phel\Lang\BigInt::fromString("4")),
-  \Phel::locationMeta(\Phel::location("Def/ratio-literal-negative.test", 1, 0), \Phel::location("Def/ratio-literal-negative.test", 1, 12))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/ratio-literal-negative.test", 1, 0), \Phel::location("Def/ratio-literal-negative.test", 1, 12))
 );

--- a/tests/php/Integration/Fixtures/Def/ratio-literal.test
+++ b/tests/php/Integration/Fixtures/Def/ratio-literal.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   \Phel\Lang\Ratio::create(\Phel\Lang\BigInt::fromString("1"), \Phel\Lang\BigInt::fromString("2")),
-  \Phel::locationMeta(\Phel::location("Def/ratio-literal.test", 1, 0), \Phel::location("Def/ratio-literal.test", 1, 11))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/ratio-literal.test", 1, 0), \Phel::location("Def/ratio-literal.test", 1, 11))
 );

--- a/tests/php/Integration/Fixtures/Def/string-literal-unicode-escape.test
+++ b/tests/php/Integration/Fixtures/Def/string-literal-unicode-escape.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   " ",
-  \Phel::locationMeta(\Phel::location("Def/string-literal-unicode-escape.test", 1, 0), \Phel::location("Def/string-literal-unicode-escape.test", 1, 16))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/string-literal-unicode-escape.test", 1, 0), \Phel::location("Def/string-literal-unicode-escape.test", 1, 16))
 );

--- a/tests/php/Integration/Fixtures/Def/symbolic-number-inf.test
+++ b/tests/php/Integration/Fixtures/Def/symbolic-number-inf.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   INF,
-  \Phel::locationMeta(\Phel::location("Def/symbolic-number-inf.test", 1, 0), \Phel::location("Def/symbolic-number-inf.test", 1, 13))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/symbolic-number-inf.test", 1, 0), \Phel::location("Def/symbolic-number-inf.test", 1, 13))
 );

--- a/tests/php/Integration/Fixtures/Def/symbolic-number-nan.test
+++ b/tests/php/Integration/Fixtures/Def/symbolic-number-nan.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   NAN,
-  \Phel::locationMeta(\Phel::location("Def/symbolic-number-nan.test", 1, 0), \Phel::location("Def/symbolic-number-nan.test", 1, 13))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/symbolic-number-nan.test", 1, 0), \Phel::location("Def/symbolic-number-nan.test", 1, 13))
 );

--- a/tests/php/Integration/Fixtures/Def/symbolic-number-neg-inf.test
+++ b/tests/php/Integration/Fixtures/Def/symbolic-number-neg-inf.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   -INF,
-  \Phel::locationMeta(\Phel::location("Def/symbolic-number-neg-inf.test", 1, 0), \Phel::location("Def/symbolic-number-neg-inf.test", 1, 14))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/symbolic-number-neg-inf.test", 1, 0), \Phel::location("Def/symbolic-number-neg-inf.test", 1, 14))
 );

--- a/tests/php/Integration/Fixtures/Def/tagged-literal-in-reader-conditional.test
+++ b/tests/php/Integration/Fixtures/Def/tagged-literal-in-reader-conditional.test
@@ -5,5 +5,5 @@
   "user",
   "x",
   42,
-  \Phel::locationMeta(\Phel::location("Def/tagged-literal-in-reader-conditional.test", 1, 0), \Phel::location("Def/tagged-literal-in-reader-conditional.test", 1, 54))
+  static fn() => \Phel::locationMeta(\Phel::location("Def/tagged-literal-in-reader-conditional.test", 1, 0), \Phel::location("Def/tagged-literal-in-reader-conditional.test", 1, 54))
 );

--- a/tests/php/Integration/Fixtures/Do/do-in-expr.test
+++ b/tests/php/Integration/Fixtures/Do/do-in-expr.test
@@ -8,5 +8,5 @@
     (1 + 2);
     return (3 + 4);
   })(),
-  \Phel::locationMeta(\Phel::location("Do/do-in-expr.test", 1, 0), \Phel::location("Do/do-in-expr.test", 1, 36))
+  static fn() => \Phel::locationMeta(\Phel::location("Do/do-in-expr.test", 1, 0), \Phel::location("Do/do-in-expr.test", 1, 36))
 );

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq-nil-param-stays-untagged.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq-nil-param-stays-untagged.test
@@ -13,7 +13,7 @@
 
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/defn-infer-phel-core-eq-nil-param-stays-untagged.test", 1, 0),
     \Phel::location("Fn/defn-infer-phel-core-eq-nil-param-stays-untagged.test", 1, 39),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(nil-check x)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq.test
@@ -12,7 +12,7 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "="))->__invoke($x, 5);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 0),
     \Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 27),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(is-five? x)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-gte.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-gte.test
@@ -11,7 +11,7 @@
       return ($x >= 0.5);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 0),
     \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 36),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(at-least-half? x)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-bigint-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-bigint-bails.test
@@ -12,7 +12,7 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, \Phel\Lang\BigInt::fromString("99999999999999999999"));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 0),
     \Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 47),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(plus-big a)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-float.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-float.test
@@ -11,7 +11,7 @@
       return ($a + 1.1);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 0),
     \Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 37),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(inc-by-one-tenth a)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-without-literal-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-without-literal-bails.test
@@ -12,7 +12,7 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, $b);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 0),
     \Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 24),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(add a b)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
@@ -12,7 +12,7 @@
 
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 0),
     \Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 82),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(fib n)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-explicit-wins.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-explicit-wins.test
@@ -12,7 +12,7 @@
       return ($a * 2);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 0),
     \Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 40),
     \Phel\Lang\Keyword::create("tag"), "int",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-inferred-callee.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-inferred-callee.test
@@ -12,7 +12,7 @@
       return is_int($x);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 0),
     \Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 31),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(check x)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-tagged.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-tagged.test
@@ -12,7 +12,7 @@
       return ($a + $b);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 0),
     \Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 43),
     \Phel\Lang\Keyword::create("tag"), "int",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-untagged.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-untagged.test
@@ -12,7 +12,7 @@
       return ($a + $b);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 0),
     \Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 38),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(add a b)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-propagates.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-propagates.test
@@ -12,7 +12,7 @@
       return ($a + $b);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 0),
     \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 43),
     \Phel\Lang\Keyword::create("tag"), "int",
@@ -33,7 +33,7 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("user", "sum"))->__invoke($x, $y);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 0),
     \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 31),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(add-pair x y)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-fqn.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-fqn.test
@@ -12,7 +12,7 @@
       return $s;
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 0),
     \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 42),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(typed s)\n```\n",
@@ -33,7 +33,7 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("user", "typed"))->__invoke($x);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 0),
     \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 27),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-nullable.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-nullable.test
@@ -12,7 +12,7 @@
       return $a;
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 0),
     \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 24),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(maybe a)\n```\n",
@@ -33,7 +33,7 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("user", "maybe"))->__invoke($x);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 0),
     \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 27),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-union.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-union.test
@@ -12,7 +12,7 @@
       return $a;
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 0),
     \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 33),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(either a)\n```\n",
@@ -33,7 +33,7 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("user", "either"))->__invoke($x);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 0),
     \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 28),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-bails-on-bigint-literal.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-bails-on-bigint-literal.test
@@ -12,7 +12,7 @@
       return random_int(0, ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($x, \Phel\Lang\BigInt::fromString("99999999999999999999")));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 0),
     \Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 64),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-int-stable.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-int-stable.test
@@ -11,7 +11,7 @@
       return random_int(0, ($x + $y));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 0),
     \Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 48),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(add-pair x y)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-bails-on-disagreement.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-bails-on-disagreement.test
@@ -11,7 +11,7 @@
       return ($a . random_int(0, $a));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 0),
     \Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 47),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(weird a)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-numeric.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-numeric.test
@@ -11,7 +11,7 @@
       return random_int(0, ($hi - $lo));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 0),
     \Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 54),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(rrange lo hi)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-recursion-cycle.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-recursion-cycle.test
@@ -11,7 +11,7 @@
       return random_int(0, $this(($n - 1)));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 0),
     \Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 51),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-phel-core-plus.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-phel-core-plus.test
@@ -12,7 +12,7 @@
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, 1);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 0),
     \Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 29),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(inc-by-one a)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-count-arg.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-count-arg.test
@@ -11,7 +11,7 @@
       return count($xs);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-php-count-arg.test", 1, 0),
     \Phel::location("Fn/fn-infer-php-count-arg.test", 1, 31),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(size xs)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-intdiv-args.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-intdiv-args.test
@@ -11,7 +11,7 @@
       return intdiv($a, $b);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 0),
     \Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 33),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(div a b)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-random-int-arg.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-random-int-arg.test
@@ -11,7 +11,7 @@
       return random_int(0, $hi);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 0),
     \Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 40),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(rrange hi)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-mixed-branches-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-mixed-branches-bails.test
@@ -13,7 +13,7 @@
 
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 0),
     \Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 57),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(mixed x flag)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-numeric.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-numeric.test
@@ -12,7 +12,7 @@
       return ($x + 1);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-param-infer-numeric.test", 1, 0),
     \Phel::location("Fn/fn-param-infer-numeric.test", 1, 27),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(add1 x)\n```\n",

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-string.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-string.test
@@ -12,7 +12,7 @@
       return ("hi " . $x);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Fn/fn-param-infer-string.test", 1, 0),
     \Phel::location("Fn/fn-param-infer-string.test", 1, 32),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(greet x)\n```\n",

--- a/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
@@ -17,7 +17,7 @@
       return null;
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Foreach/foreach-expr.test", 1, 0),
     \Phel::location("Foreach/foreach-expr.test", 3, 18),
     "min-arity", 0,

--- a/tests/php/Integration/Fixtures/Foreach/foreach-tagged-array-param-skips-adapter.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-tagged-array-param-skips-adapter.test
@@ -15,7 +15,7 @@
       return null;
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 0),
     \Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 59),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(process arr)\n```\n",

--- a/tests/php/Integration/Fixtures/GlobalVar/dynamic-var-read-keeps-the-scope-gate.test
+++ b/tests/php/Integration/Fixtures/GlobalVar/dynamic-var-read-keeps-the-scope-gate.test
@@ -20,7 +20,7 @@ require_once __DIR__ . '/phel/core.php';
   "test",
   "*dyn*",
   1,
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("GlobalVar/dynamic-var-read-keeps-the-scope-gate.test", 3, 0),
     \Phel::location("GlobalVar/dynamic-var-read-keeps-the-scope-gate.test", 3, 23),
     \Phel\Lang\Keyword::create("dynamic"), true
@@ -36,7 +36,7 @@ require_once __DIR__ . '/phel/core.php';
       return \Phel::getDefinition("test", "*dyn*");
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("GlobalVar/dynamic-var-read-keeps-the-scope-gate.test", 4, 0),
     \Phel::location("GlobalVar/dynamic-var-read-keeps-the-scope-gate.test", 4, 21),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(probe)\n```\n",

--- a/tests/php/Integration/Fixtures/GlobalVar/plain-var-read-goes-to-the-registry.test
+++ b/tests/php/Integration/Fixtures/GlobalVar/plain-var-read-goes-to-the-registry.test
@@ -20,7 +20,7 @@ require_once __DIR__ . '/phel/core.php';
   "test",
   "plain",
   1,
-  \Phel::locationMeta(\Phel::location("GlobalVar/plain-var-read-goes-to-the-registry.test", 3, 0), \Phel::location("GlobalVar/plain-var-read-goes-to-the-registry.test", 3, 13))
+  static fn() => \Phel::locationMeta(\Phel::location("GlobalVar/plain-var-read-goes-to-the-registry.test", 3, 0), \Phel::location("GlobalVar/plain-var-read-goes-to-the-registry.test", 3, 13))
 );
 \Phel::addDefinition(
   "test",
@@ -32,7 +32,7 @@ require_once __DIR__ . '/phel/core.php';
       return \Phel\Lang\Registry::readRoot("test", "plain");
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("GlobalVar/plain-var-read-goes-to-the-registry.test", 4, 0),
     \Phel::location("GlobalVar/plain-var-read-goes-to-the-registry.test", 4, 21),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(probe)\n```\n",

--- a/tests/php/Integration/Fixtures/GlobalVar/redef-var-read-keeps-the-scope-gate.test
+++ b/tests/php/Integration/Fixtures/GlobalVar/redef-var-read-keeps-the-scope-gate.test
@@ -20,7 +20,7 @@ require_once __DIR__ . '/phel/core.php';
   "test",
   "red",
   1,
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("GlobalVar/redef-var-read-keeps-the-scope-gate.test", 3, 0),
     \Phel::location("GlobalVar/redef-var-read-keeps-the-scope-gate.test", 3, 19),
     \Phel\Lang\Keyword::create("redef"), true
@@ -36,7 +36,7 @@ require_once __DIR__ . '/phel/core.php';
       return \Phel::getDefinition("test", "red");
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("GlobalVar/redef-var-read-keeps-the-scope-gate.test", 4, 0),
     \Phel::location("GlobalVar/redef-var-read-keeps-the-scope-gate.test", 4, 19),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(probe)\n```\n",

--- a/tests/php/Integration/Fixtures/Keyword/keywords.test
+++ b/tests/php/Integration/Fixtures/Keyword/keywords.test
@@ -23,23 +23,23 @@ require_once __DIR__ . '/xyz/foo.php';
   "test",
   "a",
   \Phel\Lang\Keyword::create("bar"),
-  \Phel::locationMeta(\Phel::location("Keyword/keywords.test", 3, 0), \Phel::location("Keyword/keywords.test", 3, 12))
+  static fn() => \Phel::locationMeta(\Phel::location("Keyword/keywords.test", 3, 0), \Phel::location("Keyword/keywords.test", 3, 12))
 );
 \Phel::addDefinition(
   "test",
   "b",
   \Phel\Lang\Keyword::create("bar", "test"),
-  \Phel::locationMeta(\Phel::location("Keyword/keywords.test", 4, 0), \Phel::location("Keyword/keywords.test", 4, 13))
+  static fn() => \Phel::locationMeta(\Phel::location("Keyword/keywords.test", 4, 0), \Phel::location("Keyword/keywords.test", 4, 13))
 );
 \Phel::addDefinition(
   "test",
   "c",
   \Phel\Lang\Keyword::create("bar", "xyz.foo"),
-  \Phel::locationMeta(\Phel::location("Keyword/keywords.test", 5, 0), \Phel::location("Keyword/keywords.test", 5, 17))
+  static fn() => \Phel::locationMeta(\Phel::location("Keyword/keywords.test", 5, 0), \Phel::location("Keyword/keywords.test", 5, 17))
 );
 \Phel::addDefinition(
   "test",
   "d",
   \Phel\Lang\Keyword::create("bar", "xyz\\foo"),
-  \Phel::locationMeta(\Phel::location("Keyword/keywords.test", 6, 0), \Phel::location("Keyword/keywords.test", 6, 20))
+  static fn() => \Phel::locationMeta(\Phel::location("Keyword/keywords.test", 6, 0), \Phel::location("Keyword/keywords.test", 6, 20))
 );

--- a/tests/php/Integration/Fixtures/Let/let-expr.test
+++ b/tests/php/Integration/Fixtures/Let/let-expr.test
@@ -11,5 +11,5 @@
     $y_2 = 2;
     return ($x_1 + $y_2);
   })(),
-  \Phel::locationMeta(\Phel::location("Let/let-expr.test", 1, 0), \Phel::location("Let/let-expr.test", 1, 35))
+  static fn() => \Phel::locationMeta(\Phel::location("Let/let-expr.test", 1, 0), \Phel::location("Let/let-expr.test", 1, 35))
 );

--- a/tests/php/Integration/Fixtures/Let/let-user-fn-int-return-native-add.test
+++ b/tests/php/Integration/Fixtures/Let/let-user-fn-int-return-native-add.test
@@ -12,7 +12,7 @@
       return ($n + 1);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Let/let-user-fn-int-return-native-add.test", 1, 0),
     \Phel::location("Let/let-user-fn-int-return-native-add.test", 1, 33),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(tally n)\n```\n",
@@ -35,7 +35,7 @@
       return ($t_1 + 5);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Let/let-user-fn-int-return-native-add.test", 2, 0),
     \Phel::location("Let/let-user-fn-int-return-native-add.test", 2, 53),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(use-tally n)\n```\n",

--- a/tests/php/Integration/Fixtures/Let/let-user-fn-string-return-concat.test
+++ b/tests/php/Integration/Fixtures/Let/let-user-fn-string-return-concat.test
@@ -12,7 +12,7 @@
       return ("hi " . $name);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Let/let-user-fn-string-return-concat.test", 1, 0),
     \Phel::location("Let/let-user-fn-string-return-concat.test", 1, 54),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(make-greeting name)\n```\n",
@@ -35,7 +35,7 @@
       return ($g_1 . $g_1);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Let/let-user-fn-string-return-concat.test", 2, 0),
     \Phel::location("Let/let-user-fn-string-return-concat.test", 2, 74),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(greet-twice name)\n```\n",

--- a/tests/php/Integration/Fixtures/Let/let-user-fn-vector-return-typed-nth.test
+++ b/tests/php/Integration/Fixtures/Let/let-user-fn-vector-return-typed-nth.test
@@ -12,7 +12,7 @@
       return \Phel::vector([1, 2, 3]);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Let/let-user-fn-vector-return-typed-nth.test", 1, 0),
     \Phel::location("Let/let-user-fn-vector-return-typed-nth.test", 1, 89),
     \Phel\Lang\Keyword::create("tag"), "\\Phel\\Lang\\Collections\\Vector\\PersistentVectorInterface",
@@ -35,7 +35,7 @@
       return ($a_1->get(0));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Let/let-user-fn-vector-return-typed-nth.test", 2, 0),
     \Phel::location("Let/let-user-fn-vector-return-typed-nth.test", 2, 44),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(use-it)\n```\n",

--- a/tests/php/Integration/Fixtures/MacroExpand/defmacro-env-form.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/defmacro-env-form.test
@@ -13,7 +13,7 @@
 
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("MacroExpand/defmacro-env-form.test", 1, 0),
     \Phel::location("MacroExpand/defmacro-env-form.test", 1, 52),
     \Phel\Lang\Keyword::create("macro"), true,

--- a/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
@@ -17,7 +17,7 @@
       ]);
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("MacroExpand/macro-expand.test", 1, 0),
     \Phel::location("MacroExpand/macro-expand.test", 1, 38),
     \Phel\Lang\Keyword::create("macro"), true,

--- a/tests/php/Integration/Fixtures/MacroExpand/return-array.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/return-array.test
@@ -13,7 +13,7 @@
       return array(1, 2, array(3, 4));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("MacroExpand/return-array.test", 1, 0),
     \Phel::location("MacroExpand/return-array.test", 1, 55),
     \Phel\Lang\Keyword::create("macro"), true,
@@ -26,5 +26,5 @@
   "user",
   "y",
   [0 => 1, 1 => 2, 2 => [0 => 3, 1 => 4]],
-  \Phel::locationMeta(\Phel::location("MacroExpand/return-array.test", 3, 0), \Phel::location("MacroExpand/return-array.test", 3, 13))
+  static fn() => \Phel::locationMeta(\Phel::location("MacroExpand/return-array.test", 3, 0), \Phel::location("MacroExpand/return-array.test", 3, 13))
 );

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -24,7 +24,7 @@ require_once __DIR__ . '/my_namespace/core.php';
   "hello_world",
   "x",
   10,
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Ns/munge-ns.test", 5, 0),
     \Phel::location("Ns/munge-ns.test", 5, 19),
     \Phel\Lang\Keyword::create("private"), true
@@ -55,7 +55,7 @@ final class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
       return (new \hello_world\abc($a));
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Ns/munge-ns.test", 7, 0),
     \Phel::location("Ns/munge-ns.test", 7, 19),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(abc a)\n```\nCreates a new abc struct.",
@@ -76,7 +76,7 @@ final class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
       return is_a($x, "hello_world\\abc");
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Ns/munge-ns.test", 7, 0),
     \Phel::location("Ns/munge-ns.test", 7, 19),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(abc? x)\n```\nChecks if `x` is an instance of the abc struct.",

--- a/tests/php/Integration/Fixtures/Ns/require-multiple.test
+++ b/tests/php/Integration/Fixtures/Ns/require-multiple.test
@@ -26,11 +26,11 @@ require_once __DIR__ . '/xyz/core2.php';
   "test",
   "kw",
   \Phel\Lang\Keyword::create("f1", "xyz.core"),
-  \Phel::locationMeta(\Phel::location("Ns/require-multiple.test", 6, 0), \Phel::location("Ns/require-multiple.test", 6, 15))
+  static fn() => \Phel::locationMeta(\Phel::location("Ns/require-multiple.test", 6, 0), \Phel::location("Ns/require-multiple.test", 6, 15))
 );
 \Phel::addDefinition(
   "test",
   "kw2",
   \Phel\Lang\Keyword::create("f3", "xyz.core2"),
-  \Phel::locationMeta(\Phel::location("Ns/require-multiple.test", 7, 0), \Phel::location("Ns/require-multiple.test", 7, 17))
+  static fn() => \Phel::locationMeta(\Phel::location("Ns/require-multiple.test", 7, 0), \Phel::location("Ns/require-multiple.test", 7, 17))
 );

--- a/tests/php/Integration/Fixtures/Ns/require-vector-multiple.test
+++ b/tests/php/Integration/Fixtures/Ns/require-vector-multiple.test
@@ -26,11 +26,11 @@ require_once __DIR__ . '/xyz/core2.php';
   "test",
   "kw",
   \Phel\Lang\Keyword::create("f1", "xyz.core"),
-  \Phel::locationMeta(\Phel::location("Ns/require-vector-multiple.test", 6, 0), \Phel::location("Ns/require-vector-multiple.test", 6, 15))
+  static fn() => \Phel::locationMeta(\Phel::location("Ns/require-vector-multiple.test", 6, 0), \Phel::location("Ns/require-vector-multiple.test", 6, 15))
 );
 \Phel::addDefinition(
   "test",
   "kw2",
   \Phel\Lang\Keyword::create("f3", "xyz.core2"),
-  \Phel::locationMeta(\Phel::location("Ns/require-vector-multiple.test", 7, 0), \Phel::location("Ns/require-vector-multiple.test", 7, 17))
+  static fn() => \Phel::locationMeta(\Phel::location("Ns/require-vector-multiple.test", 7, 0), \Phel::location("Ns/require-vector-multiple.test", 7, 17))
 );

--- a/tests/php/Integration/Fixtures/Ns/use-in-expression.test
+++ b/tests/php/Integration/Fixtures/Ns/use-in-expression.test
@@ -5,5 +5,5 @@
   "user",
   "u",
   null,
-  \Phel::locationMeta(\Phel::location("Ns/use-in-expression.test", 1, 0), \Phel::location("Ns/use-in-expression.test", 1, 32))
+  static fn() => \Phel::locationMeta(\Phel::location("Ns/use-in-expression.test", 1, 0), \Phel::location("Ns/use-in-expression.test", 1, 32))
 );

--- a/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
+++ b/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
@@ -6,6 +6,6 @@
   "user",
   "a",
   (new \stdClass()),
-  \Phel::locationMeta(\Phel::location("PhpObjectSet/set-class-property.test", 1, 0), \Phel::location("PhpObjectSet/set-class-property.test", 1, 27))
+  static fn() => \Phel::locationMeta(\Phel::location("PhpObjectSet/set-class-property.test", 1, 0), \Phel::location("PhpObjectSet/set-class-property.test", 1, 27))
 );
 \Phel\Lang\Registry::readRoot("user", "a")->name = "test";

--- a/tests/php/Integration/Fixtures/SetVar/set-var.test
+++ b/tests/php/Integration/Fixtures/SetVar/set-var.test
@@ -6,7 +6,7 @@
   "user",
   "x",
   1,
-  \Phel::locationMeta(\Phel::location("SetVar/set-var.test", 1, 0), \Phel::location("SetVar/set-var.test", 1, 9))
+  static fn() => \Phel::locationMeta(\Phel::location("SetVar/set-var.test", 1, 0), \Phel::location("SetVar/set-var.test", 1, 9))
 );
 \Phel::setVar(
   "user",

--- a/tests/php/Integration/Fixtures/Try/throw-expr.test
+++ b/tests/php/Integration/Fixtures/Try/throw-expr.test
@@ -14,7 +14,7 @@
       return $e_1;
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Try/throw-expr.test", 1, 0),
     \Phel::location("Try/throw-expr.test", 1, 56),
     "min-arity", 0,

--- a/tests/php/Integration/Fixtures/Try/try-catch-finally-expr-throw.test
+++ b/tests/php/Integration/Fixtures/Try/try-catch-finally-expr-throw.test
@@ -16,5 +16,5 @@
       (3 + 3);
     }
   })(),
-  \Phel::locationMeta(\Phel::location("Try/try-catch-finally-expr-throw.test", 1, 0), \Phel::location("Try/try-catch-finally-expr-throw.test", 4, 27))
+  static fn() => \Phel::locationMeta(\Phel::location("Try/try-catch-finally-expr-throw.test", 1, 0), \Phel::location("Try/try-catch-finally-expr-throw.test", 4, 27))
 );

--- a/tests/php/Integration/Fixtures/Try/try-catch-finally-expr.test
+++ b/tests/php/Integration/Fixtures/Try/try-catch-finally-expr.test
@@ -16,5 +16,5 @@
       (3 + 3);
     }
   })(),
-  \Phel::locationMeta(\Phel::location("Try/try-catch-finally-expr.test", 1, 0), \Phel::location("Try/try-catch-finally-expr.test", 4, 27))
+  static fn() => \Phel::locationMeta(\Phel::location("Try/try-catch-finally-expr.test", 1, 0), \Phel::location("Try/try-catch-finally-expr.test", 4, 27))
 );

--- a/tests/php/Integration/Fixtures/VarQuote/var-quote-emits-get-var.test
+++ b/tests/php/Integration/Fixtures/VarQuote/var-quote-emits-get-var.test
@@ -6,6 +6,6 @@
   "user",
   "x",
   1,
-  \Phel::locationMeta(\Phel::location("VarQuote/var-quote-emits-get-var.test", 1, 0), \Phel::location("VarQuote/var-quote-emits-get-var.test", 1, 9))
+  static fn() => \Phel::locationMeta(\Phel::location("VarQuote/var-quote-emits-get-var.test", 1, 0), \Phel::location("VarQuote/var-quote-emits-get-var.test", 1, 9))
 );
 \Phel\Lang\Registry::getInstance()->getVar("user", "x");

--- a/tests/php/Integration/Fixtures/VarQuote/var-special-form.test
+++ b/tests/php/Integration/Fixtures/VarQuote/var-special-form.test
@@ -6,6 +6,6 @@
   "user",
   "x",
   1,
-  \Phel::locationMeta(\Phel::location("VarQuote/var-special-form.test", 1, 0), \Phel::location("VarQuote/var-special-form.test", 1, 9))
+  static fn() => \Phel::locationMeta(\Phel::location("VarQuote/var-special-form.test", 1, 0), \Phel::location("VarQuote/var-special-form.test", 1, 9))
 );
 \Phel\Lang\Registry::getInstance()->getVar("user", "x");

--- a/tests/php/Integration/Fixtures/Yield/yield-array.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-array.test
@@ -19,7 +19,7 @@
       })();
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Yield/yield-array.test", 1, 0),
     \Phel::location("Yield/yield-array.test", 3, 26),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_array)\n```\n",

--- a/tests/php/Integration/Fixtures/Yield/yield-doseq-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-doseq-str.test
@@ -19,7 +19,7 @@
       })();
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Yield/yield-doseq-str.test", 1, 0),
     \Phel::location("Yield/yield-doseq-str.test", 3, 23),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_str)\n```\n",

--- a/tests/php/Integration/Fixtures/Yield/yield-return-context.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-return-context.test
@@ -14,7 +14,7 @@
       yield 2;
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Yield/yield-return-context.test", 1, 0),
     \Phel::location("Yield/yield-return-context.test", 3, 18),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_no_return)\n```\n",

--- a/tests/php/Integration/Fixtures/Yield/yield-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-str.test
@@ -19,7 +19,7 @@
       })();
     }
   },
-  \Phel::locationMeta(
+  static fn() => \Phel::locationMeta(
     \Phel::location("Yield/yield-str.test", 1, 0),
     \Phel::location("Yield/yield-str.test", 3, 23),
     \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_str)\n```\n",

--- a/tests/php/Unit/Architecture/public-api.snapshot.txt
+++ b/tests/php/Unit/Architecture/public-api.snapshot.txt
@@ -1282,7 +1282,7 @@ final readonly class Phel\Lang\Reduced
 
 final class Phel\Lang\Registry
   public static ?Phel\Lang\ProfilerHookInterface $profilerHook
-  public function addDefinition(string $ns, string $name, mixed $value, ?Phel\Lang\Collections\Map\PersistentMapInterface $metaData = null): Phel\Lang\PhelVar
+  public function addDefinition(string $ns, string $name, mixed $value, Closure|Phel\Lang\Collections\Map\PersistentMapInterface|null $metaData = null): Phel\Lang\PhelVar
   public function clear(): void
   public function getDefinition(string $ns, string $name): mixed
   public function getDefinitionInNamespace(string $ns): array

--- a/tests/php/Unit/Lang/RegistryTest.php
+++ b/tests/php/Unit/Lang/RegistryTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Lang;
 
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
 use Phel\Lang\PhelVar;
 use Phel\Lang\Registry;
+use Phel\Lang\TypeFactory;
 use PHPUnit\Framework\TestCase;
 
 final class RegistryTest extends TestCase
@@ -38,6 +41,43 @@ final class RegistryTest extends TestCase
 
         self::assertSame(42, Registry::readRoot('ns', 'answer'));
         self::assertSame($this->registry->getDefinition('ns', 'answer'), Registry::readRoot('ns', 'answer'));
+    }
+
+    /**
+     * Compiled code hands the meta over as a closure, so a namespace load does
+     * not build a map per definition. The registry has to force it on the
+     * first read, and only once.
+     */
+    public function test_meta_data_closure_is_forced_once_on_read(): void
+    {
+        $calls = 0;
+        $meta = TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('doc'), 'hi');
+
+        $this->registry->addDefinition('ns', 'lazy', 1, static function () use ($meta, &$calls): PersistentMapInterface {
+            ++$calls;
+            return $meta;
+        });
+
+        self::assertSame(0, $calls, 'adding a definition must not build its meta');
+
+        self::assertSame($meta, $this->registry->getDefinitionMetaData('ns', 'lazy'));
+        self::assertSame(1, $calls);
+
+        self::assertSame($meta, $this->registry->getDefinitionMetaData('ns', 'lazy'));
+        self::assertSame(1, $calls, 'the forced map replaces the closure');
+    }
+
+    /**
+     * An artifact compiled before the closure form still passes the map
+     * itself, and stays loadable.
+     */
+    public function test_meta_data_still_accepts_an_eager_map(): void
+    {
+        $meta = TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('doc'), 'hi');
+
+        $this->registry->addDefinition('ns', 'eager', 1, $meta);
+
+        self::assertSame($meta, $this->registry->getDefinitionMetaData('ns', 'eager'));
     }
 
     public function test_read_root_is_null_for_an_unknown_definition(): void


### PR DESCRIPTION
## 🤔 Background

Fifth pull request from the profiling sweep, after #3245, #3246, #3247 and #3248. This is the load-time half of it.

A host process that loads `phel.core` spends most of its time not on the registry writes but on the metadata attached to them. Profiling put `Phel::locationMeta` at **31.8% inclusive** and `Phel::location` at 22.9%, together roughly `Phel::map` at 54%, while `Registry->addDefinition` underneath was **1.1%**. Every definition builds three persistent maps at load, and almost nothing reads them: `phel doc`, `(meta …)`, the LSP, completion, the export finder, and the analyzer asking about `:macro`, `:inline` or an arity.

## 💡 Goal

Pay for a definition's metadata when something reads it, not when the namespace loads.

## 🔖 Changes

- **`Registry::addDefinition()` also accepts a `Closure` returning the map.** `getDefinitionMetaData()` forces it on the first read and stores the result, so the cost is paid once and only by a reader. Every reader already goes through that accessor. The one place that touches the storage directly, `PhelFunctionRuntimeLoader`, moves slots between arrays without dereferencing them, so a thunk passes through untouched.
- **`DefEmitter` wraps the metadata argument in `static fn() =>`.**
- **`SymbolMetaStripper` learns the new shape.** It matched `, \Phel::locationMeta(` by token, so the prefix would have silently stopped matching: `strip-symbol-meta` builds would have kept their metadata and quietly grown rather than failing.

## Measurements

Loading `phel.core` from a plain PHP host, cache cleared and a warm-up discarded between variants, three runs each:

| | baseline | branch |
|---|---|---|
| load `phel.core` | 43.3 / 43.5 / 45.2ms | 34.8 / 35.1 / 35.1ms (**−20%**) |
| peak memory | 22MB | 20MB |

**Compilation is unaffected**, which is the number that mattered most, because the analyzer forces the thunk for every macro it resolves: `bench_analyze_macro_heavy` 29.74ms against 29.79ms, `bench_compile_emit_only` 41.18ms against 41.34ms. Deferring the work could easily have moved that cost rather than removed it; it does not.

I am not quoting an OPcache figure. The measurement was unstable across passes (its own memory readings say OPcache was not effective in two of three), and a shaky number is worse than none.

## Public API

`Registry::addDefinition()` is public API, and `PublicApiSurfaceTest` failed on the signature change, which is the gate doing its job. Widening a parameter type is listed as **not breaking** in `docs/stability.md`, and the eager form still works, so an artifact compiled before this stays loadable. Snapshot updated via `composer api-surface:update`, with the CHANGELOG entry the failure asks for.

## Fixture churn

127 `.test` fixtures assert emitted PHP that now carries the prefix. They were regenerated by a script mirroring `IntegrationTest::setUpBeforeClass()` and `test_integration()` exactly, not by hand and not by scraping the runner's truncated diff. The diff is 155 lines and every one is the same insertion.

Verified: full `composer test-all` green (cs-fixer, psalm, phpstan, rector, 4873 unit, 1290 integration, 10090 core), plus new unit tests pinning that the thunk is forced exactly once and that the eager form still works.
