### PR TITLE
feat(release): let the release script cut a release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- `tools/release.sh` accepts a pre-release version (`1.0.0-rc1`): it leaves `## Unreleased` in place and publishes the GitHub release as a pre-release. (#3253)
 - `Registry::addDefinition()` also accepts a `Closure` returning the metadata map. Widening a parameter is not breaking, and the eager form still works, so an artifact compiled earlier stays loadable.
 - Resolve bare all-caps PHP names by position instead of autoload state. See [ADR 0016](docs/adr/0016-a-bare-all-caps-host-name-reads-by-position.md). (#3064)
 - Expose compiler environment and deprecation controls through `CompilerFacadeInterface`. (#3048)

--- a/tools/release-lib.sh
+++ b/tools/release-lib.sh
@@ -269,6 +269,26 @@ update_changelog() {
     mv "$changelog_file.tmp" "$changelog_file"
 }
 
+# The notes body for a version, wherever it is being rendered: a pre-release
+# reads `## Unreleased` (which it left in place), a release reads its own
+# heading. Shared so the dry-run preview and the real publish cannot drift.
+build_release_notes_body() {
+    local version="$1"
+    local changelog_file="$2"
+    local unreleased_content="${3:-}"
+
+    local notes
+    if is_prerelease "$version"; then
+        notes=$(format_release_notes "$unreleased_content")
+    else
+        notes=$(extract_release_notes "$version" "$changelog_file" 2>/dev/null || true)
+    fi
+
+    [[ -z "$notes" ]] && notes="Release v$version"
+
+    echo "$notes"
+}
+
 extract_release_notes() {
     local version="$1"
     local changelog_file="$2"
@@ -476,14 +496,7 @@ create_github_release() {
     local unreleased_content="${8:-}"
 
     local release_notes
-    if is_prerelease "$version"; then
-        # No version heading exists for a pre-release, because the changelog
-        # was left untouched: its notes are `## Unreleased` as it stands.
-        release_notes=$(format_release_notes "$unreleased_content")
-    else
-        release_notes=$(extract_release_notes "$version" "$changelog_file")
-    fi
-    [[ -z "$release_notes" ]] && release_notes="Release v$version"
+    release_notes=$(build_release_notes_body "$version" "$changelog_file" "$unreleased_content")
 
     # Generate TL;DR if Claude is available and we have unreleased content
     local tldr=""

--- a/tools/release-lib.sh
+++ b/tools/release-lib.sh
@@ -40,18 +40,80 @@ log_err() {
 # =============================================================================
 # Version Functions
 # =============================================================================
+# `X.Y.Z`, optionally with a pre-release suffix (`1.0.0-rc1`, `1.0.0-rc.2`).
+# Build metadata (`+build`) is deliberately not accepted: nothing here produces
+# it, and a tag carrying one would not round-trip through `git tag -l`.
 validate_semver() {
     local version="$1"
-    [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+    [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]
+}
+
+# True when the version carries a pre-release suffix.
+is_prerelease() {
+    [[ "$1" == *-* ]]
+}
+
+# `1.0.0-rc1` -> `1.0.0`
+version_core() {
+    echo "${1%%-*}"
+}
+
+# `1.0.0-rc1` -> `rc1`; empty for a final release.
+version_prerelease() {
+    local version="$1"
+    if [[ "$version" == *-* ]]; then
+        echo "${version#*-}"
+    else
+        echo ""
+    fi
+}
+
+# Compare two dot-separated pre-release identifier lists. Returns 0 if $1 > $2.
+# Semver 11.4: numeric identifiers compare numerically, everything else
+# lexically, and a longer list outranks a shorter one that is its prefix.
+prerelease_gt() {
+    local IFS='.'
+    read -ra A <<< "$1"
+    read -ra B <<< "$2"
+
+    local len=${#A[@]}
+    (( ${#B[@]} > len )) && len=${#B[@]}
+
+    local i
+    for (( i = 0; i < len; i++ )); do
+        local a="${A[$i]-}"
+        local b="${B[$i]-}"
+
+        [[ -z "$a" && -z "$b" ]] && continue
+        [[ -z "$a" ]] && return 1
+        [[ -z "$b" ]] && return 0
+
+        if [[ "$a" =~ ^[0-9]+$ && "$b" =~ ^[0-9]+$ ]]; then
+            (( a > b )) && return 0
+            (( a < b )) && return 1
+        else
+            [[ "$a" > "$b" ]] && return 0
+            [[ "$a" < "$b" ]] && return 1
+        fi
+    done
+
+    return 1
 }
 
 # Compare two semver strings. Returns 0 if $1 > $2
 version_gt() {
     local v1="$1"
     local v2="$2"
+
+    local core1 core2 pre1 pre2
+    core1=$(version_core "$v1")
+    core2=$(version_core "$v2")
+    pre1=$(version_prerelease "$v1")
+    pre2=$(version_prerelease "$v2")
+
     local IFS='.'
-    read -ra V1 <<< "$v1"
-    read -ra V2 <<< "$v2"
+    read -ra V1 <<< "$core1"
+    read -ra V2 <<< "$core2"
 
     for i in 0 1 2; do
         local n1="${V1[$i]:-0}"
@@ -62,7 +124,14 @@ version_gt() {
             return 1
         fi
     done
-    return 1
+
+    # Same core: a release outranks its own pre-releases (semver 11.3), so
+    # `1.0.0` > `1.0.0-rc1` and `1.0.0-rc2` > `1.0.0-rc1`.
+    [[ -z "$pre1" && -z "$pre2" ]] && return 1
+    [[ -z "$pre1" ]] && return 0
+    [[ -z "$pre2" ]] && return 1
+
+    prerelease_gt "$pre1" "$pre2"
 }
 
 get_latest_tag_version() {
@@ -90,7 +159,10 @@ get_current_version() {
     fi
 
     local version
-    version=$(sed -nE "s/.*LATEST_VERSION = 'v([0-9]+\.[0-9]+\.[0-9]+)'.*/\1/p" "$version_file" 2>/dev/null || true)
+    # The pre-release suffix has to be part of the capture: after cutting
+    # `1.0.0-rc1`, this file holds it, and the next run reads it back as the
+    # current version.
+    version=$(sed -nE "s/.*LATEST_VERSION = 'v([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?)'.*/\1/p" "$version_file" 2>/dev/null || true)
 
     if [[ -z "$version" ]]; then
         log_err "Could not extract version from VersionFinder.php"
@@ -166,7 +238,7 @@ update_version_finder() {
     local version="$1"
     local version_file="$2"
     # Use -E for extended regex, compatible with both macOS and Linux
-    sed -i.bak -E "s/LATEST_VERSION = 'v[0-9]+\.[0-9]+\.[0-9]+'/LATEST_VERSION = 'v$version'/" "$version_file"
+    sed -i.bak -E "s/LATEST_VERSION = 'v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?'/LATEST_VERSION = 'v$version'/" "$version_file"
     rm -f "$version_file.bak"
 }
 
@@ -180,6 +252,14 @@ update_changelog() {
     local version="$1"
     local changelog_file="$2"
     local current_version="$3"
+
+    # A pre-release leaves `## Unreleased` exactly where it is. Consuming it
+    # would hand the release candidate the notes the final release is meant to
+    # ship with, and there is no way back short of editing the file by hand.
+    if is_prerelease "$version"; then
+        return 0
+    fi
+
     local current_date
     current_date=$(date +%Y-%m-%d)
 
@@ -396,7 +476,13 @@ create_github_release() {
     local unreleased_content="${8:-}"
 
     local release_notes
-    release_notes=$(extract_release_notes "$version" "$changelog_file")
+    if is_prerelease "$version"; then
+        # No version heading exists for a pre-release, because the changelog
+        # was left untouched: its notes are `## Unreleased` as it stands.
+        release_notes=$(format_release_notes "$unreleased_content")
+    else
+        release_notes=$(extract_release_notes "$version" "$changelog_file")
+    fi
     [[ -z "$release_notes" ]] && release_notes="Release v$version"
 
     # Generate TL;DR if Claude is available and we have unreleased content
@@ -431,6 +517,10 @@ $contributors
 
     # Tag uses v prefix, title does not
     local gh_cmd="gh release create v$version --repo $REPO_NAME --title \"$title\" --notes-file -"
+    if is_prerelease "$version"; then
+        gh_cmd="$gh_cmd --prerelease"
+    fi
+
     if [[ "$skip_phar" -eq 0 ]] && [[ -f "$phar_output" ]]; then
         gh_cmd="$gh_cmd \"$phar_output\""
     fi
@@ -455,7 +545,10 @@ USAGE:
     release.sh [OPTIONS] [VERSION]
 
 ARGUMENTS:
-    VERSION         Semantic version number (e.g., 0.29.0)
+    VERSION         Semantic version number (e.g., 0.29.0), optionally with a
+                    pre-release suffix (e.g., 1.0.0-rc1). A pre-release leaves
+                    ## Unreleased in the changelog and is published to GitHub
+                    as a pre-release.
                     If omitted, auto-increments minor version from latest tag
 
 OPTIONS:

--- a/tools/release-test.sh
+++ b/tools/release-test.sh
@@ -539,6 +539,33 @@ function test_update_agents_version_creates_file() {
     assert_equals "0.29.0" "$(cat "$agents_version_file")"
 }
 
+function test_build_release_notes_body_reads_unreleased_for_a_prerelease() {
+    local changelog_file="$TEMP_DIR/CHANGELOG.md"
+    cat > "$changelog_file" << 'EOF'
+# Changelog
+
+## Unreleased
+
+### Added
+- New feature
+EOF
+
+    local result
+    result=$(build_release_notes_body "1.0.0-rc1" "$changelog_file" "### Added
+- New feature")
+
+    assert_same "## 🎉 Added
+- New feature" "$result"
+}
+
+function test_build_release_notes_body_falls_back_when_empty() {
+    local changelog_file="$TEMP_DIR/CHANGELOG.md"
+    printf '# Changelog
+' > "$changelog_file"
+
+    assert_same "Release v1.0.0-rc1" "$(build_release_notes_body '1.0.0-rc1' "$changelog_file" '')"
+}
+
 function test_update_changelog_leaves_unreleased_for_a_prerelease() {
     local changelog_file="$TEMP_DIR/CHANGELOG.md"
     cat > "$changelog_file" << 'EOF'

--- a/tools/release-test.sh
+++ b/tools/release-test.sh
@@ -72,6 +72,70 @@ function test_validate_semver_invalid_empty() {
 # Version Comparison Tests
 # =============================================================================
 
+function test_validate_semver_valid_prerelease() {
+    assert_successful_code "validate_semver '1.0.0-rc1'"
+}
+
+function test_validate_semver_valid_prerelease_dotted() {
+    assert_successful_code "validate_semver '1.0.0-rc.2'"
+}
+
+function test_validate_semver_invalid_empty_prerelease() {
+    local result=0
+    validate_semver '1.0.0-' || result=$?
+    assert_equals "1" "$result"
+}
+
+function test_validate_semver_invalid_build_metadata() {
+    local result=0
+    validate_semver '1.0.0+build.1' || result=$?
+    assert_equals "1" "$result"
+}
+
+function test_is_prerelease_true() {
+    assert_successful_code "is_prerelease '1.0.0-rc1'"
+}
+
+function test_is_prerelease_false() {
+    local result=0
+    is_prerelease '1.0.0' || result=$?
+    assert_equals "1" "$result"
+}
+
+function test_version_core_strips_the_suffix() {
+    assert_equals "1.0.0" "$(version_core '1.0.0-rc1')"
+}
+
+function test_version_prerelease_is_empty_for_a_release() {
+    assert_equals "" "$(version_prerelease '1.0.0')"
+}
+
+function test_version_gt_prerelease_beats_older_release() {
+    assert_successful_code "version_gt '1.0.0-rc1' '0.50.0'"
+}
+
+function test_version_gt_release_beats_its_own_prerelease() {
+    assert_successful_code "version_gt '1.0.0' '1.0.0-rc1'"
+}
+
+function test_version_gt_prerelease_does_not_beat_its_release() {
+    local result=0
+    version_gt '1.0.0-rc1' '1.0.0' || result=$?
+    assert_equals "1" "$result"
+}
+
+function test_version_gt_later_rc_beats_earlier_rc() {
+    assert_successful_code "version_gt '1.0.0-rc2' '1.0.0-rc1'"
+}
+
+function test_version_gt_numeric_prerelease_compares_numerically() {
+    assert_successful_code "version_gt '1.0.0-rc.10' '1.0.0-rc.9'"
+}
+
+function test_version_gt_longer_prerelease_outranks_its_prefix() {
+    assert_successful_code "version_gt '1.0.0-rc.1' '1.0.0-rc'"
+}
+
 function test_version_gt_greater() {
     assert_successful_code "version_gt '1.1.0' '1.0.0'"
 }
@@ -234,6 +298,34 @@ EOF
     local result
     result=$(get_current_version "$version_file")
     assert_equals "1.2.3" "$result"
+}
+
+function test_get_current_version_reads_back_a_prerelease() {
+    local version_file="$TEMP_DIR/VersionFinder.php"
+    cat > "$version_file" << 'EOF'
+<?php
+final class VersionFinder {
+    public const string LATEST_VERSION = 'v1.0.0-rc1';
+}
+EOF
+
+    local result
+    result=$(get_current_version "$version_file")
+    assert_equals "1.0.0-rc1" "$result"
+}
+
+function test_update_version_finder_replaces_a_prerelease() {
+    local version_file="$TEMP_DIR/VersionFinder.php"
+    cat > "$version_file" << 'EOF'
+<?php
+final class VersionFinder {
+    public const string LATEST_VERSION = 'v1.0.0-rc1';
+}
+EOF
+
+    update_version_finder "1.0.0" "$version_file"
+
+    assert_equals "1.0.0" "$(get_current_version "$version_file")"
 }
 
 function test_get_current_version_missing_file() {
@@ -445,6 +537,29 @@ function test_update_agents_version_creates_file() {
 
     assert_file_exists "$agents_version_file"
     assert_equals "0.29.0" "$(cat "$agents_version_file")"
+}
+
+function test_update_changelog_leaves_unreleased_for_a_prerelease() {
+    local changelog_file="$TEMP_DIR/CHANGELOG.md"
+    cat > "$changelog_file" << 'EOF'
+# Changelog
+
+## Unreleased
+
+### Added
+- New feature
+
+## [0.50.0](https://github.com/phel-lang/phel-lang/compare/v0.49.0...v0.50.0) - 2026-08-14
+
+### Fixed
+- Old fix
+EOF
+    local before
+    before=$(cat "$changelog_file")
+
+    update_changelog "1.0.0-rc1" "$changelog_file" "0.50.0"
+
+    assert_equals "$before" "$(cat "$changelog_file")"
 }
 
 function test_update_changelog() {

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -270,11 +270,7 @@ main() {
         fi
 
         local notes
-        if is_prerelease "$NEW_VERSION"; then
-            notes=$(format_release_notes "$unreleased_content")
-        else
-            notes=$(extract_release_notes "$NEW_VERSION" "$CHANGELOG_FILE" 2>/dev/null || echo "Release v$NEW_VERSION")
-        fi
+        notes=$(build_release_notes_body "$NEW_VERSION" "$CHANGELOG_FILE" "$unreleased_content")
         local contributors
         contributors=$(get_contributors "$current_version" "$REPO_ROOT")
 

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -139,10 +139,14 @@ main() {
     # Validate version
     log "${BOLD}Validating version${NC}"
     if ! validate_semver "$NEW_VERSION"; then
-        log_err "Invalid version format: $NEW_VERSION (expected X.Y.Z)"
+        log_err "Invalid version format: $NEW_VERSION (expected X.Y.Z or X.Y.Z-rc1)"
         exit 1
     fi
-    log_ok "Version format valid: $NEW_VERSION"
+    if is_prerelease "$NEW_VERSION"; then
+        log_ok "Version format valid: $NEW_VERSION (pre-release)"
+    else
+        log_ok "Version format valid: $NEW_VERSION"
+    fi
 
     # Get current version
     local current_version
@@ -186,13 +190,18 @@ main() {
     update_version_finder "$NEW_VERSION" "$VERSION_FILE"
     update_changelog "$NEW_VERSION" "$CHANGELOG_FILE" "$current_version"
     update_agents_version "$NEW_VERSION" "$AGENTS_VERSION_FILE"
+    local changelog_note="Updated CHANGELOG.md"
+    if is_prerelease "$NEW_VERSION"; then
+        changelog_note="Left CHANGELOG.md untouched (pre-release keeps ## Unreleased)"
+    fi
+
     if [[ $DRY_RUN -eq 1 ]]; then
         log "[DRY-RUN] Updated VersionFinder.php to v$NEW_VERSION"
-        log "[DRY-RUN] Updated CHANGELOG.md"
+        log "[DRY-RUN] $changelog_note"
         log "[DRY-RUN] Updated resources/agents/VERSION to $NEW_VERSION"
     else
         log_ok "Updated VersionFinder.php"
-        log_ok "Updated CHANGELOG.md"
+        log_ok "$changelog_note"
         log_ok "Updated resources/agents/VERSION"
     fi
 
@@ -247,7 +256,11 @@ main() {
     if [[ $DRY_RUN -eq 1 ]]; then
         local title="$NEW_VERSION"
         [[ -n "$RELEASE_NAME" ]] && title="$NEW_VERSION - $RELEASE_NAME"
-        log "[DRY-RUN] Would: create GitHub release \"$title\" (tag: v$NEW_VERSION)"
+        if is_prerelease "$NEW_VERSION"; then
+            log "[DRY-RUN] Would: create GitHub pre-release \"$title\" (tag: v$NEW_VERSION)"
+        else
+            log "[DRY-RUN] Would: create GitHub release \"$title\" (tag: v$NEW_VERSION)"
+        fi
 
         # Generate TL;DR if Claude is available (using pre-captured unreleased_content)
         local tldr=""
@@ -257,7 +270,11 @@ main() {
         fi
 
         local notes
-        notes=$(extract_release_notes "$NEW_VERSION" "$CHANGELOG_FILE" 2>/dev/null || echo "Release v$NEW_VERSION")
+        if is_prerelease "$NEW_VERSION"; then
+            notes=$(format_release_notes "$unreleased_content")
+        else
+            notes=$(extract_release_notes "$NEW_VERSION" "$CHANGELOG_FILE" 2>/dev/null || echo "Release v$NEW_VERSION")
+        fi
         local contributors
         contributors=$(get_contributors "$current_version" "$REPO_ROOT")
 


### PR DESCRIPTION
## 🤔 Background

Step 4 of the road to 1.0 (#2859) is "cut the 1.0 release candidate, run the full release checklist, and only then cut `1.0.0`". The tooling could not do it: `validate_semver` was `^[0-9]+\.[0-9]+\.[0-9]+$`, so `tools/release.sh 1.0.0-rc1` failed on the first check.

That matters because `.claude/rules/releases.md` says a release is **never** hand-rolled, and lists exactly what hand-rolling misses: `resources/agents/VERSION`, the changelog move, the PHAR build, the QA smoke test, the GitHub release.

Closes #3253

## 💡 Goal

Let the script cut a release candidate, and make a pre-release differ from a release in exactly the ways it should.

## 🔖 Changes

A pre-release differs in three ways and only three:

- **`## Unreleased` is left where it is.** Consuming it would hand the candidate the notes the final release is meant to ship with, recoverable only by editing the changelog by hand.
- **The notes come from that section as it stands**, since there is no version heading to read.
- **The GitHub release is published with `--prerelease`.**

`version_gt` now follows semver 11.3 and 11.4: a release outranks its own pre-releases, numeric identifiers compare numerically, and a longer identifier list outranks a shorter prefix of itself. So `1.0.0-rc1 > 0.50.0`, `1.0.0 > 1.0.0-rc1`, `1.0.0-rc2 > 1.0.0-rc1`, and `1.0.0-rc.10 > 1.0.0-rc.9`.

Build metadata (`1.0.0+build.1`) is deliberately still rejected: nothing here produces it, and a tag carrying one would not round-trip through `git tag -l`.

## Two functions that would have broken one step later

Found by reading rather than by the failing check: `get_current_version` and `update_version_finder` both hard-coded `v[0-9]+\.[0-9]+\.[0-9]+`. Once `VersionFinder` held `v1.0.0-rc1`, the first could not read it back (returning empty) and the second could not rewrite it. The candidate would have been cut successfully and the **next** run would have failed to find a current version, which is the worst moment to discover it. Both are widened, with a round-trip test.

## Refactor pass

The first draft left the same "unreleased or version heading" conditional in the dry-run preview and in the real publish, so the preview could drift from what actually ships. `build_release_notes_body` now owns that decision, including the fallback, and both callers read from it.

## Tests

`tools/release-test.sh` grows from 55 to 74 tests: the ordering rules, both `is_prerelease` directions, `version_core` / `version_prerelease`, the untouched changelog, the `VersionFinder` round-trip, and the shared notes builder. Full suite green, and `composer test-all` green (cs-fixer, psalm, phpstan, rector, 4873 unit, 1290 integration, 10090 core).
