### PR TITLE
docs(release): name the release-time steps no tooling performs

### DIFF
--- a/.agnostic-ai/rules/releases.md
+++ b/.agnostic-ai/rules/releases.md
@@ -19,4 +19,15 @@ Hand-rolling misses steps (`resources/agents/VERSION`), uses the wrong commit me
 - Name is short (1-3 words), content-themed: `--name "Life, PHP & Everything"`. Omit for AI-suggested names.
 - **`--dry-run` first** — previews everything, restores files, no side effects.
 - The real run pushes to `main` and publishes a public release: outward + irreversible. Get explicit human go first.
+- A pre-release version (`1.0.0-rc1`) is accepted: the script leaves `## Unreleased` in place and publishes to GitHub as a pre-release.
 - Full guide: `.github/RELEASE.md`.
+
+## What the script does NOT do at a major
+
+Two normative documents describe the pre-1.0 world and no tooling updates them.
+Before tagging `X.0.0`, do both by hand:
+
+- `docs/stability.md`: delete the paragraph marked `RELEASE-STEP(1.0.0)`. Until then the page reads as a *target*; from the major it is in force.
+- `docs/migration/upgrade-0.49-to-1.0.md`: check the range it claims to cover still matches the releases that exist.
+
+Grep for `RELEASE-STEP(` to find every marker.

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -54,7 +54,8 @@ Before releasing, ensure you have:
 
 ### What the Script Does
 
-1. Validates version format (X.Y.Z) and ensures new > current
+1. Validates version format (`X.Y.Z`, or `X.Y.Z-rc1` for a pre-release) and
+   ensures new > current
 2. Runs pre-flight checks (gh CLI, on `main`, in sync with `origin/main`, clean
    tree, `## Unreleased` still populated, tag absent, network)
 3. Updates `LATEST_VERSION` in [VersionFinder.php](../src/php/Shared/VersionFinder.php)
@@ -68,6 +69,24 @@ Before releasing, ensure you have:
 9. Pushes commit and tag to `main`
 10. Creates the GitHub release with notes, contributors and the PHAR attached,
     which fires `announce-release.yml`
+
+A pre-release (`tools/release.sh 1.0.0-rc1`) differs in three ways: step 4 is
+skipped so `## Unreleased` stays where it is, the notes come from that section
+as it stands, and step 10 publishes with `--prerelease`.
+
+---
+
+## What the script does not do at a major
+
+Two normative documents describe the pre-1.0 world, and no tooling updates them.
+Before tagging `X.0.0`, do both by hand:
+
+| Document | Step |
+|---|---|
+| [docs/stability.md](../docs/stability.md) | Delete the paragraph marked `RELEASE-STEP(1.0.0)`. Until the major it reads as a *target*; from the major the promises are in force. |
+| [docs/migration/upgrade-0.49-to-1.0.md](../docs/migration/upgrade-0.49-to-1.0.md) | Check the release range it claims to cover still matches the releases that exist. |
+
+`grep -rn 'RELEASE-STEP(' docs/` finds every marker.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Document the two release-time documentation steps no tooling performs, and mark the paragraph in the stability policy that flips at a major. (#3254)
 - `Registry::addDefinition()` also accepts a `Closure` returning the metadata map. Widening a parameter is not breaking, and the eager form still works, so an artifact compiled earlier stays loadable.
 - Resolve bare all-caps PHP names by position instead of autoload state. See [ADR 0016](docs/adr/0016-a-bare-all-caps-host-name-reads-by-position.md). (#3064)
 - Expose compiler environment and deprecation controls through `CompilerFacadeInterface`. (#3048)

--- a/docs/migration/upgrade-0.49-to-1.0.md
+++ b/docs/migration/upgrade-0.49-to-1.0.md
@@ -1,4 +1,8 @@
-# Upgrading from 0.49 to 1.0
+# Upgrading to 1.0
+
+Applies to any `0.49` or later release. The filename says `0.49` because that is
+where the deprecation notices this guide walks you through began; everything
+listed here also holds if you are on `0.50` or on the last minor before `1.0`.
 
 `1.0.0` is a stability commitment, not a feature release: what arrives is a
 promise that what exists stops moving. See

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -3,6 +3,7 @@
 **Normative.** What a Phel version number promises, which symbols it covers, and
 how those are allowed to change.
 
+<!-- RELEASE-STEP(1.0.0): delete the paragraph below; from 1.0.0 these promises are in force, not a target. -->
 Until `1.0.0` ships this describes the *target*: what `1.x` will guarantee, with
 the enforceable parts already gated in CI. `0.x` remains free to break, and the
 changelog marks every such change **BREAKING**.


### PR DESCRIPTION
## 🤔 Background

Two normative documents describe the pre-1.0 world, and no tooling updates them when a tag is cut.

`docs/stability.md` opens with "Until `1.0.0` ships this describes the *target*", which stops being true the moment 1.0.0 ships — on the page whose whole job is to say what the version number promises. The migration guide is titled for an upgrade from 0.49, while the release will come from 0.50 or later, and nothing in `docs/` mentions 0.50 at all.

`tools/release.sh` updates `VersionFinder.php`, `CHANGELOG.md` and `resources/agents/VERSION`. Neither of these files was on any checklist, so both depended on somebody remembering at the moment there is most else to remember.

Closes #3254

## 💡 Goal

Make the two manual steps findable and written down, rather than remembered.

## 🔖 Changes

- **`docs/stability.md`** carries a `RELEASE-STEP(1.0.0)` marker on the paragraph that has to go at the major. The paragraph itself is unchanged and still true today.
- **`.github/RELEASE.md`** gains a "What the script does not do at a major" table naming both steps, and its "What the Script Does" list now covers the pre-release variant.
- **The releases rule** (`.agnostic-ai/rules/releases.md`, the tracked source the `.claude/` and `.codex/` copies are generated from) says the same, so an agent cutting a release reads it too.
- **The migration guide** states the range it covers: any 0.49 or later release.

`grep -rn 'RELEASE-STEP(' docs/` finds every marker, so the pattern extends to the next major without a new checklist.

## Why the guide keeps its filename

Renaming it to something version-neutral was the obvious move and is wrong: seven documents link to it, two of them are **accepted ADRs** (0014 and 0015), and `.agnostic-ai/rules/architecture-decisions.md` says accepted ADRs are immutable and must be superseded rather than edited. A rename would either break those links or require editing records that are not allowed to change. The heading and an explicit scope line carry the information instead.

## Verification

`composer test-all` green (cs-fixer, psalm, phpstan, rector, 4873 unit, 1290 integration, 10090 core) and `tools/validate-agents.sh` passes, which is what covers the `.agnostic-ai/` edit.

No code changed, so the mandatory refactor pass found nothing to do beyond the wording already reviewed here.
