### PR TITLE
fix(repl): accept (exit) and (quit), and say so in the banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- REPL: `(exit)` and `(quit)` end the session, as `exit` and `quit` already did, and the banner names the call form. `(exit <code>)` sets the process status. (#3272)
+- REPL: `(exit)` and `(quit)` end the session like `exit` and `quit`, `(exit <code>)` sets the exit status, and the banner names the call form. (#3272)
 
 ## [0.51.0](https://github.com/phel-lang/phel-lang/compare/v0.50.0...v0.51.0) - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- REPL: `(exit)` and `(quit)` end the session, as `exit` and `quit` already did, and the banner names the call form. `(exit <code>)` sets the process status. (#3272)
+
 ## [0.51.0](https://github.com/phel-lang/phel-lang/compare/v0.50.0...v0.51.0) - 2026-09-05
 
 ### Added

--- a/src/php/Run/Domain/Repl/ExitException.php
+++ b/src/php/Run/Domain/Repl/ExitException.php
@@ -23,9 +23,6 @@ final class ExitException extends RuntimeException
         return new self('Exit from REPL!', $status);
     }
 
-    /**
-     * The status the process should leave with, so `(exit 2)` can mean 2.
-     */
     public function status(): int
     {
         return $this->status;

--- a/src/php/Run/Domain/Repl/ExitException.php
+++ b/src/php/Run/Domain/Repl/ExitException.php
@@ -11,8 +11,23 @@ use RuntimeException;
  */
 final class ExitException extends RuntimeException
 {
-    public static function fromRepl(): self
+    private function __construct(
+        string $message,
+        private readonly int $status,
+    ) {
+        parent::__construct($message);
+    }
+
+    public static function fromRepl(int $status = 0): self
     {
-        return new self('Exit from REPL!');
+        return new self('Exit from REPL!', $status);
+    }
+
+    /**
+     * The status the process should leave with, so `(exit 2)` can mean 2.
+     */
+    public function status(): int
+    {
+        return $this->status;
     }
 }

--- a/src/php/Run/Infrastructure/Command/ReplCommand.php
+++ b/src/php/Run/Infrastructure/Command/ReplCommand.php
@@ -54,19 +54,8 @@ final class ReplCommand extends Command
 
     private const string EXIT_REPL = 'exit';
 
-    /**
-     * The forms that end the session.
-     *
-     * The banner tells the user to type `(exit)`, and a Lisp user reaches for
-     * the call form whatever the banner says, so both `exit`/`quit` and
-     * `(exit)`/`(quit)` are accepted. `(exit 2)` carries its argument out as
-     * the process status, which is the only thing the call form can do that
-     * the bare word cannot.
-     *
-     * This lives at the REPL command layer on purpose: `exit` is not a
-     * definition in `phel\core`, and `docs/spec/language-surface.md` freezes
-     * that surface for 1.x.
-     */
+    // Matched here rather than defined in phel\core: the surface frozen by
+    // docs/spec/language-surface.md has no `exit`. `(exit 2)` exits with status 2.
     private const string EXIT_PATTERN = '/^(?:exit|quit|\(\s*(?:exit|quit)(?:\s+(\d+))?\s*\))$/';
 
     private InputResult $previousResult;

--- a/src/php/Run/Infrastructure/Command/ReplCommand.php
+++ b/src/php/Run/Infrastructure/Command/ReplCommand.php
@@ -54,6 +54,21 @@ final class ReplCommand extends Command
 
     private const string EXIT_REPL = 'exit';
 
+    /**
+     * The forms that end the session.
+     *
+     * The banner tells the user to type `(exit)`, and a Lisp user reaches for
+     * the call form whatever the banner says, so both `exit`/`quit` and
+     * `(exit)`/`(quit)` are accepted. `(exit 2)` carries its argument out as
+     * the process status, which is the only thing the call form can do that
+     * the bare word cannot.
+     *
+     * This lives at the REPL command layer on purpose: `exit` is not a
+     * definition in `phel\core`, and `docs/spec/language-surface.md` freezes
+     * that surface for 1.x.
+     */
+    private const string EXIT_PATTERN = '/^(?:exit|quit|\(\s*(?:exit|quit)(?:\s+(\d+))?\s*\))$/';
+
     private InputResult $previousResult;
 
     private readonly ReplCommandIoInterface $io;
@@ -118,7 +133,7 @@ HELP);
             sprintf('Welcome to the Phel Repl (%s)', $this->getFacade()->getVersion()),
         ));
 
-        $this->io->writeln('Type "exit" or press Ctrl-D to exit.');
+        $this->io->writeln('Type (exit) or press Ctrl-D to exit.');
 
         try {
             Phel::setupRuntimeArgs('repl', []);
@@ -132,9 +147,9 @@ HELP);
             $this->history = $history;
             $history->register();
 
-            $this->loopReadLineAndAnalyze();
+            $status = $this->loopReadLineAndAnalyze();
 
-            return self::SUCCESS;
+            return $status;
         } catch (Throwable $throwable) {
             $this->io->writeStackTrace($throwable);
             return self::FAILURE;
@@ -164,14 +179,17 @@ HELP);
         $this->getFacade()->eval('(add-tap phel.repl/print-tap)', new CompileOptions());
     }
 
-    private function loopReadLineAndAnalyze(): void
+    private function loopReadLineAndAnalyze(): int
     {
+        $status = self::SUCCESS;
+
         while (true) {
             try {
                 $this->addLineFromPromptToBuffer();
                 $this->checkExitInputBuffer();
                 $this->analyzeInputBuffer();
-            } catch (ExitException) {
+            } catch (ExitException $exitException) {
+                $status = $exitException->status();
                 break;
             } catch (Throwable $e) {
                 $this->inputBuffer = [];
@@ -180,6 +198,8 @@ HELP);
         }
 
         $this->io->writeln($this->style->yellow('Bye!'));
+
+        return $status;
     }
 
     private function addLineFromPromptToBuffer(): void
@@ -217,10 +237,10 @@ HELP);
      */
     private function checkExitInputBuffer(): void
     {
-        $firstInput = $this->inputBuffer[0] ?? '';
+        $firstInput = trim($this->inputBuffer[0] ?? '');
 
-        if ($firstInput === self::EXIT_REPL) {
-            throw ExitException::fromRepl();
+        if (preg_match(self::EXIT_PATTERN, $firstInput, $matches) === 1) {
+            throw ExitException::fromRepl(isset($matches[1]) ? (int) $matches[1] : 0);
         }
     }
 

--- a/src/php/Run/Infrastructure/Command/ReplCommand.php
+++ b/src/php/Run/Infrastructure/Command/ReplCommand.php
@@ -147,9 +147,7 @@ HELP);
             $this->history = $history;
             $history->register();
 
-            $status = $this->loopReadLineAndAnalyze();
-
-            return $status;
+            return $this->loopReadLineAndAnalyze();
         } catch (Throwable $throwable) {
             $this->io->writeStackTrace($throwable);
             return self::FAILURE;

--- a/tests/php/Integration/Run/Command/Repl/ReplExitTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplExitTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Run\Command\Repl;
+
+use Phel\Run\Infrastructure\Command\ReplCommand;
+use PhelTest\Integration\Run\Command\AbstractTestCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function str_contains;
+
+/**
+ * The banner tells the user how to leave, and a Lisp user reaches for the call
+ * form whatever the banner says. Both have to work, and the banner has to name
+ * a form the session actually accepts.
+ */
+final class ReplExitTest extends AbstractTestCommand
+{
+    use ReplCommandTestTrait;
+
+    /**
+     * @return list<array{string}>
+     */
+    public static function provideEndsTheSession(): array
+    {
+        return [
+            ['exit'],
+            ['quit'],
+            ['(exit)'],
+            ['(quit)'],
+            ['  (exit)  '],
+            ['( exit )'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideEndsTheSession
+     */
+    public function test_ends_the_session_with_status_zero(string $input): void
+    {
+        $io = $this->createReplTestIo();
+        $io->setInputs(new InputLine('user:1> ', $input));
+
+        $this->prepareRunFactory($io);
+
+        $exitCode = new ReplCommand()->run(
+            $this->createStub(InputInterface::class),
+            $this->createStub(OutputInterface::class),
+        );
+
+        self::assertSame(0, $exitCode);
+        self::assertContains('Bye!', $io->getOutputLines());
+    }
+
+    public function test_exit_with_an_argument_becomes_the_status(): void
+    {
+        $io = $this->createReplTestIo();
+        $io->setInputs(new InputLine('user:1> ', '(exit 2)'));
+
+        $this->prepareRunFactory($io);
+
+        $exitCode = new ReplCommand()->run(
+            $this->createStub(InputInterface::class),
+            $this->createStub(OutputInterface::class),
+        );
+
+        self::assertSame(2, $exitCode);
+    }
+
+    public function test_the_banner_names_a_form_the_session_accepts(): void
+    {
+        $io = $this->createReplTestIo();
+        $io->setInputs(new InputLine('user:1> ', '(exit)'));
+
+        $this->prepareRunFactory($io);
+
+        new ReplCommand()->run(
+            $this->createStub(InputInterface::class),
+            $this->createStub(OutputInterface::class),
+        );
+
+        $banner = null;
+        foreach ($io->getOutputLines() as $line) {
+            if (str_contains($line, 'press Ctrl-D to exit')) {
+                $banner = $line;
+                break;
+            }
+        }
+
+        self::assertNotNull($banner, 'the repl printed no exit banner');
+        self::assertStringContainsString('(exit)', $banner);
+    }
+
+    /**
+     * @return list<array{string}>
+     */
+    public static function provideIsOrdinaryCode(): array
+    {
+        return [
+            // A symbol that merely starts with exit is not the command.
+            ['(exit-code)'],
+            ['exits'],
+            // The word inside a string or an argument list is not the command.
+            ['(println "exit")'],
+            ['(map exit xs)'],
+            // A call form the command does not define stays a normal form, so
+            // it fails as such rather than silently ending the session.
+            ['(exit x)'],
+            ['(exit 2 3)'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideIsOrdinaryCode
+     */
+    public function test_leaves_ordinary_code_alone(string $input): void
+    {
+        $io = $this->createReplTestIo();
+        $io->setInputs(
+            new InputLine('user:1> ', $input),
+            new InputLine('user:2> ', 'exit'),
+        );
+
+        $this->prepareRunFactory($io);
+
+        $exitCode = new ReplCommand()->run(
+            $this->createStub(InputInterface::class),
+            $this->createStub(OutputInterface::class),
+        );
+
+        // It reached the second line to leave, so the first did not end the
+        // session; whether it evaluated or errored is not this test's business.
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('user:2> exit', $io->getOutputString());
+    }
+}

--- a/tests/php/Integration/Run/Command/Repl/ReplExitTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplExitTest.php
@@ -13,11 +13,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function str_contains;
 
-/**
- * The banner tells the user how to leave, and a Lisp user reaches for the call
- * form whatever the banner says. Both have to work, and the banner has to name
- * a form the session actually accepts.
- */
 final class ReplExitTest extends AbstractTestCommand
 {
     use ReplCommandTestTrait;
@@ -94,14 +89,11 @@ final class ReplExitTest extends AbstractTestCommand
      */
     public static function provideIsOrdinaryCode(): Iterator
     {
-        // A symbol that merely starts with exit is not the command.
         yield ['(exit-code)'];
         yield ['exits'];
-        // The word inside a string or an argument list is not the command.
         yield ['(println "exit")'];
         yield ['(map exit xs)'];
-        // A call form the command does not define stays a normal form, so
-        // it fails as such rather than silently ending the session.
+        // Unrecognised arguments stay a form, so they fail as one instead of ending the session.
         yield ['(exit x)'];
         yield ['(exit 2 3)'];
     }
@@ -122,8 +114,7 @@ final class ReplExitTest extends AbstractTestCommand
             $this->createStub(OutputInterface::class),
         );
 
-        // It reached the second line to leave, so the first did not end the
-        // session; whether it evaluated or errored is not this test's business.
+        // Reaching the second prompt proves the first line did not end the session.
         self::assertSame(0, $exitCode);
         self::assertStringContainsString('user:2> exit', $io->getOutputString());
     }

--- a/tests/php/Integration/Run/Command/Repl/ReplExitTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplExitTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Run\Command\Repl;
 
+use Iterator;
 use Phel\Run\Infrastructure\Command\ReplCommand;
 use PhelTest\Integration\Run\Command\AbstractTestCommand;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -21,23 +23,19 @@ final class ReplExitTest extends AbstractTestCommand
     use ReplCommandTestTrait;
 
     /**
-     * @return list<array{string}>
+     * @return Iterator<int<0, max>, array{string}>
      */
-    public static function provideEndsTheSession(): array
+    public static function provideEndsTheSession(): Iterator
     {
-        return [
-            ['exit'],
-            ['quit'],
-            ['(exit)'],
-            ['(quit)'],
-            ['  (exit)  '],
-            ['( exit )'],
-        ];
+        yield ['exit'];
+        yield ['quit'];
+        yield ['(exit)'];
+        yield ['(quit)'];
+        yield ['  (exit)  '];
+        yield ['( exit )'];
     }
 
-    /**
-     * @dataProvider provideEndsTheSession
-     */
+    #[DataProvider('provideEndsTheSession')]
     public function test_ends_the_session_with_status_zero(string $input): void
     {
         $io = $this->createReplTestIo();
@@ -67,6 +65,7 @@ final class ReplExitTest extends AbstractTestCommand
         );
 
         self::assertSame(2, $exitCode);
+        self::assertContains('Bye!', $io->getOutputLines());
     }
 
     public function test_the_banner_names_a_form_the_session_accepts(): void
@@ -81,40 +80,33 @@ final class ReplExitTest extends AbstractTestCommand
             $this->createStub(OutputInterface::class),
         );
 
-        $banner = null;
-        foreach ($io->getOutputLines() as $line) {
-            if (str_contains($line, 'press Ctrl-D to exit')) {
-                $banner = $line;
-                break;
-            }
-        }
+        $banner = array_find(
+            $io->getOutputLines(),
+            static fn(string $line): bool => str_contains($line, 'press Ctrl-D to exit'),
+        );
 
         self::assertNotNull($banner, 'the repl printed no exit banner');
         self::assertStringContainsString('(exit)', $banner);
     }
 
     /**
-     * @return list<array{string}>
+     * @return Iterator<int<0, max>, array{string}>
      */
-    public static function provideIsOrdinaryCode(): array
+    public static function provideIsOrdinaryCode(): Iterator
     {
-        return [
-            // A symbol that merely starts with exit is not the command.
-            ['(exit-code)'],
-            ['exits'],
-            // The word inside a string or an argument list is not the command.
-            ['(println "exit")'],
-            ['(map exit xs)'],
-            // A call form the command does not define stays a normal form, so
-            // it fails as such rather than silently ending the session.
-            ['(exit x)'],
-            ['(exit 2 3)'],
-        ];
+        // A symbol that merely starts with exit is not the command.
+        yield ['(exit-code)'];
+        yield ['exits'];
+        // The word inside a string or an argument list is not the command.
+        yield ['(println "exit")'];
+        yield ['(map exit xs)'];
+        // A call form the command does not define stays a normal form, so
+        // it fails as such rather than silently ending the session.
+        yield ['(exit x)'];
+        yield ['(exit 2 3)'];
     }
 
-    /**
-     * @dataProvider provideIsOrdinaryCode
-     */
+    #[DataProvider('provideIsOrdinaryCode')]
     public function test_leaves_ordinary_code_alone(string $input): void
     {
         $io = $this->createReplTestIo();


### PR DESCRIPTION
Fixes #3272.

Takes the proposal as written: handled at the REPL command layer, not as a definition, so `exit` stays out of `phel\core` and `docs/spec/language-surface.md` keeps the surface it freezes for 1.x.

```
Welcome to the Phel Repl (v0.51.0)
Type (exit) or press Ctrl-D to exit.
```

`exit`, `quit`, `(exit)` and `(quit)` all end the session. `(exit <code>)` was the optional part and I took it, because it is the only thing the call form can do that the bare word cannot — `ExitException` carries the status, `loopReadLineAndAnalyze()` returns it, and `execute()` returns that instead of a fixed `self::SUCCESS`.

## Matching exactly, and not more

The risk in a change like this is swallowing code that merely mentions `exit`. The match is anchored and the pattern is the whole of the logic:

```php
private const string EXIT_PATTERN = '/^(?:exit|quit|\(\s*(?:exit|quit)(?:\s+(\d+))?\s*\))$/';
```

Run against every shape I could think of:

```
input                  result
---------------------------------------------
'exit'                 EXIT status 0
'quit'                 EXIT status 0
'(exit)'               EXIT status 0
'(quit)'               EXIT status 0
'  (exit)  '           EXIT status 0
'( exit )'             EXIT status 0
'(exit 2)'             EXIT status 2
'(exit  7 )'           EXIT status 7
'(quit 1)'             EXIT status 1
'(exit-code)'          evaluate
'exits'                evaluate
'(println "exit")'     evaluate
'(exit x)'             evaluate
'(exit 2 3)'           evaluate
'exit 2'               evaluate
'(exitquit)'           evaluate
'(map exit xs)'        evaluate
''                     evaluate
'(+ 1 2)'              evaluate
```

`(exit x)` and `(exit 2 3)` staying ordinary code is deliberate: the command understands one optional integer, and a form it does not understand should fail as a form rather than quietly end the session on an argument it ignored.

## Tests

`tests/php/Integration/Run/Command/Repl/ReplExitTest.php`, covering the three acceptance criteria and one more:

- all four spellings, plus whitespace variants, end the session with status 0 and print `Bye!`
- `(exit 2)` exits with status 2
- the banner names a form the session accepts — it looks the banner up in the transcript and asserts `(exit)` appears in it, so the two cannot drift apart again
- the six near-misses above reach a second prompt instead of ending the session

They follow `ReplBareStdClassTest` and use the existing `ReplCommandTestTrait` / `ReplTestIo` wiring.

## Verification gap, stated plainly

**I could not run the suite.** `composer.json` requires PHP `>= 8.4` and the code uses `new Foo()->bar()`, which is 8.4 syntax; this machine has 8.3.6, where `php -l` fails on `ReplCommand.php` *on unmodified `main`* as well. So the tests are for CI to run.

What I did verify locally is the part I actually wrote: the table above comes from extracting `EXIT_PATTERN` out of the committed file with a regex and running the same `trim()` + `preg_match()` the command runs, so it is the shipped pattern being tested, not a retyped copy of it.

## Also changed

`CHANGELOG.md` gains an entry under Unreleased → Fixed.

## Note

This PR was written with AI assistance. I understand the change and can defend or revise it.
