### PR TITLE
fix(parser): point a missing closer at the line it was opened on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - REPL: `(exit)` and `(quit)` end the session like `exit` and `quit`, `(exit <code>)` sets the exit status, and the banner names the call form. (#3272)
+- Parser: an unterminated list, vector, map, set or string now names the line it was opened on, carries an error code, and puts the caret on the opening delimiter. (#3259)
 
 ## [0.51.0](https://github.com/phel-lang/phel-lang/compare/v0.50.0...v0.51.0) - 2026-09-05
 

--- a/src/php/Compiler/Application/Parser.php
+++ b/src/php/Compiler/Application/Parser.php
@@ -16,7 +16,9 @@ use Phel\Compiler\Domain\Parser\ExpressionParser\MetaParser;
 use Phel\Compiler\Domain\Parser\ExpressionParser\QuoteParser;
 use Phel\Compiler\Domain\Parser\ExpressionParser\ReaderConditionalParser;
 use Phel\Compiler\Domain\Parser\ExpressionParserFactoryInterface;
+use Phel\Compiler\Domain\Parser\OpenForm;
 use Phel\Compiler\Domain\Parser\ParserInterface;
+use Phel\Shared\Exceptions\ErrorCode;
 use Phel\Shared\Parser\Node\AbstractAtomNode;
 use Phel\Shared\Parser\Node\CommaNode;
 use Phel\Shared\Parser\Node\CommentMacroNode;
@@ -37,6 +39,9 @@ use Phel\Shared\Parser\Node\WhitespaceNode;
 
 use SplStack;
 use Throwable;
+
+use function sprintf;
+use function str_starts_with;
 
 /**
  * @internal
@@ -64,6 +69,16 @@ final readonly class Parser implements ParserInterface
     private SplStack $quasiquoteStack;
 
     /**
+     * The delimiters of the forms currently being read, innermost last. A
+     * missing closer surfaces somewhere else entirely (at the end of the file,
+     * or at the wrong closer), and only this tells the report which line was
+     * left open and which bracket is owed.
+     *
+     * @var SplStack<Token>
+     */
+    private SplStack $openForms;
+
+    /**
      * The `Parser`-dependent sub-parsers each close over this `Parser`
      * (or its fixed `$globalEnvironment`), both constant for the parser's
      * lifetime, so they are built once here instead of being allocated
@@ -85,6 +100,7 @@ final readonly class Parser implements ParserInterface
         GlobalEnvironmentInterface $globalEnvironment,
     ) {
         $this->quasiquoteStack = new SplStack();
+        $this->openForms = new SplStack();
         $this->atomParser = $parserFactory->createAtomParser($globalEnvironment);
         $this->listParser = $parserFactory->createListParser($this);
         $this->quoteParser = $parserFactory->createQuoteParser($this);
@@ -183,13 +199,13 @@ final readonly class Parser implements ParserInterface
                 Token::T_CHAR => $this->parseCharNode($token),
                 Token::T_REGEX => $this->parseRegexNode($token),
                 Token::T_HASH_FN,
-                Token::T_OPEN_PARENTHESIS => $this->parseFnListNode($token, $tokenStream),
-                Token::T_OPEN_BRACKET => $this->parseArrayListNode($token, $tokenStream),
-                Token::T_OPEN_BRACE => $this->parseMapListNode($token, $tokenStream),
-                Token::T_HASH_OPEN_BRACE => $this->parseSetListNode($token, $tokenStream),
+                Token::T_OPEN_PARENTHESIS => $this->parseListNode($token, $tokenStream, Token::T_CLOSE_PARENTHESIS),
+                Token::T_OPEN_BRACKET => $this->parseListNode($token, $tokenStream, Token::T_CLOSE_BRACKET),
+                Token::T_OPEN_BRACE,
+                Token::T_HASH_OPEN_BRACE => $this->parseListNode($token, $tokenStream, Token::T_CLOSE_BRACE),
                 Token::T_CLOSE_PARENTHESIS,
                 Token::T_CLOSE_BRACKET,
-                Token::T_CLOSE_BRACE => throw $this->createUnexceptedParserException($tokenStream, $token, 'Unterminated list (BRACKETS)'),
+                Token::T_CLOSE_BRACE => throw $this->createUnexpectedCloserException($tokenStream, $token),
                 Token::T_QUOTE,
                 Token::T_DEREF,
                 Token::T_VAR_QUOTE => $this->parseQuoteNode($token, $tokenStream),
@@ -198,18 +214,31 @@ final readonly class Parser implements ParserInterface
                 Token::T_READER_COND_SPLICING => $this->parseReaderCondSplicingNode($tokenStream, $token),
                 Token::T_SYMBOLIC_NUMBER => $this->parseSymbolicNumberNode($token),
                 Token::T_TAGGED_LITERAL => $this->parseTaggedLiteralNode($tokenStream, $token),
-                Token::T_EOF => throw $this->createUnfinishedParserException($tokenStream, $token, 'Unterminated list (EOF)'),
+                Token::T_EOF => throw $this->createEndOfFileException($tokenStream, $token),
                 default => throw $this->createUnexceptedParserException($tokenStream, $token, 'Unhandled syntax token: ' . $token->getCode()),
             };
         }
 
-        // Throw exception differently because we may have not $token
+        // A stream that stops without the terminating T_EOF the lexer appends
+        // leaves no token to anchor on, so the open form is the only location
+        // left to report.
+        $openForm = $this->innermostOpenForm();
         $snippet = $tokenStream->getCodeSnippet();
-        throw new UnfinishedParserException(
-            'Unterminated list',
+
+        if (!$openForm instanceof OpenForm) {
+            throw new UnfinishedParserException(
+                'Unexpected end of input: a form was expected.',
+                $snippet,
+                $snippet->getStartLocation(),
+                $snippet->getEndLocation(),
+            );
+        }
+
+        throw UnfinishedParserException::forSnippet(
             $snippet,
-            $snippet->getStartLocation(),
-            $snippet->getEndLocation(),
+            $openForm->getOpenToken(),
+            $openForm->unterminatedMessage(),
+            $openForm->getErrorCode(),
         );
     }
 
@@ -229,6 +258,21 @@ final readonly class Parser implements ParserInterface
      */
     private function parseAtomNode(Token $token, TokenStream $tokenStream): AbstractAtomNode
     {
+        // The lexer's atom rule excludes only bracket and hash bytes, so an
+        // unclosed `"` falls through to it instead of failing to lex. No valid
+        // Phel atom starts with a quote, which makes the leading `"` exact.
+        if (str_starts_with($token->getCode(), '"')) {
+            throw $this->createUnexceptedParserException(
+                $tokenStream,
+                $token,
+                sprintf(
+                    'Unterminated string starting at line %d. Did you forget a closing \'"\'?',
+                    $token->getStartLocation()->getLine(),
+                ),
+                ErrorCode::UNTERMINATED_STRING,
+            );
+        }
+
         try {
             return $this->atomParser->parse($token);
         } catch (KeywordParserException $keywordParserException) {
@@ -236,6 +280,7 @@ final readonly class Parser implements ParserInterface
                 $tokenStream,
                 $token,
                 $keywordParserException->getMessage(),
+                null,
                 $keywordParserException,
             );
         }
@@ -309,6 +354,7 @@ final readonly class Parser implements ParserInterface
                 $tokenStream,
                 $token,
                 $stringParserException->getMessage(),
+                null,
                 $stringParserException,
             );
         }
@@ -332,50 +378,97 @@ final readonly class Parser implements ParserInterface
         TokenStream $tokenStream,
         Token $currentToken,
         string $message,
+        ?ErrorCode $errorCode = null,
         ?Throwable $nestedException = null,
     ): UnexpectedParserException {
         return UnexpectedParserException::forSnippet(
             $tokenStream->getCodeSnippet(),
             $currentToken,
             $message,
-            null,
+            $errorCode,
             $nestedException,
         );
     }
 
-    private function createUnfinishedParserException(TokenStream $tokenStream, Token $currentToken, string $message): UnfinishedParserException
+    /**
+     * A closer reaches here only when the innermost open form did not consume
+     * it, which leaves three different faults to tell apart.
+     */
+    private function createUnexpectedCloserException(TokenStream $tokenStream, Token $closerToken): UnexpectedParserException
     {
-        return UnfinishedParserException::forSnippet($tokenStream->getCodeSnippet(), $currentToken, $message);
+        $openForm = $this->innermostOpenForm();
+        $closerText = $closerToken->getCode();
+
+        if (!$openForm instanceof OpenForm) {
+            return $this->createUnexceptedParserException(
+                $tokenStream,
+                $closerToken,
+                sprintf("Unexpected '%s': there is no open form to close.", $closerText),
+                ErrorCode::UNEXPECTED_TOKEN,
+            );
+        }
+
+        // The closer matches the open form, so a reader prefix (`'`, `^`, `#_`,
+        // `#tag`) swallowed it while still waiting for its own form.
+        if ($openForm->getCloserText() === $closerText) {
+            return $this->createUnexceptedParserException(
+                $tokenStream,
+                $closerToken,
+                sprintf("Expected a form before '%s'.", $closerText),
+                ErrorCode::UNEXPECTED_TOKEN,
+            );
+        }
+
+        return $this->createUnexceptedParserException(
+            $tokenStream,
+            $closerToken,
+            $openForm->mismatchedCloserMessage($closerText),
+            $openForm->getErrorCode(),
+        );
+    }
+
+    private function createEndOfFileException(TokenStream $tokenStream, Token $eofToken): UnfinishedParserException
+    {
+        $openForm = $this->innermostOpenForm();
+
+        if (!$openForm instanceof OpenForm) {
+            return UnfinishedParserException::forSnippet(
+                $tokenStream->getCodeSnippet(),
+                $eofToken,
+                'Unexpected end of file: a form was expected.',
+                ErrorCode::UNEXPECTED_TOKEN,
+            );
+        }
+
+        return UnfinishedParserException::forSnippet(
+            $tokenStream->getCodeSnippet(),
+            $openForm->getOpenToken(),
+            $openForm->unterminatedMessage(),
+            $openForm->getErrorCode(),
+        );
+    }
+
+    private function innermostOpenForm(): ?OpenForm
+    {
+        if ($this->openForms->isEmpty()) {
+            return null;
+        }
+
+        return new OpenForm($this->openForms->top());
     }
 
     /**
      * @throws UnfinishedParserException
      */
-    private function parseFnListNode(Token $token, TokenStream $tokenStream): ListNode
+    private function parseListNode(Token $openToken, TokenStream $tokenStream, int $endTokenType): ListNode
     {
-        return $this->listParser
-            ->parse($tokenStream, Token::T_CLOSE_PARENTHESIS, $token->getType());
-    }
+        $this->openForms->push($openToken);
 
-    /**
-     * @throws UnfinishedParserException
-     */
-    private function parseArrayListNode(Token $token, TokenStream $tokenStream): ListNode
-    {
-        return $this->listParser
-            ->parse($tokenStream, Token::T_CLOSE_BRACKET, $token->getType());
-    }
-
-    private function parseMapListNode(Token $token, TokenStream $tokenStream): ListNode
-    {
-        return $this->listParser
-            ->parse($tokenStream, Token::T_CLOSE_BRACE, $token->getType());
-    }
-
-    private function parseSetListNode(Token $token, TokenStream $tokenStream): ListNode
-    {
-        return $this->listParser
-            ->parse($tokenStream, Token::T_CLOSE_BRACE, $token->getType());
+        try {
+            return $this->listParser->parse($tokenStream, $endTokenType, $openToken->getType());
+        } finally {
+            $this->openForms->pop();
+        }
     }
 
     private function parseQuoteNode(Token $token, TokenStream $tokenStream): QuoteNode

--- a/src/php/Compiler/Application/Parser.php
+++ b/src/php/Compiler/Application/Parser.php
@@ -48,6 +48,8 @@ use function str_starts_with;
  */
 final readonly class Parser implements ParserInterface
 {
+    private const string END_OF_FILE_MESSAGE = 'Unexpected end of file: a form was expected.';
+
     /** @var array<int, true> */
     private const array TOKENS_THAT_SHOULD_STREAM_NEXT = [
         Token::T_WHITESPACE => true,
@@ -215,7 +217,7 @@ final readonly class Parser implements ParserInterface
                 Token::T_SYMBOLIC_NUMBER => $this->parseSymbolicNumberNode($token),
                 Token::T_TAGGED_LITERAL => $this->parseTaggedLiteralNode($tokenStream, $token),
                 Token::T_EOF => throw $this->createEndOfFileException($tokenStream, $token),
-                default => throw $this->createUnexceptedParserException($tokenStream, $token, 'Unhandled syntax token: ' . $token->getCode()),
+                default => throw $this->createUnexpectedParserException($tokenStream, $token, 'Unhandled syntax token: ' . $token->getCode()),
             };
         }
 
@@ -227,19 +229,14 @@ final readonly class Parser implements ParserInterface
 
         if (!$openForm instanceof OpenForm) {
             throw new UnfinishedParserException(
-                'Unexpected end of input: a form was expected.',
+                self::END_OF_FILE_MESSAGE,
                 $snippet,
                 $snippet->getStartLocation(),
                 $snippet->getEndLocation(),
             );
         }
 
-        throw UnfinishedParserException::forSnippet(
-            $snippet,
-            $openForm->getOpenToken(),
-            $openForm->unterminatedMessage(),
-            $openForm->getErrorCode(),
-        );
+        throw $this->createUnterminatedFormException($tokenStream, $openForm);
     }
 
     private function shouldTokenStreamGoNext(int $tokenType): bool
@@ -262,7 +259,7 @@ final readonly class Parser implements ParserInterface
         // unclosed `"` falls through to it instead of failing to lex. No valid
         // Phel atom starts with a quote, which makes the leading `"` exact.
         if (str_starts_with($token->getCode(), '"')) {
-            throw $this->createUnexceptedParserException(
+            throw $this->createUnexpectedParserException(
                 $tokenStream,
                 $token,
                 sprintf(
@@ -276,7 +273,7 @@ final readonly class Parser implements ParserInterface
         try {
             return $this->atomParser->parse($token);
         } catch (KeywordParserException $keywordParserException) {
-            throw $this->createUnexceptedParserException(
+            throw $this->createUnexpectedParserException(
                 $tokenStream,
                 $token,
                 $keywordParserException->getMessage(),
@@ -350,7 +347,7 @@ final readonly class Parser implements ParserInterface
                 ->createStringParser()
                 ->parse($token);
         } catch (StringParserException $stringParserException) {
-            throw $this->createUnexceptedParserException(
+            throw $this->createUnexpectedParserException(
                 $tokenStream,
                 $token,
                 $stringParserException->getMessage(),
@@ -374,7 +371,7 @@ final readonly class Parser implements ParserInterface
             ->parse($token);
     }
 
-    private function createUnexceptedParserException(
+    private function createUnexpectedParserException(
         TokenStream $tokenStream,
         Token $currentToken,
         string $message,
@@ -400,7 +397,7 @@ final readonly class Parser implements ParserInterface
         $closerText = $closerToken->getCode();
 
         if (!$openForm instanceof OpenForm) {
-            return $this->createUnexceptedParserException(
+            return $this->createUnexpectedParserException(
                 $tokenStream,
                 $closerToken,
                 sprintf("Unexpected '%s': there is no open form to close.", $closerText),
@@ -411,7 +408,7 @@ final readonly class Parser implements ParserInterface
         // The closer matches the open form, so a reader prefix (`'`, `^`, `#_`,
         // `#tag`) swallowed it while still waiting for its own form.
         if ($openForm->getCloserText() === $closerText) {
-            return $this->createUnexceptedParserException(
+            return $this->createUnexpectedParserException(
                 $tokenStream,
                 $closerToken,
                 sprintf("Expected a form before '%s'.", $closerText),
@@ -419,7 +416,7 @@ final readonly class Parser implements ParserInterface
             );
         }
 
-        return $this->createUnexceptedParserException(
+        return $this->createUnexpectedParserException(
             $tokenStream,
             $closerToken,
             $openForm->mismatchedCloserMessage($closerText),
@@ -435,11 +432,16 @@ final readonly class Parser implements ParserInterface
             return UnfinishedParserException::forSnippet(
                 $tokenStream->getCodeSnippet(),
                 $eofToken,
-                'Unexpected end of file: a form was expected.',
+                self::END_OF_FILE_MESSAGE,
                 ErrorCode::UNEXPECTED_TOKEN,
             );
         }
 
+        return $this->createUnterminatedFormException($tokenStream, $openForm);
+    }
+
+    private function createUnterminatedFormException(TokenStream $tokenStream, OpenForm $openForm): UnfinishedParserException
+    {
         return UnfinishedParserException::forSnippet(
             $tokenStream->getCodeSnippet(),
             $openForm->getOpenToken(),

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -33,6 +33,12 @@ Lexer (source → `TokenStream`) → Parser (→ `FileNode` parse tree) → Read
 - Lexer `Token` and parse-tree nodes live in `Phel\Shared\Parser\Node`; `ExpressionParserFactory` produces them (sub-parsers in `Domain/Parser/ExpressionParser/`).
 - The `#php` reader tag expands vectors to indexed PHP arrays and maps to associative PHP arrays; literal keyword map keys become strings at read time.
 
+### Unterminated-form reporting
+
+`Application/Parser` stacks the delimiter of every form it is currently inside. A closer or an end-of-file token reaches `readExpression` only when the innermost open form did not consume it, and `Domain/Parser/OpenForm` turns that stacked opener into the message, the `ErrorCode` (`UNTERMINATED_LIST` / `_VECTOR` / `_MAP` / `_TABLE`, the last one for `#{}`) and the location the caret sits on: the opening delimiter, never the position where the stream ran out. `ListParser` keeps its own throw for a stream that ends without the lexer's `T_EOF`.
+
+An unclosed `"` never fails to lex, because the atom rule swallows it (`Balance` counts on that, see `src/php/Balance/CLAUDE.md`), so `Parser::parseAtomNode` reads the leading quote and raises `UNTERMINATED_STRING` from there rather than from the lexer.
+
 ### Interop shorthand expansion
 
 Clojure-style interop spellings are sugar, expanded to `php/*` forms before analysis, never registered as special forms (`LanguageSurfaceSpecTest` fails on a spec table row with no dispatch entry):

--- a/src/php/Compiler/Domain/Parser/Exceptions/UnfinishedParserException.php
+++ b/src/php/Compiler/Domain/Parser/Exceptions/UnfinishedParserException.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Parser\Exceptions;
 
-use Phel\Lang\SourceLocation;
 use Phel\Shared\Exceptions\ErrorCode;
 use Phel\Shared\Parser\Node\Token;
 use Phel\Shared\Parser\ReadModel\CodeSnippet;
@@ -16,36 +15,7 @@ final class UnfinishedParserException extends AbstractParserException
 {
     public static function forSnippet(CodeSnippet $snippet, Token $token, string $message, ?ErrorCode $errorCode = null): self
     {
-        return self::build($message, $snippet, $token->getStartLocation(), $token->getEndLocation(), $errorCode);
-    }
-
-    /**
-     * The variant for a stream that has run out of tokens, where there is no
-     * `current()` token to point at.
-     *
-     * Asking the stream for one anyway raises "Token generator exhausted
-     * unexpectedly" *while the real diagnostic is being built*, and the user
-     * loses the message that would have told them what is wrong. Callers in
-     * that position pass where the unfinished form opened instead, which is the
-     * more useful anchor anyway: the missing bracket belongs to that line.
-     */
-    public static function forExhaustedStream(
-        CodeSnippet $snippet,
-        SourceLocation $startLocation,
-        string $message,
-        ?ErrorCode $errorCode = null,
-    ): self {
-        return self::build($message, $snippet, $startLocation, $snippet->getEndLocation(), $errorCode);
-    }
-
-    private static function build(
-        string $message,
-        CodeSnippet $snippet,
-        SourceLocation $startLocation,
-        SourceLocation $endLocation,
-        ?ErrorCode $errorCode,
-    ): self {
-        $e = new self($message, $snippet, $startLocation, $endLocation);
+        $e = new self($message, $snippet, $token->getStartLocation(), $token->getEndLocation());
 
         if ($errorCode instanceof ErrorCode) {
             $e->setErrorCode($errorCode);

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/ListParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/ListParser.php
@@ -6,25 +6,16 @@ namespace Phel\Compiler\Domain\Parser\ExpressionParser;
 
 use Phel\Compiler\Domain\Lexer\TokenStream;
 use Phel\Compiler\Domain\Parser\Exceptions\UnfinishedParserException;
+use Phel\Compiler\Domain\Parser\OpenForm;
 use Phel\Compiler\Domain\Parser\ParserInterface;
-use Phel\Shared\Exceptions\ErrorCode;
 use Phel\Shared\Parser\Node\ListNode;
 use Phel\Shared\Parser\Node\ReaderCondSplicingNode;
-use Phel\Shared\Parser\Node\Token;
-
-use function sprintf;
 
 /**
  * @internal
  */
 final readonly class ListParser
 {
-    private const array CLOSING_BRACKETS = [
-        Token::T_CLOSE_PARENTHESIS => ')',
-        Token::T_CLOSE_BRACKET => ']',
-        Token::T_CLOSE_BRACE => '}',
-    ];
-
     public function __construct(private ParserInterface $parser) {}
 
     /**
@@ -55,22 +46,17 @@ final readonly class ListParser
             }
         }
 
-        $closingBracket = self::CLOSING_BRACKETS[$endTokenType] ?? ')';
-        $message = sprintf(
-            "Unterminated list starting at line %d. Did you forget a closing '%s'?",
-            $startLocation->getLine(),
-            $closingBracket,
-        );
-
         // The loop only ends here once the stream is exhausted, so there is no
         // `current()` token left: asking for one throws "Token generator
-        // exhausted unexpectedly" and destroys the message above, which is the
-        // one the user needs. Anchor on the opening bracket instead.
-        throw UnfinishedParserException::forExhaustedStream(
+        // exhausted unexpectedly" and destroys the message being built, which
+        // is the one the user needs. Anchor on the opening bracket instead.
+        $openForm = new OpenForm($startToken);
+
+        throw UnfinishedParserException::forSnippet(
             $tokenStream->getCodeSnippet(),
-            $startLocation,
-            $message,
-            ErrorCode::UNTERMINATED_LIST,
+            $startToken,
+            $openForm->unterminatedMessage(),
+            $openForm->getErrorCode(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/ReaderConditionalParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/ReaderConditionalParser.php
@@ -8,6 +8,7 @@ use Phel\Compiler\Domain\Lexer\TokenStream;
 use Phel\Compiler\Domain\Parser\Exceptions\UnexpectedParserException;
 use Phel\Compiler\Domain\Parser\Exceptions\UnfinishedParserException;
 use Phel\Compiler\Domain\Parser\ParserInterface;
+use Phel\Shared\Exceptions\ErrorCode;
 use Phel\Shared\Parser\Node\CommentNode;
 use Phel\Shared\Parser\Node\KeywordNode;
 use Phel\Shared\Parser\Node\ListNode;
@@ -113,7 +114,12 @@ final readonly class ReaderConditionalParser
 
         // Consume the closing paren — throw if the stream is exhausted or missing ')'
         if (!$tokenStream->valid() || $tokenStream->current()->getType() !== Token::T_CLOSE_PARENTHESIS) {
-            throw UnfinishedParserException::forSnippet($tokenStream->getCodeSnippet(), $openToken, $unterminatedMessage);
+            throw UnfinishedParserException::forSnippet(
+                $tokenStream->getCodeSnippet(),
+                $openToken,
+                $unterminatedMessage,
+                ErrorCode::UNTERMINATED_LIST,
+            );
         }
 
         $tokenStream->next();
@@ -132,7 +138,11 @@ final readonly class ReaderConditionalParser
     private function readNonTriviaExpression(TokenStream $tokenStream): ?NodeInterface
     {
         while ($tokenStream->valid()) {
-            if ($tokenStream->current()->getType() === Token::T_CLOSE_PARENTHESIS) {
+            $tokenType = $tokenStream->current()->getType();
+
+            // End of file stops the scan here so `resolveBranch` can name the
+            // reader conditional; reading on would report the enclosing form.
+            if ($tokenType === Token::T_CLOSE_PARENTHESIS || $tokenType === Token::T_EOF) {
                 return null;
             }
 

--- a/src/php/Compiler/Domain/Parser/OpenForm.php
+++ b/src/php/Compiler/Domain/Parser/OpenForm.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Parser;
 
-use Phel\Lang\SourceLocation;
 use Phel\Shared\Exceptions\ErrorCode;
 use Phel\Shared\Parser\Node\Token;
 
@@ -60,11 +59,6 @@ final readonly class OpenForm
         return $this->openToken;
     }
 
-    public function getStartLocation(): SourceLocation
-    {
-        return $this->openToken->getStartLocation();
-    }
-
     public function getErrorCode(): ErrorCode
     {
         return self::ERROR_CODE_FOR_OPENER[$this->openToken->getType()] ?? ErrorCode::UNTERMINATED_LIST;
@@ -80,7 +74,7 @@ final readonly class OpenForm
         return sprintf(
             "Unterminated %s starting at line %d. Did you forget a closing '%s'?",
             $this->formName(),
-            $this->getStartLocation()->getLine(),
+            $this->line(),
             $this->getCloserText(),
         );
     }
@@ -91,7 +85,7 @@ final readonly class OpenForm
             "Expected '%s' to close the %s opened at line %d, found '%s'.",
             $this->getCloserText(),
             $this->formName(),
-            $this->getStartLocation()->getLine(),
+            $this->line(),
             $foundCloserText,
         );
     }
@@ -99,5 +93,10 @@ final readonly class OpenForm
     private function formName(): string
     {
         return self::FORM_NAME_FOR_OPENER[$this->openToken->getType()] ?? 'list';
+    }
+
+    private function line(): int
+    {
+        return $this->openToken->getStartLocation()->getLine();
     }
 }

--- a/src/php/Compiler/Domain/Parser/OpenForm.php
+++ b/src/php/Compiler/Domain/Parser/OpenForm.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Parser;
+
+use Phel\Lang\SourceLocation;
+use Phel\Shared\Exceptions\ErrorCode;
+use Phel\Shared\Parser\Node\Token;
+
+use function sprintf;
+
+/**
+ * A form whose opening delimiter has been read and whose closer has not.
+ *
+ * A missing closer is only diagnosable from the opening side. The place the
+ * parser notices it (end of file, or the wrong closer) carries neither the line
+ * the author has to fix nor the bracket they still owe.
+ *
+ * @internal
+ */
+final readonly class OpenForm
+{
+    /**
+     * `#(` and `#{` swallow their delimiter into a single token and have no
+     * closing type of their own, so opener to closer is a lookup rather than a
+     * character flip.
+     */
+    private const array CLOSER_TEXT_FOR_OPENER = [
+        Token::T_OPEN_PARENTHESIS => ')',
+        Token::T_HASH_FN => ')',
+        Token::T_OPEN_BRACKET => ']',
+        Token::T_OPEN_BRACE => '}',
+        Token::T_HASH_OPEN_BRACE => '}',
+    ];
+
+    private const array FORM_NAME_FOR_OPENER = [
+        Token::T_OPEN_PARENTHESIS => 'list',
+        Token::T_HASH_FN => 'list',
+        Token::T_OPEN_BRACKET => 'vector',
+        Token::T_OPEN_BRACE => 'map',
+        Token::T_HASH_OPEN_BRACE => 'set',
+    ];
+
+    /** PHEL103 is spelled `UNTERMINATED_TABLE` from when `#{}` sets were still written as tables. */
+    private const array ERROR_CODE_FOR_OPENER = [
+        Token::T_OPEN_PARENTHESIS => ErrorCode::UNTERMINATED_LIST,
+        Token::T_HASH_FN => ErrorCode::UNTERMINATED_LIST,
+        Token::T_OPEN_BRACKET => ErrorCode::UNTERMINATED_VECTOR,
+        Token::T_OPEN_BRACE => ErrorCode::UNTERMINATED_MAP,
+        Token::T_HASH_OPEN_BRACE => ErrorCode::UNTERMINATED_TABLE,
+    ];
+
+    public function __construct(
+        private Token $openToken,
+    ) {}
+
+    public function getOpenToken(): Token
+    {
+        return $this->openToken;
+    }
+
+    public function getStartLocation(): SourceLocation
+    {
+        return $this->openToken->getStartLocation();
+    }
+
+    public function getErrorCode(): ErrorCode
+    {
+        return self::ERROR_CODE_FOR_OPENER[$this->openToken->getType()] ?? ErrorCode::UNTERMINATED_LIST;
+    }
+
+    public function getCloserText(): string
+    {
+        return self::CLOSER_TEXT_FOR_OPENER[$this->openToken->getType()] ?? ')';
+    }
+
+    public function unterminatedMessage(): string
+    {
+        return sprintf(
+            "Unterminated %s starting at line %d. Did you forget a closing '%s'?",
+            $this->formName(),
+            $this->getStartLocation()->getLine(),
+            $this->getCloserText(),
+        );
+    }
+
+    public function mismatchedCloserMessage(string $foundCloserText): string
+    {
+        return sprintf(
+            "Expected '%s' to close the %s opened at line %d, found '%s'.",
+            $this->getCloserText(),
+            $this->formName(),
+            $this->getStartLocation()->getLine(),
+            $foundCloserText,
+        );
+    }
+
+    private function formName(): string
+    {
+        return self::FORM_NAME_FOR_OPENER[$this->openToken->getType()] ?? 'list';
+    }
+}

--- a/tests/phel/core/binding-regression-1363.phel
+++ b/tests/phel/core/binding-regression-1363.phel
@@ -7,7 +7,7 @@
 ;;   1. A `SliceGenerator::toIterable` type error when `(is (binding ...))` was
 ;;      expanded by the `is` macro. Should compile cleanly now that `is` routes
 ;;      known structured forms (including `binding`) through `assert-any`.
-;;   2. An "Unterminated list (BRACKETS)" reader error on a splicing reader
+;;   2. A mismatched-closer reader error on a splicing reader
 ;;      conditional whose `:default` branch contained nested brackets. Should
 ;;      parse cleanly because the selected branch wins and unselected branches
 ;;      are discarded.

--- a/tests/php/Integration/Compiler/Parser/ParserTest.php
+++ b/tests/php/Integration/Compiler/Parser/ParserTest.php
@@ -504,21 +504,21 @@ final class ParserTest extends TestCase
     public function test_read_unbalanced_closed_paren(): void
     {
         $this->expectException(AbstractParserException::class);
-        $this->expectExceptionMessage('Unterminated list');
+        $this->expectExceptionMessage("Unexpected ')': there is no open form to close.");
         $this->parse(')');
     }
 
     public function test_read_unbalanced_open_paren(): void
     {
         $this->expectException(AbstractParserException::class);
-        $this->expectExceptionMessage('Unterminated list');
+        $this->expectExceptionMessage("Unterminated list starting at line 1. Did you forget a closing ')'?");
         $this->parse('(');
     }
 
     public function test_read_unbalanced_open_brace(): void
     {
         $this->expectException(AbstractParserException::class);
-        $this->expectExceptionMessage('Unterminated list');
+        $this->expectExceptionMessage("Unterminated map starting at line 1. Did you forget a closing '}'?");
         $this->parse('{');
     }
 

--- a/tests/php/Integration/Compiler/Parser/UnterminatedFormReportTest.php
+++ b/tests/php/Integration/Compiler/Parser/UnterminatedFormReportTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Compiler\Parser;
+
+use Phel\Command\Application\TextExceptionPrinter;
+use Phel\Command\Domain\ErrorLogInterface;
+use Phel\Command\Domain\Exceptions\ExceptionArgsPrinterInterface;
+use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractorInterface;
+use Phel\Compiler\Application\Lexer;
+use Phel\Compiler\Application\Parser;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
+use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
+use Phel\Compiler\Domain\Parser\ExpressionParserFactory;
+use Phel\Shared\ColorStyleInterface;
+use Phel\Shared\MungeInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins what a reader mistake actually prints: the error code, the wording, the
+ * line the form was opened on, and the column the caret lands in.
+ */
+final class UnterminatedFormReportTest extends TestCase
+{
+    private const string SOURCE = 'broken.phel';
+
+    public function test_a_missing_closing_paren_names_the_line_it_was_opened_on(): void
+    {
+        $expected = <<<'REPORT'
+            [PHEL100] Unterminated list starting at line 2. Did you forget a closing ')'?
+            in broken.phel:2
+
+            2| (defn f [x] (+ x 1)
+               ^
+
+            REPORT;
+
+        self::assertSame($expected, $this->report("(ns repro)\n(defn f [x] (+ x 1)"));
+    }
+
+    public function test_a_missing_closing_bracket_names_the_vector(): void
+    {
+        $expected = <<<'REPORT'
+            [PHEL101] Unterminated vector starting at line 1. Did you forget a closing ']'?
+            in broken.phel:1
+
+            1| (def v [1 2 3
+                      ^
+
+            REPORT;
+
+        self::assertSame($expected, $this->report('(def v [1 2 3'));
+    }
+
+    public function test_a_missing_closing_brace_names_the_map(): void
+    {
+        $expected = <<<'REPORT'
+            [PHEL102] Unterminated map starting at line 1. Did you forget a closing '}'?
+            in broken.phel:1
+
+            1| (def m {:a 1
+                      ^
+
+            REPORT;
+
+        self::assertSame($expected, $this->report('(def m {:a 1'));
+    }
+
+    public function test_a_missing_closing_brace_names_the_set(): void
+    {
+        $expected = <<<'REPORT'
+            [PHEL103] Unterminated set starting at line 1. Did you forget a closing '}'?
+            in broken.phel:1
+
+            1| (def s #{1 2
+                      ^^
+
+            REPORT;
+
+        self::assertSame($expected, $this->report('(def s #{1 2'));
+    }
+
+    public function test_a_mismatched_closer_names_both_sides(): void
+    {
+        $expected = <<<'REPORT'
+            [PHEL101] Expected ']' to close the vector opened at line 3, found ')'.
+            in broken.phel:3
+
+            1| (defn c [x] (let [y (a x)
+            2|                   z (b x)]
+            3|               [y z)
+                                 ^
+
+            REPORT;
+
+        $phelCode = "(defn c [x] (let [y (a x)\n                  z (b x)]\n              [y z))";
+
+        self::assertSame($expected, $this->report($phelCode));
+    }
+
+    public function test_an_unclosed_quote_reports_the_string_and_not_the_enclosing_list(): void
+    {
+        $expected = <<<'REPORT'
+            [PHEL301] Unterminated string starting at line 1. Did you forget a closing '"'?
+            in broken.phel:1
+
+            1| (println "unterminated
+                        ^^^^^^^^^^^^^
+
+            REPORT;
+
+        self::assertSame($expected, $this->report('(println "unterminated'));
+    }
+
+    public function test_a_closer_with_nothing_open_says_so(): void
+    {
+        $expected = <<<'REPORT'
+            [PHEL110] Unexpected ')': there is no open form to close.
+            in broken.phel:1
+
+            1| )
+               ^
+
+            REPORT;
+
+        self::assertSame($expected, $this->report(')'));
+    }
+
+    private function report(string $phelCode): string
+    {
+        $parser = new Parser(new ExpressionParserFactory(), new GlobalEnvironment());
+
+        try {
+            $parser->parseAll(new Lexer()->lexString($phelCode, self::SOURCE));
+        } catch (AbstractParserException $parserException) {
+            return $this->exceptionPrinter()->getExceptionString($parserException, $parserException->getCodeSnippet());
+        }
+
+        self::fail('Expected the parser to reject: ' . $phelCode);
+    }
+
+    private function exceptionPrinter(): TextExceptionPrinter
+    {
+        $colorStyle = $this->createStub(ColorStyleInterface::class);
+        $colorStyle->method('blue')->willReturnCallback(static fn(string $msg): string => $msg);
+        $colorStyle->method('red')->willReturnCallback(static fn(string $msg): string => $msg);
+
+        return new TextExceptionPrinter(
+            $this->createStub(ExceptionArgsPrinterInterface::class),
+            $colorStyle,
+            $this->createStub(MungeInterface::class),
+            $this->createStub(FilePositionExtractorInterface::class),
+            $this->createStub(ErrorLogInterface::class),
+        );
+    }
+}

--- a/tests/php/Integration/Run/Command/Repl/Fixtures/unterminated-list-multiline-with-empty-lines.test
+++ b/tests/php/Integration/Run/Command/Repl/Fixtures/unterminated-list-multiline-with-empty-lines.test
@@ -3,7 +3,7 @@ user:1> (php/+ 1
 ....:3> 2
 ....:4>
 ....:5> ]
-Unterminated list (BRACKETS)
+[PHEL100] Expected ')' to close the list opened at line 1, found ']'.
 in string:5
 
 1| (php/+ 1

--- a/tests/php/Integration/Run/Command/Repl/Fixtures/unterminated-list-multiline.test
+++ b/tests/php/Integration/Run/Command/Repl/Fixtures/unterminated-list-multiline.test
@@ -1,7 +1,7 @@
 user:1> (php/+ 1
 ....:2> 2
 ....:3> ]
-Unterminated list (BRACKETS)
+[PHEL100] Expected ')' to close the list opened at line 1, found ']'.
 in string:3
 
 1| (php/+ 1

--- a/tests/php/Unit/Compiler/Lexer/LexerTest.php
+++ b/tests/php/Unit/Compiler/Lexer/LexerTest.php
@@ -539,7 +539,7 @@ final class LexerTest extends TestCase
     public function test_var_quote_prefix_does_not_match_comment_rule(): void
     {
         // Regression: before the fix, `#'bar)` was eaten by the comment rule
-        // up to EOL, which broke `(var? #'bar)` with "Unterminated list (EOF)".
+        // up to EOL, which broke `(var? #'bar)` with an unterminated-list error.
         $tokens = $this->lex("(var? #'bar)");
 
         self::assertSame(Token::T_OPEN_PARENTHESIS, $tokens[0]->getType());

--- a/tests/php/Unit/Compiler/Parser/ListParserTest.php
+++ b/tests/php/Unit/Compiler/Parser/ListParserTest.php
@@ -39,7 +39,8 @@ final class ListParserTest extends TestCase
 ';
 
         $this->expectException(UnfinishedParserException::class);
-        $this->expectExceptionMessageMatches('/Unterminated list/');
+        // The innermost unclosed form, on line 2, is where the next ')' goes.
+        $this->expectExceptionMessage("Unterminated list starting at line 2. Did you forget a closing ')'?");
 
         $lexer = new Lexer();
         $tokenStream = $lexer->lexString($code, 'test.phel');
@@ -51,7 +52,7 @@ final class ListParserTest extends TestCase
         $code = '[1 2 3';
 
         $this->expectException(UnfinishedParserException::class);
-        $this->expectExceptionMessageMatches('/Unterminated list/');
+        $this->expectExceptionMessage("Unterminated vector starting at line 1. Did you forget a closing ']'?");
 
         $lexer = new Lexer();
         $tokenStream = $lexer->lexString($code, 'test.phel');
@@ -63,7 +64,7 @@ final class ListParserTest extends TestCase
         $code = '{:a 1 :b 2';
 
         $this->expectException(UnfinishedParserException::class);
-        $this->expectExceptionMessageMatches('/Unterminated list/');
+        $this->expectExceptionMessage("Unterminated map starting at line 1. Did you forget a closing '}'?");
 
         $lexer = new Lexer();
         $tokenStream = $lexer->lexString($code, 'test.phel');


### PR DESCRIPTION
## 🤔 Background

A missing paren printed `Unterminated list (EOF)`: no error code, an internal token name, and a caret on the blank line after the file.

## 💡 Goal

Make the first error a new Phel user hits say what is wrong and where to fix it.

## 🔖 Changes

- A report now names the form, the line it was opened on and the bracket it needs, carries `PHEL100`-`PHEL103`, and puts the caret on the opening delimiter.
- A mismatched closer says both sides: `Expected ']' to close the vector opened at line 3, found ')'.`
- An unclosed `"` is reported as an unterminated string (`PHEL301`) instead of an unterminated list.

Closes #3259
