### PR TITLE
fix(command): point a runtime error's at line at the user's frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - REPL: `(exit)` and `(quit)` end the session like `exit` and `quit`, `(exit <code>)` sets the exit status, and the banner names the call form. (#3272)
+- A runtime error raised inside the core library points its `at` line at the user's own call site, never at the compiled-cache artifact, and an uncaught `ex-info` prints its data map. (#3260)
 
 ## [0.51.0](https://github.com/phel-lang/phel-lang/compare/v0.50.0...v0.51.0) - 2026-09-05
 

--- a/src/php/Command/Application/CommandExceptionWriter.php
+++ b/src/php/Command/Application/CommandExceptionWriter.php
@@ -112,8 +112,8 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
     }
 
     /**
-     * Renders a user-facing error, mapping the compiled PHP file/line back to its
-     * original Phel source via the source map when available.
+     * Renders a user-facing error at its anchor frame, mapping the compiled PHP
+     * file/line back to its original Phel source via the source map when available.
      *
      * When the source map resolves to a different file, the original location is
      * shown alongside the compiled one. Otherwise only the raw location is shown,

--- a/src/php/Command/Application/CommandExceptionWriter.php
+++ b/src/php/Command/Application/CommandExceptionWriter.php
@@ -7,13 +7,19 @@ namespace Phel\Command\Application;
 use Phel\Command\Domain\CommandExceptionWriterInterface;
 use Phel\Command\Domain\ErrorLogInterface;
 use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractorInterface;
+use Phel\Command\Domain\Exceptions\Extractor\ReadModel\FilePosition;
+use Phel\Command\Domain\Exceptions\InternalPathDetector;
+use Phel\Lang\ExceptionInfo;
 use Phel\Shared\Exceptions\AbstractLocatedException;
 use Phel\Shared\Exceptions\ExceptionPrinterInterface;
 use Phel\Shared\Exceptions\Hint\ExceptionHintResolver;
 use Phel\Shared\Parser\ReadModel\CodeSnippet;
+use Phel\Shared\Printer\PrinterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
+use function count;
+use function is_string;
 use function sprintf;
 use function str_ends_with;
 
@@ -32,6 +38,8 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
         private FilePositionExtractorInterface $filePositionExtractor,
         private string $staleOutputHint,
         private ExceptionHintResolver $hintResolver,
+        private InternalPathDetector $internalPathDetector,
+        private PrinterInterface $printer,
     ) {}
 
     public function writeStackTrace(OutputInterface $output, Throwable $e): void
@@ -46,6 +54,8 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
         } else {
             $this->writeUserError($output, $cause);
         }
+
+        $this->writeExceptionData($output, $e);
 
         $trace = $this->exceptionPrinter->getUserFacingTraceString($cause);
         if ($trace !== '') {
@@ -88,6 +98,20 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
     }
 
     /**
+     * Prints the data map carried by an `ex-info`, which otherwise has to be
+     * inferred from the arguments of an `ex-info` frame in the trace.
+     */
+    private function writeExceptionData(OutputInterface $output, Throwable $e): void
+    {
+        for ($current = $e; $current instanceof Throwable; $current = $current->getPrevious()) {
+            if ($current instanceof ExceptionInfo && count($current->getData()) > 0) {
+                $output->writeln('  data: ' . $this->printer->print($current->getData()));
+                return;
+            }
+        }
+    }
+
+    /**
      * Renders a user-facing error, mapping the compiled PHP file/line back to its
      * original Phel source via the source map when available.
      *
@@ -98,18 +122,16 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
      */
     private function writeUserError(OutputInterface $output, Throwable $cause): void
     {
-        $file = $cause->getFile();
-        $line = $cause->getLine();
-        $position = $this->filePositionExtractor->getOriginal($file, $line);
+        [$position, $file, $line] = $this->anchorFrame($cause);
 
         $output->writeln($cause->getMessage());
 
         if ($position->filename() !== $file) {
-            // An ephemeral eval temp file (`__phel_<hash>.php`) is an internal
-            // artifact with no meaning to a Phel user, so only show the resolved
-            // source. A persistent build artifact (`out/phel/…`) still names its
-            // compiled file, which is useful when diagnosing a stale build.
-            if ($this->isEphemeralCompiledFile($file)) {
+            // An internal artifact (the eval temp file, the compiled cache) has
+            // no meaning to a Phel user, so only show the resolved source. A
+            // persistent build artifact (`out/phel/…`) still names its compiled
+            // file, which is useful when diagnosing a stale build.
+            if ($this->internalPathDetector->isInternalArtifact($file)) {
                 $output->writeln(sprintf('  at %s:%d', $position->filename(), $position->line()));
                 return;
             }
@@ -131,12 +153,45 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
     }
 
     /**
-     * Whether the compiled file is an ephemeral eval temp file (named
-     * `__phel_<hash>.php` by the evaluator), as opposed to a persistent build
-     * artifact under `out/`.
+     * The frame the `at` line points at: the throw site when it belongs to the
+     * user's project, otherwise the innermost Phel frame that does. An error
+     * raised inside the core library names the caller rather than the core
+     * source, which is no place for the user to act on (#3260).
+     *
+     * @return array{FilePosition, string, int} the resolved position, plus the
+     *                                          compiled file and line it came from
      */
-    private function isEphemeralCompiledFile(string $file): bool
+    private function anchorFrame(Throwable $cause): array
     {
-        return str_starts_with(basename($file), '__phel');
+        $file = $cause->getFile();
+        $line = $cause->getLine();
+        $position = $this->filePositionExtractor->getOriginal($file, $line);
+
+        if (!$this->isInternalPosition($position)) {
+            return [$position, $file, $line];
+        }
+
+        foreach ($cause->getTrace() as $frame) {
+            $frameFile = $frame['file'] ?? null;
+            if (!is_string($frameFile)) {
+                continue;
+            }
+
+            $frameLine = $frame['line'] ?? 0;
+            $framePosition = $this->filePositionExtractor->getOriginal($frameFile, $frameLine);
+
+            // Only a frame mapping back to Phel source can anchor the `at`
+            // line: vendor and runtime PHP frames are not the user's call site.
+            if (str_ends_with($framePosition->filename(), '.phel') && !$this->isInternalPosition($framePosition)) {
+                return [$framePosition, $frameFile, $frameLine];
+            }
+        }
+
+        return [$position, $file, $line];
+    }
+
+    private function isInternalPosition(FilePosition $position): bool
+    {
+        return $this->internalPathDetector->isInternalSource($position->filename());
     }
 }

--- a/src/php/Command/CLAUDE.md
+++ b/src/php/Command/CLAUDE.md
@@ -35,6 +35,7 @@ Directory getters are `#[Cacheable]`.
 | `Application/CommandExceptionWriter` | writes located exceptions + stack traces; appends hints |
 | `Application/TextExceptionPrinter` | syntax-highlighted render with source pointers |
 | `Domain/Exceptions/Extractor/FilePositionExtractor` | builds the compiled→Phel line map |
+| `Domain/Exceptions/InternalPathDetector` | tells Phel's own source and compiled artifacts from the user's project |
 | `Infrastructure/SourceMapExtractor` | maps compiled PHP back to Phel source locations |
 | `Infrastructure/ComposerVendorDirectoriesFinder` | enumerates vendor source dirs |
 | `Infrastructure/ErrorLog` | full-trace sink |
@@ -45,5 +46,7 @@ Directory getters are `#[Cacheable]`.
 - `FilePositionExtractor::getFileLineMap()` (via `getCompiledFileLineMap`) is used by `phel test --coverage` to enumerate coverable Phel lines — keep its return shape (`[phpLine => phelLine]` + filename) stable.
 - `TextExceptionPrinter::getUserFacingTraceString()` keeps only Phel fn frames (mapped to `.phel:line`) and collapses PHP-native runs; the full trace still goes to the error log.
 - `CommandExceptionWriter` appends an actionable hint (from `ExceptionHintResolver`) after BOTH located-exception and stack-trace output, so failing `phel run`/`test`/`eval` get the same guidance as the REPL.
+- `CommandExceptionWriter` anchors the `at` line on the throw site only when it belongs to the user's project; an error raised inside `phel\core` walks out to the innermost user `.phel` frame instead, and the compiled path is printed only for a persistent build artifact, never for the eval temp file or the compiled cache (`InternalPathDetector`). The stdlib frames stay in the numbered trace.
+- `CommandExceptionWriter` prints the data map of an uncaught `ex-info` on its own `data:` line.
 - Hints are pure utilities in `Phel\Shared\Exceptions\Hint\`. Register new ones in `CommandFactory::createExceptionHints()` (currently `NotCallableHint`, `ArgumentCountHint`, `UndefinedSymbolHint`).
-- Config carries a stale-output-recovery hint for corrupted build state (`CommandConfig::getStaleOutputHint()`).
+- Config carries a stale-output-recovery hint for corrupted build state (`CommandConfig::getStaleOutputHint()`), built on `getCacheDir()`, which shares `PhelProjectDirectory::resolveCacheDir()` with the build and compiler configs.

--- a/src/php/Command/CommandConfig.php
+++ b/src/php/Command/CommandConfig.php
@@ -28,6 +28,8 @@ final class CommandConfig extends AbstractConfig
 
     private const string DEFAULT_OUTPUT_DIR = 'out';
 
+    private const string DEFAULT_CACHE_DIR = '.phel/cache';
+
     private const string DEFAULT_ERROR_LOG_FILE = 'phel-error.log';
 
     public function getCodeDirs(): CodeDirectories
@@ -35,26 +37,45 @@ final class CommandConfig extends AbstractConfig
         $buildConfig = $this->get(PhelConfig::BUILD_CONFIG, []);
         $buildConfig = is_array($buildConfig) ? $buildConfig : [];
 
-        // Point at the parent `src` directory (which contains `phel/`) so
-        // phel's own core library is discoverable whether phel runs from its
-        // own source tree, from a composer vendor dir, or from a PHAR.
-        //
-        // Use `dirname(..., 2)` rather than `__DIR__ . '/../..'` so the path
-        // has no literal '..' segments: inside a PHAR the stream wrapper does
-        // not normalize '..', which otherwise produces duplicate namespace
-        // registrations when the same file is also reached via a clean path.
-        //
-        // The entry deliberately points one level above `src/phel` (so it
-        // contains rather than is `src/phel`) so that entry-point detection
-        // in `RunFacade::autoDetectEntryPoint` does not accidentally return
-        // phel's own `core.phel` when the user has no entry point of their own.
-        $phelInternalSrcDir = dirname(__DIR__, 2);
-
         return new CodeDirectories(
-            $phelInternalSrcDir,
+            $this->getPhelInternalSrcDir(),
             ScalarCoercion::toStringList($this->get(PhelConfig::SRC_DIRS, self::DEFAULT_SRC_DIRS), self::DEFAULT_SRC_DIRS),
             ScalarCoercion::toStringList($this->get(PhelConfig::TEST_DIRS, self::DEFAULT_TEST_DIRS), self::DEFAULT_TEST_DIRS),
             ScalarCoercion::toString($buildConfig[PhelBuildConfig::DEST_DIR] ?? null, self::DEFAULT_OUTPUT_DIR),
+        );
+    }
+
+    /**
+     * Phel's own `src` directory (which contains `phel/`), so phel's core
+     * library is discoverable whether phel runs from its own source tree, from
+     * a composer vendor dir, or from a PHAR.
+     *
+     * Use `dirname(..., 2)` rather than `__DIR__ . '/../..'` so the path has no
+     * literal '..' segments: inside a PHAR the stream wrapper does not
+     * normalize '..', which otherwise produces duplicate namespace
+     * registrations when the same file is also reached via a clean path.
+     *
+     * It deliberately points one level above `src/phel` (so it contains rather
+     * than is `src/phel`) so that entry-point detection in
+     * `RunFacade::autoDetectEntryPoint` does not accidentally return phel's own
+     * `core.phel` when the user has no entry point of their own.
+     */
+    public function getPhelInternalSrcDir(): string
+    {
+        return dirname(__DIR__, 2);
+    }
+
+    /**
+     * Shares `PhelProjectDirectory::resolveCacheDir()` with the build and
+     * compiler configs, so an error report names the same cache directory the
+     * compiled artifacts are written to.
+     */
+    public function getCacheDir(): string
+    {
+        return PhelProjectDirectory::resolveCacheDir(
+            $this->getAppRootDir(),
+            ScalarCoercion::toString($this->get(PhelConfig::CACHE_DIR, self::DEFAULT_CACHE_DIR), self::DEFAULT_CACHE_DIR),
+            ScalarCoercion::toString($this->get(PhelConfig::PHEL_DIR, '')),
         );
     }
 
@@ -84,14 +105,10 @@ final class CommandConfig extends AbstractConfig
 
         $outputDir = ScalarCoercion::toString($buildConfig[PhelBuildConfig::DEST_DIR] ?? null, self::DEFAULT_OUTPUT_DIR);
 
-        $cacheDir = ScalarCoercion::toString($this->get(PhelConfig::CACHE_DIR, '.phel/cache'), '.phel/cache');
-        $phelDir = ScalarCoercion::toString($this->get(PhelConfig::PHEL_DIR, ''));
-        $resolvedCacheDir = PhelProjectDirectory::resolve($this->getAppRootDir(), $cacheDir, $phelDir);
-
         return sprintf(
             'stale compiled output? try `rm -rf %s %s` and rebuild.',
             rtrim($outputDir, '/'),
-            rtrim($resolvedCacheDir, '/'),
+            rtrim($this->getCacheDir(), '/'),
         );
     }
 }

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -13,6 +13,7 @@ use Phel\Command\Application\TextExceptionPrinter;
 use Phel\Command\Domain\CommandExceptionWriterInterface;
 use Phel\Command\Domain\Exceptions\ExceptionArgsPrinter;
 use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractor;
+use Phel\Command\Domain\Exceptions\InternalPathDetector;
 use Phel\Command\Domain\Finder\DirectoryFinderInterface;
 use Phel\Command\Domain\Finder\VendorDirectoriesFinderInterface;
 use Phel\Command\Infrastructure\ComposerVendorDirectoriesFinder;
@@ -44,6 +45,8 @@ final class CommandFactory extends AbstractFactory
             $this->createFilePositionExtractor(),
             $this->getConfig()->getStaleOutputHint(),
             $this->createExceptionHintResolver(),
+            $this->createInternalPathDetector(),
+            Printer::readable(),
         );
     }
 
@@ -95,6 +98,14 @@ final class CommandFactory extends AbstractFactory
         $reader = $this->getProvidedDependency(CommandProvider::PHP_CONFIG_READER);
 
         return $reader;
+    }
+
+    private function createInternalPathDetector(): InternalPathDetector
+    {
+        return new InternalPathDetector(
+            $this->getConfig()->getPhelInternalSrcDir(),
+            $this->getConfig()->getCacheDir(),
+        );
     }
 
     private function createComposerVendorDirectoriesFinder(): VendorDirectoriesFinderInterface

--- a/src/php/Command/Domain/Exceptions/InternalPathDetector.php
+++ b/src/php/Command/Domain/Exceptions/InternalPathDetector.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Command\Domain\Exceptions;
+
+use function str_starts_with;
+
+/**
+ * Tells Phel's own machinery apart from the user's project when reporting an
+ * error: the bundled core library and runtime (`<phel>/src/…`), the eval temp
+ * file and everything under the compiled cache.
+ *
+ * @internal
+ */
+final readonly class InternalPathDetector
+{
+    public function __construct(
+        private string $phelInternalSrcDir,
+        private string $cacheDir,
+    ) {}
+
+    /**
+     * Whether the source-mapped file belongs to Phel itself rather than to the
+     * user's project, and is therefore no place for the user to act on.
+     */
+    public function isInternalSource(string $file): bool
+    {
+        return $this->isUnder($file, $this->phelInternalSrcDir)
+            || $this->isInternalArtifact($file);
+    }
+
+    /**
+     * Whether the compiled file is a regenerable artifact with no meaning to a
+     * user: the eval temp file (`__phel_<hash>.php`) or the compiled cache,
+     * whose filename embeds a content hash and changes between runs. A
+     * persistent build artifact under `out/` is not one: naming it is what the
+     * stale-output hint builds on.
+     */
+    public function isInternalArtifact(string $file): bool
+    {
+        return str_starts_with(basename($file), '__phel')
+            || $this->isUnder($file, $this->cacheDir);
+    }
+
+    private function isUnder(string $file, string $directory): bool
+    {
+        if ($directory === '') {
+            return false;
+        }
+
+        // A PHAR stream path always uses `/`, whatever the host separator is.
+        $normalizedDirectory = rtrim(str_replace('\\', '/', $directory), '/') . '/';
+
+        return str_starts_with(str_replace('\\', '/', $file), $normalizedDirectory);
+    }
+}

--- a/tests/php/Integration/Run/Command/Run/Fixtures/core-error-script.phel
+++ b/tests/php/Integration/Run/Command/Run/Fixtures/core-error-script.phel
@@ -1,0 +1,6 @@
+(ns core-error-script)
+
+(defn read-fifth [xs]
+  (nth xs 5))
+
+(read-fifth [])

--- a/tests/php/Integration/Run/Command/Run/Fixtures/ex-info-script.phel
+++ b/tests/php/Integration/Run/Command/Run/Fixtures/ex-info-script.phel
@@ -1,0 +1,3 @@
+(ns ex-info-script)
+
+(throw (ex-info "boom" {:user-id 42 :op :charge}))

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -192,6 +192,33 @@ final class RunCommandTest extends AbstractTestCommand
         self::assertMatchesRegularExpression('~\.\.\. \d+ internal frames?~', $output);
     }
 
+    public function test_core_library_error_points_at_the_user_call_site(): void
+    {
+        $output = $this->captureRunOutput(
+            __DIR__ . '/Fixtures/core-error-script.phel',
+        );
+
+        self::assertStringContainsString('Vector index 5 out of bounds', $output);
+        // `nth` raises inside `phel\core`, which the user cannot act on: the
+        // `at` line names their own call site instead (#3260).
+        self::assertMatchesRegularExpression('~at .*core-error-script\.phel:4~', $output);
+        self::assertDoesNotMatchRegularExpression('~at .*sequences\.phel~', $output);
+        self::assertStringNotContainsString('cache/compiled', $output);
+        self::assertStringNotContainsString('compiled:', $output);
+    }
+
+    public function test_uncaught_ex_info_prints_its_data(): void
+    {
+        $output = $this->captureRunOutput(
+            __DIR__ . '/Fixtures/ex-info-script.phel',
+        );
+
+        self::assertStringContainsString('boom', $output);
+        self::assertStringContainsString('data: {:user-id 42, :op :charge}', $output);
+        self::assertMatchesRegularExpression('~at .*ex-info-script\.phel:3~', $output);
+        self::assertDoesNotMatchRegularExpression('~at .*exceptions\.phel~', $output);
+    }
+
     public function test_runtime_error_maps_phel_frames_on_repeated_run(): void
     {
         $scriptPath = __DIR__ . '/Fixtures/error-trace-script.phel';

--- a/tests/php/Unit/Command/Application/CommandExceptionWriterTest.php
+++ b/tests/php/Unit/Command/Application/CommandExceptionWriterTest.php
@@ -101,6 +101,9 @@ final class CommandExceptionWriterTest extends TestCase
 
         self::assertStringContainsString('at /proj/src/app/main.phel:2', $text);
         self::assertStringNotContainsString('sequences.phel', $text);
+        // A compiled path pairing the user's position with the core throw site
+        // would name the cache artifact here.
+        self::assertStringNotContainsString(self::CACHE_DIR, $text);
     }
 
     public function test_never_names_the_compiled_cache_in_user_facing_output(): void

--- a/tests/php/Unit/Command/Application/CommandExceptionWriterTest.php
+++ b/tests/php/Unit/Command/Application/CommandExceptionWriterTest.php
@@ -8,19 +8,28 @@ use Phel\Command\Application\CommandExceptionWriter;
 use Phel\Command\Domain\ErrorLogInterface;
 use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractorInterface;
 use Phel\Command\Domain\Exceptions\Extractor\ReadModel\FilePosition;
+use Phel\Command\Domain\Exceptions\InternalPathDetector;
+use Phel\Lang\ExceptionInfo;
+use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
+use Phel\Lang\TypeFactory;
 use Phel\Shared\Exceptions\AbstractLocatedException;
 use Phel\Shared\Exceptions\ExceptionPrinterInterface;
 use Phel\Shared\Exceptions\Hint\ExceptionHintResolver;
 use Phel\Shared\Exceptions\Hint\NotCallableHint;
 use Phel\Shared\Exceptions\Hint\UndefinedSymbolHint;
 use Phel\Shared\Parser\ReadModel\CodeSnippet;
+use Phel\Shared\Printer\Printer;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 final class CommandExceptionWriterTest extends TestCase
 {
+    private const string PHEL_SRC_DIR = '/proj/vendor/phel-lang/phel-lang/src';
+
+    private const string CACHE_DIR = '/proj/.phel/cache';
+
     public function test_resolves_compiled_php_to_phel_source_when_source_map_exists(): void
     {
         $compiledPath = '/proj/out/phel/http.php';
@@ -32,13 +41,7 @@ final class CommandExceptionWriterTest extends TestCase
             ->with($compiledPath, $compiledLine)
             ->willReturn(new FilePosition('/proj/src/phel/http.phel', 142));
 
-        $writer = new CommandExceptionWriter(
-            $this->createStub(ExceptionPrinterInterface::class),
-            $this->createStub(ErrorLogInterface::class),
-            $extractor,
-            'stale compiled output? try `rm -rf out /var/state/cache` and rebuild.',
-            new ExceptionHintResolver([]),
-        );
+        $writer = $this->createWriter($extractor);
 
         $output = new BufferedOutput();
         $writer->writeStackTrace($output, $this->errorAt('Value of type null is not callable', $compiledPath, $compiledLine));
@@ -61,13 +64,7 @@ final class CommandExceptionWriterTest extends TestCase
         $extractor = $this->createStub(FilePositionExtractorInterface::class);
         $extractor->method('getOriginal')->willReturn(new FilePosition('/proj/03-not-fn.phel', 3));
 
-        $writer = new CommandExceptionWriter(
-            $this->createStub(ExceptionPrinterInterface::class),
-            $this->createStub(ErrorLogInterface::class),
-            $extractor,
-            'stale hint',
-            new ExceptionHintResolver([]),
-        );
+        $writer = $this->createWriter($extractor);
 
         $output = new BufferedOutput();
         $writer->writeStackTrace($output, $this->errorAt('Value of type int is not callable', $compiledPath, $compiledLine));
@@ -80,6 +77,90 @@ final class CommandExceptionWriterTest extends TestCase
         self::assertStringNotContainsString('__phel_abc123.php', $text);
     }
 
+    public function test_at_line_points_at_the_user_frame_when_the_error_comes_from_the_core_library(): void
+    {
+        // Innermost first: the throw site inside core, core's own frame, then
+        // the user's call site, which is the first one the user can act on.
+        $extractor = $this->createStub(FilePositionExtractorInterface::class);
+        $extractor->method('getOriginal')->willReturnCallback($this->positionsThenIdentity([
+            new FilePosition(self::PHEL_SRC_DIR . '/phel/core/sequences.phel', 220),
+            new FilePosition(self::PHEL_SRC_DIR . '/phel/core/sequences.phel', 197),
+            new FilePosition('/proj/src/app/main.phel', 2),
+        ]));
+
+        $writer = $this->createWriter($extractor);
+
+        $output = new BufferedOutput();
+        $writer->writeStackTrace($output, $this->errorAt(
+            'Vector index 5 out of bounds',
+            self::CACHE_DIR . '/compiled/phel.core__e0b15747.php',
+            405,
+        ));
+
+        $text = $output->fetch();
+
+        self::assertStringContainsString('at /proj/src/app/main.phel:2', $text);
+        self::assertStringNotContainsString('sequences.phel', $text);
+    }
+
+    public function test_never_names_the_compiled_cache_in_user_facing_output(): void
+    {
+        // No user frame follows the core throw site, so the `at` line falls
+        // back to it, still without naming the regenerable artifact (#3260).
+        $extractor = $this->createStub(FilePositionExtractorInterface::class);
+        $extractor->method('getOriginal')->willReturnCallback($this->positionsThenIdentity([
+            new FilePosition(self::PHEL_SRC_DIR . '/phel/core/sequences.phel', 220),
+        ]));
+
+        $writer = $this->createWriter($extractor);
+
+        $output = new BufferedOutput();
+        $writer->writeStackTrace($output, $this->errorAt(
+            'Vector index 5 out of bounds',
+            self::CACHE_DIR . '/compiled/phel.core__e0b15747.php',
+            405,
+        ));
+
+        $text = $output->fetch();
+
+        self::assertStringContainsString('at ' . self::PHEL_SRC_DIR . '/phel/core/sequences.phel:220', $text);
+        self::assertStringNotContainsString(self::CACHE_DIR, $text);
+        self::assertStringNotContainsString('compiled:', $text);
+    }
+
+    public function test_prints_the_data_map_of_an_uncaught_ex_info(): void
+    {
+        $extractor = $this->createStub(FilePositionExtractorInterface::class);
+        $extractor->method('getOriginal')->willReturn(new FilePosition('/proj/src/app/main.phel', 2));
+
+        $writer = $this->createWriter($extractor);
+
+        $data = TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('user-id'), 42);
+
+        $output = new BufferedOutput();
+        $writer->writeStackTrace($output, new RuntimeException('wrapper', 0, new ExceptionInfo('boom', $data)));
+
+        $text = $output->fetch();
+
+        self::assertStringContainsString('boom', $text);
+        self::assertStringContainsString('data: {:user-id 42}', $text);
+    }
+
+    public function test_omits_the_data_line_for_an_ex_info_without_data(): void
+    {
+        $extractor = $this->createStub(FilePositionExtractorInterface::class);
+        $extractor->method('getOriginal')->willReturn(new FilePosition('/proj/src/app/main.phel', 2));
+
+        $writer = $this->createWriter($extractor);
+
+        $emptyData = TypeFactory::getInstance()->persistentMapFromArray();
+
+        $output = new BufferedOutput();
+        $writer->writeStackTrace($output, new RuntimeException('wrapper', 0, new ExceptionInfo('boom', $emptyData)));
+
+        self::assertStringNotContainsString('data:', $output->fetch());
+    }
+
     public function test_emits_stale_output_hint_when_source_map_missing(): void
     {
         $compiledPath = '/proj/out/phel/http.php';
@@ -89,13 +170,7 @@ final class CommandExceptionWriterTest extends TestCase
         // Same filename back => no source map resolution
         $extractor->method('getOriginal')->willReturn(new FilePosition($compiledPath, $compiledLine));
 
-        $writer = new CommandExceptionWriter(
-            $this->createStub(ExceptionPrinterInterface::class),
-            $this->createStub(ErrorLogInterface::class),
-            $extractor,
-            'stale compiled output? try `rm -rf out /var/state/cache` and rebuild.',
-            new ExceptionHintResolver([]),
-        );
+        $writer = $this->createWriter($extractor);
 
         $output = new BufferedOutput();
         $writer->writeStackTrace($output, $this->errorAt('boom', $compiledPath, $compiledLine));
@@ -119,13 +194,7 @@ final class CommandExceptionWriterTest extends TestCase
         $printer->method('getUserFacingTraceString')
             ->willReturn("#3 /proj/src/main.phel:3 : (phel\\core\\+ 1 \"boom\")\n   ... 2 internal frames\n");
 
-        $writer = new CommandExceptionWriter(
-            $printer,
-            $this->createStub(ErrorLogInterface::class),
-            $extractor,
-            'stale compiled output? try `rm -rf out /var/state/cache` and rebuild.',
-            new ExceptionHintResolver([]),
-        );
+        $writer = $this->createWriter($extractor, $printer);
 
         $output = new BufferedOutput();
         $writer->writeStackTrace(
@@ -152,13 +221,7 @@ final class CommandExceptionWriterTest extends TestCase
         $printer->method('getUserFacingTraceString')
             ->willReturn("#0 /proj/src/main.phel:6 : (app\\main\\level3 1)\n   ... 4 internal frames\n");
 
-        $writer = new CommandExceptionWriter(
-            $printer,
-            $this->createStub(ErrorLogInterface::class),
-            $extractor,
-            'stale hint',
-            new ExceptionHintResolver([]),
-        );
+        $writer = $this->createWriter($extractor, $printer);
 
         $output = new BufferedOutput();
         $writer->writeStackTrace($output, $this->errorAt('boom', '/tmp/__phel_abc.php', 9));
@@ -176,11 +239,9 @@ final class CommandExceptionWriterTest extends TestCase
 
         $located = new class("Cannot resolve symbol 'foo'") extends AbstractLocatedException {};
 
-        $writer = new CommandExceptionWriter(
-            $printer,
-            $this->createStub(ErrorLogInterface::class),
+        $writer = $this->createWriter(
             $this->createStub(FilePositionExtractorInterface::class),
-            'stale hint',
+            $printer,
             new ExceptionHintResolver([new UndefinedSymbolHint()]),
         );
 
@@ -198,11 +259,9 @@ final class CommandExceptionWriterTest extends TestCase
         $extractor = $this->createStub(FilePositionExtractorInterface::class);
         $extractor->method('getOriginal')->willReturn(new FilePosition('/proj/src/main.phel', 3));
 
-        $writer = new CommandExceptionWriter(
-            $this->createStub(ExceptionPrinterInterface::class),
-            $this->createStub(ErrorLogInterface::class),
+        $writer = $this->createWriter(
             $extractor,
-            'stale hint',
+            null,
             new ExceptionHintResolver([new NotCallableHint()]),
         );
 
@@ -220,6 +279,37 @@ final class CommandExceptionWriterTest extends TestCase
 
         self::assertStringContainsString('hint:', $text);
         self::assertStringContainsString("'vector' is not a function", $text);
+    }
+
+    private function createWriter(
+        FilePositionExtractorInterface $filePositionExtractor,
+        ?ExceptionPrinterInterface $exceptionPrinter = null,
+        ?ExceptionHintResolver $hintResolver = null,
+    ): CommandExceptionWriter {
+        return new CommandExceptionWriter(
+            $exceptionPrinter ?? $this->createStub(ExceptionPrinterInterface::class),
+            $this->createStub(ErrorLogInterface::class),
+            $filePositionExtractor,
+            'stale compiled output? try `rm -rf out /var/state/cache` and rebuild.',
+            $hintResolver ?? new ExceptionHintResolver([]),
+            new InternalPathDetector(self::PHEL_SRC_DIR, self::CACHE_DIR),
+            Printer::readable(),
+        );
+    }
+
+    /**
+     * Feeds the extractor one resolved position per lookup, innermost frame
+     * first, then maps any further frame to itself.
+     *
+     * @param list<FilePosition> $positions
+     */
+    private function positionsThenIdentity(array $positions): callable
+    {
+        return static function (string $file, int $line) use (&$positions): FilePosition {
+            $position = array_shift($positions);
+
+            return $position instanceof FilePosition ? $position : new FilePosition($file, $line);
+        };
     }
 
     private function errorAt(string $message, string $file, int $line): RuntimeException

--- a/tests/php/Unit/Command/Domain/Exceptions/InternalPathDetectorTest.php
+++ b/tests/php/Unit/Command/Domain/Exceptions/InternalPathDetectorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Command\Domain\Exceptions;
+
+use Phel\Command\Domain\Exceptions\InternalPathDetector;
+use PHPUnit\Framework\TestCase;
+
+final class InternalPathDetectorTest extends TestCase
+{
+    private const string PHEL_SRC_DIR = '/proj/vendor/phel-lang/phel-lang/src';
+
+    private const string CACHE_DIR = '/proj/.phel/cache';
+
+    public function test_core_library_source_is_internal(): void
+    {
+        self::assertTrue($this->detector()->isInternalSource(self::PHEL_SRC_DIR . '/phel/core/sequences.phel'));
+    }
+
+    public function test_project_source_is_not_internal(): void
+    {
+        self::assertFalse($this->detector()->isInternalSource('/proj/src/app/main.phel'));
+    }
+
+    public function test_a_sibling_directory_sharing_the_prefix_is_not_internal(): void
+    {
+        self::assertFalse($this->detector()->isInternalSource(self::PHEL_SRC_DIR . '-backup/phel/core/sequences.phel'));
+    }
+
+    public function test_compiled_cache_artifact_is_internal(): void
+    {
+        $artifact = self::CACHE_DIR . '/compiled/phel.core__e0b15747.php';
+
+        self::assertTrue($this->detector()->isInternalArtifact($artifact));
+        self::assertTrue($this->detector()->isInternalSource($artifact));
+    }
+
+    public function test_eval_temp_file_is_internal(): void
+    {
+        self::assertTrue($this->detector()->isInternalArtifact('/var/folders/T/phel/tmp/__phel_abc123.php'));
+    }
+
+    public function test_build_output_is_not_internal(): void
+    {
+        self::assertFalse($this->detector()->isInternalArtifact('/proj/out/phel/http.php'));
+    }
+
+    public function test_an_unconfigured_directory_matches_nothing(): void
+    {
+        $detector = new InternalPathDetector('', '');
+
+        self::assertFalse($detector->isInternalSource('/proj/src/app/main.phel'));
+    }
+
+    private function detector(): InternalPathDetector
+    {
+        return new InternalPathDetector(self::PHEL_SRC_DIR, self::CACHE_DIR);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

An error raised inside the core library reported `at src/phel/core/sequences.phel:220 (compiled: .phel/cache/compiled/phel.core__e0b15747.php:405)`. Neither line is a place the user can act on, and the cache filename embeds a hash that changes between runs.

## 💡 Goal

Make the first line of an error report name the code the user wrote.

## 🔖 Changes

- The `at` line anchors on the throw site only when it belongs to the user, and walks out to the innermost user frame otherwise.
- The compiled cache joins the eval temp file as an internal artifact whose path is never printed.
- An uncaught `ex-info` prints its data map on its own `data:` line.
- Core library frames stay in the numbered trace, where they carry context.

Closes #3260