### PR TITLE
fix(test): show the asserted form on the Form line of a failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - REPL: `(exit)` and `(quit)` end the session like `exit` and `quit`, `(exit <code>)` sets the exit status, and the banner names the call form. (#3272)
+- `phel test`: the `Form:` line of a failed assertion prints the asserted source form instead of repeating the evaluated value. (#3263)
 
 ## [0.51.0](https://github.com/phel-lang/phel-lang/compare/v0.50.0...v0.51.0) - 2026-09-05
 

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -497,7 +497,7 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
   (apply println (str label ":") (readable-str value) extras))
 
 (defn- print-form-evaluated
-  "Prints the `Form: ... / evaluated to: ...` pair shared by every failure printer that reports a single value and its computed result."
+  "Prints the `Form: ... / evaluated to: ...` pair shared by every failure printer: the asserted source form above the value it computed."
   [label-form form label-eval result]
   (print-label label-form form)
   (print-label label-eval result))
@@ -673,18 +673,18 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
   (print-error-headline data)
   (print-error-details data))
 
-(defn- print-predicate-failure [{:pred pred, :value value, :result result}]
-  (print-form-evaluated "                 Form" value
+(defn- print-predicate-failure [{:pred pred, :form form, :result result}]
+  (print-form-evaluated "                 Form" form
                         "         evaluated to" result)
   (print-label "  but doesn't satisfy" pred))
 
-(defn- print-predicate-not-failure [{:pred pred, :value value, :result result}]
-  (print-form-evaluated "              Form" value
+(defn- print-predicate-not-failure [{:pred pred, :form form, :result result}]
+  (print-form-evaluated "              Form" form
                         "      evaluated to" result)
   (print-label "  but does satisfy" pred " (it shouldn't)"))
 
-(defn- print-binary-failure [{:pred pred, :expected expected, :actual actual, :result result}]
-  (print-form-evaluated "          Form" actual
+(defn- print-binary-failure [{:pred pred, :expected expected, :form form, :result result}]
+  (print-form-evaluated "          Form" form
                         "  evaluated to" result)
   (print-label "    but is not" pred "to" (readable-str expected))
   (when (= pred '=)
@@ -693,8 +693,8 @@ Metadata attached to `test-name` is forwarded to the defined function so selecto
     (when (and (string? expected) (string? result))
       (print-string-diff expected result))))
 
-(defn- print-binary-not-failure [{:pred pred, :expected expected, :actual actual, :result result}]
-  (print-form-evaluated "          Form" actual
+(defn- print-binary-not-failure [{:pred pred, :expected expected, :form form, :result result}]
+  (print-form-evaluated "          Form" form
                         "  evaluated to" result)
   (print-label "        but is" pred "to" (readable-str expected) "(it shouldn't be)")
   (when (and (= pred 'not=)

--- a/tests/phel/reporters.phel
+++ b/tests/phel/reporters.phel
@@ -270,9 +270,8 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- default-reporter-failure-output
-  "The default reporter's output for one real failing assertion, `assert-thunk`
-  wrapping the `is` form under test so the reported event carries a genuine
-  source form and location."
+  "The default reporter's output for the one real failing assertion in
+  `assert-thunk`, so the rendered event carries a genuine source form."
   [assert-thunk]
   (let [rep (t/resolve-reporter :default)]
     (with-output-buffer

--- a/tests/phel/reporters.phel
+++ b/tests/phel/reporters.phel
@@ -266,6 +266,51 @@
         "error output renders empty strings with quotes")))
 
 ;; ---------------------------------------------------------------------------
+;; Default reporter: the Form line carries the asserted source form
+;; ---------------------------------------------------------------------------
+
+(defn- default-reporter-failure-output
+  "The default reporter's output for one real failing assertion, `assert-thunk`
+  wrapping the `is` form under test so the reported event carries a genuine
+  source form and location."
+  [assert-thunk]
+  (let [rep (t/resolve-reporter :default)]
+    (with-output-buffer
+      (t/with-isolated-reporters [rep]
+        (t/with-isolated-stats
+          (rep {:type :begin-test-run})
+          (assert-thunk)
+          (rep (summary-of-current-stats)))))))
+
+(deftest test-default-reporter-binary-failure-shows-the-asserted-form
+  (let [out (default-reporter-failure-output (fn [] (is (= 1 2))))]
+    (is (php/str_contains out "Form: (= 1 2)")
+        (str "the Form line carries the whole asserted form, got: " out))
+    (is (php/str_contains out "evaluated to: 2")
+        "the evaluated-to line still carries the computed value")))
+
+(deftest test-default-reporter-binary-not-failure-shows-the-asserted-form
+  (let [out (default-reporter-failure-output (fn [] (is (not (= 2 2)))))]
+    (is (php/str_contains out "Form: (= 2 2)")
+        (str "the Form line carries the negated form, got: " out))
+    (is (php/str_contains out "evaluated to: 2")
+        "the evaluated-to line still carries the computed value")))
+
+(deftest test-default-reporter-predicate-failure-shows-the-asserted-form
+  (let [out (default-reporter-failure-output (fn [] (is (pos? -3))))]
+    (is (php/str_contains out "Form: (pos? -3)")
+        (str "the Form line carries the predicate call, got: " out))
+    (is (php/str_contains out "evaluated to: -3")
+        "the evaluated-to line still carries the computed value")))
+
+(deftest test-default-reporter-predicate-not-failure-shows-the-asserted-form
+  (let [out (default-reporter-failure-output (fn [] (is (not (pos? 3)))))]
+    (is (php/str_contains out "Form: (pos? 3)")
+        (str "the Form line carries the negated predicate call, got: " out))
+    (is (php/str_contains out "evaluated to: 3")
+        "the evaluated-to line still carries the computed value")))
+
+;; ---------------------------------------------------------------------------
 ;; Default reporter — thrown-with-msg failure formatting
 ;; ---------------------------------------------------------------------------
 
@@ -556,7 +601,7 @@
               (rep {:type :end-test-ns :ns "dx.lib-test"}))]
     (is (= (str "::group::dx.lib-test\n"
                 "::error file=tests/dx/lib_test.phel,line=12,title=FAIL dx.lib-test/clamp-mid"
-                "::Form: (clamp 1 10 12)%0Aevaluated to: 6%0Abut is not: = to 5\n"
+                "::Form: (= 5 (clamp 1 10 12))%0Aevaluated to: 6%0Abut is not: = to 5\n"
                 "::endgroup::\n")
            out)
         "a passing assertion prints nothing; a failure is one ::error line inside the namespace group")))
@@ -633,10 +678,11 @@
               (t/with-isolated-reporters [rep]
                 (t/with-isolated-stats
                   (is (= 1 2) "real failure"))))]
-    (is (php/preg_match (str "/^::error file=tests\\/phel\\/reporters\\.phel,line=[1-9][0-9]*,"
-                             "title=FAIL test-github-reporter-reports-a-real-failing-assertion-against-its-file"
-                             "::real failure%0AForm: 2%0Aevaluated to: 2%0Abut is not: = to 1\n$/")
-                        out)
+    ;; `=` and not truthiness: a non-matching `preg_match` returns 0, which is truthy in Phel.
+    (is (= 1 (php/preg_match (str "/^::error file=tests\\/phel\\/reporters\\.phel,line=[1-9][0-9]*,"
+                                  "title=FAIL test-github-reporter-reports-a-real-failing-assertion-against-its-file"
+                                  "::real failure%0AForm: \\(= 1 2\\)%0Aevaluated to: 2%0Abut is not: = to 1\n$/")
+                             out))
         (str "file is relative to the working directory and the line is the assertion's own, got: " out))))
 
 ;; ---------------------------------------------------------------------------

--- a/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
@@ -138,8 +138,9 @@ final class ReplPromptNamespaceTest extends AbstractTestCommand
         // The test runner prints via php/print; ReplTestIo drains that into its
         // transcript, so the reported form shows up in getOutputString().
         $output = $io->getOutputString();
-        self::assertStringContainsString('Form: ""', $output);
-        self::assertStringNotContainsString('Form: ' . PHP_EOL, $output);
+        self::assertStringContainsString('Form: (= 0 "")', $output);
+        self::assertStringContainsString('evaluated to: ""', $output);
+        self::assertStringNotContainsString('evaluated to: ' . PHP_EOL, $output);
     }
 
 }


### PR DESCRIPTION
## 🤔 Background

A failing `(is (= a b))` printed the same string under `Form:` and `evaluated to:`. Both lines came from the second argument of the assertion, so the asserted form never appeared and a reader had to open the file to know which assertion failed. The `ERROR ... threw:` path already printed the whole form.

## 💡 Goal

`Form:` shows the source form of the assertion, for every failure printer that renders it.

## 🔖 Changes

- The four `print-form-evaluated` call sites read `:form` instead of `:value` / `:actual`.
- New default-reporter tests for each of the four failure printers, driven by real failing assertions.
- Updated the two GitHub-reporter pins and the REPL transcript assertion. The `preg_match` pin now compares against 1, because a non-matching `preg_match` returns 0, which is truthy in Phel.
- The refactor pass found nothing structural, only a docstring trim.

Closes #3263