### PR TITLE
fix(build): survive a concurrent prune of the OPcache file cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - A compiler deprecation prints one stderr line naming the user's file, instead of four PHP-rendered lines naming an internal Phel class. (#3262)
 - `<phel-dir>/opcache` no longer grows without bound: `phel cache:clear` empties it, every run prunes dead system-id subtrees and orphaned `.bin` files, and `phel doctor` reports its size. (#3268)
 - `phel mutate` and `phel test --coverage` collect coverage under pcov instead of reporting nothing, and a run that reached no mutant scores 0 rather than passing `--min-covered-msi`. (#3270)
+- Pruning the OPcache file cache no longer dies with a fatal `UnexpectedValueException` when a second process removes a subdirectory under it, which took down whatever command was running. (#3280)
 - Analyzer: redefining a symbol now prints the snippet, the caret, the `PHEL004` code and the line where the symbol was first defined, instead of one line followed by 31 internal frames. (#3267)
 - Printer: a host object with no printer of its own renders as `#<Class>`, so a stack-trace frame no longer shows a sentence where one argument belongs. (#3265)
 - `phel test --parallel`: the parent warms every bundled namespace before dispatching, and a namespace is re-run on a fresh worker only when the worker itself failed, never for a compile error or a failing test. (#3271)

--- a/src/php/Shared/Performance/OpcacheFileCachePruner.php
+++ b/src/php/Shared/Performance/OpcacheFileCachePruner.php
@@ -8,6 +8,7 @@ use FilesystemIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
+use UnexpectedValueException;
 
 use function file_exists;
 use function is_dir;
@@ -134,15 +135,28 @@ final readonly class OpcacheFileCachePruner
      * `RecursiveDirectoryIterator` does not descend into symlinked directories
      * unless asked to, which is what keeps a deletion inside this tree.
      *
+     * A directory that disappears while the walk runs is not an error: the
+     * cache is shared, so a second `phel` process pruning the same tree, or a
+     * `cache:clear` next to a test run, removes entries under this one's feet.
+     * `CATCH_GET_CHILD` absorbs that for a subdirectory and the catch does it
+     * for the root. Without them the walk throws `UnexpectedValueException`,
+     * which nothing along `bin/phel` handles, so pruning a cache someone else
+     * is also pruning killed the command outright.
+     *
      * @return iterable<SplFileInfo>
      */
     private function walk(string $directory): iterable
     {
-        /** @var iterable<SplFileInfo> $iterator */
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST,
-        );
+        try {
+            /** @var iterable<SplFileInfo> $iterator */
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+                RecursiveIteratorIterator::CHILD_FIRST,
+                RecursiveIteratorIterator::CATCH_GET_CHILD,
+            );
+        } catch (UnexpectedValueException) {
+            return [];
+        }
 
         return $iterator;
     }

--- a/tests/php/Unit/Shared/Performance/OpcacheFileCachePrunerTest.php
+++ b/tests/php/Unit/Shared/Performance/OpcacheFileCachePrunerTest.php
@@ -10,9 +10,11 @@ use PhelTest\Support\RemoveDirTrait;
 use PHPUnit\Framework\TestCase;
 
 use function bin2hex;
+use function chmod;
 use function dirname;
 use function file_put_contents;
 use function is_dir;
+use function is_readable;
 use function mkdir;
 use function random_bytes;
 use function symlink;
@@ -137,6 +139,63 @@ final class OpcacheFileCachePrunerTest extends TestCase
         $pruner = new OpcacheFileCachePruner(new OpcacheFileCache($this->root . '/absent'));
 
         self::assertFalse($pruner->clearContents());
+    }
+
+    /**
+     * The cache is shared, so a second `phel` process pruning the same tree
+     * removes entries under this one's feet. The walk used to throw
+     * `UnexpectedValueException` at the subdirectory it could no longer open,
+     * and nothing along `bin/phel` handles it, so the command died with a fatal
+     * error mid-prune (#3280). An unreadable subdirectory raises it the same way
+     * a vanished one does, and is the half a test can force.
+     */
+    public function test_a_subdirectory_it_cannot_open_does_not_abort_the_prune(): void
+    {
+        $this->plantBin(self::FOREIGN_ID, '/opt/app/bin/phel');
+        $this->plantBin(self::FOREIGN_ID, '/opt/other/bin/phel');
+
+        $sealed = $this->cacheDir . '/' . self::FOREIGN_ID . '/opt/app';
+        chmod($sealed, 0o000);
+        if (is_readable($sealed)) {
+            chmod($sealed, 0o755);
+            self::markTestSkipped('This user can read a directory with no permissions.');
+        }
+
+        try {
+            $removed = new OpcacheFileCachePruner($this->fileCache)->pruneForeignSystemIds(self::CURRENT_ID);
+        } finally {
+            chmod($sealed, 0o755);
+        }
+
+        self::assertSame([$this->cacheDir . '/' . self::FOREIGN_ID], $removed);
+        // The half it could reach is gone; the sealed half is left where it is.
+        self::assertFileDoesNotExist($this->cacheDir . '/' . self::FOREIGN_ID . '/opt/other/bin/phel.bin');
+    }
+
+    /**
+     * The same race one level up: the entry the walk starts at is the one it
+     * cannot open. `CATCH_GET_CHILD` only covers the descent, so the root needs
+     * its own guard.
+     */
+    public function test_an_entry_it_cannot_open_at_all_does_not_abort_the_prune(): void
+    {
+        $this->plantBin(self::FOREIGN_ID, '/opt/app/bin/phel');
+
+        $sealed = $this->cacheDir . '/' . self::FOREIGN_ID;
+        chmod($sealed, 0o000);
+        if (is_readable($sealed)) {
+            chmod($sealed, 0o755);
+            self::markTestSkipped('This user can read a directory with no permissions.');
+        }
+
+        try {
+            $removed = new OpcacheFileCachePruner($this->fileCache)->pruneForeignSystemIds(self::CURRENT_ID);
+        } finally {
+            chmod($sealed, 0o755);
+        }
+
+        self::assertSame([$sealed], $removed);
+        self::assertDirectoryExists($sealed);
     }
 
     private function plantBin(string $entry, string $sourcePath): void


### PR DESCRIPTION
## 🤔 Background

The OPcache file cache is shared: every `phel` process prunes it on boot, and `phel cache:clear` empties it. Two of them running at once is normal, a test suite under paratest does it a dozen times over.

`OpcacheFileCachePruner::walk()` opened each directory as it descended. When a second process had already removed one, `RecursiveDirectoryIterator` threw `UnexpectedValueException`. Nothing along `bin/phel` handles it, so the command died with a fatal error mid-prune and exited 255, whatever it had been asked to do:

```
PHP Fatal error:  Uncaught UnexpectedValueException: RecursiveDirectoryIterator::__construct(...): Failed to open directory: No such file or directory
```

Reproduced locally as two unrelated integration tests failing under `composer test-compiler`, both `Failed asserting that 255 is identical to 0`. They pass serially.

## 💡 Goal

A prune that loses a race finishes quietly. Nothing else about it changes.

## 🔖 Changes

- `RecursiveIteratorIterator::CATCH_GET_CHILD` absorbs the failure on a subdirectory, which is where the crash was reported.
- A `catch` around the construction covers the root entry, which `CATCH_GET_CHILD` does not reach.
- Two tests, one per branch. A directory with no permissions raises the same exception a vanished one does, and is the half a test can force; both are red without the fix.

Related #3280
