### PR TITLE
fix(analyzer): name the Phel type in diagnostics, not the PHP one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - `phel explain <code>` prints what an error code means, the smallest program that raises it and the fix. The same text is generated into `docs/errors/`, one page per code range. (#3266)
 - A runtime error carries an error code: `PHEL400` not callable, `PHEL401` arity, `PHEL402` type, `PHEL403` out of bounds, `PHEL404` division by zero. Every uncaught runtime failure used to print a bare message. (#3266)
 - **BREAKING (PHP API)**: `ErrorCode::INVALID_QUOTE`, `ErrorCode::INVALID_UNQUOTE` and `ErrorCode::INVALID_CHARACTER` are removed. They named errors Phel does not raise. (#3266)
+- Public API: `Phel\Lang\PhelType`, the PHP mirror of `phel.core/type`, so anything wording a type for a user agrees with the language. (#3290)
 
 ### Fixed
 
@@ -30,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - The error log is plain text, opens every entry with a timestamp and the command that produced it, and rotates at 1 MiB into `error.log.1` instead of growing without bound with ANSI escapes in it. (#3269)
 - Analyzer, reader and parser errors that had a code defined but never printed it now print it: `PHEL008` bindings, `PHEL009` interfaces, `PHEL010` `recur`, `PHEL202` splice. (#3266)
 - A `definterface` method with no argument vector, and a `catch` with no type or binding, report the analyzer error naming the form instead of an out-of-bounds error raised inside `PersistentList`. (#3266)
+- Analyzer messages name the Phel type, not the PHP one: `nil` instead of `null`, `boolean` instead of `bool`, `vector` and `hash-map` instead of `Collections\Vector\PersistentVector` and `Collections\Map\PersistentArrayMap`. A hash map no longer changes what it is called at eight entries. (#3290)
 
 ## [0.51.0](https://github.com/phel-lang/phel-lang/compare/v0.50.0...v0.51.0) - 2026-09-05
 

--- a/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
+++ b/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
@@ -8,6 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
+use Phel\Lang\PhelType;
 use Phel\Lang\TypeInterface;
 use Phel\Shared\Exceptions\AbstractLocatedException;
 use Phel\Shared\Exceptions\ErrorCode;
@@ -298,22 +299,17 @@ final class AnalyzerException extends AbstractLocatedException
     }
 
     /**
-     * Formats a type name for display in error messages.
-     * Strips namespace prefixes for Phel types to make messages more readable.
+     * Names the value the way the language names it, so a message agrees with
+     * what `(type value)` returns for the same value. A host object is the one
+     * place the class beats the Phel answer: `php/object` says nothing a reader
+     * can act on, and the class name says which object arrived.
      */
     private static function formatTypeName(mixed $value): string
     {
-        $type = get_debug_type($value);
+        $type = PhelType::nameOf($value);
 
-        if (str_starts_with($type, 'Phel\\Lang\\')) {
-            return substr($type, 10);
-        }
-
-        // Strip Phel\Lang\Collections\ prefix
-        if (str_starts_with($type, 'Phel\\Lang\\Collections\\')) {
-            $parts = explode('\\', $type);
-
-            return end($parts);
+        if ($type === 'php/object' || $type === PhelType::UNKNOWN) {
+            return get_debug_type($value);
         }
 
         return $type;

--- a/src/php/Lang/CLAUDE.md
+++ b/src/php/Lang/CLAUDE.md
@@ -55,6 +55,7 @@ Shared behaviour traits: `MetaTrait` (`getMeta`/`withMeta`), `HashCombinerTrait`
 | `TypeFactory` | Singleton creating persistent collections; provides `Hasher`/`Equalizer` singletons |
 | `Seq` | Static utility for sequence ops. Mostly thin delegates to `Generators/`, plus the two single-pull probes `isEmpty()` / `first()` that answer `empty?` / `first` for a source with no size or indexed access of its own |
 | `TagRegistry` | Reader literal tag-handler dispatch (`TagHandlers/`: `#inst`, `#uuid`, regex) |
+| `PhelType` | `nameOf(mixed): string`, the PHP mirror of `phel.core/type` (`nil`, `boolean`, `vector`, `hash-map`, ...). Anything on the PHP side that words a type for a user reads it from here, never from `get_debug_type()`, which names the implementation and changes a map's name at eight entries. Branch order matches `predicates.phel` exactly; `tests/phel/core/phel-type-parity.phel` pins the two together (#3290) |
 | `LoadClasspath` | Static accessor for the `(load ...)` classpath, stored in `Registry` under `phel.core/*load-classpath*`. Lives here (not Compiler) because its state is a `Registry` slot; FQN baked into generated PHP by `LoadEmitter`. Do NOT rename |
 | `\Phel` (`src/Phel.php`, NOT a Lang class) | Thin root facade proxying static calls to the `Registry` singleton via `__callStatic`. Api/Interop use it for ns/definition lookups (`getNamespaces`, `getDefinition`, `getDefinitionMetaData`). Lang's own code must NOT call it (leaf → root cycle); use `Registry`/`TypeFactory` directly |
 

--- a/src/php/Lang/PhelType.php
+++ b/src/php/Lang/PhelType.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\MapEntry;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Queue\PersistentQueue;
+use Phel\Lang\Collections\Struct\AbstractPersistentStruct;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+
+use function is_array;
+use function is_bool;
+use function is_callable;
+use function is_float;
+use function is_int;
+use function is_null;
+use function is_object;
+use function is_resource;
+use function is_string;
+
+/**
+ * Names a value the way the language names it.
+ *
+ * `phel.core/type` is the answer a Phel user gets when they ask what a value
+ * is, so it is the answer a message about that value has to give too. Anything
+ * on the PHP side that words a type for a user reads it from here rather than
+ * from `get_debug_type()`, which names the implementation: `null` for `nil`,
+ * `bool` for `boolean`, and a concrete collection class that changes with the
+ * size of the collection.
+ *
+ * `PhelTypeMatchesCoreTypeTest` pins this against `phel.core/type` itself, so
+ * the two cannot drift.
+ */
+final readonly class PhelType
+{
+    public const string UNKNOWN = 'unknown';
+
+    /**
+     * The name without a leading colon, since a message says "got vector", not
+     * "got :vector". The order matches `phel.core/type` exactly: an earlier
+     * branch wins, so moving one changes what a value is called.
+     */
+    public static function nameOf(mixed $value): string
+    {
+        return match (true) {
+            $value instanceof PersistentVectorInterface => 'vector',
+            $value instanceof PersistentListInterface => 'list',
+            $value instanceof AbstractPersistentStruct => 'struct',
+            $value instanceof PersistentMapInterface => 'hash-map',
+            $value instanceof MapEntry => 'map-entry',
+            $value instanceof PersistentHashSetInterface => 'set',
+            $value instanceof PersistentQueue => 'queue',
+            $value instanceof Keyword => 'keyword',
+            $value instanceof Symbol => 'symbol',
+            $value instanceof Atom => 'atom',
+            $value instanceof PhelVar => 'var',
+            $value instanceof Ratio => 'ratio',
+            $value instanceof BigInt => 'bigint',
+            $value instanceof BigDecimal => 'bigdec',
+            $value instanceof UUID => 'uuid',
+            $value instanceof PhpClass => 'php/class',
+            is_int($value) => 'int',
+            is_float($value) => 'float',
+            is_string($value) => 'string',
+            is_null($value) => 'nil',
+            is_bool($value) => 'boolean',
+            is_callable($value) => 'function',
+            is_array($value) => 'php/array',
+            is_resource($value) => 'php/resource',
+            is_object($value) => 'php/object',
+            default => self::UNKNOWN,
+        };
+    }
+}

--- a/tests/phel/core/phel-type-parity.phel
+++ b/tests/phel/core/phel-type-parity.phel
@@ -1,0 +1,52 @@
+(ns phel-test.core.phel-type-parity
+  (:require phel.test :refer [deftest is])
+  (:use Phel.Lang.PhelType))
+
+;; `PhelType::nameOf()` is the PHP mirror of `type`: anything on the PHP side
+;; that words a type for a user reads it from there, so an error message says
+;; `nil` where the user wrote `nil`. Two definitions of one mapping drift, and
+;; the drift is invisible until somebody reads a wrong message. This pins them
+;; together.
+
+(defstruct a-struct [x])
+
+(def- a-var 1)
+
+(defn- php-name [x]
+  (keyword (PhelType/nameOf x)))
+
+(defn- values []
+  [[1 2]
+   '(1 2)
+   {:a 1}
+   ;; Above the array-map threshold, so the hash-map implementation is covered
+   ;; too and the answer must not change with the size.
+   (apply hash-map (mapcat (fn [n] [(keyword (str "k" n)) n]) (range 0 12)))
+   (first {:a 1})
+   #{1 2}
+   :keyword
+   'symbol
+   (atom 1)
+   1
+   1.5
+   "string"
+   nil
+   true
+   false
+   (fn [n] (inc n))
+   (php/array 1 2)
+   (queue 1 2)
+   (var a-var)
+   (bigint "10")
+   (bigdec "1.5")
+   (rationalize 0.5)
+   (random-uuid)
+   (class (php/new \stdClass))
+   (php/new \stdClass)
+   (a-struct 1)
+   (php/fopen "php://memory" "r")])
+
+(deftest test-php-mirror-agrees-with-type
+  (foreach [value (values)]
+    (is (= (type value) (php-name value))
+        (str "PhelType/nameOf disagrees with type for " (print-str value)))))

--- a/tests/php/Unit/Architecture/public-api.snapshot.txt
+++ b/tests/php/Unit/Architecture/public-api.snapshot.txt
@@ -1197,6 +1197,10 @@ final class Phel\Lang\NumericOperations
   public static function rem(mixed $a, mixed $b): mixed
   public static function subtract(mixed $a, mixed $b): mixed
 
+final readonly class Phel\Lang\PhelType
+  public const string UNKNOWN = 'unknown'
+  public static function nameOf(mixed $value): string
+
 final readonly class Phel\Lang\PhelVar implements Phel\Lang\EqualsInterface, Phel\Lang\FnInterface, Phel\Lang\HashableInterface, Phel\Lang\MetaInterface
   public function __construct(string $namespace, string $name)
   public function __invoke(mixed ...$args): mixed

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/TrySymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/TrySymbolTest.php
@@ -47,7 +47,7 @@ final class TrySymbolTest extends TestCase
     public function test_a_catch_with_no_arguments_reports_the_analyzer_error(): void
     {
         $this->expectException(AnalyzerException::class);
-        $this->expectExceptionMessage("First argument of 'catch must be a Symbol, got null");
+        $this->expectExceptionMessage("First argument of 'catch must be a Symbol, got nil");
 
         $list = Phel::list([
             Symbol::create(Symbol::NAME_TRY),
@@ -60,7 +60,7 @@ final class TrySymbolTest extends TestCase
     public function test_a_catch_with_only_a_type_reports_the_analyzer_error(): void
     {
         $this->expectException(AnalyzerException::class);
-        $this->expectExceptionMessage("Second argument of 'catch must be a Symbol, got null");
+        $this->expectExceptionMessage("Second argument of 'catch must be a Symbol, got nil");
 
         $list = Phel::list([
             Symbol::create(Symbol::NAME_TRY),


### PR DESCRIPTION
## 🤔 Background

`phel.core/type` is the language's own answer to "what is this value". Analyzer diagnostics answered a different question: they printed the PHP implementation type. A user who wrote `nil` was told `null`, and a user who wrote a vector was told `Collections\Vector\PersistentVector`.

```
$ phel eval '(def nil 1)'
[PHEL003] First argument of 'def must be a Symbol, got null

$ phel eval '(def [1] 1)'
[PHEL003] First argument of 'def must be a Symbol, got Collections\Vector\PersistentVector

$ phel eval '[(type nil) (type [1])]'
[:nil :vector]
```

`AnalyzerException::formatTypeName()` had three problems in one small method:

- `null` and `bool` passed through untouched. Neither word exists in Phel.
- The `Phel\Lang\Collections\` branch was dead. `str_starts_with($type, 'Phel\Lang\')` was checked first and matched every collection, so `substr($type, 10)` returned the internal path and the second branch never ran.
- The concrete class is the wrong granularity anyway: `{}` is a `PersistentArrayMap` below eight entries and a `PersistentHashMap` above it, so the same literal produced two different diagnostics depending on its size.

## 💡 Goal

A message about a value names it the way the language names it.

## 🔖 Changes

- `Phel\Lang\PhelType::nameOf()` mirrors `phel.core/type`, branch for branch and in the same order, since an earlier branch winning is part of the answer. Public, because it is the thing anything on the PHP side should read instead of `get_debug_type()`.
- `formatTypeName()` reads it. A host object is the one case where the class beats the Phel answer: `php/object` says nothing a reader can act on, so the class name stays.
- `tests/phel/core/phel-type-parity.phel` runs 27 values through both and asserts they agree, covering all 25 named branches. Two definitions of one mapping drift, and the drift is invisible until somebody reads a wrong error message.

Closes #3290
