### PR TITLE
fix(lexer): report a lexer error the way every other compile error reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - Analyzer, reader and parser errors that had a code defined but never printed it now print it: `PHEL008` bindings, `PHEL009` interfaces, `PHEL010` `recur`, `PHEL202` splice. (#3266)
 - A `definterface` method with no argument vector, and a `catch` with no type or binding, report the analyzer error naming the form instead of an out-of-bounds error raised inside `PersistentList`. (#3266)
 - Analyzer messages name the Phel type, not the PHP one: `nil` instead of `null`, `boolean` instead of `bool`, `vector` and `hash-map` instead of `Collections\Vector\PersistentVector` and `Collections\Map\PersistentArrayMap`. A hash map no longer changes what it is called at eight entries. (#3290)
+- A lexer error reports like every other compile error: `PHEL310`, the user's file and line, the offending line and a caret under the character it stopped on. `phel run`, `phel eval`, the REPL and `phel format` all used to print the exception class and point at an internal Phel file, and `phel analyze` reported every lexer error at line 1, column 1. (#3289)
 
 ## [0.51.0](https://github.com/phel-lang/phel-lang/compare/v0.50.0...v0.51.0) - 2026-09-05
 

--- a/docs/errors/lexer.md
+++ b/docs/errors/lexer.md
@@ -26,7 +26,7 @@ A `"` opens a string that no later `"` closes. The lexer hands the rest to the a
 
 Enum case: `ErrorCode::LEXER_ERROR`
 
-No token rule matches the source at that position. A bare `#` is the usual cause: every `#` form needs the character that follows it. Editor diagnostics report it under this code; the terminal prints the raw lexer message.
+No token rule matches the source at that position. A bare `#` is the usual cause: every `#` form needs the character that follows it.
 
 ```phel
 (inc #)

--- a/src/php/Api/Application/Analysis/LexAndParseStage.php
+++ b/src/php/Api/Application/Analysis/LexAndParseStage.php
@@ -8,6 +8,7 @@ use Phel\Api\Domain\AnalysisStageInterface;
 use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
 use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
 use Phel\Shared\Api\Diagnostic;
+use Phel\Shared\Exceptions\AbstractLocatedException;
 use Phel\Shared\Exceptions\ErrorCode;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use Phel\Shared\Parser\Node\NodeInterface;
@@ -52,16 +53,7 @@ final readonly class LexAndParseStage implements AnalysisStageInterface
                 $parseTrees[] = $parseTree;
             }
         } catch (LexerValueException $lexerValueException) {
-            $diagnostics[] = new Diagnostic(
-                code: ErrorCode::LEXER_ERROR->value,
-                severity: Diagnostic::SEVERITY_ERROR,
-                message: $lexerValueException->getMessage(),
-                uri: $uri,
-                startLine: 1,
-                startCol: 1,
-                endLine: 1,
-                endCol: 1,
-            );
+            $diagnostics[] = $this->locatedDiagnostic($lexerValueException, ErrorCode::LEXER_ERROR, $uri);
         }
 
         $context['parseTrees'] = $parseTrees;
@@ -71,11 +63,24 @@ final readonly class LexAndParseStage implements AnalysisStageInterface
 
     private function parseErrorDiagnostic(AbstractParserException $e, string $uri): Diagnostic
     {
+        return $this->locatedDiagnostic($e, ErrorCode::PARSER_ERROR, $uri);
+    }
+
+    /**
+     * Both phases raise a located exception, so an editor gets the same span
+     * from either. The lexer error used to be hardcoded to 1:1 because its
+     * exception carried no location at all (#3289).
+     */
+    private function locatedDiagnostic(
+        AbstractLocatedException $e,
+        ErrorCode $fallbackCode,
+        string $uri,
+    ): Diagnostic {
         $start = $e->getStartLocation();
         $end = $e->getEndLocation();
 
         return new Diagnostic(
-            code: ($e->getErrorCode() ?? ErrorCode::PARSER_ERROR)->value,
+            code: ($e->getErrorCode() ?? $fallbackCode)->value,
             severity: Diagnostic::SEVERITY_ERROR,
             message: $e->getMessage(),
             uri: $uri,

--- a/src/php/Compiler/Application/CodeCompiler.php
+++ b/src/php/Compiler/Application/CodeCompiler.php
@@ -126,7 +126,7 @@ final readonly class CodeCompiler implements CodeCompilerInterface
                 $readerResult = $this->timed($hook, 'read', $source, fn(): ReaderResult => $this->reader->read($parseTree));
                 $entries[] = new CachedReaderResult($readerResult, Symbol::genCounter() - $genBefore);
                 $this->analyzeAndEmit($readerResult, $compileOptions, $hook, $source);
-            } catch (AbstractParserException|ReaderException $e) {
+            } catch (AbstractParserException|LexerValueException|ReaderException $e) {
                 throw new CompilerException($e, $e->getCodeSnippet());
             }
         }

--- a/src/php/Compiler/Application/EvalCompiler.php
+++ b/src/php/Compiler/Application/EvalCompiler.php
@@ -72,7 +72,7 @@ final readonly class EvalCompiler implements EvalCompilerInterface
 
                     $result = $this->evalNode($node, $compileOptions);
                 }
-            } catch (AbstractParserException|ReaderException $e) {
+            } catch (AbstractParserException|LexerValueException|ReaderException $e) {
                 throw new CompilerException($e, $e->getCodeSnippet());
             }
         }

--- a/src/php/Compiler/Application/Lexer.php
+++ b/src/php/Compiler/Application/Lexer.php
@@ -10,10 +10,16 @@ use Phel\Compiler\Domain\Lexer\LexerInterface;
 use Phel\Compiler\Domain\Lexer\TokenStream;
 use Phel\Lang\SourceLocation;
 use Phel\Shared\Parser\Node\Token;
+use Phel\Shared\Parser\ReadModel\CodeSnippet;
 
 use function count;
 use function mb_strlen;
+use function preg_match;
+use function rtrim;
 use function strlen;
+use function strpos;
+use function strrpos;
+use function substr;
 
 /**
  * @internal
@@ -113,11 +119,63 @@ final class Lexer implements LexerInterface
 
                 $startLocation = $endLocation;
             } else {
-                throw LexerValueException::unexpectedLexerState($source, $this->line, $this->column);
+                throw $this->unexpectedState($code, $source);
             }
         }
 
         yield new Token(Token::T_EOF, '', $startLocation, $startLocation);
+    }
+
+    /**
+     * The report a lexer error gets is the report every other compile error
+     * gets: the offending line as the snippet, and a caret one character wide
+     * under the byte the lexer stopped on.
+     */
+    private function unexpectedState(string $code, string $source): LexerValueException
+    {
+        $start = $this->createSourceLocation($source);
+        $end = new SourceLocation($start->getFile(), $start->getLine(), $start->getColumn() + 1);
+
+        return LexerValueException::unexpectedLexerState(
+            $this->characterAtCursor($code),
+            $this->currentLineSnippet($code, $source),
+            $start,
+            $end,
+        );
+    }
+
+    /**
+     * One code point, not one byte, so a multibyte character is named whole
+     * rather than as the first byte of itself.
+     */
+    private function characterAtCursor(string $code): string
+    {
+        $rest = substr($code, $this->cursor);
+        if ($rest === '') {
+            return '';
+        }
+
+        return preg_match('/^./us', $rest, $matches) === 1 ? $matches[0] : $rest[0];
+    }
+
+    private function currentLineSnippet(string $code, string $source): CodeSnippet
+    {
+        $lastNewLine = strrpos(substr($code, 0, $this->cursor), "\n");
+        $lineStart = $lastNewLine === false ? 0 : $lastNewLine + 1;
+
+        $nextNewLine = strpos($code, "\n", $lineStart);
+        $line = $nextNewLine === false
+            ? substr($code, $lineStart)
+            : substr($code, $lineStart, $nextNewLine - $lineStart);
+        $line = rtrim($line, "\r");
+
+        $length = $this->isAscii ? strlen($line) : mb_strlen($line, 'UTF-8');
+
+        return new CodeSnippet(
+            new SourceLocation($source, $this->line, 0),
+            new SourceLocation($source, $this->line, $length),
+            $line,
+        );
     }
 
     private function moveCursor(string $str): void

--- a/src/php/Compiler/Application/ParenthesesChecker.php
+++ b/src/php/Compiler/Application/ParenthesesChecker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Application;
 
+use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
 use Phel\Compiler\Domain\Lexer\TokenStream;
 use Phel\Shared\Parser\Node\Token;
 
@@ -18,31 +19,39 @@ final readonly class ParenthesesChecker
         $brackets = 0;
         $braces = 0;
 
-        foreach ($tokenStream as $token) {
-            switch ($token->getType()) {
-                case Token::T_OPEN_PARENTHESIS:
-                case Token::T_HASH_FN:
-                case Token::T_READER_COND:
-                case Token::T_READER_COND_SPLICING:
-                    ++$parens;
-                    break;
-                case Token::T_CLOSE_PARENTHESIS:
-                    --$parens;
-                    break;
-                case Token::T_OPEN_BRACKET:
-                    ++$brackets;
-                    break;
-                case Token::T_CLOSE_BRACKET:
-                    --$brackets;
-                    break;
-                case Token::T_OPEN_BRACE:
-                case Token::T_HASH_OPEN_BRACE:
-                    ++$braces;
-                    break;
-                case Token::T_CLOSE_BRACE:
-                    --$braces;
-                    break;
+        try {
+            foreach ($tokenStream as $token) {
+                switch ($token->getType()) {
+                    case Token::T_OPEN_PARENTHESIS:
+                    case Token::T_HASH_FN:
+                    case Token::T_READER_COND:
+                    case Token::T_READER_COND_SPLICING:
+                        ++$parens;
+                        break;
+                    case Token::T_CLOSE_PARENTHESIS:
+                        --$parens;
+                        break;
+                    case Token::T_OPEN_BRACKET:
+                        ++$brackets;
+                        break;
+                    case Token::T_CLOSE_BRACKET:
+                        --$brackets;
+                        break;
+                    case Token::T_OPEN_BRACE:
+                    case Token::T_HASH_OPEN_BRACE:
+                        ++$braces;
+                        break;
+                    case Token::T_CLOSE_BRACE:
+                        --$braces;
+                        break;
+                }
             }
+        } catch (LexerValueException) {
+            // Input that does not lex has no delimiter count to report, and
+            // the same reasoning as below applies: report it as ready so the
+            // compile path raises the located lexer error, with its snippet
+            // and caret, instead of a bare "Unbalanced parentheses." (#3289).
+            return true;
         }
 
         // A closer with no matching opener can never be repaired by appending

--- a/src/php/Compiler/Application/Parser.php
+++ b/src/php/Compiler/Application/Parser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Compiler\Application;
 
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
+use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
 use Phel\Compiler\Domain\Lexer\TokenStream;
 use Phel\Compiler\Domain\Parser\Exceptions\KeywordParserException;
 use Phel\Compiler\Domain\Parser\Exceptions\StringParserException;
@@ -114,8 +115,12 @@ final readonly class Parser implements ParserInterface
      * Reads the next expression from the token stream.
      * If the token stream reaches the end, null is returned.
      *
+     * The token stream is lazy, so the lexer runs inside this call and its
+     * error surfaces from here.
+     *
      * @param TokenStream $tokenStream The token stream to read
      *
+     * @throws LexerValueException
      * @throws UnexpectedParserException
      * @throws UnfinishedParserException
      */

--- a/src/php/Compiler/Domain/Lexer/Exceptions/LexerValueException.php
+++ b/src/php/Compiler/Domain/Lexer/Exceptions/LexerValueException.php
@@ -4,17 +4,51 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Lexer\Exceptions;
 
-use RuntimeException;
+use Phel\Lang\SourceLocation;
+use Phel\Shared\Exceptions\AbstractLocatedException;
+use Phel\Shared\Exceptions\ErrorCode;
+use Phel\Shared\Parser\ReadModel\CodeSnippet;
 
 use function sprintf;
 
 /**
+ * A located error, like every other compile error, so `phel run`, `phel eval`
+ * and the REPL report it the way they report a parser or a reader error:
+ * `[PHEL310]`, the user's file and line, the offending line, and a caret under
+ * the character the lexer stopped on. It used to be a bare `RuntimeException`,
+ * which left the CLI dumping the exception class and pointing its `at` line at
+ * this file (#3289).
+ *
  * @internal
  */
-final class LexerValueException extends RuntimeException
+final class LexerValueException extends AbstractLocatedException
 {
-    public static function unexpectedLexerState(string $file, int $line, int $column): self
+    private function __construct(
+        string $message,
+        private readonly CodeSnippet $codeSnippet,
+        SourceLocation $startLocation,
+        SourceLocation $endLocation,
+    ) {
+        parent::__construct($message, $startLocation, $endLocation);
+        $this->setErrorCode(ErrorCode::LEXER_ERROR);
+    }
+
+    public static function unexpectedLexerState(
+        string $character,
+        CodeSnippet $codeSnippet,
+        SourceLocation $startLocation,
+        SourceLocation $endLocation,
+    ): self {
+        return new self(
+            sprintf("Cannot lex '%s': no token starts with it.", $character),
+            $codeSnippet,
+            $startLocation,
+            $endLocation,
+        );
+    }
+
+    public function getCodeSnippet(): CodeSnippet
     {
-        return new self(sprintf('Cannot lex string after at column %d in %s:%d', $column, $file, $line));
+        return $this->codeSnippet;
     }
 }

--- a/src/php/Compiler/Domain/Parser/ParserInterface.php
+++ b/src/php/Compiler/Domain/Parser/ParserInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Parser;
 
+use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
 use Phel\Compiler\Domain\Lexer\TokenStream;
 use Phel\Compiler\Domain\Parser\Exceptions\UnexpectedParserException;
 use Phel\Compiler\Domain\Parser\Exceptions\UnfinishedParserException;
@@ -16,6 +17,10 @@ use Phel\Shared\Parser\Node\NodeInterface;
 interface ParserInterface
 {
     /**
+     * The token stream is lazy, so the lexer runs inside this call and its
+     * error surfaces from here.
+     *
+     * @throws LexerValueException
      * @throws UnexpectedParserException
      * @throws UnfinishedParserException
      */

--- a/src/php/Formatter/Application/PathsFormatter.php
+++ b/src/php/Formatter/Application/PathsFormatter.php
@@ -74,10 +74,10 @@ final readonly class PathsFormatter
                 if ($wasFormatted) {
                     $formattedFilePaths[] = $path;
                 }
-            } catch (AbstractParserException $e) {
+            } catch (AbstractParserException|LexerValueException $e) {
                 $this->commandFacade->writeLocatedException($output, $e, $e->getCodeSnippet());
                 $failedFilePaths[] = $path;
-            } catch (FilePathException|LexerValueException|ZipperException $e) {
+            } catch (FilePathException|ZipperException $e) {
                 $this->commandFacade->writeStackTrace($output, $e);
                 $failedFilePaths[] = $path;
             }

--- a/src/php/Shared/Exceptions/ErrorCodeCatalog.php
+++ b/src/php/Shared/Exceptions/ErrorCodeCatalog.php
@@ -224,7 +224,7 @@ final class ErrorCodeCatalog
             new ErrorCodeExplanation(
                 code: ErrorCode::LEXER_ERROR,
                 title: 'Lexer error',
-                summary: 'No token rule matches the source at that position. A bare `#` is the usual cause: every `#` form needs the character that follows it. Editor diagnostics report it under this code; the terminal prints the raw lexer message.',
+                summary: 'No token rule matches the source at that position. A bare `#` is the usual cause: every `#` form needs the character that follows it.',
                 example: '(inc #)',
                 fix: 'Delete the stray character, or complete the reader form it starts.',
             ),

--- a/tests/php/Integration/Compiler/Lexer/LexerErrorReportTest.php
+++ b/tests/php/Integration/Compiler/Lexer/LexerErrorReportTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Compiler\Lexer;
+
+use Phel\Shared\CompileOptions;
+use Phel\Shared\Exceptions\CompilerException;
+use PhelTest\Integration\Compiler\AbstractCompilerRuntimeTestCase;
+use PhelTest\Support\RendersExceptionReportTrait;
+
+/**
+ * A lexer error reports like every other compile error: `[PHEL310]`, the
+ * user's file and line, the offending line, and a caret one character wide
+ * under the byte the lexer stopped on.
+ *
+ * It used to be a bare `RuntimeException`, so the CLI printed the exception
+ * class, pointed its `at` line at `LexerValueException.php`, and showed no
+ * snippet at all (#3289).
+ */
+final class LexerErrorReportTest extends AbstractCompilerRuntimeTestCase
+{
+    use RendersExceptionReportTrait;
+
+    private const string SOURCE = 'lexer.phel';
+
+    public function test_a_stray_hash_names_the_code_and_points_at_it(): void
+    {
+        $expected = <<<'REPORT'
+            [PHEL310] Cannot lex '#': no token starts with it.
+            in lexer.phel:1
+
+            1| (inc #)
+                    ^
+
+            REPORT;
+
+        self::assertSame($expected, $this->report('(inc #)'));
+    }
+
+    public function test_the_caret_lands_on_the_line_the_character_is_on(): void
+    {
+        $expected = <<<'REPORT'
+            [PHEL310] Cannot lex '#': no token starts with it.
+            in lexer.phel:3
+
+            3| (dec #)
+                    ^
+
+            REPORT;
+
+        self::assertSame($expected, $this->report("(inc 1)\n(inc 2)\n(dec #)"));
+    }
+
+    /**
+     * The caret counts code points, not bytes, so a multibyte character
+     * earlier on the line does not push it off the character it points at.
+     */
+    public function test_the_caret_counts_code_points_not_bytes(): void
+    {
+        $expected = <<<'REPORT'
+            [PHEL310] Cannot lex '#': no token starts with it.
+            in lexer.phel:1
+
+            1| (inc "☃☃" #)
+                         ^
+
+            REPORT;
+
+        self::assertSame($expected, $this->report('(inc "☃☃" #)'));
+    }
+
+    private function report(string $phelCode): string
+    {
+        try {
+            $this->compilerFacade->compile($phelCode, new CompileOptions()->setSource(self::SOURCE));
+        } catch (CompilerException $compilerException) {
+            return $this->exceptionReport(
+                $compilerException->getNestedException(),
+                $compilerException->getCodeSnippet(),
+            );
+        }
+
+        self::fail('Expected the compiler to reject: ' . $phelCode);
+    }
+}

--- a/tests/php/Unit/Formatter/Application/PathsFormatterTest.php
+++ b/tests/php/Unit/Formatter/Application/PathsFormatterTest.php
@@ -9,7 +9,9 @@ use Phel\Formatter\Application\PathsFormatter;
 use Phel\Formatter\Domain\FormatterInterface;
 use Phel\Formatter\Domain\IO\ValidatedFileIoInterface;
 use Phel\Formatter\Domain\PathFilterInterface;
+use Phel\Lang\SourceLocation;
 use Phel\Shared\Facade\CommandFacadeInterface;
+use Phel\Shared\Parser\ReadModel\CodeSnippet;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -24,7 +26,7 @@ final class PathsFormatterTest extends TestCase
     public function test_lexer_failure_on_one_file_does_not_abort_the_batch(): void
     {
         $io = $this->fileIo(['a.phel' => '(a', 'b.phel' => '(b)']);
-        $formatter = $this->formatterThrowing('a.phel', new LexerValueException('bad token'));
+        $formatter = $this->formatterThrowing('a.phel', $this->lexerException());
 
         $output = new BufferedOutput();
         $result = new PathsFormatter(
@@ -35,13 +37,13 @@ final class PathsFormatterTest extends TestCase
         )->format(['ignored'], $output);
 
         self::assertSame(['b.phel'], $result->changedPaths());
-        self::assertStringContainsString('bad token', $output->fetch());
+        self::assertStringContainsString("Cannot lex '#'", $output->fetch());
     }
 
     public function test_unformattable_file_is_reported_as_failed(): void
     {
         $io = $this->fileIo(['a.phel' => '(a', 'b.phel' => '(b)']);
-        $formatter = $this->formatterThrowing('a.phel', new LexerValueException('bad token'));
+        $formatter = $this->formatterThrowing('a.phel', $this->lexerException());
 
         $result = new PathsFormatter(
             $this->commandFacade(),
@@ -158,6 +160,22 @@ final class PathsFormatterTest extends TestCase
      * Formats by appending a newline (so every file counts as "changed"),
      * except for $failingPath which raises $exception.
      */
+    /**
+     * The real one, built the way the lexer builds it, so the test exercises
+     * the located shape the formatter now renders rather than a bare message.
+     */
+    private function lexerException(): LexerValueException
+    {
+        $start = new SourceLocation('a.phel', 1, 2);
+
+        return LexerValueException::unexpectedLexerState(
+            '#',
+            new CodeSnippet($start, new SourceLocation('a.phel', 1, 3), '(a #'),
+            $start,
+            new SourceLocation('a.phel', 1, 3),
+        );
+    }
+
     private function formatterThrowing(?string $failingPath, ?LexerValueException $exception): FormatterInterface
     {
         return new readonly class($failingPath, $exception) implements FormatterInterface {
@@ -199,6 +217,12 @@ final class PathsFormatterTest extends TestCase
     {
         $facade = $this->createStub(CommandFacadeInterface::class);
         $facade->method('writeStackTrace')
+            ->willReturnCallback(static function (OutputInterface $output, Throwable $e): void {
+                $output->writeln($e->getMessage());
+            });
+        // A lexer error is a located error now, so the formatter reports it
+        // through the same call a parser error goes through (#3289).
+        $facade->method('writeLocatedException')
             ->willReturnCallback(static function (OutputInterface $output, Throwable $e): void {
                 $output->writeln($e->getMessage());
             });


### PR DESCRIPTION
## 🤔 Background

Every other compile error is a located exception: it prints `[PHELxxx] message`, the user's file and line, the snippet and a caret. A lexer error was not. `LexerValueException` extended `RuntimeException`, so it carried no location, no code and no snippet, and each command surfaced it differently.

`phel run`:

```
Cannot lex string after at column 14 in /tmp/lexprobe.phel:2
  at .../src/php/Compiler/Domain/Lexer/Exceptions/LexerValueException.php:18
   ... 30 internal frames (--stack-trace to show, full trace in .phel/error.log)
```

`phel eval '(inc #)'`:

```
In LexerValueException.php line 18:

  Cannot lex string after at column 5 in string:1

eval [--stack-trace] [--] [<expression>]
```

`phel format` printed a stack trace, and `phel analyze` reported every lexer error at line 1, column 1 because the diagnostic had nowhere else to get a position from.

Four defects in one: no code, an `at` line naming an internal Phel file, no snippet, and a fifth report shape after the four #3264 unified. The message had a hole in it too: `Cannot lex string after at column 14` reads as though a token was meant to follow "after", and none was ever passed.

## 💡 Goal

One report shape, whichever command hits it.

## 🔖 Changes

- `LexerValueException` is an `AbstractLocatedException` carrying the `SourceLocation` the lexer already tracked, the offending line as a `CodeSnippet`, and `PHEL310`. It keeps its class name and stays catchable: six call sites catch it by name and `CompilerFacadeInterface` documents it.
- `CodeCompiler` and `EvalCompiler` wrap it in a `CompilerException` alongside the parser and reader errors; `PathsFormatter` routes it to `writeLocatedException` with them. `parseNext()` now declares the throw, which is where it actually surfaces, since the token stream is lazy.
- The balance pre-check stops answering "Unbalanced parentheses." for input that cannot lex. It reports the input as ready and lets the compile path raise the real error, which is the reasoning that method already applied to a closer with no opener.
- The message names the character: `Cannot lex '#': no token starts with it.`
- `phel analyze` reports the diagnostic where the character is. Both phases now share one mapping.

```
[PHEL310] Cannot lex '#': no token starts with it.
in lexprobe.phel:2

2| (println (inc #))
                 ^
```

## ✅ Tests

`LexerErrorReportTest` pins the rendered report, including that the caret counts code points rather than bytes so a multibyte character earlier on the line does not push it off target. `PathsFormatterTest` builds the real exception the way the lexer does, so it exercises the located shape rather than a bare message.

Closes #3289
