### PR TITLE
fix(analyzer): name the form when a special form is given too few arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- A special form given too few arguments names the form and the shape it wanted, with a snippet and a caret. Twelve of them read past the end of their own list first, so the user got `[PHEL403] Index out of bounds` raised inside `PersistentList`, a runtime code for a compile-time problem, and four raised a bare `AssertionError` that vanished under `zend.assertions=-1`. (#3297)
 - REPL: `(exit)` and `(quit)` end the session like `exit` and `quit`, `(exit <code>)` sets the exit status, and the banner names the call form. (#3272)
 - `phel test`: the `Form:` line of a failed assertion prints the asserted source form instead of repeating the evaluated value. (#3263)
 - Parser: an unterminated list, vector, map, set or string now names the line it was opened on, carries an error code, and puts the caret on the opening delimiter. (#3259)

--- a/docs/errors/analyzer.md
+++ b/docs/errors/analyzer.md
@@ -35,7 +35,7 @@ The analyzer reached a symbol that is bound nowhere: not in the current namespac
 
 Enum case: `ErrorCode::ARITY_ERROR`
 
-The analyzer knows the arity of the function being called and the call site does not match it. It fires only for a global definition the compiler has already seen.
+The call does not match the arity the analyzer knows. For a function that means a global definition the compiler has already seen; a special form given too few arguments reports here too, and names the shape it wanted.
 
 ```phel
 (map)

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -76,6 +76,8 @@ Opt-in, off by default (`CompilerConfig::isIntermediateCacheEnabled()`). Wired o
 
 ## Key Constraints
 
+- Every special-form analyzer checks its argument count before reading an argument, via `AssertsFormArityTrait::assertArityAtLeast()`. `PersistentListInterface::get()` throws past the end, and that exception is about a list rather than about the form the user wrote: it reached them as `[PHEL403] Index out of bounds`, a runtime code, with no snippet. `SpecialFormArityTest` walks the `AnalyzePersistentList` registry and fails when a form raises anything but an `AnalyzerException` (#3297).
+
 - Never bypass a phase; each consumes only output of the previous.
 - Analyzer nodes must carry `NodeEnvironment` with correct context.
 - Emitter must handle every node type; missing cases throw, not silently skip.

--- a/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
+++ b/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
@@ -9,6 +9,7 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\PhelType;
+use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
 use Phel\Shared\Exceptions\AbstractLocatedException;
 use Phel\Shared\Exceptions\ErrorCode;
@@ -46,6 +47,29 @@ final class AnalyzerException extends AbstractLocatedException
         }
 
         return $e;
+    }
+
+    /**
+     * A special form given too few arguments. It names the form and the shape
+     * it wanted, because "wrong number of arguments" without the shape sends
+     * the reader to the documentation for something they nearly wrote.
+     *
+     * Reading an argument before checking the count let the list's own
+     * out-of-bounds error reach the user instead, under a runtime code, with
+     * no snippet and no caret (#3297).
+     *
+     * @param PersistentListInterface<mixed> $list
+     */
+    public static function wrongArity(PersistentListInterface $list, string $usage): self
+    {
+        $first = $list->first();
+        $name = $first instanceof Symbol ? $first->getFullName() : 'form';
+
+        return self::withLocation(
+            sprintf("Wrong number of arguments for '%s. Usage: %s", $name, $usage),
+            $list,
+            errorCode: ErrorCode::ARITY_ERROR,
+        );
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/AssertsFormArityTrait.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/AssertsFormArityTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+
+use function count;
+
+/**
+ * Checks a special form is long enough before its analyzer reads an argument
+ * out of it.
+ *
+ * `PersistentListInterface::get()` throws past the end, and that exception is
+ * about a list rather than about the form the user wrote: it reached them as
+ * `[PHEL403] Index out of bounds`, a runtime code, raised inside
+ * `PersistentList`, with no snippet and no caret (#3297).
+ *
+ * @internal
+ */
+trait AssertsFormArityTrait
+{
+    /**
+     * @param PersistentListInterface<mixed> $list
+     * @param int                            $arity the number of forms the whole call must have, the form's own name included
+     * @param string                         $usage the shape to show the reader, e.g. `(php/aget array key)`
+     *
+     * @throws AnalyzerException
+     */
+    private function assertArityAtLeast(PersistentListInterface $list, int $arity, string $usage): void
+    {
+        if (count($list) < $arity) {
+            throw AnalyzerException::wrongArity($list, $usage);
+        }
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefInterfaceSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefInterfaceSymbol.php
@@ -32,6 +32,7 @@ use function is_string;
  */
 final class DefInterfaceSymbol implements SpecialFormAnalyzerInterface
 {
+    use AssertsFormArityTrait;
     use WithAnalyzerTrait;
 
     /**
@@ -39,6 +40,8 @@ final class DefInterfaceSymbol implements SpecialFormAnalyzerInterface
      */
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): DefInterfaceNode
     {
+        $this->assertArityAtLeast($list, 2, '(definterface name (method [this]) ...)');
+
         $interfaceSymbol = $list->get(1);
         if (!($interfaceSymbol instanceof Symbol)) {
             throw AnalyzerException::wrongArgumentType("First argument of 'definterface", 'Symbol', $interfaceSymbol, $list);

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
@@ -34,6 +34,7 @@ use function substr;
  */
 final class NsSymbol implements SpecialFormAnalyzerInterface
 {
+    use AssertsFormArityTrait;
     use WithAnalyzerTrait;
 
     private const string INVALID_NAMESPACE_MESSAGE = <<<'TXT'
@@ -46,6 +47,8 @@ TXT;
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): NsNode
     {
+        $this->assertArityAtLeast($list, 2, '(ns name)');
+
         $nsSymbol = $list->get(1);
         if (!($nsSymbol instanceof Symbol)) {
             throw AnalyzerException::wrongArgumentType("First argument of 'ns", 'Symbol', $nsSymbol, $list);

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAGetInSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAGetInSymbol.php
@@ -6,11 +6,10 @@ namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayGetNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Traversable;
-
-use function assert;
 
 /**
  * (php/aget-in arr key1 key2 ...).
@@ -21,12 +20,20 @@ use function assert;
  */
 final class PhpAGetInSymbol implements SpecialFormAnalyzerInterface
 {
+    use AssertsFormArityTrait;
     use WithAnalyzerTrait;
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): PhpArrayGetNode
     {
+        $this->assertArityAtLeast($list, 3, '(php/aget-in array [key ...])');
+
         $keys = $list->get(2);
-        assert($keys instanceof Traversable);
+        if (!$keys instanceof Traversable) {
+            // An assertion is a statement about Phel's own code. The shape of
+            // a user's form is not one, and `assert()` is compiled out under
+            // `zend.assertions=-1`, so the same source failed two ways (#3297).
+            throw AnalyzerException::wrongArity($list, '(php/aget-in array [key ...])');
+        }
 
         $accessExprs = [];
         foreach ($keys as $k) {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAGetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAGetSymbol.php
@@ -18,10 +18,13 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
  */
 final class PhpAGetSymbol implements SpecialFormAnalyzerInterface
 {
+    use AssertsFormArityTrait;
     use WithAnalyzerTrait;
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): PhpArrayGetNode
     {
+        $this->assertArityAtLeast($list, 3, '(php/aget array key)');
+
         return new PhpArrayGetNode(
             $env,
             $this->analyzer->analyze($list->get(1), $env->withExpressionContext()),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAPushInSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAPushInSymbol.php
@@ -6,11 +6,10 @@ namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayPushNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Traversable;
-
-use function assert;
 
 /**
  * (php/apush-in arr key1 key2 ... value).
@@ -21,12 +20,20 @@ use function assert;
  */
 final class PhpAPushInSymbol implements SpecialFormAnalyzerInterface
 {
+    use AssertsFormArityTrait;
     use WithAnalyzerTrait;
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): PhpArrayPushNode
     {
+        $this->assertArityAtLeast($list, 4, '(php/apush-in array [key ...] value)');
+
         $keys = $list->get(2);
-        assert($keys instanceof Traversable);
+        if (!$keys instanceof Traversable) {
+            // An assertion is a statement about Phel's own code. The shape of
+            // a user's form is not one, and `assert()` is compiled out under
+            // `zend.assertions=-1`, so the same source failed two ways (#3297).
+            throw AnalyzerException::wrongArity($list, '(php/apush-in array [key ...] value)');
+        }
 
         $accessExprs = [];
         foreach ($keys as $k) {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAPushSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAPushSymbol.php
@@ -18,10 +18,13 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
  */
 final class PhpAPushSymbol implements SpecialFormAnalyzerInterface
 {
+    use AssertsFormArityTrait;
     use WithAnalyzerTrait;
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): PhpArrayPushNode
     {
+        $this->assertArityAtLeast($list, 3, '(php/apush array value)');
+
         return new PhpArrayPushNode(
             $env,
             $this->analyzer->analyze($list->get(1), $env->withExpressionContext()->withUseGlobalReference(true)),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpASetInSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpASetInSymbol.php
@@ -6,11 +6,10 @@ namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArraySetNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Traversable;
-
-use function assert;
 
 /**
  * (php/aset-in arr key1 key2 ... value).
@@ -21,12 +20,20 @@ use function assert;
  */
 final class PhpASetInSymbol implements SpecialFormAnalyzerInterface
 {
+    use AssertsFormArityTrait;
     use WithAnalyzerTrait;
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): PhpArraySetNode
     {
+        $this->assertArityAtLeast($list, 4, '(php/aset-in array [key ...] value)');
+
         $keys = $list->get(2);
-        assert($keys instanceof Traversable);
+        if (!$keys instanceof Traversable) {
+            // An assertion is a statement about Phel's own code. The shape of
+            // a user's form is not one, and `assert()` is compiled out under
+            // `zend.assertions=-1`, so the same source failed two ways (#3297).
+            throw AnalyzerException::wrongArity($list, '(php/aset-in array [key ...] value)');
+        }
 
         $accessExprs = [];
         foreach ($keys as $k) {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpASetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpASetSymbol.php
@@ -18,10 +18,13 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
  */
 final class PhpASetSymbol implements SpecialFormAnalyzerInterface
 {
+    use AssertsFormArityTrait;
     use WithAnalyzerTrait;
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): PhpArraySetNode
     {
+        $this->assertArityAtLeast($list, 4, '(php/aset array key value)');
+
         return new PhpArraySetNode(
             $env,
             $this->analyzer->analyze($list->get(1), $env->withExpressionContext()->withUseGlobalReference(true)),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAUnsetInSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAUnsetInSymbol.php
@@ -12,8 +12,6 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Traversable;
 
-use function assert;
-
 /**
  * (php/aunset-in arr key1 key2 ...).
  *
@@ -23,16 +21,24 @@ use function assert;
  */
 final class PhpAUnsetInSymbol implements SpecialFormAnalyzerInterface
 {
+    use AssertsFormArityTrait;
     use WithAnalyzerTrait;
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): PhpArrayUnsetNode
     {
+        $this->assertArityAtLeast($list, 3, '(php/aunset-in array [key ...])');
+
         if (!$env->isContext(NodeEnvironment::CONTEXT_STATEMENT)) {
             throw AnalyzerException::withLocation("'php/unset can only be called as Statement and not as Expression", $list);
         }
 
         $keys = $list->get(2);
-        assert($keys instanceof Traversable);
+        if (!$keys instanceof Traversable) {
+            // An assertion is a statement about Phel's own code. The shape of
+            // a user's form is not one, and `assert()` is compiled out under
+            // `zend.assertions=-1`, so the same source failed two ways (#3297).
+            throw AnalyzerException::wrongArity($list, '(php/aunset-in array [key ...])');
+        }
 
         $accessExprs = [];
         foreach ($keys as $k) {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAUnsetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAUnsetSymbol.php
@@ -20,10 +20,13 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
  */
 final class PhpAUnsetSymbol implements SpecialFormAnalyzerInterface
 {
+    use AssertsFormArityTrait;
     use WithAnalyzerTrait;
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): PhpArrayUnsetNode
     {
+        $this->assertArityAtLeast($list, 3, '(php/aunset array key)');
+
         if (!$env->isContext(NodeEnvironment::CONTEXT_STATEMENT)) {
             throw AnalyzerException::withLocation("'php/unset can only be called as Statement and not as Expression", $list);
         }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpOSetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpOSetSymbol.php
@@ -16,10 +16,13 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
  */
 final class PhpOSetSymbol implements SpecialFormAnalyzerInterface
 {
+    use AssertsFormArityTrait;
     use WithAnalyzerTrait;
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): PhpObjectSetNode
     {
+        $this->assertArityAtLeast($list, 3, '(php/oset (php/-> object property) value)');
+
         $left = $this->analyzer->analyze($list->get(1), $env->withExpressionContext());
         $right = $this->analyzer->analyze($list->get(2), $env->withExpressionContext());
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/SetVarSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/SetVarSymbol.php
@@ -20,10 +20,13 @@ use Phel\Lang\Symbol;
  */
 final class SetVarSymbol implements SpecialFormAnalyzerInterface
 {
+    use AssertsFormArityTrait;
     use WithAnalyzerTrait;
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): SetVarNode
     {
+        $this->assertArityAtLeast($list, 3, '(set-var name value)');
+
         $nameSymbol = $list->get(1);
         if (!($nameSymbol instanceof Symbol)) {
             throw AnalyzerException::wrongArgumentType("First argument of 'def", 'Symbol', $nameSymbol, $list);

--- a/src/php/Shared/Exceptions/ErrorCodeCatalog.php
+++ b/src/php/Shared/Exceptions/ErrorCodeCatalog.php
@@ -91,7 +91,7 @@ final class ErrorCodeCatalog
             new ErrorCodeExplanation(
                 code: ErrorCode::ARITY_ERROR,
                 title: 'Wrong number of arguments',
-                summary: 'The analyzer knows the arity of the function being called and the call site does not match it. It fires only for a global definition the compiler has already seen.',
+                summary: 'The call does not match the arity the analyzer knows. For a function that means a global definition the compiler has already seen; a special form given too few arguments reports here too, and names the shape it wanted.',
                 example: '(map)',
                 fix: 'Pass the number of arguments the function declares.',
             ),

--- a/tests/php/Integration/Compiler/Analyzer/SpecialFormArityTest.php
+++ b/tests/php/Integration/Compiler/Analyzer/SpecialFormArityTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Compiler\Analyzer;
+
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\AnalyzePersistentList;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use PhelTest\Integration\Compiler\AbstractCompilerRuntimeTestCase;
+use Throwable;
+
+use function implode;
+use function sprintf;
+use function str_repeat;
+
+/**
+ * A special form given too few arguments must say so itself. It used to read
+ * past the end of its own list first, so the user got `[PHEL403] Index out of
+ * bounds` raised inside `PersistentList`, or a raw `AssertionError`: a runtime
+ * error code for a compile-time problem, with no snippet, no caret, and an `at`
+ * line pointing inside Phel (#3297).
+ *
+ * The analyzer's own registry drives the cases, so a special form added without
+ * an arity check fails here rather than reaching a user. Two instances of this
+ * were fixed one at a time in #3266; fixing them singly is why the class kept
+ * coming back.
+ */
+final class SpecialFormArityTest extends AbstractCompilerRuntimeTestCase
+{
+    /** How many leading arguments to try before moving on to the next form. */
+    private const int MAX_ARGS = 2;
+
+    public function test_no_special_form_fails_with_anything_but_an_analyzer_error(): void
+    {
+        $offenders = [];
+
+        foreach ($this->specialFormNames() as $name) {
+            for ($count = 0; $count <= self::MAX_ARGS; ++$count) {
+                $source = sprintf('(%s%s)', $name, str_repeat(' 1', $count));
+                $failure = $this->analyzeAndCatch($source);
+
+                if ($failure !== null) {
+                    $offenders[] = sprintf('%s -> %s', $source, $failure);
+                }
+            }
+        }
+
+        self::assertSame([], $offenders, sprintf(
+            "These forms failed with something other than an AnalyzerException:\n%s\n\n"
+            . 'Check the argument count before reading an argument.',
+            implode("\n", $offenders),
+        ));
+    }
+
+    /**
+     * @return string|null the offending class and message, or null when the
+     *                     form analysed cleanly or was properly rejected
+     */
+    private function analyzeAndCatch(string $source): ?string
+    {
+        GlobalEnvironmentSingleton::initializeNew();
+
+        try {
+            foreach ($this->compilerFacade->readFormsBestEffort($source, 'arity.phel') as $form) {
+                $this->compilerFacade->analyze($form, NodeEnvironment::empty());
+            }
+        } catch (AnalyzerException) {
+            // The analyzer rejected the form, which is the whole point. Some
+            // forms are also legal with no arguments, so analysing cleanly is
+            // just as acceptable an outcome.
+            return null;
+        } catch (Throwable $t) {
+            return sprintf('%s: %s', $t::class, $t->getMessage());
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function specialFormNames(): array
+    {
+        return new AnalyzePersistentList(
+            $this->createStub(AnalyzerInterface::class),
+            assertsEnabled: true,
+        )->specialFormNames();
+    }
+}


### PR DESCRIPTION
## 🤔 Background

A special form given too few arguments read past the end of its own list before checking its shape, so the list's own error reached the user:

```
$ phel eval '(ns)'
[PHEL403] Index out of bounds
  at src/php/Lang/Collections/LinkedList/PersistentList.php:140
#0 .../SpecialForm/NsSymbol.php:49

$ phel eval '(php/aget-in 1 1)'
assert($keys instanceof Traversable)
```

`PHEL403` is `INDEX_OUT_OF_BOUNDS`, a runtime code from the `PHEL400-499` range added in #3266. Reporting a compile-time shape error under it is wrong twice: the phase is wrong, and `phel explain PHEL403` describes something the user did not do. There was no snippet, no caret, and the `at` line pointed inside Phel.

Analysing every special form in the `AnalyzePersistentList` registry with 0, 1 and 2 arguments found **26 of 120 probes** ending in something other than an `AnalyzerException`: 21 `IndexOutOfBoundsException` and 5 `AssertionError`, across `ns`, `set-var`, `definterface*` and the nine `php/a*` forms.

The `AssertionError` cases were the worse half. `assert()` is compiled out under `zend.assertions=-1`, so the same source failed two different ways depending on an ini flag.

Two instances of this class were already fixed one at a time in #3266 (`(try (catch))` and `(definterface Shape (draw))`). Fixing them singly is why the class was still here.

## 💡 Goal

A form the user mistyped is described to the user, not to whoever is reading a `PersistentList` stack trace.

## 🔖 Changes

- `AssertsFormArityTrait::assertArityAtLeast()` checks the count before any argument is read. Twelve analyzers use it.
- `AnalyzerException::wrongArity()` names the form and the shape it wanted, under `PHEL002`. "Wrong number of arguments" without the shape sends the reader to the documentation for something they nearly wrote.
- The four `assert($keys instanceof Traversable)` calls became the same analyzer error. An assertion is a statement about Phel's own code; the shape of a user's form is not one.
- `PHEL002`'s catalog entry says it now covers special forms too, and `docs/errors/analyzer.md` is regenerated from it.

```
$ phel eval '(php/aget)'
[PHEL002] Wrong number of arguments for 'php/aget. Usage: (php/aget array key)
in string:1

1| (php/aget)
   ^^^^^^^^^^
```

## ✅ Tests

`SpecialFormArityTest` walks the analyzer's own registry and analyses every special form with 0..2 arguments, asserting nothing but an `AnalyzerException` comes out. It reports every offender at once rather than the first, and it fails when a special form is added without an arity check. Red before this change with all 26 listed, green after.

Closes #3297
