### PR TITLE
fix(compiler): let the property shorthand reach the sigil diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `(.-$foo o)` names the sigil rule instead of failing with `Cannot resolve symbol '.-$foo'`. The diagnostics that point at a spelling now name the Clojure-style one: the sigil message drops its `(php/:: \Foo $prop)` alternative, and a dynamic `new` on a non-class says `new expects a class name or object`. (#3300)
 - A special form given too few arguments names the form and the shape it wanted, with a snippet and a caret. Twelve of them read past the end of their own list first, so the user got `[PHEL403] Index out of bounds` raised inside `PersistentList`, a runtime code for a compile-time problem, and four raised a bare `AssertionError` that vanished under `zend.assertions=-1`. (#3297)
 - REPL: `(exit)` and `(quit)` end the session like `exit` and `quit`, `(exit <code>)` sets the exit status, and the banner names the call form. (#3272)
 - `phel test`: the `Form:` line of a failed assertion prints the asserted source form instead of repeating the evaluated value. (#3263)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -307,7 +307,12 @@ final class AnalyzePersistentList
             return false;
         }
 
-        return QualifiedMemberSyntax::isIdentifierStartChar($name[2]);
+        // A `$` is accepted here so `(.-$foo o)` reaches the analyzer, which
+        // tells the writer that a sigil names a static property. Stopping at
+        // this predicate would only say "cannot resolve symbol '.-$foo'".
+        return $name[2] === '$'
+            ? $len > 3 && QualifiedMemberSyntax::isIdentifierStartChar($name[3])
+            : QualifiedMemberSyntax::isIdentifierStartChar($name[2]);
     }
 
     private function createSymbolAnalyzerByName(string $symbolName): SpecialFormAnalyzerInterface

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
@@ -144,9 +144,8 @@ final readonly class PhpObjectCallSymbol implements SpecialFormAnalyzerInterface
 
         throw AnalyzerException::withLocation(
             sprintf(
-                "'%s' names a static property, which only a class can hold: write \\Foo/%s or (php/:: \\Foo %s). "
+                "'%s' names a static property, which only a class can hold: write \\Foo/%s. "
                 . 'An instance member and a method name carry no sigil.',
-                $name,
                 $name,
                 $name,
             ),

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpNewEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpNewEmitter.php
@@ -111,7 +111,7 @@ final class PhpNewEmitter implements NodeEmitterInterface
                 );
                 $this->outputEmitter->emitLine();
                 $this->outputEmitter->emitStr(
-                    'throw new \InvalidArgumentException(sprintf("php/new expects a class name or object, %s given (%s)", get_debug_type(' . $targetVar . '), var_export(' . $targetVar . ', true)));',
+                    'throw new \InvalidArgumentException(sprintf("new expects a class name or object, %s given (%s)", get_debug_type(' . $targetVar . '), var_export(' . $targetVar . ', true)));',
                     $node->getStartSourceLocation(),
                 );
                 $this->outputEmitter->emitLine();

--- a/tests/php/Integration/Compiler/PhpNewRuntimeTest.php
+++ b/tests/php/Integration/Compiler/PhpNewRuntimeTest.php
@@ -12,7 +12,7 @@ final class PhpNewRuntimeTest extends AbstractCompilerRuntimeTestCase
     public function test_dynamic_new_with_integer_literal_throws_descriptive_error(): void
     {
         $this->expectException(EvaluatedCodeException::class);
-        $this->expectExceptionMessage('php/new expects a class name or object, int given (1)');
+        $this->expectExceptionMessage('new expects a class name or object, int given (1)');
 
         $this->compilerFacade->eval(
             '(php/new 1)',
@@ -23,7 +23,7 @@ final class PhpNewRuntimeTest extends AbstractCompilerRuntimeTestCase
     public function test_dynamic_new_with_bound_integer_throws_descriptive_error(): void
     {
         $this->expectException(EvaluatedCodeException::class);
-        $this->expectExceptionMessage('php/new expects a class name or object, int given (42)');
+        $this->expectExceptionMessage('new expects a class name or object, int given (42)');
 
         $this->compilerFacade->eval(
             '(let [x 42] (php/new x))',

--- a/tests/php/Integration/Compiler/QualifiedMemberValueRuntimeTest.php
+++ b/tests/php/Integration/Compiler/QualifiedMemberValueRuntimeTest.php
@@ -146,6 +146,22 @@ final class QualifiedMemberValueRuntimeTest extends AbstractCompilerRuntimeTestC
         );
     }
 
+    /**
+     * The shorthand has to reach the same diagnostic the `php/->` spelling
+     * reaches. Stopping at the shorthand predicate left the writer with
+     * "Cannot resolve symbol '.-$foo'", which names nothing they can act on.
+     */
+    public function test_a_sigil_on_the_property_shorthand_fails_with_the_same_message(): void
+    {
+        $this->expectException(CompilerException::class);
+        $this->expectExceptionMessage("'\$foo' names a static property, which only a class can hold");
+
+        $this->compilerFacade->eval(
+            '(let [o (new \\stdClass)] (.-$foo o))',
+            new CompileOptions(),
+        );
+    }
+
     public function test_an_all_caps_class_works_in_both_static_constant_spellings(): void
     {
         $qualified = $this->compilerFacade->eval(

--- a/tests/php/Integration/Fixtures/BareHost/php-prefixed-name-stays-the-constant.test
+++ b/tests/php/Integration/Fixtures/BareHost/php-prefixed-name-stays-the-constant.test
@@ -24,7 +24,7 @@ require_once __DIR__ . '/phel/core.php';
     public function __invoke() {
       $target_1 = WP_CLI_FIXTURE;
       if (!is_string($target_1) && !is_object($target_1)) {
-      throw new \InvalidArgumentException(sprintf("php/new expects a class name or object, %s given (%s)", get_debug_type($target_1), var_export($target_1, true)));
+      throw new \InvalidArgumentException(sprintf("new expects a class name or object, %s given (%s)", get_debug_type($target_1), var_export($target_1, true)));
       }
       return new $target_1();
     }

--- a/tests/php/Integration/Fixtures/Call/php-instanceof-bound-class-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-instanceof-bound-class-reference.test
@@ -8,7 +8,7 @@ $PHPChildT_1 = \RecursiveArrayIterator::class;
   $instanceof_value_2 = (function() use($PHPChildT_1) {
     $target_4 = $PHPChildT_1;
     if (!is_string($target_4) && !is_object($target_4)) {
-    throw new \InvalidArgumentException(sprintf("php/new expects a class name or object, %s given (%s)", get_debug_type($target_4), var_export($target_4, true)));
+    throw new \InvalidArgumentException(sprintf("new expects a class name or object, %s given (%s)", get_debug_type($target_4), var_export($target_4, true)));
     }
     return new $target_4(array());
   })();

--- a/tests/php/Integration/Fixtures/New/new-dynamic-class-statement.test
+++ b/tests/php/Integration/Fixtures/New/new-dynamic-class-statement.test
@@ -5,6 +5,6 @@
 $cls_1 = "\\DateTimeImmutable";
 $target_2 = $cls_1;
 if (!is_string($target_2) && !is_object($target_2)) {
-throw new \InvalidArgumentException(sprintf("php/new expects a class name or object, %s given (%s)", get_debug_type($target_2), var_export($target_2, true)));
+throw new \InvalidArgumentException(sprintf("new expects a class name or object, %s given (%s)", get_debug_type($target_2), var_export($target_2, true)));
 }
 new $target_2();


### PR DESCRIPTION
## 🤔 Background

Three diagnostics point the writer at a spelling. All three point at the wrong one.

`(.-$foo o)` never reaches the message that explains the sigil rule. `isPropertyAccessShorthandName` requires an identifier start character after `.-`, `$` is not one, so the shorthand is not recognised and the symbol falls through to name resolution:

```
Cannot resolve symbol '.-$foo'
```

The same mistake written the long way does reach it:

```
(php/-> o $foo)
'$foo' names a static property, which only a class can hold: ...
```

That message then recommends `(php/:: \Foo $prop)`, and a dynamic `new` on a non-class reports `php/new expects a class name or object`. ADR 0007 deprecates both spellings as source, so a reader who follows either message writes the form we are steering them away from.

## 💡 Goal

The shorthand reaches the diagnostic the long spelling reaches, and every message that names a spelling names the Clojure-style one.

## 🔖 Changes

- `isPropertyAccessShorthandName` accepts a `$` after `.-`, so `(.-$foo o)` expands and the analyzer answers with the sigil rule instead of a resolution failure. A bare `.-$` is still not a shorthand.
- The sigil message drops its `(php/:: \Foo $prop)` alternative and keeps `\Foo/$prop`.
- The dynamic-`new` runtime message says `new expects a class name or object`.
- Integration test covering `(.-$foo o)`, and the three emitter fixtures carrying the old runtime string.

Found while working on #3299; independent of the decision there.
